### PR TITLE
Show weather in the trip story day header

### DIFF
--- a/lib/features/trips/domain/entities/trip_story_day.dart
+++ b/lib/features/trips/domain/entities/trip_story_day.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
@@ -68,6 +69,31 @@ class TripStoryDay extends Equatable {
     return ids.length;
   }
 
+  /// Day-level weather summary, or null when no dive logged any weather.
+  ///
+  /// Each field is the first non-null value across the day's dives in dive
+  /// order, so a morning dive that logged only air temperature and an
+  /// afternoon dive that logged only sky conditions still combine into one
+  /// complete summary.
+  TripStoryDayWeather? get weather {
+    double? airTemp;
+    CloudCover? cloudCover;
+    Precipitation? precipitation;
+    for (final dive in dives) {
+      airTemp ??= dive.airTemp;
+      cloudCover ??= dive.cloudCover;
+      precipitation ??= dive.precipitation;
+    }
+    if (airTemp == null && cloudCover == null && precipitation == null) {
+      return null;
+    }
+    return TripStoryDayWeather(
+      airTemp: airTemp,
+      cloudCover: cloudCover,
+      precipitation: precipitation,
+    );
+  }
+
   bool get hasContent =>
       dives.isNotEmpty || media.isNotEmpty || itineraryDay != null;
 
@@ -85,6 +111,22 @@ class TripStoryDay extends Equatable {
     sightings,
     kind,
   ];
+}
+
+/// Compact weather summary for one story day, shown in the day header.
+class TripStoryDayWeather extends Equatable {
+  final double? airTemp; // celsius
+  final CloudCover? cloudCover;
+  final Precipitation? precipitation;
+
+  const TripStoryDayWeather({
+    this.airTemp,
+    this.cloudCover,
+    this.precipitation,
+  });
+
+  @override
+  List<Object?> get props => [airTemp, cloudCover, precipitation];
 }
 
 /// A mappable point contributed by a story day (dive site or itinerary port).

--- a/lib/features/trips/presentation/helpers/weather_icon.dart
+++ b/lib/features/trips/presentation/helpers/weather_icon.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/constants/enums.dart';
+
+/// Icon for a compact weather glyph, or null when there is nothing to show.
+///
+/// Active precipitation outranks cloud cover: a rainy overcast day reads as
+/// rain. [Precipitation.none] is real data ("no precipitation") but earns no
+/// glyph of its own, so it falls through to the cloud cover.
+IconData? weatherIconFor({
+  CloudCover? cloudCover,
+  Precipitation? precipitation,
+}) {
+  switch (precipitation) {
+    case Precipitation.drizzle:
+    case Precipitation.lightRain:
+      return Icons.water_drop_outlined;
+    case Precipitation.rain:
+    case Precipitation.heavyRain:
+      return Icons.water_drop;
+    case Precipitation.snow:
+      return Icons.ac_unit;
+    case Precipitation.sleet:
+      return Icons.cloudy_snowing;
+    case Precipitation.hail:
+      return Icons.grain;
+    case Precipitation.none:
+    case null:
+      break;
+  }
+  switch (cloudCover) {
+    case CloudCover.clear:
+      return Icons.wb_sunny_outlined;
+    case CloudCover.partlyCloudy:
+      return Icons.wb_cloudy_outlined;
+    case CloudCover.mostlyCloudy:
+      return Icons.cloud_outlined;
+    case CloudCover.overcast:
+      return Icons.cloud;
+    case null:
+      return null;
+  }
+}

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
@@ -1,19 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/environment_enum_display.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
 import 'package:submersion/features/trips/presentation/helpers/day_type_l10n.dart';
+import 'package:submersion/features/trips/presentation/helpers/weather_icon.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Two compact lines - "Day 3 - Wed, Jul 8" plus the day-type/port/sites
 /// subtitle - on an opaque surface so day cards scroll underneath cleanly.
+/// Days with logged weather get a trailing badge: conditions icon plus air
+/// temperature in the diver's temperature unit.
 ///
 /// Mounted in a [PinnedHeaderSliver] inside a SliverMainAxisGroup, so it sticks
 /// at the top of its day chapter until the next day's header pushes it out.
 /// PinnedHeaderSliver lets the header size itself, so scaled accessibility text
 /// grows the header rather than being clipped by a fixed sliver extent;
 /// [minHeight] only keeps short (subtitle-less) days from looking cramped.
-class TripStoryDayHeader extends StatelessWidget {
+class TripStoryDayHeader extends ConsumerWidget {
   /// Floor so every day header reads as the same band at default text scale.
   static const double minHeight = 52;
 
@@ -22,7 +31,7 @@ class TripStoryDayHeader extends StatelessWidget {
   const TripStoryDayHeader({super.key, required this.day});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final itinerary = day.itineraryDay;
     // Trim and drop blanks before joining: the itinerary edit sheet normalizes
@@ -34,6 +43,9 @@ class TripStoryDayHeader extends StatelessWidget {
       if (itinerary?.portName != null) itinerary!.portName!,
       ...day.siteNames,
     ].map((part) => part.trim()).where((part) => part.isNotEmpty).toList();
+
+    final units = UnitFormatter(ref.watch(settingsProvider));
+    final weatherBadge = _weatherBadge(context, theme, units);
 
     return Material(
       color: theme.colorScheme.surface,
@@ -69,6 +81,10 @@ class TripStoryDayHeader extends StatelessWidget {
                   ],
                 ),
               ),
+              if (weatherBadge != null) ...[
+                const SizedBox(width: 8),
+                weatherBadge,
+              ],
               if (day.kind == TripStoryDayKind.future)
                 Chip(
                   label: Text(context.l10n.trips_story_planned),
@@ -79,5 +95,55 @@ class TripStoryDayHeader extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  /// Conditions icon plus air temperature, or null when the day's dives
+  /// logged nothing displayable (wind, humidity, and the free-text weather
+  /// description stay out of the compact band on purpose).
+  Widget? _weatherBadge(
+    BuildContext context,
+    ThemeData theme,
+    UnitFormatter units,
+  ) {
+    final weather = day.weather;
+    if (weather == null) return null;
+
+    final icon = weatherIconFor(
+      cloudCover: weather.cloudCover,
+      precipitation: weather.precipitation,
+    );
+    final airTemp = weather.airTemp;
+    if (icon == null && airTemp == null) return null;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 4,
+      children: [
+        if (icon != null)
+          Icon(
+            icon,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+            semanticLabel: _conditionsLabel(context.l10n, weather),
+          ),
+        if (airTemp != null)
+          Text(
+            units.formatTemperature(airTemp),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+      ],
+    );
+  }
+
+  /// Localized name of what the icon depicts, for screen readers. Mirrors
+  /// [weatherIconFor]: active precipitation first, then cloud cover.
+  String? _conditionsLabel(AppLocalizations l10n, TripStoryDayWeather weather) {
+    final precipitation = weather.precipitation;
+    if (precipitation != null && precipitation != Precipitation.none) {
+      return precipitation.localizedName(l10n);
+    }
+    return weather.cloudCover?.localizedName(l10n);
   }
 }

--- a/test/features/trips/domain/entities/trip_story_day_test.dart
+++ b/test/features/trips/domain/entities/trip_story_day_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
@@ -9,6 +10,9 @@ Dive _dive({
   Duration? bottomTime,
   double? maxDepth,
   DiveSite? site,
+  double? airTemp,
+  CloudCover? cloudCover,
+  Precipitation? precipitation,
 }) {
   return Dive(
     id: id,
@@ -16,6 +20,9 @@ Dive _dive({
     bottomTime: bottomTime,
     maxDepth: maxDepth,
     site: site,
+    airTemp: airTemp,
+    cloudCover: cloudCover,
+    precipitation: precipitation,
   );
 }
 
@@ -106,6 +113,76 @@ void main() {
           dives: [_dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
         ).isSurface,
         isFalse,
+      );
+    });
+  });
+
+  group('weather summary', () {
+    test('null when no dive carries any weather data', () {
+      final day = TripStoryDay(
+        date: date,
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+        dives: [_dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
+      );
+      expect(day.weather, isNull);
+    });
+
+    test('null for a day with no dives', () {
+      final day = TripStoryDay(
+        date: date,
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+      );
+      expect(day.weather, isNull);
+    });
+
+    test('takes the first non-null value per field across dives', () {
+      // Morning dive logged only air temperature, afternoon dive only cloud
+      // cover and precipitation: the day summary combines all three.
+      final day = TripStoryDay(
+        date: date,
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+        dives: [
+          _dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9), airTemp: 22),
+          _dive(
+            id: 'd2',
+            dateTime: DateTime(2026, 3, 8, 14),
+            airTemp: 27,
+            cloudCover: CloudCover.partlyCloudy,
+            precipitation: Precipitation.drizzle,
+          ),
+        ],
+      );
+
+      expect(
+        day.weather,
+        const TripStoryDayWeather(
+          airTemp: 22,
+          cloudCover: CloudCover.partlyCloudy,
+          precipitation: Precipitation.drizzle,
+        ),
+      );
+    });
+
+    test('a single weather field is enough to produce a summary', () {
+      final day = TripStoryDay(
+        date: date,
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+        dives: [
+          _dive(
+            id: 'd1',
+            dateTime: DateTime(2026, 3, 8, 9),
+            cloudCover: CloudCover.overcast,
+          ),
+        ],
+      );
+
+      expect(
+        day.weather,
+        const TripStoryDayWeather(cloudCover: CloudCover.overcast),
       );
     });
   });

--- a/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/itinerary_day.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
 import 'package:submersion/features/trips/presentation/widgets/story/trip_story_day_header.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../../helpers/mock_providers.dart';
 
 ItineraryDay _itin({String? port}) => ItineraryDay(
   id: 'itin-1',
@@ -25,6 +29,7 @@ Future<void> pumpHeader(
   WidgetTester tester,
   TripStoryDay day, {
   double textScale = 1.0,
+  MockSettingsNotifier? settingsNotifier,
 }) async {
   // The header dates itself with DateFormat.MMMEd(), which resolves against
   // Intl.defaultLocale - a process global that app.dart sets from the app
@@ -35,22 +40,26 @@ Future<void> pumpHeader(
   Intl.defaultLocale = 'en';
   addTearDown(() => Intl.defaultLocale = previousLocale);
 
+  final overrides = await getBaseOverrides(settingsNotifier: settingsNotifier);
   await tester.pumpWidget(
-    MaterialApp(
-      locale: const Locale('en'),
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        // Align to the top so the header keeps its intrinsic height rather
-        // than being stretched by the body's constraints.
-        body: Align(
-          alignment: Alignment.topCenter,
-          child: Builder(
-            builder: (context) => MediaQuery(
-              data: MediaQuery.of(
-                context,
-              ).copyWith(textScaler: TextScaler.linear(textScale)),
-              child: TripStoryDayHeader(day: day),
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          // Align to the top so the header keeps its intrinsic height rather
+          // than being stretched by the body's constraints.
+          body: Align(
+            alignment: Alignment.topCenter,
+            child: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(
+                  context,
+                ).copyWith(textScaler: TextScaler.linear(textScale)),
+                child: TripStoryDayHeader(day: day),
+              ),
             ),
           ),
         ),
@@ -156,6 +165,104 @@ void main() {
       tester.getSize(find.byType(TripStoryDayHeader)).height,
       TripStoryDayHeader.minHeight,
     );
+  });
+
+  group('weather badge', () {
+    TripStoryDay dayWith({
+      double? airTemp,
+      CloudCover? cloudCover,
+      Precipitation? precipitation,
+    }) => TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+      dives: [
+        Dive(
+          id: 'd1',
+          dateTime: DateTime(2026, 3, 8, 9),
+          airTemp: airTemp,
+          cloudCover: cloudCover,
+          precipitation: precipitation,
+        ),
+      ],
+    );
+
+    testWidgets('shows the conditions icon and air temperature', (
+      tester,
+    ) async {
+      await pumpHeader(
+        tester,
+        dayWith(airTemp: 22, cloudCover: CloudCover.clear),
+      );
+
+      expect(find.byIcon(Icons.wb_sunny_outlined), findsOneWidget);
+      expect(find.text('22°C'), findsOneWidget);
+    });
+
+    testWidgets('air temperature respects the Fahrenheit setting', (
+      tester,
+    ) async {
+      final settings = MockSettingsNotifier();
+      await settings.setTemperatureUnit(TemperatureUnit.fahrenheit);
+      await pumpHeader(
+        tester,
+        dayWith(airTemp: 22, cloudCover: CloudCover.clear),
+        settingsNotifier: settings,
+      );
+
+      expect(find.text('72°F'), findsOneWidget);
+    });
+
+    testWidgets('precipitation outranks cloud cover for the icon', (
+      tester,
+    ) async {
+      await pumpHeader(
+        tester,
+        dayWith(
+          precipitation: Precipitation.rain,
+          cloudCover: CloudCover.overcast,
+        ),
+      );
+
+      expect(find.byIcon(Icons.water_drop), findsOneWidget);
+      expect(find.byIcon(Icons.cloud), findsNothing);
+    });
+
+    testWidgets('precipitation "none" falls back to the cloud cover icon', (
+      tester,
+    ) async {
+      await pumpHeader(
+        tester,
+        dayWith(
+          precipitation: Precipitation.none,
+          cloudCover: CloudCover.overcast,
+        ),
+      );
+
+      expect(find.byIcon(Icons.cloud), findsOneWidget);
+    });
+
+    testWidgets('temperature-only day shows the value without an icon', (
+      tester,
+    ) async {
+      await pumpHeader(tester, dayWith(airTemp: 22));
+
+      expect(find.text('22°C'), findsOneWidget);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('day without weather shows no badge', (tester) async {
+      final day = TripStoryDay(
+        date: DateTime(2026, 3, 8),
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+        dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
+      );
+      await pumpHeader(tester, day);
+
+      expect(find.byType(Icon), findsNothing);
+      expect(find.textContaining('°'), findsNothing);
+    });
   });
 
   testWidgets('scaled text grows the header instead of clipping it', (


### PR DESCRIPTION
## Summary

Trip story day headers now show the day's weather: a compact trailing badge with a conditions icon and the air temperature, rendered in the diver's configured temperature unit.

- **`TripStoryDay.weather`** — new derived getter returning a `TripStoryDayWeather` summary (air temp, cloud cover, precipitation). Each field takes the first non-null value across the day's dives, so a morning dive that logged only temperature and an afternoon dive that logged only sky conditions still combine into one complete badge. Null when no dive logged any weather.
- **`weatherIconFor()`** — new helper mapping the weather enums to Material icons. Active precipitation outranks cloud cover (a rainy overcast day reads as rain); `Precipitation.none` is real data that earns no glyph and falls through to the cloud cover icon.
- **`TripStoryDayHeader`** — converted to a `ConsumerWidget` watching `settingsProvider`, formatting the temperature with `UnitFormatter` (same pattern as `TripStoryDayCard`). The icon's `semanticLabel` reuses the existing `localizedName()` enum extensions, so screen readers get localized condition names in all locales with zero new ARB keys.

Deliberately kept out of the compact band: wind, humidity, and the free-text `weatherDescription` (English-only, unbounded length) — those remain on the dive detail Environment section.

## Testing

- 4 new entity tests for the `weather` getter (empty day, no-weather dives, per-field merge across dives, single-field summary)
- 6 new widget tests for the badge: icon + temperature rendering, Fahrenheit setting respected, precipitation-over-cloud precedence, `none` fallback, temperature-only day, and no-badge day (header test harness now pumps inside a `ProviderScope` for the new settings dependency)
- Full trips feature suite green (515 tests); `flutter analyze --fatal-infos` clean; `dart format .` applied