### PR TITLE
chore: bump version to 1.7.3+120

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: submersion
 description: An open-source dive logging application for scuba divers.
 publish_to: 'none'
-version: 1.7.2+119
+version: 1.7.3+120
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Opens the next beta train after promoting v1.7.2.4977. Auto-merges when checks pass; until it lands, the beta pipeline's train-closed guard fails every merge.