### PR TITLE
Format water temperature chart tooltip with unit-aware values

### DIFF
--- a/lib/features/statistics/presentation/widgets/stat_charts.dart
+++ b/lib/features/statistics/presentation/widgets/stat_charts.dart
@@ -633,6 +633,28 @@ class MultiTrendLineChart extends StatelessWidget {
               LineChartData(
                 minY: minY - padding,
                 maxY: maxY + padding,
+                lineTouchData: LineTouchData(
+                  touchTooltipData: LineTouchTooltipData(
+                    getTooltipItems: (touchedSpots) {
+                      return touchedSpots.map((spot) {
+                        final point = dataSeries[spot.barIndex][spot.spotIndex];
+                        final formattedValue =
+                            valueFormatter?.call(point.value) ??
+                            point.value.toStringAsFixed(1);
+                        final isFirst = identical(spot, touchedSpots.first);
+                        return LineTooltipItem(
+                          isFirst
+                              ? '${point.label}\n$formattedValue'
+                              : formattedValue,
+                          TextStyle(
+                            color: colors[spot.barIndex % colors.length],
+                            fontWeight: FontWeight.bold,
+                          ),
+                        );
+                      }).toList();
+                    },
+                  ),
+                ),
                 titlesData: FlTitlesData(
                   show: true,
                   bottomTitles: AxisTitles(

--- a/test/features/statistics/presentation/widgets/multi_trend_line_chart_tooltip_test.dart
+++ b/test/features/statistics/presentation/widgets/multi_trend_line_chart_tooltip_test.dart
@@ -1,0 +1,116 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+import 'package:submersion/features/statistics/presentation/widgets/stat_charts.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// Issue #864: fl_chart's default touch tooltip stringifies the raw double,
+// so a monthly average like 528/61 = 8.655737704918034 was displayed with
+// 15 decimal places on the water temperature chart. The tooltip must run
+// every value through the chart's valueFormatter (unit-aware) instead.
+
+final _minSeries = [
+  TrendDataPoint(date: DateTime(2024, 9), value: 5.0, label: 'Sep'),
+];
+final _avgSeries = [
+  TrendDataPoint(date: DateTime(2024, 9), value: 528 / 61, label: 'Sep'),
+];
+final _maxSeries = [
+  TrendDataPoint(date: DateTime(2024, 9), value: 21.0, label: 'Sep'),
+];
+
+Future<void> _pumpChart(
+  WidgetTester tester, {
+  String Function(double)? valueFormatter,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 400,
+            height: 300,
+            child: MultiTrendLineChart(
+              dataSeries: [_minSeries, _avgSeries, _maxSeries],
+              seriesLabels: const ['Min', 'Avg', 'Max'],
+              seriesColors: const [Colors.blue, Colors.green, Colors.red],
+              valueFormatter: valueFormatter,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+List<LineTooltipItem?> _tooltipItemsForAllSeries(WidgetTester tester) {
+  final chart = tester.widget<LineChart>(find.byType(LineChart));
+  final data = chart.data;
+  final touchedSpots = [
+    for (var i = 0; i < data.lineBarsData.length; i++)
+      LineBarSpot(data.lineBarsData[i], i, data.lineBarsData[i].spots.first),
+  ];
+  return data.lineTouchData.touchTooltipData.getTooltipItems(touchedSpots);
+}
+
+void main() {
+  group('MultiTrendLineChart tooltip', () {
+    testWidgets('formats values with the valueFormatter', (tester) async {
+      await _pumpChart(
+        tester,
+        valueFormatter: (value) => '${value.toStringAsFixed(1)} °C',
+      );
+
+      final items = _tooltipItemsForAllSeries(tester);
+      final texts = items.map((item) => item!.text).toList();
+
+      expect(texts, hasLength(3));
+      expect(texts.any((t) => t.contains('8.7 °C')), isTrue);
+      expect(texts.any((t) => t.contains('8.655737704918')), isFalse);
+      expect(texts.any((t) => t.contains('5.0 °C')), isTrue);
+      expect(texts.any((t) => t.contains('21.0 °C')), isTrue);
+    });
+
+    testWidgets('includes the point label once', (tester) async {
+      await _pumpChart(
+        tester,
+        valueFormatter: (value) => '${value.toStringAsFixed(1)} °C',
+      );
+
+      final items = _tooltipItemsForAllSeries(tester);
+      final texts = items.map((item) => item!.text).toList();
+
+      expect(texts.where((t) => t.contains('Sep')), hasLength(1));
+    });
+
+    testWidgets('falls back to one decimal place without a formatter', (
+      tester,
+    ) async {
+      await _pumpChart(tester);
+
+      final items = _tooltipItemsForAllSeries(tester);
+      final texts = items.map((item) => item!.text).toList();
+
+      expect(texts.any((t) => t.contains('8.7')), isTrue);
+      expect(texts.any((t) => t.contains('8.655737704918')), isFalse);
+    });
+
+    testWidgets('colors each tooltip line with its series color', (
+      tester,
+    ) async {
+      await _pumpChart(
+        tester,
+        valueFormatter: (value) => '${value.toStringAsFixed(1)} °C',
+      );
+
+      final items = _tooltipItemsForAllSeries(tester);
+      final colors = items.map((item) => item!.textStyle.color).toList();
+
+      expect(colors, [Colors.blue, Colors.green, Colors.red]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #864 — the Statistics / Conditions water temperature chart displayed the monthly average with up to 15 decimal places (e.g. `8.655737704918034`) when tapping a point.

- `MultiTrendLineChart` never configured `lineTouchData`, so tapping the chart fell through to fl_chart's default tooltip, which stringifies the raw `double`. Min/max only looked fine because they are stored as clean values; the average is a computed mean with no short decimal representation.
- Added a custom tooltip mirroring the existing `TrendLineChart` pattern: values run through the chart's `valueFormatter` (the conditions page passes `units.formatTemperature`, so the tooltip now also respects the diver's temperature unit setting), with a one-decimal fallback, the month label shown once, and each line keeping its series color.

## Testing

- New widget test file exercising the tooltip callback directly (formatted values, single label, fallback precision, per-series colors) — fl_chart paints tooltips on canvas, so the repo's established `getTooltipItems` invocation pattern is used.
- Full statistics suite passes (122 tests); `flutter analyze` clean in this worktree; `dart format` clean.
