### PR TITLE
fix(release): target the closed Play track until production access is granted

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -53,11 +53,12 @@ platform :android do
   desc "Upload AAB to the beta testing track (PLAY_BETA_TRACK, default alpha), released"
   lane :upload_beta do
     aab_path = find_aab
+    track = beta_track
 
-    UI.message("Uploading to the '#{beta_track}' testing track...")
+    UI.message("Uploading to the '#{track}' testing track...")
     upload_to_play_store(
       aab: aab_path,
-      track: beta_track,
+      track: track,
       release_status: "completed",
       skip_upload_metadata: true,
       skip_upload_changelogs: true,
@@ -65,17 +66,18 @@ platform :android do
       skip_upload_screenshots: true,
     )
 
-    UI.success("AAB released to the '#{beta_track}' track!")
+    UI.success("AAB released to the '#{track}' track!")
   end
 
-  desc "Promote an existing beta-track build to production (no upload)"
+  desc "Promote a build from the beta testing track (PLAY_BETA_TRACK, default alpha) to production"
   lane :promote_to_production do |options|
     version_code = options[:version_code] || UI.user_error!("version_code is required")
     rollout = options[:rollout] || "1.0"
+    track = beta_track
 
-    UI.message("Promoting build #{version_code} from '#{beta_track}' to production (rollout #{rollout})...")
+    UI.message("Promoting build #{version_code} from '#{track}' to production (rollout #{rollout})...")
     upload_to_play_store(
-      track: beta_track,
+      track: track,
       track_promote_to: "production",
       version_code: version_code,
       rollout: rollout,
@@ -100,7 +102,14 @@ platform :android do
   # PLAY_BETA_TRACK to 'beta' in beta.yml/promote.yml (or the default here)
   # once production access is granted.
   def beta_track
-    ENV["PLAY_BETA_TRACK"] || "alpha"
+    track = ENV["PLAY_BETA_TRACK"] || "alpha"
+    unless ["alpha", "beta"].include?(track)
+      UI.user_error!(
+        "PLAY_BETA_TRACK must be 'alpha' (closed testing) or 'beta' " \
+        "(open testing); got '#{track}'."
+      )
+    end
+    track
   end
 
   # Finds the AAB file. Checks for the renamed artifact first (CI),

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -50,14 +50,14 @@ platform :android do
     UI.success("AAB validation passed!")
   end
 
-  desc "Upload AAB to the open-testing (beta) track, released"
+  desc "Upload AAB to the beta testing track (PLAY_BETA_TRACK, default alpha), released"
   lane :upload_beta do
     aab_path = find_aab
 
-    UI.message("Uploading to the open testing (beta) track...")
+    UI.message("Uploading to the '#{beta_track}' testing track...")
     upload_to_play_store(
       aab: aab_path,
-      track: "beta",
+      track: beta_track,
       release_status: "completed",
       skip_upload_metadata: true,
       skip_upload_changelogs: true,
@@ -65,7 +65,7 @@ platform :android do
       skip_upload_screenshots: true,
     )
 
-    UI.success("AAB released to the open testing track!")
+    UI.success("AAB released to the '#{beta_track}' track!")
   end
 
   desc "Promote an existing beta-track build to production (no upload)"
@@ -73,9 +73,9 @@ platform :android do
     version_code = options[:version_code] || UI.user_error!("version_code is required")
     rollout = options[:rollout] || "1.0"
 
-    UI.message("Promoting build #{version_code} from beta to production (rollout #{rollout})...")
+    UI.message("Promoting build #{version_code} from '#{beta_track}' to production (rollout #{rollout})...")
     upload_to_play_store(
-      track: "beta",
+      track: beta_track,
       track_promote_to: "production",
       version_code: version_code,
       rollout: rollout,
@@ -93,6 +93,15 @@ platform :android do
   # ============================================================================
   # Helper Methods
   # ============================================================================
+
+  # The Play track carrying beta builds. 'alpha' (closed testing) until Google
+  # grants production access -- open testing ('beta') is gated behind it, and
+  # running a closed test (12+ testers, 14 days) is what earns it. Flip
+  # PLAY_BETA_TRACK to 'beta' in beta.yml/promote.yml (or the default here)
+  # once production access is granted.
+  def beta_track
+    ENV["PLAY_BETA_TRACK"] || "alpha"
+  end
 
   # Finds the AAB file. Checks for the renamed artifact first (CI),
   # then falls back to the default Flutter build output (local).


### PR DESCRIPTION
## Summary

The first store-lane beta run failed its Play upload with `Precondition
check failed`: this Play account does not yet have production access, and
open testing (the `beta` track) is gated behind it. Closed testing is
available today - and running a closed test with 12+ testers for 14 days
is exactly what earns production access.

Both Android lanes (`upload_beta`, `promote_to_production`) now resolve
their track from `PLAY_BETA_TRACK` (default `alpha`, the closed track).
When Google grants production access, flip the default (or set the env in
`beta.yml`/`promote.yml`) to `beta` to graduate to open testing - one
string, no other changes.

## Setup that pairs with this (Play Console)

1. Testing > Closed testing > alpha track: add countries/regions and a
   tester list (a Google Group works best - joining the group = joining
   the beta), then the opt-in URL
   `https://play.google.com/apps/testing/app.submersion` activates for
   listed testers.
2. After 12+ testers over 14 days, apply for production access.

## Test plan

- `ruby -c` clean; exercised for real by the next merge's beta run
  (the closed track accepts API releases without production access).