### PR TITLE
fix(promote): push the stable tag with RELEASE_BOT_TOKEN

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -46,10 +46,28 @@ jobs:
       semver: ${{ steps.resolve.outputs.semver }}
       build-number: ${{ steps.resolve.outputs.build-number }}
     steps:
+      # RELEASE_BOT_TOKEN, not github.token: the stable tag points at a commit
+      # whose history touches .github/workflows, and GitHub categorically
+      # rejects App tokens (which GITHUB_TOKEN is) pushing any ref that makes
+      # workflow-file changes reachable - there is no grantable `workflows`
+      # permission for it. A user PAT pushing a tag to an existing commit is
+      # allowed. First live promotion failed exactly here (#835).
+      - name: Require RELEASE_BOT_TOKEN
+        env:
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_BOT_TOKEN" ]; then
+            echo "::error::RELEASE_BOT_TOKEN secret is not configured; the" \
+              " stable tag cannot be pushed with the built-in token. See" \
+              " docs/developer/release-secrets-setup.md."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Resolve and verify the beta release
         id: resolve


### PR DESCRIPTION
## Summary

The first live promotion (run 30784942479, tracked in #835) failed at
"Create the stable tag":

```
! [remote rejected] v1.7.2.4977 (refusing to allow a GitHub App to create
  or update workflow `.github/workflows/beta.yml` without `workflows` permission)
```

Root cause: the stable tag points at a commit whose history includes
workflow-file changes, and GitHub categorically rejects App tokens (which
`GITHUB_TOKEN` is) pushing any ref that makes workflow changes reachable -
even a tag to a commit already on main, and there is no `workflows:`
permission grantable in the workflow permissions block. Since
release-channel work routinely touches workflows, every promotion would
hit this.

Fix: the promote job checks out with `RELEASE_BOT_TOKEN` (already used by
bump-pr for the same class of reason), so the tag push is authored by a
user PAT, which may create tags to existing commits. Adds the same
fail-fast guard for the missing-secret case.

No re-run cleanup needed: the failed run pushed nothing (no tag, no
release), so promotion of build 4977 can simply be re-dispatched after
this merges.