### PR TITLE
fix(dive_log): null dives.computerId before deleting a dive computer

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -291,15 +291,23 @@ class DiveComputerRepository {
 
   /// Delete a dive computer
   ///
-  /// Nulls out FK references in `dive_profiles` and `dive_data_sources` first
-  /// so the delete is not blocked by foreign key constraints.
-  /// The profile/data-source rows are preserved — only the computer link is
-  /// removed.
+  /// Nulls out FK references in `dives`, `dive_profiles`, and
+  /// `dive_data_sources` first so the delete is not blocked by foreign key
+  /// constraints. Dives and their profile/data-source rows are preserved —
+  /// only the computer link is removed.
   Future<void> deleteComputer(String id) async {
     try {
       _log.info('Deleting dive computer: $id');
 
-      // Clear FK references that would block the delete.
+      // Clear FK references that would block the delete. dive_tanks,
+      // quality_findings, dive_data_sources, dive_profile_events, and
+      // tank_pressure_profiles all declare onDelete: KeyAction.setNull in
+      // the schema and are nulled automatically; dives and dive_profiles do
+      // not declare that behavior, so they must be cleared manually here.
+      await _db.customStatement(
+        'UPDATE dives SET computer_id = NULL WHERE computer_id = ?',
+        [id],
+      );
       await _db.customStatement(
         'UPDATE dive_profiles SET computer_id = NULL WHERE computer_id = ?',
         [id],

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -440,6 +440,36 @@ void main() {
       )..where((t) => t.id.equals(computerId))).get();
       expect(computers, isEmpty);
     });
+
+    // Regression test for #654: dives.computerId has no onDelete behavior
+    // in the schema (unlike dive_profiles/dive_data_sources, which declare
+    // onDelete: KeyAction.setNull), and deleteComputer() never nulled it out
+    // manually either -- so deleting a computer that any dive still points
+    // to threw SqliteException(787): FOREIGN KEY constraint failed, and the
+    // computer (along with its already-nulled profile/data-source rows)
+    // was left undeleted.
+    test(
+      'nulls out dives.computerId before deleting instead of throwing FK-787',
+      () async {
+        final computerId = await insertComputer();
+        final diveId = await insertDive(computerId: computerId);
+
+        await repository.deleteComputer(computerId);
+
+        // The dive itself must survive, untouched apart from the FK.
+        final dives = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals(diveId))).get();
+        expect(dives, hasLength(1));
+        expect(dives.first.computerId, isNull);
+
+        // Computer should be deleted.
+        final computers = await (db.select(
+          db.diveComputers,
+        )..where((t) => t.id.equals(computerId))).get();
+        expect(computers, isEmpty);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #654.

## Summary

Deleting a dive computer that any dive still points to threw:

```
SqliteException(787): FOREIGN KEY constraint failed, constraint failed (code 787)
```

Checked every `computer_id` foreign key to `dive_computers` in the schema. Five tables (`dive_tanks`, `quality_findings`, `dive_data_sources`, `dive_profile_events`, `tank_pressure_profiles`) declare `onDelete: KeyAction.setNull` and are nulled automatically by the database on delete. Two do not: `dives.computerId` and `dive_profiles.computerId`, both declared as plain `.references(DiveComputers, #id)()` with no `onDelete` behavior, which SQLite defaults to blocking the delete.

`DiveComputerRepository.deleteComputer()` already worked around this for `dive_profiles` (and redundantly for `dive_data_sources`, which doesn't need it) with a manual `UPDATE ... SET computer_id = NULL` before the delete -- it just never added the equivalent line for `dives`. That's the entire bug.

## Changes

- Adds the missing `UPDATE dives SET computer_id = NULL WHERE computer_id = ?` before the delete, matching the existing pattern already used for `dive_profiles`.

## Confirming: no data loss

Only the `computer_id` column on affected dives is set to `NULL` -- the dive row itself, its profile samples, tanks, notes, GPS, and photos are all untouched. The dive just becomes "no computer assigned," the same as a manually-entered dive. See the discussion on #654 for what's and isn't affected, including the separate (out of scope for this PR) discussion of reattaching dives if the same physical computer is re-paired later.

## Test plan

- [x] New regression test reproducing the exact `SqliteException(787)` against a dive with `computerId` set, confirming it now succeeds and nulls the FK instead of throwing.
- [x] Full `deleteComputer` test group and the repository's error-path tests still pass.
- [x] `flutter analyze`, `dart format` clean.