### PR TITLE
fix(uddf): import the spec ppO2 elements and map UDDF circuit names

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -569,11 +569,9 @@ class UddfFullImportService {
         beforeElement,
         'divemode',
       );
-      if (diveModeStr != null) {
-        diveData['diveMode'] = UddfImportParsers.parseEnumValue(
-          diveModeStr,
-          enums.DiveMode.values,
-        );
+      final diveMode = UddfImportParsers.parseUddfDiveMode(diveModeStr);
+      if (diveMode != null) {
+        diveData['diveMode'] = diveMode;
       }
 
       // Parse planned dive flag
@@ -1557,6 +1555,7 @@ class UddfFullImportService {
       GasMix? pendingSwitchMix;
       double? lastWaypointCns;
       double? lastWaypointOtu;
+      enums.DiveMode? waypointDiveMode;
 
       // Cell readings reference sensors declared once per document, so the
       // order is resolved before walking the samples.
@@ -1761,6 +1760,17 @@ class UddfFullImportService {
           point['o2Sensor${index + 1}'] = value;
         });
 
+        // Shearwater and other computers mark the circuit per sample rather
+        // than on the dive. A dive that runs closed circuit for any part of
+        // it is a rebreather dive; bailout segments switch the samples to
+        // open circuit without changing that.
+        final waypointMode = UddfImportParsers.parseUddfDiveMode(
+          waypoint.findElements('divemode').firstOrNull?.getAttribute('type'),
+        );
+        if (waypointMode != null && waypointMode != enums.DiveMode.oc) {
+          waypointDiveMode = waypointMode;
+        }
+
         final ndlText = UddfImportParsers.getElementText(
           waypoint,
           'nodecotime',
@@ -1833,6 +1843,10 @@ class UddfFullImportService {
 
       if (profile.isNotEmpty) {
         diveData['profile'] = profile;
+      }
+      // Only fills the gap: an explicit dive-level mode always wins.
+      if (waypointDiveMode != null && diveData['diveMode'] == null) {
+        diveData['diveMode'] = waypointDiveMode;
       }
       if (lastWaypointCns != null) {
         diveData['cnsEnd'] = lastWaypointCns;

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1124,29 +1124,10 @@ class UddfFullImportService {
       }
     }
 
-    // Parse setpoint and ppO2 from waypoints (sensor readings)
-    final samplesElement = diveElement.findElements('samples').firstOrNull;
-    if (samplesElement != null) {
-      final existingProfile =
-          diveData['profile'] as List<Map<String, dynamic>>?;
-      if (existingProfile != null) {
-        // Enrich existing profile points with setpoint/ppO2
-        int idx = 0;
-        for (final waypoint in samplesElement.findElements('waypoint')) {
-          final sp = UddfImportParsers.getElementText(waypoint, 'setpoint');
-          final ppo2 = UddfImportParsers.getElementText(waypoint, 'ppo2');
-          if ((sp != null || ppo2 != null) && idx < existingProfile.length) {
-            if (sp != null) {
-              existingProfile[idx]['setpoint'] = double.tryParse(sp);
-            }
-            if (ppo2 != null) {
-              existingProfile[idx]['ppO2'] = double.tryParse(ppo2);
-            }
-          }
-          idx++;
-        }
-      }
-    }
+    // Oxygen sample data (setpoint, ppO2, per-cell readings) is parsed with
+    // the rest of the waypoint in _parseUddfDive. Enriching the profile in a
+    // second pass here would index waypoints against profile points, which
+    // drift apart as soon as a waypoint is dropped for lacking a depth.
 
     return diveData;
   }
@@ -1577,6 +1558,13 @@ class UddfFullImportService {
       double? lastWaypointCns;
       double? lastWaypointOtu;
 
+      // Cell readings reference sensors declared once per document, so the
+      // order is resolved before walking the samples.
+      final document = diveElement.document;
+      final o2SensorOrder = document == null
+          ? const <String>[]
+          : UddfImportParsers.parseO2SensorOrder(document);
+
       for (final waypoint in samplesElement.findElements('waypoint')) {
         final point = <String, dynamic>{};
 
@@ -1730,6 +1718,48 @@ class UddfFullImportService {
             lastWaypointOtu = otu;
           }
         }
+
+        // Oxygen data. The spec elements are <setpo2> (setpoint),
+        // <calculatedpo2> (a single aggregate ppO2) and <measuredpo2 ref>
+        // (one per cell). <setpoint> and bare <ppo2> are the non-standard
+        // names our own exporter writes, kept so our files round-trip.
+        final setpoint =
+            UddfImportParsers.parsePartialPressureBar(
+              UddfImportParsers.getElementText(waypoint, 'setpo2'),
+            ) ??
+            UddfImportParsers.parsePartialPressureBar(
+              UddfImportParsers.getElementText(waypoint, 'setpoint'),
+            );
+        if (setpoint != null) {
+          point['setpoint'] = setpoint;
+        }
+
+        // A <measuredpo2> or <ppo2> without a ref names no cell, so it is an
+        // aggregate loop value rather than a per-cell reading.
+        final bareLoopPpO2 =
+            [
+              ...waypoint.findElements('measuredpo2'),
+              ...waypoint.findElements('ppo2'),
+            ].where((element) {
+              final ref = element.getAttribute('ref')?.trim();
+              return ref == null || ref.isEmpty;
+            }).firstOrNull;
+        final ppO2 =
+            UddfImportParsers.parsePartialPressureBar(
+              UddfImportParsers.getElementText(waypoint, 'calculatedpo2'),
+            ) ??
+            UddfImportParsers.parsePartialPressureBar(bareLoopPpO2?.innerText);
+        if (ppO2 != null) {
+          point['ppO2'] = ppO2;
+        }
+
+        final sensorReadings = UddfImportParsers.parseO2SensorReadings(
+          waypoint,
+          o2SensorOrder,
+        );
+        sensorReadings.forEach((index, value) {
+          point['o2Sensor${index + 1}'] = value;
+        });
 
         final ndlText = UddfImportParsers.getElementText(
           waypoint,

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -565,11 +565,7 @@ class UddfFullImportService {
       }
 
       // Parse dive mode
-      final diveModeStr = UddfImportParsers.getElementText(
-        beforeElement,
-        'divemode',
-      );
-      final diveMode = UddfImportParsers.parseUddfDiveMode(diveModeStr);
+      final diveMode = UddfImportParsers.parseDiveModeIn(beforeElement);
       if (diveMode != null) {
         diveData['diveMode'] = diveMode;
       }
@@ -1009,15 +1005,9 @@ class UddfFullImportService {
         .findElements('rebreather')
         .firstOrNull;
     if (rebreatherElement != null) {
-      final diveMode = UddfImportParsers.getElementText(
-        rebreatherElement,
-        'divemode',
-      );
+      final diveMode = UddfImportParsers.parseDiveModeIn(rebreatherElement);
       if (diveMode != null) {
-        diveData['diveMode'] = UddfImportParsers.parseEnumValue(
-          diveMode,
-          enums.DiveMode.values,
-        );
+        diveData['diveMode'] = diveMode;
       }
       // CCR setpoints
       final spLow = UddfImportParsers.getElementText(
@@ -1764,9 +1754,7 @@ class UddfFullImportService {
         // than on the dive. A dive that runs closed circuit for any part of
         // it is a rebreather dive; bailout segments switch the samples to
         // open circuit without changing that.
-        final waypointMode = UddfImportParsers.parseUddfDiveMode(
-          waypoint.findElements('divemode').firstOrNull?.getAttribute('type'),
-        );
+        final waypointMode = UddfImportParsers.parseDiveModeIn(waypoint);
         if (waypointMode != null && waypointMode != enums.DiveMode.oc) {
           waypointDiveMode = waypointMode;
         }

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -42,6 +42,23 @@ class UddfImportParsers {
   /// Maximum O2 cells the profile schema can hold (o2Sensor1..o2Sensor6).
   static const int maxO2Sensors = 6;
 
+  /// Resolves a UDDF circuit name to a dive mode.
+  ///
+  /// UDDF spells the circuit out (`closedcircuit`), while our own exporter
+  /// writes the enum name (`ccr`), so both are accepted. Apnea has no
+  /// equivalent mode and stays unresolved rather than being forced to gauge.
+  static enums.DiveMode? parseUddfDiveMode(String? value) {
+    final normalized = value?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) return null;
+
+    return switch (normalized) {
+      'closedcircuit' => enums.DiveMode.ccr,
+      'semiclosedcircuit' => enums.DiveMode.scr,
+      'opencircuit' => enums.DiveMode.oc,
+      _ => parseEnumValue(normalized, enums.DiveMode.values),
+    };
+  }
+
   /// Parses a UDDF partial pressure into bar.
   ///
   /// The spec mandates Pascal (`1.27e5` for 1.27 bar), but exporters are

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -39,6 +39,86 @@ class UddfImportParsers {
         : element?.innerText.trim();
   }
 
+  /// Maximum O2 cells the profile schema can hold (o2Sensor1..o2Sensor6).
+  static const int maxO2Sensors = 6;
+
+  /// Parses a UDDF partial pressure into bar.
+  ///
+  /// The spec mandates Pascal (`1.27e5` for 1.27 bar), but exporters are
+  /// inconsistent: Shearwater Cloud writes plain bar (`0.849999964`), and our
+  /// own exporter has always written bar. The two differ by 10^5, so the
+  /// magnitude decides the unit. No breathable partial pressure reaches 100
+  /// bar, and 100 Pa (0.001 bar) is not a plausible reading either, so
+  /// anything above the threshold is Pascal.
+  static double? parsePartialPressureBar(String? text) {
+    if (text == null) return null;
+    final value = double.tryParse(text.trim());
+    if (value == null || value <= 0) return null;
+    return value > 100 ? value / 100000 : value;
+  }
+
+  /// Ordered O2 cell ids declared in the document.
+  ///
+  /// AP Diving declares them under `diver/owner/equipment/rebreather`, but the
+  /// lookup is document-wide so an exporter that puts them elsewhere still
+  /// resolves. Per-waypoint cell readings reference these ids, so declaration
+  /// order — not the order the readings appear in a waypoint — determines
+  /// which cell a reading belongs to.
+  static List<String> parseO2SensorOrder(XmlDocument document) {
+    return document
+        .findAllElements('o2sensor')
+        .map((sensor) => sensor.getAttribute('id')?.trim())
+        .whereType<String>()
+        .where((id) => id.isNotEmpty)
+        .toList();
+  }
+
+  /// Reads per-cell O2 readings from a waypoint, in bar, indexed by cell.
+  ///
+  /// Handles both the published `<measuredpo2 ref="...">` form and the
+  /// unpublished 3.3.0 draft `<ppo2 ref="...">` rename that AP Diving's
+  /// DiveSight emits. Readings whose `ref` matches no declared sensor fall
+  /// back to the order they appear in the waypoint, so an export that omits
+  /// the `<rebreather>` block still yields usable curves.
+  static Map<int, double> parseO2SensorReadings(
+    XmlElement waypoint,
+    List<String> sensorOrder,
+  ) {
+    final readings = <int, double>{};
+    final unresolved = <double>[];
+
+    for (final element in [
+      ...waypoint.findElements('measuredpo2'),
+      ...waypoint.findElements('ppo2'),
+    ]) {
+      final ref = element.getAttribute('ref')?.trim();
+      // A bare <ppo2> with no ref is our own exporter's aggregate value,
+      // not a cell reading.
+      if (ref == null || ref.isEmpty) continue;
+
+      final value = parsePartialPressureBar(element.innerText);
+      if (value == null) continue;
+
+      final index = sensorOrder.indexOf(ref);
+      if (index >= 0) {
+        if (index < maxO2Sensors) readings[index] = value;
+      } else {
+        unresolved.add(value);
+      }
+    }
+
+    for (final value in unresolved) {
+      var slot = 0;
+      while (readings.containsKey(slot)) {
+        slot++;
+      }
+      if (slot >= maxO2Sensors) break;
+      readings[slot] = value;
+    }
+
+    return readings;
+  }
+
   static GasMix parseGasMix(XmlElement mixElement) {
     final o2Text = getElementText(mixElement, 'o2');
     final heText = getElementText(mixElement, 'he');

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -42,6 +42,21 @@ class UddfImportParsers {
   /// Maximum O2 cells the profile schema can hold (o2Sensor1..o2Sensor6).
   static const int maxO2Sensors = 6;
 
+  /// Reads the dive mode from a `<divemode>` child of [parent].
+  ///
+  /// UDDF's own form is an empty element carrying the circuit in a `type`
+  /// attribute (`<divemode type="closedcircuit" />`), while our exporter
+  /// writes the enum name as inner text. Both appear at dive level, on
+  /// `<rebreather>` and on waypoints, so both are read wherever the element
+  /// occurs.
+  static enums.DiveMode? parseDiveModeIn(XmlElement parent) {
+    final element = parent.findElements('divemode').firstOrNull;
+    if (element == null) return null;
+
+    return parseUddfDiveMode(element.innerText) ??
+        parseUddfDiveMode(element.getAttribute('type'));
+  }
+
   /// Resolves a UDDF circuit name to a dive mode.
   ///
   /// UDDF spells the circuit out (`closedcircuit`), while our own exporter

--- a/test/core/deco/ccr_loop_deco_fixture_test.dart
+++ b/test/core/deco/ccr_loop_deco_fixture_test.dart
@@ -1,0 +1,113 @@
+// Regression test for the dive-mode half of #845 (raised as #846).
+//
+// A Shearwater CCR export imported as open circuit is not a cosmetic
+// mislabel: the loop is never modeled, so the long shallow stops keep
+// loading nitrogen at ~1 bar instead of the near-zero inspired inert a
+// constant-ppO2 loop actually delivers. That turned this dive into a
+// decompression violation that never happened -- our surface GF read 131
+// against the 59 the Petrel 3 logged in the same file.
+//
+// The gas is not the issue: the dive was run on air diluent throughout, and
+// modeling the loop with that same air reproduces the computer. This test
+// pins both halves, so an OC fallback cannot silently return.
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+
+const _fixture = 'test/dives/006_ccr_petrel3_shearwater-cloud-export.uddf';
+
+/// Gradient factor the Petrel 3 itself logged on its final sample.
+const _computerSurfaceGf = 59.0;
+
+void main() {
+  group('Petrel 3 CCR loop decompression (#846)', () {
+    late List<double> depths;
+    late List<int> timestamps;
+    late List<double> loopPpO2;
+    late ProfileAnalysisService service;
+
+    setUpAll(() async {
+      final content = File(_fixture).readAsStringSync();
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        content,
+      );
+      final profile =
+          result.dives.first['profile'] as List<Map<String, dynamic>>;
+
+      depths = profile.map((p) => p['depth'] as double).toList();
+      timestamps = profile.map((p) => p['timestamp'] as int).toList();
+
+      // The loop curve as the app resolves it: hold the last reading across
+      // samples with no oxygen data.
+      double? carry;
+      loopPpO2 = [
+        for (final point in profile)
+          carry = (point['ppO2'] as double?) ?? carry ?? 0.0,
+      ];
+
+      // The gradient factors the computer recorded for this dive.
+      service = ProfileAnalysisService(gfLow: 0.40, gfHigh: 0.70);
+    });
+
+    ProfileAnalysis analyzeAsCcr(GasMix diluent) {
+      final segments = buildCcrProfileGasSegments(
+        timestamps: timestamps,
+        loopPpO2Curve: loopPpO2,
+        diluentMix: diluent,
+      );
+      expect(segments, isNotNull, reason: 'loop ppO2 must yield gas segments');
+
+      return service.analyze(
+        diveId: 'ccr',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: diluent.o2 / 100,
+        heFraction: diluent.he / 100,
+        diveMode: DiveMode.ccr,
+        gasSegments: segments,
+        rebreatherPpO2Curve: loopPpO2,
+      );
+    }
+
+    test('surfacing GF matches the computer when the loop is modeled', () {
+      final analysis = analyzeAsCcr(const GasMix(o2: 21, he: 0));
+      final surfaceGf = analysis.surfaceGfCurve!.last;
+
+      expect(
+        surfaceGf,
+        closeTo(_computerSurfaceGf, 15),
+        reason:
+            'the Petrel logged $_computerSurfaceGf on its last sample; a '
+            'result far from that means the loop is not being modeled',
+      );
+    });
+
+    test('surfaces clear of any decompression obligation', () {
+      final analysis = analyzeAsCcr(const GasMix(o2: 21, he: 0));
+
+      // The diver surfaced 70 seconds after their last logged stop cleared.
+      expect(analysis.ceilingCurve.last, 0.0);
+      expect(analysis.ttsCurve!.last, 0);
+    });
+
+    test('open circuit on the same gas invents a violation', () {
+      // What the bug produced, pinned so the regression is unmistakable: the
+      // identical air, breathed open circuit, more than doubles the surface
+      // gradient and leaves the diver in deco at the surface.
+      final asOpenCircuit = service.analyze(
+        diveId: 'oc',
+        depths: depths,
+        timestamps: timestamps,
+        o2Fraction: 0.21,
+      );
+
+      expect(asOpenCircuit.surfaceGfCurve!.last, greaterThan(120));
+      expect(asOpenCircuit.ceilingCurve.last, greaterThan(0));
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -711,6 +711,62 @@ void main() {
         expect(result.dives.first['diveMode'], DiveMode.ccr);
       });
 
+      test('reads a dive-level divemode from its type attribute', () async {
+        // UDDF's own form is an empty element carrying `type`, so a file can
+        // state the circuit at dive level with no inner text at all.
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2026-08-01T09:08:48Z</datetime>
+          <divemode type="closedcircuit" />
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+        final result = await service.importAllDataFromUddf(uddfContent);
+
+        expect(result.dives.first['diveMode'], DiveMode.ccr);
+      });
+
+      test('reads a rebreather divemode from its type attribute', () async {
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2026-08-01T09:08:48Z</datetime>
+        </informationbeforedive>
+        <rebreather>
+          <divemode type="semiclosedcircuit" />
+        </rebreather>
+        <samples>
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+        final result = await service.importAllDataFromUddf(uddfContent);
+
+        expect(result.dives.first['diveMode'], DiveMode.scr);
+      });
+
       test('maps UDDF circuit spellings to dive modes', () async {
         expect(
           UddfImportParsers.parseUddfDiveMode('semiclosedcircuit'),

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 
 const _uddfEan29 = '''<uddf version="3.2.1">
@@ -676,6 +678,48 @@ void main() {
         final point = profile.single;
         expect(point['setpoint'], closeTo(1.3, 0.001));
         expect(point['ppO2'], closeTo(1.21, 0.001));
+      });
+
+      test('reads the dive mode from waypoint divemode types', () async {
+        // Shearwater marks the circuit on the samples, as a `type` attribute
+        // using UDDF's spelling. Without it the dive imports as open circuit,
+        // and the analysis discards every loop ppO2 reading it just imported
+        // in favour of a depth x FO2 curve off the diluent.
+        const uddfContent = '''
+<uddf version="3.2.3">
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2026-08-01T09:08:48Z</datetime>
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <divemode type="closedcircuit" />
+            <calculatedpo2>1.2</calculatedpo2>
+          </waypoint>
+        </samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+        final result = await service.importAllDataFromUddf(uddfContent);
+
+        expect(result.dives.first['diveMode'], DiveMode.ccr);
+      });
+
+      test('maps UDDF circuit spellings to dive modes', () async {
+        expect(
+          UddfImportParsers.parseUddfDiveMode('semiclosedcircuit'),
+          DiveMode.scr,
+        );
+        expect(UddfImportParsers.parseUddfDiveMode('opencircuit'), DiveMode.oc);
+        // Our own exporter writes the enum name rather than UDDF's spelling.
+        expect(UddfImportParsers.parseUddfDiveMode('ccr'), DiveMode.ccr);
+        expect(UddfImportParsers.parseUddfDiveMode('apnoe'), isNull);
       });
 
       test('keeps oxygen data on the waypoint it came from', () async {

--- a/test/core/services/export/uddf/uddf_full_import_service_test.dart
+++ b/test/core/services/export/uddf/uddf_full_import_service_test.dart
@@ -520,5 +520,182 @@ void main() {
       expect(profile[0]['decoType'], 2);
       expect(profile[1]['decoType'], 1);
     });
+
+    group('oxygen sample data', () {
+      Future<List<Map<String, dynamic>>> profileFrom(
+        String samples, {
+        String equipment = '',
+      }) async {
+        final uddfContent =
+            '''
+<uddf version="3.2.3">
+  <diver>
+    <owner>
+      <equipment>$equipment</equipment>
+    </owner>
+  </diver>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2026-08-01T09:08:48Z</datetime>
+        </informationbeforedive>
+        <samples>$samples</samples>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+        final result = await service.importAllDataFromUddf(uddfContent);
+        return result.dives.first['profile'] as List<Map<String, dynamic>>;
+      }
+
+      const rebreather = '''
+        <rebreather id="rb-1">
+          <o2sensor id="o2sensor_1"><name>Cell 1</name></o2sensor>
+          <o2sensor id="o2sensor_2"><name>Cell 2</name></o2sensor>
+          <o2sensor id="o2sensor_3"><name>Cell 3</name></o2sensor>
+        </rebreather>''';
+
+      test('imports calculatedpo2 as the sample ppO2', () async {
+        // Shearwater Cloud exports the aggregated loop ppO2 as
+        // <calculatedpo2>, in bar rather than the spec's Pascal.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>12.4</depth>
+            <divetime>60</divetime>
+            <calculatedpo2>0.849999964</calculatedpo2>
+          </waypoint>''');
+
+        expect(profile.single['ppO2'], closeTo(0.85, 0.001));
+      });
+
+      test('converts a Pascal calculatedpo2 to bar', () async {
+        // UDDF 3.2.3 mandates Pascal: 1.27e5 Pa is 1.27 bar.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>12.4</depth>
+            <divetime>60</divetime>
+            <calculatedpo2>1.27e5</calculatedpo2>
+          </waypoint>''');
+
+        expect(profile.single['ppO2'], closeTo(1.27, 0.001));
+      });
+
+      test('imports setpo2 as the sample setpoint', () async {
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <setpo2>1.3e5</setpo2>
+          </waypoint>''');
+
+        expect(profile.single['setpoint'], closeTo(1.3, 0.001));
+      });
+
+      test('imports repeated measuredpo2 into per-cell readings', () async {
+        // The spec form: one <measuredpo2> per cell, each referencing a
+        // declared <o2sensor>. Cell order follows the declaration order,
+        // not the order the readings appear in the waypoint.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <measuredpo2 ref="o2sensor_2">1.23e5</measuredpo2>
+            <measuredpo2 ref="o2sensor_1">1.22e5</measuredpo2>
+            <measuredpo2 ref="o2sensor_3">1.21e5</measuredpo2>
+          </waypoint>''', equipment: rebreather);
+
+        final point = profile.single;
+        expect(point['o2Sensor1'], closeTo(1.22, 0.001));
+        expect(point['o2Sensor2'], closeTo(1.23, 0.001));
+        expect(point['o2Sensor3'], closeTo(1.21, 0.001));
+      });
+
+      test('imports the draft 3.3.0 ppo2 cell form', () async {
+        // AP Diving DiveSight emits the unpublished 3.3.0 <ppo2 ref=...>
+        // rename of <measuredpo2>.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <ppo2 ref="o2sensor_1">1.22e5</ppo2>
+            <ppo2 ref="o2sensor_2">1.23e5</ppo2>
+            <ppo2 ref="o2sensor_3">1.21e5</ppo2>
+          </waypoint>''', equipment: rebreather);
+
+        final point = profile.single;
+        expect(point['o2Sensor1'], closeTo(1.22, 0.001));
+        expect(point['o2Sensor2'], closeTo(1.23, 0.001));
+        expect(point['o2Sensor3'], closeTo(1.21, 0.001));
+      });
+
+      test('falls back to waypoint order for unresolvable cell refs', () async {
+        // No <o2sensor> declarations to resolve against: keep the readings
+        // rather than dropping them, in document order.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <measuredpo2 ref="cell_a">1.22e5</measuredpo2>
+            <measuredpo2 ref="cell_b">1.23e5</measuredpo2>
+          </waypoint>''');
+
+        final point = profile.single;
+        expect(point['o2Sensor1'], closeTo(1.22, 0.001));
+        expect(point['o2Sensor2'], closeTo(1.23, 0.001));
+      });
+
+      test('treats a bare measuredpo2 as the aggregate ppO2', () async {
+        // The spec makes `ref` mandatory, but an exporter that omits it is
+        // reporting one loop value rather than a cell, so it belongs on ppO2
+        // instead of being dropped.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <measuredpo2>1.22e5</measuredpo2>
+          </waypoint>''');
+
+        final point = profile.single;
+        expect(point['ppO2'], closeTo(1.22, 0.001));
+        expect(point['o2Sensor1'], isNull);
+      });
+
+      test('still reads the names our own exporter writes', () async {
+        // Submersion exports bare <setpoint>/<ppo2> in bar; re-importing our
+        // own file has to keep working.
+        final profile = await profileFrom('''
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <setpoint>1.3</setpoint>
+            <ppo2>1.21</ppo2>
+          </waypoint>''');
+
+        final point = profile.single;
+        expect(point['setpoint'], closeTo(1.3, 0.001));
+        expect(point['ppO2'], closeTo(1.21, 0.001));
+      });
+
+      test('keeps oxygen data on the waypoint it came from', () async {
+        // A waypoint without a depth is dropped from the profile, so a
+        // second pass that indexes waypoints against profile points shifts
+        // every later reading onto the wrong sample.
+        final profile = await profileFrom('''
+          <waypoint>
+            <divetime>0</divetime>
+            <setpoint>0.7</setpoint>
+          </waypoint>
+          <waypoint>
+            <depth>30</depth>
+            <divetime>120</divetime>
+            <setpoint>1.3</setpoint>
+          </waypoint>''');
+
+        expect(profile, hasLength(1));
+        expect(profile.single['setpoint'], closeTo(1.3, 0.001));
+      });
+    });
   });
 }

--- a/test/core/services/export/uddf/uddf_shearwater_ccr_ppo2_test.dart
+++ b/test/core/services/export/uddf/uddf_shearwater_ccr_ppo2_test.dart
@@ -1,0 +1,79 @@
+// Regression suite for issue #845 (reported via #810): Shearwater Cloud
+// exports the aggregated loop ppO2 as <calculatedpo2> in bar rather than the
+// spec's <measuredpo2> in Pascal, and marks the circuit per sample as a
+// `type` attribute on <divemode>. The importer previously read neither, so a
+// CCR dive arrived as open circuit with no ppO2 at all -- and the analysis
+// discards loop data for OC dives, so the profile drew depth x FO2 off the
+// diluent instead of the measured loop value.
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+
+const _fixture = 'test/dives/006_ccr_petrel3_shearwater-cloud-export.uddf';
+
+void main() {
+  group('Shearwater Petrel 3 CCR UDDF (issue #845)', () {
+    late Map<String, dynamic> dive;
+    late List<Map<String, dynamic>> profile;
+
+    setUpAll(() async {
+      final content = File(_fixture).readAsStringSync();
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        content,
+      );
+      expect(result.dives, hasLength(1));
+      dive = result.dives.first;
+      profile = dive['profile'] as List<Map<String, dynamic>>;
+    });
+
+    test('imports as a closed-circuit dive', () {
+      // The file carries no dive-level mode: the circuit is only on the
+      // waypoints, as <divemode type="closedcircuit" />.
+      expect(dive['diveMode'], DiveMode.ccr);
+    });
+
+    test('imports the loop ppO2 from calculatedpo2', () {
+      final withPpO2 = profile
+          .map((point) => point['ppO2'] as double?)
+          .whereType<double>()
+          .toList();
+
+      expect(profile, hasLength(385));
+      expect(
+        withPpO2,
+        hasLength(262),
+        reason:
+            'the file carries 262 <calculatedpo2> samples across 385 '
+            'waypoints; the rest have no oxygen data',
+      );
+    });
+
+    test('keeps the loop ppO2 in bar', () {
+      final values = profile
+          .map((point) => point['ppO2'] as double?)
+          .whereType<double>()
+          .toList();
+
+      // Shearwater writes bar where the spec mandates Pascal. Treating these
+      // as Pascal would divide them by 100000 and flatten the curve to zero.
+      expect(values.reduce((a, b) => a < b ? a : b), closeTo(0.79, 0.01));
+      expect(values.reduce((a, b) => a > b ? a : b), closeTo(1.62, 0.01));
+    });
+
+    test('records no per-cell readings, because the export has none', () {
+      // Shearwater Cloud exports only the aggregate: no <measuredpo2>, no
+      // <ppo2 ref>, no <o2sensor> declarations. Individual cell traces need a
+      // direct download instead (issue #810).
+      final anyCell = profile.any(
+        (point) => List.generate(
+          6,
+          (index) => point['o2Sensor${index + 1}'],
+        ).any((reading) => reading != null),
+      );
+
+      expect(anyCell, isFalse);
+    });
+  });
+}

--- a/test/dives/006_ccr_petrel3_shearwater-cloud-export.uddf
+++ b/test/dives/006_ccr_petrel3_shearwater-cloud-export.uddf
@@ -1,0 +1,4153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<uddf xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.2.3" xmlns="http://www.streit.cc/uddf/3.2/">
+  <generator>
+    <name>Shearwater Cloud Desktop</name>
+    <type>logbook</type>
+    <manufacturer id="Shearwater_Research_Inc">
+      <name>Shearwater Research, Inc</name>
+      <address>
+        <street>Suite 100, 10200 Shellbridge Way</street>
+        <city>Richmond</city>
+        <postcode>V6X 2W7</postcode>
+        <country>Canada</country>
+        <province>British Columbia</province>
+      </address>
+      <contact>
+        <language>English</language>
+        <phone>604-669-9958</phone>
+        <fax>604-681-4982</fax>
+        <email>info@shearwater.com</email>
+        <homepage>https://shearwater.com</homepage>
+      </contact>
+    </manufacturer>
+    <version>2.12.10</version>
+    <datetime>2026-08-01T16:34:21Z</datetime>
+  </generator>
+  <diver>
+    <owner>
+      <equipment>
+        <divecomputer id="Petrel 3_xxxxxx">
+          <name>Petrel 3</name>
+          <manufacturer id="Shearwater_Research_Inc">
+            <name>Shearwater Research, Inc</name>
+            <address>
+              <street>Suite 100, 10200 Shellbridge Way</street>
+              <city>Richmond</city>
+              <postcode>V6X 2W7</postcode>
+              <country>Canada</country>
+              <province>British Columbia</province>
+            </address>
+            <contact>
+              <language>English</language>
+              <phone>604-669-9958</phone>
+              <fax>604-681-4982</fax>
+              <email>info@shearwater.com</email>
+              <homepage>https://shearwater.com</homepage>
+            </contact>
+          </manufacturer>
+          <model>Petrel 3</model>
+          <serialnumber>xxxxxx</serialnumber>
+          <notes>
+            <para>FirmV:103:</para>
+            <para>LogV:17:</para>
+            <para>BatType:2:</para>
+            <para>IBat:150:</para>
+            <para>DBV:12:</para>
+            <para>OEM:4:</para>
+            <para>Language:0:</para>
+            <para>Product:10:</para>
+          </notes>
+        </divecomputer>
+      </equipment>
+    </owner>
+    <buddy>
+      <personal />
+    </buddy>
+  </diver>
+  <divesite />
+  <gasdefinitions>
+    <mix id="CC1:21/00">
+      <name>CC1</name>
+      <o2>0.21</o2>
+      <he>0</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="CC2:15/55">
+      <name>CC2</name>
+      <o2>0.15</o2>
+      <he>0.55</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="CC3:12/60">
+      <name>CC3</name>
+      <o2>0.12</o2>
+      <he>0.6</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="CC4:10/70">
+      <name>CC4</name>
+      <o2>0.1</o2>
+      <he>0.7</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="CC5:07/75">
+      <name>CC5</name>
+      <o2>0.07</o2>
+      <he>0.75</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="OC1:99/00">
+      <name>OC1</name>
+      <o2>0.99</o2>
+      <he>0</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="OC2:50/20">
+      <name>OC2</name>
+      <o2>0.5</o2>
+      <he>0.2</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="OC3:27/00">
+      <name>OC3</name>
+      <o2>0.27</o2>
+      <he>0</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="OC4:25/50">
+      <name>OC4</name>
+      <o2>0.25</o2>
+      <he>0.5</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+    <mix id="OC5:15/55">
+      <name>OC5</name>
+      <o2>0.15</o2>
+      <he>0.55</he>
+      <maximumpo2>1</maximumpo2>
+    </mix>
+  </gasdefinitions>
+  <decomodel>
+    <buehlmann id="zhl16c">
+      <gradientfactorhigh>70</gradientfactorhigh>
+      <gradientfactorlow>40</gradientfactorlow>
+    </buehlmann>
+  </decomodel>
+  <profiledata>
+    <repetitiongroup>
+      <dive id="2182925401785575328">
+        <applicationdata />
+        <informationbeforedive>
+          <link ref="profile_2182925401785575328" />
+          <link ref="" />
+          <link ref=" : " />
+          <link ref="zhl16c" />
+          <divenumber>386</divenumber>
+          <datetime>2026-08-01T09:08:48Z</datetime>
+          <surfaceintervalbeforedive>
+            <passedtime>303480</passedtime>
+          </surfaceintervalbeforedive>
+          <equipmentused>
+            <link ref="Petrel 3_xxxxxx" />
+          </equipmentused>
+          <surfacepressure>96100</surfacepressure>
+        </informationbeforedive>
+        <tankdata>
+          <tankpressurebegin>13293097</tankpressurebegin>
+          <tankpressureend>9404452</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>14727207</tankpressurebegin>
+          <tankpressureend>10700667</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <tankdata>
+          <tankpressurebegin>0</tankpressurebegin>
+          <tankpressureend>0</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <calculatedpo2>0.849999964</calculatedpo2>
+            <depth>1.2</depth>
+            <divetime>0</divetime>
+            <switchmix ref="CC1:21/00" />
+            <tankpressure ref="T1">13293097</tankpressure>
+            <tankpressure ref="T2">14727207</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>0</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.9</calculatedpo2>
+            <depth>1.80000007</depth>
+            <divetime>10</divetime>
+            <tankpressure ref="T1">12962148</tankpressure>
+            <tankpressure ref="T2">14740996</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.789999962</calculatedpo2>
+            <depth>2.2</depth>
+            <divetime>20</divetime>
+            <tankpressure ref="T1">13086254</tankpressure>
+            <tankpressure ref="T2">14754786</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.859999955</calculatedpo2>
+            <depth>3.2</depth>
+            <divetime>30</divetime>
+            <tankpressure ref="T1">13100044</tankpressure>
+            <tankpressure ref="T2">14754786</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.81</calculatedpo2>
+            <depth>4.20000029</depth>
+            <divetime>40</divetime>
+            <tankpressure ref="T1">13044885</tankpressure>
+            <tankpressure ref="T2">14768575</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.9</calculatedpo2>
+            <depth>5.1</depth>
+            <divetime>50</divetime>
+            <tankpressure ref="T1">12713937</tankpressure>
+            <tankpressure ref="T2">14768575</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.909999967</calculatedpo2>
+            <depth>5.4</depth>
+            <divetime>60</divetime>
+            <tankpressure ref="T1">12713937</tankpressure>
+            <tankpressure ref="T2">14768575</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.87</calculatedpo2>
+            <depth>5.6</depth>
+            <divetime>70</divetime>
+            <tankpressure ref="T1">12727727</tankpressure>
+            <tankpressure ref="T2">14768575</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.919999957</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>80</divetime>
+            <tankpressure ref="T1">12727727</tankpressure>
+            <tankpressure ref="T2">14768575</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <gradientfactor>1</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.87</calculatedpo2>
+            <depth>7.3</depth>
+            <divetime>90</divetime>
+            <tankpressure ref="T1">12658779</tankpressure>
+            <tankpressure ref="T2">14740996</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>1</calculatedpo2>
+            <depth>8.400001</depth>
+            <divetime>100</divetime>
+            <tankpressure ref="T1">12479515</tankpressure>
+            <tankpressure ref="T2">14713417</tankpressure>
+            <temperature>297.15</temperature>
+            <divemode type="closedcircuit" />
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <calculatedpo2>0.969999969</calculatedpo2>
+            <depth>9.1</depth>
+            <divetime>110</divetime>
+            <tankpressure ref="T1">12493305</tankpressure>
+            <tankpressure ref="T2">14713417</tankpressure>
+            <temperature>297.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.919999957</calculatedpo2>
+            <depth>9.8</depth>
+            <divetime>120</divetime>
+            <tankpressure ref="T1">12369199</tankpressure>
+            <tankpressure ref="T2">14713417</tankpressure>
+            <temperature>297.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.94</calculatedpo2>
+            <depth>10.4000006</depth>
+            <divetime>130</divetime>
+            <tankpressure ref="T1">1.232783E+07</tankpressure>
+            <tankpressure ref="T2">14699628</tankpressure>
+            <temperature>297.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.919999957</calculatedpo2>
+            <depth>11.1</depth>
+            <divetime>140</divetime>
+            <tankpressure ref="T1">12189935</tankpressure>
+            <tankpressure ref="T2">14658259</tankpressure>
+            <temperature>297.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.94</calculatedpo2>
+            <depth>11.7</depth>
+            <divetime>150</divetime>
+            <tankpressure ref="T1">1.206583E+07</tankpressure>
+            <tankpressure ref="T2">14603101</tankpressure>
+            <temperature>297.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <depth>12.5</depth>
+            <divetime>160</divetime>
+            <tankpressure ref="T1">11845197</tankpressure>
+            <tankpressure ref="T2">14492785</tankpressure>
+            <temperature>296.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.859999955</calculatedpo2>
+            <depth>13.2</depth>
+            <divetime>170</divetime>
+            <tankpressure ref="T1">11858987</tankpressure>
+            <tankpressure ref="T2">14382469</tankpressure>
+            <temperature>296.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.95</calculatedpo2>
+            <depth>14.4000006</depth>
+            <divetime>180</divetime>
+            <tankpressure ref="T1">11734881</tankpressure>
+            <tankpressure ref="T2">14272153</tankpressure>
+            <temperature>296.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.96</calculatedpo2>
+            <depth>15.4000006</depth>
+            <divetime>190</divetime>
+            <tankpressure ref="T1">11583196</tankpressure>
+            <tankpressure ref="T2">14161837</tankpressure>
+            <temperature>295.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>0.9</calculatedpo2>
+            <depth>16.4</depth>
+            <divetime>200</divetime>
+            <tankpressure ref="T1">1.148667E+07</tankpressure>
+            <tankpressure ref="T2">1.405152E+07</tankpressure>
+            <temperature>295.15</temperature>
+            <nodecotime>5580</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.02</calculatedpo2>
+            <depth>17.4</depth>
+            <divetime>210</divetime>
+            <tankpressure ref="T1">11445301</tankpressure>
+            <tankpressure ref="T2">13927415</tankpressure>
+            <temperature>294.15</temperature>
+            <nodecotime>5220</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.1</calculatedpo2>
+            <depth>18.8000011</depth>
+            <divetime>220</divetime>
+            <tankpressure ref="T1">11403933</tankpressure>
+            <tankpressure ref="T2">13803309</tankpressure>
+            <temperature>294.15</temperature>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.06</calculatedpo2>
+            <depth>20.4</depth>
+            <divetime>230</divetime>
+            <tankpressure ref="T1">1.119709E+07</tankpressure>
+            <tankpressure ref="T2">13734361</tankpressure>
+            <temperature>293.15</temperature>
+            <nodecotime>3120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.12</calculatedpo2>
+            <depth>22.1</depth>
+            <divetime>240</divetime>
+            <tankpressure ref="T1">10990247</tankpressure>
+            <tankpressure ref="T2">13651624</tankpressure>
+            <temperature>292.15</temperature>
+            <nodecotime>2640</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <depth>23.5</depth>
+            <divetime>250</divetime>
+            <tankpressure ref="T1">10962668</tankpressure>
+            <tankpressure ref="T2">13610256</tankpressure>
+            <temperature>292.15</temperature>
+            <nodecotime>1920</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.18</calculatedpo2>
+            <depth>25.6</depth>
+            <divetime>260</divetime>
+            <tankpressure ref="T1">1.090751E+07</tankpressure>
+            <tankpressure ref="T2">13568887</tankpressure>
+            <temperature>291.15</temperature>
+            <nodecotime>1680</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.24</calculatedpo2>
+            <depth>28</depth>
+            <divetime>270</divetime>
+            <tankpressure ref="T1">10921299</tankpressure>
+            <tankpressure ref="T2">13527519</tankpressure>
+            <temperature>291.15</temperature>
+            <nodecotime>1260</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>1</cns>
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>30</depth>
+            <divetime>280</divetime>
+            <tankpressure ref="T1">10714457</tankpressure>
+            <tankpressure ref="T2">1.348615E+07</tankpressure>
+            <temperature>290.15</temperature>
+            <nodecotime>1140</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>32.1000023</depth>
+            <divetime>290</divetime>
+            <tankpressure ref="T1">10769615</tankpressure>
+            <tankpressure ref="T2">13472361</tankpressure>
+            <temperature>290.15</temperature>
+            <nodecotime>840</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>33.9</depth>
+            <divetime>300</divetime>
+            <tankpressure ref="T1">10728246</tankpressure>
+            <tankpressure ref="T2">13444782</tankpressure>
+            <temperature>288.15</temperature>
+            <nodecotime>840</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.35</calculatedpo2>
+            <depth>36.2</depth>
+            <divetime>310</divetime>
+            <tankpressure ref="T1">10507614</tankpressure>
+            <tankpressure ref="T2">13430992</tankpressure>
+            <temperature>288.15</temperature>
+            <nodecotime>660</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>38.4</depth>
+            <divetime>320</divetime>
+            <tankpressure ref="T1">10273192</tankpressure>
+            <tankpressure ref="T2">13417203</tankpressure>
+            <temperature>288.15</temperature>
+            <nodecotime>540</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.43</calculatedpo2>
+            <depth>39.7</depth>
+            <divetime>330</divetime>
+            <tankpressure ref="T1">10314561</tankpressure>
+            <tankpressure ref="T2">13403413</tankpressure>
+            <temperature>287.15</temperature>
+            <nodecotime>420</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>41</depth>
+            <divetime>340</divetime>
+            <tankpressure ref="T1">10107718</tankpressure>
+            <tankpressure ref="T2">13375834</tankpressure>
+            <temperature>286.15</temperature>
+            <nodecotime>420</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>41.8</depth>
+            <divetime>350</divetime>
+            <tankpressure ref="T1">10149086</tankpressure>
+            <tankpressure ref="T2">13362044</tankpressure>
+            <temperature>286.15</temperature>
+            <nodecotime>360</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>42.7</depth>
+            <divetime>360</divetime>
+            <tankpressure ref="T1">9762980</tankpressure>
+            <tankpressure ref="T2">13362044</tankpressure>
+            <temperature>286.15</temperature>
+            <nodecotime>360</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>2</cns>
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>43.3</depth>
+            <divetime>370</divetime>
+            <tankpressure ref="T1">9721611</tankpressure>
+            <tankpressure ref="T2">13348255</tankpressure>
+            <temperature>286.15</temperature>
+            <nodecotime>300</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>43.7</depth>
+            <divetime>380</divetime>
+            <tankpressure ref="T1">9776769</tankpressure>
+            <tankpressure ref="T2">13348255</tankpressure>
+            <temperature>285.15</temperature>
+            <nodecotime>300</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>44</depth>
+            <divetime>390</divetime>
+            <tankpressure ref="T1">9831927</tankpressure>
+            <tankpressure ref="T2">13334465</tankpressure>
+            <temperature>285.15</temperature>
+            <nodecotime>300</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>44.8</depth>
+            <divetime>400</divetime>
+            <tankpressure ref="T1">9845717</tankpressure>
+            <tankpressure ref="T2">13320676</tankpressure>
+            <temperature>285.15</temperature>
+            <nodecotime>240</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.48</calculatedpo2>
+            <depth>45.1000023</depth>
+            <divetime>410</divetime>
+            <tankpressure ref="T1">9873296</tankpressure>
+            <tankpressure ref="T2">13320676</tankpressure>
+            <temperature>284.15</temperature>
+            <nodecotime>240</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.49</calculatedpo2>
+            <depth>45.6000023</depth>
+            <divetime>420</divetime>
+            <tankpressure ref="T1">9887086</tankpressure>
+            <tankpressure ref="T2">13306886</tankpressure>
+            <temperature>284.15</temperature>
+            <nodecotime>240</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.48</calculatedpo2>
+            <depth>45.8</depth>
+            <divetime>430</divetime>
+            <tankpressure ref="T1">9721611</tankpressure>
+            <tankpressure ref="T2">13306886</tankpressure>
+            <temperature>284.15</temperature>
+            <nodecotime>240</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.49</calculatedpo2>
+            <depth>46.1000023</depth>
+            <divetime>440</divetime>
+            <tankpressure ref="T1">9735401</tankpressure>
+            <tankpressure ref="T2">13306886</tankpressure>
+            <temperature>284.15</temperature>
+            <nodecotime>180</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>3</cns>
+            <calculatedpo2>1.51</calculatedpo2>
+            <depth>46.5</depth>
+            <divetime>450</divetime>
+            <tankpressure ref="T1">9721611</tankpressure>
+            <tankpressure ref="T2">13293097</tankpressure>
+            <temperature>284.15</temperature>
+            <nodecotime>180</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <calculatedpo2>1.49</calculatedpo2>
+            <depth>46.6000023</depth>
+            <divetime>460</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13293097</tankpressure>
+            <temperature>283.15</temperature>
+            <nodecotime>180</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <depth>46.6000023</depth>
+            <divetime>470</divetime>
+            <tankpressure ref="T1">9597506</tankpressure>
+            <tankpressure ref="T2">13279307</tankpressure>
+            <temperature>283.15</temperature>
+            <nodecotime>180</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <depth>46.7</depth>
+            <divetime>480</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">13265518</tankpressure>
+            <temperature>283.15</temperature>
+            <nodecotime>180</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <calculatedpo2>1.5</calculatedpo2>
+            <depth>46.7</depth>
+            <divetime>490</divetime>
+            <tankpressure ref="T1">9528558</tankpressure>
+            <tankpressure ref="T2">13279307</tankpressure>
+            <temperature>283.15</temperature>
+            <nodecotime>120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <calculatedpo2>1.49</calculatedpo2>
+            <depth>46.7</depth>
+            <divetime>500</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">13279307</tankpressure>
+            <temperature>283.15</temperature>
+            <nodecotime>120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <depth>47.2</depth>
+            <divetime>510</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13251728</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>4</cns>
+            <depth>46.8</depth>
+            <divetime>520</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">13265518</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <calculatedpo2>1.48</calculatedpo2>
+            <depth>46.4</depth>
+            <divetime>530</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13251728</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>120</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>46.3</depth>
+            <divetime>540</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13251728</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>46.2</depth>
+            <divetime>550</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13251728</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <depth>46.2</depth>
+            <divetime>560</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13251728</tankpressure>
+            <temperature>282.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <depth>46.2</depth>
+            <divetime>570</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13237939</tankpressure>
+            <temperature>281.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>46.1000023</depth>
+            <divetime>580</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13237939</tankpressure>
+            <temperature>281.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <depth>46.2</depth>
+            <divetime>590</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13237939</tankpressure>
+            <temperature>281.15</temperature>
+            <nodecotime>60</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>5</cns>
+            <depth>46.4</depth>
+            <divetime>600</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13237939</tankpressure>
+            <temperature>281.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <depth>46.3</depth>
+            <divetime>610</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13224149</tankpressure>
+            <temperature>281.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <depth>46.5</depth>
+            <divetime>620</divetime>
+            <tankpressure ref="T1">9597506</tankpressure>
+            <tankpressure ref="T2">13224149</tankpressure>
+            <temperature>281.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <depth>46.6000023</depth>
+            <divetime>630</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13224149</tankpressure>
+            <temperature>281.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>46.7</depth>
+            <divetime>640</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13224149</tankpressure>
+            <temperature>281.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>46.6000023</depth>
+            <divetime>650</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">1.321036E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>46.5</depth>
+            <divetime>660</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">1.321036E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>46.5</depth>
+            <divetime>670</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">1.319657E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>6</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>46.5</depth>
+            <divetime>680</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">1.321036E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>46.6000023</depth>
+            <divetime>690</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">1.319657E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.43</calculatedpo2>
+            <depth>46.5</depth>
+            <divetime>700</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">1.319657E+07</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>46.2</depth>
+            <divetime>710</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.42</calculatedpo2>
+            <depth>46.3</depth>
+            <divetime>720</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>45.8</depth>
+            <divetime>730</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>45.2</depth>
+            <divetime>740</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>44.7</depth>
+            <divetime>750</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>43.9</depth>
+            <divetime>760</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>280.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>7</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>43.5</depth>
+            <divetime>770</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>43.4</depth>
+            <divetime>780</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13182781</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>43.2</depth>
+            <divetime>790</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>43.1000023</depth>
+            <divetime>800</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>42.9</depth>
+            <divetime>810</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>42.7</depth>
+            <divetime>820</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <depth>42.7</depth>
+            <divetime>830</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <depth>42.8</depth>
+            <divetime>840</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13155202</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>42.5</depth>
+            <divetime>850</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13155202</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>41.8</depth>
+            <divetime>860</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13168991</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.27</calculatedpo2>
+            <depth>41</depth>
+            <divetime>870</divetime>
+            <tankpressure ref="T1">9597506</tankpressure>
+            <tankpressure ref="T2">13155202</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>8</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>40.7</depth>
+            <divetime>880</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13141412</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>40.4</depth>
+            <divetime>890</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13127623</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>40.3</depth>
+            <divetime>900</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13127623</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>40.1000023</depth>
+            <divetime>910</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13127623</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>39.4</depth>
+            <divetime>920</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13113833</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>38.7</depth>
+            <divetime>930</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13127623</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>37.8</depth>
+            <divetime>940</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13113833</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>37</depth>
+            <divetime>950</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13086254</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>36.8</depth>
+            <divetime>960</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13072465</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>36.6000023</depth>
+            <divetime>970</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13086254</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>9</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>36.4</depth>
+            <divetime>980</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13086254</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>36.3</depth>
+            <divetime>990</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13086254</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>36.1000023</depth>
+            <divetime>1000</divetime>
+            <tankpressure ref="T1">9569927</tankpressure>
+            <tankpressure ref="T2">13072465</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>36.2</depth>
+            <divetime>1010</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13072465</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>35.8</depth>
+            <divetime>1020</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13072465</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>35.8</depth>
+            <divetime>1030</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13072465</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.5</depth>
+            <divetime>1040</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13058675</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.4</depth>
+            <divetime>1050</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13044885</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>35.1000023</depth>
+            <divetime>1060</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13044885</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.2</depth>
+            <divetime>1070</divetime>
+            <tankpressure ref="T1">9597506</tankpressure>
+            <tankpressure ref="T2">13031096</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.3</depth>
+            <divetime>1080</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13044885</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>10</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>35.3</depth>
+            <divetime>1090</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13031096</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.2</depth>
+            <divetime>1100</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13031096</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>35.1000023</depth>
+            <divetime>1110</divetime>
+            <tankpressure ref="T1">9597506</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.2</depth>
+            <divetime>1120</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>35.4</depth>
+            <divetime>1130</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13031096</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.6000023</depth>
+            <divetime>1140</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.6000023</depth>
+            <divetime>1150</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.7</depth>
+            <divetime>1160</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.7</depth>
+            <divetime>1170</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.7</depth>
+            <divetime>1180</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>11</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.7</depth>
+            <divetime>1190</divetime>
+            <tankpressure ref="T1">9583716</tankpressure>
+            <tankpressure ref="T2">13017306</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>35.7</depth>
+            <divetime>1200</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>35.5</depth>
+            <divetime>1210</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>36</depth>
+            <divetime>1220</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>36.1000023</depth>
+            <divetime>1230</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>35.8</depth>
+            <divetime>1240</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>36.4</depth>
+            <divetime>1250</divetime>
+            <tankpressure ref="T1">9556137</tankpressure>
+            <tankpressure ref="T2">12975938</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>36.7</depth>
+            <divetime>1260</divetime>
+            <tankpressure ref="T1">9542348</tankpressure>
+            <tankpressure ref="T2">12962148</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>36.8</depth>
+            <divetime>1270</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">12948359</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.43</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1280</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>12</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1290</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>36.8</depth>
+            <divetime>1300</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>36.9</depth>
+            <divetime>1310</divetime>
+            <tankpressure ref="T1">9363084</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1320</divetime>
+            <tankpressure ref="T1">9459610</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37</depth>
+            <divetime>1330</divetime>
+            <tankpressure ref="T1">9473400</tankpressure>
+            <tankpressure ref="T2">1.292078E+07</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>37.3</depth>
+            <divetime>1340</divetime>
+            <tankpressure ref="T1">9459610</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.3</depth>
+            <divetime>1350</divetime>
+            <tankpressure ref="T1">9473400</tankpressure>
+            <tankpressure ref="T2">12934569</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>37.4</depth>
+            <divetime>1360</divetime>
+            <tankpressure ref="T1">9473400</tankpressure>
+            <tankpressure ref="T2">1.292078E+07</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.5</depth>
+            <divetime>1370</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">1.292078E+07</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>13</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.7</depth>
+            <divetime>1380</divetime>
+            <tankpressure ref="T1">9473400</tankpressure>
+            <tankpressure ref="T2">1.290699E+07</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.6000023</depth>
+            <divetime>1390</divetime>
+            <tankpressure ref="T1">9390663</tankpressure>
+            <tankpressure ref="T2">1.292078E+07</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>37.6000023</depth>
+            <divetime>1400</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12879411</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>37.5</depth>
+            <divetime>1410</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12879411</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.6000023</depth>
+            <divetime>1420</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12879411</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>37.8</depth>
+            <divetime>1430</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12879411</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>38</depth>
+            <divetime>1440</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>38.2</depth>
+            <divetime>1450</divetime>
+            <tankpressure ref="T1">9252768</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.42</calculatedpo2>
+            <depth>38.3</depth>
+            <divetime>1460</divetime>
+            <tankpressure ref="T1">9142451</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>14</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>37.9</depth>
+            <divetime>1470</divetime>
+            <tankpressure ref="T1">9156241</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>37.2</depth>
+            <divetime>1480</divetime>
+            <tankpressure ref="T1">9170030</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>37.1000023</depth>
+            <divetime>1490</divetime>
+            <tankpressure ref="T1">9183820</tankpressure>
+            <tankpressure ref="T2">12865622</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>37.4</depth>
+            <divetime>1500</divetime>
+            <tankpressure ref="T1">9197610</tankpressure>
+            <tankpressure ref="T2">12851832</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>37.1000023</depth>
+            <divetime>1510</divetime>
+            <tankpressure ref="T1">9197610</tankpressure>
+            <tankpressure ref="T2">12851832</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1520</divetime>
+            <tankpressure ref="T1">9197610</tankpressure>
+            <tankpressure ref="T2">12838043</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>37.1000023</depth>
+            <divetime>1530</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12851832</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>37</depth>
+            <divetime>1540</divetime>
+            <tankpressure ref="T1">9225189</tankpressure>
+            <tankpressure ref="T2">12838043</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1550</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12838043</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>36.8</depth>
+            <divetime>1560</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12838043</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>15</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>36.8</depth>
+            <divetime>1570</divetime>
+            <tankpressure ref="T1">9225189</tankpressure>
+            <tankpressure ref="T2">12838043</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>36.9</depth>
+            <divetime>1580</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12824253</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>36.9</depth>
+            <divetime>1590</divetime>
+            <tankpressure ref="T1">9225189</tankpressure>
+            <tankpressure ref="T2">12824253</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37</depth>
+            <divetime>1600</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12824253</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>36.9</depth>
+            <divetime>1610</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.35</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1620</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12824253</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>36.9</depth>
+            <divetime>1630</divetime>
+            <tankpressure ref="T1">9225189</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.1000023</depth>
+            <divetime>1640</divetime>
+            <tankpressure ref="T1">9211399</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>36.9</depth>
+            <divetime>1650</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>16</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.2</depth>
+            <divetime>1660</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.3</depth>
+            <divetime>1670</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>37.2</depth>
+            <divetime>1680</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>37.3</depth>
+            <divetime>1690</divetime>
+            <tankpressure ref="T1">9045925</tankpressure>
+            <tankpressure ref="T2">12810464</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>37.2</depth>
+            <divetime>1700</divetime>
+            <tankpressure ref="T1">9045925</tankpressure>
+            <tankpressure ref="T2">12796674</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>37.5</depth>
+            <divetime>1710</divetime>
+            <tankpressure ref="T1">9059714</tankpressure>
+            <tankpressure ref="T2">12796674</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.6000023</depth>
+            <divetime>1720</divetime>
+            <tankpressure ref="T1">9059714</tankpressure>
+            <tankpressure ref="T2">12796674</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.7</depth>
+            <divetime>1730</divetime>
+            <tankpressure ref="T1">9059714</tankpressure>
+            <tankpressure ref="T2">12796674</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.8</depth>
+            <divetime>1740</divetime>
+            <tankpressure ref="T1">9059714</tankpressure>
+            <tankpressure ref="T2">12782885</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>37.9</depth>
+            <divetime>1750</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12782885</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>38.2</depth>
+            <divetime>1760</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12782885</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>17</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38.5</depth>
+            <divetime>1770</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38.4</depth>
+            <divetime>1780</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38.4</depth>
+            <divetime>1790</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>38.2</depth>
+            <divetime>1800</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38.2</depth>
+            <divetime>1810</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38</depth>
+            <divetime>1820</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12755306</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>38</depth>
+            <divetime>1830</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12769095</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>37.9</depth>
+            <divetime>1840</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12755306</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>37.7</depth>
+            <divetime>1850</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12741516</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>37.4</depth>
+            <divetime>1860</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12755306</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>18</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.3</depth>
+            <divetime>1870</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12727727</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.1000023</depth>
+            <divetime>1880</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12727727</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1890</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12727727</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>37</depth>
+            <divetime>1900</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12727727</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.9</depth>
+            <divetime>1910</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.8</depth>
+            <divetime>1920</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12727727</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.9</depth>
+            <divetime>1930</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.8</depth>
+            <divetime>1940</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.8</depth>
+            <divetime>1950</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.8</depth>
+            <divetime>1960</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>36.7</depth>
+            <divetime>1970</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>19</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>36.9</depth>
+            <divetime>1980</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12700147</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37</depth>
+            <divetime>1990</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.2</depth>
+            <divetime>2000</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12700147</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>37.3</depth>
+            <divetime>2010</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12713937</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.5</depth>
+            <divetime>2020</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12700147</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.5</depth>
+            <divetime>2030</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12700147</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.7</depth>
+            <divetime>2040</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12686358</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.5</depth>
+            <divetime>2050</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12686358</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.6000023</depth>
+            <divetime>2060</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12686358</tankpressure>
+            <temperature>279.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>37.7</depth>
+            <divetime>2070</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12686358</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>20</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>37.6000023</depth>
+            <divetime>2080</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12672568</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>37.7</depth>
+            <divetime>2090</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12672568</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.9</depth>
+            <divetime>2100</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12672568</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>37.9</depth>
+            <divetime>2110</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12672568</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38.1000023</depth>
+            <divetime>2120</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12672568</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38</depth>
+            <divetime>2130</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12658779</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38</depth>
+            <divetime>2140</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12658779</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>37.9</depth>
+            <divetime>2150</divetime>
+            <tankpressure ref="T1">9087293</tankpressure>
+            <tankpressure ref="T2">12658779</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38</depth>
+            <divetime>2160</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12658779</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38</depth>
+            <divetime>2170</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12644989</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38.3</depth>
+            <divetime>2180</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">1.26312E+07</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>21</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>38.3</depth>
+            <divetime>2190</divetime>
+            <tankpressure ref="T1">9045925</tankpressure>
+            <tankpressure ref="T2">12644989</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>38.4</depth>
+            <divetime>2200</divetime>
+            <tankpressure ref="T1">9032135</tankpressure>
+            <tankpressure ref="T2">12644989</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>38.6000023</depth>
+            <divetime>2210</divetime>
+            <tankpressure ref="T1">9045925</tankpressure>
+            <tankpressure ref="T2">12644989</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>38.8</depth>
+            <divetime>2220</divetime>
+            <tankpressure ref="T1">8880451</tankpressure>
+            <tankpressure ref="T2">1.26312E+07</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38.6000023</depth>
+            <divetime>2230</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">1.26312E+07</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>38.5</depth>
+            <divetime>2240</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">1.261741E+07</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>38.3</depth>
+            <divetime>2250</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">1.261741E+07</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38.2</depth>
+            <divetime>2260</divetime>
+            <tankpressure ref="T1">8990767</tankpressure>
+            <tankpressure ref="T2">12589831</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>38.1000023</depth>
+            <divetime>2270</divetime>
+            <tankpressure ref="T1">8976977</tankpressure>
+            <tankpressure ref="T2">12589831</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>38.3</depth>
+            <divetime>2280</divetime>
+            <tankpressure ref="T1">8990767</tankpressure>
+            <tankpressure ref="T2">12576042</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>38.3</depth>
+            <divetime>2290</divetime>
+            <tankpressure ref="T1">8825292</tankpressure>
+            <tankpressure ref="T2">12576042</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>22</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>38.5</depth>
+            <divetime>2300</divetime>
+            <tankpressure ref="T1">8935609</tankpressure>
+            <tankpressure ref="T2">12562252</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>38.9</depth>
+            <divetime>2310</divetime>
+            <tankpressure ref="T1">8935609</tankpressure>
+            <tankpressure ref="T2">12562252</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>39.1000023</depth>
+            <divetime>2320</divetime>
+            <tankpressure ref="T1">8839082</tankpressure>
+            <tankpressure ref="T2">12548463</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>38.7</depth>
+            <divetime>2330</divetime>
+            <tankpressure ref="T1">8839082</tankpressure>
+            <tankpressure ref="T2">12562252</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>38.5</depth>
+            <divetime>2340</divetime>
+            <tankpressure ref="T1">8839082</tankpressure>
+            <tankpressure ref="T2">12534673</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>38.2</depth>
+            <divetime>2350</divetime>
+            <tankpressure ref="T1">8839082</tankpressure>
+            <tankpressure ref="T2">12534673</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>37.7</depth>
+            <divetime>2360</divetime>
+            <tankpressure ref="T1">8852872</tankpressure>
+            <tankpressure ref="T2">12534673</tankpressure>
+            <temperature>278.15</temperature>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.25</calculatedpo2>
+            <depth>36.5</depth>
+            <divetime>2370</divetime>
+            <tankpressure ref="T1">8852872</tankpressure>
+            <tankpressure ref="T2">12507094</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="180" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>34.9</depth>
+            <divetime>2380</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12465726</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.35</calculatedpo2>
+            <depth>33.4</depth>
+            <divetime>2390</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12465726</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>23</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>31.5</depth>
+            <divetime>2400</divetime>
+            <tankpressure ref="T1">8839082</tankpressure>
+            <tankpressure ref="T2">12438147</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>29.6</depth>
+            <divetime>2410</divetime>
+            <tankpressure ref="T1">8852872</tankpressure>
+            <tankpressure ref="T2">12410568</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="180" />
+            <calculatedpo2>1.23</calculatedpo2>
+            <depth>27.7</depth>
+            <divetime>2420</divetime>
+            <tankpressure ref="T1">8852872</tankpressure>
+            <tankpressure ref="T2">12410568</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="180" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>26.1</depth>
+            <divetime>2430</divetime>
+            <tankpressure ref="T1">8852872</tankpressure>
+            <tankpressure ref="T2">12314041</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>24.1</depth>
+            <divetime>2440</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12314041</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>23.2</depth>
+            <divetime>2450</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">1.232783E+07</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>1</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.42</calculatedpo2>
+            <depth>21.4</depth>
+            <divetime>2460</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>2</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>20.5</depth>
+            <divetime>2470</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>278.15</temperature>
+            <gradientfactor>4</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <depth>19.4</depth>
+            <divetime>2480</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12258883</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>8</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.20999992</calculatedpo2>
+            <depth>18</depth>
+            <divetime>2490</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12258883</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>13</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>17.2</depth>
+            <divetime>2500</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12107198</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>14</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>24</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>16.5</depth>
+            <divetime>2510</divetime>
+            <tankpressure ref="T1">8866661</tankpressure>
+            <tankpressure ref="T2">12176146</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>18</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>16.1</depth>
+            <divetime>2520</divetime>
+            <tankpressure ref="T1">8880451</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>18</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>15.5</depth>
+            <divetime>2530</divetime>
+            <tankpressure ref="T1">8880451</tankpressure>
+            <tankpressure ref="T2">12176146</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>19</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>14.9000006</depth>
+            <divetime>2540</divetime>
+            <tankpressure ref="T1">8880451</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>22</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>14.3</depth>
+            <divetime>2550</divetime>
+            <tankpressure ref="T1">8894240</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.25</calculatedpo2>
+            <depth>13.5</depth>
+            <divetime>2560</divetime>
+            <tankpressure ref="T1">8908030</tankpressure>
+            <tankpressure ref="T2">12176146</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>13.2</depth>
+            <divetime>2570</divetime>
+            <tankpressure ref="T1">8908030</tankpressure>
+            <tankpressure ref="T2">12120988</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="120" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>12.9000006</depth>
+            <divetime>2580</divetime>
+            <tankpressure ref="T1">8908030</tankpressure>
+            <tankpressure ref="T2">12120988</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.32999992</calculatedpo2>
+            <depth>12.5</depth>
+            <divetime>2590</divetime>
+            <tankpressure ref="T1">8935609</tankpressure>
+            <tankpressure ref="T2">12134777</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <depth>12.6</depth>
+            <divetime>2600</divetime>
+            <tankpressure ref="T1">8949398</tankpressure>
+            <tankpressure ref="T2">12134777</tankpressure>
+            <temperature>279.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>25</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>12.7</depth>
+            <divetime>2610</divetime>
+            <tankpressure ref="T1">8949398</tankpressure>
+            <tankpressure ref="T2">12120988</tankpressure>
+            <temperature>280.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>12.6</depth>
+            <divetime>2620</divetime>
+            <tankpressure ref="T1">8949398</tankpressure>
+            <tankpressure ref="T2">12120988</tankpressure>
+            <temperature>280.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>12.1</depth>
+            <divetime>2630</divetime>
+            <tankpressure ref="T1">8976977</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>280.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="12" duration="60" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>12.4000006</depth>
+            <divetime>2640</divetime>
+            <tankpressure ref="T1">8990767</tankpressure>
+            <tankpressure ref="T2">12189935</tankpressure>
+            <temperature>280.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="9" duration="240" />
+            <depth>12.3</depth>
+            <divetime>2650</divetime>
+            <tankpressure ref="T1">9004556</tankpressure>
+            <tankpressure ref="T2">12203725</tankpressure>
+            <temperature>280.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="9" duration="240" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>11.5</depth>
+            <divetime>2660</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">12203725</tankpressure>
+            <temperature>281.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>10.7</depth>
+            <divetime>2670</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">12093409</tankpressure>
+            <temperature>281.15</temperature>
+            <gradientfactor>37</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.42</calculatedpo2>
+            <depth>10.4000006</depth>
+            <divetime>2680</divetime>
+            <tankpressure ref="T1">9018346</tankpressure>
+            <tankpressure ref="T2">12107198</tankpressure>
+            <temperature>281.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.5</batterychargecondition>
+            <cns>26</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.38</calculatedpo2>
+            <depth>9.8</depth>
+            <divetime>2690</divetime>
+            <tankpressure ref="T1">9059714</tankpressure>
+            <tankpressure ref="T2">12134777</tankpressure>
+            <temperature>282.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.35</calculatedpo2>
+            <depth>9.7</depth>
+            <divetime>2700</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>282.15</temperature>
+            <gradientfactor>39</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>9.7</depth>
+            <divetime>2710</divetime>
+            <tankpressure ref="T1">9073504</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>283.15</temperature>
+            <gradientfactor>39</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>9.7</depth>
+            <divetime>2720</divetime>
+            <tankpressure ref="T1">9114872</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>283.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <depth>9.5</depth>
+            <divetime>2730</divetime>
+            <tankpressure ref="T1">9142451</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>283.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="180" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>9.6</depth>
+            <divetime>2740</divetime>
+            <tankpressure ref="T1">9170030</tankpressure>
+            <tankpressure ref="T2">12272672</tankpressure>
+            <temperature>283.15</temperature>
+            <gradientfactor>37</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.5</batterychargecondition>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>9.400001</depth>
+            <divetime>2750</divetime>
+            <tankpressure ref="T1">9183820</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>284.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>9.5</depth>
+            <divetime>2760</divetime>
+            <tankpressure ref="T1">9197610</tankpressure>
+            <tankpressure ref="T2">1.232783E+07</tankpressure>
+            <temperature>284.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>9.6</depth>
+            <divetime>2770</divetime>
+            <tankpressure ref="T1">9225189</tankpressure>
+            <tankpressure ref="T2">1.235541E+07</tankpressure>
+            <temperature>284.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <depth>9.7</depth>
+            <divetime>2780</divetime>
+            <tankpressure ref="T1">9238978</tankpressure>
+            <tankpressure ref="T2">12369199</tankpressure>
+            <temperature>284.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>27</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>9.5</depth>
+            <divetime>2790</divetime>
+            <tankpressure ref="T1">9238978</tankpressure>
+            <tankpressure ref="T2">1.234162E+07</tankpressure>
+            <temperature>285.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="120" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>9.3</depth>
+            <divetime>2800</divetime>
+            <tankpressure ref="T1">9252768</tankpressure>
+            <tankpressure ref="T2">1.235541E+07</tankpressure>
+            <temperature>285.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>9.400001</depth>
+            <divetime>2810</divetime>
+            <tankpressure ref="T1">9266557</tankpressure>
+            <tankpressure ref="T2">12369199</tankpressure>
+            <temperature>285.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>9.7</depth>
+            <divetime>2820</divetime>
+            <tankpressure ref="T1">9252768</tankpressure>
+            <tankpressure ref="T2">12314041</tankpressure>
+            <temperature>285.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.49</calculatedpo2>
+            <depth>9.8</depth>
+            <divetime>2830</divetime>
+            <tankpressure ref="T1">9280347</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>285.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>9.7</depth>
+            <divetime>2840</divetime>
+            <tankpressure ref="T1">9280347</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>286.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <depth>9.6</depth>
+            <divetime>2850</divetime>
+            <tankpressure ref="T1">9280347</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>286.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="9" duration="60" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>9.6</depth>
+            <divetime>2860</divetime>
+            <tankpressure ref="T1">9280347</tankpressure>
+            <tankpressure ref="T2">12300251</tankpressure>
+            <temperature>286.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.5</batterychargecondition>
+            <cns>28</cns>
+            <decostop kind="mandatory" decodepth="6" duration="300" />
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>9.400001</depth>
+            <divetime>2870</divetime>
+            <tankpressure ref="T1">9280347</tankpressure>
+            <tankpressure ref="T2">12314041</tankpressure>
+            <temperature>286.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.51</batterychargecondition>
+            <cns>29</cns>
+            <decostop kind="mandatory" decodepth="6" duration="300" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>8.3</depth>
+            <divetime>2880</divetime>
+            <tankpressure ref="T1">9294136</tankpressure>
+            <tankpressure ref="T2">12314041</tankpressure>
+            <temperature>286.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>29</cns>
+            <decostop kind="mandatory" decodepth="6" duration="300" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>8</depth>
+            <divetime>2890</divetime>
+            <tankpressure ref="T1">9294136</tankpressure>
+            <tankpressure ref="T2">1.232783E+07</tankpressure>
+            <temperature>287.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>29</cns>
+            <decostop kind="mandatory" decodepth="6" duration="300" />
+            <calculatedpo2>1.27</calculatedpo2>
+            <depth>7.3</depth>
+            <divetime>2900</divetime>
+            <tankpressure ref="T1">9294136</tankpressure>
+            <tankpressure ref="T2">12382989</tankpressure>
+            <temperature>288.15</temperature>
+            <gradientfactor>40</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>29</cns>
+            <decostop kind="mandatory" decodepth="6" duration="300" />
+            <calculatedpo2>1.46999991</calculatedpo2>
+            <depth>7.3</depth>
+            <divetime>2910</divetime>
+            <tankpressure ref="T1">9321715</tankpressure>
+            <tankpressure ref="T2">12382989</tankpressure>
+            <temperature>288.15</temperature>
+            <gradientfactor>42</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>29</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.62</calculatedpo2>
+            <depth>7.20000029</depth>
+            <divetime>2920</divetime>
+            <tankpressure ref="T1">9349294</tankpressure>
+            <tankpressure ref="T2">12093409</tankpressure>
+            <temperature>288.15</temperature>
+            <gradientfactor>40</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>6.70000029</depth>
+            <divetime>2930</divetime>
+            <tankpressure ref="T1">9349294</tankpressure>
+            <tankpressure ref="T2">12176146</tankpressure>
+            <temperature>289.15</temperature>
+            <gradientfactor>44</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>2940</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>289.15</temperature>
+            <gradientfactor>48</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.43</calculatedpo2>
+            <depth>6.8</depth>
+            <divetime>2950</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">12258883</tankpressure>
+            <temperature>290.15</temperature>
+            <gradientfactor>44</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.37</calculatedpo2>
+            <depth>6.6</depth>
+            <divetime>2960</divetime>
+            <tankpressure ref="T1">9432031</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>290.15</temperature>
+            <gradientfactor>43</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>6.3</depth>
+            <divetime>2970</divetime>
+            <tankpressure ref="T1">9445821</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>290.15</temperature>
+            <gradientfactor>40</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.42</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>2980</divetime>
+            <tankpressure ref="T1">9459610</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>290.15</temperature>
+            <gradientfactor>42</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="240" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>6.3</depth>
+            <divetime>2990</divetime>
+            <tankpressure ref="T1">9473400</tankpressure>
+            <tankpressure ref="T2">12258883</tankpressure>
+            <temperature>291.15</temperature>
+            <gradientfactor>42</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="180" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>6.5</depth>
+            <divetime>3000</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">12272672</tankpressure>
+            <temperature>291.15</temperature>
+            <gradientfactor>41</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>30</cns>
+            <decostop kind="mandatory" decodepth="6" duration="180" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>6.3</depth>
+            <divetime>3010</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">12286462</tankpressure>
+            <temperature>291.15</temperature>
+            <gradientfactor>41</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="180" />
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>6.5</depth>
+            <divetime>3020</divetime>
+            <tankpressure ref="T1">9487189</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>291.15</temperature>
+            <gradientfactor>37</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="180" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>6.5</depth>
+            <divetime>3030</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="180" />
+            <calculatedpo2>1.44999993</calculatedpo2>
+            <depth>6.70000029</depth>
+            <divetime>3040</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <calculatedpo2>1.45999992</calculatedpo2>
+            <depth>6.8</depth>
+            <divetime>3050</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <depth>6.6</depth>
+            <divetime>3060</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <calculatedpo2>1.43999994</calculatedpo2>
+            <depth>6.70000029</depth>
+            <divetime>3070</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <depth>6.8</depth>
+            <divetime>3080</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12245093</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>31</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <calculatedpo2>1.43</calculatedpo2>
+            <depth>6.6</depth>
+            <divetime>3090</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12245093</tankpressure>
+            <temperature>292.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <calculatedpo2>1.41</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>3100</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="120" />
+            <depth>6.5</depth>
+            <divetime>3110</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <depth>6.5</depth>
+            <divetime>3120</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>3130</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12231304</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <depth>6.4</depth>
+            <divetime>3140</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>3150</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>293.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <depth>6.4</depth>
+            <divetime>3160</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.4</calculatedpo2>
+            <depth>6.4</depth>
+            <divetime>3170</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>32</cns>
+            <decostop kind="mandatory" decodepth="6" duration="60" />
+            <calculatedpo2>1.39</calculatedpo2>
+            <depth>6.3</depth>
+            <divetime>3180</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12203725</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>25</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="600" />
+            <calculatedpo2>1.36</calculatedpo2>
+            <depth>6.1</depth>
+            <divetime>3190</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12217514</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="600" />
+            <depth>5.9</depth>
+            <divetime>3200</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="600" />
+            <calculatedpo2>1.33999991</calculatedpo2>
+            <depth>5.20000029</depth>
+            <divetime>3210</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="600" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>5.5</depth>
+            <divetime>3220</divetime>
+            <tankpressure ref="T1">9514768</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>294.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="540" />
+            <depth>5.5</depth>
+            <divetime>3230</divetime>
+            <tankpressure ref="T1">9500979</tankpressure>
+            <tankpressure ref="T2">12162356</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="540" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>5.4</depth>
+            <divetime>3240</divetime>
+            <tankpressure ref="T1">9363084</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="540" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>5.4</depth>
+            <divetime>3250</divetime>
+            <tankpressure ref="T1">9376873</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="540" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>5.3</depth>
+            <divetime>3260</divetime>
+            <tankpressure ref="T1">9390663</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="540" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>5</depth>
+            <divetime>3270</divetime>
+            <tankpressure ref="T1">9390663</tankpressure>
+            <tankpressure ref="T2">12148567</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>33</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>5.20000029</depth>
+            <divetime>3280</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12134777</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>5</depth>
+            <divetime>3290</divetime>
+            <tankpressure ref="T1">9390663</tankpressure>
+            <tankpressure ref="T2">12134777</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <depth>4.6</depth>
+            <divetime>3300</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12107198</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <depth>4.70000029</depth>
+            <divetime>3310</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">12038251</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.31</calculatedpo2>
+            <depth>4.8</depth>
+            <divetime>3320</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11900355</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.31999993</calculatedpo2>
+            <depth>4.4</depth>
+            <divetime>3330</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11858987</tankpressure>
+            <temperature>295.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>4</depth>
+            <divetime>3340</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">1.177625E+07</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>43</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="480" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>4.1</depth>
+            <divetime>3350</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11790039</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>38</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>4.1</depth>
+            <divetime>3360</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11707302</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>4.1</depth>
+            <divetime>3370</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11707302</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>37</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>4.1</depth>
+            <divetime>3380</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11721092</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>34</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <depth>4</depth>
+            <divetime>3390</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11734881</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>3.7</depth>
+            <divetime>3400</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11734881</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>36</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="420" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>3.9</depth>
+            <divetime>3410</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11610775</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <depth>4</depth>
+            <divetime>3420</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11624565</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>33</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>4.1</depth>
+            <divetime>3430</divetime>
+            <tankpressure ref="T2">11555617</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <depth>4</depth>
+            <divetime>3440</divetime>
+            <tankpressure ref="T2">11541828</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>3.60000014</depth>
+            <divetime>3450</divetime>
+            <tankpressure ref="T2">11500459</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <calculatedpo2>1.27</calculatedpo2>
+            <depth>3.7</depth>
+            <divetime>3460</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11459091</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="360" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>3.60000014</depth>
+            <divetime>3470</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11445301</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <calculatedpo2>1.28</calculatedpo2>
+            <depth>3.7</depth>
+            <divetime>3480</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11417722</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <depth>3.8</depth>
+            <divetime>3490</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>35</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <calculatedpo2>1.29</calculatedpo2>
+            <depth>3.9</depth>
+            <divetime>3500</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <calculatedpo2>1.3</calculatedpo2>
+            <depth>4</depth>
+            <divetime>3510</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <depth>4</depth>
+            <divetime>3520</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>296.15</temperature>
+            <gradientfactor>26</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="300" />
+            <calculatedpo2>1.27</calculatedpo2>
+            <depth>3.60000014</depth>
+            <divetime>3530</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <calculatedpo2>1.26</calculatedpo2>
+            <depth>3.60000014</depth>
+            <divetime>3540</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11431512</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <calculatedpo2>1.25</calculatedpo2>
+            <depth>3.5</depth>
+            <divetime>3550</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11445301</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <calculatedpo2>1.22</calculatedpo2>
+            <depth>3.10000014</depth>
+            <divetime>3560</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11376354</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <calculatedpo2>1.23</calculatedpo2>
+            <depth>3.10000014</depth>
+            <divetime>3570</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11307406</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <calculatedpo2>1.22</calculatedpo2>
+            <depth>3.10000014</depth>
+            <divetime>3580</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11224669</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="240" />
+            <depth>2.9</depth>
+            <divetime>3590</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11224669</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <calculatedpo2>1.20999992</calculatedpo2>
+            <depth>3</depth>
+            <divetime>3600</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11238458</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <calculatedpo2>1.19999993</calculatedpo2>
+            <depth>3</depth>
+            <divetime>3610</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11238458</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>36</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <calculatedpo2>1.22</calculatedpo2>
+            <depth>3</depth>
+            <divetime>3620</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11155721</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>35</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <depth>3</depth>
+            <divetime>3630</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11059195</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>34</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <calculatedpo2>1.18999994</calculatedpo2>
+            <depth>2.7</depth>
+            <divetime>3640</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11059195</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>37</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="180" />
+            <calculatedpo2>1.20999992</calculatedpo2>
+            <depth>3.10000014</depth>
+            <divetime>3650</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11072984</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>31</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.23</calculatedpo2>
+            <depth>3</depth>
+            <divetime>3660</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11086774</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>30</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.24</calculatedpo2>
+            <depth>3.2</depth>
+            <divetime>3670</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11031616</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <depth>3.2</depth>
+            <divetime>3680</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11017826</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.22</calculatedpo2>
+            <depth>3.2</depth>
+            <divetime>3690</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">11031616</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.23</calculatedpo2>
+            <depth>3.10000014</depth>
+            <divetime>3700</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11031616</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.20999992</calculatedpo2>
+            <depth>2.7</depth>
+            <divetime>3710</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">11031616</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>32</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="120" />
+            <calculatedpo2>1.23</calculatedpo2>
+            <depth>2.9</depth>
+            <divetime>3720</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">1.089372E+07</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>29</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>3.10000014</depth>
+            <divetime>3730</divetime>
+            <tankpressure ref="T1">9418242</tankpressure>
+            <tankpressure ref="T2">1.090751E+07</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>27</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>3.10000014</depth>
+            <divetime>3740</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10921299</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>25</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>37</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>3.10000014</depth>
+            <divetime>3750</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10921299</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>24</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <calculatedpo2>1.20999992</calculatedpo2>
+            <depth>2.9</depth>
+            <divetime>3760</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10797194</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>25</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <decostop kind="mandatory" decodepth="3" duration="60" />
+            <depth>2.8</depth>
+            <divetime>3770</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10866141</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>28</gradientfactor>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <depth>2.9</depth>
+            <divetime>3780</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10797194</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>27</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <calculatedpo2>1.18999994</calculatedpo2>
+            <depth>2.5</depth>
+            <divetime>3790</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10742036</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>25</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <calculatedpo2>1.14</calculatedpo2>
+            <depth>2</depth>
+            <divetime>3800</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10714457</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>36</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.52</batterychargecondition>
+            <cns>38</cns>
+            <calculatedpo2>1.12</calculatedpo2>
+            <depth>1.9</depth>
+            <divetime>3810</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10714457</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>38</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <batterychargecondition>1.53</batterychargecondition>
+            <cns>38</cns>
+            <calculatedpo2>1.06999993</calculatedpo2>
+            <depth>1.30000007</depth>
+            <divetime>3820</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10700667</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>46</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <calculatedpo2>1.03</calculatedpo2>
+            <depth>0</depth>
+            <divetime>3830</divetime>
+            <tankpressure ref="T1">9404452</tankpressure>
+            <tankpressure ref="T2">10645509</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>49</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+          <waypoint>
+            <cns>38</cns>
+            <calculatedpo2>0.969999969</calculatedpo2>
+            <depth>0</depth>
+            <divetime>3840</divetime>
+            <tankpressure ref="T1">9266557</tankpressure>
+            <tankpressure ref="T2">10673088</tankpressure>
+            <temperature>297.15</temperature>
+            <gradientfactor>59</gradientfactor>
+            <nodecotime>5940</nodecotime>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>47.5</greatestdepth>
+          <notes>
+            <para>Summary:  
+</para>
+            <para>Environment:  
+</para>
+            <para>Gas:  
+</para>
+            <para>Gear:  
+</para>
+            <para>Issues:  
+</para>
+          </notes>
+          <anysymptoms>
+            <notes />
+          </anysymptoms>
+          <diveduration>3825</diveduration>
+          <observations>
+            <notes>
+              <para>-ShearwaterDiveModeType:0-</para>
+              <para>-ShearwaterOCRecSubModeType:0-</para>
+            </notes>
+          </observations>
+          <averagedepth>25.4913788</averagedepth>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+  <tablegeneration>
+    <calculateprofile>
+      <profile id="profile_2182925401785575328">
+        <density>1020</density>
+        <decomodel>zhl16c</decomodel>
+      </profile>
+    </calculateprofile>
+  </tablegeneration>
+</uddf>


### PR DESCRIPTION
Fixes #845. Found while investigating #810 (a Shearwater Petrel 3 CCR dive whose profile showed no sensor data).

## The problem

The UDDF waypoint oxygen parsing looked only for `<setpoint>` and bare `<ppo2>` -- the non-standard names our own exporter writes. None of the spec-legal elements were handled, so a third-party file matched nothing: the reporter's Shearwater Cloud export carried 262 `<calculatedpo2>` samples and imported with no ppO2 at all.

## Commits

### 1. Import the spec ppO2 elements (`a65d3dc`)

- Parse `<setpo2>`, `<calculatedpo2>` and per-cell `<measuredpo2 ref=...>`, plus the unpublished 3.3.0 `<ppo2 ref=...>` rename that AP Diving DiveSight emits. Cell refs resolve against the declared `<o2sensor>` ids -- an indirection, not a positional index -- falling back to waypoint order when a file omits the declarations, so readings are never silently dropped.
- Convert Pascal to bar. The spec mandates Pascal (`1.27e5`), but Shearwater writes plain bar (`0.849999964`), so the magnitude decides the unit rather than a fixed divide by 100000.
- Keep reading `<setpoint>` and bare `<ppo2>` so our own exports still round-trip, and treat a ref-less `<measuredpo2>` as an aggregate loop value instead of discarding it.
- Parse all of it inside the waypoint loop. The old second pass walked *waypoints* while indexing into *profile points*, which drift apart as soon as a waypoint is dropped for lacking a depth -- one dropped waypoint shifted every later reading onto the wrong sample. The regression test for this failed with `0.7` where `1.3` belonged.

### 2. Map UDDF circuit names to the dive mode (`bab6144`)

Not in the original ticket, but the first commit is invisible without it.

Dive mode was parsed by enum name only, so UDDF's own spelling never matched: a `closedcircuit` dive imported with no mode and fell back to open circuit. Shearwater compounds this by marking the circuit per sample, as a `type` attribute on the waypoint, which nothing read.

The mode is not cosmetic. Loop ppO2 is discarded outright for OC dives (`profile_analysis_provider.dart:960`), so a CCR dive imported as OC throws away every cell reading and draws ppO2 as depth x FO2 off the diluent instead -- the reporter's dive showed 1.19 bar at 46.6m, which is air at ambient pressure, not a measured loop value.

A dive that runs closed circuit for any part of it stays a rebreather dive, so bailout segments logged as open circuit do not flip it back. An explicit dive-level mode always wins over the waypoint fallback.

### 3. Add the Petrel 3 fixture from #810 (`024fd67`)

The reporter's export itself, as `test/dives/006_ccr_petrel3_shearwater-cloud-export.uddf`, so the parser is pinned against what Shearwater Cloud actually writes rather than what we think it writes. It carries no personal data: empty `<divesite />`, no coordinates, serial already redacted, empty buddy, blank note templates.

Pins the two properties that would silently regress -- the loop ppO2 staying in bar, and the dive resolving to CCR from the waypoint attribute alone -- plus the absence of per-cell data, which is the actual answer to #810.

### 4. Pin CCR loop decompression against the computer's own GF (`68c673b`)

The circuit mapping is not cosmetic. Measured on that fixture at GF 40/70:

| Model | Surface GF | Ceiling at end | TTS at end |
| --- | --- | --- | --- |
| Petrel 3 (logged in the file) | 59 | clear | - |
| Open circuit on air (before) | 131 | 3.7m | 47min |
| CCR loop, air diluent (after) | 64 | 0m | 0min |

On open circuit the 52 minutes of shallow stops keep loading ~1 bar of ppN2; on the loop at a ~1.2 setpoint in 1.3 bar ambient the inspired inert is near zero. Same gas, completely different decompression -- which is why the dive read as a violation that never happened. The open-circuit result is pinned too, so the fallback cannot silently return.

### 5. Read the dive mode from a textless divemode element (`32cbff1`)

Review fix. UDDF's own form for the circuit is an empty element carrying a `type` attribute, and only the waypoint reader handled it. The dive-level and `<rebreather>` readers went through `getElementText`, which returns null for an element with no inner text, so a file stating its circuit the way the spec encodes it was ignored. All three sites now share one reader accepting either form.

## Verification

Written test-first; every test was watched failing for the right reason before the implementation existed.

20 new tests: each element form and both unit conventions, cell-ref resolution and its fallback, our own exporter's names, the waypoint-alignment regression, the circuit-name mapping, the real fixture end to end, and the decompression outcome.

Checked against the file attached to #810: imports as `DiveMode.ccr` with 385 samples, 262 carrying ppO2, range 0.79-1.62 bar -- matching the raw `<calculatedpo2>` count and min/max exactly.

103 UDDF tests plus the deco fixture suite green, full suite green, `flutter analyze` clean. Commit 1 was verified in isolation before commit 2 was applied, so it stands on its own.

## Screenshots

The ppO2 curve is now imported and rendered correctly, and the decompression figures follow from it: the dive is analysed as a rebreather dive, so surface GF drops from 131 to 64 against the 59 the computer logged, the phantom 3.7m ceiling at the surface disappears, and the tissue heatmap changes accordingly.

CNS remains off (13% against the computer's 38%). That is untouched by this PR and out of scope here -- see #578.



### Before
<img width="3276" height="1780" alt="before" src="https://github.com/user-attachments/assets/e66374de-6f28-41b1-8e41-7af4a5f76272" />

### After
note also the now correct heatmap

<img width="2925" height="1609" alt="image" src="https://github.com/user-attachments/assets/c6001997-d151-40f6-9a11-6dd1ea51e331" />



## Not in scope

- `lib/core/services/export/uddf/uddf_import_service.dart` has a parallel waypoint loop with no oxygen parsing at all. Its only entry point (`ExportService.importDivesFromUddf`) has no callers, so it is left alone rather than grown.
- The exporter still writes the non-standard `<setpoint>`/`<ppo2>` names. Switching it to the spec elements is a separate change; import-side fallbacks mean it can be done without breaking existing files.
- SCR is untouched. The circuit mapping resolves `semiclosedcircuit`, but the SCR loop model is a separate follow-up.
- #846 was filed off this dive's 134% surface GF and has been closed: the diagnosis there (an unrecorded diluent) was wrong. The dive ran on air diluent throughout, and the false violation came from the circuit mapping, so the second commit here fixes it.





