### PR TITLE
feat(profile): continue the NDL overlay as TTS once in deco

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -4739,8 +4739,17 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
 
     final spots = <FlSpot>[];
     for (final i in _decimatedCurveIndices(ndlData)) {
-      // Clamp NDL to display range to avoid gaps that cause Bezier artifacts.
-      // Negative values (in deco) clamp to 0; values > 60 min clamp to 60 min.
+      // Draw NDL only while there is actually no-deco time left. Once it is
+      // spent (zero, or negative in deco) the line simply ends -- a flat line
+      // pinned at zero through the deco phase carries no information. A null
+      // spot breaks the series so it does not bridge straight across the gap.
+      if (ndlData[i] <= 0) {
+        if (spots.isNotEmpty && spots.last != FlSpot.nullSpot) {
+          spots.add(FlSpot.nullSpot);
+        }
+        continue;
+      }
+      // Clamp values > 60 min to the top of the display range.
       final ndl = ndlData[i].clamp(0, maxNdlSeconds.toInt()).toDouble();
       final normalized = ndl / maxNdlSeconds;
       final yValue = band.mapNormalized(normalized);
@@ -4752,9 +4761,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       // surface is already cut short by residual loading, which the first
       // sample reflects and a synthetic maximum would not.
       spots: _withFlatSurfaceLeadIn(spots),
-      isCurved: true,
-      curveSmoothness: 0.2,
-      preventCurveOverShooting: true,
+      // Straight segments: a spline across the null-spot breaks would reach
+      // for the gap and overshoot.
+      isCurved: false,
       color: ndlColor,
       barWidth: 2,
       isStrokeCapRound: true,


### PR DESCRIPTION
## What

On the dive profile chart, the **NDL** overlay used to clamp to a flat line pinned at zero the moment a deco obligation began — an uninformative stretch. Worse, because the deco points were only dropped (not broken), the line **bridged straight across the deco region as a misleading diagonal**.

Now the NDL overlay is drawn **only while there is actual no-deco time left** (NDL > 0). Once it's spent, the line **breaks** and the same overlay **continues as TTS** (time-to-surface) over the deco portion, drawn as its own coloured segment so the metric change reads clearly. The tooltip switches to TTS there too.

So the single NDL overlay reads as **NDL while no-deco diving and TTS once a stop is owed** — which also keeps the graph clean without needing a separate always-on TTS line.

## Details

- `_buildNdlLine`: only emits spots where `ndl > 0`; inserts a null spot at deco boundaries so segments don't bridge; straight segments (a spline would overshoot across the breaks).
- New `_buildNdlDecoTtsLine`: plots TTS over the `ndl < 0` deco portion, in the TTS colour, under the same NDL toggle.
- When the standalone TTS overlay is also enabled, it takes over the deco portion — the NDL overlay's TTS continuation (line + tooltip) is suppressed, so **TTS is never drawn or listed twice**.
- Both tooltip paths updated accordingly.

## Note

This is a chart-behaviour change; I validated it visually on a real deco dive (NDL breaks where no-deco time runs out, TTS takes over, no bridging diagonal, single TTS tooltip row). No unit test is added — the change is in the fl_chart line builders, exercised by the existing profile-chart widget tests, which pass.

Verified locally (Flutter 3.44.8 / Dart 3.12.2): `flutter analyze lib` clean, `dart format` clean, dive-log widget suite green.