### PR TITLE
Skip proactive Android BLE bonding for Shearwater devices

### DIFF
--- a/docs/superpowers/specs/2026-08-08-shearwater-skip-bonding-design.md
+++ b/docs/superpowers/specs/2026-08-08-shearwater-skip-bonding-design.md
@@ -1,0 +1,57 @@
+# Skip Android BLE bonding for Shearwater devices
+
+Issue: #910 (follow-up to #766, PR #909)
+Date: 2026-08-08
+
+## Problem
+
+The Android BLE download path (`DiveComputerHostApiImpl.performBleDownload`)
+calls `BleIoStream.ensureBonded()` unconditionally after connecting, creating
+an Android bond with the dive computer on the first download. Shearwater's
+BLE protocol has no encrypted characteristics and Shearwater Cloud connects
+without bonding; once Submersion holds the bond, Shearwater Cloud cannot
+connect until the user unpairs the computer in Android Bluetooth settings.
+
+## Decision
+
+Gate the proactive bond on the libdc vendor string: skip `ensureBonded()` for
+`Shearwater`, keep it for every other vendor.
+
+## Design
+
+- New pure-Kotlin `BondPolicy` object in the plugin's Android source set with
+  a single function `requiresProactiveBond(vendor: String): Boolean`.
+  Vendor comparison is case-insensitive; every vendor except Shearwater
+  returns true.
+- `performBleDownload` consults `BondPolicy` before calling `ensureBonded()`
+  and logs when it skips, so field logs show which path ran.
+- No change to `BleIoStream` (transport stays vendor-agnostic), the
+  stale-bond repair paths (GATT status 5 → `removeBond` + retry), or existing
+  bonds (`ensureBonded()` already returns immediately when bonded — this
+  change only stops creating new bonds).
+
+## Alternatives considered
+
+- Gate inside `BleIoStream.ensureBonded()`: mixes vendor policy into the
+  vendor-agnostic transport layer; rejected.
+- Constant set inside `DiveComputerHostApiImpl`: not testable from plain JVM
+  unit tests because that class is saturated with Android framework types;
+  rejected.
+- Also remove an existing bond for Shearwater devices: more invasive, races
+  the Bluetooth stack (see `BOND_REPAIR_SETTLE_MS`), and the user can unpair
+  once themselves; out of scope.
+
+## Safety
+
+If a Shearwater unit ever did require encryption, the Android BLE stack
+pairs transparently during the first encrypted GATT operation (documented on
+`connectAndDiscover()`), so skipping the proactive bond cannot strand a
+download.
+
+## Testing
+
+JVM unit test `BondPolicyTest` alongside the existing
+`SerialReadBufferTest`: Shearwater (any case) is exempt, other vendors and
+the empty string require bonding. The call-site wiring is exercised on
+hardware only — validation on a real Petrel 3 / Nerd 2 (downloads work
+without bond; Shearwater Cloud connects afterward) is tracked in #910.

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondPolicy.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondPolicy.kt
@@ -1,0 +1,26 @@
+package com.submersion.libdivecomputer
+
+// Decides whether the Android BLE download path should proactively bond
+// (BluetoothDevice.createBond) with a dive computer before starting I/O.
+//
+// Most vendors keep the proactive bond: devices using encrypted BLE
+// services (e.g. Aqualung i300C on the Pelagic service) need an
+// established bond before the first read. Shearwater's protocol uses no
+// encrypted characteristics -- Shearwater Cloud connects without pairing
+// -- and a bond created by Submersion blocks Shearwater Cloud from
+// connecting until the user unpairs the computer in Android Bluetooth
+// settings (issue #910).
+//
+// Skipping the proactive bond cannot strand a download: if a device does
+// demand encryption mid-session, the Android stack pairs transparently
+// during the first encrypted GATT operation (see
+// BleIoStream.connectAndDiscover).
+object BondPolicy {
+    private val vendorsWithoutProactiveBond = setOf("shearwater")
+
+    // vendor is the libdivecomputer descriptor vendor string
+    // (DiscoveredDevice.vendor), e.g. "Shearwater" for Petrel, Perdix,
+    // Teric, Nerd, Peregrine, and Tern models.
+    fun requiresProactiveBond(vendor: String): Boolean =
+        vendor.trim().lowercase() !in vendorsWithoutProactiveBond
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -386,13 +386,23 @@ class DiveComputerHostApiImpl(
         // Devices using encrypted BLE services (e.g. Aqualung i300C on
         // the Pelagic service) need an established bond. createBond()
         // works here because we have an active GATT connection.
-        if (!bleStream.ensureBonded()) {
-            reportError("bond_failed", "Failed to pair with device")
-            bleStream.close()
-            LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
-            downloadSessionPtr = 0
-            activeBleStream = null
-            return
+        // Shearwater devices are exempt: their protocol needs no bond,
+        // and holding one blocks Shearwater Cloud until the user unpairs
+        // (issue #910) -- see BondPolicy.
+        if (BondPolicy.requiresProactiveBond(device.vendor)) {
+            if (!bleStream.ensureBonded()) {
+                reportError("bond_failed", "Failed to pair with device")
+                bleStream.close()
+                LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
+                downloadSessionPtr = 0
+                activeBleStream = null
+                return
+            }
+        } else {
+            NativeLogger.d(
+                TAG, "BLE",
+                "Skipping proactive bond for ${device.vendor} (BondPolicy)"
+            )
         }
 
         val downloadCallback = makeDownloadCallback()

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondPolicyTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondPolicyTest.kt
@@ -1,0 +1,36 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// JVM tests for the vendor-keyed proactive-bond policy behind the Android
+// BLE download path (issue #910): Shearwater devices must not be bonded
+// proactively because a Submersion-created bond blocks Shearwater Cloud
+// until the user unpairs the computer.
+class BondPolicyTest {
+
+    @Test
+    fun shearwaterIsExemptFromProactiveBonding() {
+        assertFalse(BondPolicy.requiresProactiveBond("Shearwater"))
+    }
+
+    @Test
+    fun shearwaterMatchIsCaseInsensitive() {
+        assertFalse(BondPolicy.requiresProactiveBond("shearwater"))
+        assertFalse(BondPolicy.requiresProactiveBond("SHEARWATER"))
+    }
+
+    @Test
+    fun otherVendorsStillRequireProactiveBonding() {
+        assertTrue(BondPolicy.requiresProactiveBond("Aqualung"))
+        assertTrue(BondPolicy.requiresProactiveBond("Mares"))
+        assertTrue(BondPolicy.requiresProactiveBond("Suunto"))
+    }
+
+    @Test
+    fun unknownOrEmptyVendorDefaultsToBonding() {
+        assertTrue(BondPolicy.requiresProactiveBond(""))
+        assertTrue(BondPolicy.requiresProactiveBond("NoSuchVendor"))
+    }
+}


### PR DESCRIPTION
Fixes #910. Follow-up to #766 / PR #909.

## Problem

The Android BLE download path called `BleIoStream.ensureBonded()` unconditionally after connecting, creating an Android bond on the first download. Shearwater's protocol has no encrypted characteristics and Shearwater Cloud connects without bonding — once Submersion held the bond, Shearwater Cloud could not connect until the user unpaired the computer in Android Bluetooth settings.

## Change

- New `BondPolicy` object (pure Kotlin, JVM-testable): `requiresProactiveBond(vendor)` returns false for the libdc vendor string `Shearwater` (case-insensitive), true for everyone else.
- `DiveComputerHostApiImpl.performBleDownload` consults it before `ensureBonded()` and logs `Skipping proactive bond for <vendor> (BondPolicy)` on the skip path so field logs show which branch ran.
- No change to `BleIoStream` (transport stays vendor-agnostic), the GATT-status-5 stale-bond repair paths, or existing bonds (`ensureBonded()` was already a no-op when bonded — this only stops *creating* bonds).

Devices that genuinely need a pre-established bond (e.g. Aqualung i300C on the Pelagic service) are unaffected.

## Why this is safe

If a Shearwater unit ever did require encryption, the Android stack pairs transparently during the first encrypted GATT operation (already documented on `connectAndDiscover()`), so skipping the proactive bond cannot strand a download.

## Testing

- New JVM unit test `BondPolicyTest` (runs with `:libdivecomputer_plugin:testDebugUnitTest`; all plugin unit tests pass).
- Hardware validation pending, tracked in #910: verify on a real Petrel 3 / Nerd 2 that downloads work without the bond and Shearwater Cloud connects cleanly afterward.

Design spec: `docs/superpowers/specs/2026-08-08-shearwater-skip-bonding-design.md`
