### PR TITLE
Store picked photo capture times as wall-clock UTC

### DIFF
--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 
 /// Status of an asset resolution attempt.
@@ -156,10 +157,13 @@ class AssetResolutionService {
       return const ResolutionResult(status: ResolutionStatus.unavailable);
     }
 
-    // Step 3: Search gallery by metadata (with query coalescing)
+    // Step 3: Search gallery by metadata (with query coalescing). The gallery
+    // API takes LOCAL bounds, so the window is built from the same restated
+    // timestamp the matchers below compare against -- see [_asGalleryLocal].
     const timeWindow = Duration(seconds: 5);
-    final start = item.takenAt.subtract(timeWindow);
-    final end = item.takenAt.add(timeWindow);
+    final galleryTakenAt = _asGalleryLocal(item.takenAt);
+    final start = galleryTakenAt.subtract(timeWindow);
+    final end = galleryTakenAt.add(timeWindow);
 
     List<AssetInfo> candidates;
     try {
@@ -331,11 +335,12 @@ class AssetResolutionService {
     final filename = item.originalFilename;
     if (filename == null || filename.isEmpty) return null;
 
+    final takenAt = _asGalleryLocal(item.takenAt);
     final matches = candidates.where((c) {
       final candidateName = c.filename;
       if (candidateName == null || candidateName.isEmpty) return false;
       if (candidateName != filename) return false;
-      final diff = c.createDateTime.difference(item.takenAt).abs();
+      final diff = c.createDateTime.difference(takenAt).abs();
       return diff <= const Duration(seconds: 5);
     }).toList();
 
@@ -358,7 +363,7 @@ class AssetResolutionService {
   }) {
     if (item.width == null || item.height == null) return null;
 
-    final itemSecond = _truncateToSecond(item.takenAt);
+    final itemSecond = _truncateToSecond(_asGalleryLocal(item.takenAt));
     final matches = candidates.where((c) {
       if (c.width != item.width || c.height != item.height) return false;
       final diff = _truncateToSecond(
@@ -369,6 +374,20 @@ class AssetResolutionService {
 
     return matches.length == 1 ? matches.first.id : null;
   }
+
+  /// Restate a stored [MediaItem.takenAt] in the gallery's own convention.
+  ///
+  /// `taken_at` is persisted wall-clock-as-UTC (the same convention as dive
+  /// entry times), whereas photo_manager reports [AssetInfo.createDateTime] as
+  /// a LOCAL [DateTime]. Comparing the two as instants makes every candidate
+  /// look like it is off by the host's UTC offset, so each tier below matches
+  /// only on a host that happens to run at UTC. Reinterpreting the calendar
+  /// fields as local first means the remaining difference is real clock drift.
+  ///
+  /// A value that is already local is returned unchanged, so rows written
+  /// before the convention was enforced still compare the way they always did.
+  static DateTime _asGalleryLocal(DateTime takenAt) =>
+      TripMediaScanner.wallClockUtcToLocal(takenAt);
 
   /// Both sides are compared at second granularity so [Duration.zero] means
   /// "the same capture second" rather than "the same instant".

--- a/lib/features/media/data/services/asset_resolution_service.dart
+++ b/lib/features/media/data/services/asset_resolution_service.dart
@@ -158,20 +158,27 @@ class AssetResolutionService {
     }
 
     // Step 3: Search gallery by metadata (with query coalescing). The gallery
-    // API takes LOCAL bounds, so the window is built from the same restated
-    // timestamp the matchers below compare against -- see [_asGalleryLocal].
+    // API takes LOCAL bounds, so one narrow window is queried per reading the
+    // matchers below will compare against -- see [_galleryReadings]. Two
+    // +-5s windows keep each query cheap; spanning a single window across both
+    // would cover the whole UTC offset and pull in hours of unrelated assets.
     const timeWindow = Duration(seconds: 5);
-    final galleryTakenAt = _asGalleryLocal(item.takenAt);
-    final start = galleryTakenAt.subtract(timeWindow);
-    final end = galleryTakenAt.add(timeWindow);
-
-    List<AssetInfo> candidates;
-    try {
-      candidates = await _getAssetsCoalesced(start, end);
-    } catch (e) {
-      _log.error('Gallery query failed for media ${item.id}', error: e);
-      return const ResolutionResult(status: ResolutionStatus.unavailable);
+    final byId = <String, AssetInfo>{};
+    for (final reading in _galleryReadings(item.takenAt)) {
+      try {
+        final found = await _getAssetsCoalesced(
+          reading.subtract(timeWindow),
+          reading.add(timeWindow),
+        );
+        for (final asset in found) {
+          byId[asset.id] = asset;
+        }
+      } catch (e) {
+        _log.error('Gallery query failed for media ${item.id}', error: e);
+        return const ResolutionResult(status: ResolutionStatus.unavailable);
+      }
     }
+    final candidates = byId.values.toList();
 
     if (candidates.isEmpty) {
       await _cacheUnresolved(item.id);
@@ -335,13 +342,15 @@ class AssetResolutionService {
     final filename = item.originalFilename;
     if (filename == null || filename.isEmpty) return null;
 
-    final takenAt = _asGalleryLocal(item.takenAt);
+    final readings = _galleryReadings(item.takenAt);
     final matches = candidates.where((c) {
       final candidateName = c.filename;
       if (candidateName == null || candidateName.isEmpty) return false;
       if (candidateName != filename) return false;
-      final diff = c.createDateTime.difference(takenAt).abs();
-      return diff <= const Duration(seconds: 5);
+      return readings.any(
+        (r) =>
+            c.createDateTime.difference(r).abs() <= const Duration(seconds: 5),
+      );
     }).toList();
 
     return matches.length == 1 ? matches.first.id : null;
@@ -363,31 +372,47 @@ class AssetResolutionService {
   }) {
     if (item.width == null || item.height == null) return null;
 
-    final itemSecond = _truncateToSecond(_asGalleryLocal(item.takenAt));
+    final itemSeconds = _galleryReadings(
+      item.takenAt,
+    ).map(_truncateToSecond).toList();
     final matches = candidates.where((c) {
       if (c.width != item.width || c.height != item.height) return false;
-      final diff = _truncateToSecond(
-        c.createDateTime,
-      ).difference(itemSecond).abs();
-      return diff <= tolerance;
+      final candidateSecond = _truncateToSecond(c.createDateTime);
+      return itemSeconds.any(
+        (s) => candidateSecond.difference(s).abs() <= tolerance,
+      );
     }).toList();
 
     return matches.length == 1 ? matches.first.id : null;
   }
 
-  /// Restate a stored [MediaItem.takenAt] in the gallery's own convention.
+  /// The readings of a stored [MediaItem.takenAt] that could line up with a
+  /// gallery candidate's LOCAL [AssetInfo.createDateTime].
   ///
-  /// `taken_at` is persisted wall-clock-as-UTC (the same convention as dive
-  /// entry times), whereas photo_manager reports [AssetInfo.createDateTime] as
-  /// a LOCAL [DateTime]. Comparing the two as instants makes every candidate
-  /// look like it is off by the host's UTC offset, so each tier below matches
-  /// only on a host that happens to run at UTC. Reinterpreting the calendar
-  /// fields as local first means the remaining difference is real clock drift.
+  /// `taken_at` is meant to hold wall-clock-as-UTC (the same convention as dive
+  /// entry times), so restating its calendar fields as local is the correct
+  /// reading and is listed first.
   ///
-  /// A value that is already local is returned unchanged, so rows written
-  /// before the convention was enforced still compare the way they always did.
-  static DateTime _asGalleryLocal(DateTime takenAt) =>
-      TripMediaScanner.wallClockUtcToLocal(takenAt);
+  /// Rows written by the import path before it normalised, however, hold the
+  /// INSTANT of a local [DateTime]; [MediaRepository] hydrates every row as UTC
+  /// regardless, so those rows arrive with their fields shifted by the offset
+  /// that was in force at import and it is the RAW value that already lines up
+  /// with a candidate's instant. Nothing in the schema distinguishes the two
+  /// populations, so both readings are offered rather than guessing: comparing
+  /// only the restated one would make every photo linked before the fix
+  /// unresolvable the moment its `platformAssetId` went stale.
+  ///
+  /// Callers accept a candidate matching EITHER reading, and the tiers keep
+  /// refusing whenever more than one candidate qualifies -- so a library that
+  /// happens to hold a second plausible asset exactly one UTC offset away is
+  /// declined rather than mis-bound.
+  ///
+  /// On a host running at UTC the two coincide and the list collapses to one.
+  static List<DateTime> _galleryReadings(DateTime takenAt) {
+    final restated = TripMediaScanner.wallClockUtcToLocal(takenAt);
+    if (restated.isAtSameMomentAs(takenAt)) return [restated];
+    return [restated, takenAt];
+  }
 
   /// Both sides are compared at second granularity so [Duration.zero] means
   /// "the same capture second" rather than "the same instant".

--- a/lib/features/media/data/services/media_import_service.dart
+++ b/lib/features/media/data/services/media_import_service.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/enrichment_service.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 
@@ -221,7 +222,17 @@ class MediaImportService {
       localPath: isLocalFile ? path : null,
       latitude: asset.latitude,
       longitude: asset.longitude,
-      takenAt: asset.createDateTime,
+      // AssetInfo.createDateTime is contractually LOCAL (photo_manager's
+      // convention on mobile; the desktop picker mirrors it by reinterpreting
+      // the file's wall-clock capture digits as a local DateTime). MediaItem
+      // .takenAt is wall-clock-UTC -- MediaRepository persists
+      // `takenAt.millisecondsSinceEpoch` verbatim and hydrates it back with
+      // `isUtc: true`. Storing the local value would bake the host's UTC
+      // offset into that number, and the fullscreen viewer's metadata overlay,
+      // which formats the hydrated UTC value directly, would show a capture
+      // time shifted by that offset. The gallery-scan write path
+      // (TripMediaScanner) already normalises the same way.
+      takenAt: TripMediaScanner.toWallClockUtc(asset.createDateTime),
       width: asset.width,
       height: asset.height,
       durationSeconds: asset.durationSeconds,

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -757,5 +757,95 @@ void main() {
         isNull,
       );
     });
+
+    // Rows written by the pre-normalisation import path hold the INSTANT of a
+    // local DateTime, which MediaRepository then hydrates as UTC -- so their
+    // calendar fields are the capture time plus the host offset, and it is the
+    // raw value, not the restated one, that lines up with a gallery candidate.
+    // Nothing in the schema distinguishes them from correctly-written rows, so
+    // both readings have to be tried or every already-linked photo becomes
+    // unresolvable the moment its platformAssetId goes stale.
+    DateTime legacyStored(DateTime captureLocal) =>
+        DateTime.fromMillisecondsSinceEpoch(
+          captureLocal.millisecondsSinceEpoch,
+          isUtc: true,
+        );
+
+    test('tier 1 still matches a legacy row written as a local instant', () {
+      final capture = DateTime(2025, 6, 15, 10, 30, 0);
+      final item = createTestItem(
+        originalFilename: 'IMG_001.jpg',
+        takenAt: legacyStored(capture),
+      );
+
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(
+          item,
+          candidatesAt(capture),
+        ),
+        equals('local-match'),
+      );
+    });
+
+    test('tier 2 still matches a legacy row written as a local instant', () {
+      final capture = DateTime(2025, 6, 15, 10, 30, 0);
+      final item = createTestItem(
+        originalFilename: '',
+        takenAt: legacyStored(capture),
+      );
+
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          item,
+          candidatesAt(capture),
+          tolerance: Duration.zero,
+        ),
+        equals('local-match'),
+      );
+    });
+
+    test('offering both readings still refuses an ambiguous pair', () {
+      // One candidate sits on each reading of the same stored value, so the
+      // row cannot be attributed to either without guessing.
+      final capture = DateTime(2025, 6, 15, 10, 30, 0);
+      final stored = legacyStored(capture);
+      final item = createTestItem(
+        originalFilename: 'IMG_001.jpg',
+        takenAt: stored,
+      );
+
+      final ambiguous = [
+        AssetInfo(
+          id: 'on-legacy-reading',
+          type: AssetType.image,
+          createDateTime: capture,
+          width: 4032,
+          height: 3024,
+          filename: 'IMG_001.jpg',
+        ),
+        AssetInfo(
+          id: 'on-restated-reading',
+          type: AssetType.image,
+          createDateTime: DateTime(
+            stored.year,
+            stored.month,
+            stored.day,
+            stored.hour,
+            stored.minute,
+            stored.second,
+          ),
+          width: 4032,
+          height: 3024,
+          filename: 'IMG_001.jpg',
+        ),
+      ];
+
+      // Vacuous on a UTC host, where the two readings collapse to one and the
+      // list above holds two candidates at the same instant -- still ambiguous.
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(item, ambiguous),
+        isNull,
+      );
+    });
   });
 }

--- a/test/features/media/data/services/asset_resolution_service_test.dart
+++ b/test/features/media/data/services/asset_resolution_service_test.dart
@@ -689,4 +689,73 @@ void main() {
       );
     });
   });
+
+  // MediaItem.takenAt is stored wall-clock-as-UTC, while photo_manager reports
+  // AssetInfo.createDateTime as LOCAL. Both matchers used to compare the two
+  // as instants, so on any host west or east of UTC the difference was the
+  // host's offset rather than real clock drift, and every tier missed. The
+  // picker write path masked this by persisting an unnormalised local
+  // timestamp; once that was corrected these comparisons had to convert.
+  //
+  // NOTE: these cases can only fail on a host whose local time is not UTC --
+  // where the two conventions coincide there is nothing to convert. CI runners
+  // default to UTC, so treat them as a guard for developer machines.
+  group('wall-clock-UTC takenAt against a local gallery candidate', () {
+    List<AssetInfo> candidatesAt(DateTime local) => [
+      AssetInfo(
+        id: 'local-match',
+        type: AssetType.image,
+        createDateTime: local,
+        width: 4032,
+        height: 3024,
+        filename: 'IMG_001.jpg',
+      ),
+    ];
+
+    test('tier 1 matches on filename plus the same wall-clock second', () {
+      final item = createTestItem(
+        originalFilename: 'IMG_001.jpg',
+        takenAt: DateTime.utc(2025, 6, 15, 10, 30, 0),
+      );
+
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(
+          item,
+          candidatesAt(DateTime(2025, 6, 15, 10, 30, 1)),
+        ),
+        equals('local-match'),
+      );
+    });
+
+    test('tier 2 matches on the exact wall-clock capture second', () {
+      final item = createTestItem(
+        originalFilename: '',
+        takenAt: DateTime.utc(2025, 6, 15, 10, 30, 0),
+      );
+
+      expect(
+        AssetResolutionService.matchByTimestampAndDimensions(
+          item,
+          candidatesAt(DateTime(2025, 6, 15, 10, 30, 0)),
+          tolerance: Duration.zero,
+        ),
+        equals('local-match'),
+      );
+    });
+
+    test('a genuinely distant candidate is still rejected', () {
+      final item = createTestItem(
+        originalFilename: 'IMG_001.jpg',
+        takenAt: DateTime.utc(2025, 6, 15, 10, 30, 0),
+      );
+
+      expect(
+        AssetResolutionService.matchByFilenameAndTimestamp(
+          item,
+          candidatesAt(DateTime(2025, 6, 15, 10, 31, 0)),
+        ),
+        isNull,
+      );
+    });
+  });
 }

--- a/test/features/media/data/services/media_import_service_test.dart
+++ b/test/features/media/data/services/media_import_service_test.dart
@@ -515,5 +515,77 @@ void main() {
             });
       });
     });
+
+    group('importPhotosForDive - takenAt normalisation', () {
+      // AssetInfo.createDateTime is contractually LOCAL (photo_manager's
+      // convention on mobile, which the desktop picker mirrors by
+      // reinterpreting the file's wall-clock capture digits into a local
+      // DateTime). MediaItem.takenAt is wall-clock-UTC: MediaRepository
+      // persists `takenAt.millisecondsSinceEpoch` verbatim and hydrates it
+      // back with `isUtc: true`. Carrying the local value across without
+      // TripMediaScanner.toWallClockUtc bakes the host's UTC offset into the
+      // stored number, and the fullscreen viewer's metadata overlay -- which
+      // formats the hydrated UTC value directly -- then shows a capture time
+      // shifted by that offset.
+      Future<MediaItem?> persistOne(AssetInfo asset) async {
+        when(
+          mockMediaRepository.getLinkedAssetIdsForDive('dive-1'),
+        ).thenAnswer((_) async => <String>{});
+
+        MediaItem? persisted;
+        when(mockMediaRepository.createMedia(any)).thenAnswer((
+          invocation,
+        ) async {
+          persisted = invocation.positionalArguments[0] as MediaItem;
+          return _savedMediaItem(
+            id: 'media-1',
+            diveId: 'dive-1',
+            platformAssetId: persisted!.platformAssetId ?? '',
+          );
+        });
+
+        await service.importPhotosForDive(
+          selectedAssets: [asset],
+          dive: testDive,
+        );
+        return persisted;
+      }
+
+      test(
+        'stores a local-file asset capture time as wall-clock UTC',
+        () async {
+          final persisted = await persistOne(
+            _testAsset('42_998877', filePath: '/photos/DIVE_0042.JPG'),
+          );
+
+          expect(persisted, isNotNull);
+          expect(persisted!.takenAt.isUtc, isTrue);
+          expect(persisted.takenAt, DateTime.utc(2024, 1, 15, 10, 30));
+        },
+      );
+
+      test('stores a gallery asset capture time as wall-clock UTC', () async {
+        final persisted = await persistOne(_testAsset('asset-1'));
+
+        expect(persisted, isNotNull);
+        expect(persisted!.takenAt.isUtc, isTrue);
+        expect(persisted.takenAt, DateTime.utc(2024, 1, 15, 10, 30));
+      });
+
+      test('leaves an already-UTC capture time unchanged', () async {
+        final persisted = await persistOne(
+          AssetInfo(
+            id: 'asset-utc',
+            type: AssetType.image,
+            createDateTime: DateTime.utc(2024, 1, 15, 10, 30),
+            width: 1920,
+            height: 1080,
+          ),
+        );
+
+        expect(persisted, isNotNull);
+        expect(persisted!.takenAt, DateTime.utc(2024, 1, 15, 10, 30));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

The capture time in the fullscreen photo viewer's bottom metadata overlay was off by the host's UTC offset, while the depth, temperature and elapsed chips on that same overlay were correct.

`AssetInfo.createDateTime` is contractually a **local** `DateTime` — photo_manager's convention on mobile, which the desktop picker deliberately mirrors in `_assetInfoForPath`. `MediaItem.takenAt` is **wall-clock-as-UTC**: `MediaRepository` persists `takenAt.millisecondsSinceEpoch` verbatim and hydrates it back with `isUtc: true`. `MediaImportService._createMediaItemFromAsset` carried the value across that boundary without normalising, so the stored number had the host's UTC offset baked into it and the overlay — which formats the hydrated value directly — rendered the skewed digits.

The enrichment chips escaped because `_calculateEnrichment` hands `asset.createDateTime` to `EnrichmentService`, which normalises the timestamp itself. That split is what made the bug look cosmetic.

Despite the "locally linked photo" report, this was **not** desktop-only: gallery picks go through the same method and shifted identically. Only the gallery-*scan* path (`TripMediaScanner._toExtractedFile`) was ever correct — it has always applied `toWallClockUtc`.

### Two errors that cancelled

`AssetResolutionService` compared the stored `takenAt` against gallery candidates as **instants** — in the gallery window bounds and in both match tiers — which is only correct when the stored value is a local instant. It was silently depending on the write-side bug.

Fixing the writer alone would have traded a cosmetic display bug for a functional one on the gallery re-resolution path, the fallback that runs when `platformAssetId` goes stale (e.g. after an iCloud restore). Every pre-existing test in `asset_resolution_service_test.dart` built `takenAt` as a local `DateTime(...)`, encoding the accidental convention — which is why the mismatch was invisible.

### Two populations in one column

Simply restating the stored value as local is not enough either, because the column now holds two kinds of row and nothing in the schema tells them apart:

| Row origin | Old comparison | Restated as local |
| --- | --- | --- |
| Written by the pre-fix import path | 0s — matched | 4h — broken |
| Written by `TripMediaScanner` | 4h — broken | 0s — matched |

(measured on a UTC-4 host, stored row vs. the gallery candidate for the same photo)

So `_galleryReadings` offers **both** readings — restated-wall-clock first, raw instant second — and a candidate matching either is accepted. Both tiers still require exactly one qualifying candidate, so a library that happens to hold a second plausible asset exactly one UTC offset away is declined rather than mis-bound. On a UTC host the two readings coincide and the list collapses to one.

## Changes

- `media_import_service.dart` — normalise `asset.createDateTime` through `TripMediaScanner.toWallClockUtc` before storing, matching the gallery-scan write path
- `asset_resolution_service.dart` — `_galleryReadings` supplies both readings of a stored `takenAt`; both match tiers accept either, and the gallery query runs one narrow ±5s window per reading and unions by asset id (a single window spanning both would cover the whole UTC offset and pull in hours of unrelated assets)
- `media_import_service_test.dart` — three cases covering local-file, gallery and already-UTC assets
- `asset_resolution_service_test.dart` — six cases: tier 1 and tier 2 against a wall-clock-UTC row, the same two against a legacy row, a distant-candidate rejection, and an ambiguous-pair refusal

## Notes for reviewers

**No migration, deliberately.** Existing rows keep their shifted `taken_at`, so their *displayed* capture time stays wrong until the photo is unlinked and re-added — gallery re-resolution keeps working for them via the second reading. A blanket shift-back would corrupt the scan-written rows, which were always correct. Automatic healing would mean re-reading capture time from disk for `localFile` rows, which is a larger change worth scoping separately.

**The dual reading is transitional.** Once no rows written by the pre-fix import path remain, the second reading can be dropped and `_galleryReadings` collapses back to a single restatement.

**Test-host caveat.** The `asset_resolution_service` cases can only fail where local time is not UTC. CI pins no `TZ`, so GitHub runners pass them vacuously; they are a developer-machine guard, and a comment above the group says so. The `media_import_service` cases assert the `isUtc` flag directly and have teeth on any host.

**Possibly related, not verified:** the instant-vs-wall-clock mismatch in `AssetResolutionService` is a plausible contributor to #425 (Linked Photos not found on iCloud synced device). This PR does not claim to fix that issue.

Checked and found genuinely unaffected: `metadata_write_service` / `exif_write_service` carry `takenAt` into the payload but nothing consumes it, and `getGpsFromDiveMedia`'s tuple is only ever invalidated, never read.

## Test Plan

- [x] `flutter test` passes — 14934 passed, 15 skipped, 0 failures
- [x] `flutter analyze` passes — no issues found
- [x] `dart format .` clean — 0 files changed
- [x] Manual testing: link a photo to a dive on a non-UTC host and confirm the fullscreen overlay shows the true capture time
