### PR TITLE
fix(trips): open the end-date picker at the just-picked start date

### DIFF
--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -55,6 +55,11 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
   DateTime _startDate = DateTime.now();
   DateTime? _returnFlightAt;
   DateTime _endDate = DateTime.now().add(const Duration(days: 7));
+  // False until the diver deliberately sets an end date (picked here, or
+  // loaded from an existing trip) -- while false, _endDate is just the
+  // placeholder default, so the end-date picker should open at _startDate
+  // instead of dragging the diver back through the calendar to it.
+  bool _endDateTouched = false;
   bool _isLoading = false;
   bool _isSaving = false;
   bool _hasChanges = false;
@@ -128,6 +133,7 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
         setState(() {
           _startDate = trip.startDate;
           _endDate = trip.endDate;
+          _endDateTouched = true;
           _returnFlightAt = trip.returnFlightAt;
           _isShared = trip.isShared;
           _isLoading = false;
@@ -708,7 +714,9 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
   }
 
   Future<void> _selectDate(BuildContext context, bool isStartDate) async {
-    final initialDate = isStartDate ? _startDate : _endDate;
+    final initialDate = isStartDate
+        ? _startDate
+        : (_endDateTouched ? _endDate : _startDate);
     final firstDate = isStartDate ? DateTime(1950) : _startDate;
     final lastDate = DateTime(2100);
 
@@ -728,6 +736,7 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
           }
         } else {
           _endDate = pickedDate;
+          _endDateTouched = true;
         }
         _hasChanges = true;
       });

--- a/lib/features/trips/presentation/pages/trip_edit_page.dart
+++ b/lib/features/trips/presentation/pages/trip_edit_page.dart
@@ -55,10 +55,12 @@ class _TripEditPageState extends ConsumerState<TripEditPage> {
   DateTime _startDate = DateTime.now();
   DateTime? _returnFlightAt;
   DateTime _endDate = DateTime.now().add(const Duration(days: 7));
-  // False until the diver deliberately sets an end date (picked here, or
-  // loaded from an existing trip) -- while false, _endDate is just the
-  // placeholder default, so the end-date picker should open at _startDate
-  // instead of dragging the diver back through the calendar to it.
+  // Controls where the end-date picker opens, not whether _endDate still
+  // holds the placeholder value -- _endDate can also get auto-synced to
+  // _startDate (below) while this stays false. False until the diver
+  // deliberately sets an end date (picked here, or loaded from an existing
+  // trip); while false, the picker opens at _startDate instead of dragging
+  // the diver back through the calendar to it.
   bool _endDateTouched = false;
   bool _isLoading = false;
   bool _isSaving = false;

--- a/test/features/trips/presentation/pages/trip_edit_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_edit_page_test.dart
@@ -695,6 +695,59 @@ void main() {
         expect(dialog.initialDate, DateTime(2023, 1, 15));
       },
     );
+
+    testWidgets(
+      'end date picker keeps opening at an explicitly picked end date',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              tripRepositoryProvider.overrideWithValue(_MockTripRepository()),
+              tripListNotifierProvider.overrideWith((ref) {
+                return _MockTripListNotifier([]);
+              }),
+            ],
+            child: const MaterialApp(
+              locale: Locale('en'),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: TripEditPage(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Explicitly pick an end date. _startDate defaults to today for a
+        // new trip and bounds the end picker's firstDate, so the target
+        // must stay safely in the future regardless of when this runs.
+        final target = DateTime(DateTime.now().year + 2, 3, 10);
+        await tester.tap(find.text('End Date'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+        final month = target.month.toString().padLeft(2, '0');
+        final day = target.day.toString().padLeft(2, '0');
+        await tester.enterText(
+          find.descendant(
+            of: find.byType(DatePickerDialog),
+            matching: find.byType(TextField),
+          ),
+          '$month/$day/${target.year}',
+        );
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        // Reopening the end-date picker must keep showing the diver's own
+        // choice, not fall back to _startDate now that it's been touched.
+        await tester.tap(find.text('End Date'));
+        await tester.pumpAndSettle();
+
+        final dialog = tester.widget<DatePickerDialog>(
+          find.byType(DatePickerDialog),
+        );
+        expect(dialog.initialDate, target);
+      },
+    );
   });
 
   group('TripEditPage - save flow', () {

--- a/test/features/trips/presentation/pages/trip_edit_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_edit_page_test.dart
@@ -644,6 +644,57 @@ void main() {
       Navigator.of(tester.element(find.byType(DatePickerDialog))).pop();
       await tester.pumpAndSettle();
     });
+
+    testWidgets(
+      'end date picker opens positioned at the just-picked start date',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              tripRepositoryProvider.overrideWithValue(_MockTripRepository()),
+              tripListNotifierProvider.overrideWith((ref) {
+                return _MockTripListNotifier([]);
+              }),
+            ],
+            child: const MaterialApp(
+              // Pin the locale: this test types a US-format date.
+              locale: Locale('en'),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: TripEditPage(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Pick a start date far in the past -- well before the default
+        // end date (today + 7 days), so the auto-sync in _selectDate that
+        // pushes _endDate forward when start moves past it never fires.
+        // This is exactly the reported scenario: picking a start date
+        // leaves the stale, far-away default end date behind.
+        await tester.tap(find.text('Start Date'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.edit_outlined));
+        await tester.pumpAndSettle();
+        await tester.enterText(
+          find.descendant(
+            of: find.byType(DatePickerDialog),
+            matching: find.byType(TextField),
+          ),
+          '01/15/2023',
+        );
+        await tester.tap(find.text('OK'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('End Date'));
+        await tester.pumpAndSettle();
+
+        final dialog = tester.widget<DatePickerDialog>(
+          find.byType(DatePickerDialog),
+        );
+        expect(dialog.initialDate, DateTime(2023, 1, 15));
+      },
+    );
   });
 
   group('TripEditPage - save flow', () {


### PR DESCRIPTION
## Root cause

`_selectDate`'s end-date branch always passed the current `_endDate` as
`initialDate` to the picker. For a new trip, `_endDate` starts as a
hardcoded `DateTime.now().add(Duration(days: 7))` placeholder, and the
only code that keeps it in sync with a picked start date is the
"push forward" guard a few lines down, which only fires when the new
start date lands *after* the current end date. Picking a start date
any distance in the past (or a future date still short of "today + 7")
never triggers that guard, so `_endDate` -- and therefore the picker's
`initialDate` -- stayed pinned to the stale default, far from wherever
the diver had just navigated the calendar to.

## Fix

Added `_endDateTouched`, false until the diver deliberately sets an
end date (picked via the picker, or loaded from an existing trip in
`_loadTrip`). While false, the end-date picker's `initialDate`
resolves to `_startDate` instead of the untouched placeholder. Once a
real end date exists, the picker keeps opening at that value as before
-- only the untouched-default case changes. `firstDate` was already
correctly bounded to `_startDate`; this only changes where the
calendar opens.

## Tests

`trip_edit_page_test.dart`: picks a start date in the past (2023),
chosen specifically to fall before the default end date so the
existing "push forward" sync never fires, then opens the end-date
picker and asserts `DatePickerDialog.initialDate` equals the picked
start date rather than the stale default. Confirmed red against the
pre-fix code (`Actual: DateTime:<2026-08-15...>`, the today+7
placeholder) before implementing the fix.

## Verification

- `flutter test test/features/trips/presentation/pages/trip_edit_page_test.dart`: 39/39 passing, including the pre-existing "start date moves past end date" sync test (no regression).
- `flutter analyze`: no issues.
- `dart format`: no changes.
- Manually verified in a running macOS build.