### PR TITLE
fix(dive-log): keep buddy roles intact through bulk edits

### DIFF
--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -47,26 +47,22 @@ class BuddyRepository {
   /// {buddyId: the role id every one of [diveIds] agrees on for that buddy}.
   /// Buddies whose links disagree are omitted, so a caller filling in missing
   /// links can reuse a unanimous role without flattening a deliberate mix.
+  /// HAVING MIN(role) = MAX(role) keeps the mixed rows in SQLite rather than
+  /// shipping every junction row to Dart on the bulk-edit load path.
   Future<Map<String, String>> unanimousBuddyRolesForDives(
     List<String> diveIds,
   ) async {
     if (diveIds.isEmpty) return {};
-    final rows = await (_db.select(
-      _db.diveBuddies,
-    )..where((t) => t.diveId.isIn(diveIds))).get();
-    final roles = <String, String>{};
-    final mixed = <String>{};
-    for (final row in rows) {
-      if (mixed.contains(row.buddyId)) continue;
-      final seen = roles[row.buddyId];
-      if (seen == null) {
-        roles[row.buddyId] = row.role;
-      } else if (seen != row.role) {
-        mixed.add(row.buddyId);
-        roles.remove(row.buddyId);
-      }
-    }
-    return roles;
+    final j = _db.diveBuddies;
+    final minRole = j.role.min();
+    final maxRole = j.role.max();
+    final rows =
+        await (_db.selectOnly(j)
+              ..addColumns([j.buddyId, minRole])
+              ..where(j.diveId.isIn(diveIds))
+              ..groupBy([j.buddyId], having: minRole.equalsExp(maxRole)))
+            .get();
+    return {for (final r in rows) r.read(j.buddyId)!: r.read(minRole)!};
   }
 
   final SyncRepository _syncRepository = SyncRepository();

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -44,6 +44,31 @@ class BuddyRepository {
     return {for (final r in rows) r.read(j.buddyId)!: r.read(countExpr)!};
   }
 
+  /// {buddyId: the role id every one of [diveIds] agrees on for that buddy}.
+  /// Buddies whose links disagree are omitted, so a caller filling in missing
+  /// links can reuse a unanimous role without flattening a deliberate mix.
+  Future<Map<String, String>> unanimousBuddyRolesForDives(
+    List<String> diveIds,
+  ) async {
+    if (diveIds.isEmpty) return {};
+    final rows = await (_db.select(
+      _db.diveBuddies,
+    )..where((t) => t.diveId.isIn(diveIds))).get();
+    final roles = <String, String>{};
+    final mixed = <String>{};
+    for (final row in rows) {
+      if (mixed.contains(row.buddyId)) continue;
+      final seen = roles[row.buddyId];
+      if (seen == null) {
+        roles[row.buddyId] = row.role;
+      } else if (seen != row.role) {
+        mixed.add(row.buddyId);
+        roles.remove(row.buddyId);
+      }
+    }
+    return roles;
+  }
+
   final SyncRepository _syncRepository = SyncRepository();
   final CertificationRepository _certRepo = CertificationRepository();
   final _uuid = const Uuid();
@@ -596,12 +621,15 @@ class BuddyRepository {
     );
   }
 
-  /// Add each buddy (with role) to every dive. Upserts role if already linked.
+  /// Add each buddy (with role) to every dive. Upserts role if already linked,
+  /// unless [overwriteRole] is false — a membership-only add must leave the
+  /// role each existing link already carries untouched (#893).
   /// No notify/transaction — BulkDiveEditService owns those.
   Future<void> bulkAddBuddies(
     List<String> diveIds,
-    List<domain.BuddyWithRole> buddies,
-  ) async {
+    List<domain.BuddyWithRole> buddies, {
+    bool overwriteRole = true,
+  }) async {
     if (diveIds.isEmpty || buddies.isEmpty) return;
     final now = DateTime.now().millisecondsSinceEpoch;
     for (final diveId in diveIds) {
@@ -613,6 +641,7 @@ class BuddyRepository {
                 ))
                 .getSingleOrNull();
         if (existing != null) {
+          if (!overwriteRole) continue;
           await (_db.update(_db.diveBuddies)..where(
                 (t) => t.diveId.equals(diveId) & t.buddyId.equals(bwr.buddy.id),
               ))

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -249,10 +249,14 @@ class BulkDiveEditService {
           case BulkCollectionMode.replace:
             await _diveRepo.bulkReplaceEquipment(ids, equipmentIds);
         }
-      case BuddiesOp(:final mode, :final buddies):
+      case BuddiesOp(:final mode, :final buddies, :final overwriteRole):
         switch (mode) {
           case BulkCollectionMode.add:
-            await _buddyRepo.bulkAddBuddies(ids, buddies);
+            await _buddyRepo.bulkAddBuddies(
+              ids,
+              buddies,
+              overwriteRole: overwriteRole,
+            );
           case BulkCollectionMode.remove:
             await _buddyRepo.bulkRemoveBuddies(
               ids,

--- a/lib/features/dive_log/domain/entities/bulk_edit_request.dart
+++ b/lib/features/dive_log/domain/entities/bulk_edit_request.dart
@@ -39,7 +39,17 @@ class BuddiesOp extends BulkCollectionOp {
   final BulkCollectionMode mode;
   // For remove, the buddy ids are read from each entry's .buddy.id.
   final List<BuddyWithRole> buddies;
-  const BuddiesOp({required this.mode, required this.buddies});
+
+  /// Add mode only: whether each entry's role replaces the role on links that
+  /// already exist. False for a membership-only add, where the user asked for
+  /// the buddy on every dive but never touched their role (#893).
+  final bool overwriteRole;
+
+  const BuddiesOp({
+    required this.mode,
+    required this.buddies,
+    this.overwriteRole = true,
+  });
 }
 
 class TanksOp extends BulkCollectionOp {

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -935,7 +935,15 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
 
   Map<String, int> _buddyCounts = {};
   final Map<String, Buddy> _buddyById = {};
+
+  /// Roles the user picked in the buddy picker during this edit. Membership
+  /// alone never lands here, so an entry means "apply this role" (#893).
   final Map<String, DiveRole> _buddyRoleById = {};
+
+  /// Role id each buddy already carries on every selected dive that has them,
+  /// so filling in the missing links reuses it instead of the default Buddy.
+  /// Buddies with a mix of roles across the selection are absent.
+  final Map<String, String> _existingBuddyRoleIds = {};
   List<BulkMembershipItem> _buddyMembers = [];
   MembershipDelta _buddyDelta = MembershipDelta.empty;
 
@@ -1281,11 +1289,35 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         ),
       );
     }
-    if (_buddyDelta.addIds.isNotEmpty) {
+    // Membership and role are separate instructions. A row the user only
+    // ticked on must not rewrite the role of links that already exist, while a
+    // role picked in the picker applies even when membership does not change
+    // because the buddy is already on every selected dive (#893).
+    final membershipOnlyAdds = _buddyDelta.addIds
+        .where((id) => !_buddyRoleById.containsKey(id))
+        .toList();
+    final pickedRoleAdds = _buddyRoleById.keys
+        .where(
+          (id) =>
+              !_buddyDelta.removeIds.contains(id) &&
+              (_buddyDelta.addIds.contains(id) ||
+                  _buddyOnEverySelectedDive(id)),
+        )
+        .toList();
+    if (membershipOnlyAdds.isNotEmpty) {
       ops.add(
         BuddiesOp(
           mode: BulkCollectionMode.add,
-          buddies: _buddyDelta.addIds.map(_buddyWithRole).toList(),
+          buddies: membershipOnlyAdds.map(_buddyWithRole).toList(),
+          overwriteRole: false,
+        ),
+      );
+    }
+    if (pickedRoleAdds.isNotEmpty) {
+      ops.add(
+        BuddiesOp(
+          mode: BulkCollectionMode.add,
+          buddies: pickedRoleAdds.map(_buddyWithRole).toList(),
         ),
       );
     }
@@ -3164,6 +3196,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     final typeCounts = await repo.diveTypeCountsForDives(ids);
     final buddyRepo = ref.read(buddyRepositoryProvider);
     final buddyCounts = await buddyRepo.buddyCountsForDives(ids);
+    final buddyRoles = await buddyRepo.unanimousBuddyRolesForDives(ids);
 
     final equip = await EquipmentRepository().getEquipmentByIds(
       equipCounts.keys.toList(),
@@ -3217,6 +3250,9 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       _buddyById
         ..clear()
         ..addAll(buddyMap);
+      _existingBuddyRoleIds
+        ..clear()
+        ..addAll(buddyRoles);
       _buddyMembers = [
         for (final id in buddyCounts.keys)
           BulkMembershipItem(
@@ -3447,8 +3483,27 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         ),
-    role: _buddyRoleById[id] ?? DiveRole.builtInBuddy(),
+    role: _roleForBuddy(id),
   );
+
+  /// Mirrors BulkMembershipEditor's "on all" presence, which is what makes a
+  /// picked role a no-op for the membership delta.
+  bool _buddyOnEverySelectedDive(String id) {
+    final total = widget.bulkDiveIds!.length;
+    return total > 0 && (_buddyCounts[id] ?? 0) >= total;
+  }
+
+  /// A picked role wins; otherwise reuse the role the buddy already has across
+  /// the selection so a membership-only add cannot demote them to Buddy. Only
+  /// the id reaches the database, so an unresolved id stays synthetic (#893).
+  DiveRole _roleForBuddy(String id) {
+    final picked = _buddyRoleById[id];
+    if (picked != null) return picked;
+    final existing = _existingBuddyRoleIds[id];
+    return existing == null
+        ? DiveRole.builtInBuddy()
+        : DiveRole.synthetic(existing);
+  }
 
   void _saveEquipmentAsSet() {
     if (_selectedEquipment.isEmpty) return;

--- a/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
@@ -31,6 +31,12 @@ void main() {
     role: DiveRole.builtInBuddy(),
   );
 
+  domain.BuddyWithRole bwrRole(String id, String roleId) =>
+      domain.BuddyWithRole(
+        buddy: bwr(id).buddy,
+        role: DiveRole.synthetic(roleId),
+      );
+
   test('bulkAddBuddies links each buddy to each dive', () async {
     await repository.bulkAddBuddies(['d1', 'd2'], [bwr('x'), bwr('y')]);
     final d1 = await (db.select(
@@ -94,4 +100,34 @@ void main() {
       expect(rows.single.role, 'instructor'); // role updated in place
     },
   );
+
+  test(
+    'bulkAddBuddies leaves existing roles alone when not overwriting',
+    () async {
+      await repository.bulkAddBuddies(['d1'], [bwrRole('x', 'instructor')]);
+      // Membership-only add across both dives: d1 keeps instructor, d2 is new.
+      await repository.bulkAddBuddies(
+        ['d1', 'd2'],
+        [bwrRole('x', DiveRole.buddyId)],
+        overwriteRole: false,
+      );
+      final rows = await db.select(db.diveBuddies).get();
+      expect(rows.length, 2);
+      expect(
+        {for (final r in rows) r.diveId: r.role},
+        {'d1': 'instructor', 'd2': DiveRole.buddyId},
+      );
+    },
+  );
+
+  test('unanimousBuddyRolesForDives omits buddies with mixed roles', () async {
+    await repository.bulkAddBuddies(['d1', 'd2'], [bwrRole('same', 'student')]);
+    await repository.bulkAddBuddies(['d1'], [bwrRole('mixed', 'instructor')]);
+    await repository.bulkAddBuddies(['d2'], [bwrRole('mixed', 'student')]);
+
+    final roles = await repository.unanimousBuddyRolesForDives(['d1', 'd2']);
+    expect(roles['same'], 'student');
+    expect(roles.containsKey('mixed'), isFalse);
+    expect(await repository.unanimousBuddyRolesForDives(const []), isEmpty);
+  });
 }

--- a/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
@@ -101,6 +101,9 @@ void main() {
             customTankPresetsProvider.overrideWith((ref) async => []),
           ].cast(),
           child: MaterialApp(
+            // Every assertion below matches an English label, so pin the
+            // locale instead of inheriting the ambient platform one.
+            locale: const Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(

--- a/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/database/database.dart' hide Buddy, Dive;
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/widgets/buddy_picker.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -42,15 +43,24 @@ void main() {
       await tearDownTestDatabase();
     });
 
-    BuddyWithRole bwr(String id, String name) => BuddyWithRole(
-      buddy: Buddy(
-        id: id,
-        name: name,
-        createdAt: DateTime(2026, 1, 1),
-        updatedAt: DateTime(2026, 1, 1),
-      ),
-      role: DiveRole.builtInBuddy(),
+    final instructorRole = DiveRole(
+      id: DiveRole.instructorId,
+      name: 'Instructor',
+      isBuiltIn: true,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
     );
+
+    BuddyWithRole bwr(String id, String name, [DiveRole? role]) =>
+        BuddyWithRole(
+          buddy: Buddy(
+            id: id,
+            name: name,
+            createdAt: DateTime(2026, 1, 1),
+            updatedAt: DateTime(2026, 1, 1),
+          ),
+          role: role ?? DiveRole.builtInBuddy(),
+        );
 
     Future<void> seedTag(String id, String name) => db
         .into(db.tags)
@@ -293,6 +303,135 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.byType(AlertDialog), findsNothing);
       }
+    });
+
+    testWidgets('bulk-adding a buddy keeps the role picked in the picker', (
+      tester,
+    ) async {
+      await seedBuddy('b1', 'Alice');
+      await seedDive('d1');
+      await seedDive('d2');
+      await pump(tester, ['d1', 'd2']);
+
+      // Buddies "+ Add" -> dialog hosting the BuddyPicker.
+      await tapAdd(tester, 'Buddies');
+      // The picker's own "+ Add" -> buddy selection sheet.
+      await tester.tap(
+        find.descendant(
+          of: find.byType(BuddyPicker),
+          matching: find.widgetWithText(TextButton, 'Add'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Pick Alice -> role selector -> Instructor.
+      await tester.tap(find.text('Alice'));
+      await tester.pumpAndSettle();
+      expect(find.text('Select Role for Alice'), findsOneWidget);
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+
+      // Done (close the sheet) then Add (merge into the membership editor).
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Add'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      final rows = await db.select(db.diveBuddies).get();
+      expect(rows.map((r) => r.diveId), containsAll(['d1', 'd2']));
+      expect(rows.map((r) => r.role), everyElement(DiveRole.instructorId));
+    });
+
+    testWidgets('adding an existing buddy to the rest keeps their role', (
+      tester,
+    ) async {
+      await seedBuddy('b1', 'Alice');
+      await seedDive('d1');
+      await seedDive('d2');
+      // Alice is an Instructor on d1 only -> the row reads "on 1 of 2".
+      await buddyRepo.bulkAddBuddies(
+        ['d1'],
+        [bwr('b1', 'Alice', instructorRole)],
+      );
+
+      await pump(tester, ['d1', 'd2']);
+
+      final toggle = find.byKey(const ValueKey('membership-toggle-b1'));
+      await tester.ensureVisible(toggle);
+      await tester.tap(toggle);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      final rows = await db.select(db.diveBuddies).get();
+      expect(rows.map((r) => r.diveId), containsAll(['d1', 'd2']));
+      // Neither the pre-existing link nor the new one may fall back to "buddy".
+      expect(rows.map((r) => r.role), everyElement(DiveRole.instructorId));
+    });
+
+    testWidgets('re-picking a role for an already-listed buddy applies it', (
+      tester,
+    ) async {
+      await seedBuddy('b1', 'Alice');
+      await seedDive('d1');
+      await seedDive('d2');
+      // Alice is already on both dives as a plain Buddy.
+      await buddyRepo.bulkAddBuddies(['d1', 'd2'], [bwr('b1', 'Alice')]);
+
+      await pump(tester, ['d1', 'd2']);
+
+      await tapAdd(tester, 'Buddies');
+      await tester.tap(
+        find.descendant(
+          of: find.byType(BuddyPicker),
+          matching: find.widgetWithText(TextButton, 'Add'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(DraggableScrollableSheet),
+          matching: find.text('Alice'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.widgetWithText(FilledButton, 'Add'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      final rows = await db.select(db.diveBuddies).get();
+      expect(rows, hasLength(2));
+      expect(rows.map((r) => r.role), everyElement(DiveRole.instructorId));
     });
 
     testWidgets('equipment add and use-set open their pickers', (tester) async {


### PR DESCRIPTION
Fixes #893.

## Context: the reported repro is already fixed, but unreleased

The exact steps in #893 (bulk edit dives with no buddy → `+ Add` → pick a buddy → Instructor → Done → Add → Save) pass on `main` today. `git log -S` traces that to 65380fc "fix(dive-log): persist picked buddy role in bulk edit" (Fixes #699, 2026-07-23), and `git tag --contains 65380fc` is empty — the fix is in no release, including `v1.7.2.4977` which the reporter is running. A regression test for that flow is added here so it stays fixed.

## Two sibling defects that do still reproduce on main

Both write the default `buddy` role over a real one, so a user taking slightly different steps hits the same symptom:

1. **Adding an existing buddy to the rest of the selection demotes them.** `_buddyRoleById` in `DiveEditPage` was only ever written by the picker, never seeded from the database, so `_buddyWithRole()` fell back to `DiveRole.builtInBuddy()` for any buddy row loaded from the DB. Since `bulkAddBuddies` *upserts* `role`, ticking a buddy who is an Instructor on some dives up to "on all dives" rewrote their role to `buddy` on the dives that already had them.
2. **Re-picking a role for a buddy already on every selected dive is discarded.** That is `presence == all` + `ensureOn`, which `MembershipDelta.from` correctly treats as a membership no-op — so no `BuddiesOp` was emitted at all and the pick vanished with no feedback.

## Approach

`BulkMembershipItem` is `{id, label, icon}`: the tri-state editor is deliberately generic and has no per-row payload, so buddies carry data the membership delta cannot represent. Rather than widen the editor, this threads **role intent** alongside **membership intent**:

- A **membership-only** add emits `BuddiesOp(overwriteRole: false)` — existing links keep whatever role they carry, and links that have to be created reuse the role the selection already agrees on.
- An **explicitly picked** role emits its own op with `overwriteRole: true`, and applies even when membership does not change (fixing 2). It is skipped for a buddy the user then toggled off.
- New `BuddyRepository.unanimousBuddyRolesForDives()` returns the role a buddy holds on every selected dive that has them, **omitting** buddies whose links disagree — so a deliberate mix of roles across dives is never flattened.

`BuddiesOp.overwriteRole` and the `bulkAddBuddies` parameter both default to `true`, so replace mode, the undo path, and every other caller are unchanged.

Known limitation, deliberately conservative: if a buddy is on *some* dives and the user picks a role but leaves the row on "leave as is", the picked role is still dropped — "leave as is" reads as "change nothing for this buddy". A per-row role affordance in the bulk editor is the real answer there.

## Testing

- 3 widget tests in `bulk_membership_wiring_test.dart`: the reporter's flow, the demote-on-add case, and the re-pick case (the latter two fail on `main` without this change).
- 2 repository tests: `overwriteRole: false` leaves existing roles alone, and `unanimousBuddyRolesForDives` omits mixed-role buddies.
- `flutter analyze`: no issues. Full suite: 15375 passed, 15 skipped, 0 failed.
