### PR TITLE
fix(trips): put trip cards on the same text theme roles as dive and site lists

### DIFF
--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -618,6 +618,21 @@ class TripListTile extends StatelessWidget {
             : null,
         child: ListTile(
           onTap: onTap,
+          // ListTile's Material 3 defaults resolve the title to bodyLarge and
+          // the subtitle to bodyMedium. The detailed dive and site cards are
+          // hand-rolled and ask for titleMedium/bodyMedium explicitly, so the
+          // roles are restated here to keep all three lists on the same text
+          // theme roles. Theme presets differ between the title and body roles
+          // (console uses a monospace family for title roles only, minimalist
+          // uses w500 for title roles and w300 for body roles), so inheriting
+          // the default renders trip titles in a different font from the rest
+          // of the app's lists.
+          titleTextStyle: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+          subtitleTextStyle: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           leading: Consumer(
             builder: (context, ref, _) {
               final accent = resolveFeatureAccent(
@@ -657,9 +672,10 @@ class TripListTile extends StatelessWidget {
           subtitle: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Date range takes the subtitle role from the ListTile above,
+              // matching the dive card's date line.
               Text(
                 '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}',
-                style: theme.textTheme.bodySmall,
               ),
               if (trip.subtitle != null)
                 Text(
@@ -810,6 +826,14 @@ class TripSearchDelegate extends SearchDelegate<Trip?> {
                 final trip = trips[index];
                 final dateFormat = DateFormat.yMMMd();
                 return ListTile(
+                  // Same text theme roles as TripListTile so search results do
+                  // not fall back to ListTile's bodyLarge title default.
+                  titleTextStyle: Theme.of(context).textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                  subtitleTextStyle: Theme.of(context).textTheme.bodyMedium
+                      ?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                   leading: Builder(
                     builder: (context) {
                       final accent = resolveFeatureAccent(

--- a/test/features/trips/presentation/widgets/trip_list_content_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_content_test.dart
@@ -823,22 +823,31 @@ void main() {
     // roles -- so a title that falls back to a body role renders in a visibly
     // different font from the rest of the app's lists.
 
+    // Trip dates are formatted with DateFormat.yMMMd(), which resolves against
+    // Intl.defaultLocale -- a process global that app.dart sets from the app
+    // locale -- NOT the MaterialApp locale. Pin it so the date lookups below
+    // state their real dependency instead of riding on intl's implicit en_US
+    // fallback, and restore it so the global stays contained. No
+    // initializeDateFormatting is needed because GlobalMaterialLocalizations
+    // does it for widget tests.
+    setUp(() {
+      final previousLocale = Intl.defaultLocale;
+      Intl.defaultLocale = 'en';
+      addTearDown(() => Intl.defaultLocale = previousLocale);
+    });
+
+    // RenderParagraph carries the *effective* style, i.e. the widget's own
+    // style merged with any inherited DefaultTextStyle. Reading Text.style
+    // alone would not catch a title that silently inherits ListTile's
+    // Material 3 default of bodyLarge.
+    TextStyle effectiveStyleOf(WidgetTester tester, String text) =>
+        tester.renderObject<RenderParagraph>(find.text(text)).text.style!;
+
     Future<TextStyle> pumpAndResolve(
       WidgetTester tester,
       String text, {
       required String tripName,
     }) async {
-      // TripListTile dates itself with DateFormat.yMMMd(), which resolves
-      // against Intl.defaultLocale -- a process global that app.dart sets from
-      // the app locale -- NOT the MaterialApp locale. Pin it so the
-      // "Jun 1, 2024 - Jun 7, 2024" lookup states its real dependency instead
-      // of riding on intl's implicit en_US fallback, and restore it so the
-      // global stays contained. No initializeDateFormatting is needed here
-      // because GlobalMaterialLocalizations does it for widget tests.
-      final previousLocale = Intl.defaultLocale;
-      Intl.defaultLocale = 'en';
-      addTearDown(() => Intl.defaultLocale = previousLocale);
-
       final overrides = await _buildPhoneOverrides(
         trips: [_makeTrip(id: 't1', name: tripName, diveCount: 12)],
         viewMode: ListViewMode.detailed,
@@ -851,11 +860,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // RenderParagraph carries the *effective* style, i.e. the widget's own
-      // style merged with any inherited DefaultTextStyle. Reading Text.style
-      // alone would not catch a title that silently inherits ListTile's
-      // Material 3 default of bodyLarge.
-      return tester.renderObject<RenderParagraph>(find.text(text)).text.style!;
+      return effectiveStyleOf(tester, text);
     }
 
     testWidgets('title uses titleMedium like dive and site cards', (
@@ -895,6 +900,56 @@ void main() {
     testWidgets('renders the detailed card without overflow', (tester) async {
       await pumpAndResolve(tester, 'Maldives Trip', tripName: 'Maldives Trip');
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('search results use the same roles as the trip card', (
+      tester,
+    ) async {
+      // The site search delegate renders its results with the real
+      // SiteListTile, so trip search results have to match the trip card too.
+      // The list underneath the search route stays in the widget tree, so the
+      // result trip is given a distinct name and date range to keep the
+      // find.text lookups unambiguous.
+      final result = _makeTrip(
+        id: 't2',
+        name: 'Maldives Trip',
+        startDate: DateTime(2025, 3, 2),
+        endDate: DateTime(2025, 3, 9),
+      );
+      final overrides = await _buildPhoneOverrides(
+        trips: [_makeTrip(id: 't1', name: 'Alpha Trip')],
+        viewMode: ListViewMode.detailed,
+      );
+      overrides.add(
+        tripSearchProvider.overrideWith((ref, query) async => [result.trip]),
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const TripListContent(showAppBar: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'Mal');
+      await tester.pumpAndSettle();
+
+      // Resolve the expectations from the search route's own context:
+      // showSearch installs the delegate's appBarTheme, so reading the roles
+      // from anywhere else could compare against a different ThemeData.
+      final theme = Theme.of(tester.element(find.text('Maldives Trip')));
+
+      final title = effectiveStyleOf(tester, 'Maldives Trip');
+      expect(title.fontFamily, theme.textTheme.titleMedium!.fontFamily);
+      expect(title.fontSize, theme.textTheme.titleMedium!.fontSize);
+      expect(title.fontWeight, FontWeight.w600);
+
+      final subtitle = effectiveStyleOf(tester, 'Mar 2, 2025 - Mar 9, 2025');
+      expect(subtitle.fontSize, theme.textTheme.bodyMedium!.fontSize);
+      expect(subtitle.color, theme.colorScheme.onSurfaceVariant);
     });
 
     testWidgets('title keeps the title font family under the console theme', (

--- a/test/features/trips/presentation/widgets/trip_list_content_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_content_test.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
-import 'package:submersion/core/theme/full_themes/console_theme.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/theme/full_themes/console_theme.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -827,6 +828,17 @@ void main() {
       String text, {
       required String tripName,
     }) async {
+      // TripListTile dates itself with DateFormat.yMMMd(), which resolves
+      // against Intl.defaultLocale -- a process global that app.dart sets from
+      // the app locale -- NOT the MaterialApp locale. Pin it so the
+      // "Jun 1, 2024 - Jun 7, 2024" lookup states its real dependency instead
+      // of riding on intl's implicit en_US fallback, and restore it so the
+      // global stays contained. No initializeDateFormatting is needed here
+      // because GlobalMaterialLocalizations does it for widget tests.
+      final previousLocale = Intl.defaultLocale;
+      Intl.defaultLocale = 'en';
+      addTearDown(() => Intl.defaultLocale = previousLocale);
+
       final overrides = await _buildPhoneOverrides(
         trips: [_makeTrip(id: 't1', name: tripName, diveCount: 12)],
         viewMode: ListViewMode.detailed,
@@ -892,6 +904,18 @@ void main() {
       // the title roles but restores the system family for the body roles. A
       // trip title that falls back to a body role therefore renders in a
       // literally different typeface from the dive and site titles.
+      //
+      // Touching consoleLight lazily initializes it, which calls
+      // GoogleFonts.jetBrainsMonoTextTheme(). Disabling runtime fetching keeps
+      // that from reaching the network; the family name is carried on the
+      // TextStyle regardless of whether the font bytes ever load, which is all
+      // this test reads.
+      //
+      // The app_theme_registry_test hardening (await GoogleFonts.pendingFonts()
+      // plus a debugPrint override) does NOT transfer here, because that file
+      // uses plain test(). Inside testWidgets, awaiting pendingFonts() from a
+      // tear-down never completes, and reassigning debugPrint trips
+      // debugAssertAllFoundationVarsUnset, which runs before tear-downs.
       GoogleFonts.config.allowRuntimeFetching = false;
 
       final titleFamily = consoleLight.textTheme.titleMedium!.fontFamily;

--- a/test/features/trips/presentation/widgets/trip_list_content_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_content_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/theme/full_themes/console_theme.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -807,6 +810,117 @@ void main() {
       await tester.pumpAndSettle();
       // Widget rendered without error.
       expect(find.byType(TripListContent), findsOneWidget);
+    });
+  });
+
+  group('TripListTile typography', () {
+    // The detailed trip card must resolve to the same text theme roles as the
+    // detailed dive and site cards (titleMedium + w600 for the title,
+    // bodyMedium for the date line). Several theme presets differ between the
+    // title and body roles -- console_theme puts a monospace family on title
+    // roles only, minimalist_theme uses w500 for title roles and w300 for body
+    // roles -- so a title that falls back to a body role renders in a visibly
+    // different font from the rest of the app's lists.
+
+    Future<TextStyle> pumpAndResolve(
+      WidgetTester tester,
+      String text, {
+      required String tripName,
+    }) async {
+      final overrides = await _buildPhoneOverrides(
+        trips: [_makeTrip(id: 't1', name: tripName, diveCount: 12)],
+        viewMode: ListViewMode.detailed,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const TripListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // RenderParagraph carries the *effective* style, i.e. the widget's own
+      // style merged with any inherited DefaultTextStyle. Reading Text.style
+      // alone would not catch a title that silently inherits ListTile's
+      // Material 3 default of bodyLarge.
+      return tester.renderObject<RenderParagraph>(find.text(text)).text.style!;
+    }
+
+    testWidgets('title uses titleMedium like dive and site cards', (
+      tester,
+    ) async {
+      final effective = await pumpAndResolve(
+        tester,
+        'Maldives Trip',
+        tripName: 'Maldives Trip',
+      );
+
+      final theme = Theme.of(tester.element(find.byType(TripListTile)));
+      final titleMedium = theme.textTheme.titleMedium!;
+
+      expect(effective.fontFamily, titleMedium.fontFamily);
+      expect(effective.fontSize, titleMedium.fontSize);
+      expect(effective.fontWeight, FontWeight.w600);
+    });
+
+    testWidgets('date line uses bodyMedium like the dive card date line', (
+      tester,
+    ) async {
+      final effective = await pumpAndResolve(
+        tester,
+        'Jun 1, 2024 - Jun 7, 2024',
+        tripName: 'Maldives Trip',
+      );
+
+      final theme = Theme.of(tester.element(find.byType(TripListTile)));
+      final bodyMedium = theme.textTheme.bodyMedium!;
+
+      expect(effective.fontFamily, bodyMedium.fontFamily);
+      expect(effective.fontSize, bodyMedium.fontSize);
+      expect(effective.color, theme.colorScheme.onSurfaceVariant);
+    });
+
+    testWidgets('renders the detailed card without overflow', (tester) async {
+      await pumpAndResolve(tester, 'Maldives Trip', tripName: 'Maldives Trip');
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('title keeps the title font family under the console theme', (
+      tester,
+    ) async {
+      // The console preset is the sharpest case: it puts a monospace family on
+      // the title roles but restores the system family for the body roles. A
+      // trip title that falls back to a body role therefore renders in a
+      // literally different typeface from the dive and site titles.
+      GoogleFonts.config.allowRuntimeFetching = false;
+
+      final titleFamily = consoleLight.textTheme.titleMedium!.fontFamily;
+      final bodyFamily = consoleLight.textTheme.bodyLarge!.fontFamily;
+      // Guard the guard: if these ever converge the assertion below proves
+      // nothing, and this test should be pointed at another preset.
+      expect(titleFamily, isNot(bodyFamily));
+
+      final overrides = await _buildPhoneOverrides(
+        trips: [_makeTrip(id: 't1', name: 'Maldives Trip', diveCount: 12)],
+        viewMode: ListViewMode.detailed,
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: Theme(
+            data: consoleLight,
+            child: const TripListContent(showAppBar: false),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final effective = tester
+          .renderObject<RenderParagraph>(find.text('Maldives Trip'))
+          .text
+          .style!;
+
+      expect(effective.fontFamily, titleFamily);
     });
   });
 }


### PR DESCRIPTION
Trip cards rendered their title in a different font from the dive and site lists.

## Root cause

`TripListTile` was the only detailed list card in the app built on Flutter's `ListTile`. Its title was a bare `Text(trip.name)` with no style, so it fell through to `ListTile`'s Material 3 default:

```dart
// flutter/src/material/list_tile.dart:1844
TextStyle? get titleTextStyle => _textTheme.bodyLarge!.copyWith(color: _colors.onSurface);
```

The hand-rolled `DiveListTile` and `SiteListTile` both ask for `textTheme.titleMedium` + `w600` explicitly. So trip titles resolved to a **body** role while every other list resolved to a **title** role.

That is a different font *family*, not merely a different weight, under the theme presets that split on exactly that axis:

- `console_theme.dart` applies `GoogleFonts.jetBrainsMonoTextTheme` and then restores the base family for all body and label roles.
- `minimalist_theme.dart` uses `w500` for title roles against `w300` for body roles.
- `deep_theme.dart` uses `w700` for title roles only.

Under the console preset a trip title rendered in Roboto while the dive and site titles beside it rendered in JetBrains Mono.

## Changes

`TripListTile` restates the roles explicitly via `titleTextStyle` and `subtitleTextStyle` rather than being converted to a hand-rolled `Row`/`Column`, which leaves the layout untouched. The date range line drops its redundant `bodySmall` override and takes the subtitle role, matching the dive card's date line. The smaller `bodySmall` metadata rows are unchanged, since the dive and site cards use `bodySmall` for their tertiary rows too.

`TripSearchDelegate` had the same defect on a second surface. The site search delegate reuses the real `SiteListTile` for its results, so the trip delegate's unstyled `ListTile` was the outlier there as well.

Compact and dense trip tiles needed no change; they were already on `bodyMedium`/`bodySmall` + `w600` like their dive and site counterparts, so the mismatch was confined to detailed view.

## Tests

Four cases added to `trip_list_content_test.dart`, written first and confirmed red before the fix.

They assert on `RenderParagraph.text.style` rather than `Text.style`, because the divergence only exists after `Text` merges with the `DefaultTextStyle` that `ListTile` installs; reading `Text.style` would have returned `null` and proved nothing. Expected roles are resolved from the widget's own `Theme.of(context)` so the assertions hold across all five presets.

One case is pinned to `consoleLight`, where title and body roles genuinely differ in family. Removing the fix makes it fail with `Expected: 'JetBrainsMono_regular' / Actual: 'Roboto'` - the reported bug, captured directly. It also asserts the two families differ before relying on that, so it cannot pass vacuously if the preset ever changes.

## Verification

- `flutter test test/features/trips/` - 529 passed, including all 26 pre-existing tests in the touched file
- `flutter analyze` (whole project) - no issues
- `dart format .` - clean