### PR TITLE
Make Report an Issue link launch reliably with a copyable fallback

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -120,5 +120,16 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Lets url_launcher resolve browsers for web links on Android 11+
+             (package visibility); without this canLaunchUrl and launchUrl
+             cannot see any app that handles http/https. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/icons/mdi_icons.dart';
 import 'package:submersion/core/utils/currency.dart';
@@ -60,22 +61,29 @@ const _cnsSourceSubsurfaceUrl =
     'https://github.com/subsurface/subsurface/commit/a0912b38bd';
 
 /// Opens the GitHub issues page in an external browser. Falls back to a
-/// snackbar if the URL cannot be launched or an error occurs.
+/// snackbar with a copy-link action if the launch fails.
 Future<void> launchReportIssue(BuildContext context) async {
   final uri = Uri.parse(reportIssueUrl);
   var didLaunch = false;
 
-  if (await canLaunchUrl(uri)) {
-    try {
-      didLaunch = await launchUrl(uri, mode: LaunchMode.externalApplication);
-    } catch (_) {
-      didLaunch = false;
-    }
+  // No canLaunchUrl guard: it false-negatives for https on Android 11+
+  // unless the scheme is declared in the manifest <queries> block.
+  try {
+    didLaunch = await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } catch (_) {
+    didLaunch = false;
   }
 
   if (!didLaunch && context.mounted) {
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(context.l10n.settings_about_reportIssue_snackbar)),
+      SnackBar(
+        content: Text(context.l10n.settings_about_reportIssue_snackbar),
+        action: SnackBarAction(
+          label: context.l10n.settings_about_reportIssue_copy,
+          onPressed: () =>
+              Clipboard.setData(const ClipboardData(text: reportIssueUrl)),
+        ),
+      ),
     );
   }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4026,6 +4026,7 @@
   "settings_about_header": "حول",
   "settings_about_openSourceLicenses": "تراخيص المصادر المفتوحة",
   "settings_about_reportIssue": "الإبلاغ عن مشكلة",
+  "settings_about_reportIssue_copy": "نسخ الرابط",
   "settings_about_reportIssue_snackbar": "قم بزيارة github.com/submersion-app/submersion/issues",
   "settings_about_version": "الإصدار {version}",
   "settings_appBar_title": "الإعدادات",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4026,6 +4026,7 @@
   "settings_about_header": "Über",
   "settings_about_openSourceLicenses": "Open-Source-Lizenzen",
   "settings_about_reportIssue": "Problem melden",
+  "settings_about_reportIssue_copy": "Link kopieren",
   "settings_about_reportIssue_snackbar": "Besuchen Sie github.com/submersion-app/submersion/issues",
   "settings_about_version": "Version {version}",
   "settings_appBar_title": "Einstellungen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7387,6 +7387,7 @@
   "settings_about_header": "About",
   "settings_about_openSourceLicenses": "Open Source Licenses",
   "settings_about_reportIssue": "Report an Issue",
+  "settings_about_reportIssue_copy": "Copy link",
   "settings_about_reportIssue_snackbar": "Visit github.com/submersion-app/submersion/issues",
   "settings_about_version": "Version {version}",
   "@settings_about_version": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4026,6 +4026,7 @@
   "settings_about_header": "Acerca de",
   "settings_about_openSourceLicenses": "Licencias de codigo abierto",
   "settings_about_reportIssue": "Reportar un problema",
+  "settings_about_reportIssue_copy": "Copiar enlace",
   "settings_about_reportIssue_snackbar": "Visita github.com/submersion-app/submersion/issues",
   "settings_about_version": "Version {version}",
   "settings_appBar_title": "Ajustes",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -3954,6 +3954,7 @@
   "settings_about_header": "A propos",
   "settings_about_openSourceLicenses": "Licences open source",
   "settings_about_reportIssue": "Signaler un probleme",
+  "settings_about_reportIssue_copy": "Copier le lien",
   "settings_about_reportIssue_snackbar": "Rendez-vous sur github.com/submersion-app/submersion/issues",
   "settings_about_version": "Version {version}",
   "settings_appBar_title": "Reglages",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -3954,6 +3954,7 @@
   "settings_about_header": "אודות",
   "settings_about_openSourceLicenses": "רישיונות קוד פתוח",
   "settings_about_reportIssue": "דווח על בעיה",
+  "settings_about_reportIssue_copy": "העתקת קישור",
   "settings_about_reportIssue_snackbar": "בקר ב-github.com/submersion-app/submersion/issues",
   "settings_about_version": "גרסה {version}",
   "settings_appBar_title": "הגדרות",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -3954,6 +3954,7 @@
   "settings_about_header": "Rolunk",
   "settings_about_openSourceLicenses": "Nyilt forrasu licencek",
   "settings_about_reportIssue": "Hiba bejelentese",
+  "settings_about_reportIssue_copy": "Link másolása",
   "settings_about_reportIssue_snackbar": "Latogasson el: github.com/submersion-app/submersion/issues",
   "settings_about_version": "Verzio {version}",
   "settings_appBar_title": "Beallitasok",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -3954,6 +3954,7 @@
   "settings_about_header": "Informazioni",
   "settings_about_openSourceLicenses": "Licenze open source",
   "settings_about_reportIssue": "Segnala un problema",
+  "settings_about_reportIssue_copy": "Copia link",
   "settings_about_reportIssue_snackbar": "Visita github.com/submersion-app/submersion/issues",
   "settings_about_version": "Versione {version}",
   "settings_appBar_title": "Impostazioni",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -21643,6 +21643,12 @@ abstract class AppLocalizations {
   /// **'Report an Issue'**
   String get settings_about_reportIssue;
 
+  /// No description provided for @settings_about_reportIssue_copy.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy link'**
+  String get settings_about_reportIssue_copy;
+
   /// No description provided for @settings_about_reportIssue_snackbar.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -12547,6 +12547,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_about_reportIssue => 'الإبلاغ عن مشكلة';
 
   @override
+  String get settings_about_reportIssue_copy => 'نسخ الرابط';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'قم بزيارة github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -12763,6 +12763,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_about_reportIssue => 'Problem melden';
 
   @override
+  String get settings_about_reportIssue_copy => 'Link kopieren';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Besuchen Sie github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -12568,6 +12568,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_about_reportIssue => 'Report an Issue';
 
   @override
+  String get settings_about_reportIssue_copy => 'Copy link';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Visit github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -12765,6 +12765,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_about_reportIssue => 'Reportar un problema';
 
   @override
+  String get settings_about_reportIssue_copy => 'Copiar enlace';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Visita github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -12813,6 +12813,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_about_reportIssue => 'Signaler un probleme';
 
   @override
+  String get settings_about_reportIssue_copy => 'Copier le lien';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Rendez-vous sur github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -12460,6 +12460,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_about_reportIssue => 'דווח על בעיה';
 
   @override
+  String get settings_about_reportIssue_copy => 'העתקת קישור';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'בקר ב-github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -12731,6 +12731,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_about_reportIssue => 'Hiba bejelentese';
 
   @override
+  String get settings_about_reportIssue_copy => 'Link másolása';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Latogasson el: github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -12774,6 +12774,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_about_reportIssue => 'Segnala un problema';
 
   @override
+  String get settings_about_reportIssue_copy => 'Copia link';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Visita github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -12675,6 +12675,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_about_reportIssue => 'Probleem melden';
 
   @override
+  String get settings_about_reportIssue_copy => 'Link kopiëren';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Ga naar github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -12777,6 +12777,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_about_reportIssue => 'Relatar um Problema';
 
   @override
+  String get settings_about_reportIssue_copy => 'Copiar link';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       'Acesse github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -12186,6 +12186,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_about_reportIssue => '报告问题';
 
   @override
+  String get settings_about_reportIssue_copy => '复制链接';
+
+  @override
   String get settings_about_reportIssue_snackbar =>
       '请访问 github.com/submersion-app/submersion/issues';
 

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4026,6 +4026,7 @@
   "settings_about_header": "Over",
   "settings_about_openSourceLicenses": "Open source-licenties",
   "settings_about_reportIssue": "Probleem melden",
+  "settings_about_reportIssue_copy": "Link kopiëren",
   "settings_about_reportIssue_snackbar": "Ga naar github.com/submersion-app/submersion/issues",
   "settings_about_version": "Versie {version}",
   "settings_appBar_title": "Instellingen",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4026,6 +4026,7 @@
   "settings_about_header": "Sobre",
   "settings_about_openSourceLicenses": "Licencas de Codigo Aberto",
   "settings_about_reportIssue": "Relatar um Problema",
+  "settings_about_reportIssue_copy": "Copiar link",
   "settings_about_reportIssue_snackbar": "Acesse github.com/submersion-app/submersion/issues",
   "settings_about_version": "Versao {version}",
   "settings_appBar_title": "Configuracoes",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4178,6 +4178,7 @@
   "settings_about_header": "关于",
   "settings_about_openSourceLicenses": "开源许可证",
   "settings_about_reportIssue": "报告问题",
+  "settings_about_reportIssue_copy": "复制链接",
   "settings_about_reportIssue_snackbar": "请访问 github.com/submersion-app/submersion/issues",
   "settings_about_version": "版本 {version}",
   "settings_appBar_title": "设置",

--- a/test/features/settings/presentation/pages/report_issue_test.dart
+++ b/test/features/settings/presentation/pages/report_issue_test.dart
@@ -64,6 +64,102 @@ void main() {
       expect(find.byType(SnackBar), findsNothing);
     });
 
+    testWidgets('launches even when canLaunch reports false', (tester) async {
+      // canLaunchUrl false-negatives on Android 11+ without a matching
+      // <queries> entry, so launchReportIssue must not gate on it.
+      bool launchCalled = false;
+
+      const channel = MethodChannel('plugins.flutter.io/url_launcher');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+            if (methodCall.method == 'canLaunch') return false;
+            if (methodCall.method == 'launch') {
+              launchCalled = true;
+              return true;
+            }
+            return null;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () => launchReportIssue(context),
+                child: const Text('Report'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Report'));
+      await tester.pumpAndSettle();
+
+      expect(launchCalled, isTrue);
+      expect(find.byType(SnackBar), findsNothing);
+    });
+
+    testWidgets('fallback snackbar copy action copies the URL', (tester) async {
+      const channel = MethodChannel('plugins.flutter.io/url_launcher');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+            if (methodCall.method == 'launch') return false;
+            if (methodCall.method == 'canLaunch') return false;
+            return null;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+
+      final platformCalls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            platformCalls.add(call);
+            return null;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () => launchReportIssue(context),
+                child: const Text('Report'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Report'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.byType(SnackBarAction), findsOneWidget);
+
+      await tester.tap(find.byType(SnackBarAction));
+      await tester.pump();
+
+      final setData = platformCalls.firstWhere(
+        (c) => c.method == 'Clipboard.setData',
+      );
+      expect((setData.arguments as Map)['text'], reportIssueUrl);
+    });
+
     testWidgets('shows snackbar fallback when launch fails', (tester) async {
       const channel = MethodChannel('plugins.flutter.io/url_launcher');
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger


### PR DESCRIPTION
## Summary

The Settings > About > "Report an Issue" tile could end up showing the GitHub URL as inert snackbar text that was neither hyperlinked nor copyable.

Two root causes:

1. **`canLaunchUrl` false negative.** The launch was gated on `canLaunchUrl()`, which returns `false` for `https` URLs on Android 11+ unless the scheme is declared in the manifest's `<queries>` block — ours only declared `PROCESS_TEXT`. The browser never opened even though it could have, so users landed in the fallback unnecessarily.
2. **Dead-end fallback.** The fallback snackbar rendered the URL as plain `Text`; snackbar content is never selectable and there was no action, so the URL could not be tapped or copied.

## Changes

- `launchReportIssue` no longer pre-checks `canLaunchUrl`; it attempts `launchUrl` directly in a try/catch (the pattern url_launcher's docs recommend for web URLs).
- The fallback snackbar now has a **Copy link** action that puts the issues URL on the clipboard.
- The Android manifest declares `VIEW` intent queries for `http`/`https`, fixing package visibility for every web link in the app (beta enrollment, release pages, CNS sources), not just this tile.
- New l10n key `settings_about_reportIssue_copy` added to English and all 10 translated locales, with generated localizations regenerated.

## Testing

- Two new widget tests (TDD, written failing first): launch proceeds even when `canLaunch` reports false; the fallback snackbar's copy action writes the URL to the clipboard.
- All report-issue tests and the full settings feature suite (847 tests) pass; `flutter analyze` clean; `dart format` clean.