### PR TITLE
fix(planner): honour the diver's gradient factor settings, and stop settings changes from discarding an open plan

### DIFF
--- a/lib/features/dive_planner/data/services/plan_calculator_service.dart
+++ b/lib/features/dive_planner/data/services/plan_calculator_service.dart
@@ -58,6 +58,25 @@ class PlanCalculatorService {
     this.cnsMethod = CnsCalculationMethod.shearwater,
   });
 
+  /// A copy that decompresses on the given gradient factors, leaving every
+  /// other threshold as the diver configured it.
+  ///
+  /// A plan carries its own gradient factors -- seeded from the diver's deco
+  /// settings, then editable per plan -- so results computed for that plan
+  /// must use them rather than whatever the settings currently say.
+  PlanCalculatorService withGradientFactors(int gfLow, int gfHigh) {
+    return PlanCalculatorService(
+      gfLow: gfLow,
+      gfHigh: gfHigh,
+      ppO2Warning: ppO2Warning,
+      ppO2Critical: ppO2Critical,
+      cnsWarningThreshold: cnsWarningThreshold,
+      defaultAscentRate: defaultAscentRate,
+      defaultDescentRate: defaultDescentRate,
+      cnsMethod: cnsMethod,
+    );
+  }
+
   /// Calculate complete plan results from segments.
   ///
   /// [segments] - The dive plan segments in order.

--- a/lib/features/dive_planner/domain/entities/plan_result.dart
+++ b/lib/features/dive_planner/domain/entities/plan_result.dart
@@ -466,6 +466,12 @@ class DivePlanState extends Equatable {
   /// Default reserve pressure in bar.
   static const double kDefaultReservePressureBar = 50;
 
+  /// Gradient factors used only when the diver's deco settings are not
+  /// reachable. Live plans are seeded from those settings; see
+  /// [DivePlanNotifier].
+  static const int kFallbackGfLow = 30;
+  static const int kFallbackGfHigh = 70;
+
   /// Unique ID for this plan.
   final String id;
 
@@ -560,8 +566,8 @@ class DivePlanState extends Equatable {
     required this.name,
     required this.segments,
     required this.tanks,
-    this.gfLow = 30,
-    this.gfHigh = 70,
+    this.gfLow = kFallbackGfLow,
+    this.gfHigh = kFallbackGfHigh,
     this.sacRate = 15.0,
     this.ascentRate = 9.0,
     this.descentRate = 18.0,

--- a/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
+++ b/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
@@ -82,22 +82,39 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
   /// production caller must set [_loaded] as [loadPlanById] does.
   bool get isPersisted => _loaded != null;
 
-  DivePlanNotifier(
-    this._calculator, {
+  /// Resolves each defaulted source once, so the initial plan and every later
+  /// [newPlan] are provably built from the same one. Dart forbids reading a
+  /// field in an initializer list, so without this hop the private constructor
+  /// would have to repeat each `??` in its `super` call.
+  factory DivePlanNotifier(
+    PlanCalculatorService calculator, {
     double reservePressure = DivePlanState.kDefaultReservePressureBar,
     double Function()? getDefaultReservePressure,
     PlanGradientFactors Function()? getDefaultGradientFactors,
     DivePlanRepository? repository,
-  }) : _getDefaultReservePressure =
-           getDefaultReservePressure ?? (() => reservePressure),
-       _getDefaultGradientFactors =
-           getDefaultGradientFactors ?? _fallbackGradientFactors,
+  }) {
+    return DivePlanNotifier._(
+      calculator,
+      getDefaultReservePressure:
+          getDefaultReservePressure ?? (() => reservePressure),
+      getDefaultGradientFactors:
+          getDefaultGradientFactors ?? _fallbackGradientFactors,
+      repository: repository,
+    );
+  }
+
+  DivePlanNotifier._(
+    this._calculator, {
+    required double Function() getDefaultReservePressure,
+    required PlanGradientFactors Function() getDefaultGradientFactors,
+    DivePlanRepository? repository,
+  }) : _getDefaultReservePressure = getDefaultReservePressure,
+       _getDefaultGradientFactors = getDefaultGradientFactors,
        _repository = repository,
        super(
          _createInitialState(
-           reservePressure: reservePressure,
-           getGradientFactors:
-               getDefaultGradientFactors ?? _fallbackGradientFactors,
+           reservePressure: getDefaultReservePressure(),
+           getGradientFactors: getDefaultGradientFactors,
          ),
        );
 
@@ -105,9 +122,8 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
       (low: DivePlanState.kFallbackGfLow, high: DivePlanState.kFallbackGfHigh);
 
   static DivePlanState _createInitialState({
-    double reservePressure = DivePlanState.kDefaultReservePressureBar,
-    PlanGradientFactors Function() getGradientFactors =
-        _fallbackGradientFactors,
+    required double reservePressure,
+    required PlanGradientFactors Function() getGradientFactors,
   }) {
     final now = DateTime.now();
     final gradientFactors = getGradientFactors();
@@ -676,9 +692,17 @@ final divePlanNotifierProvider =
 /// Provider for auto-calculated plan results.
 ///
 /// This automatically recalculates whenever the plan state changes.
+///
+/// The gradient factors come from the plan, not the settings: the plan is
+/// seeded from the diver's settings but is editable per plan, and
+/// [planIsValidProvider] gates convert-to-dive off these results. Computing
+/// them on the settings pair would judge a plan by factors it is not using,
+/// and diverge from [planOutcomeProvider], which the canvas displays.
 final planResultsProvider = Provider<PlanResult>((ref) {
   final state = ref.watch(divePlanNotifierProvider);
-  final calculator = ref.watch(planCalculatorServiceProvider);
+  final calculator = ref
+      .watch(planCalculatorServiceProvider)
+      .withGradientFactors(state.gfLow, state.gfHigh);
 
   if (state.segments.isEmpty) {
     return PlanResult.empty();

--- a/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
+++ b/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
@@ -44,12 +44,24 @@ final planCalculatorServiceProvider = Provider<PlanCalculatorService>((ref) {
   );
 });
 
+/// The diver's configured gradient factors as one value, so a listener fires
+/// once when either half changes and not at all for unrelated settings.
+final planGradientFactorSettingsProvider = Provider<PlanGradientFactors>((ref) {
+  return (low: ref.watch(gfLowProvider), high: ref.watch(gfHighProvider));
+});
+
 // ============================================================================
 // State Notifiers
 // ============================================================================
 
 /// StateNotifier for managing dive plan editing state.
 class DivePlanNotifier extends StateNotifier<DivePlanState> {
+  /// Snapshot taken at construction, deliberately not kept in sync with the
+  /// diver's settings -- see [divePlanNotifierProvider] for why this notifier
+  /// cannot subscribe to them. Only safe for calls that read no setting, which
+  /// today means [PlanCalculatorService.generateProfilePoints] (pure geometry).
+  /// Deco math belongs in [planOutcomeProvider], which recomputes on every
+  /// settings change.
   final PlanCalculatorService _calculator;
   final double Function() _getDefaultReservePressure;
   final PlanGradientFactors Function() _getDefaultGradientFactors;
@@ -135,6 +147,27 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
     state = _createInitialState(
       reservePressure: _getDefaultReservePressure(),
       getGradientFactors: _getDefaultGradientFactors,
+    );
+  }
+
+  /// Move an untouched plan onto the diver's current gradient factors.
+  ///
+  /// Settings hydrate from the database after this notifier is built, and the
+  /// diver may change them with the planner open; either way a plan they have
+  /// not started yet should show the factors they actually dive. A plan with
+  /// segments, unsaved edits, or a persisted record is their work and is left
+  /// alone -- including a hand-tuned GF, which marks the plan dirty.
+  ///
+  /// Adopting a setting is not a diver edit, so this does not set `isDirty`.
+  void adoptGradientFactorsIfPristine(PlanGradientFactors gradientFactors) {
+    if (isPersisted || state.isDirty || state.segments.isNotEmpty) return;
+    if (state.gfLow == gradientFactors.low &&
+        state.gfHigh == gradientFactors.high) {
+      return;
+    }
+    state = state.copyWith(
+      gfLow: gradientFactors.low,
+      gfHigh: gradientFactors.high,
     );
   }
 
@@ -592,11 +625,19 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
 }
 
 /// Provider for the dive plan notifier.
+///
+/// This provider must never rebuild: rebuilding a StateNotifierProvider
+/// constructs a new notifier, which throws away the plan the diver is editing.
+/// Everything it needs is therefore resolved with `read` rather than `watch` --
+/// settings through closures evaluated when a new plan is created, and
+/// [planCalculatorServiceProvider] once at construction. Watching the latter
+/// rebound the notifier on every deco settings change, silently discarding an
+/// in-progress plan.
 final divePlanNotifierProvider =
     StateNotifierProvider<DivePlanNotifier, DivePlanState>((ref) {
-      final calculator = ref.watch(planCalculatorServiceProvider);
-      // Default reserve: 50 bar for metric, 500 psi (~34.47 bar) for imperial
       final read = ref.read;
+      final calculator = read(planCalculatorServiceProvider);
+      // Default reserve: 50 bar for metric, 500 psi (~34.47 bar) for imperial
       double defaultReserve() {
         final unit = read(pressureUnitProvider);
         return unit == PressureUnit.psi
@@ -604,18 +645,28 @@ final divePlanNotifierProvider =
             : DivePlanState.kDefaultReservePressureBar;
       }
 
-      // A new plan starts on the diver's own deco settings; per-plan edits and
-      // saved plans override this and are never overwritten by it.
+      // A new plan starts on the diver's own deco settings. Once they have
+      // touched or saved it, it is theirs: see adoptGradientFactorsIfPristine.
       PlanGradientFactors defaultGradientFactors() =>
-          (low: read(gfLowProvider), high: read(gfHighProvider));
+          read(planGradientFactorSettingsProvider);
 
-      return DivePlanNotifier(
+      final notifier = DivePlanNotifier(
         calculator,
         reservePressure: defaultReserve(),
         getDefaultReservePressure: defaultReserve,
         getDefaultGradientFactors: defaultGradientFactors,
-        repository: ref.watch(divePlanRepositoryProvider),
+        repository: read(divePlanRepositoryProvider),
       );
+
+      // `listen`, never `watch`: this reacts to settings without rebuilding,
+      // which is what lets an untouched plan track the diver's gradient
+      // factors while an in-progress one survives the same change.
+      ref.listen<PlanGradientFactors>(
+        planGradientFactorSettingsProvider,
+        (_, next) => notifier.adoptGradientFactorsIfPristine(next),
+      );
+
+      return notifier;
     });
 
 // ============================================================================

--- a/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
+++ b/lib/features/dive_planner/presentation/providers/dive_planner_providers.dart
@@ -18,6 +18,10 @@ import 'package:submersion/features/planner/presentation/providers/plan_reposito
 
 const _uuid = Uuid();
 
+/// A gradient factor pair as a percentage (0-100). The two halves are only
+/// meaningful together, so they travel as one value.
+typedef PlanGradientFactors = ({int low, int high});
+
 // ============================================================================
 // Service Providers
 // ============================================================================
@@ -48,6 +52,7 @@ final planCalculatorServiceProvider = Provider<PlanCalculatorService>((ref) {
 class DivePlanNotifier extends StateNotifier<DivePlanState> {
   final PlanCalculatorService _calculator;
   final double Function() _getDefaultReservePressure;
+  final PlanGradientFactors Function() _getDefaultGradientFactors;
   final DivePlanRepository? _repository;
 
   /// The persisted aggregate this state was loaded from (or last saved as);
@@ -69,21 +74,38 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
     this._calculator, {
     double reservePressure = DivePlanState.kDefaultReservePressureBar,
     double Function()? getDefaultReservePressure,
+    PlanGradientFactors Function()? getDefaultGradientFactors,
     DivePlanRepository? repository,
   }) : _getDefaultReservePressure =
            getDefaultReservePressure ?? (() => reservePressure),
+       _getDefaultGradientFactors =
+           getDefaultGradientFactors ?? _fallbackGradientFactors,
        _repository = repository,
-       super(_createInitialState(reservePressure: reservePressure));
+       super(
+         _createInitialState(
+           reservePressure: reservePressure,
+           getGradientFactors:
+               getDefaultGradientFactors ?? _fallbackGradientFactors,
+         ),
+       );
+
+  static PlanGradientFactors _fallbackGradientFactors() =>
+      (low: DivePlanState.kFallbackGfLow, high: DivePlanState.kFallbackGfHigh);
 
   static DivePlanState _createInitialState({
     double reservePressure = DivePlanState.kDefaultReservePressureBar,
+    PlanGradientFactors Function() getGradientFactors =
+        _fallbackGradientFactors,
   }) {
     final now = DateTime.now();
+    final gradientFactors = getGradientFactors();
     return DivePlanState(
       id: _uuid.v4(),
       name: 'New Dive Plan',
       segments: [],
       tanks: [_createDefaultTank()],
+      gfLow: gradientFactors.low,
+      gfHigh: gradientFactors.high,
       reservePressure: reservePressure,
       createdAt: now,
       updatedAt: now,
@@ -110,7 +132,10 @@ class DivePlanNotifier extends StateNotifier<DivePlanState> {
   /// Reset to a new empty plan.
   void newPlan() {
     _loaded = null;
-    state = _createInitialState(reservePressure: _getDefaultReservePressure());
+    state = _createInitialState(
+      reservePressure: _getDefaultReservePressure(),
+      getGradientFactors: _getDefaultGradientFactors,
+    );
   }
 
   /// Load an existing plan for editing.
@@ -579,10 +604,16 @@ final divePlanNotifierProvider =
             : DivePlanState.kDefaultReservePressureBar;
       }
 
+      // A new plan starts on the diver's own deco settings; per-plan edits and
+      // saved plans override this and are never overwritten by it.
+      PlanGradientFactors defaultGradientFactors() =>
+          (low: read(gfLowProvider), high: read(gfHighProvider));
+
       return DivePlanNotifier(
         calculator,
         reservePressure: defaultReserve(),
         getDefaultReservePressure: defaultReserve,
+        getDefaultGradientFactors: defaultGradientFactors,
         repository: ref.watch(divePlanRepositoryProvider),
       );
     });

--- a/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
+++ b/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
@@ -12,11 +12,16 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier({PressureUnit pressureUnit = PressureUnit.bar})
-    : super(AppSettings(pressureUnit: pressureUnit));
+  _TestSettingsNotifier({
+    PressureUnit pressureUnit = PressureUnit.bar,
+    int gfLow = 50,
+    int gfHigh = 85,
+  }) : super(
+         AppSettings(pressureUnit: pressureUnit, gfLow: gfLow, gfHigh: gfHigh),
+       );
 
   void updatePressureUnitForTest(PressureUnit unit) {
-    state = AppSettings(pressureUnit: unit);
+    state = state.copyWith(pressureUnit: unit);
   }
 
   @override
@@ -115,6 +120,55 @@ void main() {
         expect(state.reservePressure, closeTo(34.47, 0.5));
       },
     );
+
+    test(
+      'initial plan seeds gradient factors from the diver deco settings',
+      () {
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              (ref) => _TestSettingsNotifier(gfLow: 35, gfHigh: 75),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final state = container.read(divePlanNotifierProvider);
+        expect(state.gfLow, 35);
+        expect(state.gfHigh, 75);
+      },
+    );
+
+    test('newPlan re-reads gradient factors from the diver deco settings', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => _TestSettingsNotifier(gfLow: 35, gfHigh: 75),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(divePlanNotifierProvider.notifier);
+      notifier.updateGradientFactors(10, 20);
+      expect(container.read(divePlanNotifierProvider).gfLow, 10);
+
+      notifier.newPlan();
+
+      final state = container.read(divePlanNotifierProvider);
+      expect(state.gfLow, 35);
+      expect(state.gfHigh, 75);
+    });
+
+    test('newPlan uses gradient factor fallback when no callback provided', () {
+      final notifier = DivePlanNotifier(PlanCalculatorService());
+      addTearDown(notifier.dispose);
+
+      notifier.newPlan();
+
+      expect(notifier.state.gfLow, 30);
+      expect(notifier.state.gfHigh, 70);
+    });
 
     test('newPlan uses reservePressure fallback when no callback provided', () {
       final notifier = DivePlanNotifier(

--- a/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
+++ b/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
@@ -12,13 +12,16 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier({
-    PressureUnit pressureUnit = PressureUnit.bar,
-    int gfLow = 50,
-    int gfHigh = 85,
-  }) : super(
-         AppSettings(pressureUnit: pressureUnit, gfLow: gfLow, gfHigh: gfHigh),
-       );
+  // Null means "leave at the AppSettings default", so these fixtures cannot
+  // drift away from the real defaults.
+  _TestSettingsNotifier({PressureUnit? pressureUnit, int? gfLow, int? gfHigh})
+    : super(
+        const AppSettings().copyWith(
+          pressureUnit: pressureUnit,
+          gfLow: gfLow,
+          gfHigh: gfHigh,
+        ),
+      );
 
   void updatePressureUnitForTest(PressureUnit unit) {
     state = state.copyWith(pressureUnit: unit);
@@ -223,6 +226,29 @@ void main() {
       final state = container.read(divePlanNotifierProvider);
       expect(state.gfLow, 10);
       expect(state.gfHigh, 20);
+    });
+
+    test('plan results follow the plan gradient factors, not the settings', () {
+      // Settings stay liberal throughout; only the plan's own factors move.
+      int ttsForPlanFactors(int low, int high) {
+        final container = ProviderContainer(
+          overrides: [
+            settingsProvider.overrideWith(
+              (ref) => _TestSettingsNotifier(gfLow: 90, gfHigh: 95),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final notifier = container.read(divePlanNotifierProvider.notifier);
+        notifier.addSimplePlan(maxDepth: 45.0, bottomTimeMinutes: 25);
+        notifier.updateGradientFactors(low, high);
+        return container.read(planResultsProvider).ttsAtBottom;
+      }
+
+      // planIsValidProvider gates convert-to-dive off these results, so they
+      // have to describe the plan the diver is actually looking at.
+      expect(ttsForPlanFactors(20, 55), greaterThan(ttsForPlanFactors(90, 95)));
     });
 
     test('newPlan uses gradient factor fallback when no callback provided', () {

--- a/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
+++ b/test/features/dive_planner/presentation/providers/dive_planner_providers_test.dart
@@ -24,6 +24,10 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
     state = state.copyWith(pressureUnit: unit);
   }
 
+  void updateGradientFactorsForTest(int low, int high) {
+    state = state.copyWith(gfLow: low, gfHigh: high);
+  }
+
   @override
   Future<void> setMapStyle(MapStyle style) async =>
       state = state.copyWith(mapStyle: style);
@@ -158,6 +162,67 @@ void main() {
       final state = container.read(divePlanNotifierProvider);
       expect(state.gfLow, 35);
       expect(state.gfHigh, 75);
+    });
+
+    test('changing deco settings does not discard the in-progress plan', () {
+      final settingsNotifier = _TestSettingsNotifier(gfLow: 50, gfHigh: 85);
+      final container = ProviderContainer(
+        overrides: [settingsProvider.overrideWith((ref) => settingsNotifier)],
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(divePlanNotifierProvider.notifier)
+          .addSimplePlan(maxDepth: 30.0, bottomTimeMinutes: 20);
+      final planned = container.read(divePlanNotifierProvider);
+      expect(planned.segments, isNotEmpty);
+
+      settingsNotifier.updateGradientFactorsForTest(20, 60);
+
+      final state = container.read(divePlanNotifierProvider);
+      expect(state.id, planned.id);
+      expect(state.segments, planned.segments);
+      // The plan keeps the gradient factors it was built with; settings seed
+      // new plans, they do not retroactively rewrite an open one.
+      expect(state.gfLow, 50);
+      expect(state.gfHigh, 85);
+    });
+
+    test('an untouched plan follows later gradient factor settings', () {
+      final settingsNotifier = _TestSettingsNotifier(gfLow: 50, gfHigh: 85);
+      final container = ProviderContainer(
+        overrides: [settingsProvider.overrideWith((ref) => settingsNotifier)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(divePlanNotifierProvider).gfLow, 50);
+
+      // Settings hydrate from the database after this provider is first read.
+      settingsNotifier.updateGradientFactorsForTest(20, 60);
+
+      final state = container.read(divePlanNotifierProvider);
+      expect(state.gfLow, 20);
+      expect(state.gfHigh, 60);
+      // Adopting a setting is not a diver edit, so it must not arm Save.
+      expect(state.isDirty, isFalse);
+    });
+
+    test('a hand-tuned plan ignores later gradient factor settings', () {
+      final settingsNotifier = _TestSettingsNotifier(gfLow: 50, gfHigh: 85);
+      final container = ProviderContainer(
+        overrides: [settingsProvider.overrideWith((ref) => settingsNotifier)],
+      );
+      addTearDown(container.dispose);
+
+      container
+          .read(divePlanNotifierProvider.notifier)
+          .updateGradientFactors(10, 20);
+
+      settingsNotifier.updateGradientFactorsForTest(20, 60);
+
+      final state = container.read(divePlanNotifierProvider);
+      expect(state.gfLow, 10);
+      expect(state.gfHigh, 20);
     });
 
     test('newPlan uses gradient factor fallback when no callback provided', () {

--- a/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
+++ b/test/features/dive_planner/presentation/widgets/setup/plan_setup_sections_test.dart
@@ -31,14 +31,15 @@ Widget _harness(Widget child) => testApp(
 );
 
 void main() {
-  testWidgets('deco section renders both GF sliders with defaults', (
+  testWidgets('deco section renders both GF sliders at the diver settings', (
     tester,
   ) async {
     await tester.pumpWidget(_harness(const PlanDecoSection()));
     await tester.pumpAndSettle();
     expect(find.byType(Slider), findsNWidgets(2));
-    expect(find.text('30%'), findsOneWidget);
-    expect(find.text('70%'), findsOneWidget);
+    // AppSettings defaults: GF 50/85.
+    expect(find.text('50%'), findsOneWidget);
+    expect(find.text('85%'), findsOneWidget);
   });
 
   testWidgets('gas section shows SAC slider and reserve field with unit', (

--- a/test/features/dive_planner/save_load_round_trip_test.dart
+++ b/test/features/dive_planner/save_load_round_trip_test.dart
@@ -13,6 +13,10 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _TestSettingsNotifier() : super(const AppSettings());
 
+  void updateGradientFactorsForTest(int low, int high) {
+    state = state.copyWith(gfLow: low, gfHigh: high);
+  }
+
   @override
   Future<void> setMapStyle(MapStyle style) async =>
       state = state.copyWith(mapStyle: style);
@@ -23,13 +27,13 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
 
 void main() {
   late ProviderContainer container;
+  late _TestSettingsNotifier settingsNotifier;
 
   setUp(() async {
     await setUpTestDatabase();
+    settingsNotifier = _TestSettingsNotifier();
     container = ProviderContainer(
-      overrides: [
-        settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
-      ],
+      overrides: [settingsProvider.overrideWith((ref) => settingsNotifier)],
     );
     addTearDown(container.dispose);
   });
@@ -86,4 +90,28 @@ void main() {
     final notifier = container.read(divePlanNotifierProvider.notifier);
     expect(await notifier.loadPlanById('nope'), isFalse);
   });
+
+  test(
+    'a saved plan keeps its own gradient factors when settings change',
+    () async {
+      final notifier = container.read(divePlanNotifierProvider.notifier);
+      notifier.updateGradientFactors(30, 70);
+      await notifier.save(
+        summary: const PlanSummaryData(
+          maxDepth: 30.0,
+          runtimeSeconds: 30 * 60,
+          ttsSeconds: 4 * 60,
+        ),
+      );
+      // Saving clears isDirty, so being persisted is the only thing standing
+      // between this plan's deliberate gradient factors and the diver's.
+      expect(container.read(divePlanNotifierProvider).isDirty, isFalse);
+
+      settingsNotifier.updateGradientFactorsForTest(20, 60);
+
+      final state = container.read(divePlanNotifierProvider);
+      expect(state.gfLow, 30);
+      expect(state.gfHigh, 70);
+    },
+  );
 }

--- a/test/features/planner/plan_canvas_page_test.dart
+++ b/test/features/planner/plan_canvas_page_test.dart
@@ -275,7 +275,8 @@ void main() {
     await tester.pumpWidget(harness());
     seed(tester);
     await tester.pumpAndSettle();
-    await tester.tap(find.text('30/70'));
+    // Header chip shows the diver's GF settings (AppSettings default 50/85).
+    await tester.tap(find.text('50/85'));
     await tester.pumpAndSettle();
     expect(find.byType(PlanDecoSection), findsOneWidget);
   });

--- a/test/features/planner/plan_canvas_providers_test.dart
+++ b/test/features/planner/plan_canvas_providers_test.dart
@@ -9,7 +9,8 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier() : super(const AppSettings());
+  _TestSettingsNotifier({int gfLow = 50, int gfHigh = 85})
+    : super(AppSettings(gfLow: gfLow, gfHigh: gfHigh));
 
   @override
   Future<void> setMapStyle(MapStyle style) async =>
@@ -19,15 +20,22 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-ProviderContainer _container() {
+ProviderContainer _container({int gfLow = 50, int gfHigh = 85}) {
   final container = ProviderContainer(
     overrides: [
-      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      settingsProvider.overrideWith(
+        (ref) => _TestSettingsNotifier(gfLow: gfLow, gfHigh: gfHigh),
+      ),
     ],
   );
   addTearDown(container.dispose);
   return container;
 }
+
+int _totalStopSeconds(ProviderContainer container) => container
+    .read(planOutcomeProvider)
+    .stops
+    .fold(0, (sum, stop) => sum + stop.durationSeconds);
 
 void main() {
   test('scrub provider defaults to null', () {
@@ -55,6 +63,31 @@ void main() {
     }
     expect(series.maxDepth, 30.0);
     expect(series.depthAt(0), 0);
+  });
+
+  test('new plan adopts the diver gradient factor settings', () {
+    final container = _container(gfLow: 35, gfHigh: 75);
+    final state = container.read(divePlanNotifierProvider);
+
+    expect(state.gfLow, 35);
+    expect(state.gfHigh, 75);
+  });
+
+  test('conservative gradient factors lengthen the computed deco', () {
+    final conservative = _container(gfLow: 20, gfHigh: 55);
+    conservative
+        .read(divePlanNotifierProvider.notifier)
+        .addSimplePlan(maxDepth: 45.0, bottomTimeMinutes: 25);
+
+    final liberal = _container(gfLow: 90, gfHigh: 95);
+    liberal
+        .read(divePlanNotifierProvider.notifier)
+        .addSimplePlan(maxDepth: 45.0, bottomTimeMinutes: 25);
+
+    expect(
+      _totalStopSeconds(conservative),
+      greaterThan(_totalStopSeconds(liberal)),
+    );
   });
 
   test('deco plan appends stop flats and stop markers', () {

--- a/test/features/planner/plan_canvas_providers_test.dart
+++ b/test/features/planner/plan_canvas_providers_test.dart
@@ -9,8 +9,10 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
-  _TestSettingsNotifier({int gfLow = 50, int gfHigh = 85})
-    : super(AppSettings(gfLow: gfLow, gfHigh: gfHigh));
+  // Null means "leave at the AppSettings default", so these fixtures cannot
+  // drift away from the real defaults.
+  _TestSettingsNotifier({int? gfLow, int? gfHigh})
+    : super(const AppSettings().copyWith(gfLow: gfLow, gfHigh: gfHigh));
 
   @override
   Future<void> setMapStyle(MapStyle style) async =>
@@ -20,7 +22,7 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-ProviderContainer _container({int gfLow = 50, int gfHigh = 85}) {
+ProviderContainer _container({int? gfLow, int? gfHigh}) {
   final container = ProviderContainer(
     overrides: [
       settingsProvider.overrideWith(


### PR DESCRIPTION
Two related planner defects around gradient factors. The second was found while fixing the first.

## 1. New plans ignored the diver's gradient factor settings

A new dive plan always used **GF 30/70**, regardless of the gradient factors configured in the diver's deco settings.

The planner carried two independent GF values:

| Source | Value | Reaches |
| --- | --- | --- |
| `planCalculatorServiceProvider` | settings (default 50/85) | legacy `PlanCalculatorService` only |
| `DivePlanState.gfLow/gfHigh` | hardcoded **30/70** | the live canvas engine and all UI |

The settings wiring existed, but only on the branch of the provider graph the canvas had stopped using. The canvas computes through `planOutcomeProvider` -> `divePlanFromState(state)` -> `PlanEngine`, which reads `plan.gfLow` (`plan_engine.dart:170`). The `GF 30/70` header chip, the deco sliders, the saved plan record and the PDF slate read `DivePlanState` as well. `DivePlanNotifier._createInitialState()` never passed GF, so the constructor defaults won everywhere the diver could see or feel them.

This was not only a display bug. The setting had **no effect on the deco math**: before this change, a 45 m / 25 min profile produced a byte-identical stop schedule at GF 20/55 and at GF 90/95.

**Fix:** seed the initial plan state from settings through a `read`-based closure, mirroring the `getDefaultReservePressure` idiom already used in this notifier, and re-read it in `newPlan()`. The literal `30`/`70` becomes `DivePlanState.kFallbackGfLow`/`kFallbackGfHigh`, documented as the settings-unreachable fallback.

## 2. Changing a deco setting discarded the plan being edited

`divePlanNotifierProvider` watched `planCalculatorServiceProvider`, which watches six deco settings. Rebuilding a `StateNotifierProvider` constructs a **new notifier**, so the diver's in-progress plan silently vanished — a fresh plan id, no segments. The subscription bought nothing: the notifier's only use of the injected calculator is `generateProfilePoints`, pure geometry that reads no setting.

Dropping to `read` alone would have traded data loss for a seeding race. `SettingsNotifier` starts at `const AppSettings()` and hydrates from the database **asynchronously**, so the `watch` was accidentally covering that — the post-hydration rebuild re-seeded the plan. Without it, a diver with customised GFs could open the planner and get app defaults.

**Fix:** use each ref method for what it is actually for.

| Need | Mechanism |
| --- | --- |
| Calculator, repository | `read` — snapshot, never rebuilds |
| Seed GF on a new plan | `read` in a closure, evaluated at `newPlan()` |
| React to settings later | `ref.listen` — callback, **no** rebuild |

`adoptGradientFactorsIfPristine` moves the plan onto the diver's current factors only while it is genuinely untouched (not persisted, not dirty, no segments), and deliberately does not set `isDirty` — adopting a setting is not a diver edit and must not arm Save.

The `isPersisted` guard is load-bearing rather than defensive: `save()` clears `isDirty` and a GF-only plan has no segments, so it is the only thing standing between a saved plan's deliberate factors and the diver's current settings. Removing it makes the new round-trip test fail, rewriting a saved 30/70 to 20/60.

### Behaviour change worth review

A diver who changes GF settings with a **started** plan open now keeps that plan on its original factors instead of losing the plan, and can adjust it from the GF chip in the header. Silent data loss seemed clearly the worse failure, and this matches the existing rule that saved plans keep their own factors. Happy to flip it if you disagree.

## Tests

- new plans seed GF from settings (notifier and canvas level); `newPlan()` re-reads them; the fallback still applies without a callback
- conservative gradient factors produce longer computed deco than liberal ones — the engine-level guard, and the assertion that failed identically at both GFs before the fix
- an in-progress plan survives a deco settings change with its id, segments and factors intact
- an untouched plan follows later settings without becoming dirty; a hand-tuned plan does not; a saved plan keeps its own factors
- updated two existing tests that pinned the old 30/70 defaults

`flutter analyze` clean. Full suite 15,419 passing locally; the 4 failures in that run are known media/OCR flakes under full-suite load and all pass in isolation, none in the planner.
