### PR TITLE
Move conditions auto-fill to the top and derive altitude from GPS

### DIFF
--- a/docs/superpowers/plans/2026-08-06-conditions-weather-altitude.md
+++ b/docs/superpowers/plans/2026-08-06-conditions-weather-altitude.md
@@ -1,0 +1,1621 @@
+# Conditions Weather Placement and Altitude Auto-Fill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the dive edit form's weather fetch action to the top of the Conditions section and auto-fill altitude from the dive's logged GPS, the site's stored altitude, or an elevation API lookup (with site write-back).
+
+**Architecture:** A new `ElevationService` (Open-Meteo elevation API, mirroring `WeatherService`) feeds an `AltitudeResolver` that encodes one precedence rule: dive GPS lookup, then `site.altitude`, then site-coords lookup with write-back. Explicit call sites use it: the dive edit page (load / site assign / fetch retry), the site edit page (coordinate changes), and a `DiveAltitudeEnricher` on the four import/download persistence seams.
+
+**Tech Stack:** Flutter, Riverpod, Drift, `package:http` (+ `package:http/testing.dart` MockClient in tests), Open-Meteo elevation API.
+
+**Spec:** `docs/superpowers/specs/2026-08-06-conditions-weather-altitude-design.md`
+
+## Global Constraints
+
+- Run all commands from the worktree root: `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/conditions-weather-altitude` (branch `feature/conditions-weather-altitude`).
+- `dart format .` must produce no changes before every commit (format the whole project, not just changed files).
+- `flutter analyze` (whole project) must be clean — infos are CI-fatal.
+- Never pipe `flutter analyze` or `flutter test` through `| tail` or similar — it masks failures.
+- No emojis anywhere. No console prints; use `dart:developer` `log` like `WeatherService` does.
+- Anything displaying units must respect diver unit settings: altitude is stored in meters, displayed via `UnitFormatter.convertAltitude` / parsed via `altitudeToMeters`.
+- New l10n strings go in ALL 11 arb files (`lib/l10n/arb/app_{ar,de,en,es,fr,he,hu,it,nl,pt,zh}.arb`) followed by `flutter gen-l10n`.
+- Elevation values: clamp negatives to 0, round to whole meters; 0 is a valid stored value.
+- Auto-fill only ever writes an EMPTY altitude field; manual entry always wins.
+- Commit at the end of each task (plan-approved commits are pre-authorized on this feature branch).
+
+---
+
+### Task 1: ElevationService and provider
+
+**Files:**
+- Create: `lib/features/weather/data/services/elevation_service.dart`
+- Modify: `lib/features/weather/presentation/providers/weather_providers.dart`
+- Test: `test/features/weather/data/services/elevation_service_test.dart`
+
+**Interfaces:**
+- Consumes: nothing new (mirrors `WeatherService` in the same directory).
+- Produces: `class ElevationService { ElevationService({http.Client? client}); Future<double?> fetchElevation({required double latitude, required double longitude}); }` and `final elevationServiceProvider = Provider<ElevationService>` in `weather_providers.dart`. Later tasks read `ref.read(elevationServiceProvider)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/weather/data/services/elevation_service_test.dart`:
+
+```dart
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+void main() {
+  group('ElevationService', () {
+    test('returns elevation on successful response', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.host, 'api.open-meteo.com');
+        expect(request.url.path, '/v1/elevation');
+        expect(request.url.queryParameters['latitude'], '46.4');
+        expect(request.url.queryParameters['longitude'], '8.0');
+        return http.Response(
+          jsonEncode({
+            'elevation': [740.2],
+          }),
+          200,
+        );
+      });
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(
+        latitude: 46.4,
+        longitude: 8.0,
+      );
+
+      expect(result, 740.0);
+    });
+
+    test('rounds to the nearest whole meter', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'elevation': [12.6],
+          }),
+          200,
+        ),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, 13.0);
+    });
+
+    test('clamps negative elevations to zero', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'elevation': [-4.0],
+          }),
+          200,
+        ),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 27.9, longitude: -15.4);
+
+      expect(result, 0.0);
+    });
+
+    test('returns null on non-200 response', () async {
+      final mockClient = MockClient((_) async => http.Response('oops', 500));
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null on malformed body', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response('not json', 200),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when elevation list is empty', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(jsonEncode({'elevation': <double>[]}), 200),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when the request times out', () async {
+      final mockClient = MockClient(
+        (_) async => throw TimeoutException('timed out'),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/weather/data/services/elevation_service_test.dart`
+Expected: FAIL — `elevation_service.dart` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/features/weather/data/services/elevation_service.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:http/http.dart' as http;
+
+/// HTTP client for the Open-Meteo Elevation API.
+///
+/// Returns ground elevation in meters above sea level, or null on any
+/// failure (network, API error, malformed response). Never throws.
+class ElevationService {
+  final http.Client _client;
+
+  static const _baseUrl = 'api.open-meteo.com';
+  static const _path = '/v1/elevation';
+  static const _timeout = Duration(seconds: 5);
+
+  ElevationService({http.Client? client}) : _client = client ?? http.Client();
+
+  /// Fetch ground elevation for a coordinate pair.
+  ///
+  /// Negative results (offshore grid cells) clamp to 0; values round to the
+  /// nearest whole meter so a stored 0 always means sea level.
+  Future<double?> fetchElevation({
+    required double latitude,
+    required double longitude,
+  }) async {
+    try {
+      final uri = Uri.https(_baseUrl, _path, {
+        'latitude': latitude.toString(),
+        'longitude': longitude.toString(),
+      });
+
+      final response = await _client.get(uri).timeout(_timeout);
+      if (response.statusCode != 200) {
+        developer.log(
+          'Elevation API error: ${response.statusCode}',
+          name: 'ElevationService',
+        );
+        return null;
+      }
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final values = json['elevation'] as List<dynamic>?;
+      if (values == null || values.isEmpty) return null;
+      final raw = (values.first as num).toDouble();
+      return raw < 0 ? 0.0 : raw.roundToDouble();
+    } catch (e) {
+      developer.log('Elevation fetch failed: $e', name: 'ElevationService');
+      return null;
+    }
+  }
+}
+```
+
+Then add the provider to `lib/features/weather/presentation/providers/weather_providers.dart`, directly after `weatherServiceProvider` (add the import `package:submersion/features/weather/data/services/elevation_service.dart` to the import block):
+
+```dart
+/// ElevationService provider
+final elevationServiceProvider = Provider<ElevationService>((ref) {
+  final client = ref.watch(weatherHttpClientProvider);
+  return ElevationService(client: client);
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/weather/data/services/elevation_service_test.dart`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/weather test/features/weather
+git commit -m "Add ElevationService for Open-Meteo elevation lookups"
+```
+
+---
+
+### Task 2: AltitudeResolver
+
+**Files:**
+- Create: `lib/features/weather/domain/services/altitude_resolver.dart`
+- Test: `test/features/weather/domain/services/altitude_resolver_test.dart`
+
+**Interfaces:**
+- Consumes: `ElevationService.fetchElevation` (Task 1), `GeoPoint(latitude, longitude)` and `DiveSite` (fields `altitude`, `location`, `copyWith`) from `lib/features/dive_sites/domain/entities/dive_site.dart`.
+- Produces:
+  - `class AltitudeResolution { const AltitudeResolution({this.altitudeMeters, this.siteWriteBack}); final double? altitudeMeters; final DiveSite? siteWriteBack; }`
+  - `class AltitudeResolver { AltitudeResolver({required ElevationService elevationService, Map<String, double?>? cache}); Future<AltitudeResolution> resolve({GeoPoint? entryLocation, GeoPoint? exitLocation, DiveSite? site}); }`
+  - `siteWriteBack` is non-null only when the value came from a site-coords lookup; it is `site.copyWith(altitude: <result>)` and the CALLER persists it.
+  - The optional `cache` map is consulted and populated per lookup, keyed by `'<lat 4dp>,<lng 4dp>'`; used by the import enricher (Task 7) so a batch at one location does one lookup.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/weather/domain/services/altitude_resolver_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+import 'package:submersion/features/weather/domain/services/altitude_resolver.dart';
+
+/// Serves a fixed elevation and counts requests; 500s when [fail] is true.
+ElevationService _service({
+  double elevation = 740.0,
+  bool fail = false,
+  List<Uri>? requests,
+}) {
+  return ElevationService(
+    client: MockClient((request) async {
+      requests?.add(request.url);
+      if (fail) return http.Response('oops', 500);
+      return http.Response(
+        jsonEncode({
+          'elevation': [elevation],
+        }),
+        200,
+      );
+    }),
+  );
+}
+
+DiveSite _site({GeoPoint? location, double? altitude}) => DiveSite(
+  id: 'site-1',
+  name: 'Lake Test',
+  location: location,
+  altitude: altitude,
+);
+
+void main() {
+  group('AltitudeResolver', () {
+    test('prefers the dive entry location lookup', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(elevation: 740.0, requests: requests),
+      );
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(altitude: 300.0),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(result.siteWriteBack, isNull);
+      expect(requests.single.queryParameters['latitude'], '46.4');
+    });
+
+    test('uses exit location when entry is missing', () async {
+      final resolver = AltitudeResolver(elevationService: _service());
+
+      final result = await resolver.resolve(
+        exitLocation: const GeoPoint(46.5, 8.1),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+    });
+
+    test('falls back to site altitude when dive lookup fails', () async {
+      final resolver = AltitudeResolver(elevationService: _service(fail: true));
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(altitude: 300.0),
+      );
+
+      expect(result.altitudeMeters, 300.0);
+      expect(result.siteWriteBack, isNull);
+    });
+
+    test('uses site altitude when the dive has no GPS', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(requests: requests),
+      );
+
+      final result = await resolver.resolve(site: _site(altitude: 300.0));
+
+      expect(result.altitudeMeters, 300.0);
+      expect(requests, isEmpty);
+    });
+
+    test('looks up site coordinates and returns a write-back', () async {
+      final resolver = AltitudeResolver(elevationService: _service());
+
+      final result = await resolver.resolve(
+        site: _site(location: const GeoPoint(46.4, 8.0)),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(result.siteWriteBack, isNotNull);
+      expect(result.siteWriteBack!.altitude, 740.0);
+      expect(result.siteWriteBack!.id, 'site-1');
+    });
+
+    test('returns empty resolution when nothing is available', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(requests: requests),
+      );
+
+      final result = await resolver.resolve();
+
+      expect(result.altitudeMeters, isNull);
+      expect(result.siteWriteBack, isNull);
+      expect(requests, isEmpty);
+    });
+
+    test('returns empty resolution when all lookups fail', () async {
+      final resolver = AltitudeResolver(elevationService: _service(fail: true));
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(location: const GeoPoint(46.4, 8.0)),
+      );
+
+      expect(result.altitudeMeters, isNull);
+      expect(result.siteWriteBack, isNull);
+    });
+
+    test('cache dedupes lookups for nearby coordinates', () async {
+      final requests = <Uri>[];
+      final cache = <String, double?>{};
+
+      final first = AltitudeResolver(
+        elevationService: _service(requests: requests),
+        cache: cache,
+      );
+      await first.resolve(entryLocation: const GeoPoint(46.40001, 8.00001));
+
+      final second = AltitudeResolver(
+        elevationService: _service(requests: requests),
+        cache: cache,
+      );
+      final result = await second.resolve(
+        entryLocation: const GeoPoint(46.40004, 8.00003),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(requests, hasLength(1));
+    });
+
+    test('cache remembers failures within a run', () async {
+      final requests = <Uri>[];
+      final cache = <String, double?>{};
+      final resolver = AltitudeResolver(
+        elevationService: _service(fail: true, requests: requests),
+        cache: cache,
+      );
+
+      await resolver.resolve(entryLocation: const GeoPoint(46.4, 8.0));
+      await resolver.resolve(entryLocation: const GeoPoint(46.4, 8.0));
+
+      expect(requests, hasLength(1));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/weather/domain/services/altitude_resolver_test.dart`
+Expected: FAIL — `altitude_resolver.dart` does not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/features/weather/domain/services/altitude_resolver.dart`:
+
+```dart
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+/// Result of an altitude resolution.
+///
+/// [siteWriteBack] is non-null only when the altitude came from a lookup of
+/// the site's own coordinates: the caller should persist it so future dives
+/// at that site resolve locally without a network call.
+class AltitudeResolution {
+  const AltitudeResolution({this.altitudeMeters, this.siteWriteBack});
+
+  final double? altitudeMeters;
+  final DiveSite? siteWriteBack;
+}
+
+/// Encodes the altitude precedence rule from the 2026-08-06 conditions spec:
+/// dive GPS lookup, then the site's stored altitude, then a site-coordinates
+/// lookup with write-back. Auto-fill callers must only apply the result to an
+/// empty field; manual entry always wins.
+class AltitudeResolver {
+  AltitudeResolver({
+    required ElevationService elevationService,
+    Map<String, double?>? cache,
+  }) : _elevation = elevationService,
+       _cache = cache;
+
+  final ElevationService _elevation;
+
+  /// Optional per-run lookup cache keyed by coordinates rounded to 4 decimal
+  /// places (roughly 11 m) so a batch import at one location does one lookup.
+  final Map<String, double?>? _cache;
+
+  Future<AltitudeResolution> resolve({
+    GeoPoint? entryLocation,
+    GeoPoint? exitLocation,
+    DiveSite? site,
+  }) async {
+    final divePoint = entryLocation ?? exitLocation;
+    if (divePoint != null) {
+      final meters = await _lookup(divePoint);
+      if (meters != null) return AltitudeResolution(altitudeMeters: meters);
+    }
+
+    if (site == null) return const AltitudeResolution();
+    if (site.altitude != null) {
+      return AltitudeResolution(altitudeMeters: site.altitude);
+    }
+
+    final siteLocation = site.location;
+    if (siteLocation != null) {
+      final meters = await _lookup(siteLocation);
+      if (meters != null) {
+        return AltitudeResolution(
+          altitudeMeters: meters,
+          siteWriteBack: site.copyWith(altitude: meters),
+        );
+      }
+    }
+    return const AltitudeResolution();
+  }
+
+  Future<double?> _lookup(GeoPoint point) async {
+    final cache = _cache;
+    final key =
+        '${point.latitude.toStringAsFixed(4)},${point.longitude.toStringAsFixed(4)}';
+    if (cache != null && cache.containsKey(key)) return cache[key];
+    final meters = await _elevation.fetchElevation(
+      latitude: point.latitude,
+      longitude: point.longitude,
+    );
+    cache?[key] = meters;
+    return meters;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/weather/domain/services/altitude_resolver_test.dart`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/weather test/features/weather
+git commit -m "Add AltitudeResolver with dive GPS, site altitude, site lookup precedence"
+```
+
+---
+
+### Task 3: Conditions section layout and l10n
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (`_buildConditionsSection` around line 3449, `_weatherRows` around line 3579)
+- Modify: all 11 arb files `lib/l10n/arb/app_*.arb`
+- Test: `test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `FormOverline` / `FormOverlineAction` (`lib/shared/widgets/forms/form_overline.dart`), existing `_fetchWeather`, `_isFetchingWeather`, `_selectedSite`.
+- Produces: `ConditionsSection` gains a `topRows` parameter (`List<Widget>`, default `const []`) rendered before the water temperature row. New l10n getter `diveLog_edit_subsection_autofill`. Task 4 adds behavior to the fetch handler; this task only moves it.
+
+- [ ] **Step 1: Add the l10n key to all 11 arb files**
+
+In `lib/l10n/arb/app_en.arb`, directly above the existing `"diveLog_edit_subsection_weather"` entry (line ~12809), add:
+
+```json
+"diveLog_edit_subsection_autofill": "Auto-fill",
+```
+
+Add the translated entry at the same position in the other 10 files:
+
+| File | Value |
+| --- | --- |
+| app_ar.arb | `"تعبئة تلقائية"` |
+| app_de.arb | `"Automatisch ausfüllen"` |
+| app_es.arb | `"Autocompletar"` |
+| app_fr.arb | `"Remplissage automatique"` |
+| app_he.arb | `"מילוי אוטומטי"` |
+| app_hu.arb | `"Automatikus kitöltés"` |
+| app_it.arb | `"Compilazione automatica"` |
+| app_nl.arb | `"Automatisch invullen"` |
+| app_pt.arb | `"Preenchimento automático"` |
+| app_zh.arb | `"自动填充"` |
+
+Then run: `flutter gen-l10n`
+Expected: regenerates `lib/l10n/arb/app_localizations*.dart` with the new getter.
+
+- [ ] **Step 2: Write the failing widget test**
+
+Create `test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/forms/form_overline.dart';
+
+void main() {
+  Widget host({required List<Widget> topRows, required List<Widget> weatherRows}) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ConditionsSection(
+            expanded: true,
+            onToggle: () {},
+            summary: '',
+            isEmpty: true,
+            temperatureSymbol: 'C',
+            waterTempController: TextEditingController(),
+            airTempController: TextEditingController(),
+            topRows: topRows,
+            environmentRows: const [],
+            weatherRows: weatherRows,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders topRows above the temperature fields', (tester) async {
+    await tester.pumpWidget(
+      host(
+        topRows: [
+          FormOverline(
+            label: 'Auto-fill',
+            actions: [
+              FormOverlineAction(label: 'Fetch weather', onPressed: () {}),
+            ],
+          ),
+        ],
+        weatherRows: const [FormOverline(label: 'Weather')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final autofillY = tester.getTopLeft(find.text('AUTO-FILL')).dy;
+    final weatherY = tester.getTopLeft(find.text('WEATHER')).dy;
+    final firstFieldY = tester.getTopLeft(find.byType(TextField).first).dy;
+
+    expect(find.text('Fetch weather'), findsOneWidget);
+    expect(autofillY, lessThan(firstFieldY));
+    expect(autofillY, lessThan(weatherY));
+  });
+
+  testWidgets('topRows defaults to empty and renders nothing extra', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(topRows: const [], weatherRows: const []));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FormOverline), findsNothing);
+  });
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart`
+Expected: FAIL — `ConditionsSection` has no `topRows` parameter (compile error).
+
+- [ ] **Step 4: Add `topRows` to ConditionsSection**
+
+In `conditions_section.dart`, add the field, constructor parameter, and spread it first in `children`:
+
+```dart
+    this.topRows = const [],
+```
+
+```dart
+  /// Rows pinned above the temperature fields (the auto-fill action overline).
+  final List<Widget> topRows;
+```
+
+```dart
+      children: [
+        ...topRows,
+        FormRow.text(
+          label: l10n.diveLog_edit_label_waterTemp,
+```
+
+Also update the class doc comment's first line to mention the auto-fill row, e.g. "Group 3 of the dive form. An auto-fill action row leads, then water/air temperature as ordinary rows; the environment and weather row lists are page-provided...".
+
+- [ ] **Step 5: Move the fetch action in dive_edit_page.dart**
+
+In `_buildConditionsSection` (line ~3449), pass the new row:
+
+```dart
+    return ConditionsSection(
+      expanded: _isExpanded('conditions', defaultValue: false),
+      onToggle: () => _toggleSection('conditions', defaultValue: false),
+      summary: _conditionsSummary(units),
+      isEmpty: _conditionsIsEmpty(),
+      temperatureSymbol: units.temperatureSymbol,
+      waterTempController: _waterTempController,
+      airTempController: _airTempController,
+      topRows: [_autofillOverline(units)],
+      environmentRows: _environmentRows(units),
+      weatherRows: _weatherRows(units),
+    );
+```
+
+Add the new method directly above `_weatherRows`:
+
+```dart
+  Widget _autofillOverline(UnitFormatter units) {
+    final l10n = context.l10n;
+    final canFetchWeather =
+        _selectedSite != null && _selectedSite!.hasCoordinates;
+    return FormOverline(
+      label: l10n.diveLog_edit_subsection_autofill,
+      actions: [
+        FormOverlineAction(
+          label: l10n.diveLog_edit_button_fetchWeather,
+          icon: Icons.cloud_download,
+          busy: _isFetchingWeather,
+          onPressed: canFetchWeather ? () => _fetchWeather(units) : null,
+        ),
+      ],
+    );
+  }
+```
+
+In `_weatherRows` (line ~3579), replace the action-carrying overline with a plain one and delete the now-unused `canFetchWeather` local:
+
+```dart
+  List<Widget> _weatherRows(UnitFormatter units) {
+    final l10n = context.l10n;
+    return [
+      FormOverline(label: l10n.diveLog_edit_subsection_weather),
+      FormRow.text(
+        label: l10n.diveLog_edit_label_humidity,
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart`
+Expected: PASS (2 tests).
+
+Also run the existing edit page suites to catch regressions:
+`flutter test test/features/dive_log/presentation/pages/`
+Expected: PASS.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib test
+git commit -m "Move weather fetch action to the top of the conditions section"
+```
+
+---
+
+### Task 4: Dive edit page altitude auto-fill
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart`
+- Modify: `test/helpers/mock_providers.dart` (`getBaseOverrides`, line ~469)
+- Test: `test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `elevationServiceProvider` (Task 1), `AltitudeResolver`/`AltitudeResolution` (Task 2), existing page members: `_altitudeController`, `_existingDive`, `_selectedSite`, `_silently` (line ~294), `_assignSite` (line ~1974), `_fetchWeather` (line ~3644), `siteListNotifierProvider`, `settingsProvider`, `UnitFormatter`.
+- Produces: `Future<void> _maybeAutoFillAltitude()` on the page state; `getBaseOverrides` gains an optional `http.Client? weatherHttpClient` parameter and always overrides `weatherHttpClientProvider` (default: instant 500 stub so no widget test ever hits the network).
+
+- [ ] **Step 1: Wire the network stub into the shared test harness**
+
+In `test/helpers/mock_providers.dart` add imports:
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+```
+
+Extend `getBaseOverrides` (line ~469):
+
+```dart
+Future<List<Override>> getBaseOverrides({
+  MockSettingsNotifier? settingsNotifier,
+  http.Client? weatherHttpClient,
+}) async {
+```
+
+and append to the returned list:
+
+```dart
+    // Weather/elevation lookups must never hit the network in widget tests;
+    // the default stub fails fast so altitude auto-fill resolves to null.
+    weatherHttpClientProvider.overrideWithValue(
+      weatherHttpClient ?? MockClient((_) async => http.Response('', 500)),
+    ),
+```
+
+with the import `package:submersion/features/weather/presentation/providers/weather_providers.dart`.
+
+- [ ] **Step 2: Write the failing widget tests**
+
+Create `test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart`, modeled on `dive_edit_site_gps_test.dart` (same setUp/tearDown with `setUpTestDatabase`, same pump harness):
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive({double? altitude}) => Dive(
+    id: 'dive-alt',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 3, 28, 10, 0),
+    entryTime: DateTime(2026, 3, 28, 10, 5),
+    bottomTime: const Duration(minutes: 40),
+    maxDepth: 20.0,
+    altitude: altitude,
+    entryLocation: const GeoPoint(46.4, 8.0),
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  Future<void> pumpEditPage(WidgetTester tester, String diveId) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final base = await getBaseOverrides(
+      weatherHttpClient: MockClient((request) async {
+        expect(request.url.host, 'api.open-meteo.com');
+        return http.Response(
+          jsonEncode({
+            'elevation': [740.2],
+          }),
+          200,
+        );
+      }),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveEditPage(diveId: diveId, embedded: true),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> expandConditions(WidgetTester tester) async {
+    final header = find.text('Conditions');
+    await tester.ensureVisible(header);
+    await tester.pumpAndSettle();
+    await tester.tap(header);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('fills empty altitude from logged GPS on load', (tester) async {
+    final created = await repository.createDive(buildDive());
+    await pumpEditPage(tester, created.id);
+    await expandConditions(tester);
+
+    expect(find.widgetWithText(TextField, '740'), findsOneWidget);
+  });
+
+  testWidgets('never overwrites an existing altitude', (tester) async {
+    final created = await repository.createDive(buildDive(altitude: 500.0));
+    await pumpEditPage(tester, created.id);
+    await expandConditions(tester);
+
+    expect(find.widgetWithText(TextField, '500'), findsOneWidget);
+    expect(find.widgetWithText(TextField, '740'), findsNothing);
+  });
+}
+```
+
+Notes for the implementer:
+- If `find.text('Conditions')` is ambiguous or the label differs, check `diveLog_edit_group_conditions` in `app_en.arb` and use that exact string.
+- If `740` also matches another field, scope the finder to the altitude row: `find.descendant(of: find.byType(ConditionsSection), matching: find.widgetWithText(TextField, '740'))`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart`
+Expected: The first test FAILS (no auto-fill exists; altitude field is empty). The second test may already pass — that is fine; it pins the invariant.
+
+- [ ] **Step 4: Implement `_maybeAutoFillAltitude` and its hooks**
+
+In `dive_edit_page.dart`:
+
+1. Add imports: `dart:async` (for `unawaited`), `package:submersion/features/weather/domain/services/altitude_resolver.dart` (the page already imports `weather_providers.dart` at line 74).
+
+2. Add the method near `_fetchWeather`:
+
+```dart
+  /// Fill an empty altitude field from the dive's logged GPS or the selected
+  /// site (spec: 2026-08-06 conditions design). Never overwrites a value and
+  /// never marks the form dirty on its own.
+  Future<void> _maybeAutoFillAltitude() async {
+    if (_altitudeController.text.isNotEmpty) return;
+
+    final resolver = AltitudeResolver(
+      elevationService: ref.read(elevationServiceProvider),
+    );
+    final resolution = await resolver.resolve(
+      entryLocation: _existingDive?.entryLocation,
+      exitLocation: _existingDive?.exitLocation,
+      site: _selectedSite,
+    );
+    if (!mounted) return;
+
+    final writeBack = resolution.siteWriteBack;
+    if (writeBack != null) {
+      await ref.read(siteListNotifierProvider.notifier).updateSite(writeBack);
+      if (!mounted) return;
+      if (_selectedSite?.id == writeBack.id) {
+        _selectedSite = writeBack;
+      }
+    }
+
+    final meters = resolution.altitudeMeters;
+    if (meters == null || _altitudeController.text.isNotEmpty) return;
+    final units = UnitFormatter(ref.read(settingsProvider));
+    setState(() {
+      _silently(() {
+        _altitudeController.text = units
+            .convertAltitude(meters)
+            .toStringAsFixed(0);
+      });
+    });
+  }
+```
+
+3. Hook: end of `_loadExistingDive`, inside the existing `finally` block (line ~695), after `_suppressDirty = false;`:
+
+```dart
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+        _suppressDirty = false;
+        unawaited(_maybeAutoFillAltitude());
+      }
+    }
+```
+
+4. Hook: end of `_assignSite` (line ~1974) — covers the site picker, new-site creation, and new-dive prefill:
+
+```dart
+  void _assignSite(DiveSite? site) {
+    _selectedSite = site;
+    _waterType = waterTypeAfterSiteAssign(_waterType, site);
+    unawaited(_maybeAutoFillAltitude());
+  }
+```
+
+5. Hook: in `_fetchWeather`, at the end of the success `setState` path (right after the `_weatherFetchedAt = DateTime.now();` state update block, before the success snackbar):
+
+```dart
+      unawaited(_maybeAutoFillAltitude());
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Run the neighboring edit page suites**
+
+Run: `flutter test test/features/dive_log/presentation/pages/ test/helpers/`
+Expected: PASS — if any test fails on an unexpected HTTP override, it means it constructed `getBaseOverrides` differently; fix by threading the new parameter, never by removing the default stub.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib test
+git commit -m "Auto-fill dive altitude from logged GPS or site on the edit form"
+```
+
+---
+
+### Task 5: Altitude on the add-GPS-to-site action
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (`_updateSiteWithPhotoGps`, line ~1946)
+
+**Interfaces:**
+- Consumes: `elevationServiceProvider` (Task 1), existing `_updateSiteWithPhotoGps`.
+- Produces: no new API; behavior only.
+
+- [ ] **Step 1: Extend `_updateSiteWithPhotoGps`**
+
+Replace the beginning of the method so the site update carries altitude when the site has none:
+
+```dart
+  Future<void> _updateSiteWithPhotoGps(GeoPoint gps) async {
+    if (_selectedSite == null) return;
+
+    var updatedSite = _selectedSite!.copyWith(location: gps);
+    if (updatedSite.altitude == null) {
+      final meters = await ref
+          .read(elevationServiceProvider)
+          .fetchElevation(latitude: gps.latitude, longitude: gps.longitude);
+      if (!mounted) return;
+      if (meters != null) {
+        updatedSite = updatedSite.copyWith(altitude: meters);
+      }
+    }
+
+    // Update the site via the notifier
+    final siteNotifier = ref.read(siteListNotifierProvider.notifier);
+    await siteNotifier.updateSite(updatedSite);
+```
+
+The rest of the method (setState, snackbar) is unchanged.
+
+- [ ] **Step 2: Run the existing suites that exercise this page**
+
+Run: `flutter test test/features/dive_log/presentation/pages/`
+Expected: PASS — the Task 4 harness stub makes the lookup resolve null in tests, so existing photo-GPS behavior is unchanged there. This path's altitude behavior is covered by the Task 1/2 unit tests plus manual verification in Task 8.
+
+- [ ] **Step 3: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib
+git commit -m "Fill site altitude when attaching photo GPS to a site"
+```
+
+---
+
+### Task 6: Site edit page altitude auto-fill
+
+**Files:**
+- Modify: `lib/features/dive_sites/presentation/pages/site_edit_page.dart`
+- Test: `test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `elevationServiceProvider` (Task 1), existing page members: `_latitudeController`, `_longitudeController`, `_altitudeController` (line ~81), `_isApplyingInitialValues`, `_seedInitialLocation` (line ~141), `settingsProvider`, `UnitFormatter`.
+- Produces: no new API; behavior only. Coordinate changes (typed, locate action, map pick — all flow through the controllers) trigger a debounced elevation lookup that fills an empty altitude field.
+
+- [ ] **Step 1: Write the failing widget test**
+
+Create `test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart`. Model the pump harness on an existing site edit test in `test/features/dive_sites/presentation/pages/` (use the same overrides scaffolding it uses, plus `getBaseOverrides(weatherHttpClient: ...)` from Task 4):
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  testWidgets('typing coordinates fills an empty altitude field', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final base = await getBaseOverrides(
+      weatherHttpClient: MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'elevation': [740.2],
+          }),
+          200,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: base.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const SiteEditPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Expand the location group if it is collapsed, then type coordinates.
+    final latField = find.widgetWithText(TextField, 'Latitude');
+    await tester.ensureVisible(latField);
+    await tester.enterText(latField, '46.4');
+    final lngField = find.widgetWithText(TextField, 'Longitude');
+    await tester.enterText(lngField, '8.0');
+
+    // Let the 1-second debounce elapse, then the async lookup complete.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextField, '740'), findsOneWidget);
+  });
+}
+```
+
+Notes for the implementer:
+- `const SiteEditPage()` is valid — `siteId` is optional (new-site mode).
+- The rendered labels are exactly "Latitude" and "Longitude" (`diveSites_edit_gps_latitude_label` / `diveSites_edit_gps_longitude_label`). If the Location group starts collapsed, tap its header (the `diveSites_edit_group_location` string) before entering text.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart`
+Expected: FAIL on the final expect — altitude stays empty.
+
+- [ ] **Step 3: Implement the debounced lookup**
+
+In `site_edit_page.dart`:
+
+1. Add imports: `dart:async`, `package:submersion/features/weather/presentation/providers/weather_providers.dart`.
+
+2. Add state and methods to the state class:
+
+```dart
+  Timer? _altitudeLookupDebounce;
+
+  /// Debounce typed coordinate edits; locate and map-pick set both controller
+  /// texts at once and land here through the same listeners.
+  void _scheduleAltitudeLookup() {
+    if (_isApplyingInitialValues) return;
+    _altitudeLookupDebounce?.cancel();
+    _altitudeLookupDebounce = Timer(const Duration(seconds: 1), () {
+      if (mounted) _maybeFetchAltitude();
+    });
+  }
+
+  Future<void> _maybeFetchAltitude() async {
+    if (_altitudeController.text.isNotEmpty) return;
+    final lat = double.tryParse(_latitudeController.text.trim());
+    final lng = double.tryParse(_longitudeController.text.trim());
+    if (lat == null || lng == null) return;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return;
+
+    final meters = await ref
+        .read(elevationServiceProvider)
+        .fetchElevation(latitude: lat, longitude: lng);
+    if (!mounted || meters == null) return;
+    if (_altitudeController.text.isNotEmpty) return;
+
+    final units = UnitFormatter(ref.read(settingsProvider));
+    setState(() {
+      _altitudeController.text = units
+          .convertAltitude(meters)
+          .toStringAsFixed(0);
+    });
+  }
+```
+
+If the page obtains `UnitFormatter` differently (check how `_populateFields` gets its `units` at line ~200), match that pattern instead.
+
+3. In `initState` (line ~104), after the existing listener registrations:
+
+```dart
+    _latitudeController.addListener(_scheduleAltitudeLookup);
+    _longitudeController.addListener(_scheduleAltitudeLookup);
+```
+
+4. At the end of `_seedInitialLocation` (line ~141), after `_isApplyingInitialValues = false;` (seeding a new site from a dive's GPS must also fill altitude — the guard suppressed the listener):
+
+```dart
+    _scheduleAltitudeLookup();
+```
+
+5. In `dispose`, before the controller disposals:
+
+```dart
+    _altitudeLookupDebounce?.cancel();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing site edit suites**
+
+Run: `flutter test test/features/dive_sites/`
+Expected: PASS. Pending-timer failures in existing tests mean the debounce timer leaked — verify the `dispose` cancellation was added.
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib test
+git commit -m "Auto-fill site altitude when coordinates are set on the site form"
+```
+
+---
+
+### Task 7: DiveAltitudeEnricher on the import and download seams
+
+**Files:**
+- Create: `lib/features/dive_log/domain/services/dive_altitude_enricher.dart`
+- Modify: `lib/features/dive_import/presentation/providers/dive_import_providers.dart` (`performImport`, line ~339)
+- Modify: `lib/features/dive_import/data/services/uddf_entity_importer.dart` (line ~1332)
+- Modify: `lib/features/import_wizard/data/adapters/healthkit_adapter.dart` (line ~273)
+- Modify: `lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart` (`importProfile`, after the `ChecklistDiveLinker` call at line ~987)
+- Test: `test/features/dive_log/domain/services/dive_altitude_enricher_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `AltitudeResolver` (Task 2), `ElevationService` (Task 1), `DiveRepository` (`getDiveById(String)`, `updateDive(Dive)`, `createDive(Dive)`), `SiteRepository.updateSite(DiveSite)`, `Dive.copyWith(altitude:)`, `DatabaseService.instance.databaseOrNull`, `GeoPoint`.
+- Produces:
+  - `class DiveAltitudeEnricher { DiveAltitudeEnricher({ElevationService? elevationService, DiveRepository? diveRepository, SiteRepository? siteRepository}); Future<bool> applyForImportedDive(Dive dive); Future<bool> applyForDownloadedDive({required String diveId, required List<GeoPoint> points}); }`
+  - One instance per import run (holds the coordinate cache). Both methods are best-effort: any thrown error returns false and never aborts an import.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/domain/services/dive_altitude_enricher_test.dart`. Follow the test-database pattern from `dive_edit_site_gps_test.dart` (`setUpTestDatabase`/`tearDownTestDatabase`, real `DiveRepository`):
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive(String id, {GeoPoint? entryLocation, double? altitude}) =>
+      Dive(
+        id: id,
+        diveNumber: 1,
+        dateTime: DateTime(2026, 3, 28, 10, 0),
+        entryLocation: entryLocation,
+        altitude: altitude,
+        tanks: const [],
+        profile: const [],
+        equipment: const [],
+        notes: '',
+        photoIds: const [],
+        sightings: const [],
+        weights: const [],
+        tags: const [],
+      );
+
+  ElevationService countingService(List<Uri> requests) => ElevationService(
+    client: MockClient((request) async {
+      requests.add(request.url);
+      return http.Response(
+        jsonEncode({
+          'elevation': [740.2],
+        }),
+        200,
+      );
+    }),
+  );
+
+  test('fills altitude for an imported dive with GPS', () async {
+    final dive = await repository.createDive(
+      buildDive('d1', entryLocation: const GeoPoint(46.4, 8.0)),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isTrue);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('skips dives that already have altitude', () async {
+    final requests = <Uri>[];
+    final dive = await repository.createDive(
+      buildDive('d2', entryLocation: const GeoPoint(46.4, 8.0), altitude: 500),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    expect(requests, isEmpty);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 500.0);
+  });
+
+  test('skips dives with no GPS and no site', () async {
+    final requests = <Uri>[];
+    final dive = await repository.createDive(buildDive('d3'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    expect(requests, isEmpty);
+  });
+
+  test('one lookup covers a batch at the same location', () async {
+    final requests = <Uri>[];
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    for (var i = 0; i < 3; i++) {
+      final dive = await repository.createDive(
+        buildDive('batch-$i', entryLocation: const GeoPoint(46.4, 8.0)),
+      );
+      await enricher.applyForImportedDive(dive);
+    }
+
+    expect(requests, hasLength(1));
+    final stored = await repository.getDiveById('batch-2');
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('lookup failure leaves the dive importable and unchanged', () async {
+    final dive = await repository.createDive(
+      buildDive('d4', entryLocation: const GeoPoint(46.4, 8.0)),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: ElevationService(
+        client: MockClient((_) async => http.Response('oops', 500)),
+      ),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, isNull);
+  });
+
+  test('fills a downloaded dive from its GPS points', () async {
+    final dive = await repository.createDive(buildDive('d5'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForDownloadedDive(
+      diveId: dive.id,
+      points: const [GeoPoint(46.4, 8.0)],
+    );
+
+    expect(applied, isTrue);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('downloaded dive with no points is a no-op', () async {
+    final dive = await repository.createDive(buildDive('d6'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForDownloadedDive(
+      diveId: dive.id,
+      points: const [],
+    );
+
+    expect(applied, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/domain/services/dive_altitude_enricher_test.dart`
+Expected: FAIL — `dive_altitude_enricher.dart` does not exist (compile error).
+
+- [ ] **Step 3: Write the enricher**
+
+Create `lib/features/dive_log/domain/services/dive_altitude_enricher.dart`:
+
+```dart
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+import 'package:submersion/features/weather/domain/services/altitude_resolver.dart';
+
+/// Fills a newly imported or downloaded dive's altitude from its GPS fixes
+/// or linked site. Best-effort like [DiveEquipmentDefaulter]: any failure is
+/// swallowed so enrichment can never abort an import that has already
+/// persisted the dive. Create ONE instance per import run — the resolver
+/// cache dedupes lookups for a batch of dives at the same location.
+class DiveAltitudeEnricher {
+  DiveAltitudeEnricher({
+    ElevationService? elevationService,
+    DiveRepository? diveRepository,
+    SiteRepository? siteRepository,
+  }) : _resolver = AltitudeResolver(
+         elevationService: elevationService ?? ElevationService(),
+         cache: <String, double?>{},
+       ),
+       _dives = diveRepository ?? DiveRepository(),
+       _sites = siteRepository ?? SiteRepository();
+
+  final AltitudeResolver _resolver;
+  final DiveRepository _dives;
+  final SiteRepository _sites;
+
+  /// Enrich a file-imported dive (domain entity in hand). Returns true when
+  /// an altitude was written.
+  Future<bool> applyForImportedDive(Dive dive) async {
+    if (dive.altitude != null) return false;
+    if (DatabaseService.instance.databaseOrNull == null) return false;
+    try {
+      final resolution = await _resolver.resolve(
+        entryLocation: dive.entryLocation,
+        exitLocation: dive.exitLocation,
+        site: dive.site,
+      );
+      final writeBack = resolution.siteWriteBack;
+      if (writeBack != null) {
+        await _sites.updateSite(writeBack);
+      }
+      final meters = resolution.altitudeMeters;
+      if (meters == null) return false;
+      await _dives.updateDive(dive.copyWith(altitude: meters));
+      return true;
+    } catch (_) {
+      // Best-effort: never let altitude enrichment fail the dive operation.
+      return false;
+    }
+  }
+
+  /// Enrich a dive persisted by the dive computer download path, where only
+  /// the id and the entry/exit GPS fixes are in hand.
+  Future<bool> applyForDownloadedDive({
+    required String diveId,
+    required List<GeoPoint> points,
+  }) async {
+    if (points.isEmpty) return false;
+    if (DatabaseService.instance.databaseOrNull == null) return false;
+    try {
+      final resolution = await _resolver.resolve(entryLocation: points.first);
+      final meters = resolution.altitudeMeters;
+      if (meters == null) return false;
+      final dive = await _dives.getDiveById(diveId);
+      if (dive == null || dive.altitude != null) return false;
+      await _dives.updateDive(dive.copyWith(altitude: meters));
+      return true;
+    } catch (_) {
+      // Best-effort: never let altitude enrichment fail the dive operation.
+      return false;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/domain/services/dive_altitude_enricher_test.dart`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Wire the four call sites**
+
+Each site mirrors the existing `DiveEquipmentDefaulter` / `ChecklistDiveLinker` pattern. Add the import `package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart` to each file.
+
+a) `lib/features/dive_import/presentation/providers/dive_import_providers.dart`, `performImport` (line ~339): hoist one instance before the `for` loop and call it after the existing linkers:
+
+```dart
+    try {
+      final altitudeEnricher = DiveAltitudeEnricher();
+      for (final sourceId in state.selectedDiveIds) {
+```
+
+```dart
+        await repository.createDive(dive);
+        await DiveEquipmentDefaulter().applyForImportedDive(dive);
+        await ChecklistDiveLinker().applyForImportedDive(dive);
+        await altitudeEnricher.applyForImportedDive(dive);
+        imported++;
+```
+
+b) `lib/features/dive_import/data/services/uddf_entity_importer.dart` (line ~1332): find the enclosing dive `for` loop above the existing `await repos.diveRepository.createDive(dive);` block, declare `final altitudeEnricher = DiveAltitudeEnricher();` immediately before that loop, and extend the call block:
+
+```dart
+      await repos.diveRepository.createDive(dive);
+      await DiveEquipmentDefaulter().applyForImportedDive(dive);
+      await ChecklistDiveLinker().applyForImportedDive(dive);
+      await altitudeEnricher.applyForImportedDive(dive);
+```
+
+c) `lib/features/import_wizard/data/adapters/healthkit_adapter.dart` (line ~273): declare `final altitudeEnricher = DiveAltitudeEnricher();` immediately before the `for (var i = 0; i < sortedIndices.length; i++)` loop and extend the call block the same way:
+
+```dart
+      await _diveRepository.createDive(dive);
+      await DiveEquipmentDefaulter().applyForImportedDive(dive);
+      await ChecklistDiveLinker().applyForImportedDive(dive);
+      await altitudeEnricher.applyForImportedDive(dive);
+```
+
+d) `lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart`, inside `importProfile` after the `ChecklistDiveLinker().autoLinkForDive(...)` call (line ~987), reusing the `defaultPoints` list already built at line ~973:
+
+```dart
+        // Fill altitude from the entry/exit GPS fixes (best-effort).
+        await DiveAltitudeEnricher().applyForDownloadedDive(
+          diveId: diveId,
+          points: defaultPoints,
+        );
+```
+
+Note on (d): `importProfile` is called once per dive, so a per-call enricher gets no cross-dive cache there. That is acceptable — downloads arrive one at a time through this seam and the lookup is one cheap GET; do NOT try to thread an instance through the repository constructor.
+
+- [ ] **Step 6: Run the surrounding suites**
+
+Run: `flutter test test/features/dive_import/ test/features/import_wizard/ test/features/dive_log/data/`
+Expected: PASS. In the Flutter test binding, any un-mocked HTTP call returns an immediate 400, so the default-constructed enrichers resolve null quickly without network flakiness.
+
+- [ ] **Step 7: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib test
+git commit -m "Enrich imported and downloaded dives with altitude from GPS"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:**
+- No new files; fixes only if verification fails.
+
+- [ ] **Step 1: Format and analyze the whole project**
+
+```bash
+dart format .
+flutter analyze
+```
+
+Expected: no formatting changes, zero analyzer issues (infos are fatal in CI). Never pipe either command through `| tail`.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `flutter test`
+Expected: PASS. Known pre-existing flakes (per project memory): backup tests and recovery-code yo-yo tests can flake in the full run — re-run a failing file in isolation before assuming this change broke it. Budget 15+ minutes; do not kill the run early.
+
+- [ ] **Step 3: Manual smoke test on macOS (optional but recommended)**
+
+```bash
+flutter run -d macos
+```
+
+- Open a dive with a site that has coordinates: Conditions section shows the Auto-fill overline with the Fetch weather button at the very top; Weather overline below has no button.
+- Fetch weather: air temp fills; snackbar appears.
+- Assign a site with coordinates but no altitude to a dive with no altitude: altitude fills within a second or two; reopen the site in the site editor and confirm its altitude field was written back.
+- Site edit: type coordinates into a new site; altitude fills after about a second.
+
+- [ ] **Step 4: Commit any verification fixes**
+
+```bash
+git add -A
+git commit -m "Fix issues found during full-suite verification"
+```
+
+Only commit if fixes were needed; otherwise the branch is complete and ready for PR (PR descriptions carry no attribution lines or session links per CLAUDE.md).

--- a/docs/superpowers/specs/2026-08-05-adaptive-profile-legend-design.md
+++ b/docs/superpowers/specs/2026-08-05-adaptive-profile-legend-design.md
@@ -1,0 +1,97 @@
+# Adaptive Dive Profile Legend Row - Design
+
+Date: 2026-08-05
+Status: Approved
+
+## Problem
+
+The legend row above the dive profile chart (`lib/features/dive_log/presentation/widgets/dive_profile_legend.dart`) shows at most three toggles inline (Temperature, single-tank Pressure, Events) plus a "More" popover holding roughly 25 additional toggles. On wide layouts (desktop, tablet landscape, fullscreen profile) most of the row is empty while useful toggles hide behind the popover. On narrow layouts the current `Wrap` can flow to a second line, making the legend taller.
+
+## Goal
+
+Fill the available legend width with as many toggles as fit, on exactly one line, never wrapping. Toggles that do not fit remain reachable through the existing popover.
+
+## Decisions
+
+- Selection priority: active (checked) toggles claim inline space first; remaining width is filled with inactive toggles. Both groups are ordered internally by a canonical priority list.
+- Display order: the visible row always renders in canonical priority order, regardless of active state, so checking or unchecking an item never makes it change position.
+- Rich popover items (NDL, TTS, CNS, Deco Stops with DC/Calc source selectors; per-tank pressure toggles) are eligible for promotion but render inline as plain checkbox + swatch + label. Source selectors remain popover-only. Per-tank toggles promote individually with their tank label.
+- The popover becomes the complete catalog: Temperature, Pressure, and Events are added to its Overlays section so every toggle stays reachable even when the row is too narrow to show any of them inline.
+- The More button badge counts active toggles that are not currently visible inline (previously: all active secondary toggles).
+- Inline selection is derived from available width on every build. No persistence; resizing reflows immediately.
+
+## Canonical priority order
+
+Existence-gated (a toggle only competes if its data exists for the dive):
+
+1. Temperature
+2. Pressure (single tank) or per-tank pressure toggles in tank order (multi-tank)
+3. Events
+4. Ceiling
+5. Deco Stops
+6. NDL
+7. Gas Switches
+8. SAC
+9. Heart Rate
+10. Ascent rate colors
+11. Ascent rate line
+12. Max depth marker
+13. TTS
+14. CNS
+15. Mean depth
+16. GF
+17. Surface GF
+18. ppO2
+19. ppN2
+20. ppHe
+21. MOD
+22. Gas density
+23. OTU
+24. Pressure thresholds
+25. Photo markers
+26. Gas timeline
+
+Ranking rationale comes from the tech-diving domain skill: temperature, pressure, events, deco ceiling, and gas switches are the profile essentials; deco metrics matter to technical divers (and only appear when the data exists); per-gas partial pressures and density are deep-analysis tools.
+
+## Architecture
+
+All changes live in the dive_log feature; no provider, database, or l10n changes.
+
+### Components
+
+1. `_LegendCandidate` (private model in `dive_profile_legend.dart`): `id`, localized `label`, `color`, `isActive`, `onTap`, `priority`. A builder function derives the candidate list from `ProfileLegendConfig` + `ProfileLegendState`.
+2. Width measurement: `TextPainter` measures each label at `labelSmall` with `MediaQuery.textScalerOf(context)`. Item width = fixed chrome (checkbox icon 14 + swatch 10 + internal gaps + tap padding + wrap spacing) + measured label width. The chrome constant is declared adjacent to `_buildMetricToggle` with a comment binding the two; a few pixels of safety margin absorb drift.
+3. Greedy fit: inside the existing `Expanded`, a `LayoutBuilder` provides `maxWidth`. Budget = `maxWidth` minus the always-shown Depth label width, the More button width (32), and the safety margin. Candidates sorted active-first-then-priority are admitted while their cumulative width fits. Admitted candidates render in canonical priority order in a `Row` (replacing the current `Wrap`), followed by the More button.
+4. Popover (`_ChartOptionsDialog`): gains Temperature, Pressure (single-tank), and Events entries at the top of the Overlays section, reusing existing l10n labels and toggle callbacks. Otherwise unchanged.
+5. Badge: computed as active candidates minus those currently admitted inline. The admitted set is computed in the legend build and passed to `_MoreOptionsButton`.
+
+### File organization
+
+`dive_profile_legend.dart` is at 1,167 lines, above the 800-line cap. As part of this work, `_ChartOptionsDialog` (and its helpers) moves to a new `chart_options_dialog.dart` in the same directory. The legend file keeps the row, candidate selection, and zoom controls.
+
+### Scope
+
+`DiveProfileLegend` has one consumer, `dive_profile_chart.dart`, so the dive detail page and fullscreen profile page both pick up the behavior automatically. The comparison chart and planner legends are out of scope.
+
+## Constraints
+
+- Promoted inline toggles must remain visually homogeneous (checkbox + swatch + label built by `_buildMetricToggle`). The analytic width formula depends on this; heterogeneous inline children would require a dry-layout render object instead. In particular, the gas timeline toggle keeps its four-bar swatch only in the popover; inline it renders with the standard single-color swatch.
+- The row must never exceed one line height at any width or text scale.
+
+## Error handling
+
+No I/O or async paths. The only failure mode is measurement drift causing horizontal overflow; the safety margin plus a `Row` (which clips rather than wraps) bounds the blast radius, and widget tests assert no overflow at multiple widths and text scales.
+
+## Testing (TDD)
+
+Widget tests in the existing legend test file, written before implementation:
+
+- Narrow (~360 px): only highest-priority items fit; row height equals one line; no overflow errors.
+- Wide (~1200 px): inactive fillers appear beyond the active set.
+- Eviction: an active low-priority toggle wins space over an inactive high-priority one.
+- Order: visible toggles render in canonical order even when activation order differs.
+- Popover completeness: Temperature, Pressure, and Events entries appear in the popover.
+- Badge: equals the count of active toggles not visible inline.
+- Accessibility: large `textScaler` still yields a single line with fewer items admitted.
+
+Run `dart format .` and `flutter analyze` before completion.

--- a/docs/superpowers/specs/2026-08-06-conditions-weather-altitude-design.md
+++ b/docs/superpowers/specs/2026-08-06-conditions-weather-altitude-design.md
@@ -1,0 +1,156 @@
+# Conditions Section: Weather Fetch Placement and Altitude Auto-Fill
+
+**Date:** 2026-08-06
+**Status:** Approved
+
+## Problem
+
+Two related ergonomics problems in the dive edit form's Conditions section:
+
+1. The "Fetch weather" action sits at the Weather subsection overline, halfway
+   down the section, even though the fetch fills fields above it (air
+   temperature) as well as below it (humidity, wind, surface pressure, cloud
+   cover, precipitation, description).
+2. Altitude is a manual text field even though the app frequently knows where
+   the dive happened: the dive's own logged entry/exit GPS coordinates, the
+   selected site's stored `altitude`, or the site's coordinates.
+
+## Scope
+
+- Reorder rows within the Conditions section of the dive edit page.
+- Add an elevation lookup service and an altitude resolution rule.
+- Auto-fill altitude at four trigger points (site edit, add-GPS-to-site, dive
+  edit form, import paths).
+- No database schema change. No changes to the dive detail page, bulk edit, or
+  statistics.
+
+## 1. Conditions section layout
+
+New row order inside `ConditionsSection`
+(`lib/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart`,
+rows built in `dive_edit_page.dart`):
+
+1. **Auto-fill overline** (new, first row): a `FormOverline` carrying the
+   existing "Fetch weather" `FormOverlineAction`. Same enablement (selected
+   site has coordinates), same busy spinner, same confirm-before-overwrite
+   dialog, same snackbars. Only the position changes. The overline label is a
+   new l10n string ("Auto-fill"), translated to all 10 non-English locales.
+2. Water temperature, air temperature (unchanged).
+3. Environment rows, unchanged order: dive types, visibility, water type,
+   current direction, current strength, swell height, altitude (with its
+   existing deco warning), entry method, exit method.
+4. **"Weather" overline without the action button**, followed by the weather
+   rows unchanged: humidity, wind speed, wind direction, surface pressure,
+   cloud cover, precipitation, description.
+
+Behavior addition to the fetch action: after the weather fetch completes, if
+the altitude field is still empty, run the altitude resolver (section 3). This
+gives users a manual retry path when the automatic fill failed offline.
+
+## 2. ElevationService
+
+New file `lib/features/weather/data/services/elevation_service.dart`,
+mirroring `WeatherService`:
+
+- Injectable `http.Client` constructor parameter.
+- Calls Open-Meteo's elevation API: `https://api.open-meteo.com/v1/elevation`
+  with `latitude`/`longitude` query parameters; the response is
+  `{"elevation": [<double>]}`.
+- `Future<double?> fetchElevation({required double latitude, required double longitude})`
+  returns meters above sea level, or null on any failure (network, non-200,
+  malformed body). Never throws.
+- Result post-processing: clamp negative values to 0, round to the nearest
+  whole meter. A result of 0 is a valid value (sea level) and is stored.
+- Requests use a short timeout (5 seconds) so callers never hang on it.
+
+Provider `elevationServiceProvider` added to
+`lib/features/weather/presentation/providers/weather_providers.dart` beside
+`weatherServiceProvider`, watching the existing `weatherHttpClientProvider`.
+
+## 3. Altitude resolution rule
+
+A shared domain helper (new file
+`lib/features/weather/domain/services/altitude_resolver.dart`) encodes one
+precedence rule used by every trigger
+point. Given the dive's entry/exit locations and the selected site:
+
+1. **Dive's logged GPS** (entry location, else exit location): call the
+   elevation API. The dive's own position is ground truth for this dive.
+2. **Site's stored altitude** (`DiveSite.altitude`): use directly. This is
+   also the fallback when step 1's lookup fails.
+3. **Site's coordinates**: call the elevation API, and **write the result back
+   to the site record** via the site repository so step 2 resolves locally for
+   every future dive at that site.
+4. Nothing available or all lookups failed: leave the field empty; manual
+   entry works exactly as today.
+
+Invariants:
+
+- Auto-fill only ever writes to an **empty** altitude field. A manually
+  entered value is never overwritten.
+- The resolver returns the altitude in meters plus whether a site write-back
+  is needed; callers decide how to apply it (controller text vs. entity
+  field).
+
+## 4. Trigger points
+
+1. **Site edit page** (`site_edit_page.dart` / `location_section.dart`): when
+   the coordinate fields become valid — typed, filled by the locate action, or
+   set from the map picker — and the altitude field is empty, fetch elevation
+   and fill the altitude controller. The value is visible and editable before
+   the user saves. If the lookup fails, nothing happens.
+2. **Dive edit "Add GPS to site" action** (`dive_edit_page.dart`,
+   `_addGpsToSite` path): after setting the site's coordinates, fetch
+   elevation and include the altitude in the same site update when the site's
+   altitude is null.
+3. **Dive edit form**: on load of an existing or new dive, and again on site
+   assignment (`_assignSite`), if the altitude controller is empty, run the
+   resolver and fill the controller. This fill alone does not mark the form
+   dirty — opening and closing a dive must not prompt "discard changes?". The
+   value persists only when the user saves. Site write-back from step 3 of the
+   resolver does happen immediately (it is a normal site edit, not part of the
+   dive form's dirty state).
+4. **Import paths**: dive computer downloads
+   (`lib/features/dive_computer/data/services/dive_import_service.dart`) and
+   file imports (persistence path used by
+   `lib/features/dive_import/presentation/providers/dive_import_providers.dart`)
+   run a best-effort enrichment for newly created dives that have GPS
+   coordinates and null altitude. A per-run cache keyed by rounded coordinates
+   (4 decimal places, roughly 11 m) ensures a batch of dives at one location
+   triggers one lookup. Lookups never block or fail the import; on timeout or
+   error the dive imports with null altitude.
+
+## 5. Data, sync, and error handling
+
+- No schema change: `dives.altitude` and `dive_sites.altitude` already exist.
+- The site write-back is a normal repository update; HLC bumps and the change
+  syncs like any user edit.
+- All background lookups are silent best-effort: no snackbars, no retry
+  queues, no persisted error state. The existing fetch-weather snackbars
+  (success, unavailable, error) are unchanged.
+- Unit display: the altitude field continues to use
+  `UnitFormatter.convertAltitude` / `altitudeToMeters`; the resolver operates
+  in meters internally.
+
+## 6. Testing
+
+- `ElevationService` unit tests with a mocked `http.Client`: success, non-200,
+  malformed body, timeout, negative clamp, rounding.
+- Resolver unit tests covering all four precedence branches, the
+  lookup-failure fallback from step 1 to step 2, and the write-back signal.
+- Widget test for the Conditions section row order: auto-fill overline first,
+  fetch action present there and absent from the Weather overline.
+- Dive edit page tests: auto-fill on load fills an empty controller, does not
+  overwrite a populated one, and does not mark the form dirty.
+- Import enrichment test with a mocked service verifying the coordinate cache
+  (N dives at one location, one lookup) and that lookup failure still imports
+  the dive.
+- Known trap: `dive_edit_page.dart` gains a dependency on
+  `elevationServiceProvider`; existing consumer widget tests need the mock
+  wired in the same change (analyzer will not catch this).
+
+## Out of scope
+
+- Backfilling altitude for existing dives (no background maintenance job).
+- Elevation from the weather API's grid-cell elevation field.
+- Any change to deco/altitude warning calculations.

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -3,6 +3,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart'
     show DiveDataSourcesCompanion, DiveSitesCompanion, DivesCompanion;
 import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
 import 'package:submersion/features/equipment/data/services/dive_equipment_defaulter.dart';
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/core/services/location_service.dart';
@@ -1082,6 +1083,10 @@ class UddfEntityImporter {
         ? null
         : await repos.diveRepository.getNextDiveNumber(diverId: diverId);
 
+    // One instance for the run: its lookup cache collapses a batch of dives
+    // at the same location into a single elevation request.
+    final altitudeEnricher = DiveAltitudeEnricher();
+
     for (final i in sortedSelected) {
       if (cancelToken?.isCancelled ?? false) break;
 
@@ -1331,6 +1336,7 @@ class UddfEntityImporter {
       await repos.diveRepository.createDive(dive);
       await DiveEquipmentDefaulter().applyForImportedDive(dive);
       await ChecklistDiveLinker().applyForImportedDive(dive);
+      await altitudeEnricher.applyForImportedDive(dive);
       importedDiveIds.add(diveId);
       diveIdByIndex[i] = diveId;
 

--- a/lib/features/dive_import/presentation/providers/dive_import_providers.dart
+++ b/lib/features/dive_import/presentation/providers/dive_import_providers.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
 import 'package:submersion/features/equipment/data/services/dive_equipment_defaulter.dart';
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/features/dive_import/data/services/fit_parser_service.dart';
@@ -347,6 +348,9 @@ class DiveImportNotifier extends StateNotifier<DiveImportState> {
     var skipped = 0;
 
     try {
+      // One instance for the run: its lookup cache collapses a batch of dives
+      // at the same location into a single elevation request.
+      final altitudeEnricher = DiveAltitudeEnricher();
       for (final sourceId in state.selectedDiveIds) {
         final iDive = state.getDiveById(sourceId);
         if (iDive == null) continue;
@@ -383,6 +387,7 @@ class DiveImportNotifier extends StateNotifier<DiveImportState> {
         await repository.createDive(dive);
         await DiveEquipmentDefaulter().applyForImportedDive(dive);
         await ChecklistDiveLinker().applyForImportedDive(dive);
+        await altitudeEnricher.applyForImportedDive(dive);
         imported++;
       }
 

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -21,6 +21,7 @@ import 'package:submersion/core/matching/match_scorer.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     show GeoPoint;
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
 import 'package:submersion/features/equipment/data/services/dive_equipment_defaulter.dart';
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -988,6 +989,12 @@ class DiveComputerRepository {
           diveId: diveId,
           diverId: diverId,
           diveStart: DateTime.fromMillisecondsSinceEpoch(entryTimeMs),
+        );
+
+        // Fill altitude from the entry/exit GPS fixes (best-effort).
+        await DiveAltitudeEnricher().applyForDownloadedDive(
+          diveId: diveId,
+          points: defaultPoints,
         );
 
         // Create a data source record for provenance tracking.

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -32,10 +32,18 @@ import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
 
 /// Repository for managing dive computers and multi-profile support.
 class DiveComputerRepository {
+  DiveComputerRepository({DiveAltitudeEnricher? altitudeEnricher})
+    : _altitudeEnricher = altitudeEnricher ?? DiveAltitudeEnricher();
+
   AppDatabase get _db => DatabaseService.instance.database;
   final SyncRepository _syncRepository = SyncRepository();
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(DiveComputerRepository);
+
+  /// Held for the repository's lifetime so a multi-dive download shares one
+  /// elevation-lookup cache: a trip's worth of dives at the same site costs a
+  /// single request (and a single failure) instead of one per dive.
+  final DiveAltitudeEnricher _altitudeEnricher;
 
   // ============================================================================
   // CRUD Operations for Dive Computers
@@ -991,8 +999,10 @@ class DiveComputerRepository {
           diveStart: DateTime.fromMillisecondsSinceEpoch(entryTimeMs),
         );
 
-        // Fill altitude from the entry/exit GPS fixes (best-effort).
-        await DiveAltitudeEnricher().applyForDownloadedDive(
+        // Fill altitude from the entry/exit GPS fixes (best-effort). Awaited
+        // rather than fire-and-forget so the write cannot outlive the download
+        // and race a database close; the shared cache keeps the cost bounded.
+        await _altitudeEnricher.applyForDownloadedDive(
           diveId: diveId,
           points: defaultPoints,
         );

--- a/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
+++ b/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
@@ -1,0 +1,76 @@
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+import 'package:submersion/features/weather/domain/services/altitude_resolver.dart';
+
+/// Fills a newly imported or downloaded dive's altitude from its GPS fixes
+/// or linked site. Best-effort like `DiveEquipmentDefaulter`: any failure is
+/// swallowed so enrichment can never abort an import that has already
+/// persisted the dive. Create ONE instance per import run -- the resolver
+/// cache dedupes lookups for a batch of dives at the same location.
+class DiveAltitudeEnricher {
+  DiveAltitudeEnricher({
+    ElevationService? elevationService,
+    DiveRepository? diveRepository,
+    SiteRepository? siteRepository,
+  }) : _resolver = AltitudeResolver(
+         elevationService: elevationService ?? ElevationService(),
+         cache: <String, double?>{},
+       ),
+       _dives = diveRepository ?? DiveRepository(),
+       _sites = siteRepository ?? SiteRepository();
+
+  final AltitudeResolver _resolver;
+  final DiveRepository _dives;
+  final SiteRepository _sites;
+
+  /// Enrich a file-imported dive (domain entity in hand). Returns true when
+  /// an altitude was written.
+  Future<bool> applyForImportedDive(Dive dive) async {
+    if (dive.altitude != null) return false;
+    if (DatabaseService.instance.databaseOrNull == null) return false;
+    try {
+      final resolution = await _resolver.resolve(
+        entryLocation: dive.entryLocation,
+        exitLocation: dive.exitLocation,
+        site: dive.site,
+      );
+      final writeBack = resolution.siteWriteBack;
+      if (writeBack != null) {
+        await _sites.updateSite(writeBack);
+      }
+      final meters = resolution.altitudeMeters;
+      if (meters == null) return false;
+      await _dives.updateDive(dive.copyWith(altitude: meters));
+      return true;
+    } catch (_) {
+      // Best-effort: never let altitude enrichment fail the dive operation.
+      return false;
+    }
+  }
+
+  /// Enrich a dive persisted by the dive computer download path, where only
+  /// the id and the entry/exit GPS fixes are in hand.
+  Future<bool> applyForDownloadedDive({
+    required String diveId,
+    required List<GeoPoint> points,
+  }) async {
+    if (points.isEmpty) return false;
+    if (DatabaseService.instance.databaseOrNull == null) return false;
+    try {
+      final resolution = await _resolver.resolve(entryLocation: points.first);
+      final meters = resolution.altitudeMeters;
+      if (meters == null) return false;
+      final dive = await _dives.getDiveById(diveId);
+      if (dive == null || dive.altitude != null) return false;
+      await _dives.updateDive(dive.copyWith(altitude: meters));
+      return true;
+    } catch (_) {
+      // Best-effort: never let altitude enrichment fail the dive operation.
+      return false;
+    }
+  }
+}

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1949,7 +1949,18 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   Future<void> _updateSiteWithPhotoGps(GeoPoint gps) async {
     if (_selectedSite == null) return;
 
-    final updatedSite = _selectedSite!.copyWith(location: gps);
+    var updatedSite = _selectedSite!.copyWith(location: gps);
+    // A site gaining coordinates should also gain its altitude, so later dives
+    // there resolve locally without a lookup.
+    if (updatedSite.altitude == null) {
+      final meters = await ref
+          .read(elevationServiceProvider)
+          .fetchElevation(latitude: gps.latitude, longitude: gps.longitude);
+      if (!mounted) return;
+      if (meters != null) {
+        updatedSite = updatedSite.copyWith(altitude: meters);
+      }
+    }
 
     // Update the site via the notifier
     final siteNotifier = ref.read(siteListNotifierProvider.notifier);

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart' hide Visibility;
@@ -71,6 +72,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/ccr_settings_p
 import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_selector.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/scr_settings_panel.dart';
 import 'package:submersion/features/tides/presentation/providers/tide_providers.dart';
+import 'package:submersion/features/weather/domain/services/altitude_resolver.dart';
 import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
 import 'package:submersion/features/courses/domain/entities/course.dart';
 import 'package:submersion/features/courses/presentation/providers/course_providers.dart';
@@ -696,6 +698,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       if (mounted) {
         setState(() => _isLoading = false);
         _suppressDirty = false;
+        unawaited(_maybeAutoFillAltitude());
       }
     }
   }
@@ -1974,6 +1977,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   void _assignSite(DiveSite? site) {
     _selectedSite = site;
     _waterType = waterTypeAfterSiteAssign(_waterType, site);
+    unawaited(_maybeAutoFillAltitude());
   }
 
   Future<void> _showSitePicker() async {
@@ -3649,6 +3653,43 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     ];
   }
 
+  /// Fill an empty altitude field from the dive's logged GPS or the selected
+  /// site (spec: 2026-08-06 conditions design). Never overwrites a value and
+  /// never marks the form dirty on its own.
+  Future<void> _maybeAutoFillAltitude() async {
+    if (_altitudeController.text.isNotEmpty) return;
+
+    final resolver = AltitudeResolver(
+      elevationService: ref.read(elevationServiceProvider),
+    );
+    final resolution = await resolver.resolve(
+      entryLocation: _existingDive?.entryLocation,
+      exitLocation: _existingDive?.exitLocation,
+      site: _selectedSite,
+    );
+    if (!mounted) return;
+
+    final writeBack = resolution.siteWriteBack;
+    if (writeBack != null) {
+      await ref.read(siteListNotifierProvider.notifier).updateSite(writeBack);
+      if (!mounted) return;
+      if (_selectedSite?.id == writeBack.id) {
+        _selectedSite = writeBack;
+      }
+    }
+
+    final meters = resolution.altitudeMeters;
+    if (meters == null || _altitudeController.text.isNotEmpty) return;
+    final units = UnitFormatter(ref.read(settingsProvider));
+    setState(() {
+      _silently(() {
+        _altitudeController.text = units
+            .convertAltitude(meters)
+            .toStringAsFixed(0);
+      });
+    });
+  }
+
   /// Fetch weather data from Open-Meteo for the selected site and dive date.
   Future<void> _fetchWeather(UnitFormatter units) async {
     if (_selectedSite == null || !_selectedSite!.hasCoordinates) return;
@@ -3751,6 +3792,10 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         _weatherSource = WeatherSource.openMeteo;
         _weatherFetchedAt = DateTime.now();
       });
+
+      // Retry the altitude lookup: the on-load attempt may have failed while
+      // offline, and the user has just asked for a network fill.
+      unawaited(_maybeAutoFillAltitude());
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -3455,6 +3455,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       temperatureSymbol: units.temperatureSymbol,
       waterTempController: _waterTempController,
       airTempController: _airTempController,
+      topRows: [_autofillOverline(units)],
       environmentRows: _environmentRows(units),
       weatherRows: _weatherRows(units),
     );
@@ -3576,22 +3577,30 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     ];
   }
 
-  List<Widget> _weatherRows(UnitFormatter units) {
+  /// The section-leading auto-fill row: its action fills fields both above
+  /// (air temperature) and below it, so it cannot live at the weather
+  /// subsection overline.
+  Widget _autofillOverline(UnitFormatter units) {
     final l10n = context.l10n;
     final canFetchWeather =
         _selectedSite != null && _selectedSite!.hasCoordinates;
+    return FormOverline(
+      label: l10n.diveLog_edit_subsection_autofill,
+      actions: [
+        FormOverlineAction(
+          label: l10n.diveLog_edit_button_fetchWeather,
+          icon: Icons.cloud_download,
+          busy: _isFetchingWeather,
+          onPressed: canFetchWeather ? () => _fetchWeather(units) : null,
+        ),
+      ],
+    );
+  }
+
+  List<Widget> _weatherRows(UnitFormatter units) {
+    final l10n = context.l10n;
     return [
-      FormOverline(
-        label: l10n.diveLog_edit_subsection_weather,
-        actions: [
-          FormOverlineAction(
-            label: l10n.diveLog_edit_button_fetchWeather,
-            icon: Icons.cloud_download,
-            busy: _isFetchingWeather,
-            onPressed: canFetchWeather ? () => _fetchWeather(units) : null,
-          ),
-        ],
-      ),
+      FormOverline(label: l10n.diveLog_edit_subsection_weather),
       FormRow.text(
         label: l10n.diveLog_edit_label_humidity,
         controller: _humidityController,

--- a/lib/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart
@@ -5,9 +5,10 @@ import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/forms/form_row.dart';
 import 'package:submersion/shared/widgets/forms/form_section.dart';
 
-/// Group 3 of the dive form. Water/air temperature lead as ordinary rows
-/// (the hero strip is retired); the environment and weather row lists are
-/// page-provided and spread into the section so dividers separate rows.
+/// Group 3 of the dive form. An auto-fill action row leads, then water/air
+/// temperature as ordinary rows (the hero strip is retired); the top,
+/// environment and weather row lists are page-provided and spread into the
+/// section so dividers separate rows.
 class ConditionsSection extends StatelessWidget {
   const ConditionsSection({
     super.key,
@@ -20,6 +21,7 @@ class ConditionsSection extends StatelessWidget {
     required this.airTempController,
     required this.environmentRows,
     required this.weatherRows,
+    this.topRows = const [],
     this.errorCount = 0,
   });
 
@@ -32,6 +34,9 @@ class ConditionsSection extends StatelessWidget {
   final TextEditingController airTempController;
   final List<Widget> environmentRows;
   final List<Widget> weatherRows;
+
+  /// Rows pinned above the temperature fields (the auto-fill action overline).
+  final List<Widget> topRows;
   final int errorCount;
 
   @override
@@ -47,6 +52,7 @@ class ConditionsSection extends StatelessWidget {
       emptyInvitation: l10n.diveLog_edit_invite_conditions,
       errorCount: errorCount,
       children: [
+        ...topRows,
         FormRow.text(
           label: l10n.diveLog_edit_label_waterTemp,
           controller: waterTempController,

--- a/lib/features/dive_sites/presentation/pages/site_edit_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_edit_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -24,6 +25,7 @@ import 'package:submersion/features/dive_sites/presentation/widgets/location_pic
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/species_picker_dialog.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/forms/edit_form_scaffold.dart';
 import 'package:submersion/shared/widgets/forms/responsive_form_columns.dart';
@@ -88,6 +90,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
   bool _hasChanges = false;
   bool _isShared = false;
   bool _isApplyingInitialValues = false;
+  Timer? _altitudeLookupDebounce;
   DiveSite? _originalSite;
   List<Species> _expectedSpecies = [];
   Set<String> _originalExpectedSpeciesIds = {};
@@ -120,6 +123,8 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     _mooringNumberController.addListener(_onFieldChanged);
     _parkingInfoController.addListener(_onFieldChanged);
     _altitudeController.addListener(_onFieldChanged);
+    _latitudeController.addListener(_scheduleAltitudeLookup);
+    _longitudeController.addListener(_scheduleAltitudeLookup);
     _mergeLoadFuture = widget.isMerging ? _loadMergeData() : null;
     if (!widget.isEditing && !widget.isMerging) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -135,6 +140,43 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
     if (!_hasChanges && _isInitialized) {
       setState(() => _hasChanges = true);
     }
+  }
+
+  /// Debounce typed coordinate edits; the locate action and map picker set both
+  /// controller texts at once and land here through the same listeners.
+  void _scheduleAltitudeLookup() {
+    _altitudeLookupDebounce?.cancel();
+    _altitudeLookupDebounce = Timer(const Duration(seconds: 1), () {
+      if (mounted) _maybeFetchAltitude();
+    });
+  }
+
+  /// Fill an empty altitude field from the site's coordinates so altitude
+  /// diving is flagged without manual entry. Never overwrites a value.
+  Future<void> _maybeFetchAltitude() async {
+    if (_altitudeController.text.isNotEmpty) return;
+    final lat = double.tryParse(_latitudeController.text.trim());
+    final lng = double.tryParse(_longitudeController.text.trim());
+    if (lat == null || lng == null) return;
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return;
+
+    final meters = await ref
+        .read(elevationServiceProvider)
+        .fetchElevation(latitude: lat, longitude: lng);
+    if (!mounted || meters == null) return;
+    if (_altitudeController.text.isNotEmpty) return;
+
+    final units = UnitFormatter(ref.read(settingsProvider));
+    setState(() {
+      // A programmatic fill must not dirty the form on its own: opening a site
+      // that predates this feature would otherwise prompt to discard changes.
+      final wasApplying = _isApplyingInitialValues;
+      _isApplyingInitialValues = true;
+      _altitudeController.text = units
+          .convertAltitude(meters)
+          .toStringAsFixed(0);
+      _isApplyingInitialValues = wasApplying;
+    });
   }
 
   /// Seed a brand-new site form from [SiteEditPage.initialLocation]: fill the
@@ -172,6 +214,7 @@ class _SiteEditPageState extends ConsumerState<SiteEditPage> {
 
   @override
   void dispose() {
+    _altitudeLookupDebounce?.cancel();
     _nameController.dispose();
     _descriptionController.dispose();
     _countryController.dispose();

--- a/lib/features/import_wizard/data/adapters/healthkit_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/healthkit_adapter.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/domain/models/incoming_dive_data.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/data_quality/data/services/quality_scan_service.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
 import 'package:submersion/features/equipment/data/services/dive_equipment_defaulter.dart';
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
@@ -260,6 +261,10 @@ class HealthKitAdapter implements ImportSourceAdapter {
     var imported = 0;
     final importedDiveIds = <String>[];
 
+    // One instance for the run: its lookup cache collapses a batch of dives
+    // at the same location into a single elevation request.
+    final altitudeEnricher = DiveAltitudeEnricher();
+
     for (var i = 0; i < sortedIndices.length; i++) {
       if (cancelToken?.isCancelled ?? false) break;
 
@@ -272,6 +277,7 @@ class HealthKitAdapter implements ImportSourceAdapter {
       await _diveRepository.createDive(dive);
       await DiveEquipmentDefaulter().applyForImportedDive(dive);
       await ChecklistDiveLinker().applyForImportedDive(dive);
+      await altitudeEnricher.applyForImportedDive(dive);
 
       imported++;
       importedDiveIds.add(dive.id);

--- a/lib/features/weather/data/services/elevation_service.dart
+++ b/lib/features/weather/data/services/elevation_service.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:http/http.dart' as http;
+
+/// HTTP client for the Open-Meteo Elevation API.
+///
+/// Returns ground elevation in meters above sea level, or null on any
+/// failure (network, API error, malformed response). Never throws.
+class ElevationService {
+  final http.Client _client;
+
+  static const _baseUrl = 'api.open-meteo.com';
+  static const _path = '/v1/elevation';
+  static const _timeout = Duration(seconds: 5);
+
+  ElevationService({http.Client? client}) : _client = client ?? http.Client();
+
+  /// Fetch ground elevation for a coordinate pair.
+  ///
+  /// Negative results (offshore grid cells) clamp to 0; values round to the
+  /// nearest whole meter so a stored 0 always means sea level.
+  Future<double?> fetchElevation({
+    required double latitude,
+    required double longitude,
+  }) async {
+    try {
+      final uri = Uri.https(_baseUrl, _path, {
+        'latitude': latitude.toString(),
+        'longitude': longitude.toString(),
+      });
+
+      final response = await _client.get(uri).timeout(_timeout);
+      if (response.statusCode != 200) {
+        developer.log(
+          'Elevation API error: ${response.statusCode}',
+          name: 'ElevationService',
+        );
+        return null;
+      }
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final values = json['elevation'] as List<dynamic>?;
+      if (values == null || values.isEmpty) return null;
+      final raw = (values.first as num).toDouble();
+      return raw < 0 ? 0.0 : raw.roundToDouble();
+    } catch (e) {
+      developer.log('Elevation fetch failed: $e', name: 'ElevationService');
+      return null;
+    }
+  }
+}

--- a/lib/features/weather/domain/services/altitude_resolver.dart
+++ b/lib/features/weather/domain/services/altitude_resolver.dart
@@ -1,0 +1,75 @@
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+/// Result of an altitude resolution.
+///
+/// [siteWriteBack] is non-null only when the altitude came from a lookup of
+/// the site's own coordinates: the caller should persist it so future dives
+/// at that site resolve locally without a network call.
+class AltitudeResolution {
+  const AltitudeResolution({this.altitudeMeters, this.siteWriteBack});
+
+  final double? altitudeMeters;
+  final DiveSite? siteWriteBack;
+}
+
+/// Encodes the altitude precedence rule from the 2026-08-06 conditions spec:
+/// dive GPS lookup, then the site's stored altitude, then a site-coordinates
+/// lookup with write-back. Auto-fill callers must only apply the result to an
+/// empty field; manual entry always wins.
+class AltitudeResolver {
+  AltitudeResolver({
+    required ElevationService elevationService,
+    Map<String, double?>? cache,
+  }) : _elevation = elevationService,
+       _cache = cache;
+
+  final ElevationService _elevation;
+
+  /// Optional per-run lookup cache keyed by coordinates rounded to 4 decimal
+  /// places (roughly 11 m) so a batch import at one location does one lookup.
+  final Map<String, double?>? _cache;
+
+  Future<AltitudeResolution> resolve({
+    GeoPoint? entryLocation,
+    GeoPoint? exitLocation,
+    DiveSite? site,
+  }) async {
+    final divePoint = entryLocation ?? exitLocation;
+    if (divePoint != null) {
+      final meters = await _lookup(divePoint);
+      if (meters != null) return AltitudeResolution(altitudeMeters: meters);
+    }
+
+    if (site == null) return const AltitudeResolution();
+    if (site.altitude != null) {
+      return AltitudeResolution(altitudeMeters: site.altitude);
+    }
+
+    final siteLocation = site.location;
+    if (siteLocation != null) {
+      final meters = await _lookup(siteLocation);
+      if (meters != null) {
+        return AltitudeResolution(
+          altitudeMeters: meters,
+          siteWriteBack: site.copyWith(altitude: meters),
+        );
+      }
+    }
+    return const AltitudeResolution();
+  }
+
+  Future<double?> _lookup(GeoPoint point) async {
+    final cache = _cache;
+    final key =
+        '${point.latitude.toStringAsFixed(4)},'
+        '${point.longitude.toStringAsFixed(4)}';
+    if (cache != null && cache.containsKey(key)) return cache[key];
+    final meters = await _elevation.fetchElevation(
+      latitude: point.latitude,
+      longitude: point.longitude,
+    );
+    cache?[key] = meters;
+    return meters;
+  }
+}

--- a/lib/features/weather/presentation/providers/weather_providers.dart
+++ b/lib/features/weather/presentation/providers/weather_providers.dart
@@ -3,6 +3,7 @@ import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/weather/data/repositories/weather_repository.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
 import 'package:submersion/features/weather/data/services/weather_service.dart';
 import 'package:submersion/features/weather/domain/entities/weather_data.dart';
 
@@ -15,6 +16,12 @@ final weatherHttpClientProvider = Provider<http.Client>((ref) {
 final weatherServiceProvider = Provider<WeatherService>((ref) {
   final client = ref.watch(weatherHttpClientProvider);
   return WeatherService(client: client);
+});
+
+/// ElevationService provider
+final elevationServiceProvider = Provider<ElevationService>((ref) {
+  final client = ref.watch(weatherHttpClientProvider);
+  return ElevationService(client: client);
 });
 
 /// WeatherRepository provider

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "تنزيل الغطسات الجديدة فقط",
   "diveComputer_download_upToDate": "لم يتم العثور على غطسات جديدة -- سجلك محدّث",
   "diveLog_edit_section_environment": "البيئة",
+  "diveLog_edit_subsection_autofill": "تعبئة تلقائية",
   "diveLog_edit_subsection_weather": "الطقس",
   "diveLog_edit_subsection_diveConditions": "ظروف الغوص",
   "diveLog_edit_label_windSpeed": "سرعة الرياح",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "Nur neue Tauchgänge herunterladen",
   "diveComputer_download_upToDate": "Keine neuen Tauchgänge gefunden -- Ihr Logbuch ist aktuell",
   "diveLog_edit_section_environment": "Umgebung",
+  "diveLog_edit_subsection_autofill": "Automatisch ausfüllen",
   "diveLog_edit_subsection_weather": "Wetter",
   "diveLog_edit_subsection_diveConditions": "Tauchbedingungen",
   "diveLog_edit_label_windSpeed": "Windgeschwindigkeit",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12806,6 +12806,7 @@
   "settings_dataSources_appleHealth_poweredBy": "Powered by Apple HealthKit",
   "settings_dataSources_noSources": "No data source integrations are available on this platform.",
   "diveLog_edit_section_environment": "Environment",
+  "diveLog_edit_subsection_autofill": "Auto-fill",
   "diveLog_edit_subsection_weather": "Weather",
   "diveLog_edit_subsection_diveConditions": "Dive Conditions",
   "diveLog_edit_label_windSpeed": "Wind Speed",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "Descargar solo inmersiones nuevas",
   "diveComputer_download_upToDate": "No se encontraron inmersiones nuevas -- tu registro está al día",
   "diveLog_edit_section_environment": "Entorno",
+  "diveLog_edit_subsection_autofill": "Autocompletar",
   "diveLog_edit_subsection_weather": "Clima",
   "diveLog_edit_subsection_diveConditions": "Condiciones de buceo",
   "diveLog_edit_label_windSpeed": "Velocidad del viento",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5659,6 +5659,7 @@
   "buoyancy_whatIfDelta": "{delta} vs réel",
   "diveDetailSection_weights_name": "Lestage",
   "diveLog_edit_section_environment": "Environnement",
+  "diveLog_edit_subsection_autofill": "Remplissage automatique",
   "diveLog_edit_subsection_weather": "Météo",
   "diveLog_edit_subsection_diveConditions": "Conditions de plongée",
   "diveLog_edit_label_windSpeed": "Vitesse du vent",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "הורד צלילות חדשות בלבד",
   "diveComputer_download_upToDate": "לא נמצאו צלילות חדשות -- היומן שלך מעודכן",
   "diveLog_edit_section_environment": "סביבה",
+  "diveLog_edit_subsection_autofill": "מילוי אוטומטי",
   "diveLog_edit_subsection_weather": "מזג אוויר",
   "diveLog_edit_subsection_diveConditions": "תנאי צלילה",
   "diveLog_edit_label_windSpeed": "מהירות רוח",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5659,6 +5659,7 @@
   "buoyancy_whatIfDelta": "{delta} a ténylegeshez",
   "diveDetailSection_weights_name": "Súlyok",
   "diveLog_edit_section_environment": "Környezet",
+  "diveLog_edit_subsection_autofill": "Automatikus kitöltés",
   "diveLog_edit_subsection_weather": "Időjárás",
   "diveLog_edit_subsection_diveConditions": "Merülési körülmények",
   "diveLog_edit_label_windSpeed": "Szélsebesség",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5583,6 +5583,7 @@
   "diveComputer_download_newDivesOnlyTitle": "Scarica solo le nuove immersioni",
   "diveComputer_download_upToDate": "Nessuna nuova immersione trovata -- il tuo registro è aggiornato",
   "diveLog_edit_section_environment": "Ambiente",
+  "diveLog_edit_subsection_autofill": "Compilazione automatica",
   "diveLog_edit_subsection_weather": "Meteo",
   "diveLog_edit_subsection_diveConditions": "Condizioni di immersione",
   "diveLog_edit_label_windSpeed": "Velocità del vento",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -33919,6 +33919,12 @@ abstract class AppLocalizations {
   /// **'Environment'**
   String get diveLog_edit_section_environment;
 
+  /// No description provided for @diveLog_edit_subsection_autofill.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-fill'**
+  String get diveLog_edit_subsection_autofill;
+
   /// No description provided for @diveLog_edit_subsection_weather.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -19993,6 +19993,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_edit_section_environment => 'البيئة';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'تعبئة تلقائية';
+
+  @override
   String get diveLog_edit_subsection_weather => 'الطقس';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20322,6 +20322,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Umgebung';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Automatisch ausfüllen';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Wetter';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -20012,6 +20012,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Environment';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Auto-fill';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Weather';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20370,6 +20370,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Entorno';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Autocompletar';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Clima';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20425,6 +20425,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Environnement';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Remplissage automatique';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Météo';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -19849,6 +19849,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_edit_section_environment => 'סביבה';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'מילוי אוטומטי';
+
+  @override
   String get diveLog_edit_subsection_weather => 'מזג אוויר';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20293,6 +20293,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Környezet';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Automatikus kitöltés';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Időjárás';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20351,6 +20351,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Ambiente';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Compilazione automatica';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Meteo';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20191,6 +20191,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Omgeving';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Automatisch invullen';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Weer';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20359,6 +20359,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_edit_section_environment => 'Ambiente';
 
   @override
+  String get diveLog_edit_subsection_autofill => 'Preenchimento automático';
+
+  @override
   String get diveLog_edit_subsection_weather => 'Clima';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19328,6 +19328,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_edit_section_environment => '环境';
 
   @override
+  String get diveLog_edit_subsection_autofill => '自动填充';
+
+  @override
   String get diveLog_edit_subsection_weather => '天气';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "Alleen nieuwe duiken downloaden",
   "diveComputer_download_upToDate": "Geen nieuwe duiken gevonden -- je logboek is up-to-date",
   "diveLog_edit_section_environment": "Omgeving",
+  "diveLog_edit_subsection_autofill": "Automatisch invullen",
   "diveLog_edit_subsection_weather": "Weer",
   "diveLog_edit_subsection_diveConditions": "Duikomstandigheden",
   "diveLog_edit_label_windSpeed": "Windsnelheid",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5659,6 +5659,7 @@
   "diveComputer_download_newDivesOnlyTitle": "Baixar apenas novos mergulhos",
   "diveComputer_download_upToDate": "Nenhum mergulho novo encontrado -- seu registro está atualizado",
   "diveLog_edit_section_environment": "Ambiente",
+  "diveLog_edit_subsection_autofill": "Preenchimento automático",
   "diveLog_edit_subsection_weather": "Clima",
   "diveLog_edit_subsection_diveConditions": "Condições de mergulho",
   "diveLog_edit_label_windSpeed": "Velocidade do vento",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1928,6 +1928,7 @@
   "diveLog_edit_snackbar_unableToCalculateMaxDepth": "无法从轮廓计算最大深度",
   "diveLog_edit_snackbar_unableToCalculateRuntime": "无法从轮廓计算运行时间",
   "diveLog_edit_subsection_diveConditions": "潜水条件",
+  "diveLog_edit_subsection_autofill": "自动填充",
   "diveLog_edit_subsection_weather": "天气",
   "diveLog_edit_summary_items": "{count, plural, one{1 件装备} other{{count} 件装备}}",
   "diveLog_edit_summary_notes": "笔记",

--- a/test/features/dive_log/data/repositories/dive_computer_altitude_enrichment_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_altitude_enrichment_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// A batch dive-computer download runs [DiveComputerRepository.importProfile]
+/// once per dive. The repository holds a single [DiveAltitudeEnricher] so the
+/// elevation lookup is shared across the batch rather than repeated (and, on a
+/// slow network, waited on) for every dive.
+void main() {
+  late AppDatabase db;
+  late DiveRepository dives;
+  late List<Uri> requests;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    dives = DiveRepository();
+    requests = <Uri>[];
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  DiveComputerRepository repositoryWith({bool fail = false}) {
+    return DiveComputerRepository(
+      altitudeEnricher: DiveAltitudeEnricher(
+        elevationService: ElevationService(
+          client: MockClient((request) async {
+            requests.add(request.url);
+            if (fail) return http.Response('oops', 500);
+            return http.Response(
+              jsonEncode({
+                'elevation': [740.2],
+              }),
+              200,
+            );
+          }),
+        ),
+        diveRepository: dives,
+      ),
+    );
+  }
+
+  Future<String> insertComputer() async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: const Value('computer-1'),
+            name: const Value('Shearwater Perdix'),
+            manufacturer: const Value('Shearwater'),
+            model: const Value('Perdix'),
+            serialNumber: const Value('SN-12345'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return 'computer-1';
+  }
+
+  Future<String> importDive(
+    DiveComputerRepository repository,
+    String computerId,
+    DateTime start,
+  ) {
+    return repository.importProfile(
+      computerId: computerId,
+      profileStartTime: start,
+      points: const [
+        ProfilePointData(timestamp: 0, depth: 0.0),
+        ProfilePointData(timestamp: 60, depth: 12.0),
+      ],
+      durationSeconds: 40 * 60,
+      maxDepth: 20.0,
+      forceNew: true,
+      entryLatitude: 46.4,
+      entryLongitude: 8.0,
+    );
+  }
+
+  test('a batch download at one location does a single lookup', () async {
+    final computerId = await insertComputer();
+    final repository = repositoryWith();
+
+    final ids = <String>[];
+    for (var i = 0; i < 4; i++) {
+      ids.add(
+        await importDive(
+          repository,
+          computerId,
+          DateTime(2026, 3, 15, 10 + i, 0),
+        ),
+      );
+    }
+
+    expect(requests, hasLength(1));
+    for (final id in ids) {
+      final dive = await dives.getDiveById(id);
+      expect(dive!.altitude, 740.0);
+    }
+  });
+
+  test(
+    'a failing lookup is not retried per dive and imports succeed',
+    () async {
+      final computerId = await insertComputer();
+      final repository = repositoryWith(fail: true);
+
+      final ids = <String>[];
+      for (var i = 0; i < 3; i++) {
+        ids.add(
+          await importDive(
+            repository,
+            computerId,
+            DateTime(2026, 3, 15, 10 + i, 0),
+          ),
+        );
+      }
+
+      expect(requests, hasLength(1));
+      for (final id in ids) {
+        final dive = await dives.getDiveById(id);
+        expect(dive, isNotNull);
+        expect(dive!.altitude, isNull);
+      }
+    },
+  );
+}

--- a/test/features/dive_log/domain/services/dive_altitude_enricher_test.dart
+++ b/test/features/dive_log/domain/services/dive_altitude_enricher_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive(String id, {GeoPoint? entryLocation, double? altitude}) =>
+      Dive(
+        id: id,
+        diveNumber: 1,
+        dateTime: DateTime(2026, 3, 28, 10, 0),
+        entryLocation: entryLocation,
+        altitude: altitude,
+        tanks: const [],
+        profile: const [],
+        equipment: const [],
+        notes: '',
+        photoIds: const [],
+        sightings: const [],
+        weights: const [],
+        tags: const [],
+      );
+
+  ElevationService countingService(List<Uri> requests) => ElevationService(
+    client: MockClient((request) async {
+      requests.add(request.url);
+      return http.Response(
+        jsonEncode({
+          'elevation': [740.2],
+        }),
+        200,
+      );
+    }),
+  );
+
+  test('fills altitude for an imported dive with GPS', () async {
+    final dive = await repository.createDive(
+      buildDive('d1', entryLocation: const GeoPoint(46.4, 8.0)),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isTrue);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('skips dives that already have altitude', () async {
+    final requests = <Uri>[];
+    final dive = await repository.createDive(
+      buildDive('d2', entryLocation: const GeoPoint(46.4, 8.0), altitude: 500),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    expect(requests, isEmpty);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 500.0);
+  });
+
+  test('skips dives with no GPS and no site', () async {
+    final requests = <Uri>[];
+    final dive = await repository.createDive(buildDive('d3'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    expect(requests, isEmpty);
+  });
+
+  test('one lookup covers a batch at the same location', () async {
+    final requests = <Uri>[];
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService(requests),
+      diveRepository: repository,
+    );
+
+    for (var i = 0; i < 3; i++) {
+      final dive = await repository.createDive(
+        buildDive('batch-$i', entryLocation: const GeoPoint(46.4, 8.0)),
+      );
+      await enricher.applyForImportedDive(dive);
+    }
+
+    expect(requests, hasLength(1));
+    final stored = await repository.getDiveById('batch-2');
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('lookup failure leaves the dive importable and unchanged', () async {
+    final dive = await repository.createDive(
+      buildDive('d4', entryLocation: const GeoPoint(46.4, 8.0)),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: ElevationService(
+        client: MockClient((_) async => http.Response('oops', 500)),
+      ),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isFalse);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, isNull);
+  });
+
+  test('fills a downloaded dive from its GPS points', () async {
+    final dive = await repository.createDive(buildDive('d5'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForDownloadedDive(
+      diveId: dive.id,
+      points: const [GeoPoint(46.4, 8.0)],
+    );
+
+    expect(applied, isTrue);
+    final stored = await repository.getDiveById(dive.id);
+    expect(stored!.altitude, 740.0);
+  });
+
+  test('downloaded dive with no points is a no-op', () async {
+    final dive = await repository.createDive(buildDive('d6'));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: countingService([]),
+      diveRepository: repository,
+    );
+
+    final applied = await enricher.applyForDownloadedDive(
+      diveId: dive.id,
+      points: const [],
+    );
+
+    expect(applied, isFalse);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_altitude_autofill_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive({double? altitude}) => Dive(
+    id: 'dive-alt',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 3, 28, 10, 0),
+    entryTime: DateTime(2026, 3, 28, 10, 5),
+    bottomTime: const Duration(minutes: 40),
+    maxDepth: 20.0,
+    altitude: altitude,
+    entryLocation: const GeoPoint(46.4, 8.0),
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  Future<void> pumpEditPage(WidgetTester tester, String diveId) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final base = await getBaseOverrides(
+      weatherHttpClient: MockClient((request) async {
+        expect(request.url.host, 'api.open-meteo.com');
+        return http.Response(
+          jsonEncode({
+            'elevation': [740.2],
+          }),
+          200,
+        );
+      }),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveEditPage(diveId: diveId, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> expandConditions(WidgetTester tester) async {
+    final header = find.text('Conditions');
+    await tester.ensureVisible(header.first);
+    await tester.pumpAndSettle();
+    await tester.tap(header.first);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('fills empty altitude from logged GPS on load', (tester) async {
+    final created = await repository.createDive(buildDive());
+    await pumpEditPage(tester, created.id);
+    await expandConditions(tester);
+
+    // Collapsed FormRow.text renders "<value> <unit symbol>".
+    expect(find.text('740 m'), findsOneWidget);
+  });
+
+  testWidgets('never overwrites an existing altitude', (tester) async {
+    final created = await repository.createDive(buildDive(altitude: 500.0));
+    await pumpEditPage(tester, created.id);
+    await expandConditions(tester);
+
+    expect(find.text('500 m'), findsOneWidget);
+    expect(find.text('740 m'), findsNothing);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/edit_sections/conditions_section_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/conditions_section.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/forms/form_overline.dart';
+
+void main() {
+  Widget host({
+    required List<Widget> topRows,
+    required List<Widget> weatherRows,
+  }) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ConditionsSection(
+            expanded: true,
+            onToggle: () {},
+            summary: '',
+            isEmpty: true,
+            temperatureSymbol: 'C',
+            waterTempController: TextEditingController(),
+            airTempController: TextEditingController(),
+            topRows: topRows,
+            environmentRows: const [],
+            weatherRows: weatherRows,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders topRows above the temperature fields', (tester) async {
+    await tester.pumpWidget(
+      host(
+        topRows: [
+          FormOverline(
+            label: 'Auto-fill',
+            actions: [
+              FormOverlineAction(label: 'Fetch weather', onPressed: () {}),
+            ],
+          ),
+        ],
+        weatherRows: const [FormOverline(label: 'Weather')],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // FormRow.text stays collapsed until tapped, so anchor the ordering on
+    // the water temperature row's label rather than a materialized TextField.
+    final autofillY = tester.getTopLeft(find.text('AUTO-FILL')).dy;
+    final weatherY = tester.getTopLeft(find.text('WEATHER')).dy;
+    final waterTempY = tester.getTopLeft(find.text('Water Temp')).dy;
+
+    expect(find.text('Fetch weather'), findsOneWidget);
+    expect(autofillY, lessThan(waterTempY));
+    expect(waterTempY, lessThan(weatherY));
+  });
+
+  testWidgets('topRows defaults to empty and renders nothing extra', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(topRows: const [], weatherRows: const []));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FormOverline), findsNothing);
+  });
+}

--- a/test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart
+++ b/test/features/dive_sites/presentation/pages/site_edit_altitude_autofill_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/location_service.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/pages/site_edit_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Stub geocoder: the altitude path must not depend on reverse geocoding.
+class _StubLocationService implements LocationService {
+  @override
+  Future<({String? country, String? region, String? locality})> reverseGeocode(
+    double latitude,
+    double longitude,
+  ) async => (country: null, region: null, locality: null);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+List<Diver> _divers() => [
+  Diver(
+    id: 'd1',
+    name: 'Me',
+    createdAt: DateTime(2024),
+    updatedAt: DateTime(2024),
+  ),
+];
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> pumpSiteEdit(
+    WidgetTester tester, {
+    GeoPoint? initialLocation,
+    required List<Uri> requests,
+    bool fail = false,
+  }) async {
+    tester.view.physicalSize = const Size(1000, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          allDiversProvider.overrideWith((_) async => _divers()),
+          shareByDefaultProvider.overrideWith((_) async => false),
+          locationServiceProvider.overrideWithValue(_StubLocationService()),
+          weatherHttpClientProvider.overrideWithValue(
+            MockClient((request) async {
+              requests.add(request.url);
+              if (fail) return http.Response('oops', 500);
+              return http.Response(
+                jsonEncode({
+                  'elevation': [740.2],
+                }),
+                200,
+              );
+            }),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SiteEditPage(initialLocation: initialLocation),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('seeded coordinates fill an empty altitude field', (
+    tester,
+  ) async {
+    final requests = <Uri>[];
+    await pumpSiteEdit(
+      tester,
+      initialLocation: const GeoPoint(46.4, 8.0),
+      requests: requests,
+    );
+
+    // Let the 1-second debounce elapse, then the lookup complete.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    // The collapsed Location summary is "{lat}, {lng} - {altitude} {symbol}".
+    expect(requests, hasLength(1));
+    expect(
+      find.textContaining('740 m', findRichText: true),
+      findsOneWidget,
+      reason: 'altitude should appear in the collapsed location summary',
+    );
+  });
+
+  testWidgets('a failed lookup leaves altitude empty', (tester) async {
+    final requests = <Uri>[];
+    await pumpSiteEdit(
+      tester,
+      initialLocation: const GeoPoint(46.4, 8.0),
+      requests: requests,
+      fail: true,
+    );
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(requests, hasLength(1));
+    expect(find.textContaining('740 m'), findsNothing);
+  });
+
+  testWidgets('no coordinates means no lookup', (tester) async {
+    final requests = <Uri>[];
+    await pumpSiteEdit(tester, requests: requests);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(requests, isEmpty);
+  });
+}

--- a/test/features/weather/data/services/elevation_service_test.dart
+++ b/test/features/weather/data/services/elevation_service_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+void main() {
+  group('ElevationService', () {
+    test('returns elevation on successful response', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.host, 'api.open-meteo.com');
+        expect(request.url.path, '/v1/elevation');
+        expect(request.url.queryParameters['latitude'], '46.4');
+        expect(request.url.queryParameters['longitude'], '8.0');
+        return http.Response(
+          jsonEncode({
+            'elevation': [740.2],
+          }),
+          200,
+        );
+      });
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(
+        latitude: 46.4,
+        longitude: 8.0,
+      );
+
+      expect(result, 740.0);
+    });
+
+    test('rounds to the nearest whole meter', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'elevation': [12.6],
+          }),
+          200,
+        ),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, 13.0);
+    });
+
+    test('clamps negative elevations to zero', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'elevation': [-4.0],
+          }),
+          200,
+        ),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(
+        latitude: 27.9,
+        longitude: -15.4,
+      );
+
+      expect(result, 0.0);
+    });
+
+    test('returns null on non-200 response', () async {
+      final mockClient = MockClient((_) async => http.Response('oops', 500));
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null on malformed body', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response('not json', 200),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when elevation list is empty', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response(jsonEncode({'elevation': <double>[]}), 200),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+
+    test('returns null when the request times out', () async {
+      final mockClient = MockClient(
+        (_) async => throw TimeoutException('timed out'),
+      );
+
+      final service = ElevationService(client: mockClient);
+      final result = await service.fetchElevation(latitude: 1, longitude: 2);
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/weather/domain/services/altitude_resolver_test.dart
+++ b/test/features/weather/domain/services/altitude_resolver_test.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+import 'package:submersion/features/weather/domain/services/altitude_resolver.dart';
+
+/// Serves a fixed elevation and counts requests; 500s when [fail] is true.
+ElevationService _service({
+  double elevation = 740.0,
+  bool fail = false,
+  List<Uri>? requests,
+}) {
+  return ElevationService(
+    client: MockClient((request) async {
+      requests?.add(request.url);
+      if (fail) return http.Response('oops', 500);
+      return http.Response(
+        jsonEncode({
+          'elevation': [elevation],
+        }),
+        200,
+      );
+    }),
+  );
+}
+
+DiveSite _site({GeoPoint? location, double? altitude}) => DiveSite(
+  id: 'site-1',
+  name: 'Lake Test',
+  location: location,
+  altitude: altitude,
+);
+
+void main() {
+  group('AltitudeResolver', () {
+    test('prefers the dive entry location lookup', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(elevation: 740.0, requests: requests),
+      );
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(altitude: 300.0),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(result.siteWriteBack, isNull);
+      expect(requests.single.queryParameters['latitude'], '46.4');
+    });
+
+    test('uses exit location when entry is missing', () async {
+      final resolver = AltitudeResolver(elevationService: _service());
+
+      final result = await resolver.resolve(
+        exitLocation: const GeoPoint(46.5, 8.1),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+    });
+
+    test('falls back to site altitude when dive lookup fails', () async {
+      final resolver = AltitudeResolver(elevationService: _service(fail: true));
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(altitude: 300.0),
+      );
+
+      expect(result.altitudeMeters, 300.0);
+      expect(result.siteWriteBack, isNull);
+    });
+
+    test('uses site altitude when the dive has no GPS', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(requests: requests),
+      );
+
+      final result = await resolver.resolve(site: _site(altitude: 300.0));
+
+      expect(result.altitudeMeters, 300.0);
+      expect(requests, isEmpty);
+    });
+
+    test('looks up site coordinates and returns a write-back', () async {
+      final resolver = AltitudeResolver(elevationService: _service());
+
+      final result = await resolver.resolve(
+        site: _site(location: const GeoPoint(46.4, 8.0)),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(result.siteWriteBack, isNotNull);
+      expect(result.siteWriteBack!.altitude, 740.0);
+      expect(result.siteWriteBack!.id, 'site-1');
+    });
+
+    test('returns empty resolution when nothing is available', () async {
+      final requests = <Uri>[];
+      final resolver = AltitudeResolver(
+        elevationService: _service(requests: requests),
+      );
+
+      final result = await resolver.resolve();
+
+      expect(result.altitudeMeters, isNull);
+      expect(result.siteWriteBack, isNull);
+      expect(requests, isEmpty);
+    });
+
+    test('returns empty resolution when all lookups fail', () async {
+      final resolver = AltitudeResolver(elevationService: _service(fail: true));
+
+      final result = await resolver.resolve(
+        entryLocation: const GeoPoint(46.4, 8.0),
+        site: _site(location: const GeoPoint(46.4, 8.0)),
+      );
+
+      expect(result.altitudeMeters, isNull);
+      expect(result.siteWriteBack, isNull);
+    });
+
+    test('cache dedupes lookups for nearby coordinates', () async {
+      final requests = <Uri>[];
+      final cache = <String, double?>{};
+
+      final first = AltitudeResolver(
+        elevationService: _service(requests: requests),
+        cache: cache,
+      );
+      await first.resolve(entryLocation: const GeoPoint(46.40001, 8.00001));
+
+      final second = AltitudeResolver(
+        elevationService: _service(requests: requests),
+        cache: cache,
+      );
+      final result = await second.resolve(
+        entryLocation: const GeoPoint(46.40004, 8.00003),
+      );
+
+      expect(result.altitudeMeters, 740.0);
+      expect(requests, hasLength(1));
+    });
+
+    test('cache remembers failures within a run', () async {
+      final requests = <Uri>[];
+      final cache = <String, double?>{};
+      final resolver = AltitudeResolver(
+        elevationService: _service(fail: true, requests: requests),
+        cache: cache,
+      );
+
+      await resolver.resolve(entryLocation: const GeoPoint(46.4, 8.0));
+      await resolver.resolve(entryLocation: const GeoPoint(46.4, 8.0));
+
+      expect(requests, hasLength(1));
+    });
+  });
+}

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart' hide Visibility;
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 // ignore: implementation_imports
 import 'package:riverpod/src/framework.dart' as riverpod show Override;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -19,6 +21,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tissue_color_schemes.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
 
 typedef Override = riverpod.Override;
 
@@ -468,6 +471,7 @@ Dive createTestDiveWithBottomTime({
 /// Common provider overrides for widget tests
 Future<List<Override>> getBaseOverrides({
   MockSettingsNotifier? settingsNotifier,
+  http.Client? weatherHttpClient,
 }) async {
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
@@ -486,6 +490,11 @@ Future<List<Override>> getBaseOverrides({
     // timer at teardown.
     diveOpenFindingsCountProvider.overrideWith(
       (ref, diveId) => Stream.value(0),
+    ),
+    // Weather/elevation lookups must never hit the network in widget tests;
+    // the default stub fails fast so altitude auto-fill resolves to null.
+    weatherHttpClientProvider.overrideWithValue(
+      weatherHttpClient ?? MockClient((_) async => http.Response('', 500)),
     ),
   ];
 }


### PR DESCRIPTION
## Summary

The dive form's Conditions section had two ergonomics problems. The "Fetch weather" button sat at the Weather subsection overline, halfway down the section, even though the fetch fills air temperature at the top of the section as well as the weather fields below it. And altitude was a manual text entry even though the app usually already knows where the dive happened: the dive's own logged GPS, the selected site's stored altitude, or the site's coordinates.

This moves the fetch action to the top of the section and makes altitude resolve itself from whichever position source is available, with a site write-back so the lookup happens once per site rather than once per dive.

Spec: `docs/superpowers/specs/2026-08-06-conditions-weather-altitude-design.md`
Plan: `docs/superpowers/plans/2026-08-06-conditions-weather-altitude.md`

## Changes

- **Conditions section reorder.** A new "Auto-fill" overline leads the section and carries the fetch action; the Weather overline below is now a plain subsection label. `ConditionsSection` gains a `topRows` parameter for the pinned row. New l10n key translated across all 11 locales.
- **`ElevationService`** (`lib/features/weather/data/services/elevation_service.dart`) — Open-Meteo `/v1/elevation` client mirroring `WeatherService`: injectable `http.Client`, 5-second timeout, returns null on any failure, clamps negatives to 0 and rounds to whole meters so a stored 0 honestly means sea level.
- **`AltitudeResolver`** (`lib/features/weather/domain/services/altitude_resolver.dart`) — one precedence rule used by every caller: dive's logged GPS lookup, then the site's stored altitude (also the fallback when the GPS lookup fails), then a site-coordinates lookup that returns a `siteWriteBack` entity for the caller to persist. Auto-fill only ever writes an empty field; manual entry always wins. An optional coordinate cache (4dp, roughly 11 m) lets batch callers collapse many dives at one location into a single request.
- **Dive edit form** fills an empty altitude on load, on site assignment, and as a retry after a manual weather fetch. The fill does not mark the form dirty, so opening and closing a dive never prompts to discard changes.
- **Site edit form** fills an empty altitude when coordinates become valid (typed, located, or map-picked), debounced 1 second. Also suppresses the dirty flag so opening a pre-existing site does not trap the user in a discard prompt.
- **Attaching photo GPS to a site** now fills that site's altitude in the same update when it has none.
- **`DiveAltitudeEnricher`** (`lib/features/dive_log/domain/services/dive_altitude_enricher.dart`) runs on all four non-interactive creation seams — dive computer download, file import, UDDF import, HealthKit import — so imported dives get altitude without anyone opening the edit form. Best-effort like `DiveEquipmentDefaulter`: every failure is swallowed so a network hiccup can never abort an import that has already persisted the dive.

No schema change: `dives.altitude` and `dive_sites.altitude` already exist. The site write-back is a normal repository update, so it bumps its HLC and syncs like any user edit. All background lookups are silent — no snackbars, no retry queues; the existing fetch-weather snackbars are unchanged.

## Test Plan

- [x] `flutter test` passes — 14,937 tests passed, 15 pre-existing skips
- [x] `flutter analyze` passes — no issues
- [x] `dart format .` clean
- [x] Manual testing on: not yet run — worth a macOS pass to confirm the reordered section reads correctly and that live Open-Meteo elevations look sensible

New coverage: 7 tests for `ElevationService` (success, non-200, malformed body, empty list, timeout, negative clamp, rounding), 9 for `AltitudeResolver` (all precedence branches, lookup-failure fallback, write-back, cache dedup including cached failures), 7 for `DiveAltitudeEnricher` (fill, skip-when-set, skip-without-position, batch dedup, failure leaves the dive unchanged, download path), 2 for the conditions row order, 2 for dive edit auto-fill, 3 for site edit auto-fill.

`getBaseOverrides` in `test/helpers/mock_providers.dart` now always overrides `weatherHttpClientProvider` with a fail-fast stub, so no widget test can reach the network; pass `weatherHttpClient:` to supply a real fixture.

## Notes

This branch also carries `479b63f21fd` ("Add adaptive profile legend row design spec"), which was already committed on local `main` but unpushed before this work started. It is unrelated to these changes.
