### PR TITLE
fix(sync): hydrate missing schema-default columns on changeset replay

### DIFF
--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2143,7 +2143,10 @@ class SyncDataSerializer {
     String entityType,
     Map<String, dynamic> data,
   ) async {
-    data = _withoutDeviceLocalFields(data, entityType: entityType);
+    data = _withSchemaDefaults(
+      entityType,
+      _withoutDeviceLocalFields(data, entityType: entityType),
+    );
     switch (entityType) {
       case 'divers':
         await _db
@@ -2620,7 +2623,10 @@ class SyncDataSerializer {
     if (records.isEmpty) return;
     records = records
         .map(
-          (record) => _withoutDeviceLocalFields(record, entityType: entityType),
+          (record) => _withSchemaDefaults(
+            entityType,
+            _withoutDeviceLocalFields(record, entityType: entityType),
+          ),
         )
         .toList();
     switch (entityType) {
@@ -5099,6 +5105,93 @@ class SyncDataSerializer {
   // ============================================================================
   // Default Value Helpers
   // ============================================================================
+
+  /// Cached (jsonKey, fill) pairs per entity type: one entry for every
+  /// non-nullable column of the entity's table whose schema-level default can
+  /// be reconstructed at replay time (a primitive [Constant] or a
+  /// `clientDefault`). Built lazily from the live table metadata so new
+  /// columns are covered without touching this file.
+  final Map<String, List<MapEntry<String, Object? Function()>>>
+  _schemaDefaultFills = {};
+
+  /// Hydrates missing (or explicitly null) non-nullable columns in [data]
+  /// with their schema defaults before the generated `fromJson` runs (#858).
+  ///
+  /// A record exported before a schema change lacks the newer columns, and
+  /// Drift's `fromJson` does a straight cast per column -- `null` where a
+  /// non-nullable `bool`/`int`/`String` is expected throws, which permanently
+  /// blocked library adoption (the only path that replays full changeset
+  /// history through `fromJson`). Filling the column's own default mirrors
+  /// what the `ALTER TABLE ... DEFAULT` migration produced for that row on
+  /// the exporting device, so this is a faithful reconstruction, not a guess.
+  Map<String, dynamic> _withSchemaDefaults(
+    String entityType,
+    Map<String, dynamic> data,
+  ) {
+    final fills = _schemaDefaultFills.putIfAbsent(
+      entityType,
+      () => _buildSchemaDefaultFills(entityType),
+    );
+    if (fills.isEmpty) return data;
+    Map<String, dynamic>? patched;
+    for (final fill in fills) {
+      if (data[fill.key] != null) continue;
+      final value = fill.value();
+      if (value == null) continue;
+      (patched ??= Map.of(data))[fill.key] = value;
+    }
+    return patched ?? data;
+  }
+
+  List<MapEntry<String, Object? Function()>> _buildSchemaDefaultFills(
+    String entityType,
+  ) {
+    final TableInfo<Table, dynamic> table;
+    try {
+      table = _syncTableFor(entityType);
+    } on ArgumentError {
+      // upsertRecord silently ignores unknown entity types; mirror that.
+      return const [];
+    }
+    final fills = <MapEntry<String, Object? Function()>>[];
+    for (final column in table.$columns) {
+      if (column.$nullable) continue;
+      final jsonKey = _jsonKeyForSqlColumn(column.name);
+      final defaultValue = column.defaultValue;
+      final clientDefault = column.clientDefault;
+      if (defaultValue is Constant<Object>) {
+        final value = defaultValue.value;
+        // Primitives only: they match the wire format for plain and enum
+        // columns, and cover every NOT NULL DEFAULT a migration can add.
+        // Non-constant SQL defaults (e.g. currentDateAndTime) can't be
+        // evaluated here and keep today's behavior.
+        if (value is bool || value is num || value is String) {
+          fills.add(MapEntry(jsonKey, () => value));
+        }
+      } else if (clientDefault != null) {
+        fills.add(
+          MapEntry(jsonKey, () => _syncBlobSerializer.toJson(clientDefault())),
+        );
+      }
+    }
+    return fills;
+  }
+
+  /// Maps a Drift SQL column name (snake_case of the Dart getter) back to the
+  /// getter name, which is the generated `fromJson`/`toJson` key. The project
+  /// has no build.yaml renames and no `named()` overrides, so the mapping is
+  /// mechanical; a wrong key would only add an ignored extra entry, never
+  /// overwrite a real one (fills skip keys already present).
+  static String _jsonKeyForSqlColumn(String sqlName) {
+    final parts = sqlName.split('_');
+    final buffer = StringBuffer(parts.first);
+    for (final part in parts.skip(1)) {
+      if (part.isEmpty) continue;
+      buffer.write(part[0].toUpperCase());
+      buffer.write(part.substring(1));
+    }
+    return buffer.toString();
+  }
 
   /// Applies default values for DiverSettings fields that may be missing
   /// from older sync data or incomplete conflict records.

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5108,9 +5108,9 @@ class SyncDataSerializer {
 
   /// Cached (jsonKey, fill) pairs per entity type: one entry for every
   /// non-nullable column of the entity's table whose schema-level default can
-  /// be reconstructed at replay time (a primitive [Constant] or a
-  /// `clientDefault`). Built lazily from the live table metadata so new
-  /// columns are covered without touching this file.
+  /// be reconstructed at replay time (a primitive [Constant]). Built lazily
+  /// from the live table metadata so new columns are covered without touching
+  /// this file.
   final Map<String, List<MapEntry<String, Object? Function()>>>
   _schemaDefaultFills = {};
 
@@ -5156,22 +5156,17 @@ class SyncDataSerializer {
     final fills = <MapEntry<String, Object? Function()>>[];
     for (final column in table.$columns) {
       if (column.$nullable) continue;
-      final jsonKey = _jsonKeyForSqlColumn(column.name);
       final defaultValue = column.defaultValue;
-      final clientDefault = column.clientDefault;
-      if (defaultValue is Constant<Object>) {
-        final value = defaultValue.value;
-        // Primitives only: they match the wire format for plain and enum
-        // columns, and cover every NOT NULL DEFAULT a migration can add.
-        // Non-constant SQL defaults (e.g. currentDateAndTime) can't be
-        // evaluated here and keep today's behavior.
-        if (value is bool || value is num || value is String) {
-          fills.add(MapEntry(jsonKey, () => value));
-        }
-      } else if (clientDefault != null) {
-        fills.add(
-          MapEntry(jsonKey, () => _syncBlobSerializer.toJson(clientDefault())),
-        );
+      if (defaultValue is! Constant<Object>) continue;
+      final value = defaultValue.value;
+      // Primitive constants only: they match the wire format for plain and
+      // enum columns, and cover every replay-relevant column -- SQLite
+      // requires a constant DEFAULT to add a NOT NULL column, so a column
+      // that old records can be missing always has one. Non-constant SQL
+      // defaults (e.g. currentDateAndTime) can't be evaluated here and keep
+      // today's behavior.
+      if (value is bool || value is num || value is String) {
+        fills.add(MapEntry(_jsonKeyForSqlColumn(column.name), () => value));
       }
     }
     return fills;

--- a/test/core/services/sync/sync_schema_defaults_replay_test.dart
+++ b/test/core/services/sync/sync_schema_defaults_replay_test.dart
@@ -144,6 +144,16 @@ void main() {
     expect(row.isFavorite, isTrue);
   });
 
+  test('unknown entity types stay a silent no-op', () async {
+    // A payload from a newer app version can carry entity types this build
+    // has never heard of; upsertRecord ignores them, and the schema-default
+    // hydration must not turn that into a throw.
+    await serializer.upsertRecord('entityFromTheFuture', {
+      'id': 'x1',
+      'someKey': true,
+    });
+  });
+
   test(
     'single-record replay hydrates missing non-nullable bools too',
     () async {

--- a/test/core/services/sync/sync_schema_defaults_replay_test.dart
+++ b/test/core/services/sync/sync_schema_defaults_replay_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Adopting a replaced library replays the epoch's full base + changeset
+/// history through `upsertRecords` (#858). Records exported before a schema
+/// change lack the newer columns entirely, and Drift's generated `fromJson`
+/// does a straight cast per column -- a missing non-nullable bool crashes with
+/// "type 'Null' is not a subtype of type 'bool' in type cast", permanently
+/// blocking adoption. Replay must instead hydrate missing non-nullable columns
+/// with their schema defaults, for every synced entity -- not just the ones
+/// with hand-maintained fallback maps (diverSettings).
+void main() {
+  late SyncDataSerializer serializer;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    serializer = SyncDataSerializer();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  /// Exports [id] of [entityType] in wire format, then strips [keys] to
+  /// simulate a changeset written by an app version predating those columns.
+  Future<Map<String, dynamic>> legacyRecord(
+    String entityType,
+    String id,
+    List<String> keys,
+  ) async {
+    final exported = await serializer.fetchRecord(entityType, id);
+    expect(exported, isNotNull);
+    final legacy = Map<String, dynamic>.from(exported!);
+    for (final key in keys) {
+      legacy.remove(key);
+    }
+    return legacy;
+  }
+
+  test('batched replay hydrates missing non-nullable bools on dives', () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-1',
+            diveDateTime: now,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    final legacy = await legacyRecord('dives', 'dive-1', [
+      'isFavorite',
+      'isPlanned',
+    ]);
+    await (db.delete(db.dives)..where((t) => t.id.equals('dive-1'))).go();
+
+    // The adopt path (#858): must not throw on the missing bool columns.
+    await serializer.upsertRecords('dives', [legacy]);
+
+    final row = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('dive-1'))).getSingle();
+    expect(row.isFavorite, isFalse);
+    expect(row.isPlanned, isFalse);
+  });
+
+  test('replay hydrates a default-true bool with true, not false', () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.equipment)
+        .insert(
+          EquipmentCompanion.insert(
+            id: 'eq-1',
+            name: 'AL80',
+            type: 'tank',
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    final legacy = await legacyRecord('equipment', 'eq-1', ['isActive']);
+    await (db.delete(db.equipment)..where((t) => t.id.equals('eq-1'))).go();
+
+    await serializer.upsertRecords('equipment', [legacy]);
+
+    final row = await (db.select(
+      db.equipment,
+    )..where((t) => t.id.equals('eq-1'))).getSingle();
+    // The schema default is TRUE; a blanket null->false fill would silently
+    // deactivate every piece of equipment in the replayed history.
+    expect(row.isActive, isTrue);
+  });
+
+  test('replay treats an explicit null like a missing key', () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-2',
+            diveDateTime: now,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    final legacy = await legacyRecord('dives', 'dive-2', []);
+    legacy['isFavorite'] = null;
+    await (db.delete(db.dives)..where((t) => t.id.equals('dive-2'))).go();
+
+    await serializer.upsertRecords('dives', [legacy]);
+
+    final row = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('dive-2'))).getSingle();
+    expect(row.isFavorite, isFalse);
+  });
+
+  test('replay preserves non-default values that are present', () async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-3',
+            diveDateTime: now,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+    final legacy = await legacyRecord('dives', 'dive-3', []);
+    legacy['isFavorite'] = true;
+    await (db.delete(db.dives)..where((t) => t.id.equals('dive-3'))).go();
+
+    await serializer.upsertRecords('dives', [legacy]);
+
+    final row = await (db.select(
+      db.dives,
+    )..where((t) => t.id.equals('dive-3'))).getSingle();
+    expect(row.isFavorite, isTrue);
+  });
+
+  test(
+    'single-record replay hydrates missing non-nullable bools too',
+    () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion.insert(
+              id: 'dive-4',
+              diveDateTime: now,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      final legacy = await legacyRecord('dives', 'dive-4', ['isFavorite']);
+      await (db.delete(db.dives)..where((t) => t.id.equals('dive-4'))).go();
+
+      // The conflict-resolution / incremental path shares the same hydration.
+      await serializer.upsertRecord('dives', legacy);
+
+      final row = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals('dive-4'))).getSingle();
+      expect(row.isFavorite, isFalse);
+    },
+  );
+}


### PR DESCRIPTION
Fixes #858

## Problem

Adopting a replaced library (`_adoptApplyStreaming`) replays the epoch's full base + changeset history through each entity's generated `Entity.fromJson()`. Drift's serializer does a straight cast per column, so a record exported before a schema change — which lacks the newer columns entirely — throws `type 'Null' is not a subtype of type 'bool' in type cast` on the first missing non-nullable column. The transaction rolls back cleanly, but the device is left permanently stuck in `awaitingAdoption`; retrying repeats the identical crash.

Normal incremental sync never hits this because deltas are parsed once, fresh, by the app version that wrote them. Only a from-zero adopt re-parses *history* with a *newer* schema.

## Fix

A generic, schema-driven hydration step (`_withSchemaDefaults`) applied in both `upsertRecord` and `upsertRecords` before `fromJson`:

- For every **non-nullable** column of the entity's table whose JSON key is missing or explicitly null, fill the column's **own schema default** — a primitive `Constant` (`bool`/`num`/`String`) or `clientDefault` — read from live `TableInfo` metadata.
- This reconstructs exactly what the `ALTER TABLE ... ADD COLUMN ... DEFAULT` migration produced for that row on the exporting device. Default-`true` columns (e.g. `equipment.isActive`, `o2Narcotic`) hydrate to `true` — a blanket `null → false` fill would have silently corrupted them.
- Values present in the payload are never touched; nullable columns are never touched.
- Fill lists are cached per entity type so the adopt hot path (millions of rows, #358) does per-record map lookups only.

Because the fill list is derived from table metadata, every future `NOT NULL DEFAULT` column is covered automatically — no more per-column fallback maps like the v135 accent bools in `_applyDiverSettingDefaults` (existing maps are left in place).

The issue's "not yet identified" exact column is moot under this fix: all 75 bool columns (and non-bool defaulted columns) across all synced tables are covered by construction.

## Testing

- New `sync_schema_defaults_replay_test.dart` (written first, watched fail with the exact reported error): batched adopt path, single-record path, default-`true` hydration, explicit-null handling, and preservation of present values.
- Full suite: 14908 passed, 15 skipped, 0 failures. `flutter analyze` clean, `dart format` clean.
