### PR TITLE
Fix Find matching dives for shared trips

### DIFF
--- a/lib/features/trips/presentation/helpers/trip_scan_actions.dart
+++ b/lib/features/trips/presentation/helpers/trip_scan_actions.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/presentation/helpers/lightroom_scan_helper.dart';
@@ -210,7 +211,8 @@ Future<void> scanForTripDives(
   WidgetRef ref,
   Trip trip,
 ) async {
-  if (trip.diverId == null) {
+  final activeDiverId = ref.read(currentDiverIdProvider);
+  if (activeDiverId == null) {
     // Both the hero CTA and the overflow item can reach this action; without a
     // diver there's nothing to scan, so tell the user instead of returning
     // silently (an unresponsive-looking tap).
@@ -237,7 +239,7 @@ Future<void> scanForTripDives(
           tripId: trip.id,
           startDate: trip.startDate,
           endDate: trip.endDate,
-          diverId: trip.diverId!,
+          diverId: activeDiverId,
         );
 
     loading.dismiss(); // Dismiss loading before any further UI.

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -923,14 +923,17 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
           _originalTrip?.startDate != _startDate ||
           _originalTrip?.endDate != _endDate;
 
-      if (mounted && datesChanged && trip.diverId != null) {
+      final activeDiverId = await ref.read(
+        validatedCurrentDiverIdProvider.future,
+      );
+      if (mounted && datesChanged && activeDiverId != null) {
         final candidates = await ref
             .read(tripRepositoryProvider)
             .findCandidateDivesForTrip(
               tripId: savedId,
               startDate: _startDate,
               endDate: _endDate,
-              diverId: trip.diverId!,
+              diverId: activeDiverId,
             );
 
         if (candidates.isNotEmpty && mounted) {

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -923,50 +923,56 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
           _originalTrip?.startDate != _startDate ||
           _originalTrip?.endDate != _endDate;
 
-      final activeDiverId = await ref.read(
-        validatedCurrentDiverIdProvider.future,
-      );
-      if (mounted && datesChanged && activeDiverId != null) {
-        final candidates = await ref
-            .read(tripRepositoryProvider)
-            .findCandidateDivesForTrip(
-              tripId: savedId,
-              startDate: _startDate,
-              endDate: _endDate,
-              diverId: activeDiverId,
+      if (mounted && datesChanged) {
+        // Resolved only once a scan is actually going to run: this provider
+        // hits the database, and the save above may not have warmed it (the
+        // `??` at the top of this method short-circuits for existing trips).
+        final activeDiverId = await ref.read(
+          validatedCurrentDiverIdProvider.future,
+        );
+
+        if (mounted && activeDiverId != null) {
+          final candidates = await ref
+              .read(tripRepositoryProvider)
+              .findCandidateDivesForTrip(
+                tripId: savedId,
+                startDate: _startDate,
+                endDate: _endDate,
+                diverId: activeDiverId,
+              );
+
+          if (candidates.isNotEmpty && mounted) {
+            final selectedIds = await showDiveAssignmentDialog(
+              context: context,
+              candidates: candidates,
             );
 
-        if (candidates.isNotEmpty && mounted) {
-          final selectedIds = await showDiveAssignmentDialog(
-            context: context,
-            candidates: candidates,
-          );
+            if (selectedIds != null && selectedIds.isNotEmpty && mounted) {
+              // Collect old trip IDs for provider invalidation
+              final oldTripIds = candidates
+                  .where(
+                    (c) => selectedIds.contains(c.dive.id) && !c.isUnassigned,
+                  )
+                  .map((c) => c.currentTripId!)
+                  .toSet();
 
-          if (selectedIds != null && selectedIds.isNotEmpty && mounted) {
-            // Collect old trip IDs for provider invalidation
-            final oldTripIds = candidates
-                .where(
-                  (c) => selectedIds.contains(c.dive.id) && !c.isUnassigned,
-                )
-                .map((c) => c.currentTripId!)
-                .toSet();
+              await ref
+                  .read(tripListNotifierProvider.notifier)
+                  .assignDivesToTrip(
+                    selectedIds,
+                    savedId,
+                    oldTripIds: oldTripIds,
+                  );
 
-            await ref
-                .read(tripListNotifierProvider.notifier)
-                .assignDivesToTrip(
-                  selectedIds,
-                  savedId,
-                  oldTripIds: oldTripIds,
-                );
-
-            if (mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    context.l10n.trips_diveScan_added(selectedIds.length),
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      context.l10n.trips_diveScan_added(selectedIds.length),
+                    ),
                   ),
-                ),
-              );
+                );
+              }
             }
           }
         }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "لم يتم العثور على غوصات مطابقة",
-  "trips_diveScan_noDiver": "عيّن غوّاصًا لهذه الرحلة للبحث عن الغطسات",
+  "trips_diveScan_noDiver": "اختر غوّاصًا نشطًا للبحث عن الغطسات",
   "trips_diveScan_selectAll": "تحديد الكل",
   "trips_diveScan_subtitle": "تم العثور على {count} غوصات في نطاق التاريخ",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "Keine passenden Tauchgänge gefunden",
-  "trips_diveScan_noDiver": "Weise dieser Reise einen Taucher zu, um nach Tauchgängen zu suchen",
+  "trips_diveScan_noDiver": "Wähle einen aktiven Taucher aus, um nach Tauchgängen zu suchen",
   "trips_diveScan_selectAll": "Alle auswählen",
   "trips_diveScan_subtitle": "{count} Tauchgänge im Datumsbereich gefunden",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10154,7 +10154,7 @@
     }
   },
   "trips_diveScan_noMatches": "No matching dives found",
-  "trips_diveScan_noDiver": "Assign a diver to this trip to scan for dives",
+  "trips_diveScan_noDiver": "Select an active diver to scan for dives",
   "trips_diveScan_selectAll": "Select all",
   "trips_diveScan_subtitle": "{count} dives found in date range",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "No se encontraron inmersiones coincidentes",
-  "trips_diveScan_noDiver": "Asigna un buceador a este viaje para buscar inmersiones",
+  "trips_diveScan_noDiver": "Selecciona un buceador activo para buscar inmersiones",
   "trips_diveScan_selectAll": "Seleccionar todo",
   "trips_diveScan_subtitle": "{count} inmersiones encontradas en el rango de fechas",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5587,7 +5587,7 @@
     }
   },
   "trips_diveScan_noMatches": "Aucune plongee correspondante trouvee",
-  "trips_diveScan_noDiver": "Attribuez un plongeur à ce voyage pour rechercher des plongées",
+  "trips_diveScan_noDiver": "Sélectionnez un plongeur actif pour rechercher des plongées",
   "trips_diveScan_selectAll": "Tout selectionner",
   "trips_diveScan_subtitle": "{count} plongees trouvees dans la plage de dates",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "לא נמצאו צלילות תואמות",
-  "trips_diveScan_noDiver": "שייך צולל לטיול זה כדי לסרוק אחר צלילות",
+  "trips_diveScan_noDiver": "בחר צולל פעיל כדי לסרוק אחר צלילות",
   "trips_diveScan_selectAll": "בחר הכל",
   "trips_diveScan_subtitle": "נמצאו {count} צלילות בטווח התאריכים",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5587,7 +5587,7 @@
     }
   },
   "trips_diveScan_noMatches": "Nem talalhatok egyezo merulesek",
-  "trips_diveScan_noDiver": "Rendelj egy búvárt ehhez az úthoz a merülések kereséséhez",
+  "trips_diveScan_noDiver": "Válassz ki egy aktív búvárt a merülések kereséséhez",
   "trips_diveScan_selectAll": "Osszes kivalasztasa",
   "trips_diveScan_subtitle": "{count} merules talalhato a datumtartomanyban",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5583,7 +5583,7 @@
     }
   },
   "trips_diveScan_noMatches": "Nessuna immersione corrispondente trovata",
-  "trips_diveScan_noDiver": "Assegna un subacqueo a questo viaggio per cercare le immersioni",
+  "trips_diveScan_noDiver": "Seleziona un subacqueo attivo per cercare le immersioni",
   "trips_diveScan_selectAll": "Seleziona tutto",
   "trips_diveScan_subtitle": "{count} immersioni trovate nell'intervallo di date",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -29341,7 +29341,7 @@ abstract class AppLocalizations {
   /// No description provided for @trips_diveScan_noDiver.
   ///
   /// In en, this message translates to:
-  /// **'Assign a diver to this trip to scan for dives'**
+  /// **'Select an active diver to scan for dives'**
   String get trips_diveScan_noDiver;
 
   /// No description provided for @trips_diveScan_selectAll.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -17191,8 +17191,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get trips_diveScan_noMatches => 'لم يتم العثور على غوصات مطابقة';
 
   @override
-  String get trips_diveScan_noDiver =>
-      'عيّن غوّاصًا لهذه الرحلة للبحث عن الغطسات';
+  String get trips_diveScan_noDiver => 'اختر غوّاصًا نشطًا للبحث عن الغطسات';
 
   @override
   String get trips_diveScan_selectAll => 'تحديد الكل';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -17482,7 +17482,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Weise dieser Reise einen Taucher zu, um nach Tauchgängen zu suchen';
+      'Wähle einen aktiven Taucher aus, um nach Tauchgängen zu suchen';
 
   @override
   String get trips_diveScan_selectAll => 'Alle auswählen';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -17212,7 +17212,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Assign a diver to this trip to scan for dives';
+      'Select an active diver to scan for dives';
 
   @override
   String get trips_diveScan_selectAll => 'Select all';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -17528,7 +17528,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Asigna un buceador a este viaje para buscar inmersiones';
+      'Selecciona un buceador activo para buscar inmersiones';
 
   @override
   String get trips_diveScan_selectAll => 'Seleccionar todo';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -17584,7 +17584,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Attribuez un plongeur à ce voyage pour rechercher des plongées';
+      'Sélectionnez un plongeur actif pour rechercher des plongées';
 
   @override
   String get trips_diveScan_selectAll => 'Tout selectionner';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17062,8 +17062,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get trips_diveScan_noMatches => 'לא נמצאו צלילות תואמות';
 
   @override
-  String get trips_diveScan_noDiver =>
-      'שייך צולל לטיול זה כדי לסרוק אחר צלילות';
+  String get trips_diveScan_noDiver => 'בחר צולל פעיל כדי לסרוק אחר צלילות';
 
   @override
   String get trips_diveScan_selectAll => 'בחר הכל';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -17459,7 +17459,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Rendelj egy búvárt ehhez az úthoz a merülések kereséséhez';
+      'Válassz ki egy aktív búvárt a merülések kereséséhez';
 
   @override
   String get trips_diveScan_selectAll => 'Osszes kivalasztasa';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -17513,7 +17513,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Assegna un subacqueo a questo viaggio per cercare le immersioni';
+      'Seleziona un subacqueo attivo per cercare le immersioni';
 
   @override
   String get trips_diveScan_selectAll => 'Seleziona tutto';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -17366,7 +17366,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Wijs een duiker toe aan deze reis om naar duiken te zoeken';
+      'Selecteer een actieve duiker om naar duiken te zoeken';
 
   @override
   String get trips_diveScan_selectAll => 'Alles selecteren';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -17523,7 +17523,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get trips_diveScan_noDiver =>
-      'Atribua um mergulhador a esta viagem para procurar mergulhos';
+      'Selecione um mergulhador ativo para procurar mergulhos';
 
   @override
   String get trips_diveScan_selectAll => 'Selecionar tudo';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -16615,7 +16615,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trips_diveScan_noMatches => '未找到匹配的潜水';
 
   @override
-  String get trips_diveScan_noDiver => '为此行程指定潜水员以扫描潜水记录';
+  String get trips_diveScan_noDiver => '请选择当前潜水员以扫描潜水记录';
 
   @override
   String get trips_diveScan_selectAll => '全选';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "Geen overeenkomende duiken gevonden",
-  "trips_diveScan_noDiver": "Wijs een duiker toe aan deze reis om naar duiken te zoeken",
+  "trips_diveScan_noDiver": "Selecteer een actieve duiker om naar duiken te zoeken",
   "trips_diveScan_selectAll": "Alles selecteren",
   "trips_diveScan_subtitle": "{count} duiken gevonden in het datumbereik",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5659,7 +5659,7 @@
     }
   },
   "trips_diveScan_noMatches": "Nenhum mergulho correspondente encontrado",
-  "trips_diveScan_noDiver": "Atribua um mergulhador a esta viagem para procurar mergulhos",
+  "trips_diveScan_noDiver": "Selecione um mergulhador ativo para procurar mergulhos",
   "trips_diveScan_selectAll": "Selecionar tudo",
   "trips_diveScan_subtitle": "{count} mergulhos encontrados no intervalo de datas",
   "@trips_diveScan_subtitle": {

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5485,7 +5485,7 @@
   "trips_diveScan_groupOtherTrips": "在其他旅行中（{count}）",
   "trips_diveScan_groupUnassigned": "未分配（{count}）",
   "trips_diveScan_noMatches": "未找到匹配的潜水",
-  "trips_diveScan_noDiver": "为此行程指定潜水员以扫描潜水记录",
+  "trips_diveScan_noDiver": "请选择当前潜水员以扫描潜水记录",
   "trips_diveScan_selectAll": "全选",
   "trips_diveScan_subtitle": "在日期范围内找到 {count} 次潜水",
   "trips_diveScan_title": "将潜水添加到旅行",

--- a/test/features/trips/presentation/helpers/trip_scan_actions_test.dart
+++ b/test/features/trips/presentation/helpers/trip_scan_actions_test.dart
@@ -124,20 +124,23 @@ Future<void> pumpActionButton(
 }
 
 void main() {
-  testWidgets('scanForTripDives explains when there is no diver', (
+  testWidgets('scanForTripDives explains when there is no active diver', (
     tester,
   ) async {
+    // The trip has an owner; what is missing is the *active* diver, so the
+    // guard and its message must both be about the active diver. The base
+    // overrides pin currentDiverIdProvider to null.
     await pumpActionButton(
       tester,
       const [],
-      (context, ref) => scanForTripDives(context, ref, _trip()),
+      (context, ref) => scanForTripDives(context, ref, _trip(diverId: 'BAB')),
     );
     await tester.tap(find.text('go'));
     await tester.pumpAndSettle();
     // No scan runs, but the user gets feedback instead of a silent no-op.
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(
-      find.text('Assign a diver to this trip to scan for dives'),
+      find.text('Select an active diver to scan for dives'),
       findsOneWidget,
     );
   });

--- a/test/features/trips/presentation/helpers/trip_scan_actions_test.dart
+++ b/test/features/trips/presentation/helpers/trip_scan_actions_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
@@ -51,6 +52,35 @@ class _NoCandidatesRepo extends TripRepository {
   }) async => [];
 }
 
+/// Trip repository that records the diverId it was queried with, so tests
+/// can assert which diver's dives get searched.
+class _RecordingCandidatesRepo extends TripRepository {
+  String? lastDiverId;
+
+  @override
+  Future<List<DiveCandidate>> findCandidateDivesForTrip({
+    required String tripId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required String diverId,
+  }) async {
+    lastDiverId = diverId;
+    return [];
+  }
+}
+
+/// Mock CurrentDiverIdNotifier pinned to a fixed active diver.
+class _FixedDiverIdNotifier extends StateNotifier<String?>
+    implements CurrentDiverIdNotifier {
+  _FixedDiverIdNotifier(super.diverId);
+
+  @override
+  Future<void> setCurrentDiver(String id) async => state = id;
+
+  @override
+  Future<void> clearCurrentDiver() async => state = null;
+}
+
 Trip _trip({String? diverId}) => Trip(
   id: 'trip-1',
   diverId: diverId,
@@ -68,9 +98,14 @@ Future<void> pumpActionButton(
   void Function(BuildContext, WidgetRef) onPressed,
 ) async {
   final overrides = await getBaseOverrides();
+  // Let `extra` overrides win when they target a provider the base list
+  // already overrides (e.g. currentDiverIdProvider); Riverpod disallows
+  // overriding the same provider twice in one ProviderScope.
+  final extraOrigins = extra.map((o) => o.origin).toSet();
+  final deduped = overrides.where((o) => !extraOrigins.contains(o.origin));
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [...overrides, ...extra].cast(),
+      overrides: [...deduped, ...extra].cast(),
       child: MaterialApp(
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -110,10 +145,26 @@ void main() {
   testWidgets('scanForTripDives shows a no-matches snackbar', (tester) async {
     await pumpActionButton(tester, [
       tripRepositoryProvider.overrideWithValue(_NoCandidatesRepo()),
+      currentDiverIdProvider.overrideWith((ref) => _FixedDiverIdNotifier('d1')),
     ], (context, ref) => scanForTripDives(context, ref, _trip(diverId: 'd1')));
     await tester.tap(find.text('go'));
     await tester.pumpAndSettle();
     expect(find.text('No matching dives found'), findsOneWidget);
+  });
+
+  testWidgets('scanForTripDives searches the active diver, not the trip owner '
+      '(shared trip)', (tester) async {
+    // Trip is owned by BAB but shared with, and being viewed by, MAB.
+    final repo = _RecordingCandidatesRepo();
+    await pumpActionButton(tester, [
+      tripRepositoryProvider.overrideWithValue(repo),
+      currentDiverIdProvider.overrideWith(
+        (ref) => _FixedDiverIdNotifier('MAB'),
+      ),
+    ], (context, ref) => scanForTripDives(context, ref, _trip(diverId: 'BAB')));
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    expect(repo.lastDiverId, 'MAB');
   });
 
   testWidgets('scanGalleryForTripPhotos asks to add dives first when empty', (

--- a/test/features/trips/presentation/pages/trip_detail_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_page_test.dart
@@ -183,6 +183,9 @@ void main() {
                 (ref) => _MockTripListNotifier([]),
               ),
               settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
+              currentDiverIdProvider.overrideWith(
+                (ref) => MockCurrentDiverIdNotifier(),
+              ),
             ],
             child: MaterialApp(
               locale: const Locale('en'),
@@ -231,7 +234,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('Add dives first to link photos'), findsWidgets);
 
-      // scan-dives with no diverId short-circuits without error.
+      // scan-dives with no active diver short-circuits without error.
       await openMenu();
       await tester.tap(
         find.widgetWithText(PopupMenuItem<String>, 'Find matching dives'),

--- a/test/features/trips/presentation/pages/trip_edit_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_edit_page_test.dart
@@ -739,6 +739,93 @@ void main() {
       expect(find.text('Trip updated successfully'), findsOneWidget);
     });
 
+    testWidgets('save with unchanged dates runs no scan and no diver lookup', (
+      tester,
+    ) async {
+      final repo = _RecordingScanRepo();
+      var diverLookups = 0;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tripRepositoryProvider.overrideWithValue(repo),
+            tripListNotifierProvider.overrideWith(
+              (ref) => _MockTripListNotifier([]),
+            ),
+            validatedCurrentDiverIdProvider.overrideWith((ref) async {
+              diverLookups++;
+              return 'MAB';
+            }),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: TripEditPage(tripId: 'test-id'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // Edit the name only, leaving both dates alone.
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Trip Name *'),
+        'Updated Name',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(repo.scanCalls, 0);
+      // The trip already has an owner, so the `??` at the top of _saveTrip
+      // short-circuits and never resolves the provider. That leaves the scan
+      // as the only possible reader, and it must not run for unchanged dates.
+      expect(diverLookups, 0);
+    });
+
+    testWidgets(
+      'post-save scan searches the active diver, not the trip owner',
+      (tester) async {
+        // Trip is owned by BAB but shared with, and being edited by, MAB.
+        final repo = _RecordingScanRepo();
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              tripRepositoryProvider.overrideWithValue(repo),
+              tripListNotifierProvider.overrideWith(
+                (ref) => _MockTripListNotifier([]),
+              ),
+              validatedCurrentDiverIdProvider.overrideWith(
+                (ref) async => 'MAB',
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: TripEditPage(tripId: 'test-id'),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Move the start date so the post-save scan is triggered.
+        await tester.tap(find.text('Start Date'));
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.descendant(
+            of: find.byType(DatePickerDialog),
+            matching: find.text('18'),
+          ),
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+
+        expect(repo.scanCalls, 1);
+        // Ownership stays with BAB; the dives searched belong to the viewer.
+        expect(repo.scannedDiverId, 'MAB');
+      },
+    );
+
     testWidgets('save errors show error snackbar', (tester) async {
       final notifier = _ThrowingTripListNotifier();
       await tester.pumpWidget(
@@ -1377,6 +1464,37 @@ class _MockTripRepository implements TripRepository {
 }
 
 /// Mock repository that returns a test trip
+/// Existing trip owned by another diver, recording which diver the post-save
+/// scan actually queries. Mirrors the shared-trip case from issue #891.
+class _RecordingScanRepo extends _MockTripRepositoryWithTrip {
+  String? scannedDiverId;
+  int scanCalls = 0;
+
+  @override
+  Future<Trip?> getTripById(String id) async => Trip(
+    id: 'test-id',
+    diverId: 'BAB',
+    name: 'Existing Trip',
+    startDate: DateTime(2024, 1, 15),
+    endDate: DateTime(2024, 1, 22),
+    location: 'Test Location',
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  );
+
+  @override
+  Future<List<DiveCandidate>> findCandidateDivesForTrip({
+    required String tripId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required String diverId,
+  }) async {
+    scanCalls++;
+    scannedDiverId = diverId;
+    return [];
+  }
+}
+
 class _MockTripRepositoryWithTrip implements TripRepository {
   @override
   Future<Trip> createTrip(Trip trip) async => trip;

--- a/test/features/trips/presentation/pages/trip_edit_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_edit_page_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -10,7 +12,82 @@ import 'package:submersion/features/trips/presentation/pages/trip_edit_page.dart
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
 import 'package:submersion/features/trips/domain/entities/dive_candidate.dart';
+import 'package:submersion/features/trips/presentation/widgets/dive_assignment_dialog.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Pumps a fresh-trip page behind a router, so the `context.pop(savedId)` that
+/// follows a successful save has somewhere to go. Creating a trip always
+/// triggers the post-save scan (`datesChanged` is `!isEditing`), which keeps
+/// these tests clear of date-picker choreography.
+///
+/// The surface is enlarged because the assignment sheet is a
+/// `DraggableScrollableSheet` at 60% height - at the default 800x600 the
+/// candidate rows would need scrolling before they could be tapped.
+Future<void> _pumpNewTripPage(
+  WidgetTester tester, {
+  required TripRepository repository,
+  required TripListNotifier notifier,
+  required String? activeDiverId,
+}) async {
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final router = GoRouter(
+    initialLocation: '/trips/new',
+    routes: [
+      GoRoute(
+        path: '/trips',
+        builder: (context, state) => const Scaffold(body: Text('LIST_PAGE')),
+      ),
+      GoRoute(
+        path: '/trips/new',
+        builder: (context, state) => const TripEditPage(),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripRepositoryProvider.overrideWithValue(repository),
+        tripListNotifierProvider.overrideWith((ref) => notifier),
+        validatedCurrentDiverIdProvider.overrideWith(
+          (ref) async => activeDiverId,
+        ),
+      ],
+      child: MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Advances a fixed budget of frames instead of settling.
+///
+/// `pumpAndSettle` is unusable while a save is in flight: `_saveTrip` sets
+/// `_isSaving` before awaiting and only clears it on the error path, so the
+/// Save button's `CircularProgressIndicator` schedules frames for as long as
+/// the assignment sheet is open. A bounded pump advances fake time far enough
+/// to cover the awaited futures plus the sheet's entry and exit animations.
+Future<void> _pumpSaveFrames(WidgetTester tester) async {
+  for (var i = 0; i < 10; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+}
+
+Future<void> _saveNewTrip(WidgetTester tester, String name) async {
+  await tester.enterText(
+    find.widgetWithText(TextFormField, 'Trip Name *'),
+    name,
+  );
+  await tester.tap(find.text('Save'));
+  await _pumpSaveFrames(tester);
+}
 
 void main() {
   group('TripEditPage - New Trip', () {
@@ -826,6 +903,88 @@ void main() {
       },
     );
 
+    testWidgets('picked dives are assigned to the trip the save returned', (
+      tester,
+    ) async {
+      final repo = _CandidateScanRepo();
+      final notifier = _MockTripListNotifier([]);
+      await _pumpNewTripPage(
+        tester,
+        repository: repo,
+        notifier: notifier,
+        activeDiverId: 'diver-id',
+      );
+      await _saveNewTrip(tester, 'Red Sea 2024');
+
+      // The two unassigned dives arrive pre-checked. Add the Egypt Trip dive
+      // as well, and leave the Palau Trip dive untouched.
+      expect(find.text('Add 2 Dives'), findsOneWidget);
+      await tester.tap(find.text('Site 43'));
+      await tester.pump();
+      await tester.tap(find.text('Add 3 Dives'));
+      await _pumpSaveFrames(tester);
+
+      expect(notifier.assignCalls, 1);
+      expect(
+        notifier.assignedDiveIds,
+        unorderedEquals(['dive-1', 'dive-2', 'dive-3']),
+      );
+      // savedId is the id addTrip handed back, not widget.tripId (null here).
+      expect(notifier.assignedTripId, 'new-id-1');
+      // Only trips actually losing a dive get invalidated: the unassigned
+      // dives contribute nothing, and Palau was never selected.
+      expect(notifier.assignedOldTripIds, {'egypt-trip'});
+      expect(find.text('Added 3 dives to trip'), findsOneWidget);
+    });
+
+    testWidgets('dismissing the dive dialog assigns nothing', (tester) async {
+      final repo = _CandidateScanRepo();
+      final notifier = _MockTripListNotifier([]);
+      await _pumpNewTripPage(
+        tester,
+        repository: repo,
+        notifier: notifier,
+        activeDiverId: 'diver-id',
+      );
+      await _saveNewTrip(tester, 'Red Sea 2024');
+
+      expect(find.byType(DiveAssignmentDialog), findsOneWidget);
+      await tester.tap(
+        find.descendant(
+          of: find.byType(DiveAssignmentDialog),
+          matching: find.text('Cancel'),
+        ),
+      );
+      await _pumpSaveFrames(tester);
+
+      expect(notifier.assignCalls, 0);
+      expect(find.textContaining('dives to trip'), findsNothing);
+      // The trip itself is saved either way - only the dives were declined.
+      expect(notifier.addCalls, 1);
+      expect(find.text('Trip added successfully'), findsOneWidget);
+    });
+
+    testWidgets('no active diver saves the trip without scanning', (
+      tester,
+    ) async {
+      final repo = _CandidateScanRepo();
+      final notifier = _MockTripListNotifier([]);
+      await _pumpNewTripPage(
+        tester,
+        repository: repo,
+        notifier: notifier,
+        activeDiverId: null,
+      );
+      await _saveNewTrip(tester, 'Red Sea 2024');
+
+      // With no diver resolved there is nobody to scan for, so the query never
+      // runs and the dialog never opens - but the trip still saves.
+      expect(repo.scanCalls, 0);
+      expect(find.byType(DiveAssignmentDialog), findsNothing);
+      expect(notifier.addCalls, 1);
+      expect(find.text('Trip added successfully'), findsOneWidget);
+    });
+
     testWidgets('save errors show error snackbar', (tester) async {
       final notifier = _ThrowingTripListNotifier();
       await tester.pumpWidget(
@@ -1392,6 +1551,48 @@ void main() {
   });
 }
 
+/// Candidates for the post-save scan: two loose dives plus two already sitting
+/// on other trips. The assignment tests select `dive-3` and leave `dive-4`
+/// alone, so `egypt-trip` is the only trip that should get invalidated.
+List<DiveCandidate> _scanCandidates() => [
+  DiveCandidate(dive: _candidateDive('dive-1', 41)),
+  DiveCandidate(dive: _candidateDive('dive-2', 42)),
+  DiveCandidate(
+    dive: _candidateDive('dive-3', 43),
+    currentTripId: 'egypt-trip',
+    currentTripName: 'Egypt Trip',
+  ),
+  DiveCandidate(
+    dive: _candidateDive('dive-4', 44),
+    currentTripId: 'palau-trip',
+    currentTripName: 'Palau Trip',
+  ),
+];
+
+Dive _candidateDive(String id, int diveNumber) => Dive(
+  id: id,
+  dateTime: DateTime(2024, 1, 16),
+  diveNumber: diveNumber,
+  site: DiveSite(id: 'site-$id', name: 'Site $diveNumber'),
+);
+
+/// Repository for the new-trip flow that hands the page a real candidate list
+/// so the assignment dialog actually opens.
+class _CandidateScanRepo extends _MockTripRepository {
+  int scanCalls = 0;
+
+  @override
+  Future<List<DiveCandidate>> findCandidateDivesForTrip({
+    required String tripId,
+    required DateTime startDate,
+    required DateTime endDate,
+    required String diverId,
+  }) async {
+    scanCalls++;
+    return _scanCandidates();
+  }
+}
+
 /// Mock repository that returns null for trips
 class _MockTripRepository implements TripRepository {
   @override
@@ -1463,7 +1664,6 @@ class _MockTripRepository implements TripRepository {
   Stream<void> watchTripsChanges() => const Stream<void>.empty();
 }
 
-/// Mock repository that returns a test trip
 /// Existing trip owned by another diver, recording which diver the post-save
 /// scan actually queries. Mirrors the shared-trip case from issue #891.
 class _RecordingScanRepo extends _MockTripRepositoryWithTrip {
@@ -1495,6 +1695,7 @@ class _RecordingScanRepo extends _MockTripRepositoryWithTrip {
   }
 }
 
+/// Mock repository that returns a test trip
 class _MockTripRepositoryWithTrip implements TripRepository {
   @override
   Future<Trip> createTrip(Trip trip) async => trip;
@@ -1665,6 +1866,10 @@ class _MockTripListNotifier
 
   int addCalls = 0;
   int updateCalls = 0;
+  int assignCalls = 0;
+  List<String>? assignedDiveIds;
+  String? assignedTripId;
+  Set<String>? assignedOldTripIds;
 
   @override
   Future<void> refresh() async {}
@@ -1694,7 +1899,12 @@ class _MockTripListNotifier
     List<String> diveIds,
     String tripId, {
     Set<String>? oldTripIds,
-  }) async {}
+  }) async {
+    assignCalls++;
+    assignedDiveIds = diveIds;
+    assignedTripId = tripId;
+    assignedOldTripIds = oldTripIds;
+  }
 }
 
 /// Notifier whose addTrip throws - used to test error snackbar.


### PR DESCRIPTION
## Summary

`scanForTripDives` and the post-save auto-scan in `TripEditPage` searched dives owned by the trip's _owning_ diver instead of the diver currently viewing the trip. For a trip created by one diver and shared with another, this meant "Find matching dives" (both the overflow menu item and the story-view CTA) always returned zero results when viewed by the diver it was shared with, even if their own dives fell within the trip's date range.

Issue: https://github.com/submersion-app/submersion/issues/891

## Changes

- `lib/features/trips/presentation/helpers/trip_scan_actions.dart` — `scanForTripDives` now reads the active diver from `currentDiverIdProvider` for both the "no diver" guard and the `findCandidateDivesForTrip` query, instead of `trip.diverId`.
- `lib/features/trips/presentation/pages/trip_edit_page.dart` — the post-save auto-scan now resolves the active diver via `validatedCurrentDiverIdProvider` (matching the pattern already used earlier in the same save flow) instead of `trip.diverId!`.
- `test/features/trips/presentation/helpers/trip_scan_actions_test.dart` — added a regression test verifying a trip owned by one diver and viewed by another queries dives for the viewing diver; updated the existing no-matches test to pin an active diver; let explicit provider overrides win over the shared test helper's base overrides.
- `test/features/trips/presentation/pages/trip_detail_page_test.dart` — added a `currentDiverIdProvider` override so the "no active diver" short-circuit path is exercised correctly under the new guard.

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: 

