### PR TITLE
ci(promote): make the version-bump PR fully automatic

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -250,18 +250,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: promote
     timeout-minutes: 10
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # RELEASE_BOT_TOKEN (fine-grained PAT) instead of github.token: pushes
+      # made with the built-in token never trigger workflows, so CI would not
+      # run on the bump branch and auto-merge would wait forever. A PAT push
+      # fires CI normally and the PR lands itself when checks pass.
       - name: Checkout main
         uses: actions/checkout@v7
         with:
           ref: main
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
-      - name: Bump and open PR
+      - name: Bump and open auto-merging PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -279,7 +281,7 @@ jobs:
           git push origin "$BRANCH"
           gh pr create --base main --head "$BRANCH" \
             --title "chore: bump version to ${NEWVER}" \
-            --body "Opens the next beta train after promoting ${{ needs.promote.outputs.tag }}. Merge promptly: the beta pipeline's train-closed guard fails every merge until this lands. Note: CI does not auto-run on bot-pushed branches; close/reopen the PR or push an empty commit to trigger it."
+            --body "Opens the next beta train after promoting ${{ needs.promote.outputs.tag }}. Auto-merges when checks pass; until it lands, the beta pipeline's train-closed guard fails every merge."
           gh pr merge --auto --merge "$BRANCH" || \
             echo "::warning::Auto-merge unavailable; merge the bump PR manually."
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -255,6 +255,17 @@ jobs:
       # made with the built-in token never trigger workflows, so CI would not
       # run on the bump branch and auto-merge would wait forever. A PAT push
       # fires CI normally and the PR lands itself when checks pass.
+      - name: Require RELEASE_BOT_TOKEN
+        env:
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_BOT_TOKEN" ]; then
+            echo "::error::RELEASE_BOT_TOKEN secret is not configured; the bump" \
+              " branch would push without triggering CI and the PR could never" \
+              " auto-merge. See docs/developer/release-secrets-setup.md."
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v7
         with:
@@ -282,8 +293,14 @@ jobs:
           gh pr create --base main --head "$BRANCH" \
             --title "chore: bump version to ${NEWVER}" \
             --body "Opens the next beta train after promoting ${{ needs.promote.outputs.tag }}. Auto-merges when checks pass; until it lands, the beta pipeline's train-closed guard fails every merge."
-          gh pr merge --auto --merge "$BRANCH" || \
-            echo "::warning::Auto-merge unavailable; merge the bump PR manually."
+          # Fatal, not a warning: a bump PR without auto-merge silently
+          # reintroduces the manual step and leaves the beta train closed.
+          # Failing here makes notify-failures open a tracking issue.
+          gh pr merge --auto --merge "$BRANCH" || {
+            echo "::error::Could not enable auto-merge on the bump PR;" \
+              " merge it manually to reopen the beta train."
+            exit 1
+          }
 
   notify-failures:
     name: Open issue on promotion failure

--- a/docs/developer/release-secrets-setup.md
+++ b/docs/developer/release-secrets-setup.md
@@ -99,6 +99,23 @@ publish per-merge beta releases into `submersion-app/beta-builds`:
 Rotation: regenerate the token and re-run the same command. The workflow
 fails loudly on the next merge to main if the token has expired.
 
+**RELEASE_BOT_TOKEN**
+
+Fine-grained personal access token used by the Promote Beta workflow
+(`promote.yml`) to push the version-bump branch and open its auto-merging
+PR. A PAT is required because pushes made with the built-in `GITHUB_TOKEN`
+never trigger workflows, so CI would not run on the bump branch:
+
+1. Create at https://github.com/settings/personal-access-tokens/new
+2. Resource owner: `submersion-app`
+3. Repository access: only `submersion-app/submersion`
+4. Permissions: Contents - Read and write; Pull requests - Read and write
+5. Set with: `gh secret set RELEASE_BOT_TOKEN --repo submersion-app/submersion`
+
+Also requires repository auto-merge to be enabled (Settings > General >
+"Allow auto-merge"). Rotation: same as BETA_BUILDS_TOKEN; an expired token
+fails the bump-pr job of the next promotion.
+
 ## Verification
 
 After configuring all secrets, trigger a test release:


### PR DESCRIPTION
## Summary

Removes the one manual step left in the promotion flow. The bump-pr job
now pushes its branch and drives gh with the new `RELEASE_BOT_TOKEN`
fine-grained PAT instead of the built-in `GITHUB_TOKEN`. Pushes made with
the built-in token never trigger workflows (GitHub's recursion guard), so
CI never ran on the bump branch and `gh pr merge --auto` waited forever -
promoting previously required a close/reopen dance to kick CI.

With a PAT-authored push, CI runs on the bump branch normally and the
existing auto-merge lands the PR the moment checks pass. Repository
auto-merge has been enabled to support this.

Also documents `RELEASE_BOT_TOKEN` in `docs/developer/release-secrets-setup.md`
(scope: Contents + Pull requests read/write on this repo only).

## Test plan

- YAML validated; no behavior change to any other promote.yml job
- Exercised for real by the next promotion's bump-pr job (the promotion
  flow itself is still awaiting its first live run)