### PR TITLE
Fix large-backup restore: intermittent strict-close failure, UI freezes, and follow-up hazards

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3246,7 +3246,17 @@ class AppDatabase extends _$AppDatabase {
       'AND bottom_time = runtime',
     ).get();
 
+    var processed = 0;
     for (final candidate in candidates) {
+      // On an imported library nearly every dive is a candidate, and during a
+      // migration the executor is a synchronous main-isolate NativeDatabase:
+      // drift's awaits complete in microtasks, so this loop would run as one
+      // unbroken microtask chain that never reaches the timer/vsync queue —
+      // freezing the migration spinner for the whole step. A real event-loop
+      // yield every few dives lets the UI animate while the backfill runs.
+      if (processed++ % 25 == 24) {
+        await Future<void>.delayed(Duration.zero);
+      }
       final diveId = candidate.read<String>('id');
       final runtimeSeconds = candidate.read<int>('runtime');
 

--- a/lib/core/services/cloud_storage/cloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/cloud_storage_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 /// Information about a file stored in cloud storage
@@ -120,6 +121,25 @@ abstract class CloudStorageProvider {
   /// Throws [CloudStorageException] if the file doesn't exist or download fails.
   Future<Uint8List> downloadFile(String fileId);
 
+  /// Upload a local file to cloud storage.
+  ///
+  /// The path-based twin of [uploadFile] for large artifacts (database
+  /// backups): providers override it to stream from disk so the whole file is
+  /// never resident in memory. [CloudStorageProviderMixin] supplies a
+  /// buffering fallback that delegates to [uploadFile].
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  });
+
+  /// Download a file from cloud storage straight to [destinationPath].
+  ///
+  /// The path-based twin of [downloadFile]; same memory rationale as
+  /// [uploadFileFromPath]. Implementations must not leave a partial file at
+  /// [destinationPath] on failure.
+  Future<void> downloadToFile(String fileId, String destinationPath);
+
   /// Get information about a file
   ///
   /// [fileId] The ID of the file
@@ -166,8 +186,41 @@ abstract class CloudStorageProvider {
 }
 
 /// Mixin providing common functionality for cloud storage providers
-mixin CloudStorageProviderMixin {
+mixin CloudStorageProviderMixin implements CloudStorageProvider {
   static const String syncFolderName = 'Submersion Sync';
+
+  /// Buffering fallback: reads the source into memory and delegates to
+  /// [uploadFile]. Providers with a streaming transport override this.
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    final data = await File(sourcePath).readAsBytes();
+    return uploadFile(data, filename, folderId: folderId);
+  }
+
+  /// Buffering fallback: downloads into memory via [downloadFile] and spills
+  /// to [destinationPath]. Providers with a streaming transport override
+  /// this. Deletes a partial destination on failure so callers never see a
+  /// truncated file.
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    final bytes = await downloadFile(fileId);
+    final dest = File(destinationPath);
+    try {
+      await dest.writeAsBytes(bytes, flush: true);
+    } catch (_) {
+      try {
+        if (await dest.exists()) await dest.delete();
+      } catch (_) {
+        // Best-effort cleanup; the original error is the one that matters.
+      }
+      rethrow;
+    }
+  }
+
   static const String syncFileStem = 'submersion_sync';
   static const String canonicalSyncFileName = '$syncFileStem.json';
   static const String syncFilePrefix = '${syncFileStem}_';

--- a/lib/core/services/cloud_storage/dropbox_storage_provider.dart
+++ b/lib/core/services/cloud_storage/dropbox_storage_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -100,6 +102,107 @@ class DropboxStorageProvider
 
   @override
   Future<Uint8List> downloadFile(String fileId) => _client.download(fileId);
+
+  /// Chunk size for streamed transfers; matches DropboxMediaObjectStore.
+  static const int _transferChunkBytes = 8 * 1024 * 1024;
+
+  /// Streams the local file through Dropbox's upload-session API in 8 MiB
+  /// chunks (mirroring DropboxMediaObjectStore.putFile, minus resume state:
+  /// backups are one-shot artifacts and a failed upload simply reruns).
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    final source = File(sourcePath);
+    final length = await source.length();
+    if (length <= _transferChunkBytes) {
+      return uploadFile(
+        await source.readAsBytes(),
+        filename,
+        folderId: folderId,
+      );
+    }
+
+    final raf = await source.open();
+    try {
+      var chunk = await raf.read(_transferChunkBytes);
+      final sessionId = await _client.uploadSessionStart(chunk);
+      var offset = chunk.length;
+      while (true) {
+        final remaining = length - offset;
+        final isLast = remaining <= _transferChunkBytes;
+        await raf.setPosition(offset);
+        chunk = await raf.read(min(_transferChunkBytes, remaining));
+        if (isLast) {
+          final meta = await _client.uploadSessionFinish(
+            sessionId: sessionId,
+            offset: offset,
+            path: _join(folderId, filename),
+            lastChunk: chunk,
+          );
+          return UploadResult(
+            fileId: meta.pathLower,
+            uploadTime: meta.serverModified,
+          );
+        }
+        await _client.uploadSessionAppend(
+          sessionId: sessionId,
+          offset: offset,
+          chunk: chunk,
+        );
+        offset += chunk.length;
+      }
+    } finally {
+      await raf.close();
+    }
+  }
+
+  /// Ranged download straight to disk (mirroring
+  /// DropboxMediaObjectStore.getFile), one 8 MiB slice resident at a time.
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    final dest = File(destinationPath);
+    try {
+      final meta = await _client.getMetadata(fileId);
+      if (meta == null) {
+        throw CloudStorageException('File not found in Dropbox: $fileId');
+      }
+      final total = meta.size;
+      if (total == null || total <= _transferChunkBytes) {
+        final bytes = await _client.download(fileId);
+        await dest.writeAsBytes(bytes, flush: true);
+        return;
+      }
+      final raf = await dest.open(mode: FileMode.write);
+      try {
+        var received = 0;
+        while (received < total) {
+          final end = min(received + _transferChunkBytes, total) - 1;
+          final range = await _client.downloadRange(
+            fileId,
+            start: received,
+            endInclusive: end,
+          );
+          await raf.writeFrom(range.bytes);
+          received += range.bytes.length;
+        }
+        await raf.flush();
+      } finally {
+        await raf.close();
+      }
+    } catch (_) {
+      if (await dest.exists()) {
+        try {
+          await dest.delete();
+        } catch (_) {
+          // Best-effort cleanup of a partial download.
+        }
+      }
+      rethrow;
+    }
+  }
 
   @override
   Future<CloudFileInfo?> getFileInfo(String fileId) async {

--- a/lib/core/services/cloud_storage/encrypting_cloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/encrypting_cloud_storage_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
@@ -83,6 +84,74 @@ class EncryptingCloudStorageProvider implements CloudStorageProvider {
       expectedLibraryKeyId: _libraryKeyId,
       filename: name,
     );
+  }
+
+  /// Exempt (self-framed) artifacts stream through the inner provider
+  /// untouched — the whole point of the path-based API is that a large
+  /// backup never materializes in memory. Non-exempt files fall back to the
+  /// buffering seal path; they are small sync files in practice.
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    if (isExempt(filename)) {
+      final result = await inner.uploadFileFromPath(
+        sourcePath,
+        filename,
+        folderId: folderId,
+      );
+      _names[result.fileId] = filename;
+      return result;
+    }
+    final data = await File(sourcePath).readAsBytes();
+    return uploadFile(data, filename, folderId: folderId);
+  }
+
+  /// Streams via the inner provider, then sniffs the on-disk header: no SBE1
+  /// magic means plaintext (done), an exempt name means a self-framed backup
+  /// whose own codec decrypts it (done), otherwise the file is a sealed
+  /// envelope (a small sync file) — open it and rewrite the plaintext.
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    await inner.downloadToFile(fileId, destinationPath);
+    final dest = File(destinationPath);
+    try {
+      final raf = await dest.open();
+      final Uint8List head;
+      try {
+        head = await raf.read(4);
+      } finally {
+        await raf.close();
+      }
+      if (!SyncEnvelope.hasMagic(head)) return;
+
+      final name = _names[fileId] ?? (await inner.getFileInfo(fileId))?.name;
+      if (name != null && isExempt(name)) return;
+      if (name == null) {
+        throw const EnvelopeCorruptException(
+          'Encrypted file has no resolvable name for authentication',
+        );
+      }
+      _names[fileId] = name;
+      final plaintext = await SyncEnvelope.open(
+        envelope: await dest.readAsBytes(),
+        dataKey: _dataKey,
+        expectedLibraryKeyId: _libraryKeyId,
+        filename: name,
+      );
+      await dest.writeAsBytes(plaintext, flush: true);
+    } catch (_) {
+      // Never leave ciphertext (or a partial rewrite) where the caller
+      // expects plaintext.
+      try {
+        if (await dest.exists()) await dest.delete();
+      } catch (_) {
+        // Best-effort cleanup; the original error is the one that matters.
+      }
+      rethrow;
+    }
   }
 
   @override

--- a/lib/core/services/cloud_storage/google_drive_storage_provider.dart
+++ b/lib/core/services/cloud_storage/google_drive_storage_provider.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
 import 'package:extension_google_sign_in_as_googleapis_auth/extension_google_sign_in_as_googleapis_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
@@ -151,6 +153,12 @@ class GoogleDriveStorageProvider
     }
     return api;
   }
+
+  /// Test seam: injects a [drive.DriveApi] (backed by a mock HTTP client) so
+  /// the transfer paths are exercisable without a Google sign-in — the real
+  /// api is only ever minted from an authenticated session.
+  @visibleForTesting
+  void debugSetDriveApi(drive.DriveApi api) => _driveApi = api;
 
   /// Authenticated HTTP client for the media store's raw REST calls.
   /// Enables silent auth (the media attach itself is the opt-in) and

--- a/lib/core/services/cloud_storage/google_drive_storage_provider.dart
+++ b/lib/core/services/cloud_storage/google_drive_storage_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:extension_google_sign_in_as_googleapis_auth/extension_google_sign_in_as_googleapis_auth.dart';
@@ -225,6 +226,85 @@ class GoogleDriveStorageProvider
       _log.info('Downloaded file: $fileId (${allBytes.length} bytes)');
       return Uint8List.fromList(allBytes);
     } catch (e, stackTrace) {
+      _log.error(
+        'Failed to download file: $fileId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      throw CloudStorageException('Download failed: $e', e, stackTrace);
+    }
+  }
+
+  /// Streams the local file into the Drive SDK ([drive.Media] takes a byte
+  /// stream), so the artifact is never resident in memory.
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    try {
+      final targetFolder = folderId ?? await getOrCreateSyncFolder();
+      final existingFile = await _findFile(filename, targetFolder);
+
+      final source = File(sourcePath);
+      final media = drive.Media(source.openRead(), await source.length());
+
+      drive.File result;
+      if (existingFile != null) {
+        result = await _api.files.update(
+          drive.File(),
+          existingFile.id!,
+          uploadMedia: media,
+        );
+        _log.info('Updated file: $filename (${result.id})');
+      } else {
+        final fileMetadata = drive.File()
+          ..name = filename
+          ..parents = [targetFolder];
+        result = await _api.files.create(fileMetadata, uploadMedia: media);
+        _log.info('Created file: $filename (${result.id})');
+      }
+
+      return UploadResult(fileId: result.id!, uploadTime: DateTime.now());
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to upload file: $filename',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      throw CloudStorageException('Upload failed: $e', e, stackTrace);
+    }
+  }
+
+  /// Pipes the download stream straight to disk. The buffering downloadFile
+  /// holds three concurrent copies of the payload at peak (chunk list,
+  /// expanded list, Uint8List); this holds one chunk.
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    try {
+      final response = await _api.files.get(
+        fileId,
+        downloadOptions: drive.DownloadOptions.fullMedia,
+      );
+      if (response is! drive.Media) {
+        throw const CloudStorageException('Invalid download response');
+      }
+      final sink = File(destinationPath).openWrite();
+      try {
+        await response.stream.pipe(sink);
+      } finally {
+        await sink.close();
+      }
+    } catch (e, stackTrace) {
+      final partial = File(destinationPath);
+      if (await partial.exists()) {
+        try {
+          await partial.delete();
+        } catch (_) {
+          // Best-effort cleanup of a partial download.
+        }
+      }
       _log.error(
         'Failed to download file: $fileId',
         error: e,

--- a/lib/core/services/cloud_storage/icloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/icloud_storage_provider.dart
@@ -242,6 +242,88 @@ class ICloudStorageProvider
     }
   }
 
+  /// The fileId IS a container path, so a streaming upload is a same-volume
+  /// copy plus a coordinated move — the payload never crosses the method
+  /// channel (uploadFile ships the whole file as one Uint8List through the
+  /// platform codec, a second full copy in RAM).
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    try {
+      final syncFolder = await getOrCreateSyncFolder().timeout(
+        const Duration(seconds: 15),
+        onTimeout: () {
+          throw const CloudStorageException(
+            'Timeout getting sync folder (15s)',
+          );
+        },
+      );
+      final filePath = path.join(syncFolder, filename);
+
+      // Copy next to the destination so the coordinated move is same-volume,
+      // mirroring ICloudMediaObjectStore.putFile.
+      final staging = '$filePath.uploading';
+      await File(sourcePath).copy(staging);
+      try {
+        final moved = await ICloudNativeService.moveFile(staging, filePath);
+        if (!moved) {
+          throw CloudStorageException('iCloud move failed for $filename');
+        }
+      } catch (_) {
+        final stray = File(staging);
+        if (await stray.exists()) {
+          try {
+            await stray.delete();
+          } catch (_) {
+            // Best-effort staging cleanup.
+          }
+        }
+        rethrow;
+      }
+      return UploadResult(fileId: filePath, uploadTime: DateTime.now());
+    } catch (e, stackTrace) {
+      _log.error(
+        'uploadFileFromPath: FAILED - $e',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      throw CloudStorageException('Upload failed: $e', e, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    try {
+      final file = File(fileId);
+      if (!await file.exists()) {
+        throw CloudStorageException('File not found: $fileId');
+      }
+      final downloaded = await ICloudNativeService.downloadIfNeeded(fileId);
+      if (!downloaded) {
+        throw CloudStorageException('iCloud file not downloaded: $fileId');
+      }
+      await file.copy(destinationPath);
+    } catch (e, stackTrace) {
+      final partial = File(destinationPath);
+      if (await partial.exists()) {
+        try {
+          await partial.delete();
+        } catch (_) {
+          // Best-effort cleanup of a partial copy.
+        }
+      }
+      _log.error(
+        'Failed to download file from iCloud: $fileId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      throw CloudStorageException('Download failed: $e', e, stackTrace);
+    }
+  }
+
   @override
   Future<CloudFileInfo?> getFileInfo(String fileId) async {
     try {

--- a/lib/core/services/cloud_storage/icloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/icloud_storage_provider.dart
@@ -35,6 +35,15 @@ enum ICloudHostPlatform {
 /// serve this app.
 typedef ICloudContainerPathLookup = Future<String?> Function();
 
+/// Moves a staged file into the container with file coordination; false when
+/// the move could not be performed.
+typedef ICloudContainerFileMove =
+    Future<bool> Function(String sourcePath, String destinationPath);
+
+/// Materializes an iCloud container file locally before it is read; false
+/// when the file could not be downloaded.
+typedef ICloudFileDownload = Future<bool> Function(String path);
+
 /// iCloud implementation of CloudStorageProvider
 ///
 /// Uses the app's iCloud container directory for storage.
@@ -57,17 +66,29 @@ class ICloudStorageProvider
   /// reaching the channel on other hosts — so on a Linux CI runner a mocked
   /// channel is never consulted, and a test would reach its assertion via a
   /// short circuit rather than via the branch it means to exercise.
+  /// [containerFileMove] and [ensureDownloaded] default to the native channel
+  /// calls and are injectable for the same reason as [containerPathLookup]:
+  /// both carry their own Apple-platform guard and short-circuit without
+  /// reaching the channel on other hosts, so a mocked channel would go
+  /// unconsulted on the Linux CI runner.
   ICloudStorageProvider({
     ICloudHostPlatform? platform,
     ICloudContainerPathLookup? containerPathLookup,
+    ICloudContainerFileMove? containerFileMove,
+    ICloudFileDownload? ensureDownloaded,
   }) : _platform = platform ?? ICloudHostPlatform.current(),
        _lookupContainerPath =
-           containerPathLookup ?? ICloudNativeService.getContainerPath;
+           containerPathLookup ?? ICloudNativeService.getContainerPath,
+       _moveIntoContainer = containerFileMove ?? ICloudNativeService.moveFile,
+       _ensureDownloaded =
+           ensureDownloaded ?? ICloudNativeService.downloadIfNeeded;
 
   static final _log = LoggerService.forClass(ICloudStorageProvider);
 
   final ICloudHostPlatform _platform;
   final ICloudContainerPathLookup _lookupContainerPath;
+  final ICloudContainerFileMove _moveIntoContainer;
+  final ICloudFileDownload _ensureDownloaded;
 
   Directory? _icloudContainer;
   Directory? _syncFolder;
@@ -268,7 +289,7 @@ class ICloudStorageProvider
       final staging = '$filePath.uploading';
       await File(sourcePath).copy(staging);
       try {
-        final moved = await ICloudNativeService.moveFile(staging, filePath);
+        final moved = await _moveIntoContainer(staging, filePath);
         if (!moved) {
           throw CloudStorageException('iCloud move failed for $filename');
         }
@@ -301,7 +322,7 @@ class ICloudStorageProvider
       if (!await file.exists()) {
         throw CloudStorageException('File not found: $fileId');
       }
-      final downloaded = await ICloudNativeService.downloadIfNeeded(fileId);
+      final downloaded = await _ensureDownloaded(fileId);
       if (!downloaded) {
         throw CloudStorageException('iCloud file not downloaded: $fileId');
       }

--- a/lib/core/services/cloud_storage/icloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/icloud_storage_provider.dart
@@ -285,10 +285,12 @@ class ICloudStorageProvider
       final filePath = path.join(syncFolder, filename);
 
       // Copy next to the destination so the coordinated move is same-volume,
-      // mirroring ICloudMediaObjectStore.putFile.
+      // mirroring ICloudMediaObjectStore.putFile. The copy itself sits inside
+      // the cleanup guard: a failed copy (disk full, permissions) can leave a
+      // partial staging file behind just like a failed move.
       final staging = '$filePath.uploading';
-      await File(sourcePath).copy(staging);
       try {
+        await File(sourcePath).copy(staging);
         final moved = await _moveIntoContainer(staging, filePath);
         if (!moved) {
           throw CloudStorageException('iCloud move failed for $filename');

--- a/lib/core/services/cloud_storage/s3_storage_provider.dart
+++ b/lib/core/services/cloud_storage/s3_storage_provider.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -161,6 +163,124 @@ class S3StorageProvider
   Future<Uint8List> downloadFile(String fileId) async {
     final session = await _requireSession();
     return session.client.getObject(fileId);
+  }
+
+  /// Chunk/part size for streamed transfers; matches S3MediaObjectStore.
+  static const int _transferChunkBytes = 8 * 1024 * 1024;
+
+  /// Streams the local file up as a multipart upload in 8 MiB parts
+  /// (mirroring S3MediaObjectStore._putMultipart, minus resume state:
+  /// backups are one-shot artifacts). SigV4 signs each part's own payload
+  /// hash, so per-part signing works where a single streamed PUT cannot.
+  /// A failed upload aborts the session so parts never strand and bill.
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    final source = File(sourcePath);
+    final length = await source.length();
+    if (length <= _transferChunkBytes) {
+      return uploadFile(
+        await source.readAsBytes(),
+        filename,
+        folderId: folderId,
+      );
+    }
+
+    final session = await _requireSession();
+    final key = '${folderId ?? session.config.prefix}$filename';
+    String? uploadId;
+    try {
+      uploadId = await session.client.createMultipartUpload(
+        key,
+        contentType: 'application/octet-stream',
+      );
+      final parts = <S3PartInfo>[];
+      final totalParts =
+          (length + _transferChunkBytes - 1) ~/ _transferChunkBytes;
+      final raf = await source.open();
+      try {
+        for (var n = 1; n <= totalParts; n++) {
+          final offset = (n - 1) * _transferChunkBytes;
+          await raf.setPosition(offset);
+          final chunk = await raf.read(
+            min(_transferChunkBytes, length - offset),
+          );
+          final etag = await session.client.uploadPart(
+            key,
+            uploadId: uploadId,
+            partNumber: n,
+            bytes: chunk,
+          );
+          parts.add(S3PartInfo(partNumber: n, etag: etag));
+        }
+      } finally {
+        await raf.close();
+      }
+      await session.client.completeMultipartUpload(
+        key,
+        uploadId: uploadId,
+        parts: parts,
+      );
+      return UploadResult(fileId: key, uploadTime: DateTime.now().toUtc());
+    } catch (_) {
+      if (uploadId != null) {
+        try {
+          await session.client.abortMultipartUpload(key, uploadId: uploadId);
+        } catch (_) {
+          // Best-effort abort; the original error is the one that matters.
+        }
+      }
+      rethrow;
+    }
+  }
+
+  /// Ranged download straight to disk (mirroring S3MediaObjectStore.getFile),
+  /// one 8 MiB slice resident at a time.
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    final session = await _requireSession();
+    final dest = File(destinationPath);
+    try {
+      final info = await session.client.headObject(fileId);
+      if (info == null) {
+        throw CloudStorageException('File not found in S3: $fileId');
+      }
+      final total = info.size;
+      if (total == null || total <= _transferChunkBytes) {
+        final bytes = await session.client.getObject(fileId);
+        await dest.writeAsBytes(bytes, flush: true);
+        return;
+      }
+      final raf = await dest.open(mode: FileMode.write);
+      try {
+        var received = 0;
+        while (received < total) {
+          final end = min(received + _transferChunkBytes, total) - 1;
+          final range = await session.client.getObjectRange(
+            fileId,
+            start: received,
+            endInclusive: end,
+          );
+          await raf.writeFrom(range.bytes);
+          received += range.bytes.length;
+        }
+        await raf.flush();
+      } finally {
+        await raf.close();
+      }
+    } catch (_) {
+      if (await dest.exists()) {
+        try {
+          await dest.delete();
+        } catch (_) {
+          // Best-effort cleanup of a partial download.
+        }
+      }
+      rethrow;
+    }
   }
 
   @override

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/native.dart';
@@ -266,11 +267,30 @@ class DatabaseService {
     if (_database == null) return;
 
     if (strict) {
-      // No onTimeout swallow: a timeout throws TimeoutException. Clear the
-      // reference only after the close actually completed — on failure we
-      // keep it so the connection (and its locks) is not leaked and a
-      // retry can re-attempt the close before reopening.
-      await _database!.close().timeout(const Duration(seconds: 5));
+      // Graceful close first, but only briefly: GeneratedDatabase.close()
+      // awaits streamQueries.close(), which hangs for as long as ANY watch()
+      // subscription is paused — and Riverpod 3 auto-pauses the streams of
+      // providers nobody is currently listening to, so a mid-session restore
+      // almost always has one. Trusting the graceful close with a throwing
+      // timeout here made large-DB restores fail with TimeoutException until
+      // retried. On a hang, fall through and close the executor directly:
+      // idempotent when the graceful close got that far, and it sends the
+      // shutdown request the hung close never reached. Skipping the
+      // stream-store cleanup is safe on this path — the connection is being
+      // replaced, and the old stream subscriptions die with it.
+      final graceful = _database!.close();
+      try {
+        await graceful.timeout(const Duration(seconds: 2));
+      } on TimeoutException {
+        graceful.ignore();
+        // No onTimeout swallow: if even the direct executor close cannot get
+        // an acknowledgment, the connection is genuinely stuck and the caller
+        // must not race the file swap. Clear the reference only after the
+        // close actually completed — on failure we keep it so the connection
+        // (and its locks) is not leaked and a retry can re-attempt the close
+        // before reopening.
+        await _database!.executor.close().timeout(const Duration(seconds: 5));
+      }
       // Drift acknowledges the shutdown request before the worker isolate
       // runs sqlite3_close_v2, so the await above does NOT mean the file is
       // closed. A caller about to reopen the same file must wait for the
@@ -409,7 +429,15 @@ class DatabaseService {
   @visibleForTesting
   void Function(String stagingPath)? debugOnRestoreWindowOpen;
 
-  Future<void> restore(String backupPath) async {
+  /// Swap the live database for [backupPath].
+  ///
+  /// [onMigrationProgress] is forwarded to the post-swap [initialize]: when
+  /// the restored file carries an older schema, the reopen runs the upgrade
+  /// ladder, and this callback is the only feedback the user gets during it.
+  Future<void> restore(
+    String backupPath, {
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
+  }) async {
     final backupFile = File(backupPath);
     final destinationPath = await databasePath;
 
@@ -488,8 +516,9 @@ class DatabaseService {
     }
 
     // Reopen on the swapped-in file BEFORE dropping the pre-restore copy, so a
-    // cleanup hiccup can never prevent the reopen.
-    await initialize();
+    // cleanup hiccup can never prevent the reopen. An older-schema backup runs
+    // its migration ladder here; surface its progress to the caller.
+    await initialize(onMigrationProgress: onMigrationProgress);
 
     // The database is open again on the restored file; the pre-restore copy is
     // no longer needed. Its deletion is best-effort — a transient failure (e.g.

--- a/lib/features/backup/data/services/backup_crypto.dart
+++ b/lib/features/backup/data/services/backup_crypto.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
@@ -26,6 +27,13 @@ abstract final class BackupCrypto {
 
   static final AesGcm _aesGcm = AesGcm.with256bits();
 
+  /// Encrypt [inPath] into an SBE1 envelope at [outPath].
+  ///
+  /// The frame loop (synchronous file IO + AES-GCM over the whole file) runs
+  /// on a worker isolate: on a multi-hundred-MB database it is seconds to
+  /// minutes of pure-Dart work that would otherwise freeze the UI. Only the
+  /// key bytes cross the isolate boundary — [SecretKey] itself is not
+  /// reliably sendable.
   static Future<void> encryptFile({
     required String inPath,
     required String outPath,
@@ -33,7 +41,46 @@ abstract final class BackupCrypto {
     required String libraryKeyId,
     required Uint8List keyslotBytes,
   }) async {
-    final dataKey = await Keyslots.deriveDataKey(mlk);
+    final mlkBytes = Uint8List.fromList(await mlk.extractBytes());
+    return _encryptOnWorker(
+      inPath,
+      outPath,
+      mlkBytes,
+      libraryKeyId,
+      keyslotBytes,
+    );
+  }
+
+  /// Minimal-scope hop to the worker isolate. Kept as its own method so the
+  /// [Isolate.run] closure's enclosing scope holds only sendable values —
+  /// Dart closures capture the whole scope, not just what they reference.
+  static Future<void> _encryptOnWorker(
+    String inPath,
+    String outPath,
+    Uint8List mlkBytes,
+    String libraryKeyId,
+    Uint8List keyslotBytes,
+  ) {
+    return Isolate.run(
+      () => _encryptFileImpl(
+        inPath: inPath,
+        outPath: outPath,
+        mlkBytes: mlkBytes,
+        libraryKeyId: libraryKeyId,
+        keyslotBytes: keyslotBytes,
+      ),
+      debugName: 'sbe-encrypt',
+    );
+  }
+
+  static Future<void> _encryptFileImpl({
+    required String inPath,
+    required String outPath,
+    required Uint8List mlkBytes,
+    required String libraryKeyId,
+    required Uint8List keyslotBytes,
+  }) async {
+    final dataKey = await Keyslots.deriveDataKey(SecretKey(mlkBytes));
     final keyIdBytes = UuidValue.withValidation(libraryKeyId).toBytes();
     final input = File(inPath).openSync();
     final out = File(outPath).openSync(mode: FileMode.write);
@@ -73,7 +120,23 @@ abstract final class BackupCrypto {
 
   /// Decrypt using the artifact's embedded keyslots and a passphrase or
   /// recovery code. Throws [WrongPassphraseException] when no slot opens.
+  ///
+  /// Runs on a worker isolate: the Argon2id KDF (64 MiB, several passes) and
+  /// the full-file AES-GCM frame loop are both heavy pure-Dart work. The
+  /// thrown exceptions are simple const classes, so they propagate across the
+  /// isolate boundary unchanged.
   static Future<void> decryptFile({
+    required String inPath,
+    required String outPath,
+    required String secret,
+  }) {
+    return Isolate.run(
+      () => _decryptFileImpl(inPath: inPath, outPath: outPath, secret: secret),
+      debugName: 'sbe-decrypt',
+    );
+  }
+
+  static Future<void> _decryptFileImpl({
     required String inPath,
     required String outPath,
     required String secret,
@@ -93,10 +156,45 @@ abstract final class BackupCrypto {
 
   /// Decrypt silently with an already-unlocked key. Throws
   /// [SyncEncryptionRequired] when the artifact's key differs.
+  ///
+  /// Runs on a worker isolate for the same reason as [decryptFile].
   static Future<void> decryptFileWithKey({
     required String inPath,
     required String outPath,
     required SecretKey mlk,
+    required String expectedLibraryKeyId,
+  }) async {
+    final mlkBytes = Uint8List.fromList(await mlk.extractBytes());
+    return _decryptWithKeyOnWorker(
+      inPath,
+      outPath,
+      mlkBytes,
+      expectedLibraryKeyId,
+    );
+  }
+
+  /// See [_encryptOnWorker] for why this hop is a separate minimal scope.
+  static Future<void> _decryptWithKeyOnWorker(
+    String inPath,
+    String outPath,
+    Uint8List mlkBytes,
+    String expectedLibraryKeyId,
+  ) {
+    return Isolate.run(
+      () => _decryptFileWithKeyImpl(
+        inPath: inPath,
+        outPath: outPath,
+        mlkBytes: mlkBytes,
+        expectedLibraryKeyId: expectedLibraryKeyId,
+      ),
+      debugName: 'sbe-decrypt',
+    );
+  }
+
+  static Future<void> _decryptFileWithKeyImpl({
+    required String inPath,
+    required String outPath,
+    required Uint8List mlkBytes,
     required String expectedLibraryKeyId,
   }) async {
     final input = File(inPath).openSync();
@@ -109,7 +207,7 @@ abstract final class BackupCrypto {
           message: 'Backup is encrypted under a different library key',
         );
       }
-      final dataKey = await Keyslots.deriveDataKey(mlk);
+      final dataKey = await Keyslots.deriveDataKey(SecretKey(mlkBytes));
       await _decryptFrames(input, outPath, dataKey, header.keyIdBytes);
     } finally {
       input.closeSync();

--- a/lib/features/backup/data/services/backup_database_adapter.dart
+++ b/lib/features/backup/data/services/backup_database_adapter.dart
@@ -9,7 +9,16 @@ import 'package:submersion/core/services/database_service.dart';
 /// circular import.
 abstract class BackupDatabaseAdapter {
   Future<void> backup(String destinationPath);
-  Future<void> restore(String backupPath);
+
+  /// Swap the live database for [backupPath].
+  ///
+  /// [onMigrationProgress] fires per migration step when the restored file
+  /// carries an older schema and the reopen runs the upgrade ladder — the only
+  /// long-running phase of the swap, and otherwise invisible to the user.
+  Future<void> restore(
+    String backupPath, {
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
+  });
   Future<String> get databasePath;
   AppDatabase get database;
 }
@@ -30,7 +39,11 @@ class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
       _dbAdapter.backup(destinationPath);
 
   @override
-  Future<void> restore(String backupPath) => _dbAdapter.restore(backupPath);
+  Future<void> restore(
+    String backupPath, {
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
+  }) =>
+      _dbAdapter.restore(backupPath, onMigrationProgress: onMigrationProgress);
 
   @override
   Future<String> get databasePath => _dbAdapter.databasePath;

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -625,12 +625,9 @@ class BackupService {
     BackupRecord record, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     _log.info('Starting restore from: ${record.filename} (mode: $mode)');
-
-    // Create a proper backup before restoring so the user can find it
-    // in their configured backup location and in the history list.
-    await performBackup();
 
     // Determine backup source path. A SAF (content://) ref is streamed to a
     // temp file first; SQLite open + validation need a real filesystem path.
@@ -674,10 +671,20 @@ class BackupService {
         );
       }
 
+      // Create a proper backup before restoring so the user can find it
+      // in their configured backup location and in the history list. Runs
+      // only after decryption + validation succeeded, so a wrong passphrase
+      // or corrupt artifact aborts the flow without side effects (parity
+      // with restoreFromFile).
+      await performBackup();
+
       // Restore using DatabaseService (handles close/copy/reinitialize), then
       // re-baseline sync so the restored data syncs cleanly instead of
       // replaying the backup's stale sync position.
-      await _replaceDatabaseAndRebaselineSync(materialized.path);
+      await _replaceDatabaseAndRebaselineSync(
+        materialized.path,
+        onMigrationProgress: onMigrationProgress,
+      );
     } finally {
       await materialized.cleanUp();
     }
@@ -703,6 +710,7 @@ class BackupService {
     String filePath, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     _log.info('Starting restore from file: $filePath (mode: $mode)');
 
@@ -724,7 +732,10 @@ class BackupService {
 
       // Restore using DatabaseService, then re-baseline sync (see
       // _replaceDatabaseAndRebaselineSync).
-      await _replaceDatabaseAndRebaselineSync(materialized.path);
+      await _replaceDatabaseAndRebaselineSync(
+        materialized.path,
+        onMigrationProgress: onMigrationProgress,
+      );
     } finally {
       await materialized.cleanUp();
     }
@@ -748,7 +759,10 @@ class BackupService {
   /// resurrect from a peer's still-live copy. This preserves the live device
   /// identity (captured before the swap) and clears the sync position so the
   /// next sync cleanly reconciles the restored data.
-  Future<void> _replaceDatabaseAndRebaselineSync(String sourcePath) async {
+  Future<void> _replaceDatabaseAndRebaselineSync(
+    String sourcePath, {
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
+  }) async {
     String liveDeviceId;
     try {
       liveDeviceId = await _syncRepository.getDeviceId();
@@ -780,7 +794,10 @@ class BackupService {
       liveEpochId = _epochStore?.lastAcceptedEpochId;
     }
 
-    await _dbAdapter.restore(sourcePath);
+    await _dbAdapter.restore(
+      sourcePath,
+      onMigrationProgress: onMigrationProgress,
+    );
 
     try {
       await _syncRepository.rebaselineAfterRestore(
@@ -1227,9 +1244,10 @@ class BackupService {
     }
 
     try {
-      final bytes = await File(uploadPath).readAsBytes();
-      final result = await _cloudProvider.uploadFile(
-        Uint8List.fromList(bytes),
+      // Path-based upload: providers stream from disk, so a multi-hundred-MB
+      // backup is never resident in memory.
+      final result = await _cloudProvider.uploadFileFromPath(
+        uploadPath,
         uploadName,
         folderId: folderId,
       );
@@ -1331,10 +1349,11 @@ class BackupService {
       throw const BackupException('No cloud provider available for download');
     }
 
-    final bytes = await _cloudProvider.downloadFile(cloudFileId);
     final tempDir = await resolveSyncTempDir();
     final tempPath = p.join(tempDir.path, filename);
-    await File(tempPath).writeAsBytes(bytes);
+    // Path-based download: providers stream to disk and delete a partial
+    // file on failure, so the backup is never resident in memory.
+    await _cloudProvider.downloadToFile(cloudFileId, tempPath);
     return tempPath;
   }
 

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -266,6 +266,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         record,
         mode: mode,
         encryptionSecret: encryptionSecret,
+        onMigrationProgress: _onRestoreMigrationProgress,
       );
       await _syncActiveDiverAfterRestore();
       state = const BackupOperationState(
@@ -400,6 +401,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         filePath,
         mode: mode,
         encryptionSecret: encryptionSecret,
+        onMigrationProgress: _onRestoreMigrationProgress,
       );
       await _syncActiveDiverAfterRestore();
       state = const BackupOperationState(
@@ -422,6 +424,17 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         message: 'Restore failed: $e',
       );
     }
+  }
+
+  /// Surface migration-ladder progress while a restored older-schema backup
+  /// upgrades to the current schema — the only long phase of the swap, and
+  /// otherwise a silent stall behind the restore barrier.
+  void _onRestoreMigrationProgress(int currentStep, int totalSteps) {
+    state = BackupOperationState(
+      status: BackupOperationStatus.inProgress,
+      message: 'Upgrading database (step $currentStep of $totalSteps)...',
+      isRestoring: true,
+    );
   }
 
   /// Reset status back to idle

--- a/test/core/services/cloud_storage/cloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/cloud_storage_provider_test.dart
@@ -49,6 +49,21 @@ void main() {
       );
       expect(await dest.exists(), isFalse);
     });
+
+    test(
+      'downloadToFile surfaces a write failure and attempts cleanup',
+      () async {
+        provider.stored['id-1'] = Uint8List.fromList([1]);
+        // A destination inside a directory that does not exist makes the write
+        // itself fail after a successful download.
+        final dest = File('${tempDir.path}/no-such-dir/dest.bin');
+        await expectLater(
+          provider.downloadToFile('id-1', dest.path),
+          throwsA(isA<FileSystemException>()),
+        );
+        expect(await dest.exists(), isFalse);
+      },
+    );
   });
 
   group('CloudStorageException.displayMessage', () {

--- a/test/core/services/cloud_storage/cloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/cloud_storage_provider_test.dart
@@ -1,7 +1,56 @@
+import 'dart:io';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 
 void main() {
+  group('CloudStorageProviderMixin path-based defaults', () {
+    late Directory tempDir;
+    late _ByteOnlyProvider provider;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('csp_mixin_test_');
+      provider = _ByteOnlyProvider();
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test(
+      'uploadFileFromPath falls back to uploadFile with the file bytes',
+      () async {
+        final src = File('${tempDir.path}/src.bin');
+        await src.writeAsBytes([1, 2, 3, 4]);
+
+        final result = await provider.uploadFileFromPath(src.path, 'a.bin');
+
+        expect(provider.stored[result.fileId], [1, 2, 3, 4]);
+      },
+    );
+
+    test('downloadToFile falls back to downloadFile and writes the '
+        'destination', () async {
+      provider.stored['id-1'] = Uint8List.fromList([9, 8, 7]);
+      final dest = File('${tempDir.path}/dest.bin');
+
+      await provider.downloadToFile('id-1', dest.path);
+
+      expect(await dest.readAsBytes(), [9, 8, 7]);
+    });
+
+    test('downloadToFile surfaces the download error without leaving a '
+        'partial file', () async {
+      final dest = File('${tempDir.path}/dest.bin');
+      await expectLater(
+        provider.downloadToFile('missing', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(await dest.exists(), isFalse);
+    });
+  });
+
   group('CloudStorageException.displayMessage', () {
     test('returns the bare message when there is no cause', () {
       const exception = CloudStorageException('Could not reach S3 endpoint');
@@ -38,4 +87,64 @@ void main() {
 class _Hostile {
   @override
   String toString() => throw StateError('boom');
+}
+
+/// Minimal provider with only the byte-based transfers implemented, so the
+/// mixin's path-based fallbacks are what the test exercises.
+class _ByteOnlyProvider extends CloudStorageProvider
+    with CloudStorageProviderMixin {
+  final Map<String, Uint8List> stored = {};
+  int _nextId = 0;
+
+  @override
+  String get providerName => 'ByteOnly';
+  @override
+  String get providerId => 'byteonly';
+  @override
+  Future<bool> isAvailable() async => true;
+  @override
+  Future<bool> isAuthenticated() async => true;
+  @override
+  Future<void> authenticate() async {}
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<String?> getUserEmail() async => null;
+
+  @override
+  Future<UploadResult> uploadFile(
+    Uint8List data,
+    String filename, {
+    String? folderId,
+  }) async {
+    final id = 'id-${_nextId++}';
+    stored[id] = Uint8List.fromList(data);
+    return UploadResult(fileId: id, uploadTime: DateTime.now());
+  }
+
+  @override
+  Future<Uint8List> downloadFile(String fileId) async {
+    final data = stored[fileId];
+    if (data == null) throw CloudStorageException('not found: $fileId');
+    return data;
+  }
+
+  @override
+  Future<CloudFileInfo?> getFileInfo(String fileId) async => null;
+  @override
+  Future<List<CloudFileInfo>> listFiles({
+    String? folderId,
+    String? namePattern,
+  }) async => const [];
+  @override
+  Future<void> deleteFile(String fileId) async {}
+  @override
+  Future<bool> fileExists(String fileId) async => stored.containsKey(fileId);
+  @override
+  Future<String> createFolder(
+    String folderName, {
+    String? parentFolderId,
+  }) async => folderName;
+  @override
+  Future<String> getOrCreateSyncFolder() async => 'sync';
 }

--- a/test/core/services/cloud_storage/dropbox_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/dropbox_storage_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -219,6 +220,181 @@ void main() {
     final p = provider(mockApi((_) async => json({})));
     await p.signOut();
     expect(await store.load(), isNull);
+  });
+
+  group('path-based transfers', () {
+    // 8 MiB, matching the provider's transfer chunk size.
+    const chunk = 8 * 1024 * 1024;
+    late Directory tempDir;
+
+    setUp(() async {
+      await connect();
+      tempDir = Directory.systemTemp.createTempSync('dropbox_provider_test');
+    });
+
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    File writeSource(int length) {
+      final file = File('${tempDir.path}/src.bin');
+      file.writeAsBytesSync(
+        Uint8List.fromList(List<int>.generate(length, (i) => i % 251)),
+      );
+      return file;
+    }
+
+    Map<String, Object?> fileEntrySized(String name, int size) => {
+      ...fileEntry(name),
+      'size': size,
+    };
+
+    test('small uploads take the single upload endpoint', () async {
+      final src = writeSource(1024);
+      final paths = <String>[];
+      final p = provider(
+        mockApi((request) async {
+          paths.add(request.url.path);
+          return json(fileEntry('small.db'));
+        }),
+      );
+
+      final result = await p.uploadFileFromPath(src.path, 'small.db');
+
+      expect(paths, ['/2/files/upload']);
+      expect(result.fileId, '/small.db');
+    });
+
+    test(
+      'large uploads stream through an upload session, byte-identical',
+      () async {
+        final src = writeSource(2 * chunk + 1024); // start + append + finish
+        final paths = <String>[];
+        final received = BytesBuilder(copy: false);
+        final p = provider(
+          mockApi((request) async {
+            paths.add(request.url.path);
+            received.add(request.bodyBytes);
+            switch (request.url.path) {
+              case '/2/files/upload_session/start':
+                return json({'session_id': 's1'});
+              case '/2/files/upload_session/append_v2':
+                return json({});
+              case '/2/files/upload_session/finish':
+                return json(fileEntrySized('big.db', 2 * chunk + 1024));
+              default:
+                return http.Response('unexpected', 500);
+            }
+          }),
+        );
+
+        final result = await p.uploadFileFromPath(src.path, 'big.db');
+
+        expect(paths, [
+          '/2/files/upload_session/start',
+          '/2/files/upload_session/append_v2',
+          '/2/files/upload_session/finish',
+        ]);
+        expect(
+          received.takeBytes(),
+          src.readAsBytesSync(),
+          reason: 'session chunks must reassemble byte-identical',
+        );
+        expect(result.fileId, '/big.db');
+      },
+    );
+
+    test('small downloads take the single download endpoint', () async {
+      final p = provider(
+        mockApi((request) async {
+          if (request.url.path == '/2/files/get_metadata') {
+            return json(fileEntry('f.db'));
+          }
+          return http.Response.bytes([1, 2, 3], 200);
+        }),
+      );
+      final dest = File('${tempDir.path}/out.bin');
+
+      await p.downloadToFile('/f.db', dest.path);
+
+      expect(dest.readAsBytesSync(), [1, 2, 3]);
+    });
+
+    test('large downloads stream by ranges, byte-identical', () async {
+      final data = Uint8List.fromList(
+        List<int>.generate(chunk + 4096, (i) => i % 249),
+      );
+      final p = provider(
+        mockApi((request) async {
+          if (request.url.path == '/2/files/get_metadata') {
+            return json(fileEntrySized('big.db', data.length));
+          }
+          final range = request.headers['Range']!;
+          final m = RegExp(r'bytes=(\d+)-(\d+)').firstMatch(range)!;
+          final start = int.parse(m.group(1)!);
+          final end = int.parse(m.group(2)!).clamp(0, data.length - 1);
+          return http.Response.bytes(
+            Uint8List.sublistView(data, start, end + 1),
+            206,
+            headers: {'content-range': 'bytes $start-$end/${data.length}'},
+          );
+        }),
+      );
+      final dest = File('${tempDir.path}/out.bin');
+
+      await p.downloadToFile('/big.db', dest.path);
+
+      expect(dest.readAsBytesSync(), data);
+    });
+
+    test('a missing file throws and leaves no destination file', () async {
+      final p = provider(
+        mockApi(
+          (request) async => http.Response(
+            jsonEncode({'error_summary': 'path/not_found/..'}),
+            409,
+          ),
+        ),
+      );
+      final dest = File('${tempDir.path}/out.bin');
+
+      await expectLater(
+        p.downloadToFile('/nope.db', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(dest.existsSync(), isFalse);
+    });
+
+    test('a mid-range failure deletes the partial download', () async {
+      final data = Uint8List.fromList(
+        List<int>.generate(chunk + 4096, (i) => i % 249),
+      );
+      final p = provider(
+        mockApi((request) async {
+          if (request.url.path == '/2/files/get_metadata') {
+            return json(fileEntrySized('big.db', data.length));
+          }
+          final range = request.headers['Range']!;
+          if (!range.startsWith('bytes=0-')) {
+            return http.Response('boom', 500);
+          }
+          return http.Response.bytes(
+            Uint8List.sublistView(data, 0, chunk),
+            206,
+            headers: {'content-range': 'bytes 0-${chunk - 1}/${data.length}'},
+          );
+        }),
+      );
+      final dest = File('${tempDir.path}/out.bin');
+
+      await expectLater(
+        p.downloadToFile('/big.db', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(
+        dest.existsSync(),
+        isFalse,
+        reason: 'a truncated download must never be left for the caller',
+      );
+    });
   });
 
   test('mixin conflict detection matches Dropbox conflicted-copy names', () {

--- a/test/core/services/cloud_storage/encrypting_cloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/encrypting_cloud_storage_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
@@ -174,6 +175,106 @@ void main() {
     );
   });
 
+  group('path-based transfers', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('enc_provider_test_');
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('uploadFileFromPath seals non-exempt files; downloadToFile '
+        'round-trips plaintext', () async {
+      final src = File('${tempDir.path}/src.json');
+      await src.writeAsString('{"cs":1}');
+
+      final up = await provider.uploadFileFromPath(
+        src.path,
+        'ssv1.devA.cs.00001.json',
+      );
+      // At rest (inner fake) the bytes must be an envelope:
+      final atRest = await inner.downloadFile(up.fileId);
+      expect(SyncEnvelope.hasMagic(atRest), isTrue);
+
+      // Through the decorator the file lands as plaintext:
+      final dest = File('${tempDir.path}/dest.json');
+      await provider.downloadToFile(up.fileId, dest.path);
+      expect(await dest.readAsString(), '{"cs":1}');
+    });
+
+    test('uploadFileFromPath streams exempt backups through untouched '
+        '(never buffers into an envelope)', () async {
+      final framed = Uint8List.fromList([
+        ...SyncEnvelope.magic,
+        ...List<int>.filled(64, 7),
+      ]);
+      final src = File('${tempDir.path}/backup.sbe');
+      await src.writeAsBytes(framed);
+
+      final up = await provider.uploadFileFromPath(
+        src.path,
+        'submersion_backup_2026-08-05.sbe',
+      );
+      final atRest = await inner.downloadFile(up.fileId);
+      expect(atRest, framed, reason: 'exempt artifact must pass through raw');
+    });
+
+    test('downloadToFile passes framed backups through untouched', () async {
+      final framed = Uint8List.fromList([
+        ...SyncEnvelope.magic,
+        ...List<int>.filled(64, 7),
+      ]);
+      final up = await inner.uploadFile(
+        framed,
+        'submersion_backup_2026-08-05.sbe',
+      );
+      await provider.listFiles(namePattern: 'submersion_backup_');
+
+      final dest = File('${tempDir.path}/restored.sbe');
+      await provider.downloadToFile(up.fileId, dest.path);
+      expect(
+        await dest.readAsBytes(),
+        framed,
+        reason: 'exempt artifact must not be decrypted',
+      );
+    });
+
+    test('downloadToFile passes plaintext files through untouched', () async {
+      final up = await inner.uploadFile(
+        bytesOf('{"legacy":true}'),
+        'submersion_library_epoch.json',
+      );
+      final dest = File('${tempDir.path}/epoch.json');
+      await provider.downloadToFile(up.fileId, dest.path);
+      expect(await dest.readAsString(), '{"legacy":true}');
+    });
+
+    test('downloadToFile deletes the file when the name is unresolvable '
+        '(never leaves ciphertext behind)', () async {
+      final sealed = await SyncEnvelope.seal(
+        plaintext: bytesOf('{"x":1}'),
+        dataKey: dataKey,
+        libraryKeyId: _keyId,
+        filename: 'ssv1.devA.cs.9.json',
+      );
+      final nameless = _NamelessProvider(sealed);
+      final wrapped = EncryptingCloudStorageProvider(
+        nameless,
+        dataKey: dataKey,
+        libraryKeyId: _keyId,
+      );
+      final dest = File('${tempDir.path}/leaky.json');
+      await expectLater(
+        wrapped.downloadToFile('whatever', dest.path),
+        throwsA(isA<EnvelopeCorruptException>()),
+      );
+      expect(await dest.exists(), isFalse);
+    });
+  });
+
   test(
     'download throws when an encrypted file has no resolvable name',
     () async {
@@ -208,6 +309,11 @@ class _NamelessProvider extends Fake implements CloudStorageProvider {
 
   @override
   Future<Uint8List> downloadFile(String fileId) async => _bytes;
+
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    await File(destinationPath).writeAsBytes(_bytes, flush: true);
+  }
 
   @override
   Future<CloudFileInfo?> getFileInfo(String fileId) async => null;

--- a/test/core/services/cloud_storage/google_drive_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/google_drive_storage_provider_test.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:googleapis/drive/v3.dart' as drive;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive_storage_provider.dart';
+
+/// Exercises the provider's transfer paths through a [drive.DriveApi] backed
+/// by a mock HTTP client (injected via the debugSetDriveApi seam), since the
+/// real api is only ever minted from an authenticated Google session.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('gdrive_provider_test');
+  });
+
+  tearDown(() => tempDir.deleteSync(recursive: true));
+
+  http.Response jsonResponse(Object? body) => http.Response(
+    jsonEncode(body),
+    200,
+    headers: {'content-type': 'application/json'},
+  );
+
+  GoogleDriveStorageProvider providerWith(MockClient mock) =>
+      GoogleDriveStorageProvider()..debugSetDriveApi(drive.DriveApi(mock));
+
+  /// Routes the Drive REST surface: file listing (for _findFile), multipart
+  /// AND resumable upload protocols (googleapis picks one), and alt=media
+  /// downloads.
+  MockClient driveMock({
+    List<Map<String, Object?>> existingFiles = const [],
+    List<int>? mediaBytes,
+    int mediaStatus = 200,
+    void Function(http.Request request)? onRequest,
+  }) {
+    return MockClient((request) async {
+      onRequest?.call(request);
+      final path = request.url.path;
+      if (path == '/drive/v3/files' && request.method == 'GET') {
+        return jsonResponse({'files': existingFiles});
+      }
+      if (path.startsWith('/upload/')) {
+        if (request.url.queryParameters['uploadType'] == 'resumable' &&
+            request.method == 'POST') {
+          return http.Response(
+            '',
+            200,
+            headers: {
+              'location':
+                  'https://www.googleapis.com/upload/session/fake-session',
+            },
+          );
+        }
+        // Multipart upload, or a resumable-session data PUT.
+        return jsonResponse({'id': 'uploaded-id', 'name': 'b.db'});
+      }
+      if (path.startsWith('/drive/v3/files/') &&
+          request.url.queryParameters['alt'] == 'media') {
+        if (mediaStatus != 200) {
+          return http.Response('not found', mediaStatus);
+        }
+        return http.Response.bytes(
+          mediaBytes!,
+          200,
+          headers: {
+            'content-type': 'application/octet-stream',
+            'content-length': '${mediaBytes.length}',
+          },
+        );
+      }
+      return http.Response('unexpected: ${request.method} $path', 500);
+    });
+  }
+
+  group('uploadFileFromPath', () {
+    test('streams a new file into the target folder', () async {
+      final src = File('${tempDir.path}/backup.db')
+        ..writeAsBytesSync(List<int>.generate(4096, (i) => i % 251));
+      final methods = <String>[];
+      final provider = providerWith(
+        driveMock(onRequest: (r) => methods.add(r.method)),
+      );
+
+      final result = await provider.uploadFileFromPath(
+        src.path,
+        'b.db',
+        folderId: 'folder-1',
+      );
+
+      expect(result.fileId, 'uploaded-id');
+      // The file did not exist, so the create path ran (a POST, not a PATCH).
+      expect(methods, contains('POST'));
+      expect(methods, isNot(contains('PATCH')));
+    });
+
+    test('updates in place when the file already exists', () async {
+      final src = File('${tempDir.path}/backup.db')
+        ..writeAsBytesSync(List<int>.generate(1024, (i) => i % 251));
+      final methods = <String>[];
+      final provider = providerWith(
+        driveMock(
+          existingFiles: [
+            {'id': 'uploaded-id', 'name': 'b.db'},
+          ],
+          onRequest: (r) => methods.add(r.method),
+        ),
+      );
+
+      final result = await provider.uploadFileFromPath(
+        src.path,
+        'b.db',
+        folderId: 'folder-1',
+      );
+
+      expect(result.fileId, 'uploaded-id');
+      expect(
+        methods,
+        contains('PATCH'),
+        reason: 'an existing file must be updated, not duplicated',
+      );
+    });
+
+    test('wraps transport failures in CloudStorageException', () async {
+      final src = File('${tempDir.path}/backup.db')..writeAsBytesSync([1]);
+      final provider = providerWith(
+        MockClient((_) async => http.Response('boom', 500)),
+      );
+
+      await expectLater(
+        provider.uploadFileFromPath(src.path, 'b.db', folderId: 'folder-1'),
+        throwsA(isA<CloudStorageException>()),
+      );
+    });
+  });
+
+  group('downloadToFile', () {
+    test('pipes the media stream straight to disk', () async {
+      final data = List<int>.generate(64 * 1024, (i) => i % 249);
+      final provider = providerWith(driveMock(mediaBytes: data));
+      final dest = File('${tempDir.path}/out.bin');
+
+      await provider.downloadToFile('file-1', dest.path);
+
+      expect(dest.readAsBytesSync(), Uint8List.fromList(data));
+    });
+
+    test('a missing file throws and leaves no destination file', () async {
+      final provider = providerWith(driveMock(mediaStatus: 404));
+      final dest = File('${tempDir.path}/out.bin');
+
+      await expectLater(
+        provider.downloadToFile('file-1', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(dest.existsSync(), isFalse);
+    });
+  });
+}

--- a/test/core/services/cloud_storage/icloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/icloud_storage_provider_test.dart
@@ -134,6 +134,117 @@ void main() {
     );
   });
 
+  group('path-based transfers', () {
+    late String containerPath;
+
+    setUp(() {
+      containerPath = p.join(tempDir.path, 'container');
+      Directory(containerPath).createSync(recursive: true);
+    });
+
+    ICloudStorageProvider transferProvider({
+      Future<bool> Function(String source, String destination)? move,
+      Future<bool> Function(String path)? download,
+    }) {
+      return ICloudStorageProvider(
+        platform: ICloudHostPlatform.ios,
+        containerPathLookup: () async => containerPath,
+        containerFileMove:
+            move ??
+            (source, destination) async {
+              File(source).renameSync(destination);
+              return true;
+            },
+        ensureDownloaded: download ?? (path) async => true,
+      );
+    }
+
+    test('uploadFileFromPath copies, moves into the container, and cleans '
+        'the staging file', () async {
+      final src = File(p.join(tempDir.path, 'backup.db'));
+      src.writeAsStringSync('payload');
+
+      final result = await transferProvider().uploadFileFromPath(
+        src.path,
+        'submersion_backup_x.db',
+      );
+
+      expect(File(result.fileId).readAsStringSync(), 'payload');
+      expect(
+        File('${result.fileId}.uploading').existsSync(),
+        isFalse,
+        reason: 'staging sibling must not be left behind',
+      );
+      // The source file is untouched (copied, not moved).
+      expect(src.existsSync(), isTrue);
+    });
+
+    test('uploadFileFromPath cleans the staging file when the coordinated '
+        'move fails', () async {
+      final src = File(p.join(tempDir.path, 'backup.db'));
+      src.writeAsStringSync('payload');
+      final provider = transferProvider(move: (_, _) async => false);
+
+      await expectLater(
+        provider.uploadFileFromPath(src.path, 'submersion_backup_x.db'),
+        throwsA(isA<CloudStorageException>()),
+      );
+
+      final syncDir = Directory(containerPath).listSync(recursive: true);
+      expect(
+        syncDir.whereType<File>().where((f) => f.path.endsWith('.uploading')),
+        isEmpty,
+        reason: 'a failed move must not strand its staging copy',
+      );
+    });
+
+    test('downloadToFile materializes and copies the container file', () async {
+      final containerFile = File(p.join(containerPath, 'b.db'))
+        ..writeAsStringSync('bytes');
+      final dest = p.join(tempDir.path, 'restored.db');
+      final downloadedPaths = <String>[];
+      final provider = transferProvider(
+        download: (path) async {
+          downloadedPaths.add(path);
+          return true;
+        },
+      );
+
+      await provider.downloadToFile(containerFile.path, dest);
+
+      expect(File(dest).readAsStringSync(), 'bytes');
+      expect(downloadedPaths, [containerFile.path]);
+    });
+
+    test('downloadToFile throws when the container file is missing', () async {
+      final dest = p.join(tempDir.path, 'restored.db');
+      await expectLater(
+        transferProvider().downloadToFile(
+          p.join(containerPath, 'missing.db'),
+          dest,
+        ),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(File(dest).existsSync(), isFalse);
+    });
+
+    test(
+      'downloadToFile throws when iCloud cannot materialize the file',
+      () async {
+        final containerFile = File(p.join(containerPath, 'b.db'))
+          ..writeAsStringSync('bytes');
+        final dest = p.join(tempDir.path, 'restored.db');
+        final provider = transferProvider(download: (_) async => false);
+
+        await expectLater(
+          provider.downloadToFile(containerFile.path, dest),
+          throwsA(isA<CloudStorageException>()),
+        );
+        expect(File(dest).existsSync(), isFalse);
+      },
+    );
+  });
+
   group('ICloudHostPlatform', () {
     test('treats both Apple platforms as Apple', () {
       expect(ICloudHostPlatform.ios.isApple, isTrue);

--- a/test/core/services/cloud_storage/icloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/icloud_storage_provider_test.dart
@@ -198,6 +198,30 @@ void main() {
       );
     });
 
+    test('uploadFileFromPath cleans the staging file when the copy itself '
+        'fails', () async {
+      // A missing source makes the staging copy throw before the move ever
+      // runs; the cleanup guard must cover this leg too (a real-world failed
+      // copy — disk full — can leave a partial staging file).
+      final provider = transferProvider(
+        move: (_, _) async => fail('move must not run when the copy fails'),
+      );
+
+      await expectLater(
+        provider.uploadFileFromPath(
+          p.join(tempDir.path, 'does-not-exist.db'),
+          'submersion_backup_x.db',
+        ),
+        throwsA(isA<CloudStorageException>()),
+      );
+
+      final syncDir = Directory(containerPath).listSync(recursive: true);
+      expect(
+        syncDir.whereType<File>().where((f) => f.path.endsWith('.uploading')),
+        isEmpty,
+      );
+    });
+
     test('downloadToFile materializes and copies the container file', () async {
       final containerFile = File(p.join(containerPath, 'b.db'))
         ..writeAsStringSync('bytes');

--- a/test/core/services/cloud_storage/s3_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/s3_storage_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -87,6 +88,85 @@ class _FakeS3ApiClient extends Fake implements S3ApiClient {
     _assertOpen();
     calls.add('list:$prefix');
     return listing;
+  }
+
+  // Multipart + range support for the streamed transfer tests.
+  final Map<String, BytesBuilder> _sessions = {};
+  final List<String> abortedUploads = [];
+
+  /// When set, uploadPart throws for this part number (failure injection).
+  int? failAtPart;
+
+  /// When set, getObjectRange throws for the range starting here.
+  int? failRangeAtStart;
+
+  @override
+  Future<String> createMultipartUpload(
+    String key, {
+    required String contentType,
+  }) async {
+    _assertOpen();
+    calls.add('createMultipart:$key');
+    final uploadId = 'up-$key';
+    _sessions[uploadId] = BytesBuilder(copy: false);
+    return uploadId;
+  }
+
+  @override
+  Future<String> uploadPart(
+    String key, {
+    required String uploadId,
+    required int partNumber,
+    required Uint8List bytes,
+  }) async {
+    _assertOpen();
+    calls.add('part:$partNumber(${bytes.length})');
+    if (failAtPart == partNumber) {
+      throw CloudStorageException('injected part $partNumber failure');
+    }
+    _sessions[uploadId]!.add(bytes);
+    return 'etag-$partNumber';
+  }
+
+  @override
+  Future<void> completeMultipartUpload(
+    String key, {
+    required String uploadId,
+    required List<S3PartInfo> parts,
+  }) async {
+    _assertOpen();
+    calls.add('completeMultipart:$key(${parts.length})');
+    objects[key] = _sessions.remove(uploadId)!.takeBytes();
+  }
+
+  @override
+  Future<void> abortMultipartUpload(
+    String key, {
+    required String uploadId,
+  }) async {
+    calls.add('abortMultipart:$key');
+    abortedUploads.add(uploadId);
+    _sessions.remove(uploadId);
+  }
+
+  @override
+  Future<({Uint8List bytes, int totalLength})> getObjectRange(
+    String key, {
+    required int start,
+    required int endInclusive,
+  }) async {
+    _assertOpen();
+    calls.add('range:$start-$endInclusive');
+    if (failRangeAtStart == start) {
+      throw const CloudStorageException('injected range failure');
+    }
+    final data = objects[key];
+    if (data == null) throw CloudStorageException('File not found in S3: $key');
+    final end = endInclusive < data.length - 1 ? endInclusive : data.length - 1;
+    return (
+      bytes: Uint8List.sublistView(data, start, end + 1),
+      totalLength: data.length,
+    );
   }
 
   @override
@@ -259,6 +339,138 @@ void main() {
       expect(store.stored, isNull);
       expect(builtClients.single.closed, isTrue);
       expect(builtClients.single.calls.first, startsWith('list:'));
+    });
+  });
+
+  group('path-based transfers', () {
+    // 8 MiB, matching the provider's transfer chunk size.
+    const chunk = 8 * 1024 * 1024;
+    late Directory tempDir;
+
+    setUp(() {
+      store.stored = config();
+      tempDir = Directory.systemTemp.createTempSync('s3_provider_test');
+    });
+
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    File writeSource(int length) {
+      final file = File('${tempDir.path}/src.bin');
+      // Position-dependent bytes so reassembly errors are detectable.
+      file.writeAsBytesSync(
+        Uint8List.fromList(List<int>.generate(length, (i) => i % 251)),
+      );
+      return file;
+    }
+
+    test('small uploads take the single putObject path', () async {
+      final src = writeSource(1024);
+      final result = await provider.uploadFileFromPath(src.path, 'small.db');
+      expect(result.fileId, 'submersion-sync/small.db');
+      final client = builtClients.single;
+      expect(client.calls, contains('put:submersion-sync/small.db'));
+      expect(client.objects['submersion-sync/small.db']!.length, 1024);
+    });
+
+    test('large uploads go multipart and reassemble byte-identical', () async {
+      final src = writeSource(chunk + 1024);
+      final result = await provider.uploadFileFromPath(src.path, 'big.db');
+      expect(result.fileId, 'submersion-sync/big.db');
+      final client = builtClients.single;
+      expect(client.calls, contains('createMultipart:submersion-sync/big.db'));
+      expect(client.calls, contains('part:1($chunk)'));
+      expect(client.calls, contains('part:2(1024)'));
+      expect(
+        client.objects['submersion-sync/big.db'],
+        src.readAsBytesSync(),
+        reason: 'multipart reassembly must be byte-identical',
+      );
+      expect(client.abortedUploads, isEmpty);
+    });
+
+    test('a failed part aborts the multipart session', () async {
+      final src = writeSource(chunk + 1024);
+      // The factory builds one client per session; prime the failure on the
+      // client the upload will build by making the factory set it.
+      provider = S3StorageProvider(
+        store: store,
+        apiClientFactory: (config, {onRegionCorrected}) {
+          final client = _FakeS3ApiClient(config)..failAtPart = 2;
+          builtClients.add(client);
+          return client;
+        },
+      );
+
+      await expectLater(
+        provider.uploadFileFromPath(src.path, 'big.db'),
+        throwsA(isA<CloudStorageException>()),
+      );
+      final client = builtClients.single;
+      expect(client.abortedUploads, [
+        'up-submersion-sync/big.db',
+      ], reason: 'uploaded parts must not strand and bill');
+    });
+
+    test('small downloads take the single getObject path', () async {
+      await provider.uploadFile(Uint8List.fromList([1, 2, 3]), 'f.db');
+      final dest = File('${tempDir.path}/out.bin');
+
+      await provider.downloadToFile('submersion-sync/f.db', dest.path);
+
+      expect(dest.readAsBytesSync(), [1, 2, 3]);
+    });
+
+    test('large downloads stream by ranges, byte-identical', () async {
+      final data = Uint8List.fromList(
+        List<int>.generate(chunk + 4096, (i) => i % 249),
+      );
+      builtClients.clear();
+      await provider.uploadFile(data, 'big.db');
+      final client = builtClients.single;
+      final dest = File('${tempDir.path}/out.bin');
+
+      await provider.downloadToFile('submersion-sync/big.db', dest.path);
+
+      expect(dest.readAsBytesSync(), data);
+      expect(client.calls, contains('range:0-${chunk - 1}'));
+      // The final range is clamped to the object's total size.
+      expect(client.calls, contains('range:$chunk-${chunk + 4096 - 1}'));
+    });
+
+    test('a missing object throws and leaves no destination file', () async {
+      final dest = File('${tempDir.path}/out.bin');
+      await expectLater(
+        provider.downloadToFile('submersion-sync/nope.db', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(dest.existsSync(), isFalse);
+    });
+
+    test('a mid-range failure deletes the partial download', () async {
+      final data = Uint8List.fromList(
+        List<int>.generate(chunk + 4096, (i) => i % 249),
+      );
+      provider = S3StorageProvider(
+        store: store,
+        apiClientFactory: (config, {onRegionCorrected}) {
+          final client = _FakeS3ApiClient(config)..failRangeAtStart = chunk;
+          builtClients.add(client);
+          return client;
+        },
+      );
+      builtClients.clear();
+      await provider.uploadFile(data, 'big.db');
+      final dest = File('${tempDir.path}/out.bin');
+
+      await expectLater(
+        provider.downloadToFile('submersion-sync/big.db', dest.path),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(
+        dest.existsSync(),
+        isFalse,
+        reason: 'a truncated download must never be left for the caller',
+      );
     });
   });
 

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -381,6 +381,47 @@ void main() {
     },
   );
 
+  test('restore succeeds while a watch() subscription is paused', () async {
+    // Riverpod 3 auto-pauses the streams of providers nobody is listening to,
+    // and drift's graceful close() awaits streamQueries.close(), which hangs
+    // while ANY watch() subscription is paused. In a real session there is
+    // almost always at least one paused watch stream (any previously visited
+    // page), so a strict close that trusts the graceful close with a throwing
+    // timeout makes restore fail with TimeoutException until retried.
+    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(defaultPath),
+    );
+    await DatabaseService.instance.database
+        .customSelect('SELECT 1')
+        .getSingle();
+    final backupPath = p.join(tempDir.path, 'backup.db');
+    await DatabaseService.instance.backup(backupPath);
+
+    // Simulate Riverpod's auto-pause: subscribe to a watch() stream, then
+    // pause the subscription and leave it paused across the restore.
+    final subscription = DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .watch()
+        .listen((_) {});
+    subscription.pause();
+    addTearDown(() async {
+      try {
+        await subscription.cancel();
+      } catch (_) {
+        // The stream's database was closed by the restore; a cancel error
+        // here is irrelevant to the assertion.
+      }
+    });
+
+    await DatabaseService.instance.restore(backupPath);
+
+    final one = await DatabaseService.instance.database
+        .customSelect('SELECT 1 AS v')
+        .getSingle();
+    expect(one.read<int>('v'), 1);
+  });
+
   test('restore with a missing backup file leaves the live DB open', () async {
     // A restore pointed at a nonexistent file must be a true no-op: it must
     // NOT close the database (which would open an unavailable window for

--- a/test/features/backup/data/services/backup_encryption_backup_test.dart
+++ b/test/features/backup/data/services/backup_encryption_backup_test.dart
@@ -31,7 +31,10 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/fake/db/path';

--- a/test/features/backup/data/services/backup_service_encryption_test.dart
+++ b/test/features/backup/data/services/backup_service_encryption_test.dart
@@ -30,7 +30,10 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/fake/db/path';

--- a/test/features/backup/data/services/backup_service_replace_test.dart
+++ b/test/features/backup/data/services/backup_service_replace_test.dart
@@ -25,7 +25,10 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/fake/db/path';
@@ -169,6 +172,44 @@ void main() {
         throwsA(isA<BackupException>()),
       );
     });
+
+    test(
+      'a rejected restore leaves no safety backup or history entry',
+      () async {
+        // The pre-restore safety backup must run only after the source has been
+        // materialized (decrypted) and validated: a corrupt file or wrong
+        // passphrase aborts the flow without side effects. Running it first left
+        // a stray backup + history record behind every failed restore attempt.
+        final corrupt = File('${tempDir.path}/corrupt2.db');
+        await corrupt.writeAsString('not a database');
+        final record = BackupRecord(
+          id: 'r4',
+          filename: 'corrupt2.db',
+          timestamp: DateTime(2026),
+          sizeBytes: 10,
+          location: BackupLocation.local,
+          localPath: corrupt.path,
+        );
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: _EpochSpySyncRepository(),
+          epochStore: epochStore,
+        );
+
+        await expectLater(
+          () => service.restoreFromBackup(record),
+          throwsA(isA<BackupException>()),
+        );
+
+        expect(
+          preferences.getHistory(),
+          isEmpty,
+          reason: 'a failed restore must not mint a safety backup',
+        );
+      },
+    );
 
     test('history restore in replace mode mints a pending replace', () async {
       final dbFile = File('${tempDir.path}/valid_replace.db');

--- a/test/features/backup/data/services/backup_service_saf_io_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_io_test.dart
@@ -27,7 +27,10 @@ class _FileWritingAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async => restoreCalls++;
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async => restoreCalls++;
 
   @override
   Future<String> get databasePath async => dbPath;

--- a/test/features/backup/data/services/backup_service_saf_refs_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_refs_test.dart
@@ -15,7 +15,10 @@ class _NoopAdapter implements BackupDatabaseAdapter {
   Future<void> backup(String destinationPath) async {}
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/data/live.db';

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -43,7 +43,10 @@ class FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async {
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {
     restoreCallCount++;
     lastRestorePath = backupPath;
   }
@@ -152,6 +155,22 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
       throw const CloudStorageException('Download failed');
     }
     return storedFiles[fileId] ?? Uint8List(0);
+  }
+
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    final data = await File(sourcePath).readAsBytes();
+    return uploadFile(data, filename, folderId: folderId);
+  }
+
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    final bytes = await downloadFile(fileId);
+    await File(destinationPath).writeAsBytes(bytes, flush: true);
   }
 
   @override

--- a/test/features/backup/data/services/backup_target_test.dart
+++ b/test/features/backup/data/services/backup_target_test.dart
@@ -20,7 +20,10 @@ class _FakeAdapter implements BackupDatabaseAdapter {
   }
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => dbPath;

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -603,8 +603,10 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
       throw UnimplementedError('not used');
 
   @override
-  Future<void> restore(String backupPath) async =>
-      throw UnimplementedError('not used');
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async => throw UnimplementedError('not used');
 
   @override
   Future<String> get databasePath async => '/fake/db/path';
@@ -634,6 +636,7 @@ class _RecordingRestoreService extends BackupService {
     BackupRecord record, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     calls.add('restoreFromBackup');
     lastMode = mode;
@@ -644,6 +647,7 @@ class _RecordingRestoreService extends BackupService {
     String filePath, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     calls.add('restoreFromFile');
     lastMode = mode;

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -25,7 +25,10 @@ class _NoopAdapter implements BackupDatabaseAdapter {
   Future<void> backup(String destinationPath) async {}
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/noop';
@@ -53,6 +56,11 @@ class _RecordingBackupService extends BackupService {
   /// in-flight (mid-restore) state.
   Completer<void>? restoreGate;
 
+  /// When set, restore fires the caller's onMigrationProgress with these
+  /// (currentStep, totalSteps) values, modelling an older-schema backup whose
+  /// post-swap reopen runs the migration ladder.
+  (int, int)? migrationProgressToEmit;
+
   _RecordingBackupService(BackupPreferences prefs)
     : super(dbAdapter: _NoopAdapter(), preferences: prefs);
 
@@ -74,11 +82,14 @@ class _RecordingBackupService extends BackupService {
     BackupRecord record, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     calls.add('restoreFromBackup');
     lastMode = mode;
     lastSecret = encryptionSecret;
     _gate(encryptionSecret);
+    final progress = migrationProgressToEmit;
+    if (progress != null) onMigrationProgress?.call(progress.$1, progress.$2);
     if (restoreGate != null) await restoreGate!.future;
   }
 
@@ -87,11 +98,14 @@ class _RecordingBackupService extends BackupService {
     String filePath, {
     RestoreMode mode = RestoreMode.merge,
     String? encryptionSecret,
+    void Function(int currentStep, int totalSteps)? onMigrationProgress,
   }) async {
     calls.add('restoreFromFile');
     lastMode = mode;
     lastSecret = encryptionSecret;
     _gate(encryptionSecret);
+    final progress = migrationProgressToEmit;
+    if (progress != null) onMigrationProgress?.call(progress.$1, progress.$2);
   }
 }
 
@@ -141,6 +155,38 @@ void main() {
 
     expect(service.calls, ['restoreFromFile']);
     expect(service.lastMode, RestoreMode.replace);
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.restoreComplete,
+    );
+  });
+
+  test('migration progress surfaces in the operation state message', () async {
+    // An older-schema backup runs the migration ladder during the post-swap
+    // reopen. The barrier renders the operation message, so each ladder step
+    // must land there — otherwise a long upgrade is a silent stall.
+    final container = makeContainer();
+    service.migrationProgressToEmit = (3, 7);
+    final messages = <String?>[];
+    container.listen(
+      backupOperationProvider,
+      (_, next) => messages.add(next.message),
+    );
+    final tmp = File(
+      '${Directory.systemTemp.path}/notifier_restore_migration_'
+      '${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    await tmp.writeAsString('db');
+    addTearDown(() async {
+      if (await tmp.exists()) await tmp.delete();
+    });
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath(tmp.path);
+
+    expect(messages, contains('Upgrading database (step 3 of 7)...'));
+    // The restore still finishes normally after progress updates.
     expect(
       container.read(backupOperationProvider).status,
       BackupOperationStatus.restoreComplete,

--- a/test/features/backup/presentation/widgets/backup_encryption_section_test.dart
+++ b/test/features/backup/presentation/widgets/backup_encryption_section_test.dart
@@ -59,7 +59,10 @@ class _FakeDbAdapter implements BackupDatabaseAdapter {
   @override
   Future<void> backup(String destinationPath) async {}
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
   @override
   Future<String> get databasePath async => '/fake/db';
   @override

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -107,7 +107,10 @@ class _NoopBackupAdapter implements BackupDatabaseAdapter {
   Future<void> backup(String destinationPath) async {}
 
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
 
   @override
   Future<String> get databasePath async => '/noop';

--- a/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
+++ b/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
@@ -144,7 +144,10 @@ class _NoopBackupAdapter implements BackupDatabaseAdapter {
   @override
   Future<void> backup(String destinationPath) async {}
   @override
-  Future<void> restore(String backupPath) async {}
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
   @override
   Future<String> get databasePath async => '/noop';
   @override

--- a/test/support/fake_cloud_storage_provider.dart
+++ b/test/support/fake_cloud_storage_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -77,6 +78,22 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
       throw CloudStorageException('Fake: not found: $fileId');
     }
     return Uint8List.fromList(data);
+  }
+
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async {
+    final data = await File(sourcePath).readAsBytes();
+    return uploadFile(data, filename, folderId: folderId);
+  }
+
+  @override
+  Future<void> downloadToFile(String fileId, String destinationPath) async {
+    final bytes = await downloadFile(fileId);
+    await File(destinationPath).writeAsBytes(bytes, flush: true);
   }
 
   @override


### PR DESCRIPTION
## Summary

Restoring a large backup froze the UI for long stretches and intermittently failed with `Restore failed: TimeoutException after 0:00:05`, succeeding only after several retries. This PR fixes both root causes and the remaining large-file hazards on the restore path.

### Root cause 1: intermittent failure (the retry-succeeds signature)

`DatabaseService.close(strict: true)` — the close that runs right before the restore's file swap — trusted drift's *graceful* `close()` with a throwing 5-second timeout. Drift's graceful close awaits `streamQueries.close()`, which hangs for as long as **any `watch()` subscription is paused**, and Riverpod 3 auto-pauses the streams of providers nobody is currently listening to. A mid-session restore almost always has at least one paused stream (any previously visited page), so the close hung, the timeout threw, and the restore failed. Retrying eventually worked because the abandoned close future completed in the background once navigation resumed the paused streams — the next attempt found the connection already closed. Setup-wizard restores (fresh session, no paused streams) were unaffected, which is why the failure looked random.

Strict close now mirrors the proven `closeDatabaseForAppShutdown` pattern: a brief graceful attempt, then a direct executor close on timeout. The existing 60-second worker-exit wait remains the real guarantee that the SQLite file handle is released before the swap. Regression test: `restore succeeds while a watch() subscription is paused` (fails on the old code with the exact reported TimeoutException).

### Root cause 2: UI freeze

The backup crypto — the AES-GCM frame loops encrypting the pre-restore safety backup and decrypting `.sbe` restores, plus the Argon2id KDF (64 MiB, t=3) — ran pure-Dart with synchronous file IO **on the UI isolate**. A multi-hundred-MB backup meant the UI thread did roughly twice the file size of pure-Dart AES. All three `BackupCrypto` entry points now run their heavy bodies in `Isolate.run`, passing only sendable inputs (paths, raw key bytes, the secret); `WrongPassphraseException`, `EnvelopeCorruptException`, and `SyncEncryptionRequired` propagate across the isolate boundary unchanged, which the existing crypto suite exercises end-to-end.

### Follow-up hazards fixed

- **Restore ordering:** `restoreFromBackup` ran the pre-restore safety backup *before* decrypting/validating the source, so a wrong passphrase or corrupt file still minted a backup + history entry. It now decrypts and validates first (parity with `restoreFromFile`), with a regression test.
- **Silent migration stall:** restoring an older-schema backup runs the migration ladder during the post-swap reopen with no feedback. Migration progress now flows through `DatabaseService.restore` → adapter → `BackupService` → `BackupOperationState`, so the restore barrier shows `Upgrading database (step X of Y)...`.
- **Whole-file RAM buffering on cloud transfers:** cloud backup upload/download held the entire artifact in memory (`readAsBytes` + a gratuitous `Uint8List.fromList` second copy on upload; full-buffer download on restore). New path-based `uploadFileFromPath`/`downloadToFile` on `CloudStorageProvider`, with buffering fallbacks in the mixin so all implementations and test fakes keep working, and streaming overrides per provider:
  - **iCloud**: same-volume copy + coordinated move — the payload no longer crosses the method channel as one `Uint8List`
  - **Google Drive**: file stream into `drive.Media`; downloads piped straight to disk (the buffering path held three concurrent full copies at peak)
  - **Dropbox**: upload-session chunks / ranged downloads, one 8 MiB slice resident at a time
  - **S3**: multipart upload with abort-on-failure / ranged downloads
  - **Encrypting decorator**: exempt self-framed backups stream through the inner provider untouched; sealed envelopes are opened after a header sniff, and failures never leave ciphertext or a partial file at the destination

  The transfer loops are ports of the contract-tested `MediaObjectStore` implementations, minus resume state (backups are one-shot artifacts).

## Testing

- New tests: paused-watch-stream restore regression, restore-ordering (no stray safety backup on failure), migration-progress surfacing, encrypting-decorator path-based transfers (seal/pass-through/cleanup), mixin fallback behavior
- `flutter test test/features/backup/ test/features/settings/ test/core/services/ test/core/data/` — 2586 passed
- `flutter analyze` — no issues; `dart format .` — clean
