### PR TITLE
fix(promote): atomic tag+release, legacy-run guard, and App Store whatsNew

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -231,10 +231,14 @@ jobs:
           set -euo pipefail
           # Apple requires whatsNew on a new App Store version; deliver reads
           # it from metadata/en-US/release_notes.txt (the only metadata file
-          # we provide, so nothing else is touched). 4000-char Apple limit.
+          # we provide, so nothing else is touched). Truncated in CHARACTERS
+          # (not bytes, which could split a multi-byte UTF-8 sequence and
+          # produce invalid text) below Apple's 4000-char limit, CRLF
+          # normalized.
           mkdir -p ios/fastlane/metadata/en-US macos/fastlane/metadata/en-US
           gh release view "$TAG_NAME" --repo ${{ github.repository }} \
-            --json body -q .body | head -c 3900 \
+            --json body -q .body \
+            | python3 -c 'import sys; sys.stdout.write(sys.stdin.read().replace("\r\n", "\n")[:3900])' \
             > ios/fastlane/metadata/en-US/release_notes.txt
           cp ios/fastlane/metadata/en-US/release_notes.txt \
             macos/fastlane/metadata/en-US/release_notes.txt

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -118,14 +118,6 @@ jobs:
           git merge-base --is-ancestor "${{ steps.resolve.outputs.sha }}" origin/main || {
             echo "::error::Beta source commit is not on main."; exit 1; }
 
-      - name: Create the stable tag
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.resolve.outputs.tag }}" "${{ steps.resolve.outputs.sha }}"
-          git push origin "refs/tags/${{ steps.resolve.outputs.tag }}"
-
       - name: Generate release notes and stable appcast
         env:
           TAG_NAME: ${{ steps.resolve.outputs.tag }}
@@ -145,15 +137,23 @@ jobs:
             release-notes.html > appcast.xml
           python3 -c "import xml.dom.minidom;xml.dom.minidom.parse('appcast.xml')"
 
-      - name: Create the stable GitHub release
+      - name: Create the stable tag and release atomically
         env:
-          GH_TOKEN: ${{ github.token }}
+          # RELEASE_BOT_TOKEN with the Workflows permission: creating the tag
+          # (via --target) is a ref that makes workflow-file changes reachable,
+          # which GitHub rejects for tokens without it.
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           TAG_NAME: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
+          # --target creates the tag together with the release, so release.yml
+          # (triggered by the tag push, now that a PAT pushes it) never
+          # observes a promoted tag without its release - its precheck skips
+          # the legacy rebuild by seeing the release exists.
           # Submersion-* (with hyphen) deliberately excludes the store-only
           # Submersion.pkg, matching the historical stable asset list.
           gh release create "$TAG_NAME" --repo ${{ github.repository }} \
+            --target "${{ steps.resolve.outputs.sha }}" \
             --title "$TAG_NAME" --notes-file release-notes.md --latest \
             promoted/Submersion-* promoted/checksums-sha256.txt \
             appcast.xml release-notes.html
@@ -222,6 +222,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Prepare What's New from the release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.promote.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Apple requires whatsNew on a new App Store version; deliver reads
+          # it from metadata/en-US/release_notes.txt (the only metadata file
+          # we provide, so nothing else is touched). 4000-char Apple limit.
+          mkdir -p ios/fastlane/metadata/en-US macos/fastlane/metadata/en-US
+          gh release view "$TAG_NAME" --repo ${{ github.repository }} \
+            --json body -q .body | head -c 3900 \
+            > ios/fastlane/metadata/en-US/release_notes.txt
+          cp ios/fastlane/metadata/en-US/release_notes.txt \
+            macos/fastlane/metadata/en-US/release_notes.txt
+          test -s ios/fastlane/metadata/en-US/release_notes.txt
 
       - name: Setup Ruby (iOS)
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,45 @@ env:
 
 jobs:
   # ============================================================================
+  # Skip promoted tags: promote.yml creates the tag and its release atomically
+  # (the tag is pushed by a PAT, which - unlike GITHUB_TOKEN - triggers this
+  # workflow). A release that already exists for this tag means it was
+  # promoted from tested beta artifacts and the legacy rebuild must not run,
+  # or it would overwrite those artifacts with a fresh rebuild. Legacy tags
+  # (hotfix escape hatch) have no release yet and proceed normally.
+  # ============================================================================
+  precheck:
+    name: Skip if already promoted
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - name: Check whether this tag already has a release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Retry once: guards the small window between the atomic
+          # release-create call and its tag-push event reaching this workflow.
+          for attempt in 1 2; do
+            if gh release view "$TAG_NAME" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              echo "Release $TAG_NAME already exists (promoted); skipping the legacy rebuild."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            [ "$attempt" -eq 1 ] && sleep 60
+          done
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+  # ============================================================================
   # All platform builds (reusable workflow shared with beta.yml)
   # ============================================================================
   build:
     name: Build all platforms
+    needs: precheck
+    if: needs.precheck.outputs.proceed == 'true'
     uses: ./.github/workflows/build-all.yml
     with:
       version-tag: ${{ github.ref_name }}
@@ -300,8 +335,10 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build, generate-appcast]
-    if: ${{ !cancelled() && !failure() }}
+    needs: [precheck, build, generate-appcast]
+    # The explicit proceed check matters: !cancelled() && !failure() alone
+    # would still run this job when the whole graph was skipped by precheck.
+    if: ${{ !cancelled() && !failure() && needs.precheck.outputs.proceed == 'true' }}
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,27 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # Retry once: guards the small window between the atomic
+          # Fail CLOSED: only a definite HTTP 404 (release genuinely absent)
+          # may let the legacy rebuild proceed. Any other failure - auth, API
+          # outage - errors the job rather than risking a rebuild that would
+          # overwrite a promoted release's artifacts.
+          # Retry once on 404: guards the small window between the atomic
           # release-create call and its tag-push event reaching this workflow.
           for attempt in 1 2; do
-            if gh release view "$TAG_NAME" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            set +e
+            RESPONSE=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
+            STATUS=$?
+            set -e
+            if [ "$STATUS" -eq 0 ]; then
               echo "Release $TAG_NAME already exists (promoted); skipping the legacy rebuild."
               echo "proceed=false" >> "$GITHUB_OUTPUT"
               exit 0
+            fi
+            if ! echo "$RESPONSE" | grep -q "HTTP 404"; then
+              echo "::error::Could not determine whether $TAG_NAME already has a" \
+                " release (non-404 failure); refusing to run the legacy rebuild." \
+                " Response: $RESPONSE"
+              exit 1
             fi
             [ "$attempt" -eq 1 ] && sleep 60
           done

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -298,7 +298,11 @@ platform :ios do
       build_number: build_number.to_s,
       skip_binary_upload: true,
       skip_screenshots: true,
-      skip_metadata: true,
+      # skip_metadata false so deliver uploads metadata/en-US/release_notes.txt
+      # (written by promote.yml from the GitHub release notes) - Apple requires
+      # whatsNew on a new version. Only files present are uploaded, and that is
+      # the only metadata file provided.
+      skip_metadata: false,
       submit_for_review: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -380,7 +380,11 @@ platform :mac do
       build_number: build_number.to_s,
       skip_binary_upload: true,
       skip_screenshots: true,
-      skip_metadata: true,
+      # skip_metadata false so deliver uploads metadata/en-US/release_notes.txt
+      # (written by promote.yml from the GitHub release notes) - Apple requires
+      # whatsNew on a new version. Only files present are uploaded, and that is
+      # the only metadata file provided.
+      skip_metadata: false,
       submit_for_review: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,


### PR DESCRIPTION
## Summary

Hardening from the first successful promotion (run 30786014840 published
stable v1.7.2.4977; three seams surfaced around it):

### 1. Duplicate legacy release run (run 30786036298, cancelled)

`RELEASE_BOT_TOKEN` pushing the stable tag triggers `release.yml` - PAT
pushes fire workflows where `GITHUB_TOKEN` pushes never did, an implicit
assumption the token fix invalidated. The legacy pipeline started a full
rebuild that would have overwritten the promoted release's assets with
rebuilt binaries (defeating promote-not-rebuild). Two changes:

- `promote.yml` creates the tag and release atomically
  (`gh release create --target <sha>`), removing the separate tag push -
  the tag now never exists without its release.
- `release.yml` gains a `precheck` job: if the tag's release already
  exists, the whole graph skips (with a retry to cover event-delivery
  lag). Legacy hotfix tags have no release yet and proceed normally.
  `create-release`'s `!cancelled() && !failure()` condition gets an
  explicit proceed check, since skipped dependencies would otherwise
  satisfy it.

### 2. App Store submission: missing whatsNew

Apple requires What's New text on a new App Store version; the submit
lanes skipped all metadata. `promote.yml` now writes the GitHub release
notes into `metadata/en-US/release_notes.txt` for both platforms
(truncated to Apple's limit), and the `submit_existing` lanes set
`skip_metadata: false` - deliver uploads only files present, and that is
the only metadata file provided.

### 3. Current state of v1.7.2.4977

Published and safe: stable release live with all 9 assets, appcast
serving. Remaining legs to re-run after this and #840 merge: bump-pr
(sed fix) and submit-appstore (this PR). promote-play stays expected-fail
until Play production access exists.