### PR TITLE
Release channels phases 3-5: channel toggle, store beta lanes, and promotion

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -357,7 +357,12 @@ jobs:
       - name: Setup Google Play service account key
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
-        run: echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" > android/fastlane/play-store-key.json
+        # The secret is stored base64-encoded; release.yml decodes it the same
+        # way and has authenticated against Play in production. Writing it raw
+        # yields base64 text in a .json file and fastlane fails to parse it.
+        run: |
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" | base64 --decode > android/fastlane/play-store-key.json
+          chmod 600 android/fastlane/play-store-key.json
 
       - name: Download Android AAB artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -3,7 +3,7 @@ name: Beta
 # Per-merge beta pipeline (release-channels spec, Phase 2). Runs after CI/CD
 # succeeds on main, builds the exact validated SHA via build-all.yml, and
 # publishes the artifact set as a release in submersion-app/beta-builds.
-# Store lanes (TestFlight / Play beta track) are Phase 4 and not wired here.
+# Store lanes: TestFlight (Public Beta group) and Play open testing (Phase 4).
 on:
   workflow_run:
     workflows: ["CI/CD"]
@@ -213,3 +213,174 @@ jobs:
             echo "Pruning $tag"
             gh release delete "$tag" --repo submersion-app/beta-builds --yes --cleanup-tag
           done
+
+  upload-testflight-ios:
+    name: Upload iOS beta to TestFlight
+    runs-on: macos-15
+    needs: [precheck, build]
+    if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.precheck.outputs.sha }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          mkdir -p ios/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > ios/fastlane/AuthKey.p8
+
+      - name: Download iOS IPA artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ios-ipa
+
+      - name: Upload to TestFlight (Public Beta)
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BETA_CHANGELOG: "Beta ${{ needs.precheck.outputs.tag }} - automated per-merge build."
+        run: |
+          IPA_PATH=$(ls $GITHUB_WORKSPACE/Submersion-*-iOS.ipa 2>/dev/null | head -1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "Error: No IPA artifact found"
+            exit 1
+          fi
+          for attempt in 1 2; do
+            if bundle exec fastlane upload_testflight_beta ipa:"$IPA_PATH"; then
+              break
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Fastlane upload failed after 2 attempts"
+              exit 1
+            fi
+            echo "Fastlane attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f ios/fastlane/AuthKey.p8
+
+  upload-testflight-macos:
+    name: Upload macOS beta to TestFlight
+    runs-on: macos-15
+    needs: [precheck, build]
+    if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.precheck.outputs.sha }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: macos
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          mkdir -p macos/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > macos/fastlane/AuthKey.p8
+
+      - name: Download Mac App Store pkg artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-pkg
+
+      - name: Upload to TestFlight (Public Beta)
+        working-directory: macos
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BETA_CHANGELOG: "Beta ${{ needs.precheck.outputs.tag }} - automated per-merge build."
+        run: |
+          # The Mac App Store package keeps its fixed name (no tag prefix).
+          PKG_PATH="$GITHUB_WORKSPACE/Submersion.pkg"
+          if [ ! -f "$PKG_PATH" ]; then
+            echo "Error: No pkg artifact found at $PKG_PATH"
+            exit 1
+          fi
+          for attempt in 1 2; do
+            if bundle exec fastlane upload_testflight_beta pkg:"$PKG_PATH"; then
+              break
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Fastlane upload failed after 2 attempts"
+              exit 1
+            fi
+            echo "Fastlane attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f macos/fastlane/AuthKey.p8
+
+  upload-play:
+    name: Upload Android beta to Play open testing
+    runs-on: ubuntu-latest
+    needs: [precheck, build]
+    if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.precheck.outputs.sha }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: android
+
+      - name: Setup Google Play service account key
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
+        run: echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" > android/fastlane/play-store-key.json
+
+      - name: Download Android AAB artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: android-aab
+
+      - name: Upload to Play open testing
+        working-directory: android
+        env:
+          GOOGLE_PLAY_JSON_KEY_PATH: fastlane/play-store-key.json
+        run: |
+          for attempt in 1 2; do
+            if bundle exec fastlane upload_beta; then
+              break
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Fastlane upload failed after 2 attempts"
+              exit 1
+            fi
+            echo "Fastlane attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f android/fastlane/play-store-key.json

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -168,7 +168,12 @@ jobs:
       - name: Setup Google Play service account key
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
-        run: echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" > android/fastlane/play-store-key.json
+        # The secret is stored base64-encoded; release.yml decodes it the same
+        # way and has authenticated against Play in production. Writing it raw
+        # yields base64 text in a .json file and fastlane fails to parse it.
+        run: |
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" | base64 --decode > android/fastlane/play-store-key.json
+          chmod 600 android/fastlane/play-store-key.json
 
       - name: Promote beta track to production
         working-directory: android

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,296 @@
+name: Promote Beta
+
+# Phase 5 of the release-channels spec: promotes an already-published beta
+# to the stable channel everywhere, without rebuilding anything. GitHub gets
+# the copied artifacts + a stable appcast entry (signature was computed at
+# beta build time); Play promotes the identical AAB from the beta track;
+# the App Store gets the existing TestFlight build submitted for review;
+# and the marketing-version bump PR opens immediately so the next merge
+# starts the next beta train (App Store trains close on release).
+on:
+  workflow_dispatch:
+    inputs:
+      build-number:
+        description: 'Beta build number to promote (e.g. 4951)'
+        required: true
+        type: string
+      play-rollout:
+        description: 'Play production rollout fraction (0.0-1.0)'
+        required: false
+        type: string
+        default: '1.0'
+      next-bump:
+        description: 'Version bump to open the next beta train'
+        required: false
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Publish stable release from beta
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: read
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      semver: ${{ steps.resolve.outputs.semver }}
+      build-number: ${{ steps.resolve.outputs.build-number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify the beta release
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.BETA_BUILDS_TOKEN }}
+          BUILD: ${{ inputs.build-number }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh release list --repo submersion-app/beta-builds \
+            --json tagName -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+          if [ -z "$TAG" ]; then
+            echo "::error::No beta release ending in .${BUILD} found (pruned or never built)."
+            exit 1
+          fi
+          mkdir -p promoted && cd promoted
+          gh release download "$TAG" --repo submersion-app/beta-builds
+          sha256sum -c checksums-sha256.txt
+          SEMVER=$(python3 -c "import json;print(json.load(open('metadata.json'))['semver'])")
+          SHA=$(python3 -c "import json;print(json.load(open('metadata.json'))['sourceSha'])")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "build-number=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check for beta blockers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh issue list --repo ${{ github.repository }} \
+            --label beta-blocker --state open --json number -q 'length')
+          if [ "$OPEN" != "0" ]; then
+            echo "::error::$OPEN open beta-blocker issue(s); resolve them before promoting."
+            exit 1
+          fi
+
+      - name: Verify the source commit is on main
+        run: |
+          set -euo pipefail
+          git merge-base --is-ancestor "${{ steps.resolve.outputs.sha }}" origin/main || {
+            echo "::error::Beta source commit is not on main."; exit 1; }
+
+      - name: Create the stable tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.resolve.outputs.tag }}" "${{ steps.resolve.outputs.sha }}"
+          git push origin "refs/tags/${{ steps.resolve.outputs.tag }}"
+
+      - name: Generate release notes and stable appcast
+        env:
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git checkout "${{ steps.resolve.outputs.sha }}"
+          ./scripts/release/generate_changelog.sh --notes-only > release-notes.md
+          ./scripts/generate_release_notes_html.sh < release-notes.md > release-notes.html
+          VERSION="${TAG_NAME#v}"
+          export SPARKLE_EDDSA_SIGNATURE=$(python3 -c "import json;print(json.load(open('promoted/metadata.json'))['eddsaSignature'])")
+          export SPARKLE_DMG_LENGTH=$(python3 -c "import json;print(json.load(open('promoted/metadata.json'))['dmgLength'])")
+          BASE="https://github.com/${{ github.repository }}/releases/download/${TAG_NAME}"
+          ./scripts/generate_appcast.sh "$VERSION" "${{ steps.resolve.outputs.build-number }}" \
+            "$(date -R)" \
+            "${BASE}/Submersion-${TAG_NAME}-macOS.dmg" \
+            "${BASE}/Submersion-${TAG_NAME}-Windows-Setup.exe" \
+            release-notes.html > appcast.xml
+          python3 -c "import xml.dom.minidom;xml.dom.minidom.parse('appcast.xml')"
+
+      - name: Create the stable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Submersion-* (with hyphen) deliberately excludes the store-only
+          # Submersion.pkg, matching the historical stable asset list.
+          gh release create "$TAG_NAME" --repo ${{ github.repository }} \
+            --title "$TAG_NAME" --notes-file release-notes.md --latest \
+            promoted/Submersion-* promoted/checksums-sha256.txt \
+            appcast.xml release-notes.html
+
+      - name: Validate the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p check && cd check
+          gh release download "$TAG_NAME" --repo ${{ github.repository }}
+          # --ignore-missing: the beta checksums include Submersion.pkg (a
+          # store-only artifact deliberately not re-hosted on the stable
+          # release, matching the historical stable asset list).
+          sha256sum -c --ignore-missing checksums-sha256.txt
+          for suffix in macOS.dmg Windows-Setup.exe Linux.tar.gz Android.apk Android.aab iOS.ipa; do
+            ls Submersion-*-$suffix >/dev/null || { echo "::error::Missing $suffix"; exit 1; }
+          done
+          test -s appcast.xml
+
+  promote-play:
+    name: Promote Play build to production
+    runs-on: ubuntu-latest
+    needs: promote
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: android
+
+      - name: Setup Google Play service account key
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
+        run: echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" > android/fastlane/play-store-key.json
+
+      - name: Promote beta track to production
+        working-directory: android
+        env:
+          GOOGLE_PLAY_JSON_KEY_PATH: fastlane/play-store-key.json
+        run: |
+          bundle exec fastlane promote_to_production \
+            version_code:"${{ needs.promote.outputs.build-number }}" \
+            rollout:"${{ inputs.play-rollout }}"
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f android/fastlane/play-store-key.json
+
+  submit-appstore:
+    name: Submit existing builds for App Review
+    runs-on: macos-15
+    needs: promote
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby (iOS)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          mkdir -p ios/fastlane macos/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > ios/fastlane/AuthKey.p8
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > macos/fastlane/AuthKey.p8
+
+      - name: Submit iOS build
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+        run: |
+          bundle exec fastlane submit_existing \
+            app_version:"${{ needs.promote.outputs.semver }}" \
+            build_number:"${{ needs.promote.outputs.build-number }}"
+
+      - name: Setup Ruby (macOS)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: macos
+
+      - name: Submit macOS build
+        working-directory: macos
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+        run: |
+          bundle exec fastlane submit_existing \
+            app_version:"${{ needs.promote.outputs.semver }}" \
+            build_number:"${{ needs.promote.outputs.build-number }}"
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f ios/fastlane/AuthKey.p8 macos/fastlane/AuthKey.p8
+
+  bump-pr:
+    name: Open the version bump PR
+    runs-on: ubuntu-latest
+    needs: promote
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Bump and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          ./scripts/release/bump_version.sh --${{ inputs.next-bump }}
+          NEWVER=$(grep '^version:' pubspec.yaml | sed 's/version: *//')
+          BRANCH="chore/bump-${NEWVER//+/-}"
+          git checkout -b "$BRANCH"
+          git add pubspec.yaml
+          git commit -m "chore: bump version to ${NEWVER}
+
+          Opens the next beta train after promoting ${{ needs.promote.outputs.tag }};
+          the App Store closes a version train on release, so betas cannot
+          continue on the promoted marketing version."
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: bump version to ${NEWVER}" \
+            --body "Opens the next beta train after promoting ${{ needs.promote.outputs.tag }}. Merge promptly: the beta pipeline's train-closed guard fails every merge until this lands. Note: CI does not auto-run on bot-pushed branches; close/reopen the PR or push an empty commit to trigger it."
+          gh pr merge --auto --merge "$BRANCH" || \
+            echo "::warning::Auto-merge unavailable; merge the bump PR manually."
+
+  notify-failures:
+    name: Open issue on promotion failure
+    runs-on: ubuntu-latest
+    needs: [promote, promote-play, submit-appstore, bump-pr]
+    if: always() && contains(needs.*.result, 'failure')
+    permissions:
+      issues: write
+    steps:
+      - name: Open tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo ${{ github.repository }} \
+            --title "Promotion of build ${{ inputs.build-number }} partially failed" \
+            --label ci \
+            --body "One or more promotion jobs failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. The GitHub release, Play promotion, App Store submission, and bump PR are independent - check which succeeded before re-running."

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ Most dive logging software falls into two categories: desktop applications stuck
 - **macOS / Windows / Linux / Android** — [GitHub Releases](https://github.com/submersion-app/submersion/releases)
 - **iOS** — [App Store](https://apps.apple.com/us/app/submersion-dive-log/id6757456915)
 
+### Beta channel
+
+Want fixes and features weeks early? Every change merged into Submersion is
+published as a beta build. Betas may upgrade your dive log's database ahead
+of the stable release; downgrading is not supported, and devices that sync
+together should all use the same channel. A backup is taken automatically
+before any database upgrade.
+
+- **Desktop** — Settings > About > Update channel > Beta (updates then arrive
+  through the normal auto-updater), or download directly from
+  [beta-builds](https://github.com/submersion-app/beta-builds/releases)
+- **Android** — [join the open test](https://play.google.com/apps/testing/app.submersion),
+  then Play delivers beta updates automatically
+- **iOS / Mac App Store** — TestFlight public link (coming soon)
+
 ## Data Philosophy
 
 Submersion is built on these principles:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ before any database upgrade.
   [beta-builds](https://github.com/submersion-app/beta-builds/releases)
 - **Android** — [join the open test](https://play.google.com/apps/testing/app.submersion),
   then Play delivers beta updates automatically
-- **iOS / Mac App Store** — TestFlight public link (coming soon)
+- **iOS / Mac App Store** — [join via TestFlight](https://testflight.apple.com/join/aMD393sB)
 
 ## Data Philosophy
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -50,6 +50,46 @@ platform :android do
     UI.success("AAB validation passed!")
   end
 
+  desc "Upload AAB to the open-testing (beta) track, released"
+  lane :upload_beta do
+    aab_path = find_aab
+
+    UI.message("Uploading to the open testing (beta) track...")
+    upload_to_play_store(
+      aab: aab_path,
+      track: "beta",
+      release_status: "completed",
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+
+    UI.success("AAB released to the open testing track!")
+  end
+
+  desc "Promote an existing beta-track build to production (no upload)"
+  lane :promote_to_production do |options|
+    version_code = options[:version_code] || UI.user_error!("version_code is required")
+    rollout = options[:rollout] || "1.0"
+
+    UI.message("Promoting build #{version_code} from beta to production (rollout #{rollout})...")
+    upload_to_play_store(
+      track: "beta",
+      track_promote_to: "production",
+      version_code: version_code,
+      rollout: rollout,
+      skip_upload_aab: true,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+
+    UI.success("Build #{version_code} promoted to production!")
+  end
+
   # ============================================================================
   # Helper Methods
   # ============================================================================

--- a/docs/superpowers/plans/2026-08-01-release-channels-phase3-channel-ui.md
+++ b/docs/superpowers/plans/2026-08-01-release-channels-phase3-channel-ui.md
@@ -1,0 +1,633 @@
+# Release Channels Phase 3: In-App Channel Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give users a Stable/Beta update-channel setting: desktop builds switch their update feed live (Sparkle beta appcast on macOS/Windows, `beta-builds` repo polling on Linux), store builds get "Join the beta" signposts (activated in Phase 4), the About row shows the channel, and the sync page surfaces "a peer runs a newer version". Also fixes the confirmed Linux perpetual-update-banner bug.
+
+**Architecture:** A new `ReleaseChannel` enum (distinct from the existing compile-time distribution `UpdateChannel`) persisted in `UpdatePreferences`. `updateServiceProvider` starts watching the channel and constructs the service against channel-dependent coordinates (feed URL / repo). `SparkleUpdateService` re-applies `setFeedURL` per instance, so invalidation is the switch mechanism. All new user-facing strings go through l10n (11 ARB files + `flutter gen-l10n`); the Updates card's existing hardcoded strings get localized in passing since we are rebuilding that card anyway.
+
+**Tech Stack:** Flutter, Riverpod (legacy providers via `core/providers/provider.dart` barrel), SharedPreferences, `auto_updater`, `url_launcher`, `flutter gen-l10n`.
+
+## Global Constraints
+
+- `dart format .` clean; `flutter analyze` clean (infos fatal). Full test suite at the end; new provider dependencies can break consumer tests in ways analyze cannot catch — run the FULL suite, not just touched files.
+- Every new user-visible string is localized: add to `lib/l10n/arb/app_en.arb` (alphabetically sorted, `settings_updates_*` / `settings_cloudSync_*` prefixes) AND translated into all 10 non-English ARBs (`ar de es fr he hu it nl pt zh`), then run `flutter gen-l10n` (generated files are checked in).
+- Name collision: the new enum is `ReleaseChannel { stable, beta }` — never `UpdateChannel` (taken by the compile-time distribution channel).
+- Widget tests touching the updates card need the two documented workarounds: seed `SharedPreferences.setMockInitialValues({'auto_update_enabled': false})` and drain the 5s startup timer with `await tester.pump(const Duration(seconds: 6))`.
+- Dialog conventions: `showDialog<bool>`, cancel via `MaterialLocalizations.of(context).cancelButtonLabel`, affirmative `FilledButton`, `if (confirmed == true)`.
+- Work on branch `release-channels-phase3` (stacked on phase1-2); commit per task.
+
+---
+
+### Task 1: `ReleaseChannel` + preference
+
+**Files:**
+- Create: `lib/features/auto_update/domain/entities/release_channel.dart`
+- Modify: `lib/features/auto_update/data/repositories/update_preferences.dart`
+- Test: `test/features/auto_update/data/repositories/update_preferences_test.dart`
+
+**Interfaces:**
+- Produces: `enum ReleaseChannel { stable, beta }` with `static ReleaseChannel fromName(String? name)` (unknown/null → stable); `UpdatePreferences.releaseChannel` getter (default `ReleaseChannel.stable`) and `Future<void> setReleaseChannel(ReleaseChannel value)` storing `value.name` under key `'update_release_channel'`. Tasks 3-5 depend on these names.
+
+- [ ] **Step 1: Write failing tests** (extend the existing file's pattern — `SharedPreferences.setMockInitialValues({})` then `UpdatePreferences(await SharedPreferences.getInstance())`):
+
+```dart
+  test('releaseChannel defaults to stable', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = UpdatePreferences(await SharedPreferences.getInstance());
+    expect(prefs.releaseChannel, ReleaseChannel.stable);
+  });
+
+  test('setReleaseChannel round-trips', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = UpdatePreferences(await SharedPreferences.getInstance());
+    await prefs.setReleaseChannel(ReleaseChannel.beta);
+    expect(prefs.releaseChannel, ReleaseChannel.beta);
+  });
+
+  test('releaseChannel tolerates an unknown stored value', () async {
+    SharedPreferences.setMockInitialValues({
+      'update_release_channel': 'nightly',
+    });
+    final prefs = UpdatePreferences(await SharedPreferences.getInstance());
+    expect(prefs.releaseChannel, ReleaseChannel.stable);
+  });
+```
+
+Add `import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';`.
+
+- [ ] **Step 2: Run to verify failure** — `flutter test test/features/auto_update/data/repositories/update_preferences_test.dart` fails to compile.
+
+- [ ] **Step 3: Implement.** New file `release_channel.dart`:
+
+```dart
+/// The user-selected update channel: stable releases only, or per-merge
+/// beta builds. Distinct from [UpdateChannel], which is the compile-time
+/// distribution channel (github/appstore/playstore/...).
+enum ReleaseChannel {
+  stable,
+  beta;
+
+  /// Parses a stored name, falling back to [stable] for null/unknown values
+  /// so downgraded or corrupted preferences never strand a user on beta.
+  static ReleaseChannel fromName(String? name) {
+    for (final channel in ReleaseChannel.values) {
+      if (channel.name == name) return channel;
+    }
+    return ReleaseChannel.stable;
+  }
+}
+```
+
+In `update_preferences.dart`: add `import '../../domain/entities/release_channel.dart';` (match the file's existing relative/absolute import style — it uses package imports, so `package:submersion/features/auto_update/domain/entities/release_channel.dart`), a key `static const _keyReleaseChannel = 'update_release_channel';`, and:
+
+```dart
+  ReleaseChannel get releaseChannel =>
+      ReleaseChannel.fromName(_prefs.getString(_keyReleaseChannel));
+
+  Future<void> setReleaseChannel(ReleaseChannel value) =>
+      _prefs.setString(_keyReleaseChannel, value.name);
+```
+
+- [ ] **Step 4: Run to verify pass**, then commit:
+
+```bash
+git add lib/features/auto_update/domain/entities/release_channel.dart lib/features/auto_update/data/repositories/update_preferences.dart test/features/auto_update/data/repositories/update_preferences_test.dart
+git commit -m "feat(auto-update): add a persisted stable/beta release channel preference"
+```
+
+---
+
+### Task 2: Fix the Linux perpetual-update-banner bug
+
+`packageInfo.version` is 3-segment (`1.7.1`) while release tags are 4-segment (`v1.7.1.118`); `isNewer('1.7.1.118','1.7.1')` is true, so Linux shows "update available" forever on a current install.
+
+**Files:**
+- Modify: `lib/features/auto_update/presentation/providers/update_providers.dart:45`
+- Test: `test/features/auto_update/data/services/github_update_service_test.dart`
+
+- [ ] **Step 1: Write the failing-shaped service test** (documents the fix contract at the service level):
+
+```dart
+    test('4-segment current version equal to the release tag is up to date',
+        () async {
+      final client = MockClient((request) async {
+        return http.Response(jsonEncode(makeRelease(tagName: 'v1.7.1.118')), 200);
+      });
+
+      final service = GithubUpdateService(
+        owner: owner,
+        repo: repo,
+        currentVersion: '1.7.1.118',
+        platformSuffix: 'Linux.tar.gz',
+        httpClient: client,
+      );
+
+      expect(await service.checkForUpdate(), isA<UpToDate>());
+    });
+```
+
+(This passes immediately — it pins the contract the provider fix relies on. The provider-side change is not directly unit-testable because `PackageInfo.fromPlatform` and `Platform` checks live inline; the contract test plus Step 2's one-liner carry the fix.)
+
+- [ ] **Step 2: Fix the provider** — in `update_providers.dart`, replace:
+
+```dart
+  final currentVersion = packageInfo.version;
+```
+
+with:
+
+```dart
+  // Release tags are 4-segment (vX.Y.Z.N) while packageInfo.version is the
+  // 3-segment marketing version; without the build number appended, a
+  // current install always compares as older than its own release tag.
+  final currentVersion = packageInfo.version.endsWith(
+        '.${packageInfo.buildNumber}',
+      )
+      ? packageInfo.version
+      : '${packageInfo.version}.${packageInfo.buildNumber}';
+```
+
+- [ ] **Step 3: Run module tests + commit:**
+
+```bash
+flutter test test/features/auto_update/
+git add lib/features/auto_update/presentation/providers/update_providers.dart test/features/auto_update/data/services/github_update_service_test.dart
+git commit -m "fix(auto-update): compare 4-segment versions so current installs read as up to date"
+```
+
+---
+
+### Task 3: Channel-aware update service selection
+
+**Files:**
+- Modify: `lib/features/auto_update/presentation/providers/update_providers.dart`
+- Test: `test/features/auto_update/presentation/providers/update_feed_selection_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `UpdatePreferences.releaseChannel` (Task 1).
+- Produces: `releaseChannelProvider` (`Provider<ReleaseChannel>`); pure helpers `appcastUrlFor(ReleaseChannel)` and `githubRepoFor(ReleaseChannel)` (top-level, exported from `update_providers.dart`); `updateServiceProvider` now watches `releaseChannelProvider`. Task 4's toggle relies on `ref.invalidate(updatePreferencesProvider)` cascading through these.
+
+- [ ] **Step 1: Write failing tests** in the new test file:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
+import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
+
+void main() {
+  test('stable channel uses the main repo appcast', () {
+    expect(
+      appcastUrlFor(ReleaseChannel.stable),
+      'https://github.com/submersion-app/submersion/releases/latest/download/appcast.xml',
+    );
+    expect(githubRepoFor(ReleaseChannel.stable), 'submersion');
+  });
+
+  test('beta channel uses the beta-builds superset feed and repo', () {
+    expect(
+      appcastUrlFor(ReleaseChannel.beta),
+      'https://github.com/submersion-app/beta-builds/releases/latest/download/appcast-beta.xml',
+    );
+    expect(githubRepoFor(ReleaseChannel.beta), 'beta-builds');
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (functions undefined).
+
+- [ ] **Step 3: Implement** in `update_providers.dart`. Replace the `_appcastUrl` const block with:
+
+```dart
+/// Repository holding per-merge beta releases (superset appcast + artifacts).
+const _betaRepo = 'beta-builds';
+
+/// Appcast feed URL for Sparkle/WinSparkle (macOS + Windows) per channel.
+/// The beta feed is a superset (beta items first, stable items appended), so
+/// a device switched back to stable still walks forward onto the next stable.
+String appcastUrlFor(ReleaseChannel channel) => switch (channel) {
+  ReleaseChannel.stable =>
+    'https://github.com/$_githubOwner/$_githubRepo/releases/latest/download/appcast.xml',
+  ReleaseChannel.beta =>
+    'https://github.com/$_githubOwner/$_betaRepo/releases/latest/download/appcast-beta.xml',
+};
+
+/// GitHub repo polled by the non-Sparkle updater (Linux/Android) per channel.
+String githubRepoFor(ReleaseChannel channel) => switch (channel) {
+  ReleaseChannel.stable => _githubRepo,
+  ReleaseChannel.beta => _betaRepo,
+};
+
+/// The user-selected release channel, re-evaluated when preferences reload.
+final releaseChannelProvider = Provider<ReleaseChannel>((ref) {
+  return ref.watch(updatePreferencesProvider).releaseChannel;
+});
+```
+
+and change `updateServiceProvider`'s body to consume it:
+
+```dart
+final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
+  if (!UpdateChannelConfig.isAutoUpdateEnabled) return null;
+
+  final channel = ref.watch(releaseChannelProvider);
+  final packageInfo = await PackageInfo.fromPlatform();
+  // (currentVersion block from Task 2 stays as-is)
+
+  if (_useSparkleEngine) {
+    return SparkleUpdateService(feedUrl: appcastUrlFor(channel));
+  }
+
+  return GithubUpdateService(
+    owner: _githubOwner,
+    repo: githubRepoFor(channel),
+    currentVersion: currentVersion,
+    platformSuffix: _platformSuffix,
+  );
+});
+```
+
+Add the `release_channel.dart` import. No `SparkleUpdateService` changes needed: `_initialized` is per-instance, so the fresh instance created after invalidation re-calls `autoUpdater.setFeedURL` with the new URL on its next check.
+
+- [ ] **Step 4: Run tests + the whole module, commit:**
+
+```bash
+flutter test test/features/auto_update/
+git add lib/features/auto_update/presentation/providers/update_providers.dart test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+git commit -m "feat(auto-update): select the update feed by release channel"
+```
+
+---
+
+### Task 4: Updates card — channel selector, opt-in dialog, localization
+
+Rebuilds `_buildUpdatesCard` (settings_page.dart:2795) with a channel row and localizes the card's existing hardcoded strings in the same pass.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/settings_page.dart` (`_buildUpdatesCard`, `_AboutSectionContentState`, the `'Updates'` header at :2742)
+- Modify: `lib/l10n/arb/app_en.arb` + the 10 non-English ARBs; run `flutter gen-l10n`
+- Test: `test/features/settings/presentation/pages/settings_page_test.dart`
+
+**Interfaces:**
+- Consumes: `releaseChannelProvider`, `UpdatePreferences.setReleaseChannel`, `updateStatusProvider.notifier.checkForUpdate()`.
+
+- [ ] **Step 1: Add ARB entries** to `app_en.arb` (alphabetical position among `settings_*`; placeholder metadata entries follow the file's existing `@key` pattern):
+
+```json
+  "settings_updates_automaticUpdates": "Automatic updates",
+  "settings_updates_automaticUpdatesSubtitle": "Check for updates periodically",
+  "settings_updates_betaDialogBody": "Beta builds are published from every change and may upgrade your dive log's database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.",
+  "settings_updates_betaDialogConfirm": "Switch to Beta",
+  "settings_updates_betaDialogTitle": "Receive beta updates?",
+  "settings_updates_channel": "Update channel",
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "New builds from every change, ahead of stable",
+  "settings_updates_channelStable": "Stable",
+  "settings_updates_channelStableSubtitle": "Tested releases only",
+  "settings_updates_checkForUpdates": "Check for Updates",
+  "settings_updates_checking": "Checking...",
+  "settings_updates_downloading": "Downloading... {progress}%",
+  "settings_updates_error": "Error: {message}",
+  "settings_updates_header": "Updates",
+  "settings_updates_lastChecked": "Last checked",
+  "settings_updates_never": "Never",
+  "settings_updates_readyToInstall": "Version {version} ready to install",
+  "settings_updates_stableSwitchNotice": "You will stay on this beta until the next stable release is newer than it.",
+  "settings_updates_upToDate": "Up to date",
+  "settings_updates_versionAvailable": "Version {version} available",
+```
+
+with `@`-metadata for `downloading` (`progress`, `int`... use `String` to match preformatted int: pass `(progress * 100).toInt().toString()`; declare type `String`), `error`, `readyToInstall`, `versionAvailable` (all `String` placeholders). Translate all keys into the 10 other ARBs (match each file's tone; `he`/`ar` are RTL — plain text, no directional characters needed). Run `flutter gen-l10n`.
+
+- [ ] **Step 2: Write failing widget tests** (extend `settings_page_test.dart` using its `buildTestWidget`/`getOverrides` helpers plus the update-banner workarounds; the Updates card renders on the test host because `isAutoUpdateEnabled` is true off-store on desktop VMs):
+
+```dart
+    testWidgets('updates card shows the channel selector on stable', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.text('Update channel'), 300);
+      expect(find.text('Update channel'), findsOneWidget);
+      expect(find.text('Stable'), findsOneWidget);
+    });
+
+    testWidgets('switching to beta asks for confirmation first', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.text('Update channel'), 300);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta').last);
+      await tester.pumpAndSettle();
+      expect(find.text('Receive beta updates?'), findsOneWidget);
+    });
+```
+
+(Adapt the scroll target/velocity to the file's existing `scrollUntilVisible` idiom; check `getOverrides` seeds `sharedPreferencesProvider` — add `'auto_update_enabled': false` to its mock initial values for these tests.)
+
+- [ ] **Step 3: Implement.** In `_AboutSectionContentState`:
+- Header: `'Updates'` → `context.l10n.settings_updates_header`.
+- Rewrite `_buildUpdatesCard`'s `statusText` arms and tiles to the new l10n keys (`Up to date` → `context.l10n.settings_updates_upToDate`, etc.; `lastCheckText` `'Never'` → `settings_updates_never`).
+- Insert the channel tile after the automatic-updates `SwitchListTile` (before the last-checked tile), using the file's picker idiom (`_showTimeFormatPicker` at :816 is the model):
+
+```dart
+          const Divider(height: 1),
+          ListTile(
+            leading: const Icon(Icons.alt_route),
+            title: Text(context.l10n.settings_updates_channel),
+            subtitle: Text(
+              channel == ReleaseChannel.beta
+                  ? context.l10n.settings_updates_channelBeta
+                  : context.l10n.settings_updates_channelStable,
+            ),
+            onTap: () => _showChannelPicker(context),
+          ),
+```
+
+where `channel` comes from `ref.watch(releaseChannelProvider)` at the top of `_buildUpdatesCard`, and:
+
+```dart
+  Future<void> _showChannelPicker(BuildContext context) async {
+    final current = ref.read(releaseChannelProvider);
+    final selected = await showDialog<ReleaseChannel>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(ctx.l10n.settings_updates_channel),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final channel in ReleaseChannel.values)
+              ListTile(
+                title: Text(switch (channel) {
+                  ReleaseChannel.stable =>
+                    ctx.l10n.settings_updates_channelStable,
+                  ReleaseChannel.beta => ctx.l10n.settings_updates_channelBeta,
+                }),
+                subtitle: Text(switch (channel) {
+                  ReleaseChannel.stable =>
+                    ctx.l10n.settings_updates_channelStableSubtitle,
+                  ReleaseChannel.beta =>
+                    ctx.l10n.settings_updates_channelBetaSubtitle,
+                }),
+                trailing: channel == current
+                    ? Icon(
+                        Icons.check,
+                        color: Theme.of(ctx).colorScheme.primary,
+                      )
+                    : null,
+                onTap: () => Navigator.of(ctx).pop(channel),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (selected == null || selected == current || !context.mounted) return;
+
+    if (selected == ReleaseChannel.beta) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(ctx.l10n.settings_updates_betaDialogTitle),
+          content: Text(ctx.l10n.settings_updates_betaDialogBody),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(ctx.l10n.settings_updates_betaDialogConfirm),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+    }
+
+    final prefs = ref.read(updatePreferencesProvider);
+    await prefs.setReleaseChannel(selected);
+    ref.invalidate(updatePreferencesProvider);
+    // releaseChannelProvider and updateServiceProvider re-derive from the
+    // invalidated preferences; the fresh service applies the new feed.
+    if (!mounted) return;
+    if (selected == ReleaseChannel.stable) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.settings_updates_stableSwitchNotice),
+        ),
+      );
+    }
+    await ref.read(updateStatusProvider.notifier).checkForUpdate();
+  }
+```
+
+Add imports for `release_channel.dart` (the providers import already exists).
+
+- [ ] **Step 4: Run** `flutter gen-l10n && flutter test test/features/settings/presentation/pages/settings_page_test.dart && flutter test test/features/auto_update/`, fix fallout, then commit everything (lib + ARBs + generated l10n + tests):
+
+```bash
+git add -A lib/l10n lib/features/settings test/features/settings
+git commit -m "feat(settings): add the stable/beta update channel selector"
+```
+
+---
+
+### Task 5: Channel badge + store-build beta signposts
+
+**Files:**
+- Create: `lib/features/auto_update/domain/beta_program_links.dart`
+- Modify: `lib/features/settings/presentation/pages/settings_page.dart` (version row :2681-2691 area; About card)
+- Modify: ARBs (3 keys) + gen-l10n
+- Test: `test/features/settings/presentation/pages/settings_page_test.dart`
+
+- [ ] **Step 1: ARB keys:**
+
+```json
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "settings_updates_joinBeta": "Join the Beta",
+  "settings_updates_joinBetaSubtitle": "Get new features early through the beta program",
+```
+
+(`channelBadgeBeta` has a `version` String placeholder.) Translate into all 10 locales; `flutter gen-l10n`.
+
+- [ ] **Step 2: `beta_program_links.dart`** — empty constants until Phase 4 creates the store artifacts; empty string hides the UI:
+
+```dart
+/// Public enrollment links for the beta program. Empty until the TestFlight
+/// public link and Play open-testing track exist (release-channels Phase 4);
+/// the Join-the-Beta tiles hide themselves while these are empty.
+const kTestFlightBetaUrl = '';
+const kPlayBetaOptInUrl = '';
+```
+
+- [ ] **Step 3: Version row badge** — in the `versionString` computation (settings_page.dart:2682-2691), after building `version`, wrap:
+
+```dart
+        final base = context.l10n.settings_about_version(version);
+        final isBeta =
+            UpdateChannelConfig.isAutoUpdateEnabled &&
+            ref.read(releaseChannelProvider) == ReleaseChannel.beta;
+        return isBeta
+            ? context.l10n.settings_updates_channelBadgeBeta(base)
+            : base;
+```
+
+(Change `ref.read` to a `ref.watch` hoisted above the `when` if the analyzer flags read-in-build; watching is correct here.)
+
+- [ ] **Step 4: Signpost tiles** — in the About card's `Column`, after the license tile, add (visible only on store builds with a link configured):
+
+```dart
+                if (!UpdateChannelConfig.isAutoUpdateEnabled &&
+                    _betaEnrollUrl.isNotEmpty) ...[
+                  const Divider(height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.science_outlined),
+                    title: Text(context.l10n.settings_updates_joinBeta),
+                    subtitle: Text(
+                      context.l10n.settings_updates_joinBetaSubtitle,
+                    ),
+                    onTap: () => launchUrl(
+                      Uri.parse(_betaEnrollUrl),
+                      mode: LaunchMode.externalApplication,
+                    ),
+                  ),
+                ],
+```
+
+with a small getter on the state class:
+
+```dart
+  String get _betaEnrollUrl {
+    if (Platform.isIOS || Platform.isMacOS) return kTestFlightBetaUrl;
+    if (Platform.isAndroid) return kPlayBetaOptInUrl;
+    return '';
+  }
+```
+
+Imports: `dart:io` (already imported in settings_page? verify), `beta_program_links.dart`, `url_launcher` (already used at :66).
+
+- [ ] **Step 5: Widget test** — badge only (signposts are invisible until Phase 4 fills the constants, and store-build gating cannot flip in a test VM):
+
+```dart
+    testWidgets('version row shows a beta badge when on the beta channel', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({
+        'auto_update_enabled': false,
+        'update_release_channel': 'beta',
+      });
+      // rebuild overrides from these prefs per the file's helper pattern
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.textContaining('(Beta)'), 300);
+      expect(find.textContaining('(Beta)'), findsOneWidget);
+    });
+```
+
+(Adapt to how `getOverrides` builds `sharedPreferencesProvider` — seed via its mechanism.)
+
+- [ ] **Step 6: Run, commit:**
+
+```bash
+flutter gen-l10n && flutter test test/features/settings/presentation/pages/settings_page_test.dart
+git add -A lib/l10n lib/features/settings lib/features/auto_update/domain/beta_program_links.dart test/features/settings
+git commit -m "feat(settings): show the beta badge and store beta signposts"
+```
+
+---
+
+### Task 6: "Peer requires update" sync banner
+
+Completes Plan A's deferred item: `SyncResult.newerSchemaPeerDeviceIds` currently reaches the UI only as prose in `result.message`.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/providers/sync_providers.dart` (SyncState + result mapping ~:1064)
+- Modify: `lib/features/settings/presentation/pages/cloud_sync_page.dart` (banner stack in `_buildSyncActions`, model: the `replaceAwaitingAdoption` card at :899-924)
+- Modify: ARBs (1 key) + gen-l10n
+- Test: `test/features/settings/presentation/pages/cloud_sync_page_test.dart`
+
+- [ ] **Step 1: ARB key** (plural via placeholder count):
+
+```json
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 device syncs from a newer version of Submersion. Update this device to receive its latest changes.} other{{count} devices sync from a newer version of Submersion. Update this device to receive their latest changes.}}",
+```
+
+with `@` metadata (`count`, `num`, plural). Translate all 10 locales; `flutter gen-l10n`.
+
+- [ ] **Step 2: Failing widget test** in `cloud_sync_page_test.dart`, following that file's existing pattern for seeding a `SyncState` (find its state-override helper; assert):
+
+```dart
+    expect(
+      find.textContaining('newer version of Submersion'),
+      findsOneWidget,
+    );
+```
+
+for a state with `newerSchemaPeerCount: 2`, and `findsNothing` for the default state.
+
+- [ ] **Step 3: Implement.**
+- `SyncState`: add `final int newerSchemaPeerCount;` default `0` in the const constructor, plain `int? newerSchemaPeerCount` in `copyWith` (`?? this.newerSchemaPeerCount` — non-nullable field needs no sentinel).
+- Result mapping: in the `result.isSuccess` branch (sync_providers.dart:1064-1072, the one that already maps `conflicts: result.conflictsFound`), add `newerSchemaPeerCount: result.newerSchemaPeerDeviceIds.length,`. Also reset to `0` where a fresh sync starts (the `copyWith(status: SyncStatus.syncing...)` transition) so a resolved peer clears the banner on the next clean sync.
+- Banner in `_buildSyncActions`, inserted after the `firstSyncAwaitingConfirmation` banner:
+
+```dart
+          if (syncState.newerSchemaPeerCount > 0)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Card(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.system_update_alt,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSecondaryContainer,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          context.l10n.settings_cloudSync_peerRequiresUpdate_banner(
+                            syncState.newerSchemaPeerCount,
+                          ),
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+```
+
+- [ ] **Step 4: Run + commit:**
+
+```bash
+flutter gen-l10n && flutter test test/features/settings/
+git add -A lib/l10n lib/features/settings test/features/settings
+git commit -m "feat(sync): banner when a peer publishes from a newer app version"
+```
+
+---
+
+### Task 7: Full verification
+
+- [ ] **Step 1:** `dart format . && flutter analyze && flutter test` — FULL suite (the new `updateServiceProvider` dependency on preferences is exactly the class of change that breaks distant consumer tests without an analyze warning). Known full-suite-only flaky backup tests: rerun the failing file in isolation once before blaming this work.
+- [ ] **Step 2:** Manual smoke on macOS (`flutter run -d macos`): switch to Beta → confirm dialog → Sparkle offers the current beta from the `beta-builds` feed (a real `v1.7.2.4951` beta exists); switch back → snackbar; About row shows the badge.
+- [ ] **Step 3:** Commit stragglers, if any.
+
+## Deferred
+
+- Filling `kTestFlightBetaUrl` / `kPlayBetaOptInUrl` (Phase 4, when the TestFlight public link and Play open-testing track exist).
+- iOS TestFlight-receipt channel detection (needs native code; revisit in Phase 4 if wanted).
+- Localizing the rest of settings_page's stray hardcoded strings (only the Updates card is in scope).
+
+## Risks
+
+- The updates card was fully hardcoded English; localizing it changes existing UI strings — any test asserting `'Check for Updates'` etc. must be updated in the same commit (Task 4 Step 4 catches these).
+- `updateStatusProvider` holds a `Checking`/`UpdateAvailable` state from the OLD channel across a switch; the immediate `checkForUpdate()` after switching refreshes it, and `UpdateStatusNotifier` reads the service fresh via `ref.read(...future)` each check, so no stale service is retained.

--- a/docs/superpowers/plans/2026-08-02-release-channels-phase4-5-store-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-release-channels-phase4-5-store-promotion.md
@@ -196,7 +196,7 @@ git commit -m "feat(release): add beta store lanes alongside the legacy upload l
         run: rm -f ios/fastlane/AuthKey.p8
 ```
 
-`upload-testflight-macos`: identical shape with `working-directory: macos`, artifact `macos-pkg`, glob `Submersion-*-macOS.pkg` — verify the actual pkg artifact filename first (`gh release view` on a recent beta or the build-all upload step; the MAS pkg was added to beta publishing in commit `edcb5173677`, use whatever name that step produces) — and lane call `bundle exec fastlane upload_testflight_beta pkg:"$PKG_PATH"`.
+`upload-testflight-macos`: identical shape with `working-directory: macos`, artifact `macos-pkg`. Verified: the MAS package keeps its fixed name `Submersion.pkg` (no tag prefix — release.yml's upload job consumes it by that name, and commit `edcb5173677` widened the beta checksum/upload globs to `Submersion*` to include it), so the lane call is `bundle exec fastlane upload_testflight_beta pkg:"$GITHUB_WORKSPACE/Submersion.pkg"` with an existence check instead of a glob.
 
 `upload-play` (ubuntu-latest, `timeout-minutes: 15`): model on `release.yml`'s `upload-android` job (checkout ref like above, Setup Ruby wd `android`, write `android/fastlane/play-store-key.json` from `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY`, download `android-aab` artifact, retry loop around `bundle exec fastlane upload_beta`, `if: always()` cleanup of the key file).
 
@@ -376,7 +376,10 @@ jobs:
           set -euo pipefail
           mkdir -p check && cd check
           gh release download "$TAG_NAME" --repo ${{ github.repository }}
-          sha256sum -c checksums-sha256.txt
+          # --ignore-missing: the beta checksums include Submersion.pkg (a
+          # store-only artifact deliberately not re-hosted on the stable
+          # release, matching the historical stable asset list).
+          sha256sum -c --ignore-missing checksums-sha256.txt
           for suffix in macOS.dmg Windows-Setup.exe Linux.tar.gz Android.apk Android.aab iOS.ipa; do
             ls Submersion-*-$suffix >/dev/null || { echo "::error::Missing $suffix"; exit 1; }
           done

--- a/docs/superpowers/plans/2026-08-02-release-channels-phase4-5-store-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-release-channels-phase4-5-store-promotion.md
@@ -1,0 +1,663 @@
+# Release Channels Phases 4-5: Store Beta Lanes & Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the mobile/store beta lanes into `beta.yml` (TestFlight external group with public link, Play open-testing track), fill the in-app enrollment links, and build `promote.yml` — the metadata-only promotion that turns a soaked beta into the stable release everywhere (GitHub + appcast, Play track promotion, App Store submission of the existing build, and the version-bump PR).
+
+**Architecture:** New parallel fastlane lanes (`upload_testflight_beta` on iOS/macOS with external distribution, `upload_beta` and `promote_to_production` on Android) leave today's lanes untouched for the legacy tag path. `beta.yml` gains three upload jobs modeled byte-for-byte on `release.yml`'s upload jobs. `promote.yml` is `workflow_dispatch`-only: it copies artifacts from the chosen `beta-builds` release, re-hosts them as the main-repo stable release with an appcast entry built from the stored Sparkle signature, promotes/submits the identical store builds, and opens the bump PR that reopens the beta train.
+
+**Tech Stack:** GitHub Actions, fastlane (`upload_to_testflight`, `upload_to_play_store`, `upload_to_app_store`), `gh` CLI, bash.
+
+## Global Constraints
+
+- No new secrets: `BETA_BUILDS_TOKEN`, `APP_STORE_CONNECT_API_KEY_*`, `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY` all exist. `GITHUB_TOKEN` job permissions are declared per job, minimal.
+- Existing fastlane lanes (`upload`, `upload_only`, `upload_testflight_only`, `validate`) are NOT modified — `release.yml`'s legacy tag path keeps working unchanged.
+- YAML validated with `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" <file>`; Ruby Fastfiles syntax-checked with `ruby -c <file>`.
+- Store uploads cannot be exercised without live credentials: the acceptance test for Phase 4 is the first real merge after this stack lands on `main`; for Phase 5 it is the first deliberate promotion. Both are called out as monitored events, not fire-and-forget.
+- Dart: only `beta_program_links.dart` changes; `dart format .` + `flutter analyze` still must pass.
+- Branch `release-channels-phase4-5` (stacked on phase3 → #822). Commit per task.
+
+---
+
+### Task 1: USER ACTIONS — store-side beta program setup
+
+Nothing in this task is code; it gates when the lanes can actually deliver. Collect the results before Task 4.
+
+- [ ] **Step 1 (user): TestFlight external group.** In App Store Connect → Submersion → TestFlight (repeat for iOS and macOS platforms of the app record): create an external tester group named exactly `Public Beta`, and enable its **public link**. Record the link (`https://testflight.apple.com/join/XXXXXXXX`). The first beta build of each version train distributed to this group triggers Beta App Review (~hours, once per train).
+- [ ] **Step 2 (user): Play open testing.** The first `upload_beta` run (Task 5's post-merge acceptance) creates a release on the `beta` track; then in Play Console → Testing → Open testing: confirm the track is configured as **open** (anyone with the link can join) and publish it. The opt-in URL is deterministic: `https://play.google.com/apps/testing/app.submersion`.
+- [ ] **Step 3 (user): create the promotion-gate label** (used by `promote.yml`'s preflight):
+
+```bash
+env -u GITHUB_TOKEN gh label create beta-blocker --repo submersion-app/submersion \
+  --color B60205 --description "Blocks promoting the current beta to stable"
+```
+
+---
+
+### Task 2: fastlane beta lanes
+
+**Files:**
+- Modify: `android/fastlane/Fastfile`
+- Modify: `ios/fastlane/Fastfile`
+- Modify: `macos/fastlane/Fastfile`
+
+**Interfaces:**
+- Produces: android lanes `upload_beta` and `promote_to_production` (options: `version_code`, `rollout`); ios/macos lane `upload_testflight_beta` (options: `ipa:`/`pkg:`, reads `BETA_CHANGELOG` env). Tasks 3 and 5 invoke these exact names.
+
+- [ ] **Step 1: Android lanes.** In `android/fastlane/Fastfile`, after the `validate` lane, add:
+
+```ruby
+  desc "Upload AAB to the open-testing (beta) track, released"
+  lane :upload_beta do
+    aab_path = find_aab
+
+    UI.message("Uploading to the open testing (beta) track...")
+    upload_to_play_store(
+      aab: aab_path,
+      track: "beta",
+      release_status: "completed",
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+
+    UI.success("AAB released to the open testing track!")
+  end
+
+  desc "Promote an existing beta-track build to production (no upload)"
+  lane :promote_to_production do |options|
+    version_code = options[:version_code] || UI.user_error!("version_code is required")
+    rollout = options[:rollout] || "1.0"
+
+    UI.message("Promoting build #{version_code} from beta to production (rollout #{rollout})...")
+    upload_to_play_store(
+      track: "beta",
+      track_promote_to: "production",
+      version_code: version_code,
+      rollout: rollout,
+      skip_upload_aab: true,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+
+    UI.success("Build #{version_code} promoted to production!")
+  end
+```
+
+- [ ] **Step 2: iOS beta TestFlight lane.** In `ios/fastlane/Fastfile`, after `upload_testflight_only`, add:
+
+```ruby
+  desc "Upload pre-built IPA to TestFlight and distribute to the Public Beta group"
+  lane :upload_testflight_beta do |options|
+    api_key = load_api_key
+    ipa_path = options[:ipa] || "./build/Submersion.ipa"
+
+    UI.message("Uploading IPA to TestFlight (Public Beta): #{ipa_path}")
+    # distribute_external requires waiting for processing so the build can be
+    # assigned to the group; expect several minutes per upload.
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ipa_path,
+      distribute_external: true,
+      groups: ["Public Beta"],
+      changelog: ENV["BETA_CHANGELOG"] || "Automated beta build.",
+    )
+    UI.success("iOS beta distributed to the Public Beta group!")
+  end
+```
+
+- [ ] **Step 3: macOS beta TestFlight lane.** Same in `macos/fastlane/Fastfile` after its `upload_testflight_only`, with `pkg_path = options[:pkg] || "./build/Submersion.pkg"` and `pkg: pkg_path` instead of `ipa:`.
+
+- [ ] **Step 4: Syntax-check and commit:**
+
+```bash
+ruby -c android/fastlane/Fastfile && ruby -c ios/fastlane/Fastfile && ruby -c macos/fastlane/Fastfile
+git add android/fastlane/Fastfile ios/fastlane/Fastfile macos/fastlane/Fastfile
+git commit -m "feat(release): add beta store lanes alongside the legacy upload lanes"
+```
+
+---
+
+### Task 3: `beta.yml` store upload jobs
+
+**Files:**
+- Modify: `.github/workflows/beta.yml`
+
+**Interfaces:**
+- Consumes: Task 2's lanes; artifacts `ios-ipa`, `macos-pkg`, `android-aab` from `build-all.yml`; existing secrets.
+
+- [ ] **Step 1: Add three jobs** after `publish-beta` (all gated the same way as `publish-beta`: `needs: [precheck, build]`, `if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true`). Model each on `release.yml`'s corresponding upload job with these differences: fixed lane name instead of tag sniffing, the beta changelog env, and the artifact glob matching the beta tag.
+
+`upload-testflight-ios` (macos-15, `timeout-minutes: 45` — external distribution waits for processing):
+
+```yaml
+  upload-testflight-ios:
+    name: Upload iOS beta to TestFlight
+    runs-on: macos-15
+    needs: [precheck, build]
+    if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.precheck.outputs.sha }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          mkdir -p ios/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > ios/fastlane/AuthKey.p8
+
+      - name: Download iOS IPA artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ios-ipa
+
+      - name: Upload to TestFlight (Public Beta)
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BETA_CHANGELOG: "Beta ${{ needs.precheck.outputs.tag }} - automated per-merge build."
+        run: |
+          IPA_PATH=$(ls $GITHUB_WORKSPACE/Submersion-*-iOS.ipa 2>/dev/null | head -1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "Error: No IPA artifact found"
+            exit 1
+          fi
+          for attempt in 1 2; do
+            if bundle exec fastlane upload_testflight_beta ipa:"$IPA_PATH"; then
+              break
+            fi
+            if [ "$attempt" -eq 2 ]; then
+              echo "Fastlane upload failed after 2 attempts"
+              exit 1
+            fi
+            echo "Fastlane attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f ios/fastlane/AuthKey.p8
+```
+
+`upload-testflight-macos`: identical shape with `working-directory: macos`, artifact `macos-pkg`, glob `Submersion-*-macOS.pkg` — verify the actual pkg artifact filename first (`gh release view` on a recent beta or the build-all upload step; the MAS pkg was added to beta publishing in commit `edcb5173677`, use whatever name that step produces) — and lane call `bundle exec fastlane upload_testflight_beta pkg:"$PKG_PATH"`.
+
+`upload-play` (ubuntu-latest, `timeout-minutes: 15`): model on `release.yml`'s `upload-android` job (checkout ref like above, Setup Ruby wd `android`, write `android/fastlane/play-store-key.json` from `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY`, download `android-aab` artifact, retry loop around `bundle exec fastlane upload_beta`, `if: always()` cleanup of the key file).
+
+- [ ] **Step 2: Validate and commit:**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/beta.yml')); print('YAML OK')"
+git add .github/workflows/beta.yml
+git commit -m "ci(beta): deliver per-merge betas to TestFlight and Play open testing"
+```
+
+---
+
+### Task 4: Fill the in-app enrollment links
+
+**Files:**
+- Modify: `lib/features/auto_update/domain/beta_program_links.dart`
+
+- [ ] **Step 1:** Set `kPlayBetaOptInUrl = 'https://play.google.com/apps/testing/app.submersion';` (deterministic). Set `kTestFlightBetaUrl` to the public link from Task 1 if the user has provided it; otherwise leave `''` and record a TODO-free note in the PR body that one constant awaits the link (the tile stays hidden until then — designed behavior).
+- [ ] **Step 2:** `dart format . && flutter analyze && flutter test test/features/settings/presentation/pages/settings_page_test.dart`, then:
+
+```bash
+git add lib/features/auto_update/domain/beta_program_links.dart
+git commit -m "feat(settings): enable the Play beta enrollment link"
+```
+
+---
+
+### Task 5: `promote.yml`
+
+**Files:**
+- Create: `.github/workflows/promote.yml`
+
+**Interfaces:**
+- Consumes: `beta-builds` release assets + `metadata.json` (`sourceSha`, `semver`, `buildNumber`, `eddsaSignature`, `dmgLength`); `scripts/generate_appcast.sh`; `scripts/release/generate_changelog.sh`; `scripts/generate_release_notes_html.sh`; Task 2's `promote_to_production` and new `submit_existing` lanes (Step 2 below adds them).
+
+- [ ] **Step 1: Write the workflow:**
+
+```yaml
+name: Promote Beta
+
+# Phase 5 of the release-channels spec: promotes an already-published beta
+# to the stable channel everywhere, without rebuilding anything. GitHub gets
+# the copied artifacts + a stable appcast entry (signature was computed at
+# beta build time); Play promotes the identical AAB from the beta track;
+# the App Store gets the existing TestFlight build submitted for review;
+# and the marketing-version bump PR opens immediately so the next merge
+# starts the next beta train (App Store trains close on release).
+on:
+  workflow_dispatch:
+    inputs:
+      build-number:
+        description: 'Beta build number to promote (e.g. 4951)'
+        required: true
+        type: string
+      play-rollout:
+        description: 'Play production rollout fraction (0.0-1.0)'
+        required: false
+        type: string
+        default: '1.0'
+      next-bump:
+        description: 'Version bump to open the next beta train'
+        required: false
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Publish stable release from beta
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: read
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      semver: ${{ steps.resolve.outputs.semver }}
+      build-number: ${{ steps.resolve.outputs.build-number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify the beta release
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.BETA_BUILDS_TOKEN }}
+          BUILD: ${{ inputs.build-number }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh release list --repo submersion-app/beta-builds \
+            --json tagName -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+          if [ -z "$TAG" ]; then
+            echo "::error::No beta release ending in .${BUILD} found (pruned or never built)."
+            exit 1
+          fi
+          mkdir -p promoted && cd promoted
+          gh release download "$TAG" --repo submersion-app/beta-builds
+          sha256sum -c checksums-sha256.txt
+          SEMVER=$(python3 -c "import json;print(json.load(open('metadata.json'))['semver'])")
+          SHA=$(python3 -c "import json;print(json.load(open('metadata.json'))['sourceSha'])")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "build-number=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check for beta blockers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh issue list --repo ${{ github.repository }} \
+            --label beta-blocker --state open --json number -q 'length')
+          if [ "$OPEN" != "0" ]; then
+            echo "::error::$OPEN open beta-blocker issue(s); resolve them before promoting."
+            exit 1
+          fi
+
+      - name: Verify the source commit is on main
+        run: |
+          set -euo pipefail
+          git merge-base --is-ancestor "${{ steps.resolve.outputs.sha }}" origin/main || {
+            echo "::error::Beta source commit is not on main."; exit 1; }
+
+      - name: Create the stable tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.resolve.outputs.tag }}" "${{ steps.resolve.outputs.sha }}"
+          git push origin "refs/tags/${{ steps.resolve.outputs.tag }}"
+
+      - name: Generate release notes and stable appcast
+        env:
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git checkout "${{ steps.resolve.outputs.sha }}"
+          ./scripts/release/generate_changelog.sh --notes-only > release-notes.md
+          ./scripts/generate_release_notes_html.sh < release-notes.md > release-notes.html
+          VERSION="${TAG_NAME#v}"
+          export SPARKLE_EDDSA_SIGNATURE=$(python3 -c "import json;print(json.load(open('promoted/metadata.json'))['eddsaSignature'])")
+          export SPARKLE_DMG_LENGTH=$(python3 -c "import json;print(json.load(open('promoted/metadata.json'))['dmgLength'])")
+          BASE="https://github.com/${{ github.repository }}/releases/download/${TAG_NAME}"
+          ./scripts/generate_appcast.sh "$VERSION" "${{ steps.resolve.outputs.build-number }}" \
+            "$(date -R)" \
+            "${BASE}/Submersion-${TAG_NAME}-macOS.dmg" \
+            "${BASE}/Submersion-${TAG_NAME}-Windows-Setup.exe" \
+            release-notes.html > appcast.xml
+          python3 -c "import xml.dom.minidom;xml.dom.minidom.parse('appcast.xml')"
+
+      - name: Create the stable GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG_NAME" --repo ${{ github.repository }} \
+            --title "$TAG_NAME" --notes-file release-notes.md --latest \
+            promoted/Submersion-* promoted/checksums-sha256.txt \
+            appcast.xml release-notes.html
+
+      - name: Validate the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p check && cd check
+          gh release download "$TAG_NAME" --repo ${{ github.repository }}
+          sha256sum -c checksums-sha256.txt
+          for suffix in macOS.dmg Windows-Setup.exe Linux.tar.gz Android.apk Android.aab iOS.ipa; do
+            ls Submersion-*-$suffix >/dev/null || { echo "::error::Missing $suffix"; exit 1; }
+          done
+          test -s appcast.xml
+
+  promote-play:
+    name: Promote Play build to production
+    runs-on: ubuntu-latest
+    needs: promote
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: android
+
+      - name: Setup Google Play service account key
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY }}
+        run: echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY" > android/fastlane/play-store-key.json
+
+      - name: Promote beta track to production
+        working-directory: android
+        env:
+          GOOGLE_PLAY_JSON_KEY_PATH: fastlane/play-store-key.json
+        run: |
+          bundle exec fastlane promote_to_production \
+            version_code:"${{ needs.promote.outputs.build-number }}" \
+            rollout:"${{ inputs.play-rollout }}"
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f android/fastlane/play-store-key.json
+
+  submit-appstore:
+    name: Submit existing builds for App Review
+    runs-on: macos-15
+    needs: promote
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Ruby (iOS)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Setup App Store Connect API Key
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          mkdir -p ios/fastlane macos/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > ios/fastlane/AuthKey.p8
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > macos/fastlane/AuthKey.p8
+
+      - name: Submit iOS build
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+        run: |
+          bundle exec fastlane submit_existing \
+            app_version:"${{ needs.promote.outputs.semver }}" \
+            build_number:"${{ needs.promote.outputs.build-number }}"
+
+      - name: Setup Ruby (macOS)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: macos
+
+      - name: Submit macOS build
+        working-directory: macos
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+        run: |
+          bundle exec fastlane submit_existing \
+            app_version:"${{ needs.promote.outputs.semver }}" \
+            build_number:"${{ needs.promote.outputs.build-number }}"
+
+      - name: Cleanup sensitive files
+        if: always()
+        run: rm -f ios/fastlane/AuthKey.p8 macos/fastlane/AuthKey.p8
+
+  bump-pr:
+    name: Open the version bump PR
+    runs-on: ubuntu-latest
+    needs: promote
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Bump and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          ./scripts/release/bump_version.sh --${{ inputs.next-bump }}
+          NEWVER=$(grep '^version:' pubspec.yaml | sed 's/version: *//')
+          BRANCH="chore/bump-${NEWVER//+/-}"
+          git checkout -b "$BRANCH"
+          git add pubspec.yaml
+          git commit -m "chore: bump version to ${NEWVER}
+
+Opens the next beta train after promoting ${{ needs.promote.outputs.tag }};
+the App Store closes a version train on release, so betas cannot continue
+on the promoted marketing version."
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: bump version to ${NEWVER}" \
+            --body "Opens the next beta train after promoting ${{ needs.promote.outputs.tag }}. Merge promptly: the beta pipeline's train-closed guard fails every merge until this lands. Note: CI does not auto-run on bot-pushed branches; close/reopen the PR or push an empty commit to trigger it."
+          gh pr merge --auto --merge "$BRANCH" || \
+            echo "::warning::Auto-merge unavailable; merge the bump PR manually."
+
+  notify-failures:
+    name: Open issue on promotion failure
+    runs-on: ubuntu-latest
+    needs: [promote, promote-play, submit-appstore, bump-pr]
+    if: always() && contains(needs.*.result, 'failure')
+    permissions:
+      issues: write
+    steps:
+      - name: Open tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo ${{ github.repository }} \
+            --title "Promotion of build ${{ inputs.build-number }} partially failed" \
+            --label ci \
+            --body "One or more promotion jobs failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. The GitHub release, Play promotion, App Store submission, and bump PR are independent - check which succeeded before re-running."
+```
+
+- [ ] **Step 2: `submit_existing` fastlane lanes.** In `ios/fastlane/Fastfile` after `upload_testflight_beta`:
+
+```ruby
+  desc "Submit an already-uploaded build for App Review (no upload)"
+  lane :submit_existing do |options|
+    api_key = load_api_key
+    app_version = options[:app_version] || UI.user_error!("app_version is required")
+    build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
+    upload_to_app_store(
+      api_key: api_key,
+      app_version: app_version,
+      build_number: build_number.to_s,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      submit_for_review: true,
+      automatic_release: false,
+      precheck_include_in_app_purchases: false,
+      submission_information: { add_id_info_uses_idfa: false },
+    )
+    UI.success("Submitted for review; release manually in App Store Connect on approval.")
+  end
+```
+
+Same lane in `macos/fastlane/Fastfile` (identical body — deliver selects the platform from the Appfile/app record context).
+
+- [ ] **Step 3: Validate and commit:**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/promote.yml')); print('YAML OK')"
+ruby -c ios/fastlane/Fastfile && ruby -c macos/fastlane/Fastfile
+git add .github/workflows/promote.yml ios/fastlane/Fastfile macos/fastlane/Fastfile
+git commit -m "ci: add the beta-to-stable promotion workflow"
+```
+
+---
+
+### Task 6: `scripts/release/promote.sh`
+
+**Files:**
+- Create: `scripts/release/promote.sh` (`chmod +x`)
+
+- [ ] **Step 1:**
+
+```bash
+#!/usr/bin/env bash
+# Promote a published beta build to the stable channel everywhere.
+#
+# Usage: ./scripts/release/promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]
+#
+# Thin wrapper over the Promote Beta workflow (.github/workflows/promote.yml):
+# verifies the beta exists and shows what will be promoted before dispatching.
+
+set -euo pipefail
+
+BUILD="${1:?Usage: promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]}"
+shift
+ROLLOUT="1.0"
+BUMP="patch"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rollout) ROLLOUT="$2"; shift 2 ;;
+    --bump) BUMP="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
+  -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+if [ -z "$TAG" ]; then
+  echo "Error: no beta release ending in .${BUILD} found in beta-builds." >&2
+  exit 1
+fi
+
+BLOCKERS=$(gh issue list --repo submersion-app/submersion \
+  --label beta-blocker --state open --json number -q 'length')
+if [ "$BLOCKERS" != "0" ]; then
+  echo "Error: $BLOCKERS open beta-blocker issue(s). Resolve before promoting." >&2
+  exit 1
+fi
+
+echo "About to promote $TAG to stable (Play rollout $ROLLOUT, next bump: $BUMP)."
+read -r -p "Continue? [y/N] " answer
+[ "$answer" = "y" ] || { echo "Aborted."; exit 1; }
+
+gh workflow run promote.yml \
+  -f build-number="$BUILD" -f play-rollout="$ROLLOUT" -f next-bump="$BUMP"
+echo "Dispatched. Watch with:"
+echo "  gh run watch \$(gh run list --workflow=promote.yml --limit 1 --json databaseId -q '.[0].databaseId')"
+```
+
+- [ ] **Step 2:** `bash -n scripts/release/promote.sh && chmod +x scripts/release/promote.sh`, commit:
+
+```bash
+git add scripts/release/promote.sh
+git commit -m "feat(release): add the promote.sh wrapper"
+```
+
+---
+
+### Task 7: README beta-channel documentation
+
+**Files:**
+- Modify: `README.md` (Download section)
+
+- [ ] **Step 1:** After the existing Download platform list, add a short "Beta channel" paragraph: what it is (per-merge builds, ahead of stable, may migrate the database early, no downgrade), how to join on desktop (Settings > About > Update channel > Beta), the `beta-builds` releases page link, the Play opt-in URL, and the TestFlight public link (or "coming soon" if Task 1's link is still pending). Match the README's existing tone and formatting (plain markdown, no HTML style attributes).
+- [ ] **Step 2:** Commit:
+
+```bash
+git add README.md
+git commit -m "docs: describe the beta channel and how to join it"
+```
+
+---
+
+### Task 8: Verification
+
+- [ ] **Step 1:** `dart format . && flutter analyze && python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/beta.yml','.github/workflows/promote.yml']]; print('YAML OK')" && ruby -c android/fastlane/Fastfile && ruby -c ios/fastlane/Fastfile && ruby -c macos/fastlane/Fastfile && flutter test test/features/settings/ test/features/auto_update/`
+- [ ] **Step 2:** Full suite once: `flutter test` (only one Dart constant changed, but the stack rule stands).
+- [ ] **Step 3:** Document the two live acceptance events in the PR body (they cannot run pre-merge):
+  - Phase 4: the first merge to `main` after the stack lands must be watched — TestFlight processing + Public Beta assignment, Play beta-track release.
+  - Phase 5: the first real promotion (`scripts/release/promote.sh <build>`) is a deliberate release event; run it for the next stable and watch all five jobs.
+
+## Risks
+
+- `distribute_external` waits for Apple build processing (minutes, occasionally flaky) — the 2-attempt retry and 45-minute timeout absorb normal variance; a processing outage fails the job visibly and the next merge retries.
+- First build of each version train to the external group triggers Beta App Review; testers see that train's builds only after approval (internal testers are unaffected).
+- `submit_for_review: true` via the API is the most brittle store step; if it fails persistently, the fallback is manual submission in App Store Connect (select the build, Submit) — everything else in the promotion is unaffected.
+- The bump PR cannot trigger CI (bot-pushed branches don't fire workflows); until it merges, every beta merge fails the train-closed guard loudly. The PR body says exactly what to do.
+- Play `rollout` fractions only apply to production promotion; open-testing releases are always full.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -267,6 +267,46 @@ platform :ios do
     UI.success("iOS build uploaded to TestFlight!")
   end
 
+  desc "Upload pre-built IPA to TestFlight and distribute to the Public Beta group"
+  lane :upload_testflight_beta do |options|
+    api_key = load_api_key
+    ipa_path = options[:ipa] || "./build/Submersion.ipa"
+
+    UI.message("Uploading IPA to TestFlight (Public Beta): #{ipa_path}")
+    # distribute_external requires waiting for processing so the build can be
+    # assigned to the group; expect several minutes per upload.
+    upload_to_testflight(
+      api_key: api_key,
+      ipa: ipa_path,
+      distribute_external: true,
+      groups: ["Public Beta"],
+      changelog: ENV["BETA_CHANGELOG"] || "Automated beta build.",
+    )
+    UI.success("iOS beta distributed to the Public Beta group!")
+  end
+
+  desc "Submit an already-uploaded build for App Review (no upload)"
+  lane :submit_existing do |options|
+    api_key = load_api_key
+    app_version = options[:app_version] || UI.user_error!("app_version is required")
+    build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
+    upload_to_app_store(
+      api_key: api_key,
+      app_version: app_version,
+      build_number: build_number.to_s,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      submit_for_review: true,
+      automatic_release: false,
+      precheck_include_in_app_purchases: false,
+      submission_information: { add_id_info_uses_idfa: false },
+    )
+    UI.success("Submitted for review; release manually in App Store Connect on approval.")
+  end
+
   desc "Full release: capture screenshots, upload everything, and submit build"
   lane :full_release do
     screenshots

--- a/lib/features/auto_update/data/repositories/update_preferences.dart
+++ b/lib/features/auto_update/data/repositories/update_preferences.dart
@@ -1,11 +1,14 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
+
 class UpdatePreferences {
   final SharedPreferences _prefs;
 
   static const _keyAutoUpdateEnabled = 'auto_update_enabled';
   static const _keyLastCheckTime = 'auto_update_last_check';
   static const _keyCheckIntervalHours = 'auto_update_check_interval_hours';
+  static const _keyReleaseChannel = 'update_release_channel';
 
   UpdatePreferences(this._prefs);
 
@@ -22,6 +25,12 @@ class UpdatePreferences {
 
   Future<void> setLastCheckTime(DateTime time) =>
       _prefs.setInt(_keyLastCheckTime, time.millisecondsSinceEpoch);
+
+  ReleaseChannel get releaseChannel =>
+      ReleaseChannel.fromName(_prefs.getString(_keyReleaseChannel));
+
+  Future<void> setReleaseChannel(ReleaseChannel value) =>
+      _prefs.setString(_keyReleaseChannel, value.name);
 
   int get checkIntervalHours => _prefs.getInt(_keyCheckIntervalHours) ?? 4;
 

--- a/lib/features/auto_update/domain/beta_program_links.dart
+++ b/lib/features/auto_update/domain/beta_program_links.dart
@@ -1,0 +1,5 @@
+/// Public enrollment links for the beta program. Empty until the TestFlight
+/// public link and Play open-testing track exist (release-channels Phase 4);
+/// the Join-the-Beta tiles hide themselves while these are empty.
+const kTestFlightBetaUrl = '';
+const kPlayBetaOptInUrl = '';

--- a/lib/features/auto_update/domain/beta_program_links.dart
+++ b/lib/features/auto_update/domain/beta_program_links.dart
@@ -1,7 +1,5 @@
 /// Public enrollment links for the beta program. An empty link hides the
 /// corresponding Join-the-Beta tile.
 ///
-/// The TestFlight link is minted in App Store Connect when the Public Beta
-/// external group's public link is enabled; fill it in once created.
-const kTestFlightBetaUrl = '';
+const kTestFlightBetaUrl = 'https://testflight.apple.com/join/aMD393sB';
 const kPlayBetaOptInUrl = 'https://play.google.com/apps/testing/app.submersion';

--- a/lib/features/auto_update/domain/beta_program_links.dart
+++ b/lib/features/auto_update/domain/beta_program_links.dart
@@ -1,5 +1,7 @@
-/// Public enrollment links for the beta program. Empty until the TestFlight
-/// public link and Play open-testing track exist (release-channels Phase 4);
-/// the Join-the-Beta tiles hide themselves while these are empty.
+/// Public enrollment links for the beta program. An empty link hides the
+/// corresponding Join-the-Beta tile.
+///
+/// The TestFlight link is minted in App Store Connect when the Public Beta
+/// external group's public link is enabled; fill it in once created.
 const kTestFlightBetaUrl = '';
-const kPlayBetaOptInUrl = '';
+const kPlayBetaOptInUrl = 'https://play.google.com/apps/testing/app.submersion';

--- a/lib/features/auto_update/domain/entities/release_channel.dart
+++ b/lib/features/auto_update/domain/entities/release_channel.dart
@@ -1,0 +1,16 @@
+/// The user-selected update channel: stable releases only, or per-merge
+/// beta builds. Distinct from [UpdateChannel], which is the compile-time
+/// distribution channel (github/appstore/playstore/...).
+enum ReleaseChannel {
+  stable,
+  beta;
+
+  /// Parses a stored name, falling back to [stable] for null/unknown values
+  /// so downgraded or corrupted preferences never strand a user on beta.
+  static ReleaseChannel fromName(String? name) {
+    for (final channel in ReleaseChannel.values) {
+      if (channel.name == name) return channel;
+    }
+    return ReleaseChannel.stable;
+  }
+}

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -42,7 +42,13 @@ final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
   if (!UpdateChannelConfig.isAutoUpdateEnabled) return null;
 
   final packageInfo = await PackageInfo.fromPlatform();
-  final currentVersion = packageInfo.version;
+  // Release tags are 4-segment (vX.Y.Z.N) while packageInfo.version is the
+  // 3-segment marketing version; without the build number appended, a
+  // current install always compares as older than its own release tag.
+  final currentVersion =
+      packageInfo.version.endsWith('.${packageInfo.buildNumber}')
+      ? packageInfo.version
+      : '${packageInfo.version}.${packageInfo.buildNumber}';
 
   if (_useSparkleEngine) {
     return SparkleUpdateService(feedUrl: _appcastUrl);

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/auto_update/data/repositories/update_prefere
 import 'package:submersion/features/auto_update/data/services/github_update_service.dart';
 import 'package:submersion/features/auto_update/data/services/sparkle_update_service.dart';
 import 'package:submersion/features/auto_update/data/services/update_service.dart';
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_status.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -15,9 +16,24 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 const _githubOwner = 'submersion-app';
 const _githubRepo = 'submersion';
 
-/// Appcast feed URL for Sparkle/WinSparkle (macOS + Windows).
-const _appcastUrl =
-    'https://github.com/$_githubOwner/$_githubRepo/releases/latest/download/appcast.xml';
+/// Repository holding per-merge beta releases (superset appcast + artifacts).
+const _betaRepo = 'beta-builds';
+
+/// Appcast feed URL for Sparkle/WinSparkle (macOS + Windows) per channel.
+/// The beta feed is a superset (beta items first, stable items appended), so
+/// a device switched back to stable still walks forward onto the next stable.
+String appcastUrlFor(ReleaseChannel channel) => switch (channel) {
+  ReleaseChannel.stable =>
+    'https://github.com/$_githubOwner/$_githubRepo/releases/latest/download/appcast.xml',
+  ReleaseChannel.beta =>
+    'https://github.com/$_githubOwner/$_betaRepo/releases/latest/download/appcast-beta.xml',
+};
+
+/// GitHub repo polled by the non-Sparkle updater (Linux/Android) per channel.
+String githubRepoFor(ReleaseChannel channel) => switch (channel) {
+  ReleaseChannel.stable => _githubRepo,
+  ReleaseChannel.beta => _betaRepo,
+};
 
 /// Platform-specific asset suffix for GitHub Releases downloads.
 String get _platformSuffix {
@@ -37,10 +53,16 @@ final updatePreferencesProvider = Provider<UpdatePreferences>((ref) {
   return UpdatePreferences(prefs);
 });
 
+/// The user-selected release channel, re-evaluated when preferences reload.
+final releaseChannelProvider = Provider<ReleaseChannel>((ref) {
+  return ref.watch(updatePreferencesProvider).releaseChannel;
+});
+
 /// The platform-appropriate update service.
 final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
   if (!UpdateChannelConfig.isAutoUpdateEnabled) return null;
 
+  final channel = ref.watch(releaseChannelProvider);
   final packageInfo = await PackageInfo.fromPlatform();
   // Release tags are 4-segment (vX.Y.Z.N) while packageInfo.version is the
   // 3-segment marketing version; without the build number appended, a
@@ -51,12 +73,12 @@ final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
       : '${packageInfo.version}.${packageInfo.buildNumber}';
 
   if (_useSparkleEngine) {
-    return SparkleUpdateService(feedUrl: _appcastUrl);
+    return SparkleUpdateService(feedUrl: appcastUrlFor(channel));
   }
 
   return GithubUpdateService(
     owner: _githubOwner,
-    repo: _githubRepo,
+    repo: githubRepoFor(channel),
     currentVersion: currentVersion,
     platformSuffix: _platformSuffix,
   );

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -993,6 +993,36 @@ class CloudSyncPage extends ConsumerWidget {
                 ),
               ),
             ),
+          if (syncState.newerSchemaPeerCount > 0)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Card(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.system_update_alt,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSecondaryContainer,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          context.l10n
+                              .settings_cloudSync_peerRequiresUpdate_banner(
+                                syncState.newerSchemaPeerCount,
+                              ),
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           if (syncState.movedMarker != null)
             _buildMovedBanner(context, ref, syncState.movedMarker!),
           if (syncState.cleanupOldBackendProviderId != null)

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -1015,7 +1015,16 @@ class CloudSyncPage extends ConsumerWidget {
                               .settings_cloudSync_peerRequiresUpdate_banner(
                                 syncState.newerSchemaPeerCount,
                               ),
-                          style: Theme.of(context).textTheme.bodyMedium,
+                          // Card is secondaryContainer, and Material does not
+                          // re-derive text colour from its background, so
+                          // bodyMedium would keep onSurface. Pair it with the
+                          // container explicitly, as the icon already is.
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSecondaryContainer,
+                              ),
                         ),
                       ),
                     ],
@@ -1095,7 +1104,11 @@ class CloudSyncPage extends ConsumerWidget {
                         marker.displayName,
                         marker.toProviderDisplay,
                       ),
-                      style: theme.textTheme.bodyMedium,
+                      // Same secondaryContainer pairing as the peer-update
+                      // banner above; kept in step so the two read alike.
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSecondaryContainer,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -35,6 +35,8 @@ import 'package:submersion/features/settings/presentation/widgets/settings_summa
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_import/presentation/providers/dive_import_providers.dart';
+import 'package:submersion/features/auto_update/domain/beta_program_links.dart';
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_channel.dart';
 import 'package:submersion/features/auto_update/domain/entities/update_status.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
@@ -2680,12 +2682,18 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
   @override
   Widget build(BuildContext context) {
     final packageInfoAsync = ref.watch(packageInfoProvider);
+    final isBetaChannel =
+        UpdateChannelConfig.isAutoUpdateEnabled &&
+        ref.watch(releaseChannelProvider) == ReleaseChannel.beta;
     final versionString = packageInfoAsync.when(
       data: (info) {
         final version = info.version.endsWith('.${info.buildNumber}')
             ? info.version
             : '${info.version}.${info.buildNumber}';
-        return context.l10n.settings_about_version(version);
+        final base = context.l10n.settings_about_version(version);
+        return isBetaChannel
+            ? context.l10n.settings_updates_channelBadgeBeta(base)
+            : base;
       },
       loading: () => '',
       error: (_, _) => '',
@@ -2718,6 +2726,24 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
                     );
                   },
                 ),
+                // Beta enrollment signpost for store builds: the app cannot
+                // switch channels itself there, so link to the store's beta
+                // program. Hidden until the enrollment links exist.
+                if (!UpdateChannelConfig.isAutoUpdateEnabled &&
+                    _betaEnrollUrl.isNotEmpty) ...[
+                  const Divider(height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.science_outlined),
+                    title: Text(context.l10n.settings_updates_joinBeta),
+                    subtitle: Text(
+                      context.l10n.settings_updates_joinBetaSubtitle,
+                    ),
+                    onTap: () => launchUrl(
+                      Uri.parse(_betaEnrollUrl),
+                      mode: LaunchMode.externalApplication,
+                    ),
+                  ),
+                ],
                 const Divider(height: 1),
                 ListTile(
                   leading: const Icon(Icons.bug_report),
@@ -2740,7 +2766,7 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
           // Auto-update section (only for non-store builds)
           if (UpdateChannelConfig.isAutoUpdateEnabled) ...[
             const SizedBox(height: 24),
-            _buildSectionHeader(context, 'Updates'),
+            _buildSectionHeader(context, context.l10n.settings_updates_header),
             const SizedBox(height: 8),
             _buildUpdatesCard(context),
           ],
@@ -2795,15 +2821,21 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
   Widget _buildUpdatesCard(BuildContext context) {
     final updateStatus = ref.watch(updateStatusProvider);
     final prefs = ref.watch(updatePreferencesProvider);
+    final channel = ref.watch(releaseChannelProvider);
 
     final statusText = switch (updateStatus) {
-      UpToDate() => 'Up to date',
-      Checking() => 'Checking...',
-      UpdateAvailable(:final version) => 'Version $version available',
-      Downloading(:final progress) =>
-        'Downloading... ${(progress * 100).toInt()}%',
-      ReadyToInstall(:final version) => 'Version $version ready to install',
-      UpdateError(:final message) => 'Error: $message',
+      UpToDate() => context.l10n.settings_updates_upToDate,
+      Checking() => context.l10n.settings_updates_checking,
+      UpdateAvailable(:final version) =>
+        context.l10n.settings_updates_versionAvailable(version),
+      Downloading(:final progress) => context.l10n.settings_updates_downloading(
+        (progress * 100).toInt().toString(),
+      ),
+      ReadyToInstall(:final version) =>
+        context.l10n.settings_updates_readyToInstall(version),
+      UpdateError(:final message) => context.l10n.settings_updates_error(
+        message,
+      ),
     };
 
     final lastCheck = prefs.lastCheckTime;
@@ -2811,14 +2843,14 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
         ? '${lastCheck.month}/${lastCheck.day}/${lastCheck.year} '
               '${lastCheck.hour.toString().padLeft(2, '0')}:'
               '${lastCheck.minute.toString().padLeft(2, '0')}'
-        : 'Never';
+        : context.l10n.settings_updates_never;
 
     return Card(
       child: Column(
         children: [
           ListTile(
             leading: const Icon(Icons.refresh),
-            title: const Text('Check for Updates'),
+            title: Text(context.l10n.settings_updates_checkForUpdates),
             subtitle: Text(statusText),
             onTap: updateStatus is Checking
                 ? null
@@ -2829,8 +2861,10 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
           const Divider(height: 1),
           SwitchListTile(
             secondary: const Icon(Icons.auto_mode),
-            title: const Text('Automatic updates'),
-            subtitle: const Text('Check for updates periodically'),
+            title: Text(context.l10n.settings_updates_automaticUpdates),
+            subtitle: Text(
+              context.l10n.settings_updates_automaticUpdatesSubtitle,
+            ),
             value: prefs.autoUpdateEnabled,
             onChanged: (value) async {
               await prefs.setAutoUpdateEnabled(value);
@@ -2839,13 +2873,105 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
           ),
           const Divider(height: 1),
           ListTile(
+            leading: const Icon(Icons.alt_route),
+            title: Text(context.l10n.settings_updates_channel),
+            subtitle: Text(
+              channel == ReleaseChannel.beta
+                  ? context.l10n.settings_updates_channelBeta
+                  : context.l10n.settings_updates_channelStable,
+            ),
+            onTap: () => _showChannelPicker(context),
+          ),
+          const Divider(height: 1),
+          ListTile(
             leading: const Icon(Icons.schedule),
-            title: const Text('Last checked'),
+            title: Text(context.l10n.settings_updates_lastChecked),
             subtitle: Text(lastCheckText),
           ),
         ],
       ),
     );
+  }
+
+  /// The store beta-program URL for this platform ('' hides the signpost).
+  String get _betaEnrollUrl {
+    if (Platform.isIOS || Platform.isMacOS) return kTestFlightBetaUrl;
+    if (Platform.isAndroid) return kPlayBetaOptInUrl;
+    return '';
+  }
+
+  Future<void> _showChannelPicker(BuildContext context) async {
+    final current = ref.read(releaseChannelProvider);
+    final selected = await showDialog<ReleaseChannel>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(ctx.l10n.settings_updates_channel),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final channel in ReleaseChannel.values)
+              ListTile(
+                title: Text(switch (channel) {
+                  ReleaseChannel.stable =>
+                    ctx.l10n.settings_updates_channelStable,
+                  ReleaseChannel.beta => ctx.l10n.settings_updates_channelBeta,
+                }),
+                subtitle: Text(switch (channel) {
+                  ReleaseChannel.stable =>
+                    ctx.l10n.settings_updates_channelStableSubtitle,
+                  ReleaseChannel.beta =>
+                    ctx.l10n.settings_updates_channelBetaSubtitle,
+                }),
+                trailing: channel == current
+                    ? Icon(
+                        Icons.check,
+                        color: Theme.of(ctx).colorScheme.primary,
+                      )
+                    : null,
+                onTap: () => Navigator.of(ctx).pop(channel),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (selected == null || selected == current || !context.mounted) return;
+
+    if (selected == ReleaseChannel.beta) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text(ctx.l10n.settings_updates_betaDialogTitle),
+          content: Text(ctx.l10n.settings_updates_betaDialogBody),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(ctx.l10n.settings_updates_betaDialogConfirm),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+    }
+
+    final prefs = ref.read(updatePreferencesProvider);
+    await prefs.setReleaseChannel(selected);
+    ref.invalidate(updatePreferencesProvider);
+    // releaseChannelProvider and updateServiceProvider re-derive from the
+    // invalidated preferences; the fresh service applies the new feed on
+    // its next check.
+    if (!mounted || !context.mounted) return;
+    if (selected == ReleaseChannel.stable) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.settings_updates_stableSwitchNotice),
+        ),
+      );
+    }
+    await ref.read(updateStatusProvider.notifier).checkForUpdate();
   }
 
   void _showAboutDialog(BuildContext context, String versionString) {

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -460,6 +460,11 @@ class SyncState {
   final DateTime? lastSync;
   final int pendingChanges;
   final int conflicts;
+
+  /// How many peers were held during the last pull because they publish from
+  /// a newer database schema than this build. Drives the "update this
+  /// device" banner; cleared when a fresh sync starts.
+  final int newerSchemaPeerCount;
   final bool isAuthenticated;
   final bool firstSyncAwaitingConfirmation;
 
@@ -501,6 +506,7 @@ class SyncState {
     this.lastSync,
     this.pendingChanges = 0,
     this.conflicts = 0,
+    this.newerSchemaPeerCount = 0,
     this.isAuthenticated = false,
     this.firstSyncAwaitingConfirmation = false,
     this.postRestoreSyncing = false,
@@ -518,6 +524,7 @@ class SyncState {
     DateTime? lastSync,
     int? pendingChanges,
     int? conflicts,
+    int? newerSchemaPeerCount,
     bool? isAuthenticated,
     bool? firstSyncAwaitingConfirmation,
     bool? postRestoreSyncing,
@@ -536,6 +543,7 @@ class SyncState {
       lastSync: lastSync ?? this.lastSync,
       pendingChanges: pendingChanges ?? this.pendingChanges,
       conflicts: conflicts ?? this.conflicts,
+      newerSchemaPeerCount: newerSchemaPeerCount ?? this.newerSchemaPeerCount,
       isAuthenticated: isAuthenticated ?? this.isAuthenticated,
       firstSyncAwaitingConfirmation:
           firstSyncAwaitingConfirmation ?? this.firstSyncAwaitingConfirmation,
@@ -999,6 +1007,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
         status: SyncStatus.syncing,
         message: 'Starting sync...',
         progress: 0.0,
+        newerSchemaPeerCount: 0,
         firstSyncAwaitingConfirmation: false,
         replaceAwaitingAdoption: false,
         needsPassphrase: false,
@@ -1072,6 +1081,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
             message: result.message ?? defaultMessage,
             lastSync: result.lastSyncTime,
             conflicts: result.conflictsFound,
+            newerSchemaPeerCount: result.newerSchemaPeerDeviceIds.length,
             progress: 1.0,
           );
           // Mark this provider established and consume any post-restore intent:

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4099,6 +4099,7 @@
   "settings_cloudSync_header_syncBehavior": "سلوك المزامنة",
   "settings_cloudSync_lastSynced": "آخر مزامنة: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{تغيير معلق واحد} other{{count} تغييرات معلقة}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{جهاز واحد يتزامن من إصدار أحدث من Submersion. حدّث هذا الجهاز لتلقي أحدث تغييراته.} other{{count} أجهزة تتزامن من إصدار أحدث من Submersion. حدّث هذا الجهاز لتلقي أحدث تغييراتها.}}",
   "settings_cloudSync_provider_connected": "متصل",
   "settings_cloudSync_provider_connectedTo": "متصل بـ {providerName}",
   "settings_cloudSync_provider_connectionFailed": "فشل الاتصال بـ {providerName}: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "الوزن",
   "settings_units_weight_kilograms": "كيلوغرام (kg)",
   "settings_units_weight_pounds": "أرطال (lbs)",
+  "settings_updates_automaticUpdates": "التحديثات التلقائية",
+  "settings_updates_automaticUpdatesSubtitle": "التحقق من التحديثات بشكل دوري",
+  "settings_updates_betaDialogBody": "تُنشر إصدارات البيتا مع كل تغيير وقد تقوم بترقية قاعدة بيانات سجل الغوص قبل الإصدار المستقر. العودة لاحقًا إلى القناة المستقرة لن تعيد التطبيق إلى إصدار أقدم، وينبغي أن تستخدم جميع الأجهزة التي تتزامن معًا القناة نفسها. يتم إنشاء نسخة احتياطية تلقائيًا قبل أي ترقية لقاعدة البيانات.",
+  "settings_updates_betaDialogConfirm": "التبديل إلى البيتا",
+  "settings_updates_betaDialogTitle": "هل تريد تلقي تحديثات البيتا؟",
+  "settings_updates_channel": "قناة التحديث",
+  "settings_updates_channelBadgeBeta": "{version} (بيتا)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "بيتا",
+  "settings_updates_channelBetaSubtitle": "إصدارات جديدة مع كل تغيير، قبل الإصدار المستقر",
+  "settings_updates_channelStable": "مستقر",
+  "settings_updates_channelStableSubtitle": "الإصدارات المختبرة فقط",
+  "settings_updates_checkForUpdates": "التحقق من التحديثات",
+  "settings_updates_checking": "جارٍ التحقق...",
+  "settings_updates_downloading": "جارٍ التنزيل... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "خطأ: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "التحديثات",
+  "settings_updates_joinBeta": "الانضمام إلى البيتا",
+  "settings_updates_joinBetaSubtitle": "احصل على الميزات الجديدة مبكرًا من خلال برنامج البيتا",
+  "settings_updates_lastChecked": "آخر تحقق",
+  "settings_updates_never": "أبدًا",
+  "settings_updates_readyToInstall": "الإصدار {version} جاهز للتثبيت",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "ستبقى على إصدار البيتا هذا حتى يصبح الإصدار المستقر التالي أحدث منه.",
+  "settings_updates_upToDate": "محدّث",
+  "settings_updates_versionAvailable": "الإصدار {version} متاح",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "مسح",
   "signatures_action_closeSignatureView": "إغلاق عرض التوقيع",
   "signatures_action_deleteSignature": "حذف التوقيع",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4099,6 +4099,7 @@
   "settings_cloudSync_header_syncBehavior": "Synchronisierungsverhalten",
   "settings_cloudSync_lastSynced": "Zuletzt synchronisiert: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 ausstehende Änderung} other{{count} ausstehende Änderungen}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 Gerät synchronisiert von einer neueren Version von Submersion. Aktualisieren Sie dieses Gerät, um dessen neueste Änderungen zu erhalten.} other{{count} Geräte synchronisieren von einer neueren Version von Submersion. Aktualisieren Sie dieses Gerät, um deren neueste Änderungen zu erhalten.}}",
   "settings_cloudSync_provider_connected": "Verbunden",
   "settings_cloudSync_provider_connectedTo": "Verbunden mit {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Verbindung zu {providerName} fehlgeschlagen: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "Gewicht",
   "settings_units_weight_kilograms": "Kilogramm (kg)",
   "settings_units_weight_pounds": "Pfund (lbs)",
+  "settings_updates_automaticUpdates": "Automatische Updates",
+  "settings_updates_automaticUpdatesSubtitle": "Regelmäßig nach Updates suchen",
+  "settings_updates_betaDialogBody": "Beta-Builds werden aus jeder Änderung veröffentlicht und können die Datenbank Ihres Tauchlogbuchs vor der stabilen Version aktualisieren. Ein späterer Wechsel zurück zu Stabil stuft die App nicht herab, und alle Geräte, die miteinander synchronisieren, sollten denselben Kanal verwenden. Vor jedem Datenbank-Upgrade wird automatisch ein Backup erstellt.",
+  "settings_updates_betaDialogConfirm": "Zu Beta wechseln",
+  "settings_updates_betaDialogTitle": "Beta-Updates erhalten?",
+  "settings_updates_channel": "Update-Kanal",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "Neue Builds aus jeder Änderung, vor der stabilen Version",
+  "settings_updates_channelStable": "Stabil",
+  "settings_updates_channelStableSubtitle": "Nur getestete Versionen",
+  "settings_updates_checkForUpdates": "Nach Updates suchen",
+  "settings_updates_checking": "Wird geprüft...",
+  "settings_updates_downloading": "Wird heruntergeladen... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Fehler: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Updates",
+  "settings_updates_joinBeta": "An der Beta teilnehmen",
+  "settings_updates_joinBetaSubtitle": "Erhalten Sie neue Funktionen frühzeitig über das Beta-Programm",
+  "settings_updates_lastChecked": "Zuletzt geprüft",
+  "settings_updates_never": "Nie",
+  "settings_updates_readyToInstall": "Version {version} bereit zur Installation",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Sie bleiben auf dieser Beta, bis die nächste stabile Version neuer ist als diese.",
+  "settings_updates_upToDate": "Auf dem neuesten Stand",
+  "settings_updates_versionAvailable": "Version {version} verfügbar",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Löschen",
   "signatures_action_closeSignatureView": "Signaturansicht schließen",
   "signatures_action_deleteSignature": "Signatur löschen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7861,6 +7861,7 @@
   "settings_cloudSync_header_syncBehavior": "Sync Behavior",
   "settings_cloudSync_lastSynced": "Last synced: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 pending change} other{{count} pending changes}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 device syncs from a newer version of Submersion. Update this device to receive its latest changes.} other{{count} devices sync from a newer version of Submersion. Update this device to receive their latest changes.}}",
   "settings_cloudSync_provider_connected": "Connected",
   "settings_cloudSync_provider_connectedTo": "Connected to {providerName}",
   "settings_cloudSync_provider_connectionFailed": "{providerName} connection failed: {error}",
@@ -8343,6 +8344,65 @@
   "settings_units_weight": "Weight",
   "settings_units_weight_kilograms": "Kilograms (kg)",
   "settings_units_weight_pounds": "Pounds (lbs)",
+  "settings_updates_automaticUpdates": "Automatic updates",
+  "settings_updates_automaticUpdatesSubtitle": "Check for updates periodically",
+  "settings_updates_betaDialogBody": "Beta builds are published from every change and may upgrade your dive log's database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.",
+  "settings_updates_betaDialogConfirm": "Switch to Beta",
+  "settings_updates_betaDialogTitle": "Receive beta updates?",
+  "settings_updates_channel": "Update channel",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "New builds from every change, ahead of stable",
+  "settings_updates_channelStable": "Stable",
+  "settings_updates_channelStableSubtitle": "Tested releases only",
+  "settings_updates_checkForUpdates": "Check for Updates",
+  "settings_updates_checking": "Checking...",
+  "settings_updates_downloading": "Downloading... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Error: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Updates",
+  "settings_updates_joinBeta": "Join the Beta",
+  "settings_updates_joinBetaSubtitle": "Get new features early through the beta program",
+  "settings_updates_lastChecked": "Last checked",
+  "settings_updates_never": "Never",
+  "settings_updates_readyToInstall": "Version {version} ready to install",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "You will stay on this beta until the next stable release is newer than it.",
+  "settings_updates_upToDate": "Up to date",
+  "settings_updates_versionAvailable": "Version {version} available",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "@settings_cloudSync_conflictItems": {
     "placeholders": {
       "count": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4099,6 +4099,7 @@
   "settings_cloudSync_header_syncBehavior": "Comportamiento de sincronizacion",
   "settings_cloudSync_lastSynced": "Ultima sincronizacion: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 cambio pendiente} other{{count} cambios pendientes}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 dispositivo sincroniza desde una versión más reciente de Submersion. Actualiza este dispositivo para recibir sus últimos cambios.} other{{count} dispositivos sincronizan desde una versión más reciente de Submersion. Actualiza este dispositivo para recibir sus últimos cambios.}}",
   "settings_cloudSync_provider_connected": "Conectado",
   "settings_cloudSync_provider_connectedTo": "Conectado a {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Error de conexion con {providerName}: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "Peso",
   "settings_units_weight_kilograms": "Kilogramos (kg)",
   "settings_units_weight_pounds": "Libras (lbs)",
+  "settings_updates_automaticUpdates": "Actualizaciones automáticas",
+  "settings_updates_automaticUpdatesSubtitle": "Buscar actualizaciones periódicamente",
+  "settings_updates_betaDialogBody": "Las versiones beta se publican con cada cambio y pueden actualizar la base de datos de tu registro de buceo antes que la versión estable. Volver luego al canal estable no revertirá la app a una versión anterior, y todos los dispositivos que se sincronizan entre sí deberían usar el mismo canal. Se realiza una copia de seguridad automáticamente antes de cualquier actualización de la base de datos.",
+  "settings_updates_betaDialogConfirm": "Cambiar a Beta",
+  "settings_updates_betaDialogTitle": "¿Recibir actualizaciones beta?",
+  "settings_updates_channel": "Canal de actualizaciones",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "Nuevas versiones con cada cambio, por delante de la estable",
+  "settings_updates_channelStable": "Estable",
+  "settings_updates_channelStableSubtitle": "Solo versiones probadas",
+  "settings_updates_checkForUpdates": "Buscar actualizaciones",
+  "settings_updates_checking": "Comprobando...",
+  "settings_updates_downloading": "Descargando... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Error: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Actualizaciones",
+  "settings_updates_joinBeta": "Únete a la Beta",
+  "settings_updates_joinBetaSubtitle": "Recibe nuevas funciones antes a través del programa beta",
+  "settings_updates_lastChecked": "Última comprobación",
+  "settings_updates_never": "Nunca",
+  "settings_updates_readyToInstall": "Versión {version} lista para instalar",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Permanecerás en esta beta hasta que la próxima versión estable sea más reciente que ella.",
+  "settings_updates_upToDate": "Actualizado",
+  "settings_updates_versionAvailable": "Versión {version} disponible",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Limpiar",
   "signatures_action_closeSignatureView": "Cerrar vista de firma",
   "signatures_action_deleteSignature": "Eliminar firma",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4029,6 +4029,7 @@
   "settings_cloudSync_header_syncBehavior": "Comportement de synchronisation",
   "settings_cloudSync_lastSynced": "Derniere synchronisation : {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 modification en attente} other{{count} modifications en attente}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 appareil se synchronise depuis une version plus récente de Submersion. Mettez à jour cet appareil pour recevoir ses derniers changements.} other{{count} appareils se synchronisent depuis une version plus récente de Submersion. Mettez à jour cet appareil pour recevoir leurs derniers changements.}}",
   "settings_cloudSync_provider_connected": "Connecte",
   "settings_cloudSync_provider_connectedTo": "Connecte a {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Echec de la connexion a {providerName} : {error}",
@@ -4456,6 +4457,65 @@
   "settings_units_weight": "Poids",
   "settings_units_weight_kilograms": "Kilogrammes (kg)",
   "settings_units_weight_pounds": "Livres (lbs)",
+  "settings_updates_automaticUpdates": "Mises à jour automatiques",
+  "settings_updates_automaticUpdatesSubtitle": "Rechercher les mises à jour périodiquement",
+  "settings_updates_betaDialogBody": "Les versions bêta sont publiées à chaque modification et peuvent mettre à niveau la base de données de votre carnet de plongée avant la version stable. Revenir ensuite au canal stable ne rétrogradera pas l'application, et tous les appareils qui se synchronisent ensemble devraient utiliser le même canal. Une sauvegarde est effectuée automatiquement avant toute mise à niveau de la base de données.",
+  "settings_updates_betaDialogConfirm": "Passer à la bêta",
+  "settings_updates_betaDialogTitle": "Recevoir les mises à jour bêta ?",
+  "settings_updates_channel": "Canal de mise à jour",
+  "settings_updates_channelBadgeBeta": "{version} (Bêta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Bêta",
+  "settings_updates_channelBetaSubtitle": "Nouvelles versions à chaque modification, en avance sur la stable",
+  "settings_updates_channelStable": "Stable",
+  "settings_updates_channelStableSubtitle": "Versions testées uniquement",
+  "settings_updates_checkForUpdates": "Rechercher les mises à jour",
+  "settings_updates_checking": "Vérification...",
+  "settings_updates_downloading": "Téléchargement... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Erreur : {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Mises à jour",
+  "settings_updates_joinBeta": "Rejoindre la bêta",
+  "settings_updates_joinBetaSubtitle": "Recevez les nouvelles fonctionnalités en avant-première grâce au programme bêta",
+  "settings_updates_lastChecked": "Dernière vérification",
+  "settings_updates_never": "Jamais",
+  "settings_updates_readyToInstall": "Version {version} prête à installer",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Vous resterez sur cette bêta jusqu'à ce que la prochaine version stable soit plus récente qu'elle.",
+  "settings_updates_upToDate": "À jour",
+  "settings_updates_versionAvailable": "Version {version} disponible",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Effacer",
   "signatures_action_closeSignatureView": "Fermer la vue signature",
   "signatures_action_deleteSignature": "Supprimer la signature",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4103,6 +4103,7 @@
   "settings_cloudSync_header_syncBehavior": "התנהגות סנכרון",
   "settings_cloudSync_lastSynced": "סנכרון אחרון: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{שינוי ממתין אחד} other{{count} שינויים ממתינים}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{מכשיר אחד מסתנכרן מגרסה חדשה יותר של Submersion. עדכן מכשיר זה כדי לקבל את השינויים האחרונים שלו.} other{{count} מכשירים מסתנכרנים מגרסה חדשה יותר של Submersion. עדכן מכשיר זה כדי לקבל את השינויים האחרונים שלהם.}}",
   "settings_cloudSync_provider_connected": "מחובר",
   "settings_cloudSync_provider_connectedTo": "מחובר אל {providerName}",
   "settings_cloudSync_provider_connectionFailed": "החיבור אל {providerName} נכשל: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "משקל",
   "settings_units_weight_kilograms": "קילוגרם (kg)",
   "settings_units_weight_pounds": "ליברות (lbs)",
+  "settings_updates_automaticUpdates": "עדכונים אוטומטיים",
+  "settings_updates_automaticUpdatesSubtitle": "בדיקת עדכונים מעת לעת",
+  "settings_updates_betaDialogBody": "גרסאות בטא מתפרסמות מכל שינוי ועשויות לשדרג את מסד הנתונים של יומן הצלילה שלך לפני הגרסה היציבה. חזרה מאוחר יותר לערוץ היציב לא תחזיר את האפליקציה לגרסה קודמת, וכל המכשירים שמסתנכרנים יחד צריכים להשתמש באותו ערוץ. גיבוי נוצר אוטומטית לפני כל שדרוג של מסד הנתונים.",
+  "settings_updates_betaDialogConfirm": "מעבר לבטא",
+  "settings_updates_betaDialogTitle": "לקבל עדכוני בטא?",
+  "settings_updates_channel": "ערוץ עדכונים",
+  "settings_updates_channelBadgeBeta": "{version} (בטא)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "בטא",
+  "settings_updates_channelBetaSubtitle": "גרסאות חדשות מכל שינוי, לפני היציבה",
+  "settings_updates_channelStable": "יציב",
+  "settings_updates_channelStableSubtitle": "גרסאות שנבדקו בלבד",
+  "settings_updates_checkForUpdates": "בדוק אם יש עדכונים",
+  "settings_updates_checking": "בודק...",
+  "settings_updates_downloading": "מוריד... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "שגיאה: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "עדכונים",
+  "settings_updates_joinBeta": "הצטרפות לבטא",
+  "settings_updates_joinBetaSubtitle": "קבל תכונות חדשות מוקדם דרך תוכנית הבטא",
+  "settings_updates_lastChecked": "בדיקה אחרונה",
+  "settings_updates_never": "אף פעם",
+  "settings_updates_readyToInstall": "גרסה {version} מוכנה להתקנה",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "תישאר בגרסת הבטא הזו עד שהגרסה היציבה הבאה תהיה חדשה ממנה.",
+  "settings_updates_upToDate": "מעודכן",
+  "settings_updates_versionAvailable": "גרסה {version} זמינה",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "נקה",
   "signatures_action_closeSignatureView": "סגור תצוגת חתימה",
   "signatures_action_deleteSignature": "מחק חתימה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4029,6 +4029,7 @@
   "settings_cloudSync_header_syncBehavior": "Szinkronizalasi viselkedes",
   "settings_cloudSync_lastSynced": "Utolso szinkronizalas: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 függo valtoztatas} other{{count} függo valtoztatas}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 eszköz a Submersion újabb verziójából szinkronizál. Frissítsd ezt az eszközt, hogy megkapd a legújabb változtatásait.} other{{count} eszköz a Submersion újabb verziójából szinkronizál. Frissítsd ezt az eszközt, hogy megkapd a legújabb változtatásaikat.}}",
   "settings_cloudSync_provider_connected": "Csatlakoztatva",
   "settings_cloudSync_provider_connectedTo": "Csatlakoztatva: {providerName}",
   "settings_cloudSync_provider_connectionFailed": "{providerName} csatlakozas sikertelen: {error}",
@@ -4456,6 +4457,65 @@
   "settings_units_weight": "Suly",
   "settings_units_weight_kilograms": "Kilogramm (kg)",
   "settings_units_weight_pounds": "Font (lbs)",
+  "settings_updates_automaticUpdates": "Automatikus frissítések",
+  "settings_updates_automaticUpdatesSubtitle": "Frissítések rendszeres keresése",
+  "settings_updates_betaDialogBody": "A béta buildek minden változtatásból megjelennek, és a merülési napló adatbázisát a stabil kiadás előtt frissíthetik. Ha később visszaváltasz a stabil csatornára, az alkalmazás nem áll vissza korábbi verzióra, és az együtt szinkronizáló eszközöknek ugyanazt a csatornát érdemes használniuk. Minden adatbázis-frissítés előtt automatikusan biztonsági mentés készül.",
+  "settings_updates_betaDialogConfirm": "Váltás bétára",
+  "settings_updates_betaDialogTitle": "Szeretnél béta frissítéseket kapni?",
+  "settings_updates_channel": "Frissítési csatorna",
+  "settings_updates_channelBadgeBeta": "{version} (Béta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Béta",
+  "settings_updates_channelBetaSubtitle": "Új buildek minden változtatásból, a stabil előtt",
+  "settings_updates_channelStable": "Stabil",
+  "settings_updates_channelStableSubtitle": "Csak tesztelt kiadások",
+  "settings_updates_checkForUpdates": "Frissítések keresése",
+  "settings_updates_checking": "Keresés...",
+  "settings_updates_downloading": "Letöltés... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Hiba: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Frissítések",
+  "settings_updates_joinBeta": "Csatlakozz a bétához",
+  "settings_updates_joinBetaSubtitle": "Kapd meg korábban az új funkciókat a bétaprogramon keresztül",
+  "settings_updates_lastChecked": "Utolsó ellenőrzés",
+  "settings_updates_never": "Soha",
+  "settings_updates_readyToInstall": "A(z) {version} verzió telepítésre kész",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Ezen a bétán maradsz, amíg a következő stabil kiadás nem lesz nála újabb.",
+  "settings_updates_upToDate": "Naprakész",
+  "settings_updates_versionAvailable": "A(z) {version} verzió elérhető",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Törlés",
   "signatures_action_closeSignatureView": "Aláírás nézet bezárása",
   "signatures_action_deleteSignature": "Aláírás törlése",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4029,6 +4029,7 @@
   "settings_cloudSync_header_syncBehavior": "Comportamento sincronizzazione",
   "settings_cloudSync_lastSynced": "Ultima sincronizzazione: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 modifica in sospeso} other{{count} modifiche in sospeso}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 dispositivo si sincronizza da una versione più recente di Submersion. Aggiorna questo dispositivo per ricevere le sue ultime modifiche.} other{{count} dispositivi si sincronizzano da una versione più recente di Submersion. Aggiorna questo dispositivo per ricevere le loro ultime modifiche.}}",
   "settings_cloudSync_provider_connected": "Connesso",
   "settings_cloudSync_provider_connectedTo": "Connesso a {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Connessione a {providerName} non riuscita: {error}",
@@ -4452,6 +4453,65 @@
   "settings_units_weight": "Peso",
   "settings_units_weight_kilograms": "Chilogrammi (kg)",
   "settings_units_weight_pounds": "Libbre (lbs)",
+  "settings_updates_automaticUpdates": "Aggiornamenti automatici",
+  "settings_updates_automaticUpdatesSubtitle": "Controlla periodicamente gli aggiornamenti",
+  "settings_updates_betaDialogBody": "Le build beta vengono pubblicate a ogni modifica e possono aggiornare il database del tuo diario immersioni prima della versione stabile. Tornare in seguito al canale stabile non riporterà l'app a una versione precedente, e tutti i dispositivi che si sincronizzano tra loro dovrebbero usare lo stesso canale. Prima di ogni aggiornamento del database viene eseguito automaticamente un backup.",
+  "settings_updates_betaDialogConfirm": "Passa alla Beta",
+  "settings_updates_betaDialogTitle": "Ricevere aggiornamenti beta?",
+  "settings_updates_channel": "Canale di aggiornamento",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "Nuove build a ogni modifica, in anticipo sulla stabile",
+  "settings_updates_channelStable": "Stabile",
+  "settings_updates_channelStableSubtitle": "Solo versioni testate",
+  "settings_updates_checkForUpdates": "Controlla aggiornamenti",
+  "settings_updates_checking": "Controllo in corso...",
+  "settings_updates_downloading": "Download in corso... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Errore: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Aggiornamenti",
+  "settings_updates_joinBeta": "Partecipa alla Beta",
+  "settings_updates_joinBetaSubtitle": "Ricevi in anteprima le nuove funzionalità tramite il programma beta",
+  "settings_updates_lastChecked": "Ultimo controllo",
+  "settings_updates_never": "Mai",
+  "settings_updates_readyToInstall": "Versione {version} pronta per l'installazione",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Rimarrai su questa beta finché la prossima versione stabile non sarà più recente di essa.",
+  "settings_updates_upToDate": "Aggiornato",
+  "settings_updates_versionAvailable": "Versione {version} disponibile",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Cancella",
   "signatures_action_closeSignatureView": "Chiudi vista firma",
   "signatures_action_deleteSignature": "Elimina firma",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -22979,6 +22979,12 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 pending change} other{{count} pending changes}}'**
   String settings_cloudSync_pendingChanges(int count);
 
+  /// No description provided for @settings_cloudSync_peerRequiresUpdate_banner.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 device syncs from a newer version of Submersion. Update this device to receive its latest changes.} other{{count} devices sync from a newer version of Submersion. Update this device to receive their latest changes.}}'**
+  String settings_cloudSync_peerRequiresUpdate_banner(num count);
+
   /// No description provided for @settings_cloudSync_provider_connected.
   ///
   /// In en, this message translates to:
@@ -25519,6 +25525,150 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Pounds (lbs)'**
   String get settings_units_weight_pounds;
+
+  /// No description provided for @settings_updates_automaticUpdates.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic updates'**
+  String get settings_updates_automaticUpdates;
+
+  /// No description provided for @settings_updates_automaticUpdatesSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Check for updates periodically'**
+  String get settings_updates_automaticUpdatesSubtitle;
+
+  /// No description provided for @settings_updates_betaDialogBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Beta builds are published from every change and may upgrade your dive log\'s database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.'**
+  String get settings_updates_betaDialogBody;
+
+  /// No description provided for @settings_updates_betaDialogConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch to Beta'**
+  String get settings_updates_betaDialogConfirm;
+
+  /// No description provided for @settings_updates_betaDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Receive beta updates?'**
+  String get settings_updates_betaDialogTitle;
+
+  /// No description provided for @settings_updates_channel.
+  ///
+  /// In en, this message translates to:
+  /// **'Update channel'**
+  String get settings_updates_channel;
+
+  /// No description provided for @settings_updates_channelBadgeBeta.
+  ///
+  /// In en, this message translates to:
+  /// **'{version} (Beta)'**
+  String settings_updates_channelBadgeBeta(String version);
+
+  /// No description provided for @settings_updates_channelBeta.
+  ///
+  /// In en, this message translates to:
+  /// **'Beta'**
+  String get settings_updates_channelBeta;
+
+  /// No description provided for @settings_updates_channelBetaSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'New builds from every change, ahead of stable'**
+  String get settings_updates_channelBetaSubtitle;
+
+  /// No description provided for @settings_updates_channelStable.
+  ///
+  /// In en, this message translates to:
+  /// **'Stable'**
+  String get settings_updates_channelStable;
+
+  /// No description provided for @settings_updates_channelStableSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Tested releases only'**
+  String get settings_updates_channelStableSubtitle;
+
+  /// No description provided for @settings_updates_checkForUpdates.
+  ///
+  /// In en, this message translates to:
+  /// **'Check for Updates'**
+  String get settings_updates_checkForUpdates;
+
+  /// No description provided for @settings_updates_checking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking...'**
+  String get settings_updates_checking;
+
+  /// No description provided for @settings_updates_downloading.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading... {progress}%'**
+  String settings_updates_downloading(String progress);
+
+  /// No description provided for @settings_updates_error.
+  ///
+  /// In en, this message translates to:
+  /// **'Error: {message}'**
+  String settings_updates_error(String message);
+
+  /// No description provided for @settings_updates_header.
+  ///
+  /// In en, this message translates to:
+  /// **'Updates'**
+  String get settings_updates_header;
+
+  /// No description provided for @settings_updates_joinBeta.
+  ///
+  /// In en, this message translates to:
+  /// **'Join the Beta'**
+  String get settings_updates_joinBeta;
+
+  /// No description provided for @settings_updates_joinBetaSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Get new features early through the beta program'**
+  String get settings_updates_joinBetaSubtitle;
+
+  /// No description provided for @settings_updates_lastChecked.
+  ///
+  /// In en, this message translates to:
+  /// **'Last checked'**
+  String get settings_updates_lastChecked;
+
+  /// No description provided for @settings_updates_never.
+  ///
+  /// In en, this message translates to:
+  /// **'Never'**
+  String get settings_updates_never;
+
+  /// No description provided for @settings_updates_readyToInstall.
+  ///
+  /// In en, this message translates to:
+  /// **'Version {version} ready to install'**
+  String settings_updates_readyToInstall(String version);
+
+  /// No description provided for @settings_updates_stableSwitchNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'You will stay on this beta until the next stable release is newer than it.'**
+  String get settings_updates_stableSwitchNotice;
+
+  /// No description provided for @settings_updates_upToDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Up to date'**
+  String get settings_updates_upToDate;
+
+  /// No description provided for @settings_updates_versionAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Version {version} available'**
+  String settings_updates_versionAvailable(String version);
 
   /// Button label to clear the signature canvas
   ///

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13360,6 +13360,19 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count أجهزة تتزامن من إصدار أحدث من Submersion. حدّث هذا الجهاز لتلقي أحدث تغييراتها.',
+      one:
+          'جهاز واحد يتزامن من إصدار أحدث من Submersion. حدّث هذا الجهاز لتلقي أحدث تغييراته.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'متصل';
 
   @override
@@ -14845,6 +14858,93 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'أرطال (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'التحديثات التلقائية';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'التحقق من التحديثات بشكل دوري';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'تُنشر إصدارات البيتا مع كل تغيير وقد تقوم بترقية قاعدة بيانات سجل الغوص قبل الإصدار المستقر. العودة لاحقًا إلى القناة المستقرة لن تعيد التطبيق إلى إصدار أقدم، وينبغي أن تستخدم جميع الأجهزة التي تتزامن معًا القناة نفسها. يتم إنشاء نسخة احتياطية تلقائيًا قبل أي ترقية لقاعدة البيانات.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'التبديل إلى البيتا';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'هل تريد تلقي تحديثات البيتا؟';
+
+  @override
+  String get settings_updates_channel => 'قناة التحديث';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (بيتا)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'بيتا';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'إصدارات جديدة مع كل تغيير، قبل الإصدار المستقر';
+
+  @override
+  String get settings_updates_channelStable => 'مستقر';
+
+  @override
+  String get settings_updates_channelStableSubtitle => 'الإصدارات المختبرة فقط';
+
+  @override
+  String get settings_updates_checkForUpdates => 'التحقق من التحديثات';
+
+  @override
+  String get settings_updates_checking => 'جارٍ التحقق...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'جارٍ التنزيل... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'خطأ: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'التحديثات';
+
+  @override
+  String get settings_updates_joinBeta => 'الانضمام إلى البيتا';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'احصل على الميزات الجديدة مبكرًا من خلال برنامج البيتا';
+
+  @override
+  String get settings_updates_lastChecked => 'آخر تحقق';
+
+  @override
+  String get settings_updates_never => 'أبدًا';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'الإصدار $version جاهز للتثبيت';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'ستبقى على إصدار البيتا هذا حتى يصبح الإصدار المستقر التالي أحدث منه.';
+
+  @override
+  String get settings_updates_upToDate => 'محدّث';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'الإصدار $version متاح';
+  }
 
   @override
   String get signatures_action_clear => 'مسح';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -13587,6 +13587,19 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count Geräte synchronisieren von einer neueren Version von Submersion. Aktualisieren Sie dieses Gerät, um deren neueste Änderungen zu erhalten.',
+      one:
+          '1 Gerät synchronisiert von einer neueren Version von Submersion. Aktualisieren Sie dieses Gerät, um dessen neueste Änderungen zu erhalten.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Verbunden';
 
   @override
@@ -15099,6 +15112,94 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Pfund (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Automatische Updates';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Regelmäßig nach Updates suchen';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Beta-Builds werden aus jeder Änderung veröffentlicht und können die Datenbank Ihres Tauchlogbuchs vor der stabilen Version aktualisieren. Ein späterer Wechsel zurück zu Stabil stuft die App nicht herab, und alle Geräte, die miteinander synchronisieren, sollten denselben Kanal verwenden. Vor jedem Datenbank-Upgrade wird automatisch ein Backup erstellt.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Zu Beta wechseln';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'Beta-Updates erhalten?';
+
+  @override
+  String get settings_updates_channel => 'Update-Kanal';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Neue Builds aus jeder Änderung, vor der stabilen Version';
+
+  @override
+  String get settings_updates_channelStable => 'Stabil';
+
+  @override
+  String get settings_updates_channelStableSubtitle =>
+      'Nur getestete Versionen';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Nach Updates suchen';
+
+  @override
+  String get settings_updates_checking => 'Wird geprüft...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Wird heruntergeladen... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Fehler: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Updates';
+
+  @override
+  String get settings_updates_joinBeta => 'An der Beta teilnehmen';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Erhalten Sie neue Funktionen frühzeitig über das Beta-Programm';
+
+  @override
+  String get settings_updates_lastChecked => 'Zuletzt geprüft';
+
+  @override
+  String get settings_updates_never => 'Nie';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Version $version bereit zur Installation';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Sie bleiben auf dieser Beta, bis die nächste stabile Version neuer ist als diese.';
+
+  @override
+  String get settings_updates_upToDate => 'Auf dem neuesten Stand';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Version $version verfügbar';
+  }
 
   @override
   String get signatures_action_clear => 'Löschen';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13377,6 +13377,19 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count devices sync from a newer version of Submersion. Update this device to receive their latest changes.',
+      one:
+          '1 device syncs from a newer version of Submersion. Update this device to receive its latest changes.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Connected';
 
   @override
@@ -14863,6 +14876,93 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Pounds (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Automatic updates';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Check for updates periodically';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Beta builds are published from every change and may upgrade your dive log\'s database before the stable release does. Switching back to stable later will not downgrade the app, and all devices that sync together should use the same channel. A backup is taken automatically before any database upgrade.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Switch to Beta';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'Receive beta updates?';
+
+  @override
+  String get settings_updates_channel => 'Update channel';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'New builds from every change, ahead of stable';
+
+  @override
+  String get settings_updates_channelStable => 'Stable';
+
+  @override
+  String get settings_updates_channelStableSubtitle => 'Tested releases only';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Check for Updates';
+
+  @override
+  String get settings_updates_checking => 'Checking...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Downloading... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Error: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Updates';
+
+  @override
+  String get settings_updates_joinBeta => 'Join the Beta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Get new features early through the beta program';
+
+  @override
+  String get settings_updates_lastChecked => 'Last checked';
+
+  @override
+  String get settings_updates_never => 'Never';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Version $version ready to install';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'You will stay on this beta until the next stable release is newer than it.';
+
+  @override
+  String get settings_updates_upToDate => 'Up to date';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Version $version available';
+  }
 
   @override
   String get signatures_action_clear => 'Clear';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -13598,6 +13598,19 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count dispositivos sincronizan desde una versión más reciente de Submersion. Actualiza este dispositivo para recibir sus últimos cambios.',
+      one:
+          '1 dispositivo sincroniza desde una versión más reciente de Submersion. Actualiza este dispositivo para recibir sus últimos cambios.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Conectado';
 
   @override
@@ -15118,6 +15131,95 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Libras (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Actualizaciones automáticas';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Buscar actualizaciones periódicamente';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Las versiones beta se publican con cada cambio y pueden actualizar la base de datos de tu registro de buceo antes que la versión estable. Volver luego al canal estable no revertirá la app a una versión anterior, y todos los dispositivos que se sincronizan entre sí deberían usar el mismo canal. Se realiza una copia de seguridad automáticamente antes de cualquier actualización de la base de datos.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Cambiar a Beta';
+
+  @override
+  String get settings_updates_betaDialogTitle =>
+      '¿Recibir actualizaciones beta?';
+
+  @override
+  String get settings_updates_channel => 'Canal de actualizaciones';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Nuevas versiones con cada cambio, por delante de la estable';
+
+  @override
+  String get settings_updates_channelStable => 'Estable';
+
+  @override
+  String get settings_updates_channelStableSubtitle =>
+      'Solo versiones probadas';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Buscar actualizaciones';
+
+  @override
+  String get settings_updates_checking => 'Comprobando...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Descargando... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Error: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Actualizaciones';
+
+  @override
+  String get settings_updates_joinBeta => 'Únete a la Beta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Recibe nuevas funciones antes a través del programa beta';
+
+  @override
+  String get settings_updates_lastChecked => 'Última comprobación';
+
+  @override
+  String get settings_updates_never => 'Nunca';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Versión $version lista para instalar';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Permanecerás en esta beta hasta que la próxima versión estable sea más reciente que ella.';
+
+  @override
+  String get settings_updates_upToDate => 'Actualizado';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Versión $version disponible';
+  }
 
   @override
   String get signatures_action_clear => 'Limpiar';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -13646,6 +13646,19 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count appareils se synchronisent depuis une version plus récente de Submersion. Mettez à jour cet appareil pour recevoir leurs derniers changements.',
+      one:
+          '1 appareil se synchronise depuis une version plus récente de Submersion. Mettez à jour cet appareil pour recevoir ses derniers changements.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Connecte';
 
   @override
@@ -15173,6 +15186,95 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Livres (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Mises à jour automatiques';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Rechercher les mises à jour périodiquement';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Les versions bêta sont publiées à chaque modification et peuvent mettre à niveau la base de données de votre carnet de plongée avant la version stable. Revenir ensuite au canal stable ne rétrogradera pas l\'application, et tous les appareils qui se synchronisent ensemble devraient utiliser le même canal. Une sauvegarde est effectuée automatiquement avant toute mise à niveau de la base de données.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Passer à la bêta';
+
+  @override
+  String get settings_updates_betaDialogTitle =>
+      'Recevoir les mises à jour bêta ?';
+
+  @override
+  String get settings_updates_channel => 'Canal de mise à jour';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Bêta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Bêta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Nouvelles versions à chaque modification, en avance sur la stable';
+
+  @override
+  String get settings_updates_channelStable => 'Stable';
+
+  @override
+  String get settings_updates_channelStableSubtitle =>
+      'Versions testées uniquement';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Rechercher les mises à jour';
+
+  @override
+  String get settings_updates_checking => 'Vérification...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Téléchargement... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Erreur : $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Mises à jour';
+
+  @override
+  String get settings_updates_joinBeta => 'Rejoindre la bêta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Recevez les nouvelles fonctionnalités en avant-première grâce au programme bêta';
+
+  @override
+  String get settings_updates_lastChecked => 'Dernière vérification';
+
+  @override
+  String get settings_updates_never => 'Jamais';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Version $version prête à installer';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Vous resterez sur cette bêta jusqu\'à ce que la prochaine version stable soit plus récente qu\'elle.';
+
+  @override
+  String get settings_updates_upToDate => 'À jour';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Version $version disponible';
+  }
 
   @override
   String get signatures_action_clear => 'Effacer';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13266,6 +13266,19 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count מכשירים מסתנכרנים מגרסה חדשה יותר של Submersion. עדכן מכשיר זה כדי לקבל את השינויים האחרונים שלהם.',
+      one:
+          'מכשיר אחד מסתנכרן מגרסה חדשה יותר של Submersion. עדכן מכשיר זה כדי לקבל את השינויים האחרונים שלו.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'מחובר';
 
   @override
@@ -14737,6 +14750,93 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'ליברות (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'עדכונים אוטומטיים';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'בדיקת עדכונים מעת לעת';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'גרסאות בטא מתפרסמות מכל שינוי ועשויות לשדרג את מסד הנתונים של יומן הצלילה שלך לפני הגרסה היציבה. חזרה מאוחר יותר לערוץ היציב לא תחזיר את האפליקציה לגרסה קודמת, וכל המכשירים שמסתנכרנים יחד צריכים להשתמש באותו ערוץ. גיבוי נוצר אוטומטית לפני כל שדרוג של מסד הנתונים.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'מעבר לבטא';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'לקבל עדכוני בטא?';
+
+  @override
+  String get settings_updates_channel => 'ערוץ עדכונים';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (בטא)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'בטא';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'גרסאות חדשות מכל שינוי, לפני היציבה';
+
+  @override
+  String get settings_updates_channelStable => 'יציב';
+
+  @override
+  String get settings_updates_channelStableSubtitle => 'גרסאות שנבדקו בלבד';
+
+  @override
+  String get settings_updates_checkForUpdates => 'בדוק אם יש עדכונים';
+
+  @override
+  String get settings_updates_checking => 'בודק...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'מוריד... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'שגיאה: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'עדכונים';
+
+  @override
+  String get settings_updates_joinBeta => 'הצטרפות לבטא';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'קבל תכונות חדשות מוקדם דרך תוכנית הבטא';
+
+  @override
+  String get settings_updates_lastChecked => 'בדיקה אחרונה';
+
+  @override
+  String get settings_updates_never => 'אף פעם';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'גרסה $version מוכנה להתקנה';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'תישאר בגרסת הבטא הזו עד שהגרסה היציבה הבאה תהיה חדשה ממנה.';
+
+  @override
+  String get settings_updates_upToDate => 'מעודכן';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'גרסה $version זמינה';
+  }
 
   @override
   String get signatures_action_clear => 'נקה';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -13559,6 +13559,19 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count eszköz a Submersion újabb verziójából szinkronizál. Frissítsd ezt az eszközt, hogy megkapd a legújabb változtatásaikat.',
+      one:
+          '1 eszköz a Submersion újabb verziójából szinkronizál. Frissítsd ezt az eszközt, hogy megkapd a legújabb változtatásait.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Csatlakoztatva';
 
   @override
@@ -15074,6 +15087,94 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Font (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Automatikus frissítések';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Frissítések rendszeres keresése';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'A béta buildek minden változtatásból megjelennek, és a merülési napló adatbázisát a stabil kiadás előtt frissíthetik. Ha később visszaváltasz a stabil csatornára, az alkalmazás nem áll vissza korábbi verzióra, és az együtt szinkronizáló eszközöknek ugyanazt a csatornát érdemes használniuk. Minden adatbázis-frissítés előtt automatikusan biztonsági mentés készül.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Váltás bétára';
+
+  @override
+  String get settings_updates_betaDialogTitle =>
+      'Szeretnél béta frissítéseket kapni?';
+
+  @override
+  String get settings_updates_channel => 'Frissítési csatorna';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Béta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Béta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Új buildek minden változtatásból, a stabil előtt';
+
+  @override
+  String get settings_updates_channelStable => 'Stabil';
+
+  @override
+  String get settings_updates_channelStableSubtitle => 'Csak tesztelt kiadások';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Frissítések keresése';
+
+  @override
+  String get settings_updates_checking => 'Keresés...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Letöltés... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Hiba: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Frissítések';
+
+  @override
+  String get settings_updates_joinBeta => 'Csatlakozz a bétához';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Kapd meg korábban az új funkciókat a bétaprogramon keresztül';
+
+  @override
+  String get settings_updates_lastChecked => 'Utolsó ellenőrzés';
+
+  @override
+  String get settings_updates_never => 'Soha';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'A(z) $version verzió telepítésre kész';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Ezen a bétán maradsz, amíg a következő stabil kiadás nem lesz nála újabb.';
+
+  @override
+  String get settings_updates_upToDate => 'Naprakész';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'A(z) $version verzió elérhető';
+  }
 
   @override
   String get signatures_action_clear => 'Törlés';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -13600,6 +13600,19 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count dispositivi si sincronizzano da una versione più recente di Submersion. Aggiorna questo dispositivo per ricevere le loro ultime modifiche.',
+      one:
+          '1 dispositivo si sincronizza da una versione più recente di Submersion. Aggiorna questo dispositivo per ricevere le sue ultime modifiche.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Connesso';
 
   @override
@@ -15114,6 +15127,93 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Libbre (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Aggiornamenti automatici';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Controlla periodicamente gli aggiornamenti';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Le build beta vengono pubblicate a ogni modifica e possono aggiornare il database del tuo diario immersioni prima della versione stabile. Tornare in seguito al canale stabile non riporterà l\'app a una versione precedente, e tutti i dispositivi che si sincronizzano tra loro dovrebbero usare lo stesso canale. Prima di ogni aggiornamento del database viene eseguito automaticamente un backup.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Passa alla Beta';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'Ricevere aggiornamenti beta?';
+
+  @override
+  String get settings_updates_channel => 'Canale di aggiornamento';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Nuove build a ogni modifica, in anticipo sulla stabile';
+
+  @override
+  String get settings_updates_channelStable => 'Stabile';
+
+  @override
+  String get settings_updates_channelStableSubtitle => 'Solo versioni testate';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Controlla aggiornamenti';
+
+  @override
+  String get settings_updates_checking => 'Controllo in corso...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Download in corso... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Errore: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Aggiornamenti';
+
+  @override
+  String get settings_updates_joinBeta => 'Partecipa alla Beta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Ricevi in anteprima le nuove funzionalità tramite il programma beta';
+
+  @override
+  String get settings_updates_lastChecked => 'Ultimo controllo';
+
+  @override
+  String get settings_updates_never => 'Mai';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Versione $version pronta per l\'installazione';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Rimarrai su questa beta finché la prossima versione stabile non sarà più recente di essa.';
+
+  @override
+  String get settings_updates_upToDate => 'Aggiornato';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Versione $version disponibile';
+  }
 
   @override
   String get signatures_action_clear => 'Cancella';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13495,6 +13495,19 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count apparaten synchroniseren vanaf een nieuwere versie van Submersion. Werk dit apparaat bij om hun nieuwste wijzigingen te ontvangen.',
+      one:
+          '1 apparaat synchroniseert vanaf een nieuwere versie van Submersion. Werk dit apparaat bij om de nieuwste wijzigingen ervan te ontvangen.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Verbonden';
 
   @override
@@ -14991,6 +15004,94 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Pond (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Automatische updates';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Periodiek controleren op updates';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Bètabuilds worden bij elke wijziging gepubliceerd en kunnen de database van je duiklogboek upgraden vóór de stabiele versie. Later terugschakelen naar stabiel zet de app niet terug naar een oudere versie, en alle apparaten die met elkaar synchroniseren moeten hetzelfde kanaal gebruiken. Vóór elke database-upgrade wordt automatisch een back-up gemaakt.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Overschakelen naar bèta';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'Bèta-updates ontvangen?';
+
+  @override
+  String get settings_updates_channel => 'Updatekanaal';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Bèta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Bèta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Nieuwe builds bij elke wijziging, vóór de stabiele versie';
+
+  @override
+  String get settings_updates_channelStable => 'Stabiel';
+
+  @override
+  String get settings_updates_channelStableSubtitle =>
+      'Alleen geteste releases';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Controleren op updates';
+
+  @override
+  String get settings_updates_checking => 'Controleren...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Downloaden... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Fout: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Updates';
+
+  @override
+  String get settings_updates_joinBeta => 'Doe mee aan de bèta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Krijg nieuwe functies eerder via het bètaprogramma';
+
+  @override
+  String get settings_updates_lastChecked => 'Laatst gecontroleerd';
+
+  @override
+  String get settings_updates_never => 'Nooit';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Versie $version klaar om te installeren';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Je blijft op deze bèta totdat de volgende stabiele versie nieuwer is.';
+
+  @override
+  String get settings_updates_upToDate => 'Up-to-date';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Versie $version beschikbaar';
+  }
 
   @override
   String get signatures_action_clear => 'Wissen';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -13606,6 +13606,19 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          '$count dispositivos sincronizam a partir de uma versão mais recente do Submersion. Atualize este dispositivo para receber as alterações mais recentes deles.',
+      one:
+          '1 dispositivo sincroniza a partir de uma versão mais recente do Submersion. Atualize este dispositivo para receber as alterações mais recentes dele.',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => 'Conectado';
 
   @override
@@ -15125,6 +15138,94 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => 'Libras (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => 'Atualizações automáticas';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle =>
+      'Verificar atualizações periodicamente';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'As versões beta são publicadas a cada alteração e podem atualizar o banco de dados do seu registro de mergulhos antes da versão estável. Voltar depois para o canal estável não fará downgrade do app, e todos os dispositivos que sincronizam entre si devem usar o mesmo canal. Um backup é feito automaticamente antes de qualquer atualização do banco de dados.';
+
+  @override
+  String get settings_updates_betaDialogConfirm => 'Mudar para Beta';
+
+  @override
+  String get settings_updates_betaDialogTitle => 'Receber atualizações beta?';
+
+  @override
+  String get settings_updates_channel => 'Canal de atualização';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle =>
+      'Novas versões a cada alteração, antes da estável';
+
+  @override
+  String get settings_updates_channelStable => 'Estável';
+
+  @override
+  String get settings_updates_channelStableSubtitle =>
+      'Apenas versões testadas';
+
+  @override
+  String get settings_updates_checkForUpdates => 'Verificar atualizações';
+
+  @override
+  String get settings_updates_checking => 'Verificando...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return 'Baixando... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return 'Erro: $message';
+  }
+
+  @override
+  String get settings_updates_header => 'Atualizações';
+
+  @override
+  String get settings_updates_joinBeta => 'Participar do Beta';
+
+  @override
+  String get settings_updates_joinBetaSubtitle =>
+      'Receba novos recursos antes através do programa beta';
+
+  @override
+  String get settings_updates_lastChecked => 'Última verificação';
+
+  @override
+  String get settings_updates_never => 'Nunca';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return 'Versão $version pronta para instalar';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      'Você permanecerá nesta beta até que a próxima versão estável seja mais recente que ela.';
+
+  @override
+  String get settings_updates_upToDate => 'Atualizado';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return 'Versão $version disponível';
+  }
 
   @override
   String get signatures_action_clear => 'Limpar';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -12954,6 +12954,17 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_peerRequiresUpdate_banner(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 台设备正在从更新版本的 Submersion 同步。请更新此设备以接收它们的最新更改。',
+      one: '1 台设备正在从更新版本的 Submersion 同步。请更新此设备以接收其最新更改。',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get settings_cloudSync_provider_connected => '已连接';
 
   @override
@@ -14376,6 +14387,90 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_units_weight_pounds => '磅 (lbs)';
+
+  @override
+  String get settings_updates_automaticUpdates => '自动更新';
+
+  @override
+  String get settings_updates_automaticUpdatesSubtitle => '定期检查更新';
+
+  @override
+  String get settings_updates_betaDialogBody =>
+      'Beta 版本会随每次更改发布，可能会先于稳定版升级您的潜水日志数据库。之后切换回稳定版不会降级应用，并且所有相互同步的设备应使用相同的更新渠道。每次数据库升级前都会自动创建备份。';
+
+  @override
+  String get settings_updates_betaDialogConfirm => '切换到 Beta';
+
+  @override
+  String get settings_updates_betaDialogTitle => '接收 Beta 更新？';
+
+  @override
+  String get settings_updates_channel => '更新渠道';
+
+  @override
+  String settings_updates_channelBadgeBeta(String version) {
+    return '$version (Beta)';
+  }
+
+  @override
+  String get settings_updates_channelBeta => 'Beta';
+
+  @override
+  String get settings_updates_channelBetaSubtitle => '每次更改都会发布新版本，先于稳定版';
+
+  @override
+  String get settings_updates_channelStable => '稳定版';
+
+  @override
+  String get settings_updates_channelStableSubtitle => '仅提供经过测试的版本';
+
+  @override
+  String get settings_updates_checkForUpdates => '检查更新';
+
+  @override
+  String get settings_updates_checking => '正在检查...';
+
+  @override
+  String settings_updates_downloading(String progress) {
+    return '正在下载... $progress%';
+  }
+
+  @override
+  String settings_updates_error(String message) {
+    return '错误：$message';
+  }
+
+  @override
+  String get settings_updates_header => '更新';
+
+  @override
+  String get settings_updates_joinBeta => '加入 Beta 计划';
+
+  @override
+  String get settings_updates_joinBetaSubtitle => '通过 Beta 计划抢先体验新功能';
+
+  @override
+  String get settings_updates_lastChecked => '上次检查';
+
+  @override
+  String get settings_updates_never => '从未';
+
+  @override
+  String settings_updates_readyToInstall(String version) {
+    return '版本 $version 已准备好安装';
+  }
+
+  @override
+  String get settings_updates_stableSwitchNotice =>
+      '在下一个稳定版比当前 Beta 版更新之前，将保持在此 Beta 版上。';
+
+  @override
+  String get settings_updates_upToDate => '已是最新版本';
+
+  @override
+  String settings_updates_versionAvailable(String version) {
+    return '版本 $version 可用';
+  }
 
   @override
   String get signatures_action_clear => '清除';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4099,6 +4099,7 @@
   "settings_cloudSync_header_syncBehavior": "Synchronisatiegedrag",
   "settings_cloudSync_lastSynced": "Laatst gesynchroniseerd: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 wachtende wijziging} other{{count} wachtende wijzigingen}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 apparaat synchroniseert vanaf een nieuwere versie van Submersion. Werk dit apparaat bij om de nieuwste wijzigingen ervan te ontvangen.} other{{count} apparaten synchroniseren vanaf een nieuwere versie van Submersion. Werk dit apparaat bij om hun nieuwste wijzigingen te ontvangen.}}",
   "settings_cloudSync_provider_connected": "Verbonden",
   "settings_cloudSync_provider_connectedTo": "Verbonden met {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Verbinding met {providerName} mislukt: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "Gewicht",
   "settings_units_weight_kilograms": "Kilogram (kg)",
   "settings_units_weight_pounds": "Pond (lbs)",
+  "settings_updates_automaticUpdates": "Automatische updates",
+  "settings_updates_automaticUpdatesSubtitle": "Periodiek controleren op updates",
+  "settings_updates_betaDialogBody": "Bètabuilds worden bij elke wijziging gepubliceerd en kunnen de database van je duiklogboek upgraden vóór de stabiele versie. Later terugschakelen naar stabiel zet de app niet terug naar een oudere versie, en alle apparaten die met elkaar synchroniseren moeten hetzelfde kanaal gebruiken. Vóór elke database-upgrade wordt automatisch een back-up gemaakt.",
+  "settings_updates_betaDialogConfirm": "Overschakelen naar bèta",
+  "settings_updates_betaDialogTitle": "Bèta-updates ontvangen?",
+  "settings_updates_channel": "Updatekanaal",
+  "settings_updates_channelBadgeBeta": "{version} (Bèta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Bèta",
+  "settings_updates_channelBetaSubtitle": "Nieuwe builds bij elke wijziging, vóór de stabiele versie",
+  "settings_updates_channelStable": "Stabiel",
+  "settings_updates_channelStableSubtitle": "Alleen geteste releases",
+  "settings_updates_checkForUpdates": "Controleren op updates",
+  "settings_updates_checking": "Controleren...",
+  "settings_updates_downloading": "Downloaden... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Fout: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Updates",
+  "settings_updates_joinBeta": "Doe mee aan de bèta",
+  "settings_updates_joinBetaSubtitle": "Krijg nieuwe functies eerder via het bètaprogramma",
+  "settings_updates_lastChecked": "Laatst gecontroleerd",
+  "settings_updates_never": "Nooit",
+  "settings_updates_readyToInstall": "Versie {version} klaar om te installeren",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Je blijft op deze bèta totdat de volgende stabiele versie nieuwer is.",
+  "settings_updates_upToDate": "Up-to-date",
+  "settings_updates_versionAvailable": "Versie {version} beschikbaar",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Wissen",
   "signatures_action_closeSignatureView": "Handtekeningweergave sluiten",
   "signatures_action_deleteSignature": "Handtekening verwijderen",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4099,6 +4099,7 @@
   "settings_cloudSync_header_syncBehavior": "Comportamento de Sincronizacao",
   "settings_cloudSync_lastSynced": "Ultima sincronizacao: {time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 alteracao pendente} other{{count} alteracoes pendentes}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 dispositivo sincroniza a partir de uma versão mais recente do Submersion. Atualize este dispositivo para receber as alterações mais recentes dele.} other{{count} dispositivos sincronizam a partir de uma versão mais recente do Submersion. Atualize este dispositivo para receber as alterações mais recentes deles.}}",
   "settings_cloudSync_provider_connected": "Conectado",
   "settings_cloudSync_provider_connectedTo": "Conectado a {providerName}",
   "settings_cloudSync_provider_connectionFailed": "Falha na conexao com {providerName}: {error}",
@@ -4526,6 +4527,65 @@
   "settings_units_weight": "Peso",
   "settings_units_weight_kilograms": "Quilogramas (kg)",
   "settings_units_weight_pounds": "Libras (lbs)",
+  "settings_updates_automaticUpdates": "Atualizações automáticas",
+  "settings_updates_automaticUpdatesSubtitle": "Verificar atualizações periodicamente",
+  "settings_updates_betaDialogBody": "As versões beta são publicadas a cada alteração e podem atualizar o banco de dados do seu registro de mergulhos antes da versão estável. Voltar depois para o canal estável não fará downgrade do app, e todos os dispositivos que sincronizam entre si devem usar o mesmo canal. Um backup é feito automaticamente antes de qualquer atualização do banco de dados.",
+  "settings_updates_betaDialogConfirm": "Mudar para Beta",
+  "settings_updates_betaDialogTitle": "Receber atualizações beta?",
+  "settings_updates_channel": "Canal de atualização",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "Novas versões a cada alteração, antes da estável",
+  "settings_updates_channelStable": "Estável",
+  "settings_updates_channelStableSubtitle": "Apenas versões testadas",
+  "settings_updates_checkForUpdates": "Verificar atualizações",
+  "settings_updates_checking": "Verificando...",
+  "settings_updates_downloading": "Baixando... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "Erro: {message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "Atualizações",
+  "settings_updates_joinBeta": "Participar do Beta",
+  "settings_updates_joinBetaSubtitle": "Receba novos recursos antes através do programa beta",
+  "settings_updates_lastChecked": "Última verificação",
+  "settings_updates_never": "Nunca",
+  "settings_updates_readyToInstall": "Versão {version} pronta para instalar",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "Você permanecerá nesta beta até que a próxima versão estável seja mais recente que ela.",
+  "settings_updates_upToDate": "Atualizado",
+  "settings_updates_versionAvailable": "Versão {version} disponível",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "Limpar",
   "signatures_action_closeSignatureView": "Fechar visualização de assinatura",
   "signatures_action_deleteSignature": "Excluir assinatura",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4252,6 +4252,7 @@
   "settings_cloudSync_header_syncBehavior": "同步行为",
   "settings_cloudSync_lastSynced": "上次同步：{time}",
   "settings_cloudSync_pendingChanges": "{count, plural, =1{1 个待同步更改} other{{count} 个待同步更改}}",
+  "settings_cloudSync_peerRequiresUpdate_banner": "{count, plural, =1{1 台设备正在从更新版本的 Submersion 同步。请更新此设备以接收其最新更改。} other{{count} 台设备正在从更新版本的 Submersion 同步。请更新此设备以接收它们的最新更改。}}",
   "settings_cloudSync_provider_connected": "已连接",
   "settings_cloudSync_provider_connectedTo": "已连接到 {providerName}",
   "settings_cloudSync_provider_connectionFailed": "{providerName} 连接失败：{error}",
@@ -4700,6 +4701,65 @@
   "settings_units_weight": "重量",
   "settings_units_weight_kilograms": "千克 (kg)",
   "settings_units_weight_pounds": "磅 (lbs)",
+  "settings_updates_automaticUpdates": "自动更新",
+  "settings_updates_automaticUpdatesSubtitle": "定期检查更新",
+  "settings_updates_betaDialogBody": "Beta 版本会随每次更改发布，可能会先于稳定版升级您的潜水日志数据库。之后切换回稳定版不会降级应用，并且所有相互同步的设备应使用相同的更新渠道。每次数据库升级前都会自动创建备份。",
+  "settings_updates_betaDialogConfirm": "切换到 Beta",
+  "settings_updates_betaDialogTitle": "接收 Beta 更新？",
+  "settings_updates_channel": "更新渠道",
+  "settings_updates_channelBadgeBeta": "{version} (Beta)",
+  "@settings_updates_channelBadgeBeta": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_channelBeta": "Beta",
+  "settings_updates_channelBetaSubtitle": "每次更改都会发布新版本，先于稳定版",
+  "settings_updates_channelStable": "稳定版",
+  "settings_updates_channelStableSubtitle": "仅提供经过测试的版本",
+  "settings_updates_checkForUpdates": "检查更新",
+  "settings_updates_checking": "正在检查...",
+  "settings_updates_downloading": "正在下载... {progress}%",
+  "@settings_updates_downloading": {
+    "placeholders": {
+      "progress": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_error": "错误：{message}",
+  "@settings_updates_error": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_header": "更新",
+  "settings_updates_joinBeta": "加入 Beta 计划",
+  "settings_updates_joinBetaSubtitle": "通过 Beta 计划抢先体验新功能",
+  "settings_updates_lastChecked": "上次检查",
+  "settings_updates_never": "从未",
+  "settings_updates_readyToInstall": "版本 {version} 已准备好安装",
+  "@settings_updates_readyToInstall": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "settings_updates_stableSwitchNotice": "在下一个稳定版比当前 Beta 版更新之前，将保持在此 Beta 版上。",
+  "settings_updates_upToDate": "已是最新版本",
+  "settings_updates_versionAvailable": "版本 {version} 可用",
+  "@settings_updates_versionAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "signatures_action_clear": "清除",
   "signatures_action_closeSignatureView": "关闭签名视图",
   "signatures_action_deleteSignature": "删除签名",

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -349,6 +349,46 @@ platform :mac do
     UI.success("macOS build uploaded to TestFlight!")
   end
 
+  desc "Upload pre-built pkg to TestFlight and distribute to the Public Beta group"
+  lane :upload_testflight_beta do |options|
+    api_key = load_api_key
+    pkg_path = options[:pkg] || "./build/Submersion.pkg"
+
+    UI.message("Uploading pkg to TestFlight (Public Beta): #{pkg_path}")
+    # distribute_external requires waiting for processing so the build can be
+    # assigned to the group; expect several minutes per upload.
+    upload_to_testflight(
+      api_key: api_key,
+      pkg: pkg_path,
+      distribute_external: true,
+      groups: ["Public Beta"],
+      changelog: ENV["BETA_CHANGELOG"] || "Automated beta build.",
+    )
+    UI.success("macOS beta distributed to the Public Beta group!")
+  end
+
+  desc "Submit an already-uploaded build for App Review (no upload)"
+  lane :submit_existing do |options|
+    api_key = load_api_key
+    app_version = options[:app_version] || UI.user_error!("app_version is required")
+    build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
+    upload_to_app_store(
+      api_key: api_key,
+      app_version: app_version,
+      build_number: build_number.to_s,
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      submit_for_review: true,
+      automatic_release: false,
+      precheck_include_in_app_purchases: false,
+      submission_information: { add_id_info_uses_idfa: false },
+    )
+    UI.success("Submitted for review; release manually in App Store Connect on approval.")
+  end
+
   desc "Full release: capture screenshots, upload everything, and submit build"
   lane :full_release do
     screenshots

--- a/scripts/release/promote.sh
+++ b/scripts/release/promote.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Promote a published beta build to the stable channel everywhere.
+#
+# Usage: ./scripts/release/promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]
+#
+# Thin wrapper over the Promote Beta workflow (.github/workflows/promote.yml):
+# verifies the beta exists and shows what will be promoted before dispatching.
+
+set -euo pipefail
+
+BUILD="${1:?Usage: promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]}"
+shift
+ROLLOUT="1.0"
+BUMP="patch"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rollout) ROLLOUT="$2"; shift 2 ;;
+    --bump) BUMP="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
+  -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+if [ -z "$TAG" ]; then
+  echo "Error: no beta release ending in .${BUILD} found in beta-builds." >&2
+  exit 1
+fi
+
+BLOCKERS=$(gh issue list --repo submersion-app/submersion \
+  --label beta-blocker --state open --json number -q 'length')
+if [ "$BLOCKERS" != "0" ]; then
+  echo "Error: $BLOCKERS open beta-blocker issue(s). Resolve before promoting." >&2
+  exit 1
+fi
+
+echo "About to promote $TAG to stable (Play rollout $ROLLOUT, next bump: $BUMP)."
+read -r -p "Continue? [y/N] " answer
+[ "$answer" = "y" ] || { echo "Aborted."; exit 1; }
+
+gh workflow run promote.yml \
+  -f build-number="$BUILD" -f play-rollout="$ROLLOUT" -f next-bump="$BUMP"
+echo "Dispatched. Watch with:"
+echo "  gh run watch \$(gh run list --workflow=promote.yml --limit 1 --json databaseId -q '.[0].databaseId')"

--- a/test/features/auto_update/data/repositories/update_preferences_test.dart
+++ b/test/features/auto_update/data/repositories/update_preferences_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/features/auto_update/data/repositories/update_preferences.dart';
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
 
 void main() {
   late UpdatePreferences prefs;
@@ -54,6 +55,23 @@ void main() {
       final oldTime = DateTime.now().subtract(const Duration(hours: 5));
       await prefs.setLastCheckTime(oldTime);
       expect(prefs.isDueForCheck, true);
+    });
+
+    test('releaseChannel defaults to stable', () {
+      expect(prefs.releaseChannel, ReleaseChannel.stable);
+    });
+
+    test('setReleaseChannel round-trips', () async {
+      await prefs.setReleaseChannel(ReleaseChannel.beta);
+      expect(prefs.releaseChannel, ReleaseChannel.beta);
+    });
+
+    test('releaseChannel tolerates an unknown stored value', () async {
+      SharedPreferences.setMockInitialValues({
+        'update_release_channel': 'nightly',
+      });
+      final tolerant = UpdatePreferences(await SharedPreferences.getInstance());
+      expect(tolerant.releaseChannel, ReleaseChannel.stable);
     });
   });
 }

--- a/test/features/auto_update/data/services/github_update_service_test.dart
+++ b/test/features/auto_update/data/services/github_update_service_test.dart
@@ -91,6 +91,28 @@ void main() {
       expect(available.downloadUrl, contains('Linux.tar.gz'));
     });
 
+    test(
+      '4-segment current version equal to the release tag is up to date',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response(
+            jsonEncode(makeRelease(tagName: 'v1.7.1.118')),
+            200,
+          );
+        });
+
+        final service = GithubUpdateService(
+          owner: owner,
+          repo: repo,
+          currentVersion: '1.7.1.118',
+          platformSuffix: 'Linux.tar.gz',
+          httpClient: client,
+        );
+
+        expect(await service.checkForUpdate(), isA<UpToDate>());
+      },
+    );
+
     test('finds the Windows installer asset by its real suffix', () async {
       final client = MockClient((request) async {
         return http.Response(

--- a/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+++ b/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
+import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
+
+void main() {
+  test('stable channel uses the main repo appcast', () {
+    expect(
+      appcastUrlFor(ReleaseChannel.stable),
+      'https://github.com/submersion-app/submersion/releases/latest/download/appcast.xml',
+    );
+    expect(githubRepoFor(ReleaseChannel.stable), 'submersion');
+  });
+
+  test('beta channel uses the beta-builds superset feed and repo', () {
+    expect(
+      appcastUrlFor(ReleaseChannel.beta),
+      'https://github.com/submersion-app/beta-builds/releases/latest/download/appcast-beta.xml',
+    );
+    expect(githubRepoFor(ReleaseChannel.beta), 'beta-builds');
+  });
+}

--- a/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+++ b/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
@@ -15,7 +15,7 @@ void main() {
   /// the platform-appropriate update service out of it.
   Future<Object?> serviceFor(String? channel) async {
     SharedPreferences.setMockInitialValues({
-      if (channel != null) 'update_release_channel': channel,
+      'update_release_channel': ?channel,
     });
     PackageInfo.setMockInitialValues(
       appName: 'Submersion',

--- a/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
+++ b/test/features/auto_update/presentation/providers/update_feed_selection_test.dart
@@ -1,8 +1,63 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/auto_update/data/services/github_update_service.dart';
+import 'package:submersion/features/auto_update/data/services/sparkle_update_service.dart';
 import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
 import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Builds a container whose preferences carry the given channel and reads
+  /// the platform-appropriate update service out of it.
+  Future<Object?> serviceFor(String? channel) async {
+    SharedPreferences.setMockInitialValues({
+      if (channel != null) 'update_release_channel': channel,
+    });
+    PackageInfo.setMockInitialValues(
+      appName: 'Submersion',
+      packageName: 'app.submersion',
+      version: '1.7.2',
+      buildNumber: '119',
+      buildSignature: '',
+      installerStore: null,
+    );
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+    return container.read(updateServiceProvider.future);
+  }
+
+  test('service provider builds the stable-feed service by default', () async {
+    final service = await serviceFor(null);
+    // The engine differs by host platform (Sparkle on macOS/Windows, GitHub
+    // polling elsewhere); both must point at the stable channel.
+    if (service is SparkleUpdateService) {
+      expect(service.feedUrl, appcastUrlFor(ReleaseChannel.stable));
+    } else {
+      expect(
+        (service as GithubUpdateService).repo,
+        githubRepoFor(ReleaseChannel.stable),
+      );
+    }
+  });
+
+  test('service provider follows the beta channel preference', () async {
+    final service = await serviceFor('beta');
+    if (service is SparkleUpdateService) {
+      expect(service.feedUrl, appcastUrlFor(ReleaseChannel.beta));
+    } else {
+      expect(
+        (service as GithubUpdateService).repo,
+        githubRepoFor(ReleaseChannel.beta),
+      );
+    }
+  });
   test('stable channel uses the main repo appcast', () {
     expect(
       appcastUrlFor(ReleaseChannel.stable),

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1016,6 +1016,33 @@ void main() {
       expect(find.textContaining('First sync is waiting'), findsOneWidget);
     });
 
+    testWidgets('shows the update banner when peers run a newer version', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        selectedProvider: CloudProviderType.icloud,
+        syncState: const SyncState(newerSchemaPeerCount: 2),
+      );
+
+      expect(
+        find.textContaining('newer version of Submersion'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('no update banner when no newer-schema peers were held', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        selectedProvider: CloudProviderType.icloud,
+        syncState: const SyncState(),
+      );
+
+      expect(find.textContaining('newer version of Submersion'), findsNothing);
+    });
+
     testWidgets('shows the replace banner while adoption is pending', (
       tester,
     ) async {

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -1031,6 +1031,27 @@ void main() {
       );
     });
 
+    testWidgets('update banner text is paired with its container colour', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        selectedProvider: CloudProviderType.icloud,
+        syncState: const SyncState(newerSchemaPeerCount: 2),
+      );
+
+      // Material does not re-derive text colour from the Card background, so
+      // without an explicit colour this text falls back to onSurface while the
+      // icon beside it uses onSecondaryContainer.
+      final banner = tester.widget<Text>(
+        find.textContaining('newer version of Submersion'),
+      );
+      final scheme = Theme.of(
+        tester.element(find.textContaining('newer version of Submersion')),
+      ).colorScheme;
+      expect(banner.style?.color, scheme.onSecondaryContainer);
+    });
+
     testWidgets('no update banner when no newer-schema peers were held', (
       tester,
     ) async {

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
@@ -748,6 +749,101 @@ void main() {
 
       expect(tapPrefs.getBool('debug_mode_enabled'), isTrue);
       expect(container.read(debugModeNotifierProvider), isTrue);
+    });
+  });
+
+  group('About section updates card', () {
+    /// Renders the About detail page (which hosts the Updates card) via the
+    /// same GoRouter ?selected= mechanism the appearance tests use.
+    Widget buildAboutWidget(List<Override> overrides) {
+      final router = GoRouter(
+        initialLocation: '/settings?selected=about',
+        routes: [
+          GoRoute(
+            path: '/settings',
+            builder: (context, state) => const SettingsPage(),
+          ),
+        ],
+      );
+      return ProviderScope(
+        overrides: overrides,
+        child: MaterialApp.router(
+          locale: const Locale('en'),
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
+    }
+
+    /// Seeds prefs so the UpdateStatusNotifier's delayed startup check
+    /// short-circuits; tests still pump 6s to drain the timer itself.
+    Future<List<Override>> aboutOverrides({String? channel}) async {
+      SharedPreferences.setMockInitialValues({
+        'auto_update_enabled': false,
+        'update_release_channel': ?channel,
+      });
+      final aboutPrefs = await SharedPreferences.getInstance();
+      // Mirrors getOverrides() but with these prefs; a provider must not be
+      // overridden twice in one container, so the list is built explicitly.
+      return [
+        sharedPreferencesProvider.overrideWithValue(aboutPrefs),
+        logFileServiceProvider.overrideWithValue(logFileService),
+        settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
+        currentDiverIdProvider.overrideWith(
+          (ref) => _MockCurrentDiverIdNotifier(),
+        ),
+        currentDiverProvider.overrideWith((ref) async => null),
+        diverListNotifierProvider.overrideWith(
+          (ref) => _MockDiverListNotifier(),
+        ),
+      ];
+    }
+
+    testWidgets('shows the channel selector on stable', (tester) async {
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      expect(find.text('Update channel'), findsOneWidget);
+      expect(find.text('Stable'), findsOneWidget);
+    });
+
+    testWidgets('switching to beta asks for confirmation first', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Receive beta updates?'), findsOneWidget);
+    });
+
+    testWidgets('version row shows a beta badge on the beta channel', (
+      tester,
+    ) async {
+      PackageInfo.setMockInitialValues(
+        appName: 'Submersion',
+        packageName: 'app.submersion',
+        version: '1.7.2',
+        buildNumber: '119',
+        buildSignature: '',
+        installerStore: null,
+      );
+      await tester.pumpWidget(
+        buildAboutWidget(await aboutOverrides(channel: 'beta')),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      expect(find.textContaining('(Beta)'), findsOneWidget);
     });
   });
 

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -7,6 +7,8 @@ import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/auto_update/domain/entities/update_status.dart';
+import 'package:submersion/features/auto_update/presentation/providers/update_providers.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:submersion/core/providers/provider.dart';
@@ -778,10 +780,15 @@ void main() {
 
     /// Seeds prefs so the UpdateStatusNotifier's delayed startup check
     /// short-circuits; tests still pump 6s to drain the timer itself.
-    Future<List<Override>> aboutOverrides({String? channel}) async {
+    Future<List<Override>> aboutOverrides({
+      String? channel,
+      Map<String, Object> extraPrefs = const {},
+      UpdateStatus? status,
+    }) async {
       SharedPreferences.setMockInitialValues({
         'auto_update_enabled': false,
         'update_release_channel': ?channel,
+        ...extraPrefs,
       });
       final aboutPrefs = await SharedPreferences.getInstance();
       // Mirrors getOverrides() but with these prefs; a provider must not be
@@ -797,6 +804,13 @@ void main() {
         diverListNotifierProvider.overrideWith(
           (ref) => _MockDiverListNotifier(),
         ),
+        // No real update service: channel-switch tests exercise the settings
+        // flow, not Sparkle/GitHub polling.
+        updateServiceProvider.overrideWith((ref) async => null),
+        if (status != null)
+          updateStatusProvider.overrideWith(
+            (ref) => UpdateStatusNotifier(ref)..state = status,
+          ),
       ];
     }
 
@@ -824,6 +838,149 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Receive beta updates?'), findsOneWidget);
+    });
+
+    testWidgets('confirming the beta dialog switches the channel', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Switch to Beta'));
+      await tester.pumpAndSettle();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('update_release_channel'), 'beta');
+      expect(find.text('Beta'), findsOneWidget); // channel row subtitle
+    });
+
+    testWidgets('cancelling the beta dialog keeps the stable channel', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('update_release_channel'), isNull);
+    });
+
+    testWidgets('re-selecting the current channel is a no-op', (tester) async {
+      await tester.pumpWidget(buildAboutWidget(await aboutOverrides()));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Tested releases only'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Receive beta updates?'), findsNothing);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('update_release_channel'), isNull);
+    });
+
+    testWidgets('switching back to stable shows the ride-forward notice', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildAboutWidget(await aboutOverrides(channel: 'beta')),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+
+      await tester.scrollUntilVisible(find.text('Update channel'), 100);
+      await tester.tap(find.text('Update channel'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Tested releases only'));
+      await tester.pumpAndSettle();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('update_release_channel'), 'stable');
+      expect(
+        find.textContaining('until the next stable release'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('status text renders the downloading and ready states', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildAboutWidget(
+          await aboutOverrides(status: const Downloading(progress: 0.42)),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.text('Downloading... 42%'), 100);
+      expect(find.text('Downloading... 42%'), findsOneWidget);
+    });
+
+    testWidgets('status text renders ready-to-install and error states', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildAboutWidget(
+          await aboutOverrides(
+            status: const ReadyToInstall(version: '9.9.9', localPath: '/tmp/x'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(
+        find.text('Version 9.9.9 ready to install'),
+        100,
+      );
+      expect(find.text('Version 9.9.9 ready to install'), findsOneWidget);
+    });
+
+    testWidgets('status text renders the error state', (tester) async {
+      await tester.pumpWidget(
+        buildAboutWidget(
+          await aboutOverrides(status: const UpdateError(message: 'offline')),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.text('Error: offline'), 100);
+      expect(find.text('Error: offline'), findsOneWidget);
+    });
+
+    testWidgets('a recorded last-check time is formatted, not Never', (
+      tester,
+    ) async {
+      final lastCheck = DateTime(2026, 7, 4, 9, 5);
+      await tester.pumpWidget(
+        buildAboutWidget(
+          await aboutOverrides(
+            extraPrefs: {
+              'auto_update_last_check': lastCheck.millisecondsSinceEpoch,
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 6));
+      await tester.scrollUntilVisible(find.text('Last checked'), 100);
+      expect(find.text('7/4/2026 09:05'), findsOneWidget);
+      expect(find.text('Never'), findsNothing);
     });
 
     testWidgets('version row shows a beta badge on the beta channel', (


### PR DESCRIPTION
## Summary

Stacked on #820 (which stacks on #762). Completes the release-channels
program: Phase 3 (in-app channel toggle), Phase 4 (store beta lanes), and
Phase 5 (promotion). Plans:
`docs/superpowers/plans/2026-08-01-release-channels-phase3-channel-ui.md`,
`docs/superpowers/plans/2026-08-02-release-channels-phase4-5-store-promotion.md`.

### Phase 3: channel toggle
- `ReleaseChannel {stable, beta}` preference + Settings picker with a
  one-time beta opt-in dialog (schema-ahead migrations, no downgrade,
  one channel per sync fleet); Sparkle/WinSparkle switch to the
  `beta-builds` superset feed, the Linux poller switches repos; version
  row shows "(Beta)"; fully localized (11 locales), including the
  previously hardcoded Updates card.
- Fixes the Linux perpetual-update-banner bug (3-segment vs 4-segment
  version comparison).
- Cloud Sync page banner when peers publish from a newer schema
  (surfaces Phase 0's sync gate).

### Phase 4: store beta lanes
- New fastlane lanes (legacy lanes untouched): `upload_testflight_beta`
  (iOS + macOS, external distribution to the "Public Beta" group with
  public link), `upload_beta` (Play open-testing track, released).
- `beta.yml` gains three upload jobs; every green merge now reaches
  TestFlight and Play open testing as well as `beta-builds`.
- Enrollment links live in-app and in the README:
  TestFlight https://testflight.apple.com/join/aMD393sB, Play
  https://play.google.com/apps/testing/app.submersion.

### Phase 5: promotion
- `promote.yml` (manual dispatch, `scripts/release/promote.sh` wrapper):
  verifies the chosen beta (checksums, beta-blocker label, source commit
  on main), re-hosts the identical artifacts as the stable GitHub release
  with an appcast entry built from the stored Sparkle signature, promotes
  the same AAB from the Play beta track to production (staged rollout
  supported), submits the existing TestFlight builds for App Review, and
  opens the version-bump PR immediately (App Store trains close on
  release). Partial failures open a tracking issue.

## Test plan
- Full suite green (14,472); analyze clean; workflows YAML-validated;
  Fastfiles syntax-checked
- Store lanes and promotion cannot run pre-merge (live credentials,
  workflow_run/dispatch on default branch). Two monitored acceptance
  events after the stack lands:
  1. First merge to main: watch beta.yml's TestFlight (processing +
     Public Beta assignment, Beta App Review on the first build of the
     train) and Play beta-track jobs.
  2. First promotion (`scripts/release/promote.sh <build>`): a real
     release event; watch all five jobs.
- Reviewer smoke still open from Phase 3: macOS channel switch offering
  the current beta via Sparkle.

## Remaining user setup
- Play Console: after the first beta lands on the beta track, configure
  it as open testing and publish.
- `gh label create beta-blocker` (promotion preflight gate).

## Merge order
#762 -> #820 -> this PR, retargeting and refreshing each successor.