### PR TITLE
feat(release): add --latest and --help to promote.sh

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -58,6 +58,12 @@ jobs:
           BUILD: ${{ inputs.build-number }}
         run: |
           set -euo pipefail
+          # Digits only: BUILD lands in a grep pattern, where e.g. "49.7"
+          # (dot matches anything) could resolve the wrong release.
+          if ! [[ "$BUILD" =~ ^[0-9]+$ ]]; then
+            echo "::error::build-number must be digits only (got: ${BUILD})."
+            exit 1
+          fi
           TAG=$(gh release list --repo submersion-app/beta-builds \
             --json tagName -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
           if [ -z "$TAG" ]; then

--- a/scripts/release/promote.sh
+++ b/scripts/release/promote.sh
@@ -1,29 +1,78 @@
 #!/usr/bin/env bash
 # Promote a published beta build to the stable channel everywhere.
 #
-# Usage: ./scripts/release/promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]
-#
 # Thin wrapper over the Promote Beta workflow (.github/workflows/promote.yml):
 # verifies the beta exists and shows what will be promoted before dispatching.
 
 set -euo pipefail
 
-BUILD="${1:?Usage: promote.sh <build-number> [--rollout FRACTION] [--bump patch|minor|major]}"
-shift
+usage() {
+  cat <<'USAGE'
+Promote a published beta build to the stable channel everywhere.
+
+Usage:
+  promote.sh <build-number> [options]
+  promote.sh --latest [options]
+
+Arguments:
+  <build-number>       Beta build number to promote (the last segment of the
+                       beta version, e.g. 4957 for v1.7.2.4957)
+
+Options:
+  --latest             Promote the newest beta in submersion-app/beta-builds
+  --rollout FRACTION   Play production rollout fraction 0.0-1.0 (default 1.0)
+  --bump LEVEL         Version bump opening the next beta train:
+                       patch | minor | major (default patch)
+  -h, --help           Show this help and exit
+
+What promotion does (no rebuilds; the tested beta artifacts ship as-is):
+  - Tags main and publishes the stable GitHub release + Sparkle appcast
+  - Promotes the identical AAB from the Play beta track to production
+  - Submits the existing TestFlight builds for App Review
+  - Opens the auto-merging version-bump PR for the next beta train
+USAGE
+}
+
+BUILD=""
+LATEST=false
 ROLLOUT="1.0"
 BUMP="patch"
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --rollout) ROLLOUT="$2"; shift 2 ;;
-    --bump) BUMP="$2"; shift 2 ;;
-    *) echo "Unknown option: $1" >&2; exit 1 ;;
+    -h|--help) usage; exit 0 ;;
+    --latest) LATEST=true; shift ;;
+    --rollout) ROLLOUT="${2:?--rollout requires a value}"; shift 2 ;;
+    --bump) BUMP="${2:?--bump requires a value}"; shift 2 ;;
+    -*) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+    *)
+      if [ -n "$BUILD" ]; then
+        echo "Unexpected argument: $1" >&2; usage >&2; exit 1
+      fi
+      BUILD="$1"; shift ;;
   esac
 done
 
-TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
-  -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
-if [ -z "$TAG" ]; then
-  echo "Error: no beta release ending in .${BUILD} found in beta-builds." >&2
+case "$BUMP" in patch|minor|major) ;; *)
+  echo "Error: --bump must be patch, minor, or major (got: $BUMP)" >&2; exit 1 ;;
+esac
+
+if $LATEST; then
+  if [ -n "$BUILD" ]; then
+    echo "Error: give either a build number or --latest, not both." >&2
+    exit 1
+  fi
+  TAG=$(gh release view --repo submersion-app/beta-builds --json tagName -q .tagName)
+  BUILD="${TAG##*.}"
+elif [ -n "$BUILD" ]; then
+  TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
+    -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
+  if [ -z "$TAG" ]; then
+    echo "Error: no beta release ending in .${BUILD} found in beta-builds." >&2
+    exit 1
+  fi
+else
+  usage >&2
   exit 1
 fi
 

--- a/scripts/release/promote.sh
+++ b/scripts/release/promote.sh
@@ -57,6 +57,16 @@ case "$BUMP" in patch|minor|major) ;; *)
   echo "Error: --bump must be patch, minor, or major (got: $BUMP)" >&2; exit 1 ;;
 esac
 
+# The build number is interpolated into a grep pattern and shipped to the
+# promote workflow; anything but digits (e.g. "49.7", where the dot matches
+# any character) could silently resolve the wrong release.
+require_numeric_build() {
+  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: build number must be digits only (got: $1)" >&2
+    exit 1
+  fi
+}
+
 if $LATEST; then
   if [ -n "$BUILD" ]; then
     echo "Error: give either a build number or --latest, not both." >&2
@@ -64,7 +74,9 @@ if $LATEST; then
   fi
   TAG=$(gh release view --repo submersion-app/beta-builds --json tagName -q .tagName)
   BUILD="${TAG##*.}"
+  require_numeric_build "$BUILD"
 elif [ -n "$BUILD" ]; then
+  require_numeric_build "$BUILD"
   TAG=$(gh release list --repo submersion-app/beta-builds --json tagName \
     -q ".[].tagName" | grep -E "\.${BUILD}$" | head -1)
   if [ -z "$TAG" ]; then


### PR DESCRIPTION
## Summary

Two conveniences for the promotion wrapper:

- `promote.sh --latest` resolves the newest beta in
  `submersion-app/beta-builds` and shows its full tag in the confirmation
  prompt, so the common promote-the-top-build case needs no build-number
  lookup.
- `-h`/`--help` prints proper usage, including a summary of what promotion
  actually does. Bare invocation now prints usage instead of a terse
  parameter error, and `--bump` values are validated up front.

## Test plan

Exercised locally: `--help` output, `--latest` (resolved the real newest
beta v1.7.2.4977, aborted at the confirmation prompt), invalid `--bump`
rejected, bare invocation prints usage. `bash -n` clean.