### PR TITLE
Fix display zoom below 100% killing hit testing at the screen edges

### DIFF
--- a/lib/core/theme/display_zoom.dart
+++ b/lib/core/theme/display_zoom.dart
@@ -88,21 +88,33 @@ class DisplayZoomScope extends StatelessWidget {
         // ImageConfiguration consults this to select asset resolution.
         devicePixelRatio: mq.devicePixelRatio * scale,
       ),
-      child: Transform.scale(
-        scale: scale,
+      // OverflowBox, not SizedBox: MaterialApp.builder passes TIGHT
+      // constraints equal to the physical window, which would force a SizedBox
+      // back to the physical size. The child would then be scaled below the
+      // window (unpainted band at zoom < 1) or past it (clipped overflow at
+      // zoom > 1). OverflowBox lets the subtree take the enlarged logical size
+      // regardless of the incoming constraints.
+      //
+      // The OverflowBox must sit OUTSIDE the Transform, not inside it. Both
+      // orders paint identically, but only this one hit-tests. OverflowBox is
+      // sizedByParent, so it always measures the physical window no matter how
+      // large its child grows, and RenderBox.hitTest drops any position its own
+      // size does not contain before it ever reaches a child. With the
+      // OverflowBox inside, Transform handed it pointer positions already
+      // divided by the scale - up to logical size - and every one past the
+      // window rect was discarded, leaving the bottom and right edges of the
+      // screen dead below 100% zoom. Outside, the box the Transform descends
+      // into is the one actually laid out at the logical size, so the whole
+      // painted area stays live.
+      child: OverflowBox(
         alignment: Alignment.topLeft,
-        // OverflowBox, not SizedBox: MaterialApp.builder passes TIGHT
-        // constraints equal to the physical window, which would force a
-        // SizedBox back to the physical size. The child would then be scaled
-        // below the window (unpainted band at zoom < 1) or past it (clipped
-        // overflow at zoom > 1). OverflowBox lets the child take the enlarged
-        // logical size regardless of the incoming constraints.
-        child: OverflowBox(
+        minWidth: logical.width,
+        maxWidth: logical.width,
+        minHeight: logical.height,
+        maxHeight: logical.height,
+        child: Transform.scale(
+          scale: scale,
           alignment: Alignment.topLeft,
-          minWidth: logical.width,
-          maxWidth: logical.width,
-          minHeight: logical.height,
-          maxHeight: logical.height,
           child: child,
         ),
       ),

--- a/test/core/theme/display_zoom_hit_test.dart
+++ b/test/core/theme/display_zoom_hit_test.dart
@@ -31,4 +31,94 @@ void main() {
       expect(taps, 1, reason: 'tap must register at zoom $zoom');
     });
   }
+
+  // A centred target is not enough. The transform is anchored top-left, so a
+  // widget at the middle of the screen sits at zoom * centre in the scaled
+  // space and stays inside the window rect no matter how the boxes are
+  // nested. Only targets past that rect expose a hit-test region that is
+  // narrower than the painted area.
+  for (final zoom in const [0.7, 0.8, 1.0, 1.3, 1.4]) {
+    testWidgets('registers a tap on the bottom navigation bar at zoom $zoom', (
+      tester,
+    ) async {
+      var selected = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DisplayZoomScope(
+            zoom: zoom,
+            child: Scaffold(
+              body: const SizedBox.expand(),
+              bottomNavigationBar: NavigationBar(
+                selectedIndex: selected,
+                onDestinationSelected: (index) => selected = index,
+                destinations: const [
+                  NavigationDestination(
+                    icon: Icon(Icons.scuba_diving),
+                    label: 'Dives',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.place),
+                    label: 'Sites',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Sites'));
+      await tester.pump();
+
+      expect(
+        selected,
+        1,
+        reason: 'bottom navigation bar must be tappable at zoom $zoom',
+      );
+    });
+  }
+
+  for (final zoom in const [0.7, 0.8, 1.0, 1.3, 1.4]) {
+    testWidgets('hit-tests every corner of the window at zoom $zoom', (
+      tester,
+    ) async {
+      final hits = <Offset>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DisplayZoomScope(
+            zoom: zoom,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTapDown: (details) => hits.add(details.globalPosition),
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      );
+
+      final window = tester.view.physicalSize / tester.view.devicePixelRatio;
+      final corners = <Offset>[
+        const Offset(1, 1),
+        Offset(window.width - 1, 1),
+        Offset(1, window.height - 1),
+        Offset(window.width - 1, window.height - 1),
+      ];
+
+      for (final corner in corners) {
+        await tester.tapAt(corner);
+        await tester.pump();
+      }
+
+      expect(
+        hits,
+        corners,
+        reason:
+            'the whole painted window must stay hit-testable at zoom $zoom; '
+            'missing corners mean the scaled subtree is laid out larger than '
+            'the box that guards the hit test',
+      );
+    });
+  }
 }

--- a/test/core/theme/display_zoom_scope_test.dart
+++ b/test/core/theme/display_zoom_scope_test.dart
@@ -110,6 +110,17 @@ void main() {
       );
 
       expect(tester.getSize(find.byKey(const Key('zoomed-child'))), expected);
+
+      // getSize is the child's own local size; getRect walks the ancestor
+      // transforms. Together they pin the two invariants this widget has to
+      // satisfy at once: laid out at the logical size, painted across the whole
+      // physical window. Asserting only the first let a nesting that painted
+      // correctly but hit-tested against the wrong box look healthy.
+      expect(
+        tester.getRect(find.byKey(const Key('zoomed-child'))),
+        Rect.fromLTWH(0, 0, physical.width, physical.height),
+        reason: 'the scaled child must cover exactly the physical window',
+      );
     });
   }
 


### PR DESCRIPTION
## Problem

At any display zoom below 100%, the primary bottom navigation bar and the right
edge of the window stopped responding to clicks and hover. Zoom at or above 100%
was unaffected.

## Root cause

`DisplayZoomScope` nested `OverflowBox` **inside** `Transform.scale`. Both
orders paint identically, which is why this shipped.

`RenderConstrainedOverflowBox` is `sizedByParent`: it always measures the
*physical* window (`constraints.biggest`), and only its **child** receives the
enlarged logical constraints. `RenderBox.hitTest` discards any position its own
`size` does not contain *before* descending into children. `RenderTransform`
hands down pointer positions already divided by the scale, so at 70% zoom every
position past 70% x 70% of the window was dropped en route to the app.

That also explains the asymmetry: at zoom >= 1 the inverse map shrinks
positions, so they always land inside the box.

## Fix

`OverflowBox` moved outside, `Transform.scale` inside. The box the transform
descends into is now the one actually laid out at the logical size. Paint
output is unchanged.

## Tests

The existing hit test tapped a **centred** button. With a top-left-anchored
transform, the centre maps to `zoom * centre` and stays inside the broken rect
at every zoom level, so it passed against broken code.

- `display_zoom_hit_test.dart` now also taps all four window corners and a real
  `NavigationBar`, across 0.7 / 0.8 / 1.0 / 1.3 / 1.4.
- `display_zoom_scope_test.dart` pairs `tester.getSize` (local, = logical size)
  with `tester.getRect` (walks ancestor transforms, = physical window) so both
  invariants are pinned at once.

Red-green verified: the new tests fail on the previous nesting (bottom bar dead
at 0.7/0.8; 1 of 4 corners registering) and pass after the change.

## Verification

- `flutter test`: 15424 passed, 15 skipped.
- `flutter analyze`: no issues.
- `dart format` applied.
- Confirmed with real OS clicks in a running macOS build: bottom-right corner
  and rightmost bottom-menu item both fire at 70% and 125%.
