### PR TITLE
docs(promote): RELEASE_BOT_TOKEN needs the Workflows permission

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -48,10 +48,12 @@ jobs:
     steps:
       # RELEASE_BOT_TOKEN, not github.token: the stable tag points at a commit
       # whose history touches .github/workflows, and GitHub rejects ANY token
-      # pushing a ref that makes workflow-file changes reachable unless it has
-      # workflow permission - which is not grantable to GITHUB_TOKEN at all,
-      # and on the fine-grained PAT requires "Workflows: Read and write"
-      # (both variants of the rejection were hit live: #835, run 30785339668).
+      # pushing a ref that makes workflow-file changes reachable unless the
+      # token carries the workflow-editing capability. Exact names by token
+      # type: not grantable to GITHUB_TOKEN at all; classic PAT `workflow`
+      # scope; fine-grained PAT "Workflows: Read and write" (what
+      # RELEASE_BOT_TOKEN uses). Both rejection variants were hit live:
+      # #835, run 30785339668.
       - name: Require RELEASE_BOT_TOKEN
         env:
           RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -47,11 +47,11 @@ jobs:
       build-number: ${{ steps.resolve.outputs.build-number }}
     steps:
       # RELEASE_BOT_TOKEN, not github.token: the stable tag points at a commit
-      # whose history touches .github/workflows, and GitHub categorically
-      # rejects App tokens (which GITHUB_TOKEN is) pushing any ref that makes
-      # workflow-file changes reachable - there is no grantable `workflows`
-      # permission for it. A user PAT pushing a tag to an existing commit is
-      # allowed. First live promotion failed exactly here (#835).
+      # whose history touches .github/workflows, and GitHub rejects ANY token
+      # pushing a ref that makes workflow-file changes reachable unless it has
+      # workflow permission - which is not grantable to GITHUB_TOKEN at all,
+      # and on the fine-grained PAT requires "Workflows: Read and write"
+      # (both variants of the rejection were hit live: #835, run 30785339668).
       - name: Require RELEASE_BOT_TOKEN
         env:
           RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}

--- a/docs/developer/release-secrets-setup.md
+++ b/docs/developer/release-secrets-setup.md
@@ -109,7 +109,10 @@ never trigger workflows, so CI would not run on the bump branch:
 1. Create at https://github.com/settings/personal-access-tokens/new
 2. Resource owner: `submersion-app`
 3. Repository access: only `submersion-app/submersion`
-4. Permissions: Contents - Read and write; Pull requests - Read and write
+4. Permissions: Contents - Read and write; Pull requests - Read and write;
+   Workflows - Read and write (required to push the stable tag: it points at
+   commits whose history touches `.github/workflows`, and GitHub rejects the
+   push without this permission)
 5. Set with: `gh secret set RELEASE_BOT_TOKEN --repo submersion-app/submersion`
 
 Also requires repository auto-merge to be enabled (Settings > General >


### PR DESCRIPTION
## Summary

The re-run of the first promotion (run 30785339668) failed at the same
tag-push step with the PAT variant of the workflow-reachability rejection:

```
! [remote rejected] v1.7.2.4977 (refusing to allow a Personal Access Token
  to create or update workflow `.github/workflows/beta.yml` without `workflow` scope)
```

So the check applies to every token type; the difference from #836's
GITHUB_TOKEN case is that for fine-grained PATs the permission is
grantable: Workflows - Read and write.

No code change needed (the workflow already pushes with the PAT). This PR
corrects the promote.yml comment that claimed user PATs were exempt and
adds Workflows to the documented RELEASE_BOT_TOKEN permission set.

Operator action (already requested): edit the RELEASE_BOT_TOKEN
fine-grained PAT to add Workflows: Read and write - the token value is
unchanged, so the secret does not need re-setting - then re-dispatch the
promotion of build 4977 (nothing persisted from either failed run).