### PR TITLE
Mirror exit method from entry method in dive edit form

### DIFF
--- a/docs/superpowers/plans/2026-08-06-entry-exit-method-mirroring.md
+++ b/docs/superpowers/plans/2026-08-06-entry-exit-method-mirroring.md
@@ -1,0 +1,493 @@
+# Entry/Exit Method Mirroring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the single-dive edit form, the exit-method picker mirrors the entry-method picker until the user explicitly changes exit, so the common identical-entry-and-exit dive needs one selection instead of two.
+
+**Architecture:** Pure edit-form state change inside `_DiveEditPageState`: one new boolean `_exitMethodLinked` plus updated `onChanged` closures on the two `EnumPickerRow` call sites in `_environmentRows`. No schema, entity, sync, import/export, statistics, or bulk-edit changes — both concrete values are always stored.
+
+**Tech Stack:** Flutter widget tests (`flutter_test`), Riverpod provider overrides, in-memory Drift test database via existing `test_database.dart` helpers.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-entry-exit-method-mirroring-design.md`
+
+## Global Constraints
+
+- Bulk edit must be untouched: the bulk layout (`_buildBulkForm`) shares the same `_entryMethod` / `_exitMethod` state fields — mirroring logic must live ONLY in the single-dive `EnumPickerRow` `onChanged` closures, never in a shared setter or in the `_enumDropdown` handlers.
+- Opening an existing dive and saving without touching either picker must never change stored values (no backfill of an empty exit).
+- No new l10n strings, no database/entity changes.
+- All Dart code must pass `dart format .` with no changes (run before every commit).
+- `flutter analyze` treats infos as fatal in CI — run it on the whole project and fix everything it reports in touched files.
+- Never pipe `flutter analyze` or `flutter test` output through `tail`/`head` in a way that masks the exit code.
+
+## Codebase Orientation (read once before Task 1)
+
+Key facts an implementer needs, all verified against the current tree:
+
+- `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (~4400 lines) hosts BOTH the single-dive form and the bulk-edit form in one `ConsumerStatefulWidget` state class.
+  - State fields `_entryMethod` / `_exitMethod` (type `EntryMethod?`) are declared at lines 190-191.
+  - Existing-dive load populates them at lines 614-615.
+  - Single-dive form pickers: two `EnumPickerRow<EntryMethod>` widgets at lines ~3562-3575 inside `_environmentRows`, which is spread into `ConditionsSection` (collapsed by default: `_isExpanded('conditions', defaultValue: false)`).
+  - Bulk form pickers: `_enumDropdown<EntryMethod>` wrapped in `_gatedRow(BulkField.entryMethod, ...)` / `_gatedRow(BulkField.exitMethod, ...)` at lines ~1356-1379. DO NOT TOUCH THESE.
+- `EntryMethod` enum (`lib/core/constants/enums.dart:237`): `shore`, `boat`, `backRoll`, `giantStride`, `seatedEntry`, `ladder`, `platform`, `jetty`, `other`.
+- `EnumPickerRow` (`lib/shared/widgets/forms/enum_picker_row.dart`) opens a modal bottom sheet of `ListTile` options; choosing "Not specified" calls `onChanged(null)`; dismissing the sheet calls nothing.
+- English strings (used as widget-test finders): row labels `'Entry Method'` / `'Exit Method'`, options `'Shore Entry'`, `'Boat Entry'`, `'Ladder'`, `'Giant Stride'`, clear option `'Not specified'`, section header `'Conditions'`, save button `'Save'`.
+- `FormSection` header: the whole header row (including the plain-cased label text) is wrapped in the toggle `InkWell`, so `tester.tap(find.text('Conditions'))` expands the section. Collapsed sections do NOT mount their children.
+
+Widget-test traps (learned the hard way in this codebase):
+
+- `pumpAndSettle` TIMES OUT on a NEW `DiveEditPage` (a continuous animation never settles). For new-dive tests use a bounded pump loop. For existing-dive tests `pumpAndSettle` works.
+- The form is a lazy `ListView`: widgets below viewport+cacheExtent are not in the element tree, so `find` returns nothing and `ensureVisible` throws. Use `tester.scrollUntilVisible(finder, 300, scrollable: find.byType(Scrollable).first)`.
+- Set a tall test view (`tester.view.physicalSize = const Size(1200, 4000)` with `devicePixelRatio = 1.0`) to minimize scrolling.
+- When a bottom sheet is open, the page rows behind it are still in the tree — tap sheet options via `find.widgetWithText(ListTile, ...)` (only the sheet uses `ListTile`), and make row-value assertions only AFTER the sheet has closed.
+
+---
+
+### Task 1: New-dive mirroring (link, follow, break, clear)
+
+**Files:**
+- Create: `test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (state field ~line 191, two `EnumPickerRow` closures ~lines 3562-3575)
+
+**Interfaces:**
+- Consumes: `DiveEditPage(embedded: true)` create-mode constructor; test helpers `setUpTestDatabase()` / `tearDownTestDatabase()` (`test/helpers/test_database.dart`) and `getBaseOverrides()` (`test/helpers/mock_providers.dart`); `DiveRepository` from `dive_repository_impl.dart`.
+- Produces: state field `bool _exitMethodLinked` (initialized `true`) in `_DiveEditPageState` — Task 2 adds its load-time initialization. Test-file helpers `pumpFrames`, `expandConditions`, `pickMethod`, `buildOverrides`, `pumpEditPage` — Tasks 2 and 3 add tests to this same file using them.
+
+- [ ] **Step 1: Write the test file with helpers and four failing tests**
+
+Create `test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// New-dive pages host a continuous animation, so pumpAndSettle never
+/// settles; a bounded pump loop drains async work and animations instead.
+Future<void> pumpFrames(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+/// The Conditions section is collapsed by default and its children are not
+/// mounted while collapsed. The whole header row (including the label text)
+/// is the toggle tap target.
+Future<void> expandConditions(WidgetTester tester) async {
+  final header = find.text('Conditions');
+  await tester.scrollUntilVisible(
+    header,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.tap(header);
+  await pumpFrames(tester);
+}
+
+/// Opens the EnumPickerRow labeled [rowLabel] and taps the sheet option
+/// [optionText]. Sheet options are ListTiles; page rows are not, so
+/// widgetWithText(ListTile, ...) cannot hit the row behind the sheet.
+Future<void> pickMethod(
+  WidgetTester tester,
+  String rowLabel,
+  String optionText,
+) async {
+  final row = find.text(rowLabel);
+  await tester.scrollUntilVisible(
+    row,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.tap(row);
+  await pumpFrames(tester);
+  await tester.tap(find.widgetWithText(ListTile, optionText));
+  await pumpFrames(tester);
+}
+
+void main() {
+  group('DiveEditPage entry/exit mirroring (new dive)', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    List<dynamic> buildOverrides(List<dynamic> base) {
+      return [
+        ...base,
+        diveRepositoryProvider.overrideWithValue(repository),
+        diveListNotifierProvider.overrideWith((ref) {
+          return DiveListNotifier(repository, ref);
+        }),
+        customTankPresetsProvider.overrideWith((ref) async => []),
+      ];
+    }
+
+    Future<void> pumpNewDivePage(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const Scaffold(body: DiveEditPage(embedded: true)),
+          ),
+        ),
+      );
+      await pumpFrames(tester);
+    }
+
+    testWidgets('selecting entry method fills exit method', (tester) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+
+      // Entry row value + mirrored exit row value.
+      expect(find.text('Shore Entry'), findsNWidgets(2));
+    });
+
+    testWidgets('exit follows subsequent entry changes while linked', (
+      tester,
+    ) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsNWidgets(2));
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+
+    testWidgets('touching exit breaks the link for the session', (
+      tester,
+    ) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Exit Method', 'Ladder');
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      // Entry changed alone; exit kept its explicit value.
+      expect(find.text('Boat Entry'), findsOneWidget);
+      expect(find.text('Ladder'), findsOneWidget);
+    });
+
+    testWidgets('clearing entry while linked clears exit', (tester) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Entry Method', 'Not specified');
+
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+
+Expected: the first, second, and fourth tests FAIL (exit row does not mirror — e.g. `findsNWidgets(2)` finds 1). The third test may PASS already (independent pickers also satisfy it); that is fine — it exists to guard the link-breaking behavior once mirroring lands. If tests fail for navigation reasons instead (finder not found, tap off-screen), fix the test navigation first — the failure must be the missing feature, not broken plumbing.
+
+- [ ] **Step 3: Implement mirroring in dive_edit_page.dart**
+
+In `lib/features/dive_log/presentation/pages/dive_edit_page.dart`, add the state field directly below `_exitMethod` (line ~191):
+
+```dart
+  EntryMethod? _entryMethod;
+  EntryMethod? _exitMethod;
+  // Exit mirrors entry until the user edits the exit picker directly.
+  // Single-dive form only; the bulk layout's dropdowns share these value
+  // fields but must never trigger mirroring.
+  bool _exitMethodLinked = true;
+```
+
+Then replace the two `EnumPickerRow` closures in `_environmentRows` (lines ~3562-3575):
+
+```dart
+      EnumPickerRow<EntryMethod>(
+        label: l10n.diveLog_edit_label_entryMethod,
+        value: _entryMethod,
+        values: EntryMethod.values,
+        displayName: (v) => v.localizedName(l10n),
+        onChanged: (v) => setState(() {
+          _entryMethod = v;
+          if (_exitMethodLinked) _exitMethod = v;
+        }),
+      ),
+      EnumPickerRow<EntryMethod>(
+        label: l10n.diveLog_edit_label_exitMethod,
+        value: _exitMethod,
+        values: EntryMethod.values,
+        displayName: (v) => v.localizedName(l10n),
+        onChanged: (v) => setState(() {
+          _exitMethod = v;
+          _exitMethodLinked = false;
+        }),
+      ),
+```
+
+Do NOT modify the `_enumDropdown` handlers in `_buildBulkForm` (lines ~1356-1379).
+
+- [ ] **Step 4: Run the tests to verify all four pass**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+git commit -m "Mirror exit method from entry method on new dives"
+```
+
+---
+
+### Task 2: Link state when opening an existing dive
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (load path, lines ~614-615)
+- Modify: `test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart` (add a second group)
+
+**Interfaces:**
+- Consumes: `bool _exitMethodLinked` from Task 1; test helpers `pumpFrames`, `expandConditions`, `pickMethod`, `buildOverrides` from Task 1's file; `DiveRepository.createDive(Dive)` and the `Dive` entity constructor.
+- Produces: load-time initialization `_exitMethodLinked = _exitMethod == null || _exitMethod == _entryMethod;` — Task 3 relies on this exact rule for the empty-exit case.
+
+- [ ] **Step 1: Add two failing tests for existing dives**
+
+Append a second group inside `main()` in `dive_edit_entry_exit_mirror_test.dart`. Add these imports at the top of the file:
+
+```dart
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+```
+
+```dart
+  group('DiveEditPage entry/exit mirroring (existing dive)', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    List<dynamic> buildOverrides(List<dynamic> base) {
+      return [
+        ...base,
+        diveRepositoryProvider.overrideWithValue(repository),
+        diveListNotifierProvider.overrideWith((ref) {
+          return DiveListNotifier(repository, ref);
+        }),
+        customTankPresetsProvider.overrideWith((ref) async => []),
+      ];
+    }
+
+    Dive buildDive({EntryMethod? entry, EntryMethod? exit}) => Dive(
+      id: 'dive-entry-exit',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 3, 28, 10, 0),
+      entryTime: DateTime(2026, 3, 28, 10, 5),
+      bottomTime: const Duration(minutes: 40),
+      maxDepth: 20.0,
+      entryMethod: entry,
+      exitMethod: exit,
+      tanks: const [],
+      profile: const [],
+      equipment: const [],
+      notes: '',
+      photoIds: const [],
+      sightings: const [],
+      weights: const [],
+      tags: const [],
+    );
+
+    Future<void> pumpExistingDivePage(
+      WidgetTester tester,
+      String diveId,
+    ) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(diveId: diveId, embedded: true),
+            ),
+          ),
+        ),
+      );
+      // Existing-dive pages settle normally (no perpetual animation).
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('equal saved values open linked: entry change updates both', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.shore, exit: EntryMethod.shore),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsNWidgets(2));
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+
+    testWidgets('differing saved values open unlinked: exit stays put', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.giantStride, exit: EntryMethod.ladder),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsOneWidget);
+      expect(find.text('Ladder'), findsOneWidget);
+      expect(find.text('Giant Stride'), findsNothing);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the new group to verify the second test fails**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+
+Expected: 'equal saved values' PASSES already (Task 1 initialized `_exitMethodLinked = true` and the load path does not yet overwrite it — equal values happen to behave linked). 'differing saved values' FAILS: without load-time initialization the page still considers the pickers linked, so changing entry drags exit along ('Ladder' disappears, 'Boat Entry' found twice).
+
+- [ ] **Step 3: Initialize link state in the load path**
+
+In `dive_edit_page.dart`, extend the conditions-loading block (lines ~614-615):
+
+```dart
+          _entryMethod = dive.entryMethod;
+          _exitMethod = dive.exitMethod;
+          _exitMethodLinked =
+              _exitMethod == null || _exitMethod == _entryMethod;
+```
+
+- [ ] **Step 4: Run the full test file to verify all six pass**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/pages/dive_edit_page.dart test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+git commit -m "Initialize entry/exit link state when loading an existing dive"
+```
+
+---
+
+### Task 3: No silent backfill on untouched save + full verification
+
+**Files:**
+- Modify: `test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart` (one test added to the existing-dive group)
+- No production changes expected — this is a regression guard proving the Task 1/2 implementation does not write on load.
+
+**Interfaces:**
+- Consumes: `buildDive`, `pumpExistingDivePage`, `expandConditions` from Task 2; `DiveRepository.getDiveById(String) → Future<Dive?>`; save button label `'Save'` (rendered by `EditFormScaffold`).
+- Produces: nothing consumed later; final gate before review.
+
+- [ ] **Step 1: Add the untouched-save test**
+
+Append inside the existing-dive group from Task 2:
+
+```dart
+    testWidgets('untouched open-and-save never backfills an empty exit', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.shore, exit: null),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      // Exit row shows no value on load — only the entry row has one.
+      expect(find.text('Shore Entry'), findsOneWidget);
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final saved = await repository.getDiveById(created.id);
+      expect(saved!.entryMethod, EntryMethod.shore);
+      expect(saved.exitMethod, isNull);
+    });
+```
+
+- [ ] **Step 2: Run the test file — all seven should pass with no production change**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart`
+
+Expected: 7 tests PASS. If this test fails because exit was saved as `shore`, mirroring leaked into the load path — re-check that Task 2 only sets `_exitMethodLinked` and never assigns `_exitMethod` outside the two `onChanged` closures.
+
+- [ ] **Step 3: Guard the neighbors — run the surrounding suites**
+
+Run: `flutter test test/features/dive_log/presentation/pages/`
+
+Expected: all tests in the directory PASS (this covers the existing edit-page tests and every bulk-edit test, proving bulk behavior is untouched). Note: some suites in this repo are flaky only in the FULL test run, not per-directory; if something unrelated fails here, re-run that file alone before assuming this change broke it.
+
+- [ ] **Step 4: Analyze and format the whole project**
+
+```bash
+flutter analyze
+dart format .
+```
+
+Expected: analyze reports no issues (infos are fatal in CI); format changes nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+git commit -m "Guard against exit-method backfill on untouched save"
+```
+
+---
+
+## Out of Scope (verbatim from spec)
+
+- Bulk edit (`bulk_edit_field_set.dart` and the bulk layout inside `dive_edit_page.dart`): entry and exit dropdowns stay fully independent.
+- Database schema, `Dive` entity, sync/HLC handling.
+- UDDF export/import, MacDive import, statistics, dive detail page display.
+- l10n: no new strings.
+- No visual link indicator on the exit row.

--- a/docs/superpowers/specs/2026-08-06-entry-exit-method-mirroring-design.md
+++ b/docs/superpowers/specs/2026-08-06-entry-exit-method-mirroring-design.md
@@ -1,0 +1,109 @@
+# Entry/Exit Method Mirroring — Design
+
+Date: 2026-08-06
+Status: Approved
+
+## Problem
+
+The dive edit form has two independent pickers for entry method and exit
+method, both drawing from the shared `EntryMethod` enum
+(`lib/core/constants/enums.dart`). For most dives — especially shore dives —
+the two values are identical, so divers select the same value twice on every
+log entry. Entry and exit methods should be identical by default, with the
+ability to override when they genuinely differ (for example giant stride
+entry, ladder exit on a boat dive).
+
+## Decision
+
+This is an **edit-form convenience only**. The saved dive always stores both
+concrete values, exactly as today. There is no data-model inheritance, no
+schema change, and no change to how any consumer reads the fields.
+
+## Behavior
+
+### Linking
+
+In the single-dive edit page (`dive_edit_page.dart`, used for both new and
+existing dives), the exit-method picker is *linked* to the entry-method
+picker:
+
+- While linked, changing the entry picker sets the exit picker to the same
+  value. Clearing entry clears exit.
+- The moment the user changes the exit picker directly, the link breaks for
+  the remainder of the editing session. Exit then behaves exactly as it does
+  today. The link does not re-form within the session, even if the user
+  manually sets exit equal to entry.
+- There is no visual link indicator. The behavior is the familiar
+  "billing address same as shipping" pattern: follow until touched.
+
+### Link state on open
+
+- New dive: linked.
+- Existing dive: linked when the saved exit equals the saved entry, or when
+  the saved exit is empty. Unlinked when they differ.
+- Opening a dive and saving without touching either picker never changes
+  stored values. An empty exit is only backfilled if the user actively
+  changes the entry picker during the session (a deliberate act while
+  linked), never on load or on an untouched save.
+
+### Out of scope (explicitly unchanged)
+
+- Bulk edit (`bulk_edit_field_set.dart`): its entry and exit dropdowns stay
+  fully independent. Mirroring there would silently activate the exit field
+  and overwrite per-dive exit values across the selection.
+- Database schema, `Dive` entity, sync/HLC handling.
+- UDDF export/import, MacDive import.
+- Statistics (Conditions breakdowns), dive detail page display.
+- l10n: no new strings.
+
+## Implementation
+
+All contained in the `dive_edit_page.dart` state class:
+
+- One new field: `bool _exitMethodLinked`.
+- Initialization: `true` for new dives; for loaded dives,
+  `_exitMethod == null || _exitMethod == _entryMethod`.
+- Entry picker `onChanged`: in addition to setting `_entryMethod`, when
+  `_exitMethodLinked` is true also set `_exitMethod` to the same value
+  (including null when cleared).
+- Exit picker `onChanged`: set `_exitMethod` and set
+  `_exitMethodLinked = false`.
+
+Both `EnumPickerRow` call sites (around `dive_edit_page.dart:3562`) are the
+only UI touch points. Save paths are unchanged — they already read
+`_entryMethod` / `_exitMethod`.
+
+Caution: the same state class also renders the bulk-edit layout
+(`_buildBulkForm`, which wraps `_enumDropdown` pickers for the same
+`_entryMethod` / `_exitMethod` fields in `BulkFieldGate` rows). The
+mirroring logic must therefore live in the single-dive `EnumPickerRow`
+`onChanged` handlers only — never in a shared setter — so bulk mode cannot
+inherit it accidentally.
+
+## Testing (TDD)
+
+Widget tests for the dive edit page:
+
+1. New dive: selecting an entry method fills the exit picker with the same
+   value.
+2. New dive: changing entry again updates the mirrored exit (follow
+   behavior).
+3. Touching the exit picker breaks the link: subsequent entry changes leave
+   exit alone for the rest of the session.
+4. Existing dive with entry == exit: opens linked; changing entry updates
+   both.
+5. Existing dive with entry != exit: opens unlinked; changing entry leaves
+   exit alone.
+6. Existing dive with entry set and exit empty: open and save untouched —
+   exit remains empty (no silent backfill).
+7. Clearing entry while linked clears exit.
+
+Existing edit-page and bulk-edit tests must continue to pass unmodified
+except where they assert the old independent-picker behavior on a new dive.
+
+## Risks
+
+- The re-link-on-open rule infers intent from value equality rather than a
+  stored flag. A diver who deliberately set entry = exit = Shore and later
+  edits entry to Boat will see exit follow. This is judged the desired
+  outcome in almost all cases and avoids schema creep for a form nicety.

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -617,6 +617,8 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           _currentStrength = dive.currentStrength;
           _entryMethod = dive.entryMethod;
           _exitMethod = dive.exitMethod;
+          _exitMethodLinked =
+              _exitMethod == null || _exitMethod == _entryMethod;
           _waterType = dive.waterType;
           _swellHeightController.text = dive.swellHeight != null
               ? units.convertDepth(dive.swellHeight!).toStringAsFixed(1)

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -189,6 +189,10 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   CurrentStrength? _currentStrength;
   EntryMethod? _entryMethod;
   EntryMethod? _exitMethod;
+  // Exit mirrors entry until the user edits the exit picker directly.
+  // Single-dive form only; the bulk layout's dropdowns share these value
+  // fields but must never trigger mirroring.
+  bool _exitMethodLinked = true;
   WaterType? _waterType;
   final _swellHeightController = TextEditingController();
   final _altitudeController = TextEditingController();
@@ -3620,14 +3624,20 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         value: _entryMethod,
         values: EntryMethod.values,
         displayName: (v) => v.localizedName(l10n),
-        onChanged: (v) => setState(() => _entryMethod = v),
+        onChanged: (v) => setState(() {
+          _entryMethod = v;
+          if (_exitMethodLinked) _exitMethod = v;
+        }),
       ),
       EnumPickerRow<EntryMethod>(
         label: l10n.diveLog_edit_label_exitMethod,
         value: _exitMethod,
         values: EntryMethod.values,
         displayName: (v) => v.localizedName(l10n),
-        onChanged: (v) => setState(() => _exitMethod = v),
+        onChanged: (v) => setState(() {
+          _exitMethod = v;
+          _exitMethodLinked = false;
+        }),
       ),
     ];
   }

--- a/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
@@ -140,6 +142,102 @@ void main() {
       await pickMethod(tester, 'Entry Method', 'Not specified');
 
       expect(find.text('Shore Entry'), findsNothing);
+    });
+  });
+
+  group('DiveEditPage entry/exit mirroring (existing dive)', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    List<dynamic> buildOverrides(List<dynamic> base) {
+      return [
+        ...base,
+        diveRepositoryProvider.overrideWithValue(repository),
+        diveListNotifierProvider.overrideWith((ref) {
+          return DiveListNotifier(repository, ref);
+        }),
+        customTankPresetsProvider.overrideWith((ref) async => []),
+      ];
+    }
+
+    Dive buildDive({EntryMethod? entry, EntryMethod? exit}) => Dive(
+      id: 'dive-entry-exit',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 3, 28, 10, 0),
+      entryTime: DateTime(2026, 3, 28, 10, 5),
+      bottomTime: const Duration(minutes: 40),
+      maxDepth: 20.0,
+      entryMethod: entry,
+      exitMethod: exit,
+      tanks: const [],
+      profile: const [],
+      equipment: const [],
+      notes: '',
+      photoIds: const [],
+      sightings: const [],
+      weights: const [],
+      tags: const [],
+    );
+
+    Future<void> pumpExistingDivePage(
+      WidgetTester tester,
+      String diveId,
+    ) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: DiveEditPage(diveId: diveId, embedded: true)),
+          ),
+        ),
+      );
+      // Existing-dive pages settle normally (no perpetual animation).
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('equal saved values open linked: entry change updates both', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.shore, exit: EntryMethod.shore),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsNWidgets(2));
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+
+    testWidgets('differing saved values open unlinked: exit stays put', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.giantStride, exit: EntryMethod.ladder),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsOneWidget);
+      expect(find.text('Ladder'), findsOneWidget);
+      expect(find.text('Giant Stride'), findsNothing);
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
@@ -86,10 +86,10 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: buildOverrides(overrides).cast(),
-          child: MaterialApp(
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: const Scaffold(body: DiveEditPage(embedded: true)),
+            home: Scaffold(body: DiveEditPage(embedded: true)),
           ),
         ),
       );
@@ -238,6 +238,26 @@ void main() {
       expect(find.text('Boat Entry'), findsOneWidget);
       expect(find.text('Ladder'), findsOneWidget);
       expect(find.text('Giant Stride'), findsNothing);
+    });
+
+    testWidgets('untouched open-and-save never backfills an empty exit', (
+      tester,
+    ) async {
+      final created = await repository.createDive(
+        buildDive(entry: EntryMethod.shore, exit: null),
+      );
+      await pumpExistingDivePage(tester, created.id);
+      await expandConditions(tester);
+
+      // Exit row shows no value on load — only the entry row has one.
+      expect(find.text('Shore Entry'), findsOneWidget);
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final saved = await repository.getDiveById(created.id);
+      expect(saved!.entryMethod, EntryMethod.shore);
+      expect(saved.exitMethod, isNull);
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
-import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
-import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
 import '../../../../helpers/test_database.dart';
 
 /// New-dive pages host a continuous animation, so pumpAndSettle never
@@ -84,13 +83,10 @@ void main() {
       addTearDown(tester.view.reset);
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: buildOverrides(overrides).cast(),
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: DiveEditPage(embedded: true)),
-          ),
+        testApp(
+          overrides: buildOverrides(overrides),
+          locale: const Locale('en'),
+          child: const DiveEditPage(embedded: true),
         ),
       );
       await pumpFrames(tester);
@@ -196,13 +192,10 @@ void main() {
       addTearDown(tester.view.reset);
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
-        ProviderScope(
-          overrides: buildOverrides(overrides).cast(),
-          child: MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: DiveEditPage(diveId: diveId, embedded: true)),
-          ),
+        testApp(
+          overrides: buildOverrides(overrides),
+          locale: const Locale('en'),
+          child: DiveEditPage(diveId: diveId, embedded: true),
         ),
       );
       // Existing-dive pages settle normally (no perpetual animation).

--- a/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_entry_exit_mirror_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// New-dive pages host a continuous animation, so pumpAndSettle never
+/// settles; a bounded pump loop drains async work and animations instead.
+Future<void> pumpFrames(WidgetTester tester) async {
+  for (var i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+/// The Conditions section is collapsed by default and its children are not
+/// mounted while collapsed. The whole header row (including the label text)
+/// is the toggle tap target.
+Future<void> expandConditions(WidgetTester tester) async {
+  final header = find.text('Conditions');
+  await tester.scrollUntilVisible(
+    header,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.tap(header);
+  await pumpFrames(tester);
+}
+
+/// Opens the EnumPickerRow labeled [rowLabel] and taps the sheet option
+/// [optionText]. Sheet options are ListTiles; page rows are not, so
+/// widgetWithText(ListTile, ...) cannot hit the row behind the sheet.
+Future<void> pickMethod(
+  WidgetTester tester,
+  String rowLabel,
+  String optionText,
+) async {
+  final row = find.text(rowLabel);
+  await tester.scrollUntilVisible(
+    row,
+    300,
+    scrollable: find.byType(Scrollable).first,
+  );
+  await tester.tap(row);
+  await pumpFrames(tester);
+  await tester.tap(find.widgetWithText(ListTile, optionText));
+  await pumpFrames(tester);
+}
+
+void main() {
+  group('DiveEditPage entry/exit mirroring (new dive)', () {
+    late DiveRepository repository;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      repository = DiveRepository();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    List<dynamic> buildOverrides(List<dynamic> base) {
+      return [
+        ...base,
+        diveRepositoryProvider.overrideWithValue(repository),
+        diveListNotifierProvider.overrideWith((ref) {
+          return DiveListNotifier(repository, ref);
+        }),
+        customTankPresetsProvider.overrideWith((ref) async => []),
+      ];
+    }
+
+    Future<void> pumpNewDivePage(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: const Scaffold(body: DiveEditPage(embedded: true)),
+          ),
+        ),
+      );
+      await pumpFrames(tester);
+    }
+
+    testWidgets('selecting entry method fills exit method', (tester) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+
+      // Entry row value + mirrored exit row value.
+      expect(find.text('Shore Entry'), findsNWidgets(2));
+    });
+
+    testWidgets('exit follows subsequent entry changes while linked', (
+      tester,
+    ) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      expect(find.text('Boat Entry'), findsNWidgets(2));
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+
+    testWidgets('touching exit breaks the link for the session', (
+      tester,
+    ) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Exit Method', 'Ladder');
+      await pickMethod(tester, 'Entry Method', 'Boat Entry');
+
+      // Entry changed alone; exit kept its explicit value.
+      expect(find.text('Boat Entry'), findsOneWidget);
+      expect(find.text('Ladder'), findsOneWidget);
+    });
+
+    testWidgets('clearing entry while linked clears exit', (tester) async {
+      await pumpNewDivePage(tester);
+      await expandConditions(tester);
+
+      await pickMethod(tester, 'Entry Method', 'Shore Entry');
+      await pickMethod(tester, 'Entry Method', 'Not specified');
+
+      expect(find.text('Shore Entry'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

In the single-dive edit form, the exit-method picker now mirrors the entry-method picker until the user explicitly changes exit. Most dives (especially shore dives) enter and exit the same way, so this removes a duplicate selection from every log entry. Both concrete values are still stored — no schema, sync, import/export, or statistics changes.

## Changes

- Add `_exitMethodLinked` state to `DiveEditPage`: picking an entry method also sets exit while linked; editing the exit picker directly breaks the link for the session; clearing entry while linked clears exit.
- Existing dives open linked when saved exit equals saved entry or exit is empty, and unlinked when they differ. Opening and saving an untouched form never changes stored values (no backfill of an empty exit).
- Bulk edit is deliberately untouched: the bulk layout shares the same state fields, so mirroring is wired only into the single-dive `EnumPickerRow` handlers.
- 7 new widget tests in `dive_edit_entry_exit_mirror_test.dart` covering fill, follow, link-break, clear, both load states, and the no-backfill-on-save guarantee.
- Design spec and implementation plan under `docs/superpowers/`.

## Test Plan

- [x] `flutter test` passes (15,087 tests, full suite run locally)
- [x] `flutter analyze` passes (no issues)
- [x] Manual testing on: macOS