### PR TITLE
feat(promote): make promotion re-dispatchable end to end

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -150,8 +150,10 @@ jobs:
           # store leg after the release already published. If the release
           # exists AND its checksums match this beta's, leave it untouched;
           # a checksum mismatch or an ambiguous API failure aborts.
+          # -i prepends the HTTP status line, a protocol-stable format,
+          # rather than grepping gh's free-form error prose.
           set +e
-          RESPONSE=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
+          RESPONSE=$(gh api -i "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
           STATUS=$?
           set -e
           if [ "$STATUS" -eq 0 ]; then
@@ -167,7 +169,7 @@ jobs:
               " skipping creation (re-entrant run)."
             exit 0
           fi
-          if ! echo "$RESPONSE" | grep -q "HTTP 404"; then
+          if ! echo "$RESPONSE" | head -1 | grep -qE '^HTTP/[0-9.]+ 404'; then
             echo "::error::Could not determine whether $TAG_NAME already" \
               " exists: $RESPONSE"
             exit 1
@@ -354,10 +356,17 @@ jobs:
           # merged (pubspec moved past the promoted version) or already be an
           # open PR from the previous attempt - both mean nothing to do here.
           CURRENT_SEMVER=$(grep '^version:' pubspec.yaml | sed 's/version: *//; s/+.*//')
-          if [ "$CURRENT_SEMVER" != "${{ needs.promote.outputs.semver }}" ]; then
-            echo "pubspec is at ${CURRENT_SEMVER}, already past promoted" \
-              " ${{ needs.promote.outputs.semver }}; skipping the bump."
-            exit 0
+          PROMOTED_SEMVER="${{ needs.promote.outputs.semver }}"
+          if [ "$CURRENT_SEMVER" != "$PROMOTED_SEMVER" ]; then
+            HIGHEST=$(printf '%s\n%s\n' "$CURRENT_SEMVER" "$PROMOTED_SEMVER" | sort -V | tail -1)
+            if [ "$HIGHEST" = "$CURRENT_SEMVER" ]; then
+              echo "pubspec is at ${CURRENT_SEMVER}, already past promoted" \
+                " ${PROMOTED_SEMVER}; the bump has landed - skipping."
+              exit 0
+            fi
+            echo "::error::pubspec is at ${CURRENT_SEMVER}, BEHIND the promoted" \
+              " ${PROMOTED_SEMVER} - unexpected state, refusing to bump."
+            exit 1
           fi
           OPEN_BUMP=$(gh pr list --repo ${{ github.repository }} --state open \
             --json headRefName -q '.[] | select(.headRefName | startswith("chore/bump-")) | .headRefName' | head -1)

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -137,7 +137,7 @@ jobs:
             release-notes.html > appcast.xml
           python3 -c "import xml.dom.minidom;xml.dom.minidom.parse('appcast.xml')"
 
-      - name: Create the stable tag and release atomically
+      - name: Create or verify the stable tag and release
         env:
           # RELEASE_BOT_TOKEN with the Workflows permission: creating the tag
           # (via --target) is a ref that makes workflow-file changes reachable,
@@ -146,6 +146,32 @@ jobs:
           TAG_NAME: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
+          # Re-entrancy: a promotion can be re-dispatched to redo a failed
+          # store leg after the release already published. If the release
+          # exists AND its checksums match this beta's, leave it untouched;
+          # a checksum mismatch or an ambiguous API failure aborts.
+          set +e
+          RESPONSE=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -eq 0 ]; then
+            mkdir -p existing && cd existing
+            gh release download "$TAG_NAME" --repo ${{ github.repository }} \
+              -p checksums-sha256.txt
+            if ! diff -q checksums-sha256.txt ../promoted/checksums-sha256.txt; then
+              echo "::error::Release $TAG_NAME already exists with different" \
+                " checksums than beta build ${TAG_NAME}; refusing to touch it."
+              exit 1
+            fi
+            echo "Release $TAG_NAME already published with matching checksums;" \
+              " skipping creation (re-entrant run)."
+            exit 0
+          fi
+          if ! echo "$RESPONSE" | grep -q "HTTP 404"; then
+            echo "::error::Could not determine whether $TAG_NAME already" \
+              " exists: $RESPONSE"
+            exit 1
+          fi
           # --target creates the tag together with the release, so release.yml
           # (triggered by the tag push, now that a PAT pushes it) never
           # observes a promoted tag without its release - its precheck skips
@@ -324,6 +350,21 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: |
           set -euo pipefail
+          # Re-entrancy: on a re-dispatched promotion the bump may already be
+          # merged (pubspec moved past the promoted version) or already be an
+          # open PR from the previous attempt - both mean nothing to do here.
+          CURRENT_SEMVER=$(grep '^version:' pubspec.yaml | sed 's/version: *//; s/+.*//')
+          if [ "$CURRENT_SEMVER" != "${{ needs.promote.outputs.semver }}" ]; then
+            echo "pubspec is at ${CURRENT_SEMVER}, already past promoted" \
+              " ${{ needs.promote.outputs.semver }}; skipping the bump."
+            exit 0
+          fi
+          OPEN_BUMP=$(gh pr list --repo ${{ github.repository }} --state open \
+            --json headRefName -q '.[] | select(.headRefName | startswith("chore/bump-")) | .headRefName' | head -1)
+          if [ -n "$OPEN_BUMP" ]; then
+            echo "Bump PR from branch ${OPEN_BUMP} is already open; skipping."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           ./scripts/release/bump_version.sh --${{ inputs.next-bump }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
           # release-create call and its tag-push event reaching this workflow.
           for attempt in 1 2; do
             set +e
-            RESPONSE=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
+            # -i prepends the HTTP status line, a protocol-stable format,
+            # rather than grepping gh's free-form error prose.
+            RESPONSE=$(gh api -i "repos/${{ github.repository }}/releases/tags/${TAG_NAME}" 2>&1)
             STATUS=$?
             set -e
             if [ "$STATUS" -eq 0 ]; then
@@ -65,7 +67,7 @@ jobs:
               echo "proceed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            if ! echo "$RESPONSE" | grep -q "HTTP 404"; then
+            if ! echo "$RESPONSE" | head -1 | grep -qE '^HTTP/[0-9.]+ 404'; then
               echo "::error::Could not determine whether $TAG_NAME already has a" \
                 " release (non-404 failure); refusing to run the legacy rebuild." \
                 " Response: $RESPONSE"

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -108,7 +108,7 @@ a build number above the current commit count. Expected to be rare.
 | TestFlight upload slow (~10+ min) | External distribution waits for Apple build processing | Normal; 45-minute job timeout absorbs it |
 | Testers not seeing a new TestFlight build | First build of a new version train awaits Beta App Review | Normal; once per train, internal testers unaffected |
 | Promotion: "pruned or never built" | The build aged out of the newest-30 window | Promote a retained build instead |
-| Store upload leg failed after release published | Legs are independent | Fix the cause and re-run just that leg via workflow re-run |
+| Store upload leg failed after release published | Legs are independent | Fix the cause, then dispatch the SAME promotion again - it is re-entrant (existing release is verified by checksum and left untouched; a merged or already-open bump PR is skipped). Avoid GitHub's "re-run failed jobs": it replays the workflow definition pinned at the original run, without any fixes merged since |
 
 ## Pointers
 


### PR DESCRIPTION
## Summary

Closes the last operational gap the first live promotion exposed: when a
store leg fails after the GitHub release publishes, there was no clean way
to finish. Re-dispatching died at release creation (already exists), and
GitHub's "re-run failed jobs" replays the workflow definition pinned at
the original run - meaning fixes merged after the run started never apply
(exactly what happened with the whatsNew fix on attempt 2).

With this change, the recovery for any partial promotion failure is:
merge the fix, then dispatch the SAME promotion again.

- **Release step**: if the release already exists, its
  `checksums-sha256.txt` is diffed against the beta's - matching content
  skips creation and proceeds; a mismatch or ambiguous API failure aborts
  (same fail-closed posture as release.yml's precheck).
- **Bump job**: skips when `pubspec` already moved past the promoted
  version (bump merged) or a `chore/bump-*` PR is already open (bump
  pending) - otherwise a re-dispatch would double-bump or fail pushing an
  existing branch.
- Unchanged legs (`promote-play`, `submit-appstore`) were already
  idempotent: Play track promotion of an already-promoted build no-ops,
  and deliver reuses the existing App Store version record.
- Runbook updated: re-dispatch, don't re-run failed jobs.

## Test plan

- YAML validated; guard logic is straight-line bash mirroring the
  fail-closed pattern already reviewed in #841
- Live proof on the next partial failure (or the next promotion of an
  already-released build, which now verifies-and-skips instead of failing)