### PR TITLE
fix(release): make the version bump sed portable to Linux

### DIFF
--- a/scripts/release/bump_version.sh
+++ b/scripts/release/bump_version.sh
@@ -119,7 +119,10 @@ if [ "$DRY_RUN" = true ]; then
 fi
 
 # --- Update pubspec.yaml ---
-sed -i '' "s/^version: .*/version: ${NEW_FULL}/" "$PUBSPEC"
+# perl, not sed -i: BSD sed (macOS) requires `-i ''` while GNU sed (the
+# promote workflow's ubuntu runner) reads that '' as the script and fails
+# with "can't read s/...: No such file or directory". perl -pi is portable.
+perl -pi -e "s/^version: .*/version: ${NEW_FULL}/" "$PUBSPEC"
 
 # Verify the change
 UPDATED=$(grep '^version:' "$PUBSPEC" | sed 's/version: *//')


### PR DESCRIPTION
## Summary

Promotion run 30786014840 succeeded through the stable release (v1.7.2.4977
is tagged and published) but the bump-pr job failed on its first-ever Linux
execution of `bump_version.sh`:

```
sed: can't read s/^version: .*/version: 1.7.3+120/: No such file or directory
```

BSD sed (macOS, where the script has always run) requires `-i ''`; GNU sed
reads that `''` as the script and the real script as a filename. Replaced
with `perl -pi -e`, the same portable idiom `build-all.yml` already uses
for its in-place pubspec edit.

Verified on macOS: `--dry-run` and a real bump (1.7.2+119 -> 1.7.3+120,
then reverted) both work.

## After merging

Re-run the failed jobs on run 30786014840: `bump-pr` checks out `main`
fresh and picks up the fixed script. (`promote-play` will fail again until
Play production access exists - expected and independent.)