### PR TITLE
Even out the Tissue Loading card header icons

### DIFF
--- a/lib/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart
@@ -10,6 +10,20 @@ import 'package:submersion/features/dive_log/presentation/widgets/tissue_heat_ma
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Glyph size for every control in the card header.
+const double _headerIconSize = 16;
+
+/// Shared style for every control in the card header.
+///
+/// The header mixes plain [IconButton]s with a [PopupMenuButton], so the only
+/// way the icons stay evenly spaced is for all of them to lay out to the same
+/// box. [ButtonStyle.tapTargetSize] is deliberately left unset so it falls
+/// back to the theme default of [MaterialTapTargetSize.padded]: that is what
+/// gives each control an accessible touch target of
+/// `kMinInteractiveDimension` (48) plus the compact density adjustment (-8),
+/// i.e. 40x40 around a [_headerIconSize] glyph.
+const _headerButtonStyle = ButtonStyle(visualDensity: VisualDensity.compact);
+
 /// Compact card displaying tissue loading visualizations and live data.
 ///
 /// Contains:
@@ -124,13 +138,27 @@ class _CompactTissueLoadingCardState
                   ),
                 ],
                 const Spacer(),
-                _buildVizModeToggle(colorScheme, vizMode),
-                const SizedBox(width: 4),
+                // Every control below shares _headerButtonStyle, so each one
+                // lays out to the same box and the gaps stay even. Do not add
+                // manual spacers between them: the icons are built from three
+                // different widget types whose intrinsic widths differ, and
+                // uniform spacers on top of non-uniform boxes is exactly what
+                // made the spacing drift before.
+                _modeIcon(
+                  Icons.grid_on,
+                  TissueVizMode.heatMap,
+                  vizMode,
+                  colorScheme,
+                ),
+                _modeIcon(
+                  Icons.area_chart,
+                  TissueVizMode.stackedArea,
+                  vizMode,
+                  colorScheme,
+                ),
                 _buildColorSchemeSelector(colorScheme),
-                if (widget.onOpen3dView != null) ...[
-                  const SizedBox(width: 4),
+                if (widget.onOpen3dView != null)
                   _build3dViewButton(colorScheme),
-                ],
               ],
             ),
             const SizedBox(height: 14),
@@ -538,29 +566,6 @@ class _CompactTissueLoadingCardState
     );
   }
 
-  Widget _buildVizModeToggle(
-    ColorScheme colorScheme,
-    TissueVizMode currentMode,
-  ) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _modeIcon(
-          Icons.grid_on,
-          TissueVizMode.heatMap,
-          currentMode,
-          colorScheme,
-        ),
-        _modeIcon(
-          Icons.area_chart,
-          TissueVizMode.stackedArea,
-          currentMode,
-          colorScheme,
-        ),
-      ],
-    );
-  }
-
   Widget _modeIcon(
     IconData icon,
     TissueVizMode mode,
@@ -568,36 +573,33 @@ class _CompactTissueLoadingCardState
     ColorScheme colorScheme,
   ) {
     final isActive = mode == currentMode;
-    return GestureDetector(
-      onTap: () => ref.read(settingsProvider.notifier).setTissueVizMode(mode),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 2),
-        child: Icon(
-          icon,
-          size: 16,
-          color: isActive
-              ? colorScheme.primary
-              : colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-        ),
+    return IconButton(
+      icon: Icon(
+        icon,
+        size: _headerIconSize,
+        color: isActive
+            ? colorScheme.primary
+            : colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
       ),
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(),
+      style: _headerButtonStyle,
+      onPressed: () =>
+          ref.read(settingsProvider.notifier).setTissueVizMode(mode),
     );
   }
 
   Widget _build3dViewButton(ColorScheme colorScheme) {
-    // padding/constraints keep the layout box as tight as the other header
-    // controls; the tap target size is left at the platform default, so
-    // touch platforms get the full 48x48 hit region (padded expands the hit
-    // test area without growing the layout) while desktop stays compact.
     return IconButton(
       icon: Icon(
         Icons.view_in_ar,
-        size: 16,
+        size: _headerIconSize,
         color: colorScheme.onSurfaceVariant,
       ),
       tooltip: context.l10n.dive3d_previewTitle,
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(),
-      style: const ButtonStyle(visualDensity: VisualDensity.compact),
+      style: _headerButtonStyle,
       onPressed: widget.onOpen3dView,
     );
   }
@@ -606,15 +608,14 @@ class _CompactTissueLoadingCardState
     return PopupMenuButton<TissueColorScheme>(
       icon: Icon(
         Icons.palette_outlined,
-        size: 16,
+        size: _headerIconSize,
         color: colorScheme.onSurfaceVariant,
       ),
+      // No `constraints:` here. On PopupMenuButton that parameter sizes the
+      // popup menu, not the button, so passing it the button's BoxConstraints
+      // only stripped the menu's standard minimum width.
       padding: EdgeInsets.zero,
-      constraints: const BoxConstraints(),
-      style: const ButtonStyle(
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        visualDensity: VisualDensity.compact,
-      ),
+      style: _headerButtonStyle,
       itemBuilder: (context) => TissueColorScheme.values.map((scheme) {
         return PopupMenuItem<TissueColorScheme>(
           value: scheme,

--- a/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
@@ -32,6 +32,31 @@ const _status = DecoStatus(
   ambientPressureBar: 2.0,
 );
 
+const _comp2 = TissueCompartment(
+  compartmentNumber: 2,
+  halfTimeN2: 8.0,
+  halfTimeHe: 3.02,
+  mValueAN2: 1.0000,
+  mValueBN2: 0.6514,
+  mValueAHe: 1.3830,
+  mValueBHe: 0.5747,
+);
+
+// The area chart spreads hue across `compartments.length - 1`, so a
+// single-compartment status divides by zero. Real deco models always emit all
+// 16 compartments; use at least two here to stay on a realistic code path.
+const _multiCompStatus = DecoStatus(
+  compartments: [_comp, _comp2],
+  ndlSeconds: 600,
+  ceilingMeters: 0.0,
+  ttsSeconds: 0,
+  gfLow: 0.4,
+  gfHigh: 0.85,
+  decoStops: [],
+  currentDepthMeters: 10.0,
+  ambientPressureBar: 2.0,
+);
+
 // A compartment loaded well past its M-value. surfaceMValue for these
 // coefficients is ~3.24 bar, so currentPN2 4.5 is ~139% loading, which clamps
 // the bar to full chart height -- the case where the highlight outline used to
@@ -136,6 +161,79 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.view_in_ar), findsNothing);
+    });
+  });
+
+  group('CompactTissueLoadingCard header icons', () {
+    // Header controls in left-to-right render order.
+    const headerIcons = [
+      Icons.grid_on,
+      Icons.area_chart,
+      Icons.palette_outlined,
+      Icons.view_in_ar,
+    ];
+
+    testWidgets('are spaced evenly across the header row', (tester) async {
+      await tester.pumpWidget(buildCard(onOpen3dView: () {}));
+      await tester.pumpAndSettle();
+
+      final rects = headerIcons
+          .map((icon) => tester.getRect(find.byIcon(icon)))
+          .toList();
+
+      // Guard the assumed render order before measuring the gaps.
+      for (var i = 1; i < rects.length; i++) {
+        expect(rects[i].left, greaterThan(rects[i - 1].left));
+      }
+
+      final gaps = [
+        for (var i = 1; i < rects.length; i++)
+          rects[i].left - rects[i - 1].right,
+      ];
+      for (final gap in gaps) {
+        expect(gap, closeTo(gaps.first, 0.5), reason: 'gaps were $gaps');
+      }
+    });
+
+    testWidgets('share one layout box so the gaps cannot drift', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildCard(onOpen3dView: () {}));
+      await tester.pumpAndSettle();
+
+      final sizes = headerIcons
+          .map(
+            (icon) => tester.getSize(
+              find.ancestor(
+                of: find.byIcon(icon),
+                matching: find.byType(IconButton),
+              ),
+            ),
+          )
+          .toList();
+
+      for (final size in sizes) {
+        // Every control carries the same accessible touch target as the 3D
+        // button (48 minus the compact visual density adjustment).
+        expect(size.width, greaterThanOrEqualTo(40));
+        expect(size.height, greaterThanOrEqualTo(40));
+        expect(size, sizes.first, reason: 'sizes were $sizes');
+      }
+    });
+
+    testWidgets('switch the visualization mode when tapped', (tester) async {
+      await tester.pumpWidget(
+        buildCard(status: _multiCompStatus, decoStatuses: [_multiCompStatus]),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.area_chart));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.byIcon(Icons.grid_on));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_tissue_loading_card_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/deco/entities/deco_status.dart';
 import 'package:submersion/core/deco/entities/tissue_compartment.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/compact_tissue_loading_card.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/tissue_area_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tissue_heat_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -227,13 +228,44 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      // The card renders exactly one of the two visualizations, chosen by
+      // tissueVizMode, so the rendered chart type is what proves the tap
+      // took effect. AppSettings defaults to TissueVizMode.heatMap.
+      expect(find.byType(TissueHeatMapStrip), findsOneWidget);
+      expect(find.byType(TissueAreaChart), findsNothing);
+
       await tester.tap(find.byIcon(Icons.area_chart));
       await tester.pumpAndSettle();
-      expect(tester.takeException(), isNull);
+      expect(find.byType(TissueAreaChart), findsOneWidget);
+      expect(find.byType(TissueHeatMapStrip), findsNothing);
 
       await tester.tap(find.byIcon(Icons.grid_on));
       await tester.pumpAndSettle();
-      expect(tester.takeException(), isNull);
+      expect(find.byType(TissueHeatMapStrip), findsOneWidget);
+      expect(find.byType(TissueAreaChart), findsNothing);
+    });
+
+    testWidgets('tint the active visualization mode icon', (tester) async {
+      await tester.pumpWidget(
+        buildCard(status: _multiCompStatus, decoStatuses: [_multiCompStatus]),
+      );
+      await tester.pumpAndSettle();
+
+      final primary = Theme.of(
+        tester.element(find.byType(CompactTissueLoadingCard)),
+      ).colorScheme.primary;
+
+      Color? colorOf(IconData icon) =>
+          tester.widget<Icon>(find.byIcon(icon)).color;
+
+      expect(colorOf(Icons.grid_on), primary);
+      expect(colorOf(Icons.area_chart), isNot(primary));
+
+      await tester.tap(find.byIcon(Icons.area_chart));
+      await tester.pumpAndSettle();
+
+      expect(colorOf(Icons.area_chart), primary);
+      expect(colorOf(Icons.grid_on), isNot(primary));
     });
   });
 


### PR DESCRIPTION
## Summary

The icons at the top of the Tissue Loading card were unevenly spaced. The four
header controls were built three different ways, so each icon sat in a
differently sized layout box. Measured gaps between the glyphs were **4.0, 14.0
and 24.0** logical pixels; they are now **24.0 across the board**.

The `SizedBox(width: 4)` separators were already uniform and were never the
cause. The variance came entirely from the invisible boxes they sat between,
which is why the bug is not visible when reading the `Row` and obvious when you
measure it:

- `MaterialTapTargetSize.padded` — the `ThemeData` default on every platform,
  not just mobile — wraps a button in `RenderInputPadding`, which grows the
  **layout size**, not just the hit-test area. The 3D `IconButton` left
  `tapTargetSize` unset and so measured 40px wide against 20px neighbours. The
  comment on that button asserted the opposite.
- `PopupMenuButton.constraints` sizes the **popup menu**, not the button. The
  colour scheme selector was passed the button's `BoxConstraints`, which did
  nothing for its box and quietly stripped the menu's standard 112px minimum
  width.

Fix: give every header control one shared `_headerButtonStyle` so they lay out
to an identical 40x40 box, then drop the manual spacers entirely — uniform
spacers on top of non-uniform boxes is what made the spacing drift.

Levelling the icons *up* to 40x40 rather than shrinking the 3D button down
preserves the accessible touch target that
`compact_tissue_loading_card_test.dart` already asserts, and brings the two
visualization mode icons up to the same bar — they were 20px
`GestureDetector`s and are now `IconButton`s with hover and ink affordance.

**Card height is unchanged at 232px in the shipping configuration**, where the
dive detail page always supplies `onOpen3dView` and the 40px row height was
therefore already in force. Only the hypothetical no-3D-button case grows 8px.

## Changes

- `compact_tissue_loading_card.dart`: added `_headerButtonStyle` and
  `_headerIconSize`, shared by all four header controls.
- Converted the two visualization mode icons from bare `GestureDetector` +
  `Padding` to `IconButton`, and removed the now-redundant
  `_buildVizModeToggle` wrapper `Row`.
- Removed `tapTargetSize: shrinkWrap` from the colour scheme selector and the
  `constraints:` argument that was sizing the popup menu rather than the button.
- Removed the `SizedBox(width: 4)` separators between header controls.
- Replaced the inaccurate comment on the 3D button with the actual mechanism.
- Three regression tests. The two spacing tests measure rendered icon rects
  rather than widget structure, so they still hold if the controls are rebuilt
  from different widgets later.

## Test Plan

- [x] `flutter test` passes — 15,345 passed, 15 skipped, 0 failures
- [x] `flutter analyze` passes — no issues found
- [x] `dart format .` clean
- [x] Manual testing on: not run. Verified by measurement instead — the header
      geometry was captured before and after via widget tests
      (`tester.getRect` on each icon), giving the 4/14/24 -> 24/24/24 gap
      figures and the unchanged 232px card height quoted above.

## Notes

One unrelated latent issue was found while writing the tap test and
deliberately **not** fixed here, to keep this PR to the reported bug:
`tissue_area_chart.dart:467` computes `hue = compIdx / (numCompartments - 1)`,
which is `0/0` -> `NaN` -> an assertion failure in `HSVColor.fromAHSV` when a
status carries a single compartment. It is unreachable in production because
both Bühlmann and VPM-B always emit 16 compartments, so the test fixture uses
realistic multi-compartment data rather than patching the painter. Happy to add
a one-line guard if wanted.
