### PR TITLE
Disable implicit chart animation on interaction-driven profile charts

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -3281,6 +3281,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               ),
             ),
           ),
+          // The chart rebuilds on every hover, pan, and cursor move. The
+          // default 150ms implicit animation lerps old data to new, lagging
+          // the highlight cursor behind the pointer, sliding event markers
+          // (verticalLines lerp by index, and cursor lines shift the
+          // indices), and smearing bars while panning. Render immediately.
+          duration: Duration.zero,
         ),
         // Right axis tap overlay for metric selection
         if (effectiveRightAxisMetric != null)

--- a/lib/features/dive_log/presentation/widgets/profile_editor_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_editor_chart.dart
@@ -135,6 +135,11 @@ class _ProfileEditorChartState extends ConsumerState<ProfileEditorChart> {
               verticalLines: [],
             ),
           ),
+          // Editing rebuilds the chart data (waypoints shift marker indices,
+          // range shading tracks the selection). The default 150ms implicit
+          // animation lerps old data to new by list index, sliding markers
+          // between unrelated positions; render every edit immediately.
+          duration: Duration.zero,
         ),
       ),
     );

--- a/lib/features/media/presentation/widgets/mini_dive_profile_overlay.dart
+++ b/lib/features/media/presentation/widgets/mini_dive_profile_overlay.dart
@@ -212,6 +212,10 @@ class MiniDiveProfileOverlay extends StatelessWidget {
                   ],
                 ),
               ),
+              // The marker dot below is a Positioned widget that jumps
+              // instantly when the photo changes; without this the marker
+              // line would trail it by the default 150ms implicit animation.
+              duration: Duration.zero,
             ),
 
             // Photo marker dot (positioned on top of the chart)

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -412,6 +412,21 @@ void main() {
       // Empty profile should show empty state placeholder.
       expect(find.byType(DiveProfileChart), findsOneWidget);
     });
+
+    testWidgets('chart data changes are not implicitly animated', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart());
+      await tester.pumpAndSettle();
+
+      // The chart rebuilds on every hover / pan / cursor move. fl_chart's
+      // default 150ms implicit animation lerps old data to new, which makes
+      // the highlight cursor lag the pointer, slides event markers when
+      // cursor lines shift verticalLines indices, and smears line bars while
+      // panning. Interaction-driven rebuilds must render immediately.
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      expect(chart.duration, Duration.zero);
+    });
   });
 
   group('DiveProfileChart - overlay source rendering', () {

--- a/test/features/dive_log/presentation/widgets/profile_editor_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_editor_chart_test.dart
@@ -1,0 +1,80 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_editor_chart.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+List<DiveProfilePoint> _makeProfile({int points = 10}) {
+  return List.generate(
+    points,
+    (i) => DiveProfilePoint(
+      timestamp: i * 30,
+      depth: (i < points / 2 ? i * 3.0 : (points - i) * 3.0),
+    ),
+  );
+}
+
+Widget _buildChart() {
+  final profile = _makeProfile();
+  return ProviderScope(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 300,
+          child: ProfileEditorChart(
+            originalProfile: profile,
+            editedProfile: profile,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ProfileEditorChart', () {
+    testWidgets('renders without crashing', (tester) async {
+      await tester.pumpWidget(_buildChart());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProfileEditorChart), findsOneWidget);
+    });
+
+    testWidgets('chart data changes are not implicitly animated', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildChart());
+      await tester.pumpAndSettle();
+
+      // Editing rebuilds the chart data (adding a waypoint shifts marker
+      // indices; range selection shading tracks the pointer). fl_chart's
+      // default 150ms lerp would slide markers between unrelated positions
+      // and lag the selection behind the cursor, so the editor must render
+      // every data change immediately.
+      final chart = tester.widget<LineChart>(find.byType(LineChart));
+      expect(chart.duration, Duration.zero);
+    });
+  });
+}

--- a/test/features/media/presentation/widgets/mini_dive_profile_overlay_test.dart
+++ b/test/features/media/presentation/widgets/mini_dive_profile_overlay_test.dart
@@ -81,6 +81,28 @@ void main() {
     expect(bar.spots.first.x, 0);
   });
 
+  testWidgets('marker line moves without implicit animation', (tester) async {
+    // The photo marker dot is a Positioned widget that jumps instantly when
+    // the photo changes; the marker VerticalLine lives in fl_chart data and
+    // would trail it by the default 150ms lerp. Both must move together.
+    final profile = [
+      for (var i = 0; i < 8; i++)
+        DiveProfilePoint(timestamp: i * 10, depth: i * 2.0),
+    ];
+    await tester.pumpWidget(
+      _host(
+        MiniDiveProfileOverlay(
+          profile: profile,
+          photoElapsedSeconds: 30,
+          settings: settings,
+        ),
+      ),
+    );
+
+    final chart = tester.widget<LineChart>(find.byType(LineChart));
+    expect(chart.duration, Duration.zero);
+  });
+
   testWidgets('a trimmed profile keeps its gap', (tester) async {
     // First sample far past one interval: no fabricated descent.
     final profile = [


### PR DESCRIPTION
## Summary

Hovering, panning, and zooming the dive profile chart produced visible rendering artifacts: event markers slid/animated into position, the dotted highlight cursor line lagged behind the pointer, and line bars redrew themselves while panning when zoomed in.

All three symptoms share one root cause: fl_chart's `LineChart` is an implicitly animated widget with a default `duration` of 150ms, and none of our charts overrode it. Every rebuild lerps the old `LineChartData` into the new over 150ms. Since the profile chart's data encodes interaction state (viewport bounds, cursor lines, hover indicators), every pointer event became a visible tween:

- **Lagging dotted cursor**: hover fires `onPointSelected` -> `profileTrackingIndexProvider` -> rebuild with a new `highlightedTimestamp`, whose dashed `VerticalLine` then animates toward the pointer while fl_chart's built-in touch indicator draws instantly, so the dotted line perpetually trails.
- **Sliding event markers**: fl_chart lerps `verticalLines` by list index (`lerpList` pairs `a[i]` with `b[i]` even when lengths differ). The playback/highlight cursor lines are spliced in ahead of the event lines, so a cursor appearing or disappearing pairs each event marker with a different line's old position and it visibly slides into place.
- **Smearing during pan**: panning changes `minX`/`maxX` (and decimation buckets) every frame, and each frame starts a fresh 150ms lerp of all line bars.

## Fix

Set `duration: Duration.zero` on the charts whose data rebuilds from pointer interactions:

- `DiveProfileChart` — hover cursor, pan/zoom viewport, event markers (the reported bug).
- `ProfileEditorChart` — editing rebuilds chart data; index-shift lerp would slide markers, and an editing surface needs immediate feedback.
- `MiniDiveProfileOverlay` — the photo marker dot is a `Positioned` widget that jumps instantly while the marker `VerticalLine` lerped 150ms behind it.

Charts whose data only changes on discrete choices or async loads (statistics, tides, tissue recovery, buoyancy, sparklines, plan compare, overlay legend toggles, the static mini thumbnail) keep the default animation, where it is harmless or desirable.

## Testing

- New regression tests assert `duration == Duration.zero` on all three charts, with comments documenting why (each failed at 150ms before the fix).
- `flutter test test/features/dive_log test/features/media`: 3,140 passed.
- `flutter analyze`: clean; `dart format .` applied.
