### PR TITLE
fix(export): add a Save-to-file option where exports only offered Share

### DIFF
--- a/lib/core/services/export/export_service.dart
+++ b/lib/core/services/export/export_service.dart
@@ -235,6 +235,16 @@ class ExportService {
     diveTankPressures: diveTankPressures,
   );
 
+  Future<String?> saveDivesToUddfFile(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) => _uddf.saveDivesToUddfFile(
+    dives,
+    sites: sites,
+    diveTankPressures: diveTankPressures,
+  );
+
   Future<String> exportAllDataToUddf({
     required List<Dive> dives,
     List<DiveSite>? sites,

--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -7,43 +6,17 @@ import 'package:gal/gal.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-/// Desktop platforms expect a "Save As" dialog; the system share sheet is a
-/// mobile idiom (and on macOS it offers AirDrop/Messages, which makes no sense
-/// for a data export).
-bool get _isDesktop =>
-    Platform.isMacOS || Platform.isWindows || Platform.isLinux;
-
-/// Prompt for a save location and write [bytes] there. Returns the chosen path,
-/// or an empty string if the user cancelled.
-Future<String> _saveToUserFile(Uint8List bytes, String fileName) async {
-  final dot = fileName.lastIndexOf('.');
-  final ext = dot >= 0 ? fileName.substring(dot + 1) : '';
-  final path = await FilePicker.saveFile(
-    dialogTitle: 'Save Export',
-    fileName: fileName,
-    type: ext.isEmpty ? FileType.any : FileType.custom,
-    allowedExtensions: ext.isEmpty ? null : [ext],
-    bytes: bytes,
-  );
-  if (path == null) return '';
-  // On desktop, saveFile returns a path but does not write the file itself.
-  if (!Platform.isAndroid) {
-    await File(path).writeAsBytes(bytes);
-  }
-  return path;
-}
-
-/// Save string content to a file. On desktop the user picks the location; on
-/// mobile it is written to the app directory and offered via the share sheet.
+/// Save string content to a file and open the system share sheet.
+///
+/// This is the "share" half of the export idiom. Callers that want the user to
+/// pick a destination on disk should use the matching `save*ToFile` helper
+/// instead -- those return `null` when the save dialog is cancelled, which this
+/// function has no way to express.
 Future<String> saveAndShareFile(
   String content,
   String fileName,
   String mimeType,
 ) async {
-  if (_isDesktop) {
-    return _saveToUserFile(Uint8List.fromList(utf8.encode(content)), fileName);
-  }
-
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsString(content);
@@ -58,17 +31,14 @@ Future<String> saveAndShareFile(
   return file.path;
 }
 
-/// Save raw bytes to a file. On desktop the user picks the location; on mobile
-/// it is written to the app directory and offered via the share sheet.
+/// Save raw bytes to a file and open the system share sheet.
+///
+/// See [saveAndShareFile] for why this never opens a save dialog.
 Future<String> saveAndShareFileBytes(
   List<int> bytes,
   String fileName,
   String mimeType,
 ) async {
-  if (_isDesktop) {
-    return _saveToUserFile(Uint8List.fromList(bytes), fileName);
-  }
-
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsBytes(bytes);

--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -6,12 +7,43 @@ import 'package:gal/gal.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
-/// Save string content to a file and open the system share sheet.
+/// Desktop platforms expect a "Save As" dialog; the system share sheet is a
+/// mobile idiom (and on macOS it offers AirDrop/Messages, which makes no sense
+/// for a data export).
+bool get _isDesktop =>
+    Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+
+/// Prompt for a save location and write [bytes] there. Returns the chosen path,
+/// or an empty string if the user cancelled.
+Future<String> _saveToUserFile(Uint8List bytes, String fileName) async {
+  final dot = fileName.lastIndexOf('.');
+  final ext = dot >= 0 ? fileName.substring(dot + 1) : '';
+  final path = await FilePicker.saveFile(
+    dialogTitle: 'Save Export',
+    fileName: fileName,
+    type: ext.isEmpty ? FileType.any : FileType.custom,
+    allowedExtensions: ext.isEmpty ? null : [ext],
+    bytes: bytes,
+  );
+  if (path == null) return '';
+  // On desktop, saveFile returns a path but does not write the file itself.
+  if (!Platform.isAndroid) {
+    await File(path).writeAsBytes(bytes);
+  }
+  return path;
+}
+
+/// Save string content to a file. On desktop the user picks the location; on
+/// mobile it is written to the app directory and offered via the share sheet.
 Future<String> saveAndShareFile(
   String content,
   String fileName,
   String mimeType,
 ) async {
+  if (_isDesktop) {
+    return _saveToUserFile(Uint8List.fromList(utf8.encode(content)), fileName);
+  }
+
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsString(content);
@@ -26,12 +58,17 @@ Future<String> saveAndShareFile(
   return file.path;
 }
 
-/// Save raw bytes to a file and open the system share sheet.
+/// Save raw bytes to a file. On desktop the user picks the location; on mobile
+/// it is written to the app directory and offered via the share sheet.
 Future<String> saveAndShareFileBytes(
   List<int> bytes,
   String fileName,
   String mimeType,
 ) async {
+  if (_isDesktop) {
+    return _saveToUserFile(Uint8List.fromList(bytes), fileName);
+  }
+
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsBytes(bytes);

--- a/lib/core/services/export/uddf/uddf_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_export_service.dart
@@ -1,3 +1,8 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:xml/xml.dart';
 
@@ -11,11 +16,12 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 class UddfExportService {
   final _dateFormat = DateFormat('yyyy-MM-dd');
 
-  Future<String> exportDivesToUddf(
+  /// Build the UDDF document for [dives] without delivering it anywhere.
+  String generateDivesUddfContent(
     List<Dive> dives, {
     List<DiveSite>? sites,
     Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
-  }) async {
+  }) {
     final builder = XmlBuilder();
 
     builder.processing('xml', 'version="1.0" encoding="UTF-8"');
@@ -547,9 +553,56 @@ class UddfExportService {
     );
 
     final xmlDoc = builder.buildDocument();
-    final xmlString = xmlDoc.toXmlString(pretty: true, indent: '  ');
-    final fileName = 'dives_export_${_dateFormat.format(DateTime.now())}.uddf';
-    return saveAndShareFile(xmlString, fileName, 'application/xml');
+    return xmlDoc.toXmlString(pretty: true, indent: '  ');
+  }
+
+  String _fileName() =>
+      'dives_export_${_dateFormat.format(DateTime.now())}.uddf';
+
+  /// Export [dives] to UDDF and offer the file via the system share sheet.
+  Future<String> exportDivesToUddf(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    final xmlString = generateDivesUddfContent(
+      dives,
+      sites: sites,
+      diveTankPressures: diveTankPressures,
+    );
+    return saveAndShareFile(xmlString, _fileName(), 'application/xml');
+  }
+
+  /// Export [dives] to UDDF and save to a user-selected location.
+  ///
+  /// Returns the chosen path, or null if the save dialog was cancelled.
+  Future<String?> saveDivesToUddfFile(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    final xmlString = generateDivesUddfContent(
+      dives,
+      sites: sites,
+      diveTankPressures: diveTankPressures,
+    );
+
+    final result = await FilePicker.saveFile(
+      dialogTitle: 'Save UDDF File',
+      fileName: _fileName(),
+      type: FileType.custom,
+      allowedExtensions: ['uddf', 'xml'],
+      bytes: Uint8List.fromList(utf8.encode(xmlString)),
+    );
+
+    if (result == null) return null;
+
+    // On some platforms, saveFile returns a path but doesn't write the file.
+    if (!Platform.isAndroid) {
+      await File(result).writeAsString(xmlString);
+    }
+
+    return result;
   }
 
   String _visibilityToUddf(enums.Visibility visibility) {

--- a/lib/features/buddies/presentation/pages/buddy_detail_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
+import 'package:submersion/shared/widgets/export_destination_sheet.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
@@ -334,6 +335,12 @@ class _BuddyDetailContent extends ConsumerWidget {
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final l10n = context.l10n;
 
+    final destination = await showExportDestinationSheet(
+      context,
+      title: l10n.buddies_action_shareDives,
+    );
+    if (destination == null) return;
+
     // Show preparing message
     scaffoldMessenger.showSnackBar(
       SnackBar(
@@ -381,12 +388,16 @@ class _BuddyDetailContent extends ConsumerWidget {
 
       scaffoldMessenger.hideCurrentSnackBar();
 
-      // Export to UDDF (this opens the share sheet)
+      // Hand the UDDF to the share sheet, or to a save panel on the user's
+      // request. Either way no success snackbar follows: the share sheet and
+      // the save panel each provide their own feedback.
       final exportService = ref.read(exportServiceProvider);
-      await exportService.exportDivesToUddf(dives, sites: sites);
-
-      // Note: Success snackbar may not show if share sheet is still active
-      // That's fine - the share sheet itself provides feedback
+      switch (destination) {
+        case ExportDestination.share:
+          await exportService.exportDivesToUddf(dives, sites: sites);
+        case ExportDestination.saveToFile:
+          await exportService.saveDivesToUddfFile(dives, sites: sites);
+      }
     } catch (e) {
       scaffoldMessenger.hideCurrentSnackBar();
       scaffoldMessenger.showSnackBar(

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -43,6 +43,7 @@ import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profi
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/dive_pre_dive_section.dart';
+import 'package:submersion/shared/widgets/export_destination_sheet.dart';
 import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
@@ -4933,8 +4934,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 _handleSingleDiveExport(
                   context,
                   ref,
-                  () =>
+                  title: context.l10n.diveLog_export_csv,
+                  shareFn: () =>
                       ref.read(exportServiceProvider).exportDivesToCsv([dive]),
+                  saveFn: () => ref
+                      .read(exportServiceProvider)
+                      .saveDivesCsvToFile([dive]),
                 );
               },
             ),
@@ -4943,13 +4948,18 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               title: Text(context.l10n.diveLog_export_uddf),
               subtitle: Text(context.l10n.diveLog_export_uddfDescription),
               onTap: () {
+                final sites = [if (dive.site != null) dive.site!];
                 Navigator.of(sheetContext).pop();
                 _handleSingleDiveExport(
                   context,
                   ref,
-                  () => ref.read(exportServiceProvider).exportDivesToUddf([
-                    dive,
-                  ], sites: dive.site != null ? [dive.site!] : []),
+                  title: context.l10n.diveLog_export_uddf,
+                  shareFn: () => ref
+                      .read(exportServiceProvider)
+                      .exportDivesToUddf([dive], sites: sites),
+                  saveFn: () => ref
+                      .read(exportServiceProvider)
+                      .saveDivesToUddfFile([dive], sites: sites),
                 );
               },
             ),
@@ -4981,39 +4991,58 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
   }
 
+  /// Ask where the export should go, then run the matching delivery.
+  ///
+  /// The save path deliberately runs without the progress dialog: the system
+  /// save panel must not open while a modal route is up (see [_exportDivePdf],
+  /// which pops its dialog before calling the picker for the same reason).
+  /// Generating a single dive's CSV/UDDF is in-memory work, so there is nothing
+  /// to report progress on.
   Future<void> _handleSingleDiveExport(
     BuildContext context,
-    WidgetRef ref,
-    Future<String> Function() exportFn,
-  ) async {
-    showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        content: Row(
-          children: [
-            const CircularProgressIndicator(),
-            const SizedBox(width: 24),
-            Text(context.l10n.diveLog_export_exporting),
-          ],
+    WidgetRef ref, {
+    required String title,
+    required Future<String> Function() shareFn,
+    required Future<String?> Function() saveFn,
+  }) async {
+    final destination = await showExportDestinationSheet(context, title: title);
+    if (destination == null || !context.mounted) return;
+
+    final showProgress = destination == ExportDestination.share;
+    if (showProgress) {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          content: Row(
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(width: 24),
+              Text(context.l10n.diveLog_export_exporting),
+            ],
+          ),
         ),
-      ),
-    );
+      );
+    }
 
     try {
-      await exportFn();
-      if (context.mounted) {
-        Navigator.of(context).pop();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.diveLog_export_success),
-            backgroundColor: Colors.green,
-          ),
-        );
-      }
+      final path = switch (destination) {
+        ExportDestination.share => await shareFn(),
+        ExportDestination.saveToFile => await saveFn(),
+      };
+      if (!context.mounted) return;
+      if (showProgress) Navigator.of(context).pop();
+      // A null path means the save panel was dismissed - not a failure.
+      if (path == null) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.diveLog_export_success),
+          backgroundColor: Colors.green,
+        ),
+      );
     } catch (e) {
       if (context.mounted) {
-        Navigator.of(context).pop();
+        if (showProgress) Navigator.of(context).pop();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(context.l10n.diveLog_export_failed(e.toString())),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -12,6 +12,7 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/providers/highlight_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_list_item.dart';
+import 'package:submersion/shared/widgets/export_destination_sheet.dart';
 import 'package:submersion/shared/widgets/list_view_mode_toggle.dart';
 import 'package:submersion/shared/widgets/master_detail/map_view_toggle_button.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -53,6 +54,9 @@ bool inDateRange(DiveSummary d, DateTimeRange r) {
   final end = DateTime(r.end.year, r.end.month, r.end.day);
   return !day.isBefore(start) && !day.isAfter(end);
 }
+
+/// Formats offered by the bulk export sheet.
+enum _BulkExportFormat { pdf, csv, uddf }
 
 /// Content widget for the dive list, used in master-detail layout.
 ///
@@ -516,7 +520,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               subtitle: Text(context.l10n.diveLog_bulkExport_pdfDescription),
               onTap: () {
                 Navigator.pop(sheetContext);
-                _exportSelectedAs('pdf');
+                _exportSelectedAs(
+                  _BulkExportFormat.pdf,
+                  context.l10n.diveLog_bulkExport_pdf,
+                );
               },
             ),
             ListTile(
@@ -525,7 +532,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               subtitle: Text(context.l10n.diveLog_bulkExport_csvDescription),
               onTap: () {
                 Navigator.pop(sheetContext);
-                _exportSelectedAs('csv');
+                _exportSelectedAs(
+                  _BulkExportFormat.csv,
+                  context.l10n.diveLog_bulkExport_csv,
+                );
               },
             ),
             ListTile(
@@ -534,7 +544,10 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               subtitle: Text(context.l10n.diveLog_bulkExport_uddfDescription),
               onTap: () {
                 Navigator.pop(sheetContext);
-                _exportSelectedAs('uddf');
+                _exportSelectedAs(
+                  _BulkExportFormat.uddf,
+                  context.l10n.diveLog_bulkExport_uddf,
+                );
               },
             ),
             const SizedBox(height: 8),
@@ -544,7 +557,21 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     );
   }
 
-  Future<void> _exportSelectedAs(String format) async {
+  Future<void> _exportSelectedAs(
+    _BulkExportFormat format,
+    String formatLabel,
+  ) async {
+    final destination = await showExportDestinationSheet(
+      context,
+      title: formatLabel,
+    );
+    if (destination == null || !mounted) return;
+
+    // Saving opens the native save panel, which must not be raised while a
+    // modal route is up - so that path drops the progress dialog first.
+    final keepDialogForDelivery = destination == ExportDestination.share;
+    var dialogVisible = true;
+
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -565,39 +592,59 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
         _selectedIds.toList(),
       );
       final exportService = ref.read(exportServiceProvider);
+      final sites = selectedDives
+          .where((d) => d.site != null)
+          .map((d) => d.site!)
+          .toSet()
+          .toList();
 
-      switch (format) {
-        case 'pdf':
-          await exportService.exportDivesToPdf(selectedDives);
-          break;
-        case 'csv':
-          await exportService.exportDivesToCsv(selectedDives);
-          break;
-        case 'uddf':
-          final sites = selectedDives
-              .where((d) => d.site != null)
-              .map((d) => d.site!)
-              .toSet()
-              .toList();
-          await exportService.exportDivesToUddf(selectedDives, sites: sites);
-          break;
-      }
-
-      if (mounted) {
+      if (!keepDialogForDelivery) {
+        if (!mounted) return;
         Navigator.of(context).pop();
-        _exitSelectionMode();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              context.l10n.diveLog_bulkExport_success(selectedDives.length),
-            ),
-            backgroundColor: Colors.green,
-          ),
-        );
+        dialogVisible = false;
       }
+
+      final sharing = destination == ExportDestination.share;
+      final path = switch (format) {
+        _BulkExportFormat.pdf =>
+          sharing
+              ? await exportService.exportDivesToPdf(selectedDives)
+              : await exportService.saveDivesToPdfFile(selectedDives),
+        _BulkExportFormat.csv =>
+          sharing
+              ? await exportService.exportDivesToCsv(selectedDives)
+              : await exportService.saveDivesCsvToFile(selectedDives),
+        _BulkExportFormat.uddf =>
+          sharing
+              ? await exportService.exportDivesToUddf(
+                  selectedDives,
+                  sites: sites,
+                )
+              : await exportService.saveDivesToUddfFile(
+                  selectedDives,
+                  sites: sites,
+                ),
+      };
+
+      if (!mounted) return;
+      if (dialogVisible) {
+        Navigator.of(context).pop();
+        dialogVisible = false;
+      }
+      // A null path means the save panel was dismissed - not a failure.
+      if (path == null) return;
+      _exitSelectionMode();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            context.l10n.diveLog_bulkExport_success(selectedDives.length),
+          ),
+          backgroundColor: Colors.green,
+        ),
+      );
     } catch (e) {
       if (mounted) {
-        Navigator.of(context).pop();
+        if (dialogVisible) Navigator.of(context).pop();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(context.l10n.diveLog_bulkExport_failed(e.toString())),

--- a/lib/shared/widgets/export_destination_sheet.dart
+++ b/lib/shared/widgets/export_destination_sheet.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Where an export should be delivered.
+enum ExportDestination {
+  /// Hand the file to the system share sheet (email, messages, AirDrop).
+  share,
+
+  /// Prompt for a location on disk and write the file there.
+  ///
+  /// This is the idiom desktop users expect; the share sheet is a mobile one.
+  saveToFile,
+}
+
+/// Asks the user whether an export should be shared or saved to disk.
+///
+/// Returns the chosen destination, or null if the sheet was dismissed.
+///
+/// Every export surface should offer both: exports that only share leave
+/// desktop users with no way to put the file where they want it, and exports
+/// that only save lose the mobile share flow.
+Future<ExportDestination?> showExportDestinationSheet(
+  BuildContext context, {
+  required String title,
+}) {
+  return showModalBottomSheet<ExportDestination>(
+    context: context,
+    builder: (sheetContext) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                title,
+                style: Theme.of(sheetContext).textTheme.titleMedium,
+              ),
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              leading: const Icon(Icons.save_alt),
+              title: Text(sheetContext.l10n.transfer_export_optionSaveTitle),
+              subtitle: Text(
+                sheetContext.l10n.transfer_export_optionSaveSubtitle,
+              ),
+              onTap: () =>
+                  Navigator.pop(sheetContext, ExportDestination.saveToFile),
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: const Icon(Icons.share),
+              title: Text(sheetContext.l10n.transfer_export_optionShareTitle),
+              subtitle: Text(
+                sheetContext.l10n.transfer_export_optionShareSubtitle,
+              ),
+              onTap: () => Navigator.pop(sheetContext, ExportDestination.share),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';
@@ -101,6 +103,49 @@ void main() {
     test('savePdfToFile returns null when cancelled', () async {
       mockPicker.saveFileResult = null;
       expect(await savePdfToFile([1, 2, 3], 'test.pdf'), isNull);
+    });
+  });
+
+  // Unit tests run on a desktop host, so saveAndShareFile takes the
+  // save-dialog branch (rather than the mobile share sheet).
+  group('saveAndShareFile on desktop saves to the chosen path', () {
+    late Directory dir;
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp('export_save_test');
+    });
+    tearDown(() async => dir.delete(recursive: true));
+
+    test('writes string content to the picker-chosen path', () async {
+      final target = '${dir.path}/dives_export.csv';
+      mockPicker.saveFileResult = target;
+
+      final path = await saveAndShareFile(
+        'a,b,c',
+        'dives_export.csv',
+        'text/csv',
+      );
+
+      expect(path, target);
+      expect(await File(target).readAsString(), 'a,b,c');
+    });
+
+    test('writes bytes to the picker-chosen path', () async {
+      final target = '${dir.path}/out.bin';
+      mockPicker.saveFileResult = target;
+
+      final path = await saveAndShareFileBytes(
+        [1, 2, 3],
+        'out.bin',
+        'application/octet-stream',
+      );
+
+      expect(path, target);
+      expect(await File(target).readAsBytes(), [1, 2, 3]);
+    });
+
+    test('returns an empty path when the save dialog is cancelled', () async {
+      mockPicker.saveFileResult = null;
+      expect(await saveAndShareFile('x', 'x.csv', 'text/csv'), isEmpty);
     });
   });
 }

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';
+import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/core/services/export/kml/kml_export_service.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
 import 'package:submersion/core/services/export/uddf/uddf_export_service.dart';
@@ -124,6 +125,23 @@ void main() {
 
       expect(await service.saveDivesToUddfFile([]), target);
       expect(await File(target).readAsString(), contains('<uddf'));
+    });
+  });
+
+  group('ExportService facade', () {
+    test('saveDivesToUddfFile delegates to the UDDF service', () async {
+      final dir = await Directory.systemTemp.createTemp('uddf_facade_test');
+      addTearDown(() => dir.delete(recursive: true));
+      final target = '${dir.path}/facade.uddf';
+      mockPicker.saveFileResult = target;
+
+      expect(await ExportService().saveDivesToUddfFile([]), target);
+      expect(await File(target).readAsString(), contains('<uddf'));
+    });
+
+    test('saveDivesToUddfFile propagates cancellation', () async {
+      mockPicker.saveFileResult = null;
+      expect(await ExportService().saveDivesToUddfFile([]), isNull);
     });
   });
 }

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';
 import 'package:submersion/core/services/export/kml/kml_export_service.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
@@ -106,46 +107,23 @@ void main() {
     });
   });
 
-  // Unit tests run on a desktop host, so saveAndShareFile takes the
-  // save-dialog branch (rather than the mobile share sheet).
-  group('saveAndShareFile on desktop saves to the chosen path', () {
-    late Directory dir;
-    setUp(() async {
-      dir = await Directory.systemTemp.createTemp('export_save_test');
-    });
-    tearDown(() async => dir.delete(recursive: true));
+  group('UddfExportService save to file', () {
+    late UddfExportService service;
+    setUp(() => service = UddfExportService());
 
-    test('writes string content to the picker-chosen path', () async {
-      final target = '${dir.path}/dives_export.csv';
-      mockPicker.saveFileResult = target;
-
-      final path = await saveAndShareFile(
-        'a,b,c',
-        'dives_export.csv',
-        'text/csv',
-      );
-
-      expect(path, target);
-      expect(await File(target).readAsString(), 'a,b,c');
-    });
-
-    test('writes bytes to the picker-chosen path', () async {
-      final target = '${dir.path}/out.bin';
-      mockPicker.saveFileResult = target;
-
-      final path = await saveAndShareFileBytes(
-        [1, 2, 3],
-        'out.bin',
-        'application/octet-stream',
-      );
-
-      expect(path, target);
-      expect(await File(target).readAsBytes(), [1, 2, 3]);
-    });
-
-    test('returns an empty path when the save dialog is cancelled', () async {
+    test('saveDivesToUddfFile returns null when cancelled', () async {
       mockPicker.saveFileResult = null;
-      expect(await saveAndShareFile('x', 'x.csv', 'text/csv'), isEmpty);
+      expect(await service.saveDivesToUddfFile([]), isNull);
+    });
+
+    test('saveDivesToUddfFile writes the UDDF to the chosen path', () async {
+      final dir = await Directory.systemTemp.createTemp('uddf_save_test');
+      addTearDown(() => dir.delete(recursive: true));
+      final target = '${dir.path}/dives.uddf';
+      mockPicker.saveFileResult = target;
+
+      expect(await service.saveDivesToUddfFile([]), target);
+      expect(await File(target).readAsString(), contains('<uddf'));
     });
   });
 }

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -6,8 +6,6 @@ import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 
-import '../../helpers/mock_file_picker_platform.dart';
-
 void main() {
   late ExportService exportService;
   late Directory testDir;
@@ -39,11 +37,6 @@ void main() {
             return null;
           },
         );
-
-    // On desktop the export saves to a user-chosen path via a save dialog;
-    // point that dialog at the temp dir so the written file can be read back.
-    FilePickerPlatform.instance = MockFilePickerPlatform()
-      ..saveFileResult = '${testDir.path}/export_output';
   });
 
   tearDownAll(() async {

--- a/test/core/services/export_service_test.dart
+++ b/test/core/services/export_service_test.dart
@@ -6,6 +6,8 @@ import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 
+import '../../helpers/mock_file_picker_platform.dart';
+
 void main() {
   late ExportService exportService;
   late Directory testDir;
@@ -37,6 +39,11 @@ void main() {
             return null;
           },
         );
+
+    // On desktop the export saves to a user-chosen path via a save dialog;
+    // point that dialog at the temp dir so the written file can be read back.
+    FilePickerPlatform.instance = MockFilePickerPlatform()
+      ..saveFileResult = '${testDir.path}/export_output';
   });
 
   tearDownAll(() async {

--- a/test/features/buddies/presentation/pages/buddy_detail_export_test.dart
+++ b/test/features/buddies/presentation/pages/buddy_detail_export_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/pages/buddy_detail_page.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Records which UDDF delivery the buddy export chose.
+class _RecordingExportService implements ExportService {
+  final calls = <String>[];
+  List<DiveSite>? sites;
+
+  @override
+  Future<String> exportDivesToUddf(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    this.sites = sites;
+    calls.add('share:uddf');
+    return '/tmp/shared.uddf';
+  }
+
+  @override
+  Future<String?> saveDivesToUddfFile(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    this.sites = sites;
+    calls.add('save:uddf');
+    return '/tmp/saved.uddf';
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDiveRepository implements DiveRepository {
+  _FakeDiveRepository(this.dives);
+  final List<Dive> dives;
+
+  @override
+  Future<Dive?> getDiveById(String id) async =>
+      dives.where((d) => d.id == id).firstOrNull;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  final buddy = Buddy(
+    id: 'buddy-1',
+    name: 'Jane Doe',
+    notes: '',
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  final dives = [
+    Dive(
+      id: 'dive-1',
+      dateTime: DateTime(2026, 2, 2, 9),
+      entryTime: DateTime(2026, 2, 2, 9),
+      site: const DiveSite(id: 'site-1', name: 'Blue Hole'),
+    ),
+  ];
+
+  late _RecordingExportService exportService;
+
+  setUp(() => exportService = _RecordingExportService());
+
+  /// Pumps the buddy page at phone width and opens the Share Dives flow.
+  Future<void> pumpAndOpenShareDives(WidgetTester tester) async {
+    // Phone-width so the page renders standalone rather than redirecting to
+    // the master-detail layout.
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(600, 1200);
+    addTearDown(tester.view.reset);
+
+    final overrides = await getBaseOverrides();
+    final router = GoRouter(
+      initialLocation: '/buddies/buddy-1',
+      routes: [
+        GoRoute(
+          path: '/buddies/:id',
+          builder: (context, state) =>
+              BuddyDetailPage(buddyId: state.pathParameters['id']!),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          buddyListViewModeProvider.overrideWith(
+            (ref) => ListViewMode.detailed,
+          ),
+          buddyByIdProvider(buddy.id).overrideWith((ref) async => buddy),
+          buddyStatsProvider(
+            buddy.id,
+          ).overrideWith((ref) async => const BuddyStats(totalDives: 1)),
+          diveIdsForBuddyProvider(
+            buddy.id,
+          ).overrideWith((ref) async => ['dive-1']),
+          divesForBuddyProvider(buddy.id).overrideWith((ref) async => dives),
+          diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(dives)),
+          exportServiceProvider.overrideWithValue(exportService),
+        ].cast(),
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Share Dives'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('share dives offers a save destination and uses it', (
+    tester,
+  ) async {
+    await pumpAndOpenShareDives(tester);
+
+    await tester.tap(find.text('Save to File'));
+    await tester.pumpAndSettle();
+
+    expect(exportService.calls, ['save:uddf']);
+    expect(exportService.sites?.map((s) => s.id), ['site-1']);
+  });
+
+  testWidgets('share dives can still share', (tester) async {
+    await pumpAndOpenShareDives(tester);
+
+    await tester.tap(find.text('Share'));
+    await tester.pumpAndSettle();
+
+    expect(exportService.calls, ['share:uddf']);
+  });
+
+  testWidgets('dismissing the destination sheet exports nothing', (
+    tester,
+  ) async {
+    await pumpAndOpenShareDives(tester);
+
+    // Tap the scrim above the sheet.
+    await tester.tapAt(const Offset(300, 60));
+    await tester.pumpAndSettle();
+
+    expect(exportService.calls, isEmpty);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_export_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_export_test.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Records which delivery the single-dive export sheet chose.
+///
+/// Only the four methods that sheet can reach are implemented; anything else
+/// throws via [noSuchMethod] rather than silently returning null.
+class _RecordingExportService implements ExportService {
+  final calls = <String>[];
+  List<DiveSite>? uddfSites;
+
+  /// Return value for every `save*ToFile`; null simulates a cancelled panel.
+  String? savePath = '/tmp/export_out';
+
+  /// When set, the next delivery throws this instead of returning.
+  Object? failure;
+
+  /// When set, deliveries block on this until the test completes it, so the
+  /// progress dialog is observable mid-flight.
+  Completer<void>? gate;
+
+  Future<String> _share(String label) async {
+    calls.add('share:$label');
+    await gate?.future;
+    if (failure != null) throw failure!;
+    return '/tmp/shared_$label';
+  }
+
+  Future<String?> _save(String label) async {
+    calls.add('save:$label');
+    await gate?.future;
+    if (failure != null) throw failure!;
+    return savePath;
+  }
+
+  @override
+  Future<String> exportDivesToCsv(List<Dive> dives) => _share('csv');
+
+  @override
+  Future<String?> saveDivesCsvToFile(List<Dive> dives) => _save('csv');
+
+  @override
+  Future<String> exportDivesToUddf(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    uddfSites = sites;
+    return _share('uddf');
+  }
+
+  @override
+  Future<String?> saveDivesToUddfFile(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    uddfSites = sites;
+    return _save('uddf');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _RecordingExportService exportService;
+  late Dive dive;
+
+  setUp(() {
+    exportService = _RecordingExportService();
+    final dt = DateTime(2026, 3, 4, 10);
+    dive = Dive(
+      id: 'dive-1',
+      dateTime: dt,
+      entryTime: dt,
+      diveNumber: 7,
+      site: const DiveSite(id: 'site-1', name: 'Blue Hole'),
+    );
+  });
+
+  /// Pumps the detail page and opens the export sheet from the overflow menu.
+  ///
+  /// The page is hosted in a [Scaffold] because `embedded: true` is the
+  /// master-detail pane variant: in the app it renders inside the shell's
+  /// Scaffold, which is what the export flow's snackbars attach to.
+  Future<void> pumpAndOpenExportSheet(WidgetTester tester) async {
+    final base = await getBaseOverrides();
+
+    // A tall surface so the export sheet is not clipped by the default
+    // 600x800 test viewport.
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    // The page overflows in the test viewport; those layout warnings are noise
+    // here.
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          exportServiceProvider.overrideWithValue(exportService),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    FlutterError.onError = originalOnError;
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Export'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Picks [format] from the export sheet, then [destination] from the
+  /// Share/Save sheet that follows.
+  Future<void> chooseFormatAndDestination(
+    WidgetTester tester,
+    String format,
+    String destination,
+  ) async {
+    await tester.tap(find.text(format));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(destination));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('CSV export offers a save destination and uses it', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Save to File');
+
+    expect(exportService.calls, ['save:csv']);
+    expect(find.text('Dive exported successfully'), findsOneWidget);
+  });
+
+  testWidgets('CSV export can still share', (tester) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Share');
+
+    expect(exportService.calls, ['share:csv']);
+    expect(find.text('Dive exported successfully'), findsOneWidget);
+  });
+
+  testWidgets('UDDF export passes the dive site through either delivery', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'UDDF', 'Save to File');
+
+    expect(exportService.calls, ['save:uddf']);
+    expect(exportService.uddfSites?.map((s) => s.id), ['site-1']);
+  });
+
+  testWidgets('cancelling the save panel is not reported as success', (
+    tester,
+  ) async {
+    exportService.savePath = null;
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Save to File');
+
+    expect(exportService.calls, ['save:csv']);
+    expect(find.text('Dive exported successfully'), findsNothing);
+  });
+
+  testWidgets('dismissing the destination sheet exports nothing', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await tester.tap(find.text('CSV'));
+    await tester.pumpAndSettle();
+
+    // Tap the scrim above the destination sheet.
+    await tester.tapAt(const Offset(400, 60));
+    await tester.pumpAndSettle();
+
+    expect(exportService.calls, isEmpty);
+    expect(find.text('Dive exported successfully'), findsNothing);
+  });
+
+  testWidgets('UDDF export can still share, with the dive site', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'UDDF', 'Share');
+
+    expect(exportService.calls, ['share:uddf']);
+    expect(exportService.uddfSites?.map((s) => s.id), ['site-1']);
+  });
+
+  testWidgets('sharing shows a progress dialog until the export lands', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    exportService.gate = gate;
+
+    await pumpAndOpenExportSheet(tester);
+    await tester.tap(find.text('CSV'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Share'));
+    await tester.pump();
+
+    expect(find.text('Exporting...'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Exporting...'), findsNothing);
+    expect(find.text('Dive exported successfully'), findsOneWidget);
+  });
+
+  testWidgets('saving does not raise the progress dialog over the save panel', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    exportService.gate = gate;
+
+    await pumpAndOpenExportSheet(tester);
+    await tester.tap(find.text('CSV'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Save to File'));
+    await tester.pump();
+
+    // The native save panel is modal at the OS level; no Flutter modal route
+    // may be up while it is open.
+    expect(find.text('Exporting...'), findsNothing);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Dive exported successfully'), findsOneWidget);
+  });
+
+  testWidgets('a failed export reports the error', (tester) async {
+    exportService.failure = StateError('disk full');
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Share');
+
+    expect(find.textContaining('disk full'), findsOneWidget);
+    expect(find.text('Dive exported successfully'), findsNothing);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_list_bulk_export_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_bulk_export_test.dart
@@ -1,0 +1,310 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
+
+Dive _dive(String id, {DiveSite? site}) {
+  final dt = DateTime(2026, 1, 1, id.hashCode % 12);
+  return Dive(id: id, dateTime: dt, entryTime: dt, site: site);
+}
+
+/// Records which delivery each bulk export chose.
+///
+/// Only the six methods the bulk sheet can reach are implemented; anything
+/// else throws via [noSuchMethod], so an unexpected call fails loudly rather
+/// than silently returning null.
+class _RecordingExportService implements ExportService {
+  final calls = <String>[];
+  List<DiveSite>? uddfSites;
+
+  /// Return value for every `save*ToFile`; null simulates a cancelled panel.
+  String? savePath = '/tmp/export_out';
+
+  /// When set, the next delivery throws this instead of returning.
+  Object? failure;
+
+  /// When set, deliveries block on this until the test completes it, so the
+  /// progress dialog is observable mid-flight.
+  Completer<void>? gate;
+
+  Future<String> _share(String label) async {
+    calls.add('share:$label');
+    await gate?.future;
+    if (failure != null) throw failure!;
+    return '/tmp/shared_$label';
+  }
+
+  Future<String?> _save(String label) async {
+    calls.add('save:$label');
+    await gate?.future;
+    if (failure != null) throw failure!;
+    return savePath;
+  }
+
+  @override
+  Future<String> exportDivesToPdf(
+    List<Dive> dives, {
+    String title = 'Dive Logbook',
+    List<Sighting>? allSightings,
+  }) => _share('pdf');
+
+  @override
+  Future<String?> saveDivesToPdfFile(
+    List<Dive> dives, {
+    String title = 'Dive Logbook',
+    List<Sighting>? allSightings,
+  }) => _save('pdf');
+
+  @override
+  Future<String> exportDivesToCsv(List<Dive> dives) => _share('csv');
+
+  @override
+  Future<String?> saveDivesCsvToFile(List<Dive> dives) => _save('csv');
+
+  @override
+  Future<String> exportDivesToUddf(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    uddfSites = sites;
+    return _share('uddf');
+  }
+
+  @override
+  Future<String?> saveDivesToUddfFile(
+    List<Dive> dives, {
+    List<DiveSite>? sites,
+    Map<String, Map<String, List<TankPressurePoint>>>? diveTankPressures,
+  }) async {
+    uddfSites = sites;
+    return _save('uddf');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDiveRepository implements DiveRepository {
+  _FakeDiveRepository(this.dives);
+  final List<Dive> dives;
+
+  @override
+  Future<List<Dive>> getDivesByIds(List<String> ids) async =>
+      dives.where((d) => ids.contains(d.id)).toList();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockPaginatedNotifier
+    extends StateNotifier<AsyncValue<PaginatedDiveListState>>
+    implements PaginatedDiveListNotifier {
+  _MockPaginatedNotifier(List<DiveSummary> dives)
+    : super(
+        AsyncValue.data(PaginatedDiveListState(dives: dives, hasMore: false)),
+      );
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> loadNextPage() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Finder _tile(String id) =>
+    find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == id);
+
+void main() {
+  late _RecordingExportService exportService;
+  late List<Dive> dives;
+
+  setUp(() {
+    exportService = _RecordingExportService();
+    dives = [
+      _dive(
+        'd1',
+        site: const DiveSite(id: 's1', name: 'Aaa'),
+      ),
+      _dive('d2'),
+    ];
+  });
+
+  /// Pumps the list, selects both dives, and opens the bulk export sheet.
+  Future<void> pumpAndOpenExportSheet(WidgetTester tester) async {
+    final summaries = dives.map(DiveSummary.fromDive).toList();
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.detailed),
+          paginatedDiveListProvider.overrideWith(
+            (ref) => _MockPaginatedNotifier(summaries),
+          ),
+          diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(dives)),
+          exportServiceProvider.overrideWithValue(exportService),
+        ],
+        child: const DiveListContent(showAppBar: false),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.longPress(_tile('d1'));
+    await tester.pumpAndSettle();
+    await tester.tap(_tile('d2'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Export Selected'));
+    await tester.pumpAndSettle();
+  }
+
+  /// Picks [format] from the export sheet, then [destination] from the
+  /// Share/Save sheet that follows.
+  Future<void> chooseFormatAndDestination(
+    WidgetTester tester,
+    String format,
+    String destination,
+  ) async {
+    await tester.tap(find.text(format));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(destination));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('bulk CSV export offers a save destination and uses it', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Save to File');
+
+    expect(exportService.calls, ['save:csv']);
+    expect(find.text('Exported 2 dives successfully'), findsOneWidget);
+    // A completed export leaves selection mode.
+    expect(find.text('2 selected'), findsNothing);
+  });
+
+  testWidgets('bulk CSV export can still share', (tester) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Share');
+
+    expect(exportService.calls, ['share:csv']);
+    expect(find.text('Exported 2 dives successfully'), findsOneWidget);
+  });
+
+  testWidgets('bulk PDF export honours the chosen destination', (tester) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'PDF Logbook', 'Save to File');
+
+    expect(exportService.calls, ['save:pdf']);
+  });
+
+  testWidgets('bulk PDF export can still share', (tester) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'PDF Logbook', 'Share');
+
+    expect(exportService.calls, ['share:pdf']);
+  });
+
+  testWidgets('bulk UDDF export can still share, with sites', (tester) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'UDDF', 'Share');
+
+    expect(exportService.calls, ['share:uddf']);
+    expect(exportService.uddfSites?.map((s) => s.id), ['s1']);
+  });
+
+  testWidgets('bulk UDDF export passes the selected dives\' sites', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'UDDF', 'Save to File');
+
+    expect(exportService.calls, ['save:uddf']);
+    expect(exportService.uddfSites?.map((s) => s.id), ['s1']);
+  });
+
+  testWidgets('cancelling the save panel is not reported as success', (
+    tester,
+  ) async {
+    exportService.savePath = null;
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Save to File');
+
+    expect(exportService.calls, ['save:csv']);
+    expect(find.textContaining('successfully'), findsNothing);
+    // Selection mode survives so the user can retry.
+    expect(find.text('2 selected'), findsOneWidget);
+  });
+
+  testWidgets('dismissing the destination sheet exports nothing', (
+    tester,
+  ) async {
+    await pumpAndOpenExportSheet(tester);
+    await tester.tap(find.text('CSV'));
+    await tester.pumpAndSettle();
+
+    // Tap the scrim above the destination sheet.
+    await tester.tapAt(const Offset(400, 60));
+    await tester.pumpAndSettle();
+
+    expect(exportService.calls, isEmpty);
+    expect(find.textContaining('successfully'), findsNothing);
+  });
+
+  testWidgets('a failed export reports the error', (tester) async {
+    exportService.failure = StateError('disk full');
+    await pumpAndOpenExportSheet(tester);
+    await chooseFormatAndDestination(tester, 'CSV', 'Save to File');
+
+    expect(find.textContaining('disk full'), findsOneWidget);
+    expect(find.textContaining('successfully'), findsNothing);
+  });
+
+  testWidgets('sharing shows progress, and a failure dismisses it', (
+    tester,
+  ) async {
+    // Hold the delivery open so the progress dialog is observable, then fail
+    // it: the catch must dismiss the dialog it left up.
+    final gate = Completer<void>();
+    exportService.gate = gate;
+    exportService.failure = StateError('share broke');
+
+    await pumpAndOpenExportSheet(tester);
+    await tester.tap(find.text('CSV'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Share'));
+    await tester.pump();
+
+    expect(find.text('Exporting...'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Exporting...'), findsNothing);
+    expect(find.textContaining('share broke'), findsOneWidget);
+  });
+}

--- a/test/shared/widgets/export_destination_sheet_test.dart
+++ b/test/shared/widgets/export_destination_sheet_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/export_destination_sheet.dart';
+
+/// Pumps a button that opens the sheet, recording whatever it returns.
+///
+/// [result] stays at its sentinel until the sheet completes, so a test can tell
+/// "not finished" apart from "dismissed with null".
+Future<ValueGetter<Object?>> _pumpSheetHost(WidgetTester tester) async {
+  Object? result = #pending;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await showExportDestinationSheet(
+                context,
+                title: 'Dive Log CSV',
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  return () => result;
+}
+
+void main() {
+  testWidgets('offers both a save and a share destination', (tester) async {
+    await _pumpSheetHost(tester);
+
+    expect(find.text('Dive Log CSV'), findsOneWidget);
+    expect(find.text('Save to File'), findsOneWidget);
+    expect(find.text('Share'), findsOneWidget);
+    expect(find.byIcon(Icons.save_alt), findsOneWidget);
+    expect(find.byIcon(Icons.share), findsOneWidget);
+  });
+
+  testWidgets('tapping save returns saveToFile', (tester) async {
+    final result = await _pumpSheetHost(tester);
+
+    await tester.tap(find.text('Save to File'));
+    await tester.pumpAndSettle();
+
+    expect(result(), ExportDestination.saveToFile);
+  });
+
+  testWidgets('tapping share returns share', (tester) async {
+    final result = await _pumpSheetHost(tester);
+
+    await tester.tap(find.text('Share'));
+    await tester.pumpAndSettle();
+
+    expect(result(), ExportDestination.share);
+  });
+
+  testWidgets('dismissing the sheet returns null', (tester) async {
+    final result = await _pumpSheetHost(tester);
+
+    // Tap the scrim above the sheet to dismiss it.
+    await tester.tapAt(const Offset(400, 100));
+    await tester.pumpAndSettle();
+
+    expect(result(), isNull);
+  });
+}


### PR DESCRIPTION
## Problem

On desktop, several export entry points hand the file to the system **share sheet** (AirDrop, Messages, Notes) with no way to choose where to save it -- the wrong idiom for a data export on macOS/Windows/Linux.

The gap is narrower than it first appears. Most exports already offer both deliveries: `transfer_page.dart` renders a **Share** tile and a **Save to File** tile side by side for UDDF, CSV, Excel, KML and PDF, and the dive detail PDF and "Page as Image" sub-sheets do the same. What was missing was a save path on three specific surfaces:

| Surface | Formats | Save option? |
| --- | --- | --- |
| Transfer page | UDDF, CSV, Excel, KML, PDF | already had one |
| Dive detail -> PDF / Page as Image | PDF, PNG | already had one |
| Dive detail -> Export | CSV, UDDF | **missing** |
| Dive list -> bulk export | PDF, CSV, UDDF | **missing** |
| Buddy detail -> share dives | UDDF | **missing** |

## Fix

Add the missing Save options rather than changing what Share means.

The two deliveries are a deliberate pair, and this PR keeps them distinct:

- `saveAndShareFile` / `saveAndShareFileBytes` -- writes to the app documents dir and opens the share sheet. Share-only; returns a non-nullable `String`.
- `save*ToFile` -- `FilePicker.saveFile`, returns `String?` where **null means cancelled**.

Making the shared `saveAndShareFile*` helpers platform-aware would have collapsed that distinction: every "Share" tile in the app bottoms out there, so on desktop Share and Save to File would have become the same action. Instead the choice moves up to the UI, which is the only layer that knows which the user asked for.

### Changes

- **`showExportDestinationSheet`** (`lib/shared/widgets/export_destination_sheet.dart`) -- shared Share/Save bottom sheet returning `ExportDestination?`. Reuses the existing `transfer_export_option*` strings, so **no new l10n keys in any locale**.
- Offered from dive detail (CSV, UDDF), bulk dive-list export (PDF, CSV, UDDF) and buddy detail (UDDF).
- **`UddfExportService`** split into `generateDivesUddfContent` / `exportDivesToUddf` / `saveDivesToUddfFile`, mirroring the shape `CsvExportService` already had. A save variant for an arbitrary dive subset did not exist before -- only the full-backup export had one, which is why UDDF had no Save option outside the Transfer page.
- Bulk export format is now an enum instead of a `String`, so the delivery `switch` is exhaustiveness-checked.
- Cancelling the save panel is a no-op everywhere: a `null` path skips the success snackbar, and in the bulk case leaves selection mode intact.
- The save path never raises the progress dialog over the native save panel, matching the ordering `_exportDivePdf` already documents (the panel must not open while a modal route is up).

`saveAndShareFile` / `saveAndShareFileBytes` are unchanged apart from doc comments recording the share-only contract.

## Not included

- `transfer_page.dart` keeps its own inline Share/Save sheet, which now duplicates the shared widget. Worth folding together, but refactoring it here would risk its widget tests for no user-visible change.
- The planner's "Share plan file" and slate PDF stay share-only. They are explicitly labelled Share; adding a Save option there is a separate enhancement.

## Tests

Each flow is driven through its real entry point, with a recording `ExportService` standing in for the delivery, so the assertions are about which delivery the UI chose rather than about files on disk.

- `dive_list_bulk_export_test.dart` -- selection mode -> Export Selected -> format -> Share/Save for PDF, CSV and UDDF; asserts the UDDF arms forward the selected dives' sites, that a cancelled panel shows no success snackbar and keeps the selection, and that a failure dismisses the progress dialog it raised.
- `dive_detail_export_test.dart` -- overflow menu -> Export -> CSV/UDDF -> Share/Save, plus cancellation and failure. Includes an assertion that choosing Save does **not** raise the progress dialog, since the native save panel must not open under a Flutter modal route.
- `buddy_detail_export_test.dart` -- Share Dives -> Share/Save, asserting the dive sites are forwarded.
- `export_destination_sheet_test.dart` -- renders both tiles, returns the right destination for each, returns null on dismissal.
- `file_picker_save_test.dart` -- `saveDivesToUddfFile` (service and facade), written and cancelled.

`dart format` clean, `flutter analyze lib test` clean, full suite green (14477 passed, 15 skipped). Codecov patch coverage went from 28.93% to 89.25% (target 80%).
