### PR TITLE
Allow course dates more than one year in the future

### DIFF
--- a/lib/features/courses/presentation/pages/course_edit_page.dart
+++ b/lib/features/courses/presentation/pages/course_edit_page.dart
@@ -393,11 +393,19 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
     BuildContext context, {
     required bool isStart,
   }) async {
-    final initialDate = isStart
-        ? _startDate
-        : (_completionDate ?? DateTime.now());
     final firstDate = isStart ? DateTime(1950) : _startDate;
     final lastDate = DateTime(2100);
+    // Clamp into [firstDate, lastDate]: a completion date defaults to today,
+    // which precedes a future start date and would trip showDatePicker's
+    // initialDate assertion.
+    var initialDate = isStart
+        ? _startDate
+        : (_completionDate ?? DateTime.now());
+    if (initialDate.isBefore(firstDate)) {
+      initialDate = firstDate;
+    } else if (initialDate.isAfter(lastDate)) {
+      initialDate = lastDate;
+    }
 
     final picked = await showDatePicker(
       context: context,

--- a/lib/features/courses/presentation/pages/course_edit_page.dart
+++ b/lib/features/courses/presentation/pages/course_edit_page.dart
@@ -397,7 +397,7 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
         ? _startDate
         : (_completionDate ?? DateTime.now());
     final firstDate = isStart ? DateTime(1950) : _startDate;
-    final lastDate = DateTime.now().add(const Duration(days: 365));
+    final lastDate = DateTime(2100);
 
     final picked = await showDatePicker(
       context: context,

--- a/test/features/courses/presentation/pages/course_edit_date_range_test.dart
+++ b/test/features/courses/presentation/pages/course_edit_date_range_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/courses/presentation/pages/course_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Widget buildHarness({required List<dynamic> overrides}) {
+    return ProviderScope(
+      overrides: overrides.cast(),
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: CourseEditPage(embedded: true)),
+      ),
+    );
+  }
+
+  // Enters a date via the picker's text-input mode and confirms with OK.
+  // Calendar mode cannot even display out-of-range dates, so typed input is
+  // the only way to probe the picker's lastDate bound behaviorally: an
+  // out-of-range date leaves the dialog open with an "Out of range." error.
+  Future<void> enterDateInPicker(WidgetTester tester, DateTime date) async {
+    await tester.tap(find.byIcon(Icons.edit_outlined));
+    await tester.pumpAndSettle();
+
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    await tester.enterText(
+      find.byType(TextField).last,
+      '$month/$day/${date.year}',
+    );
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('start date can be set more than one year in the future', (
+    tester,
+  ) async {
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(buildHarness(overrides: overrides));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Start Date'));
+    await tester.pumpAndSettle();
+
+    final target = DateTime(DateTime.now().year + 2, 6, 15);
+    await enterDateInPicker(tester, target);
+
+    expect(find.byType(DatePickerDialog), findsNothing);
+    expect(find.textContaining('${target.year}'), findsOneWidget);
+  });
+}

--- a/test/features/courses/presentation/pages/course_edit_date_range_test.dart
+++ b/test/features/courses/presentation/pages/course_edit_date_range_test.dart
@@ -20,6 +20,9 @@ void main() {
     return ProviderScope(
       overrides: overrides.cast(),
       child: const MaterialApp(
+        // Pin the locale: the test asserts on English labels and types a
+        // US-format date into the picker.
+        locale: Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(body: CourseEditPage(embedded: true)),
@@ -38,11 +41,20 @@ void main() {
     final month = date.month.toString().padLeft(2, '0');
     final day = date.day.toString().padLeft(2, '0');
     await tester.enterText(
-      find.byType(TextField).last,
+      find.descendant(
+        of: find.byType(DatePickerDialog),
+        matching: find.byType(TextField),
+      ),
       '$month/$day/${date.year}',
     );
     await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
+  }
+
+  Future<void> pickFutureStartDate(WidgetTester tester, DateTime date) async {
+    await tester.tap(find.text('Start Date'));
+    await tester.pumpAndSettle();
+    await enterDateInPicker(tester, date);
   }
 
   testWidgets('start date can be set more than one year in the future', (
@@ -52,13 +64,32 @@ void main() {
     await tester.pumpWidget(buildHarness(overrides: overrides));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Start Date'));
-    await tester.pumpAndSettle();
-
     final target = DateTime(DateTime.now().year + 2, 6, 15);
-    await enterDateInPicker(tester, target);
+    await pickFutureStartDate(tester, target);
 
     expect(find.byType(DatePickerDialog), findsNothing);
     expect(find.textContaining('${target.year}'), findsOneWidget);
   });
+
+  testWidgets(
+    'completion date picker opens when the start date is in the future',
+    (tester) async {
+      // Toggling "Completed" initializes the completion date to today, which
+      // is before a future start date. The picker must clamp its initialDate
+      // into [firstDate, lastDate] or showDatePicker throws an assertion.
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(buildHarness(overrides: overrides));
+      await tester.pumpAndSettle();
+
+      final target = DateTime(DateTime.now().year + 2, 6, 15);
+      await pickFutureStartDate(tester, target);
+
+      await tester.tap(find.text('Completed'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Completion Date'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DatePickerDialog), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- The course edit page's date picker capped `lastDate` at one year from today, so a course start (or completion) date could never be set further out — blocking use cases like planning 2027 diving in August 2026.
- Replace the cap with `DateTime(2100)`, matching the bound already used by the trip edit page, so courses and trips behave consistently.

## Test plan
- New widget test `course_edit_date_range_test.dart` opens the course edit page, switches the start-date picker to text-input mode, enters a date two years out, and asserts the picker accepts it. With the old bound the dialog stays open with an "Out of range" error; the test was verified to fail before the fix.
- `flutter analyze` clean, `dart format` clean, all 125 courses-feature tests pass.

Fixes #807
