### PR TITLE
fix(dc): Shearwater downloads aborting with zero dives (#766) and dive computer deletion (#823)

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -300,15 +300,21 @@ class DiveComputerRepository {
 
   /// Delete a dive computer
   ///
-  /// Nulls out FK references in `dive_profiles` and `dive_data_sources` first
-  /// so the delete is not blocked by foreign key constraints.
-  /// The profile/data-source rows are preserved — only the computer link is
-  /// removed.
+  /// Nulls out FK references in `dives`, `dive_profiles`, and
+  /// `dive_data_sources` first so the delete is not blocked by foreign key
+  /// constraints. The dive/profile/data-source rows are preserved — only the
+  /// computer link is removed.
   Future<void> deleteComputer(String id) async {
     try {
       _log.info('Deleting dive computer: $id');
 
-      // Clear FK references that would block the delete.
+      // Clear FK references that would block the delete. dives.computer_id
+      // has no ON DELETE action, so leaving it set fails the delete with
+      // SqliteException(787) on any computer that a dive references (#823).
+      await _db.customStatement(
+        'UPDATE dives SET computer_id = NULL WHERE computer_id = ?',
+        [id],
+      );
       await _db.customStatement(
         'UPDATE dive_profiles SET computer_id = NULL WHERE computer_id = ?',
         [id],

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -235,6 +235,10 @@ class DiveComputerRepository {
         recordId: id,
         localUpdatedAt: now,
       );
+
+      // If a computer with this hardware identity was deleted earlier, its
+      // dives kept provenance snapshots; give them their link back.
+      await _relinkOrphanedRows(id, computer);
       SyncEventBus.notifyLocalChange();
 
       _log.info('Created dive computer with id: $id');
@@ -300,13 +304,24 @@ class DiveComputerRepository {
 
   /// Delete a dive computer
   ///
-  /// Nulls out FK references in `dives`, `dive_profiles`, and
-  /// `dive_data_sources` first so the delete is not blocked by foreign key
-  /// constraints. The dive/profile/data-source rows are preserved — only the
-  /// computer link is removed.
+  /// Every dive referencing the computer keeps a `dive_data_sources` text
+  /// snapshot (model + serial) of the device that produced it, backfilled
+  /// here when missing, so the provenance record survives the delete and
+  /// [_relinkOrphanedRows] can restore the links if the same hardware is
+  /// added again. FK references in `dives`, `dive_profiles`, and
+  /// `dive_data_sources` are then nulled out so the delete is not blocked by
+  /// foreign key constraints; the dive/profile/data-source rows themselves
+  /// are preserved.
   Future<void> deleteComputer(String id) async {
     try {
       _log.info('Deleting dive computer: $id');
+
+      final row = await (_db.select(
+        _db.diveComputers,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      if (row != null) {
+        await _backfillProvenanceSnapshots(_mapRowToComputer(row));
+      }
 
       // Clear FK references that would block the delete. dives.computer_id
       // has no ON DELETE action, so leaving it set fails the delete with
@@ -338,6 +353,153 @@ class DiveComputerRepository {
         stackTrace: stackTrace,
       );
       rethrow;
+    }
+  }
+
+  /// Insert a `dive_data_sources` snapshot for every dive that references
+  /// [computer] but has no data source row for it (dives imported before
+  /// provenance rows existed). The snapshot's text columns are what the UI
+  /// shows and what relinking matches on once the computer row is gone.
+  Future<void> _backfillProvenanceSnapshots(
+    domain.DiveComputer computer,
+  ) async {
+    final orphanDives = await _db
+        .customSelect(
+          'SELECT d.id AS dive_id, '
+          'NOT EXISTS(SELECT 1 FROM dive_data_sources p '
+          'WHERE p.dive_id = d.id AND p.is_primary = 1) AS needs_primary '
+          'FROM dives d WHERE d.computer_id = ? AND NOT EXISTS('
+          'SELECT 1 FROM dive_data_sources s WHERE s.dive_id = d.id '
+          'AND s.computer_id = ?)',
+          variables: [Variable(computer.id), Variable(computer.id)],
+          readsFrom: {_db.dives, _db.diveDataSources},
+        )
+        .get();
+    if (orphanDives.isEmpty) return;
+
+    final now = DateTime.now();
+    for (final row in orphanDives) {
+      await _db
+          .into(_db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion.insert(
+              id: _uuid.v4(),
+              diveId: row.read<String>('dive_id'),
+              isPrimary: Value(row.read<int>('needs_primary') == 1),
+              computerModel: Value(computer.fullName),
+              computerSerial: Value(computer.serialNumber),
+              sourceFormat: const Value('dive_computer'),
+              importedAt: now,
+              createdAt: now,
+            ),
+          );
+    }
+    _log.info(
+      'Backfilled ${orphanDives.length} provenance snapshot(s) '
+      'for computer ${computer.id}',
+    );
+  }
+
+  /// Restore the links a deleted computer with this hardware identity left
+  /// behind. Orphaned `dive_data_sources` rows are matched on the model +
+  /// serial snapshot; their dives (when the matched source is the dive's
+  /// primary and no live computer claims the dive) and, for dives whose
+  /// computer attribution is unambiguous, their profiles get [computerId]
+  /// back. Relinked dives are marked pending so the restored link syncs.
+  /// Best-effort: a relink failure must never fail the computer creation.
+  Future<void> _relinkOrphanedRows(
+    String computerId,
+    domain.DiveComputer computer,
+  ) async {
+    final serial = computer.serialNumber;
+    if (serial == null || serial.isEmpty) return;
+    try {
+      final matched = await _db
+          .customSelect(
+            'SELECT id, dive_id, is_primary FROM dive_data_sources '
+            'WHERE computer_id IS NULL AND source_format = ? '
+            'AND computer_model = ? AND computer_serial = ?',
+            variables: [
+              const Variable('dive_computer'),
+              Variable(computer.fullName),
+              Variable(serial),
+            ],
+            readsFrom: {_db.diveDataSources},
+          )
+          .get();
+      if (matched.isEmpty) return;
+
+      final sourceIds = matched.map((r) => r.read<String>('id')).toList();
+      final sourcePh = List.filled(sourceIds.length, '?').join(', ');
+      await _db.customStatement(
+        'UPDATE dive_data_sources SET computer_id = ? WHERE id IN ($sourcePh)',
+        [computerId, ...sourceIds],
+      );
+
+      // Restore the dive's primary-computer link where the matched source is
+      // the dive's primary and no live computer claims the dive.
+      final primaryDiveIds = matched
+          .where((r) => r.read<int>('is_primary') != 0)
+          .map((r) => r.read<String>('dive_id'))
+          .toSet()
+          .toList();
+      if (primaryDiveIds.isNotEmpty) {
+        final divePh = List.filled(primaryDiveIds.length, '?').join(', ');
+        final claimable = await _db
+            .customSelect(
+              'SELECT id FROM dives '
+              'WHERE computer_id IS NULL AND id IN ($divePh)',
+              variables: [for (final d in primaryDiveIds) Variable(d)],
+              readsFrom: {_db.dives},
+            )
+            .get();
+        final diveIds = claimable.map((r) => r.read<String>('id')).toList();
+        if (diveIds.isNotEmpty) {
+          final now = DateTime.now().millisecondsSinceEpoch;
+          final ph = List.filled(diveIds.length, '?').join(', ');
+          await _db.customStatement(
+            'UPDATE dives SET computer_id = ?, updated_at = ? '
+            'WHERE id IN ($ph)',
+            [computerId, now, ...diveIds],
+          );
+          for (final diveId in diveIds) {
+            await _syncRepository.markRecordPending(
+              entityType: 'dives',
+              recordId: diveId,
+              localUpdatedAt: now,
+            );
+          }
+        }
+      }
+
+      // Profiles carry no serial snapshot of their own, so restore them only
+      // when the dive's computer attribution is unambiguous: exactly one
+      // dive_computer source row.
+      final matchedDiveIds = matched
+          .map((r) => r.read<String>('dive_id'))
+          .toSet()
+          .toList();
+      final matchedPh = List.filled(matchedDiveIds.length, '?').join(', ');
+      await _db.customStatement(
+        'UPDATE dive_profiles SET computer_id = ? '
+        'WHERE computer_id IS NULL AND dive_id IN ($matchedPh) '
+        'AND (SELECT COUNT(*) FROM dive_data_sources s '
+        'WHERE s.dive_id = dive_profiles.dive_id '
+        "AND s.source_format = 'dive_computer') = 1",
+        [computerId, ...matchedDiveIds],
+      );
+
+      _log.info(
+        'Relinked ${sourceIds.length} data source(s) from previous '
+        '${computer.fullName} (${computer.serialNumber}) '
+        'to computer $computerId',
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to relink orphaned rows to computer $computerId',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -650,6 +650,17 @@ static int jni_io_close(void *userdata) {
     return LIBDC_STATUS_SUCCESS;
 }
 
+// Context for the libdivecomputer log callback: WARNING/ERROR messages are
+// forwarded to NativeTrace.writeLibdc so they land in the user-exportable
+// debug log, not only logcat. Cached once per process; the global ref and
+// jmethodID stay valid for the app's lifetime.
+struct LogForwardContext {
+    JavaVM *jvm;
+    jobject traceInstance;  // global ref to NativeTrace.INSTANCE
+    jmethodID writeLibdc;   // writeLibdc(String, String)
+};
+static LogForwardContext g_log_forward = {nullptr, nullptr, nullptr};
+
 extern "C" JNIEXPORT jint JNICALL
 Java_com_submersion_libdivecomputer_LibdcWrapper_nativeDownloadRun(
     JNIEnv *env, jclass,
@@ -737,11 +748,36 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeDownloadRun(
         }
     }
 
+    // Resolve NativeTrace once so the libdivecomputer log callback can
+    // forward WARNING/ERROR diagnostics into the user-exportable debug log.
+    // Issue #766 took three rounds of user logs to localize because the
+    // protocol-level messages only ever reached logcat.
+    if (g_log_forward.traceInstance == nullptr) {
+        jclass traceCls =
+            env->FindClass("com/submersion/libdivecomputer/NativeTrace");
+        if (traceCls != nullptr) {
+            jfieldID instField = env->GetStaticFieldID(traceCls, "INSTANCE",
+                "Lcom/submersion/libdivecomputer/NativeTrace;");
+            jmethodID writeMethod = env->GetMethodID(traceCls, "writeLibdc",
+                "(Ljava/lang/String;Ljava/lang/String;)V");
+            if (instField != nullptr && writeMethod != nullptr) {
+                jobject inst = env->GetStaticObjectField(traceCls, instField);
+                if (inst != nullptr) {
+                    g_log_forward.jvm = jvm;
+                    g_log_forward.writeLibdc = writeMethod;
+                    g_log_forward.traceInstance = env->NewGlobalRef(inst);
+                }
+            }
+            env->DeleteLocalRef(traceCls);
+        }
+        env->ExceptionClear();
+    }
+
     // Register libdivecomputer log callback so internal diagnostic messages
     // appear in logcat. Android's NativeLogger already wraps Log.d(), so
     // logcat output is captured by the platform-level logging infrastructure.
     libdc_set_log_callback(
-        [](int level, const char *message, void *) {
+        [](int level, const char *message, void *userdata) {
             // Map dc_loglevel_t: ERROR=1, WARNING=2, INFO=3, DEBUG=4+
             android_LogPriority priority;
             switch (level) {
@@ -759,8 +795,30 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeDownloadRun(
                 break;
             }
             __android_log_print(priority, "libdc", "%s", message);
+
+            // Forward WARNING/ERROR into the crash-survivable debug log so
+            // protocol-level failures reach user-exported logs.
+            auto *fwd = static_cast<LogForwardContext *>(userdata);
+            if (fwd == nullptr || fwd->traceInstance == nullptr || level > 2)
+                return;
+            JNIEnv *cbEnv;
+            if (fwd->jvm->GetEnv(reinterpret_cast<void **>(&cbEnv),
+                                 JNI_VERSION_1_6) != JNI_OK) {
+                // Only forward from already-attached threads (the download
+                // thread entered through JNI); logging must stay passive.
+                return;
+            }
+            jstring jlevel = cbEnv->NewStringUTF(level == 1 ? "ERROR" : "WARN");
+            jstring jmessage = cbEnv->NewStringUTF(message);
+            if (jlevel != nullptr && jmessage != nullptr) {
+                cbEnv->CallVoidMethod(fwd->traceInstance, fwd->writeLibdc,
+                                      jlevel, jmessage);
+            }
+            cbEnv->ExceptionClear();
+            if (jlevel != nullptr) cbEnv->DeleteLocalRef(jlevel);
+            if (jmessage != nullptr) cbEnv->DeleteLocalRef(jmessage);
         },
-        nullptr
+        &g_log_forward
     );
 
     // Run the download.

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -766,6 +766,7 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeDownloadRun(
                     g_log_forward.jvm = jvm;
                     g_log_forward.writeLibdc = writeMethod;
                     g_log_forward.traceInstance = env->NewGlobalRef(inst);
+                    env->DeleteLocalRef(inst);
                 }
             }
             env->DeleteLocalRef(traceCls);

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/NativeTrace.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/NativeTrace.kt
@@ -50,10 +50,24 @@ object NativeTrace {
      * A no-op unless debug mode has created the log file.
      */
     @Synchronized
-    fun write(level: String, message: String) {
+    fun write(level: String, message: String) = writeLine("SER", level, message)
+
+    /**
+     * Appends a libdivecomputer diagnostic under the LDC channel. Called from
+     * JNI (nativeDownloadRun's log callback) for WARNING/ERROR messages, so
+     * protocol-level failures like a NAK'd Shearwater dive request (#766)
+     * land in the user-exportable debug log instead of only logcat.
+     */
+    @Synchronized
+    fun writeLibdc(level: String, message: String) =
+        writeLine("LDC", level, message)
+
+    @Synchronized
+    private fun writeLine(channel: String, level: String, message: String) {
         val file = logFile ?: return
         if (!file.exists()) return
-        val line = "[${timestampFormat.format(Date())}] [SER] [$level] $message\n"
+        val line =
+            "[${timestampFormat.format(Date())}] [$channel] [$level] $message\n"
         try {
             FileOutputStream(file, true).use { out ->
                 out.write(line.toByteArray(Charsets.UTF_8))

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -28,6 +28,12 @@
 struct libdc_download_session {
     volatile int cancelled;
     dc_context_t *context;
+    // Last ERROR-level message libdivecomputer logged during this session's
+    // run. The generic "Download failed" surfaced to the app hid the
+    // protocol-level cause (issue #766 took three rounds of user logs to
+    // localize); appending this message to error_buf puts the diagnosis in
+    // the app log and the UI on every platform.
+    char last_error[160];
 };
 
 // Data passed through the download pipeline callbacks.
@@ -535,9 +541,16 @@ static void libdc_logfunc_wrapper(dc_context_t *context, dc_loglevel_t loglevel,
                                    const char *file, unsigned int line,
                                    const char *function, const char *message,
                                    void *userdata) {
-    (void)context; (void)file; (void)line; (void)function; (void)userdata;
+    (void)context; (void)file; (void)line; (void)function;
     if (g_log_callback != NULL && message != NULL) {
         g_log_callback((int)loglevel, message, g_log_userdata);
+    }
+    // Keep the most recent ERROR so a failed run can report its actual
+    // protocol-level cause instead of a bare "Download failed".
+    libdc_download_session_t *session = (libdc_download_session_t *)userdata;
+    if (session != NULL && message != NULL && loglevel == DC_LOGLEVEL_ERROR) {
+        strncpy(session->last_error, message, sizeof(session->last_error) - 1);
+        session->last_error[sizeof(session->last_error) - 1] = '\0';
     }
 }
 
@@ -554,11 +567,10 @@ libdc_download_session_t *libdc_download_session_new(void) {
     }
 
     // Route libdivecomputer's internal diagnostic messages through the
-    // registered log callback if one has been set.
-    if (g_log_callback != NULL) {
-        dc_context_set_loglevel(session->context, DC_LOGLEVEL_ALL);
-        dc_context_set_logfunc(session->context, libdc_logfunc_wrapper, NULL);
-    }
+    // registered log callback if one has been set, and capture the last
+    // error-level message for failure reporting either way.
+    dc_context_set_loglevel(session->context, DC_LOGLEVEL_ALL);
+    dc_context_set_logfunc(session->context, libdc_logfunc_wrapper, session);
 
     return session;
 }
@@ -600,6 +612,7 @@ int libdc_download_run(
     state.callbacks = callbacks;
     state.error_buf = error_buf;
     state.error_buf_size = error_buf_size;
+    session->last_error[0] = '\0';
 
     // 1. Find matching descriptor.
     state.descriptor = find_descriptor(vendor, product, model);
@@ -678,6 +691,14 @@ int libdc_download_run(
         if (session->cancelled) {
             set_error(&state, "Download cancelled");
             result = LIBDC_STATUS_CANCELLED;
+        } else if (session->last_error[0] != '\0') {
+            // Surface the protocol-level cause libdivecomputer logged, not
+            // just the generic failure (issue #766).
+            char msg[224];
+            snprintf(msg, sizeof(msg), "Download failed: %s",
+                     session->last_error);
+            set_error(&state, msg);
+            result = (int)status;
         } else {
             set_error(&state, "Download failed");
             result = (int)status;

--- a/packages/libdivecomputer_plugin/patches/0006-shearwater-nak-skip.patch
+++ b/packages/libdivecomputer_plugin/patches/0006-shearwater-nak-skip.patch
@@ -1,0 +1,92 @@
+diff --git a/src/shearwater_common.c b/src/shearwater_common.c
+index ef3e71f..f3c3a0d 100644
+--- a/src/shearwater_common.c
++++ b/src/shearwater_common.c
+@@ -483,6 +483,14 @@ shearwater_common_download (shearwater_common_device_t *device, dc_buffer_t *buf
+ 
+ 	// Verify the init response.
+ 	if (n < 2 || response[0] != UPLOAD_INIT_RESPONSE) {
++		if (n == 3 && response[0] == NAK && response[1] == UPLOAD_INIT_REQUEST) {
++			// A well-formed refusal, not line noise: the device cannot
++			// (or will not) serve the requested address. Return
++			// DC_STATUS_UNSUPPORTED, like the rdbi/wdbi NAK handling,
++			// so the caller can distinguish it from a protocol error.
++			ERROR (abstract->context, "Received NAK packet with error code 0x%02x.", response[2]);
++			return DC_STATUS_UNSUPPORTED;
++		}
+ 		ERROR (abstract->context, "Unexpected response packet.");
+ 		return DC_STATUS_PROTOCOL;
+ 	}
+diff --git a/src/shearwater_petrel.c b/src/shearwater_petrel.c
+index ab1eef2..530eb34 100644
+--- a/src/shearwater_petrel.c
++++ b/src/shearwater_petrel.c
+@@ -263,6 +263,20 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 		progress.current = NSTEPS * current;
+ 		progress.maximum = NSTEPS * maximum;
+ 		rc = shearwater_common_download (&device->base, buffer, MANIFEST_ADDR, MANIFEST_SIZE, 0, &progress);
++		if (rc == DC_STATUS_UNSUPPORTED && dc_buffer_get_size (manifests) != 0) {
++			// The device refused (NAK'd) this page. When the record area
++			// ends exactly on a page boundary, a full final page is
++			// indistinguishable from a truncated one, so the walk asks
++			// for one page too many and the refusal is the normal end
++			// of the manifest, not an error. Roll back this page's
++			// speculative progress contribution. A refused FIRST page
++			// stays an error: nothing was read yet, so it cannot be an
++			// end-of-manifest signal.
++			WARNING (abstract->context, "Treating the refused manifest page as the end of the manifest.");
++			maximum -= 1 + RECORD_COUNT;
++			rc = DC_STATUS_SUCCESS;
++			break;
++		}
+ 		if (rc != DC_STATUS_SUCCESS) {
+ 			ERROR (abstract->context, "Failed to download the manifest.");
+ 			dc_buffer_free (buffer);
+@@ -359,6 +373,7 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 	// remains a correct fingerprint to resume from on the next attempt.
+ 	unsigned int nrecords = size / RECORD_SIZE;
+ 	unsigned int delivered = 0;
++	unsigned int skipped = 0;
+ 	for (unsigned int i = nrecords; i > 0; --i) {
+ 		unsigned int offset = (i - 1) * RECORD_SIZE;
+ 
+@@ -404,6 +419,22 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 			}
+ 		}
+ 		if (rc != DC_STATUS_SUCCESS) {
++			if (rc == DC_STATUS_UNSUPPORTED) {
++				// The device refused (NAK'd) the init request: the
++				// record references dive data the device can no longer
++				// serve, so neither a retry nor an abort can help.
++				// Skip it like a deleted record and keep the pass
++				// alive. The skipped dive is older than every dive
++				// still to come, so the newest-delivered-fingerprint
++				// resume contract is unaffected.
++				WARNING (abstract->context,
++					"Skipping manifest record %u: the device refused the dive at address %08x.",
++					i - 1, base_addr + address);
++				skipped++;
++				maximum -= 1;
++				rc = DC_STATUS_SUCCESS;
++				continue;
++			}
+ 			if (rc != DC_STATUS_CANCELLED && delivered > 0) {
+ 				// Persistent failure mid-pass: keep what was delivered
+ 				// instead of reporting a total failure. The oldest-first
+@@ -433,6 +464,16 @@ shearwater_petrel_device_foreach (dc_device_t *abstract, dc_dive_callback_t call
+ 			break;
+ 	}
+ 
++	// Refusal of every requested dive is not a poisoned record but
++	// something systemic (e.g. requesting dives at the wrong logbook base
++	// address); reporting success with zero dives would hide it.
++	if (rc == DC_STATUS_SUCCESS && delivered == 0 && skipped > 0) {
++		ERROR (abstract->context, "The device refused every dive request.");
++		dc_buffer_free (manifests);
++		dc_buffer_free (buffer);
++		return DC_STATUS_UNSUPPORTED;
++	}
++
+ 	// Update and emit a progress event.
+ 	progress.current = NSTEPS * current;
+ 	progress.maximum = NSTEPS * maximum;

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -104,6 +104,32 @@ target_include_directories(test_shearwater_petrel_foreach PRIVATE
     ${CONFIG_DIR}
 )
 
+# Regression test for issue #766: shearwater_common_download must decode a
+# NAK'd init request (a well-formed device refusal) as DC_STATUS_UNSUPPORTED
+# instead of the generic DC_STATUS_PROTOCOL, so the petrel foreach loop can
+# skip refused records rather than aborting the whole pass. The test #includes
+# shearwater_common.c to drive the real SLIP framing over a mock BLE iostream,
+# so only leaf dependencies are linked.
+add_executable(test_shearwater_common_download
+    test_shearwater_common_download.c
+    ${LIBDC_DIR}/src/iostream.c
+    ${LIBDC_DIR}/src/custom.c
+    ${LIBDC_DIR}/src/array.c
+    ${LIBDC_DIR}/src/buffer.c
+    ${LIBDC_DIR}/src/context.c
+    ${LIBDC_DIR}/src/common.c
+    ${LIBDC_DIR}/src/platform.c
+    # datetime.c: the #included shearwater_common.c also carries the timesync
+    # helpers, which call dc_datetime_mktime.
+    ${LIBDC_DIR}/src/datetime.c
+)
+target_include_directories(test_shearwater_common_download PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${CONFIG_DIR}
+)
+
 # test_parse_raw_dive requires the full libdivecomputer + wrapper linked in.
 # Use the Windows config on Windows, macOS config otherwise.
 if(WIN32)
@@ -147,6 +173,7 @@ add_test(NAME test_descriptor_matcher COMMAND test_descriptor_matcher)
 add_test(NAME test_descriptor_match_integration COMMAND test_descriptor_match_integration)
 add_test(NAME test_hw_ostc3_read COMMAND test_hw_ostc3_read)
 add_test(NAME test_shearwater_petrel_foreach COMMAND test_shearwater_petrel_foreach)
+add_test(NAME test_shearwater_common_download COMMAND test_shearwater_common_download)
 add_test(NAME test_parse_raw_dive COMMAND test_parse_raw_dive
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/packages/libdivecomputer_plugin/test/native/test_shearwater_common_download.c
+++ b/packages/libdivecomputer_plugin/test/native/test_shearwater_common_download.c
@@ -1,0 +1,237 @@
+// Regression test for issue #766: the Shearwater Petrel 3 / Nerd 2 answer the
+// download init request (0x35) for certain manifest records with a NAK packet
+// (0x7F 0x35 <code>) instead of an init response (0x75). On the wire that NAK
+// is a 10-byte BLE notification -- the same length as a valid init response --
+// and shearwater_common_download() treated it as a generic "Unexpected
+// response packet" and returned DC_STATUS_PROTOCOL, which the petrel foreach
+// loop escalated into aborting the whole download with zero dives.
+//
+// A NAK is a well-formed, deterministic refusal by the device, not line noise.
+// shearwater_common_download() must decode it and return DC_STATUS_UNSUPPORTED
+// (the same contract shearwater_common_rdbi/wdbi already follow), so callers
+// can skip the refused record instead of aborting the pass. A genuinely
+// malformed response must keep returning DC_STATUS_PROTOCOL.
+//
+// shearwater_common.c is #included so the test drives the real
+// slip_read/slip_write framing over a mock BLE iostream that serves scripted
+// notifications one per read (the BLE packet-boundary contract). The scripted
+// frames use the V1 BLE encoding observed in the issue's debug logs: a 2-byte
+// frame header, the FF 01 / 01 FF packet header, the payload, and the SLIP
+// END terminator -- so the NAK frame here is byte-for-byte the 10-byte
+// notification from the reporter's log.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libdivecomputer/common.h>
+#include <libdivecomputer/context.h>
+#include <libdivecomputer/custom.h>
+#include <libdivecomputer/buffer.h>
+
+#include "shearwater_common.c"  // for the static SLIP framing + V1/V2 macros
+
+// Stubs for the device-private symbols the #included TU references. device.c
+// cannot be linked (its dc_device_open switch-dispatches to every driver);
+// neither the cancellation path nor progress events are under test here.
+int device_is_cancelled(dc_device_t *device) {
+  (void)device;
+  return 0;
+}
+void device_event_emit(dc_device_t *device, dc_event_type_t event,
+                       const void *data) {
+  (void)device;
+  (void)event;
+  (void)data;
+}
+
+// ---------------------------------------------------------------------------
+// Mock BLE iostream: serves scripted notifications ONE per read (the BLE
+// packet-boundary contract) and records the size of every write so the tests
+// can pin the on-wire request sizes against the issue's debug logs.
+// ---------------------------------------------------------------------------
+
+#define MAX_NOTIFICATIONS 8
+#define MAX_WRITES 16
+
+typedef struct {
+  struct {
+    unsigned char data[64];
+    size_t size;
+  } notifications[MAX_NOTIFICATIONS];
+  int nnotifications;
+  int next;
+  size_t write_sizes[MAX_WRITES];
+  int nwrites;
+} mock_stream_t;
+
+static mock_stream_t g_mock;
+
+static void mock_reset(void) { memset(&g_mock, 0, sizeof(g_mock)); }
+
+static void mock_add_notification(const unsigned char *data, size_t size) {
+  assert(g_mock.nnotifications < MAX_NOTIFICATIONS);
+  assert(size <= sizeof(g_mock.notifications[0].data));
+  memcpy(g_mock.notifications[g_mock.nnotifications].data, data, size);
+  g_mock.notifications[g_mock.nnotifications].size = size;
+  g_mock.nnotifications++;
+}
+
+static dc_status_t mock_read(void *userdata, void *data, size_t size,
+                             size_t *actual) {
+  (void)userdata;
+  if (g_mock.next >= g_mock.nnotifications)
+    return DC_STATUS_TIMEOUT;  // nothing more scripted: a dead line
+  size_t n = g_mock.notifications[g_mock.next].size;
+  if (n > size) n = size;
+  memcpy(data, g_mock.notifications[g_mock.next].data, n);
+  g_mock.next++;
+  if (actual) *actual = n;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t mock_write(void *userdata, const void *data, size_t size,
+                              size_t *actual) {
+  (void)userdata;
+  (void)data;
+  if (g_mock.nwrites < MAX_WRITES) g_mock.write_sizes[g_mock.nwrites] = size;
+  g_mock.nwrites++;
+  if (actual) *actual = size;
+  return DC_STATUS_SUCCESS;
+}
+
+static dc_status_t mock_close(void *userdata) {
+  (void)userdata;
+  return DC_STATUS_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+static int failures = 0;
+
+static void expect(int cond, const char *label) {
+  if (cond) {
+    printf("PASS: %s\n", label);
+  } else {
+    printf("FAIL: %s\n", label);
+    failures++;
+  }
+}
+
+// Runs shearwater_common_download(address=0x80001000, size, compression=0)
+// against the scripted notifications and returns the status. The downloaded
+// bytes land in *buffer when the caller passes one.
+static dc_status_t run_download(unsigned int size, dc_buffer_t *buffer) {
+  dc_context_t *ctx = NULL;
+  assert(dc_context_new(&ctx) == DC_STATUS_SUCCESS);
+
+  dc_custom_cbs_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.read = mock_read;
+  cbs.write = mock_write;
+  cbs.close = mock_close;
+
+  dc_iostream_t *iostream = NULL;
+  assert(dc_custom_open(&iostream, ctx, DC_TRANSPORT_BLE, &cbs, NULL) ==
+         DC_STATUS_SUCCESS);
+
+  shearwater_common_device_t dev;
+  memset(&dev, 0, sizeof(dev));
+  dev.base.context = ctx;
+  dev.iostream = iostream;
+  dev.protocol = V1;  // Petrel 3 / Nerd 2 speak the V1 protocol
+
+  dc_status_t rc = shearwater_common_download(&dev, buffer, 0x80001000, size,
+                                              0, NULL);
+
+  dc_iostream_close(iostream);
+  dc_context_free(ctx);
+  return rc;
+}
+
+// The device refuses the init request: 0x7F 0x35 <code>, framed as the exact
+// 10-byte notification from the issue #766 logs. The refusal must surface as
+// DC_STATUS_UNSUPPORTED so the caller can skip the record, and the driver
+// must stop after the single init write (no block requests, no retry).
+static void test_nak_init_returns_unsupported(void) {
+  mock_reset();
+  const unsigned char nak[] = {0x01, 0x00,              // BLE frame header
+                               0x01, 0xFF, 0x04, 0x00,  // packet header
+                               0x7F, 0x35, 0x13,        // NAK, init, code
+                               0xC0};                   // SLIP END
+  mock_add_notification(nak, sizeof(nak));
+
+  dc_buffer_t *buffer = dc_buffer_new(16);
+  dc_status_t rc = run_download(4, buffer);
+  expect(rc == DC_STATUS_UNSUPPORTED,
+         "a NAK'd init returns DC_STATUS_UNSUPPORTED (#766)");
+  if (rc != DC_STATUS_UNSUPPORTED) printf("  rc=%d\n", (int)rc);
+  expect(g_mock.nwrites == 1 && g_mock.write_sizes[0] == 17,
+         "the refusal stops the transfer after the single 17-byte init");
+  if (g_mock.nwrites != 1)
+    printf("  %d writes\n", g_mock.nwrites);
+  dc_buffer_free(buffer);
+}
+
+// A complete tiny transfer: init response (block size 0x80), one 4-byte data
+// block, and the exit response. Pins the happy path around the NAK decode,
+// and pins the request sizes (17-byte init, 9-byte block request, 8-byte
+// exit) that identified the protocol phases in the issue's debug logs.
+static void test_successful_download_unchanged(void) {
+  mock_reset();
+  const unsigned char init_ack[] = {0x01, 0x00, 0x01, 0xFF, 0x04, 0x00,
+                                    0x75, 0x10, 0x80, 0xC0};
+  const unsigned char block[] = {0x01, 0x00, 0x01, 0xFF, 0x07, 0x00,
+                                 0x76, 0x01, 0xDE, 0xAD, 0xBE, 0xEF, 0xC0};
+  const unsigned char exit_ack[] = {0x01, 0x00, 0x01, 0xFF, 0x03, 0x00,
+                                    0x77, 0x00, 0xC0};
+  mock_add_notification(init_ack, sizeof(init_ack));
+  mock_add_notification(block, sizeof(block));
+  mock_add_notification(exit_ack, sizeof(exit_ack));
+
+  dc_buffer_t *buffer = dc_buffer_new(16);
+  dc_status_t rc = run_download(4, buffer);
+  const unsigned char want[] = {0xDE, 0xAD, 0xBE, 0xEF};
+  expect(rc == DC_STATUS_SUCCESS, "a normal download still succeeds");
+  if (rc != DC_STATUS_SUCCESS) printf("  rc=%d\n", (int)rc);
+  expect(dc_buffer_get_size(buffer) == 4 &&
+             memcmp(dc_buffer_get_data(buffer), want, 4) == 0,
+         "the downloaded bytes round-trip through the SLIP framing");
+  expect(g_mock.nwrites == 3 && g_mock.write_sizes[0] == 17 &&
+             g_mock.write_sizes[1] == 9 && g_mock.write_sizes[2] == 8,
+         "request sizes stay 17 (init), 9 (block), 8 (exit)");
+  if (g_mock.nwrites != 3)
+    printf("  %d writes\n", g_mock.nwrites);
+  dc_buffer_free(buffer);
+}
+
+// A malformed init response (unknown opcode) is line garbage, not a device
+// refusal: it must keep returning DC_STATUS_PROTOCOL.
+static void test_malformed_init_stays_protocol(void) {
+  mock_reset();
+  const unsigned char garbage[] = {0x01, 0x00, 0x01, 0xFF, 0x04, 0x00,
+                                   0x99, 0x01, 0x02, 0xC0};
+  mock_add_notification(garbage, sizeof(garbage));
+
+  dc_buffer_t *buffer = dc_buffer_new(16);
+  dc_status_t rc = run_download(4, buffer);
+  expect(rc == DC_STATUS_PROTOCOL,
+         "a malformed init response still returns DC_STATUS_PROTOCOL");
+  if (rc != DC_STATUS_PROTOCOL) printf("  rc=%d\n", (int)rc);
+  dc_buffer_free(buffer);
+}
+
+int main(void) {
+  test_nak_init_returns_unsupported();
+  test_successful_download_unchanged();
+  test_malformed_init_stays_protocol();
+
+  if (failures == 0) {
+    printf("All shearwater_common_download tests passed.\n");
+    return 0;
+  }
+  printf("%d shearwater_common_download test(s) FAILED.\n", failures);
+  return 1;
+}

--- a/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
+++ b/packages/libdivecomputer_plugin/test/native/test_shearwater_petrel_foreach.c
@@ -99,9 +99,11 @@ typedef struct {
   unsigned char pages[MAX_PAGES][MANIFEST_SIZE];
   int npages;
   int next_page;
+  int manifest_nak;  // NAK (DC_STATUS_UNSUPPORTED) any page past the scripted ones
   struct {
     unsigned char id;
     int fail;  // serve DC_STATUS_TIMEOUT this many more times, then succeed
+    int nak;   // device refuses this dive outright (DC_STATUS_UNSUPPORTED)
   } dives[MAX_DIVES];
   int ndives;
 } script_t;
@@ -121,6 +123,17 @@ static void script_add_dive(unsigned char id, int fail) {
   assert(g_script.ndives < MAX_DIVES);  // fail fast on script overflow
   g_script.dives[g_script.ndives].id = id;
   g_script.dives[g_script.ndives].fail = fail;
+  g_script.dives[g_script.ndives].nak = 0;
+  g_script.ndives++;
+}
+
+// The device refuses this dive's download init outright, the way a real unit
+// NAKs a manifest record whose dive data it can no longer serve (issue #766).
+static void script_add_dive_nak(unsigned char id) {
+  assert(g_script.ndives < MAX_DIVES);
+  g_script.dives[g_script.ndives].id = id;
+  g_script.dives[g_script.ndives].fail = 0;
+  g_script.dives[g_script.ndives].nak = 1;
   g_script.ndives++;
 }
 
@@ -265,7 +278,10 @@ dc_status_t shearwater_common_download(shearwater_common_device_t *device,
 
   if (address == MANIFEST_ADDR) {
     if (g_script.next_page >= g_script.npages)
-      return DC_STATUS_IO;  // the driver asked for more pages than scripted
+      // Past the scripted pages: a real device NAKs the request when the
+      // record area ends exactly on a page boundary (manifest_nak); an
+      // unscripted request in any other test is still a script error (IO).
+      return g_script.manifest_nak ? DC_STATUS_UNSUPPORTED : DC_STATUS_IO;
     if (!dc_buffer_append(buffer, g_script.pages[g_script.next_page],
                           MANIFEST_SIZE))
       return DC_STATUS_NOMEMORY;
@@ -276,6 +292,8 @@ dc_status_t shearwater_common_download(shearwater_common_device_t *device,
   for (int i = 0; i < g_script.ndives; i++) {
     unsigned char id = g_script.dives[i].id;
     if (BASE_ADDR + (unsigned int)id * 0x1000 != address) continue;
+    if (g_script.dives[i].nak)
+      return DC_STATUS_UNSUPPORTED;
     if (g_script.dives[i].fail > 0) {
       g_script.dives[i].fail--;
       return DC_STATUS_TIMEOUT;
@@ -672,6 +690,140 @@ static void test_floor_deleted_record_below_floor_unaffected(void) {
            g_last_progress.maximum);
 }
 
+// ---------------------------------------------------------------------------
+// Issue #766: the reporter's Petrel 3 and Nerd 2 NAK the download init for
+// the OLDEST manifest record (data the device can no longer serve), and with
+// oldest-first delivery that refusal struck before any dive was delivered, so
+// every download attempt aborted with zero dives. A refused record must be
+// skipped -- it is deterministic, the retry loop cannot help, and the data is
+// gone -- while refusal of EVERY record must still surface as an error so a
+// wrong logbook base address stays diagnosable.
+// ---------------------------------------------------------------------------
+
+// The oldest record is refused: the pass must skip it, deliver everything
+// else, and end with exact progress accounting.
+static void check_nak_oldest_dive_skipped(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 3);  // newest
+  set_record(0, 1, 0, 2);
+  set_record(0, 2, 0, 1);  // oldest; the device refuses to serve it
+  script_add_dive_nak(1);
+  script_add_dive(2, 0);
+  script_add_dive(3, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  const unsigned char want[] = {2, 3};
+  expect(rc == DC_STATUS_SUCCESS,
+         "a refused oldest dive does not abort the pass (#766)");
+  expect(order_is(&s, want, 2),
+         "the refused dive is skipped and the rest delivered oldest first");
+  if (s.n != 2 || memcmp(s.order, want, 2) != 0) print_order(&s);
+  expect(g_last_progress.current == g_last_progress.maximum,
+         "final progress reaches 100% despite the skipped dive");
+  // 1 manifest page + 2 delivered dives; the refused record is dropped from
+  // the maximum like a deleted or below-floor record.
+  expect(g_last_progress.maximum == 3 * NSTEPS,
+         "the refused dive is dropped from the progress maximum");
+  if (g_last_progress.current != g_last_progress.maximum ||
+      g_last_progress.maximum != 3 * NSTEPS)
+    printf("  final progress %u / %u\n", g_last_progress.current,
+           g_last_progress.maximum);
+}
+
+// A refusal in the middle of the pass must skip only that dive: everything
+// after it (newer) still downloads, unlike the keep-partial path that ends
+// the pass at the first persistent TIMEOUT.
+static void check_nak_mid_pass_skipped(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 3);  // newest
+  set_record(0, 1, 0, 2);  // refused
+  set_record(0, 2, 0, 1);  // oldest
+  script_add_dive(1, 0);
+  script_add_dive_nak(2);
+  script_add_dive(3, 0);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  const unsigned char want[] = {1, 3};
+  expect(rc == DC_STATUS_SUCCESS, "a mid-pass refusal does not end the pass");
+  expect(order_is(&s, want, 2),
+         "only the refused dive is skipped; newer dives still download");
+  if (s.n != 2 || memcmp(s.order, want, 2) != 0) print_order(&s);
+}
+
+// Every record refused and nothing delivered: this is NOT a poisoned oldest
+// record but something systemic (e.g. requesting dives at the wrong logbook
+// base address), and reporting success with zero dives would make it
+// undiagnosable. The error must propagate.
+static void check_all_nak_still_errors(void) {
+  script_reset();
+  g_script.npages = 1;
+  set_record(0, 0, 0, 2);  // newest
+  set_record(0, 1, 0, 1);  // oldest
+  script_add_dive_nak(1);
+  script_add_dive_nak(2);
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  expect(rc != DC_STATUS_SUCCESS,
+         "refusal of every dive with nothing delivered stays an error");
+  expect(s.n == 0, "no dives delivered when every request is refused");
+  if (s.n != 0) print_order(&s);
+}
+
+// A logbook whose record area ends exactly on a page boundary: the walk
+// cannot tell a full final page from a truncated one, so it requests one
+// page too many and the device NAKs it. That refusal is the normal end of
+// the manifest, not an error (#766).
+static void check_manifest_nak_after_full_page_ends_walk(void) {
+  script_reset();
+  g_script.npages = 1;
+  g_script.manifest_nak = 1;
+  for (int slot = 0; slot < (int)RECORD_COUNT; slot++) {
+    unsigned char id = (unsigned char)(RECORD_COUNT - slot);  // ids 48..1
+    set_record(0, slot, 0, id);
+    script_add_dive(id, 0);
+  }
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  unsigned char want[RECORD_COUNT];
+  for (int i = 0; i < (int)RECORD_COUNT; i++) want[i] = (unsigned char)(i + 1);
+  expect(rc == DC_STATUS_SUCCESS,
+         "a refused page after a full page ends the manifest walk");
+  expect(order_is(&s, want, (int)RECORD_COUNT),
+         "every dive from the full page is still delivered oldest first");
+  if (s.n != (int)RECORD_COUNT) print_order(&s);
+  expect(g_last_progress.current == g_last_progress.maximum,
+         "final progress reaches 100% after the refused page");
+  // 1 delivered page + 48 dives; the refused page contributes nothing.
+  expect(g_last_progress.maximum == (1 + RECORD_COUNT) * NSTEPS,
+         "the refused page is dropped from the progress maximum");
+  if (g_last_progress.current != g_last_progress.maximum ||
+      g_last_progress.maximum != (1 + RECORD_COUNT) * NSTEPS)
+    printf("  final progress %u / %u\n", g_last_progress.current,
+           g_last_progress.maximum);
+}
+
+// A refusal of the FIRST page is not an end-of-manifest signal: nothing was
+// read yet, so something is wrong with the device or the request, and the
+// error must propagate rather than masquerade as an empty logbook.
+static void check_manifest_nak_first_page_still_errors(void) {
+  script_reset();
+  g_script.npages = 0;
+  g_script.manifest_nak = 1;
+
+  cb_state_t s;
+  dc_status_t rc = run_foreach(NULL, &s);
+  expect(rc != DC_STATUS_SUCCESS,
+         "a refused first manifest page stays an error");
+  expect(s.n == 0, "no dives delivered on a refused first page");
+  if (s.n != 0) print_order(&s);
+}
+
 int main(void) {
   check_oldest_first();
   check_deleted_records_preserved();
@@ -685,6 +837,11 @@ int main(void) {
   test_exact_match_behavior_unchanged();
   test_zero_fingerprint_downloads_all();
   test_floor_deleted_record_below_floor_unaffected();
+  check_nak_oldest_dive_skipped();
+  check_nak_mid_pass_skipped();
+  check_all_nak_still_errors();
+  check_manifest_nak_after_full_page_ends_walk();
+  check_manifest_nak_first_page_still_errors();
 
   if (failures == 0) {
     printf("All shearwater_petrel_foreach tests passed.\n");

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -440,6 +440,30 @@ void main() {
       )..where((t) => t.id.equals(computerId))).get();
       expect(computers, isEmpty);
     });
+
+    test('deletes a computer linked as a dive\'s primary computer with foreign '
+        'keys enforced (issue #823)', () async {
+      // The app's real connection runs with PRAGMA foreign_keys = ON, but
+      // the in-memory test database defaults to OFF, which masked the
+      // missing dives.computer_id clearing: deleting a computer that any
+      // dive referenced failed with SqliteException(787) on devices.
+      await db.customStatement('PRAGMA foreign_keys = ON');
+      final computerId = await insertComputer();
+      final diveId = await insertDive(computerId: computerId);
+
+      await repository.deleteComputer(computerId);
+
+      // Computer gone; the dive survives with the link cleared.
+      final computers = await (db.select(
+        db.diveComputers,
+      )..where((t) => t.id.equals(computerId))).get();
+      expect(computers, isEmpty);
+      final dives = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals(diveId))).get();
+      expect(dives, hasLength(1));
+      expect(dives.first.computerId, isNull);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
+    as domain;
 
 import '../../../../helpers/test_database.dart';
 
@@ -110,6 +112,9 @@ void main() {
     required String diveId,
     String? computerId,
     bool isPrimary = false,
+    String? computerModel,
+    String? computerSerial,
+    String? sourceFormat,
   }) async {
     final id = 'ds-${DateTime.now().microsecondsSinceEpoch}';
     final now = DateTime.now();
@@ -121,6 +126,9 @@ void main() {
             diveId: Value(diveId),
             computerId: Value(computerId),
             isPrimary: Value(isPrimary),
+            computerModel: Value(computerModel),
+            computerSerial: Value(computerSerial),
+            sourceFormat: Value(sourceFormat),
             importedAt: Value(now),
             createdAt: Value(now),
           ),
@@ -464,6 +472,233 @@ void main() {
       expect(dives, hasLength(1));
       expect(dives.first.computerId, isNull);
     });
+
+    test(
+      'backfills a provenance snapshot for dives lacking a data source row',
+      () async {
+        // Legacy dives predate dive_data_sources: without a snapshot, deleting
+        // the computer would permanently lose which device produced the dive.
+        final computerId = await insertComputer(
+          manufacturer: 'Shearwater',
+          model: 'Perdix',
+          serialNumber: 'SN-12345',
+        );
+        final diveId = await insertDive(computerId: computerId);
+
+        await repository.deleteComputer(computerId);
+
+        final sources = await (db.select(
+          db.diveDataSources,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        expect(sources, hasLength(1));
+        expect(sources.first.computerModel, equals('Shearwater Perdix'));
+        expect(sources.first.computerSerial, equals('SN-12345'));
+        expect(sources.first.sourceFormat, equals('dive_computer'));
+        expect(sources.first.computerId, isNull);
+        expect(sources.first.isPrimary, isTrue);
+      },
+    );
+
+    test('does not duplicate an existing provenance snapshot', () async {
+      final computerId = await insertComputer(
+        manufacturer: 'Shearwater',
+        model: 'Perdix',
+        serialNumber: 'SN-12345',
+      );
+      final diveId = await insertDive(computerId: computerId);
+      await insertDataSource(
+        diveId: diveId,
+        computerId: computerId,
+        isPrimary: true,
+        computerModel: 'Shearwater Perdix',
+        computerSerial: 'SN-12345',
+        sourceFormat: 'dive_computer',
+      );
+
+      await repository.deleteComputer(computerId);
+
+      final sources = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      expect(sources, hasLength(1));
+      expect(sources.first.computerId, isNull);
+      expect(sources.first.computerModel, equals('Shearwater Perdix'));
+      expect(sources.first.computerSerial, equals('SN-12345'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createComputer - relinking orphaned dives when the same hardware returns
+  // ---------------------------------------------------------------------------
+
+  group('createComputer relinking', () {
+    domain.DiveComputer newComputer({
+      String? serialNumber = 'SN-12345',
+      String manufacturer = 'Shearwater',
+      String model = 'Perdix',
+    }) {
+      final now = DateTime.now();
+      return domain.DiveComputer(
+        id: '',
+        name: 'My Perdix',
+        manufacturer: manufacturer,
+        model: model,
+        serialNumber: serialNumber,
+        createdAt: now,
+        updatedAt: now,
+      );
+    }
+
+    test(
+      'relinks orphaned dive, source, and profile rows from the same hardware',
+      () async {
+        final oldId = await insertComputer(
+          manufacturer: 'Shearwater',
+          model: 'Perdix',
+          serialNumber: 'SN-12345',
+        );
+        final diveId = await insertDive(computerId: oldId);
+        await insertDataSource(
+          diveId: diveId,
+          computerId: oldId,
+          isPrimary: true,
+          computerModel: 'Shearwater Perdix',
+          computerSerial: 'SN-12345',
+          sourceFormat: 'dive_computer',
+        );
+        await insertProfile(diveId: diveId, computerId: oldId);
+        await repository.deleteComputer(oldId);
+
+        final created = await repository.createComputer(newComputer());
+
+        final sources = await (db.select(
+          db.diveDataSources,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        expect(sources.single.computerId, equals(created.id));
+        final dive = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals(diveId))).getSingle();
+        expect(dive.computerId, equals(created.id));
+        final profiles = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        expect(profiles.single.computerId, equals(created.id));
+      },
+    );
+
+    test('does not relink without a serial number', () async {
+      final oldId = await insertComputer(
+        manufacturer: 'Shearwater',
+        model: 'Perdix',
+        serialNumber: null,
+      );
+      final diveId = await insertDive(computerId: oldId);
+      await insertDataSource(
+        diveId: diveId,
+        computerId: oldId,
+        isPrimary: true,
+        computerModel: 'Shearwater Perdix',
+        sourceFormat: 'dive_computer',
+      );
+      await repository.deleteComputer(oldId);
+
+      await repository.createComputer(newComputer(serialNumber: null));
+
+      final sources = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      expect(sources.single.computerId, isNull);
+      final dive = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals(diveId))).getSingle();
+      expect(dive.computerId, isNull);
+    });
+
+    test('leaves rows linked to another computer untouched', () async {
+      final otherId = await insertComputer(
+        id: 'other-computer',
+        manufacturer: 'Shearwater',
+        model: 'Perdix',
+        serialNumber: 'SN-12345',
+      );
+      final diveId = await insertDive(computerId: otherId);
+      await insertDataSource(
+        diveId: diveId,
+        computerId: otherId,
+        isPrimary: true,
+        computerModel: 'Shearwater Perdix',
+        computerSerial: 'SN-12345',
+        sourceFormat: 'dive_computer',
+      );
+
+      final created = await repository.createComputer(newComputer());
+
+      final sources = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      expect(sources.single.computerId, equals(otherId));
+      final dive = await (db.select(
+        db.dives,
+      )..where((t) => t.id.equals(diveId))).getSingle();
+      expect(dive.computerId, equals(otherId));
+      expect(created.id, isNot(equals(otherId)));
+    });
+
+    test(
+      'relinks profiles only when the dive has a single computer source',
+      () async {
+        // A dive built from two computers keeps profile attribution ambiguous
+        // once one of them is deleted, so only the source row is relinked.
+        final oldId = await insertComputer(
+          manufacturer: 'Shearwater',
+          model: 'Perdix',
+          serialNumber: 'SN-12345',
+        );
+        final liveId = await insertComputer(
+          id: 'live-computer',
+          manufacturer: 'Shearwater',
+          model: 'Teric',
+          serialNumber: 'SN-99999',
+        );
+        final diveId = await insertDive(computerId: oldId);
+        await insertDataSource(
+          diveId: diveId,
+          computerId: oldId,
+          isPrimary: true,
+          computerModel: 'Shearwater Perdix',
+          computerSerial: 'SN-12345',
+          sourceFormat: 'dive_computer',
+        );
+        await insertDataSource(
+          diveId: diveId,
+          computerId: liveId,
+          computerModel: 'Shearwater Teric',
+          computerSerial: 'SN-99999',
+          sourceFormat: 'dive_computer',
+        );
+        await insertProfile(diveId: diveId, computerId: oldId);
+        await repository.deleteComputer(oldId);
+
+        final created = await repository.createComputer(newComputer());
+
+        final sources =
+            await (db.select(db.diveDataSources)
+                  ..where((t) => t.diveId.equals(diveId))
+                  ..orderBy([(t) => OrderingTerm.asc(t.computerSerial)]))
+                .get();
+        expect(sources, hasLength(2));
+        expect(sources.first.computerId, equals(created.id));
+        expect(sources.last.computerId, equals(liveId));
+        final dive = await (db.select(
+          db.dives,
+        )..where((t) => t.id.equals(diveId))).getSingle();
+        expect(dive.computerId, equals(created.id));
+        final profiles = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        expect(profiles.single.computerId, isNull);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Petrel 3 and Nerd 2 in #766 fail every download with `-8` (`DC_STATUS_PROTOCOL`) after the manifest phase completes. Decoding the debug logs against the driver shows the devices answer the `UPLOAD_INIT` (0x35) request for their **oldest manifest record** with a NAK (`0x7F 0x35 <code>` — a 10-byte BLE notification, byte-identical in length to a valid init ack). The driver treated any non-ack as a fatal protocol error, and because delivery is oldest-first (since build 114), the refusal struck before any dive had been delivered: the `#759` retry loop re-issued the same deterministically refused request (three inits exactly `SHEARWATER_RETRY_DELAY`=300ms apart in the 2026-08-08 log; single init on v1.7.1.118, which predates the retry), the keep-partial path could not engage with `delivered == 0`, and the pass aborted with zero dives. Long-history devices (5 and 9 full manifest pages in the logs) hit this; short-history devices never do, which is why other units work. Shearwater Cloud syncs newest-first and so never trips on the stale oldest record.

## Changes

- **Fork commit `6fc6ca1`** (branch `shearwater-nak-skip`, mirrored as `patches/0006`): `shearwater_common_download` decodes the init NAK and returns `DC_STATUS_UNSUPPORTED` (the existing rdbi/wdbi NAK contract). The petrel foreach loop skips refused records like deleted ones (the skipped dive is older than everything still to come, so the newest-delivered-fingerprint resume contract holds), treats a refused manifest page after at least one delivered page as the normal end of the manifest (a record area ending exactly on a page boundary makes the walk request one page too many), and still fails the pass when the device refuses every request so a systemic refusal (e.g. wrong logbook base address) stays diagnosable.
- **Diagnostics**: `libdc_download.c` appends the last ERROR-level libdivecomputer message to the failure surfaced to the app (`Download failed: Received NAK packet with error code 0x…`) on every platform; the Android JNI log callback additionally forwards WARNING/ERROR messages into the crash-survivable debug log under an `LDC` channel. #766 took three rounds of user logs to localize because these messages previously reached only logcat.
- **#823**: `deleteComputer` cleared `dive_profiles.computer_id` and `dive_data_sources.computer_id` but never `dives.computer_id` (a legacy FK with no `ON DELETE` action), so deleting any computer a dive references failed with `SqliteException(787)`. The repository now clears it like the other legacy references. The existing tests passed because the in-memory test database leaves `foreign_keys` OFF; the new regression test enables the pragma to match the app connection.
- **Provenance + relink on delete**: deleting a computer no longer silently unassociates its dives. `deleteComputer` backfills a `dive_data_sources` snapshot (model + serial text columns, the same provenance `importProfile` writes) for any referencing dive that lacks one, so "downloaded with Shearwater Perdix (SN…)" stays visible in the dive detail after the computer row is gone. `createComputer` runs a relink pass for the new computer's hardware identity: orphaned source rows matching the model + serial snapshot get the new id, dives whose matched source is primary (and that no live computer claims) get their primary-computer link back with a fresh HLC so the restore syncs, and profiles are restored only when the dive's computer attribution is unambiguous (a single `dive_computer` source). No serial → no relink; rows linked to a live computer are never stolen. Since the download adapter's find-or-create calls `createComputer`, reconnecting a previously deleted computer relinks automatically.

## Tests

- New `test_shearwater_common_download` drives the real SLIP framing over a mock BLE iostream; the NAK frame is byte-for-byte the 10-byte notification from the reporter's log, and the request-size assertions pin the 17/9/8-byte writes used to decode those logs.
- `test_shearwater_petrel_foreach` gains refused-record scripting: oldest-refused skip, mid-pass skip, all-refused error, refused page after a full page, refused first page.
- `dive_computer_repository_impl_test` gains the FK-enforced delete regression, the provenance-backfill cases, and five relink scenarios (full relink, no-serial, live-computer untouched, multi-source profile guard, snapshot dedup).
- Full native suite 8/8; `flutter analyze` clean; affected Dart suites green.

## Hardware verification

The NAK hypothesis explains every byte of all three logs, but only the reporter's devices can confirm it — no local device reproduces the refusal. With this build, either the download completes (skip warnings now visible in the exported debug log, including the NAK error code), or the export carries `Download failed: Received NAK packet with error code 0x…`, which pins the exact refusal either way.

## Out of scope

The pairing/bonding complaint in #766 (Shearwater Cloud connects without bonding; Submersion's Android path bonds unconditionally, which then blocks Shearwater Cloud until the user unpairs) is real but orthogonal — bonding succeeded in every log. Worth a follow-up issue to skip `ensureBonded` for Shearwater devices on Android after hardware validation.

Fixes #766. Fixes #823.
