### PR TITLE
Fix unreadable release notes in dark-mode update dialogs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -385,6 +385,9 @@ jobs:
       - name: Run appcast beta feed test
         run: ./scripts/generate_appcast_beta_test.sh
 
+      - name: Run release notes HTML test
+        run: ./scripts/generate_release_notes_html_test.sh
+
       - name: Upload coverage
         uses: codecov/codecov-action@v7
         if: always()

--- a/scripts/generate_release_notes_html.sh
+++ b/scripts/generate_release_notes_html.sh
@@ -33,9 +33,17 @@ cat <<HTML_TEMPLATE
     margin: 16px;
     font-size: 14px;
     color: #222;
+    background-color: #fff;
     line-height: 1.5;
   }
   h2 { font-size: 18px; border-bottom: 1px solid #ddd; padding-bottom: 6px; }
+  @media (prefers-color-scheme: dark) {
+    body {
+      color: #e8e8e8;
+      background-color: #1e1e1e;
+    }
+    h2 { border-bottom-color: #444; }
+  }
   h3 { font-size: 15px; margin-top: 16px; margin-bottom: 4px; }
   ul { padding-left: 24px; margin-top: 4px; }
   li { margin: 3px 0; }

--- a/scripts/generate_release_notes_html_test.sh
+++ b/scripts/generate_release_notes_html_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tests for generate_release_notes_html.sh: markdown conversion and the
+# explicit light/dark colour pairs that keep the notes readable inside the
+# Sparkle/WinSparkle web views regardless of the OS theme (issue #849).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+OUT=$(printf '## Heading\n\n### Sub\n\n- one\n- two\n\nplain text\n' \
+  | "$SCRIPT_DIR/generate_release_notes_html.sh")
+
+# Markdown conversion basics.
+echo "$OUT" | grep -q "<h2>Heading</h2>" || fail "h2 heading not converted"
+echo "$OUT" | grep -q "<h3>Sub</h3>" || fail "h3 subheading not converted"
+echo "$OUT" | grep -q "<li>one</li>" || fail "bullet not converted to li"
+[ "$(echo "$OUT" | grep -c '<ul>')" -eq 1 ] || fail "bullets not wrapped in a single ul"
+echo "$OUT" | grep -q "<p>plain text</p>" || fail "plain line not wrapped in p"
+
+# The body must declare text and background colours as a pair. A text colour
+# without a background lets the embedded web view paint a theme-dependent
+# background, producing near-black text on a dark page (issue #849).
+BODY_RULE=$(echo "$OUT" | sed -n '/body {/,/}/p')
+echo "$BODY_RULE" | grep -q "color: #222" || fail "body text colour missing"
+echo "$BODY_RULE" | grep -q "background-color: #fff" \
+  || fail "body background colour missing; dark-mode web views paint #222 text on a dark page"
+
+# Dark mode must be handled explicitly with the inverse pair, plus a visible
+# h2 border (the light #ddd border disappears on a dark background).
+DARK_RULE=$(echo "$OUT" | sed -n '/@media (prefers-color-scheme: dark)/,/^  }/p')
+[ -n "$DARK_RULE" ] || fail "no prefers-color-scheme: dark block"
+echo "$DARK_RULE" | grep -q "color: #e8e8e8" || fail "dark-mode text colour missing"
+echo "$DARK_RULE" | grep -q "background-color: #1e1e1e" || fail "dark-mode background colour missing"
+echo "$OUT" | sed -n '/@media (prefers-color-scheme: dark)/,/^<\/style>/p' \
+  | grep -q "border-bottom-color: #444" || fail "dark-mode h2 border colour missing"
+
+echo "PASS: all generate_release_notes_html tests passed"


### PR DESCRIPTION
## Summary

Fixes #849 — on Windows in dark mode, the WinSparkle update dialog's release notes pane rendered near-black text on a dark background.

`generate_release_notes_html.sh` declared a body text colour (`#222`) but no background, so the embedded web view fell back to the OS theme and painted the page dark under the dark text. The `h2` bottom border (`#ddd`) had the inverse problem.

## Changes

- **`scripts/generate_release_notes_html.sh`**: declare `color` and `background-color` as a pair (`#222` on `#fff`), and add a `prefers-color-scheme: dark` block with the inverse pair (`#e8e8e8` on `#1e1e1e`) plus an `h2` border override (`#444`). The explicit light background alone fixes the readability bug even in web views that ignore the media query; the dark block lets theme-aware views (WKWebView on macOS, WebView2) match the OS instead of glowing white.
- **`scripts/generate_release_notes_html_test.sh`** (new): asserts the markdown conversion basics and that both colour pairs plus the dark h2 border are present. Written first; it failed on exactly the missing background colour before the fix.
- **`.github/workflows/ci.yaml`**: run the new test alongside the existing appcast beta feed test.

Since the same generator feeds Sparkle (macOS), WinSparkle (Windows), and the beta/promote pipelines, this covers the macOS updater noted at the bottom of the issue as well.

## Test plan

- [x] `./scripts/generate_release_notes_html_test.sh` passes (and failed before the fix)
- [x] `./scripts/generate_appcast_beta_test.sh` still passes