### PR TITLE
Zip macOS PR artifact as a runnable app bundle

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -155,8 +155,9 @@ jobs:
               rows,
               '',
               'Artifacts expire in 7 days. Downloading requires being signed in to GitHub. ' +
-              'The macOS download contains `submersion-macos.zip` — extract it to get ' +
-              '`submersion.app`. The build is ad-hoc signed — right-click → Open on first launch.',
+              'macOS needs two extractions: unzip the downloaded artifact, then unzip the ' +
+              '`submersion-macos.zip` inside it to get a runnable `submersion.app`. ' +
+              'The build is ad-hoc signed — right-click → Open on first launch.',
               '',
               '<sub>Updated automatically on each push.</sub>',
               '',

--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -155,7 +155,8 @@ jobs:
               rows,
               '',
               'Artifacts expire in 7 days. Downloading requires being signed in to GitHub. ' +
-              'The macOS build is ad-hoc signed — right-click → Open on first launch.',
+              'The macOS download contains `submersion-macos.zip` — extract it to get ' +
+              '`submersion.app`. The build is ad-hoc signed — right-click → Open on first launch.',
               '',
               '<sub>Updated automatically on each push.</sub>',
               '',

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -660,6 +660,19 @@ jobs:
             --entitlements macos/Runner/ReleaseNoSandbox.entitlements \
             build/macos/Build/Products/Release/submersion.app
 
+      # Zip with ditto before upload: upload-artifact would otherwise root the
+      # archive inside the .app bundle (losing the submersion.app wrapper) and
+      # strip the symlinks, permission bits, and codesign seal the bundle
+      # needs to be runnable.
+      - name: Zip macOS app bundle
+        if: >
+          github.event_name == 'pull_request' ||
+          (github.ref == 'refs/heads/main' && github.event_name == 'push')
+        run: |
+          ditto -c -k --keepParent \
+            build/macos/Build/Products/Release/submersion.app \
+            build/macos/Build/Products/Release/submersion-macos.zip
+
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v7
         if: >
@@ -667,7 +680,7 @@ jobs:
           (github.ref == 'refs/heads/main' && github.event_name == 'push')
         with:
           name: macos-build
-          path: build/macos/Build/Products/Release/submersion.app
+          path: build/macos/Build/Products/Release/submersion-macos.zip
           retention-days: 7
 
   build-android:


### PR DESCRIPTION
## Summary

The `macos-build` PR artifact was unusable as downloaded: `upload-artifact` was pointed directly at `submersion.app`, and since it roots the archive at the deepest common parent of the matched files, the zip contained only a bare `Contents/` folder. Manually rebuilding the bundle (create `submersion` folder, move `Contents` in, add `.app`) was also fragile because upload-artifact's own zipping drops symlinks and POSIX permission bits, which can break the framework links and ad-hoc codesign seal.

## Changes

- **ci.yaml**: add a "Zip macOS app bundle" step (same `if:` guard as the upload) that runs `ditto -c -k --keepParent` to produce `submersion-macos.zip` with the `submersion.app/` wrapper, symlinks, permissions, and signing seal intact; upload that zip instead of the raw bundle.
- **artifact-links.yml**: update the sticky PR comment to note the artifact contains `submersion-macos.zip` which extracts to `submersion.app`.

## Testing

- Both workflow files validated with a YAML parser.
- The `ci.yaml` half runs from the PR branch, so this PR's own `macos-build` artifact can be downloaded to verify: unzip the artifact, then unzip `submersion-macos.zip`, and `submersion.app` should launch via right-click → Open.
- The comment-wording half of `artifact-links.yml` only takes effect after merge (`workflow_run` executes the workflow definition from main).