### PR TITLE
ci(beta): retain the newest 30 beta releases

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release list --repo submersion-app/beta-builds \
-            --json tagName --limit 100 -q '.[15:][].tagName' | while read -r tag; do
+            --json tagName --limit 100 -q '.[30:][].tagName' | while read -r tag; do
             echo "Pruning $tag"
             gh release delete "$tag" --repo submersion-app/beta-builds --yes --cleanup-tag
           done


### PR DESCRIPTION
Doubles the beta retention window from 15 to 30 releases (~16 GB of artifacts at ~550 MB per release), giving roughly 30 merges of headroom to promote a well-soaked build before it is pruned. The promote workflow already fails fast if a requested build has been pruned; this just makes that scenario rarer. Tune by editing the `.[30:]` slice in the prune step.