### PR TITLE
fix(beta): point supply at the Play release notes it was ignoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ ios/fastlane/api_key.json
 ios/fastlane/AuthKey_*.p8
 android/fastlane/play-store-key.json
 
+# Play release notes, written per build by the upload_beta lane so they always
+# match the AAB being uploaded rather than whatever was last committed.
+android/fastlane/metadata/
+
 # Python
 *__pycache__/
 *.py[cod]

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -15,6 +15,21 @@ default_platform(:android)
 # Google Play rejects a release-notes body over 500 characters per locale.
 PLAY_CHANGELOG_LIMIT = 500
 
+# Where supply looks for release notes. fastlane runs lane bodies and helper
+# methods in this `fastlane` directory but wraps every action in Dir.chdir(".."),
+# and supply resolves its default metadata_path from there by globbing
+# "./fastlane/metadata/android". Writing to that same path from a helper landed
+# the notes one directory deeper than supply looked, so supply resolved
+# metadata_path to nil, skipped its whole metadata phase, and reported a
+# successful upload with no release notes attached - which is what Play beta
+# testers saw while TestFlight testers got the full changelog.
+#
+# Anchored to this file rather than to the working directory. Keep it at the top
+# level: fastlane evaluates the Fastfile with __FILE__ set to a bare "Fastfile",
+# so __dir__ only resolves while fastlane's own chdir into this folder is still
+# in effect.
+PLAY_METADATA_ROOT = File.expand_path(File.join(__dir__, "metadata", "android"))
+
 platform :android do
   desc "Upload AAB to internal testing track"
   lane :upload do
@@ -57,17 +72,22 @@ platform :android do
   lane :upload_beta do
     aab_path = find_aab
     track = beta_track
-    has_changelog = write_beta_changelog
+    changelog_root = write_beta_changelog
 
     UI.message("Uploading to the '#{track}' testing track...")
     upload_to_play_store(
       aab: aab_path,
       track: track,
       release_status: "completed",
+      # Passed explicitly, and taken from the helper that just wrote the file, so
+      # the directory supply reads is the directory the notes went into. supply's
+      # own default is resolved from a different working directory than lane code
+      # runs in, which silently cost every Play beta its release notes.
+      metadata_path: changelog_root || PLAY_METADATA_ROOT,
       skip_upload_metadata: true,
       # Beta testers need to know what a build changed; the other lanes stay
       # silent because their notes are managed in the Play Console.
-      skip_upload_changelogs: !has_changelog,
+      skip_upload_changelogs: changelog_root.nil?,
       skip_upload_images: true,
       skip_upload_screenshots: true,
     )
@@ -137,11 +157,12 @@ platform :android do
   end
 
   # Writes the beta release notes where supply expects them:
-  # fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt. The file is
-  # generated per build rather than committed, so the notes always match the AAB
-  # being uploaded. Returns false when there is nothing to write, which leaves
-  # the existing Play notes untouched instead of blanking them.
-  def write_beta_changelog
+  # <metadata_root>/<locale>/changelogs/<versionCode>.txt. The file is generated
+  # per build rather than committed, so the notes always match the AAB being
+  # uploaded. Returns the absolute metadata root so the caller can hand supply
+  # the same path, or nil when there is nothing to write, which leaves the
+  # existing Play notes untouched instead of blanking them.
+  def write_beta_changelog(metadata_root = PLAY_METADATA_ROOT)
     notes = read_beta_notes.strip
     version_code = ENV["PLAY_VERSION_CODE"].to_s.strip
 
@@ -150,7 +171,7 @@ platform :android do
         "PLAY_BETA_CHANGELOG or PLAY_VERSION_CODE is unset; uploading without " \
         "release notes."
       )
-      return false
+      return nil
     end
 
     unless version_code.match?(/\A\d+\z/)
@@ -166,11 +187,11 @@ platform :android do
       )
     end
 
-    dir = File.join("fastlane", "metadata", "android", "en-US", "changelogs")
+    dir = File.join(metadata_root, "en-US", "changelogs")
     FileUtils.mkdir_p(dir)
     File.write(File.join(dir, "#{version_code}.txt"), notes[0, PLAY_CHANGELOG_LIMIT])
-    UI.message("Wrote Play release notes for version code #{version_code}.")
-    true
+    UI.message("Wrote Play release notes for version code #{version_code} to #{dir}.")
+    metadata_root
   end
 
   # Finds the AAB file. Checks for the renamed artifact first (CI),

--- a/scripts/release/fastlane_beta_changelog_test.rb
+++ b/scripts/release/fastlane_beta_changelog_test.rb
@@ -36,8 +36,13 @@ end
 def default_platform(_name); end
 def desc(_text); end
 
-# Lane bodies are never run here, so the block is deliberately not yielded.
-def lane(_name, &_block); end
+# Lane bodies are recorded rather than run. Most are never invoked, but the Play
+# beta lane is executed against stubs further down, because the wiring between
+# the changelog helper and the upload action is what broke in production.
+LANES = {}
+def lane(name, &block)
+  LANES[name] = block
+end
 
 # Platform blocks are yielded so the `def`s inside them land at top level.
 def platform(_name)
@@ -126,74 +131,129 @@ end
 
 load File.join(ROOT, 'android', 'fastlane', 'Fastfile')
 
+# Where the notes have to land, derived the way *supply* derives it rather than
+# the way the Fastfile does, so this check keeps its value if the writer moves.
+#
+# fastlane runs lane bodies and helper methods in the `fastlane` directory, but
+# wraps every action in Dir.chdir("..") to reach the project directory. supply
+# resolves its default metadata_path from there, by globbing
+# "./fastlane/metadata/android". A helper writing to that same relative path
+# therefore landed one directory deeper than supply looked, supply resolved
+# metadata_path to nil, and every Play beta uploaded successfully with no release
+# notes at all - the Android half of the gap this file exists to close.
+supply_metadata_path =
+  File.expand_path(File.join(ROOT, 'android', 'fastlane', 'metadata', 'android'))
+
+check(PLAY_METADATA_ROOT == supply_metadata_path,
+      "notes are written to #{PLAY_METADATA_ROOT}, but supply reads #{supply_metadata_path}")
+check(File.absolute_path(PLAY_METADATA_ROOT) == PLAY_METADATA_ROOT,
+      'PLAY_METADATA_ROOT is relative, so which directory fastlane happens to be ' \
+      'in decides whether supply finds the notes')
+
 Dir.mktmpdir do |tmp|
-  Dir.chdir(tmp) do
-    changelog_path = lambda do |code|
-      File.join(tmp, 'fastlane', 'metadata', 'android', 'en-US', 'changelogs', "#{code}.txt")
+  changelog_path = lambda do |code|
+    File.join(tmp, 'en-US', 'changelogs', "#{code}.txt")
+  end
+
+  # Missing inputs must not write a file, and must report that the upload
+  # should skip changelogs rather than blanking the notes already on Play.
+  with_env('PLAY_BETA_CHANGELOG' => nil, 'PLAY_VERSION_CODE' => '123') do
+    check(write_beta_changelog(tmp).nil?, 'missing notes did not disable changelog upload')
+    check(!File.exist?(changelog_path.call(123)), 'missing notes still wrote a changelog file')
+  end
+
+  with_env('PLAY_BETA_CHANGELOG' => 'something', 'PLAY_VERSION_CODE' => nil) do
+    check(write_beta_changelog(tmp).nil?, 'missing version code did not disable changelog upload')
+  end
+
+  with_env('PLAY_BETA_CHANGELOG' => '  ', 'PLAY_VERSION_CODE' => '123') do
+    check(write_beta_changelog(tmp).nil?, 'blank notes did not disable changelog upload')
+  end
+
+  # A non-numeric version code would silently produce a file supply never
+  # reads, so it fails loudly instead.
+  with_env('PLAY_BETA_CHANGELOG' => 'notes', 'PLAY_VERSION_CODE' => 'v1.2.3') do
+    raised = begin
+      write_beta_changelog(tmp)
+      false
+    rescue ArgumentError
+      true
+    end
+    check(raised, 'a non-numeric PLAY_VERSION_CODE was accepted')
+  end
+
+  with_env('PLAY_BETA_CHANGELOG' => "New in this build\n- a real change",
+           'PLAY_VERSION_CODE' => '5163') do
+    check(write_beta_changelog(tmp) == tmp, 'valid inputs did not report the metadata root')
+    written = File.read(changelog_path.call(5163))
+    check(written.include?('a real change'), 'notes were not written to the changelog file')
+  end
+
+  # Same file-based contract as the TestFlight lanes, so the workflow never
+  # interpolates commit-derived text into a shell or environment assignment.
+  Dir.mktmpdir do |notes_dir|
+    notes_file = File.join(notes_dir, 'beta-notes-play.txt')
+    File.write(notes_file, "New in this build\n- a change from a file\n")
+
+    with_env('PLAY_BETA_CHANGELOG_FILE' => notes_file, 'PLAY_BETA_CHANGELOG' => nil,
+             'PLAY_VERSION_CODE' => '5165') do
+      check(write_beta_changelog(tmp) == tmp, 'file-based notes did not report the metadata root')
+      check(File.read(changelog_path.call(5165)).include?('a change from a file'),
+            'file-based notes were not written to the changelog file')
     end
 
-    # Missing inputs must not write a file, and must report that the upload
-    # should skip changelogs rather than blanking the notes already on Play.
-    with_env('PLAY_BETA_CHANGELOG' => nil, 'PLAY_VERSION_CODE' => '123') do
-      check(write_beta_changelog == false, 'missing notes did not disable changelog upload')
-      check(!File.exist?(changelog_path.call(123)), 'missing notes still wrote a changelog file')
-    end
-
-    with_env('PLAY_BETA_CHANGELOG' => 'something', 'PLAY_VERSION_CODE' => nil) do
-      check(write_beta_changelog == false, 'missing version code did not disable changelog upload')
-    end
-
-    with_env('PLAY_BETA_CHANGELOG' => '  ', 'PLAY_VERSION_CODE' => '123') do
-      check(write_beta_changelog == false, 'blank notes did not disable changelog upload')
-    end
-
-    # A non-numeric version code would silently produce a file supply never
-    # reads, so it fails loudly instead.
-    with_env('PLAY_BETA_CHANGELOG' => 'notes', 'PLAY_VERSION_CODE' => 'v1.2.3') do
-      raised = begin
-        write_beta_changelog
-        false
-      rescue ArgumentError
-        true
-      end
-      check(raised, 'a non-numeric PLAY_VERSION_CODE was accepted')
-    end
-
-    with_env('PLAY_BETA_CHANGELOG' => "New in this build\n- a real change",
-             'PLAY_VERSION_CODE' => '5163') do
-      check(write_beta_changelog == true, 'valid inputs did not enable changelog upload')
-      written = File.read(changelog_path.call(5163))
-      check(written.include?('a real change'), 'notes were not written to the changelog file')
-    end
-
-    # Same file-based contract as the TestFlight lanes, so the workflow never
-    # interpolates commit-derived text into a shell or environment assignment.
-    Dir.mktmpdir do |notes_dir|
-      notes_file = File.join(notes_dir, 'beta-notes-play.txt')
-      File.write(notes_file, "New in this build\n- a change from a file\n")
-
-      with_env('PLAY_BETA_CHANGELOG_FILE' => notes_file, 'PLAY_BETA_CHANGELOG' => nil,
-               'PLAY_VERSION_CODE' => '5165') do
-        check(write_beta_changelog == true, 'file-based notes did not enable changelog upload')
-        check(File.read(changelog_path.call(5165)).include?('a change from a file'),
-              'file-based notes were not written to the changelog file')
-      end
-
-      with_env('PLAY_BETA_CHANGELOG_FILE' => File.join(notes_dir, 'nope.txt'),
-               'PLAY_BETA_CHANGELOG' => nil, 'PLAY_VERSION_CODE' => '5166') do
-        check(write_beta_changelog == false, 'a missing notes file did not disable changelog upload')
-        check(!File.exist?(changelog_path.call(5166)), 'a missing notes file still wrote a changelog')
-      end
-    end
-
-    with_env('PLAY_BETA_CHANGELOG' => 'y' * 900, 'PLAY_VERSION_CODE' => '5164') do
-      write_beta_changelog
-      written = File.read(changelog_path.call(5164))
-      check(written.length <= 500,
-            "Play changelog was #{written.length} chars, over Google's 500 limit")
+    with_env('PLAY_BETA_CHANGELOG_FILE' => File.join(notes_dir, 'nope.txt'),
+             'PLAY_BETA_CHANGELOG' => nil, 'PLAY_VERSION_CODE' => '5166') do
+      check(write_beta_changelog(tmp).nil?, 'a missing notes file did not disable changelog upload')
+      check(!File.exist?(changelog_path.call(5166)), 'a missing notes file still wrote a changelog')
     end
   end
+
+  with_env('PLAY_BETA_CHANGELOG' => 'y' * 900, 'PLAY_VERSION_CODE' => '5164') do
+    write_beta_changelog(tmp)
+    written = File.read(changelog_path.call(5164))
+    check(written.length <= 500,
+          "Play changelog was #{written.length} chars, over Google's 500 limit")
+  end
 end
+
+# --- Play lane wiring -------------------------------------------------------
+# Writing the notes is only half of it: the lane also has to tell supply where
+# they are. It did not, and nothing failed - supply uploaded the AAB, reported
+# success, and left the release notes empty. Run the real lane body against
+# stubs so the helper and the action cannot drift apart again.
+
+$upload_params = nil
+$stub_changelog_root = nil
+
+def find_aab
+  '/nonexistent/Submersion-test-Android.aab'
+end
+
+def upload_to_play_store(params)
+  $upload_params = params
+end
+
+def write_beta_changelog(_metadata_root = nil)
+  $stub_changelog_root
+end
+
+$stub_changelog_root = '/somewhere/else/metadata/android'
+LANES[:upload_beta].call
+check($upload_params[:metadata_path] == $stub_changelog_root,
+      "the lane pointed supply at #{$upload_params[:metadata_path].inspect} " \
+      "instead of #{$stub_changelog_root.inspect}, where the notes were written")
+check($upload_params[:skip_upload_changelogs] == false,
+      'the lane skipped changelog upload even though notes were written')
+
+# With nothing written, the upload must still name a metadata path (nil is not a
+# value supply accepts) while leaving the notes already on Play untouched.
+$stub_changelog_root = nil
+$upload_params = nil
+LANES[:upload_beta].call
+check($upload_params[:skip_upload_changelogs] == true,
+      'the lane uploaded changelogs when there were no notes to upload')
+check(!$upload_params[:metadata_path].nil?, 'the lane passed a nil metadata_path')
 
 # --- Report -----------------------------------------------------------------
 

--- a/scripts/release/fastlane_beta_changelog_test.rb
+++ b/scripts/release/fastlane_beta_changelog_test.rb
@@ -238,22 +238,43 @@ def write_beta_changelog(_metadata_root = nil)
   $stub_changelog_root
 end
 
+# Runs the recorded lane body and returns the params it handed the upload action,
+# or nil. Guarded rather than called bare: this file collects failures and prints
+# them together at the end, so a renamed lane or a lane that never reaches the
+# upload has to be reported as a failure, not raised as a NoMethodError that
+# aborts the run and takes every earlier failure's message with it.
+def run_upload_beta_lane
+  $upload_params = nil
+  lane_body = LANES[:upload_beta]
+  unless lane_body
+    check(false, 'the android Fastfile no longer defines an upload_beta lane to check')
+    return nil
+  end
+
+  lane_body.call
+  check(!$upload_params.nil?, 'the upload_beta lane never called upload_to_play_store')
+  $upload_params
+end
+
 $stub_changelog_root = '/somewhere/else/metadata/android'
-LANES[:upload_beta].call
-check($upload_params[:metadata_path] == $stub_changelog_root,
-      "the lane pointed supply at #{$upload_params[:metadata_path].inspect} " \
-      "instead of #{$stub_changelog_root.inspect}, where the notes were written")
-check($upload_params[:skip_upload_changelogs] == false,
-      'the lane skipped changelog upload even though notes were written')
+params = run_upload_beta_lane
+if params
+  check(params[:metadata_path] == $stub_changelog_root,
+        "the lane pointed supply at #{params[:metadata_path].inspect} " \
+        "instead of #{$stub_changelog_root.inspect}, where the notes were written")
+  check(params[:skip_upload_changelogs] == false,
+        'the lane skipped changelog upload even though notes were written')
+end
 
 # With nothing written, the upload must still name a metadata path (nil is not a
 # value supply accepts) while leaving the notes already on Play untouched.
 $stub_changelog_root = nil
-$upload_params = nil
-LANES[:upload_beta].call
-check($upload_params[:skip_upload_changelogs] == true,
-      'the lane uploaded changelogs when there were no notes to upload')
-check(!$upload_params[:metadata_path].nil?, 'the lane passed a nil metadata_path')
+params = run_upload_beta_lane
+if params
+  check(params[:skip_upload_changelogs] == true,
+        'the lane uploaded changelogs when there were no notes to upload')
+  check(!params[:metadata_path].nil?, 'the lane passed a nil metadata_path')
+end
 
 # --- Report -----------------------------------------------------------------
 


### PR DESCRIPTION
Android beta testers saw no release notes on Google Play while TestFlight testers got the full changelog ([report on ScubaBoard](https://scubaboard.com/community/threads/submersion-free-open-source-dive-log-app-all-platforms-looking-for-dive-computer-testers.667061/post-10808195)).

## What was happening

The notes were generated and written correctly. The `Upload Android beta to Play open testing` job for v1.7.3.5371 logged `Wrote Play release notes for version code 5371` and ran with `skip_upload_changelogs: false`. supply then discarded them and reported a successful upload.

fastlane runs lane bodies and helper methods in the `fastlane` directory, but wraps every **action** in `Dir.chdir("..")` to reach the project directory (`runner.rb`: `custom_dir ||= ".."`). supply resolves its default `metadata_path` from there, by globbing `./fastlane/metadata/android`:

| Code | Working directory | Path |
| --- | --- | --- |
| `write_beta_changelog` (helper) | `android/fastlane/` | wrote `android/fastlane/`**`fastlane/`**`metadata/android/en-US/changelogs/5371.txt` |
| `upload_to_play_store` (action) | `android/` | looked in `android/fastlane/metadata/android` |

The two never met. `metadata_path` resolved to `nil`, and `perform_upload_meta`'s `... && metadata_path` guard skipped the entire metadata phase silently.

Two things in the job log confirm it: `metadata_path` is absent from supply's printed config table, and supply's per-language line `Preparing uploads for language 'en-US'...` never appears — the log jumps straight from `Preparing aab` to `Updating track 'alpha'`.

This is also why `find_aab`'s `../../` glob works: that is helper code, two levels up from `android/fastlane`.

## The fix

- `PLAY_METADATA_ROOT` is anchored to `__dir__` rather than the working directory. It has to stay at the top level: fastlane evaluates the Fastfile with `__FILE__` set to a bare `"Fastfile"`, so `__dir__` only resolves while fastlane's own chdir into that folder is in effect. Commented in place.
- `write_beta_changelog` takes the metadata root as a parameter and returns the root it wrote to (or `nil`), instead of a boolean.
- The lane passes `metadata_path: changelog_root || PLAY_METADATA_ROOT`, so supply is told exactly where the notes went. Explicit beats a default resolved from a directory lane code never runs in.
- `android/fastlane/metadata/` is gitignored, since it is generated per build.

`skip_upload_metadata: true` is unchanged and safe: supply guards each artifact type separately inside its upload worker (`upload_metadata(...) unless Supply.config[:skip_upload_metadata]`), so only changelogs upload and the store listing is untouched.

## Tests

The existing test could not catch this. It `Dir.chdir`'d into a tmpdir and asserted the file appeared at the same relative path the code wrote to, which proves the writer is self-consistent but never that supply agrees.

It now:
- derives the expected metadata root the way **supply** does (from the project directory), so the check stays honest if the writer moves;
- asserts the root is absolute;
- executes the real `upload_beta` lane body against stubs, checking that the path the helper returned is the path handed to the action, and that `skip_upload_changelogs` tracks whether anything was written.

Mutation-tested both ways. Restoring the old relative path fails with `notes are written to fastlane/metadata/android, but supply reads .../android/fastlane/metadata/android`; dropping `metadata_path` from the lane fails with `the lane pointed supply at nil`.

`scripts/release/fastlane_beta_changelog_test.rb` and `scripts/release/beta_release_notes_test.sh` both pass; both Fastfiles pass `ruby -c`. No Dart changed.

## Verifying after merge

This cannot be verified end to end without a real beta run. In the next `Upload Android beta to Play open testing` log, the confirming signal is the line `Preparing uploads for language 'en-US'...`. If it is there, the notes attached.

One thing worth a glance in the Play Console: the notes go out as `en-US`, so testers on other locales fall back to whatever the listing's default language is.
