### PR TITLE
fix(dive_sites): expose 3D History in the master-detail site pane

### DIFF
--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -349,6 +349,20 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
                 ),
               ),
             ),
+          // Unconditional, matching the standalone AppBar: career terrain is
+          // built from dive profiles, not from the site's coordinates.
+          IconButton(
+            icon: const Icon(Icons.view_in_ar, size: 20),
+            tooltip: context.l10n.dive3d_career_title,
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => CareerTerrainPage(
+                  query: careerSiteQuery(widget.siteId),
+                  title: site.name,
+                ),
+              ),
+            ),
+          ),
           IconButton(
             icon: const Icon(Icons.edit, size: 20),
             tooltip: context.l10n.diveSites_detail_editTooltipShort,

--- a/test/features/dive_sites/presentation/pages/site_detail_page_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_detail_page_test.dart
@@ -4,6 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_3d/application/career_providers.dart';
+import 'package:submersion/features/dive_3d/domain/career/career_geometry_service.dart';
+import 'package:submersion/features/dive_3d/presentation/pages/career_terrain_page.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
@@ -245,6 +248,64 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.byTooltip('Site Seascape'), findsNothing);
+    });
+  });
+
+  group('SiteDetailPage embedded 3D history action', () {
+    const bareSite = DiveSite(id: 'history-site', name: 'Mystery');
+
+    testWidgets('embedded header shows the 3D history button even without '
+        'coordinates', (tester) async {
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            siteProvider(bareSite.id).overrideWith((ref) async => bareSite),
+            siteDiveCountProvider(bareSite.id).overrideWith((ref) async => 0),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SiteDetailPage(siteId: bareSite.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('3D History'), findsOneWidget);
+    });
+
+    testWidgets('embedded 3D history button opens the career terrain page', (
+      tester,
+    ) async {
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            siteProvider(bareSite.id).overrideWith((ref) async => bareSite),
+            siteDiveCountProvider(bareSite.id).overrideWith((ref) async => 0),
+            careerGeometryProvider((
+              query: careerSiteQuery(bareSite.id),
+              colorMode: CareerColorMode.recency,
+            )).overrideWith((ref) async => null),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SiteDetailPage(siteId: bareSite.id, embedded: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('3D History'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CareerTerrainPage), findsOneWidget);
+      expect(find.text('No dives with profiles to show'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
Fixes #852

## Problem

`SiteDetailPage` renders two chrome variants: a `Scaffold`/`AppBar` when standalone, and `_buildEmbeddedHeader` when `embedded: true` — the latter being what `MasterDetailScaffold` shows in the detail pane. The AppBar carried **two** 3D entry points, but the embedded header only mirrored one:

| Icon | Destination | Label | AppBar | Embedded header |
| --- | --- | --- | --- | --- |
| `Icons.terrain` | `SiteSeascapePage` | Site Seascape | yes | yes |
| `Icons.view_in_ar` | `CareerTerrainPage` | **3D History** | yes | **no** |

This made 3D History unreachable rather than merely awkward. A standalone `/sites/:id` visit redirects to `/sites?selected=...` whenever the viewport is at or above the master-detail breakpoint (1100px), so on desktop the AppBar variant never renders and the button had no reachable host at all.

## Fix

Add the missing action to the embedded header, matching the AppBar's ordering and the embedded header's `size: 20` icon convention.

It is deliberately **not** wrapped in the seascape's `if (site.hasCoordinates)` guard. Career terrain is built from dive profiles (`careerSiteQuery` filters on `dive.site?.id`), not from site GPS, so a site logged without coordinates still has 3D history worth seeing. The seascape button keeps its guard because bathymetry genuinely needs a lat/lon.

The fix also reaches the site pane embedded inside dive detail, which renders the same `SiteDetailPage(embedded: true)`.

## Layout safety

`MasterDetailScaffold` uses a fixed 440px master pane and `Expanded` for the detail pane, and master-detail only activates at >=1100px. The narrowest possible detail pane is roughly `1100 - 80 (nav rail) - 440 - 1 (divider) = 580px`; the header's fixed chrome with a fourth icon is ~292px, leaving the `Expanded` site-name column ample room. No `RenderFlex` overflow risk.

## Tests

Two cases added to the existing `site_detail_page_test.dart`, both confirmed failing before the change:

- the button renders in the embedded header for a site **without** coordinates (pins the guard decision)
- tapping it pushes `CareerTerrainPage`, with `careerGeometryProvider` overridden to `null` so the empty-state text is the assertion

`dart format .` clean, `flutter analyze` clean, and 398 tests across `test/features/dive_sites/` plus the embedded-site consumers in `dive_log` pass.

## Follow-up worth considering (not in this PR)

Two hand-maintained chrome variants with no shared action list is a drift magnet — `git log -L` shows the seascape icon being changed in the AppBar in a later commit while its embedded twin was updated by hand, the same drift that dropped this button. Extracting the actions into a single `List<Widget> _detailActions({required double iconSize})` consumed by both paths would make it impossible for a new action to silently miss a layout mode.
