### PR TITLE
Present every trip story day with the same heading

### DIFF
--- a/lib/features/trips/domain/entities/trip_story_day.dart
+++ b/lib/features/trips/domain/entities/trip_story_day.dart
@@ -98,7 +98,8 @@ class TripStoryDay extends Equatable {
       dives.isNotEmpty || media.isNotEmpty || itineraryDay != null;
 
   /// A day with nothing to show: no dives, media, or itinerary entry, and not
-  /// a planned (future) day. Rendered as a slim row with no sticky header.
+  /// a planned (future) day. Still gets the standard sticky day header, labeled
+  /// "Surface day" in place of a day type; only its card body is empty.
   bool get isSurface => !hasContent && kind != TripStoryDayKind.future;
 
   @override

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 
 import 'package:submersion/core/providers/async_value_extensions.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -37,14 +36,11 @@ class TripStoryDayCard extends ConsumerWidget {
     // Built once for the day's dives rather than per row.
     final diveTypeLabelResolver = watchDiveTypeLabelResolver(ref, context.l10n);
 
-    if (day.isSurface) {
-      return _SurfaceDayRow(day: day);
-    }
-
     // The day title, subtitle, and Planned chip live in the sticky
     // TripStoryDayHeader above this card; the card is body-only. A planned
     // day whose itinerary has nothing to show would produce an empty card,
-    // so skip it entirely.
+    // so skip it entirely. A surface day has nothing by definition and takes
+    // the same exit: its header is the whole chapter.
     // Blank is not content: a whitespace-only port or note would otherwise
     // defeat this guard and render a card with nothing in it. The edit sheet
     // normalizes empties away, but sync and import payloads do not.
@@ -106,42 +102,6 @@ class TripStoryDayCard extends ConsumerWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Slim row for a day with no dives, media, or itinerary entry.
-class _SurfaceDayRow extends StatelessWidget {
-  final TripStoryDay day;
-
-  const _SurfaceDayRow({required this.day});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final dateFormat = DateFormat.MMMEd();
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
-      child: Row(
-        children: [
-          Icon(
-            Icons.waves,
-            size: 16,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${context.l10n.trips_story_dayLabel(day.dayNumber)}'
-              ' - ${dateFormat.format(day.date)}'
-              ' - ${context.l10n.trips_story_surfaceDay}',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
@@ -17,6 +17,11 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Days with logged weather get a trailing badge: conditions icon plus air
 /// temperature in the diver's temperature unit.
 ///
+/// Every day of the trip gets one of these, including surface days (which
+/// carry no card body at all and are nothing but this header). Presenting a
+/// dive-free day in some slimmer, quieter form makes it read as a lesser entry
+/// and easy to miss when scanning the story.
+///
 /// Mounted in a [PinnedHeaderSliver] inside a SliverMainAxisGroup, so it sticks
 /// at the top of its day chapter until the next day's header pushes it out.
 /// PinnedHeaderSliver lets the header size itself, so scaled accessibility text
@@ -38,7 +43,11 @@ class TripStoryDayHeader extends ConsumerWidget {
     // an empty port to null, but sync and import payloads write the nullable
     // column directly, and a site name is equally free to be blank. Joining
     // either verbatim would render a doubled separator ("Dive Day -  - Site").
+    // A surface day has no itinerary and no dives by definition, so it owns the
+    // subtitle outright - it reads in the same slot where an itinerary day
+    // leads with its day type ("Dive Day", "Travel Day").
     final subtitleParts = <String>[
+      if (day.isSurface) context.l10n.trips_story_surfaceDay,
       if (itinerary != null) itinerary.dayType.localizedName(context),
       if (itinerary?.portName != null) itinerary!.portName!,
       ...day.siteNames,

--- a/lib/features/trips/presentation/widgets/story/trip_story_view.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_view.dart
@@ -226,8 +226,8 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
   }
 
   /// One day chapter: a SliverMainAxisGroup whose pinned header sticks below
-  /// the map until the next day's group pushes it out. Surface days render
-  /// their slim row with no header.
+  /// the map until the next day's group pushes it out. Every day gets the same
+  /// header, surface days included - theirs simply has no body under it.
   Widget _daySliver(TripStory story, int index, int? todayIndex) {
     final day = story.days[index];
     final showTodayDivider = todayIndex != null && index == todayIndex;
@@ -246,11 +246,6 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
       ),
     );
 
-    if (day.isSurface) {
-      return SliverMainAxisGroup(
-        slivers: [if (showTodayDivider) divider, body],
-      );
-    }
     return SliverMainAxisGroup(
       slivers: [
         if (showTodayDivider) divider,

--- a/lib/features/trips/presentation/widgets/story/trip_story_view.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_view.dart
@@ -235,6 +235,14 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
       padding: EdgeInsets.symmetric(horizontal: 16),
       sliver: SliverToBoxAdapter(child: _TodayDivider()),
     );
+    // Unconditional, even for the days whose card renders nothing (surface
+    // days, content-less planned days). It looks like dead weight there but is
+    // not: it carries _dayKeys[index], which _onScroll and _scrollToDay read
+    // positions from, and they skip days whose key context is unmounted -- so
+    // dropping it would quietly take those days out of active-day resolution.
+    // Its 8px bottom inset is also the gap between consecutive chapters, and
+    // is painted in the same surface color as the headers, so it separates
+    // them rather than showing as a blank band.
     final body = SliverPadding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
       sliver: SliverToBoxAdapter(

--- a/test/features/trips/presentation/pages/trip_detail_checklist_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_checklist_test.dart
@@ -213,6 +213,13 @@ void main() {
         );
         expect(checklistTile, findsOneWidget);
 
+        // scrollUntilVisible stops as soon as the finder matches, and slivers
+        // build children inside the cache extent — so the tile can be "found"
+        // while still below the fold, where a tap hits nothing. Pull it fully
+        // on screen before tapping rather than relying on the story's height.
+        await tester.ensureVisible(checklistTile);
+        await tester.pumpAndSettle();
+
         // Expanding it reveals the checklist item.
         await tester.tap(checklistTile);
         await tester.pumpAndSettle();

--- a/test/features/trips/presentation/widgets/story/trip_story_day_card_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_card_test.dart
@@ -103,14 +103,18 @@ void main() {
     expect(find.byType(DiveListItem), findsOneWidget);
   });
 
-  testWidgets('surface day renders the slim variant', (tester) async {
+  testWidgets('surface day renders no card body', (tester) async {
+    // The whole day is now its sticky header - title, date, and the "Surface
+    // day" label all live there, leaving the card with nothing to draw.
     final day = TripStoryDay(
       date: DateTime(2026, 3, 9),
       dayNumber: 3,
       kind: TripStoryDayKind.past,
     );
     await pumpCard(tester, day);
-    expect(find.textContaining('Surface day'), findsOneWidget);
+    expect(find.textContaining('Surface day'), findsNothing);
+    expect(find.textContaining('Day 3'), findsNothing);
+    expect(find.byType(Card), findsNothing);
     expect(find.byType(DayRhythmBar), findsNothing);
   });
 

--- a/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
@@ -129,15 +129,76 @@ void main() {
   });
 
   testWidgets('no subtitle line when there is nothing to say', (tester) async {
+    // A dive with no site on a day with no itinerary: nothing to subtitle with,
+    // but the dive keeps it off the surface-day path (which has its own label).
     final day = TripStoryDay(
       date: DateTime(2026, 3, 8),
       dayNumber: 2,
       kind: TripStoryDayKind.past,
+      dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
     );
     await pumpHeader(tester, day);
 
     // Only the title line renders.
     expect(find.byType(Text), findsOneWidget);
+  });
+
+  group('surface day', () {
+    TripStoryDay surfaceDay() => TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+    );
+
+    testWidgets('gets the same title line as any other day', (tester) async {
+      await pumpHeader(tester, surfaceDay());
+
+      expect(find.textContaining('Day 2'), findsOneWidget);
+      expect(find.textContaining('Mar 8'), findsOneWidget);
+    });
+
+    testWidgets('labels itself in the subtitle slot', (tester) async {
+      await pumpHeader(tester, surfaceDay());
+
+      expect(find.text('Surface day'), findsOneWidget);
+    });
+
+    testWidgets('title style matches a dive day title exactly', (tester) async {
+      // The point of the shared header: a surface day must not read as a
+      // lesser, smaller entry than the dive day above or below it.
+      await pumpHeader(tester, surfaceDay());
+      final surfaceStyle = tester
+          .widget<Text>(find.textContaining('Day 2'))
+          .style;
+
+      await pumpHeader(
+        tester,
+        TripStoryDay(
+          date: DateTime(2026, 3, 8),
+          dayNumber: 2,
+          kind: TripStoryDayKind.past,
+          dives: [
+            Dive(
+              id: 'd1',
+              dateTime: DateTime(2026, 3, 8, 9),
+              site: const DiveSite(id: 'site-a', name: 'Blue Corner'),
+            ),
+          ],
+        ),
+      );
+      final diveStyle = tester.widget<Text>(find.textContaining('Day 2')).style;
+
+      expect(surfaceStyle, diveStyle);
+      expect(surfaceStyle?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('carries no leading icon', (tester) async {
+      // The old slim row led with a waves icon; no other day header does, so
+      // keeping it would reintroduce the asymmetry the shared header removes.
+      await pumpHeader(tester, surfaceDay());
+
+      expect(find.byType(Icon), findsNothing);
+    });
   });
 
   testWidgets('future day shows the planned chip', (tester) async {
@@ -153,11 +214,13 @@ void main() {
 
   testWidgets('short day still fills the minimum band height', (tester) async {
     // Title line only: shorter than the band, so the floor applies and every
-    // day header reads as the same height at default text scale.
+    // day header reads as the same height at default text scale. A siteless
+    // dive keeps the subtitle empty without taking the surface-day path.
     final day = TripStoryDay(
       date: DateTime(2026, 3, 8),
       dayNumber: 2,
       kind: TripStoryDayKind.past,
+      dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
     );
     await pumpHeader(tester, day);
 

--- a/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
@@ -322,7 +322,9 @@ void main() {
     expect(find.textContaining('Day 1 -'), findsNothing);
   });
 
-  testWidgets('surface days get no sticky header', (tester) async {
+  testWidgets('surface days get the same sticky header as dive days', (
+    tester,
+  ) async {
     final trip = _trip(
       start: DateTime(2026, 3, 25),
       end: DateTime(2026, 3, 27),
@@ -338,9 +340,10 @@ void main() {
     );
     await pumpView(tester, story);
 
-    // Tall harness viewport: all three days are mounted, but only the two
-    // dive days contribute sticky headers.
-    expect(find.byType(TripStoryDayHeader), findsNWidgets(2));
-    expect(find.textContaining('Surface day'), findsOneWidget);
+    // Tall harness viewport: all three days are mounted, and every one of them
+    // contributes a sticky header, surface day included.
+    expect(find.byType(TripStoryDayHeader), findsNWidgets(3));
+    expect(find.textContaining('Day 2 -'), findsOneWidget);
+    expect(find.text('Surface day'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Problem

In the trip story, a **surface day** (no dives, media, or itinerary entry) rendered through a completely separate path from every other day:

| | Surface day | Every other day |
|---|---|---|
| Widget | `_SurfaceDayRow` | `TripStoryDayHeader` |
| Type | `bodySmall`, muted | `titleMedium`, bold |
| Height | ~24px | 52px band |
| Sticky | no | pinned |
| Icon | leading waves icon | none |

The result was that surface days read as incidental text between the real entries rather than as days of the trip, and were easy to miss when scanning.

## Fix

Mostly deletion. `TripStoryDayCard` no longer branches to a slim row, `_daySliver` no longer builds a header-less sliver group for surface days, and `_SurfaceDayRow` is gone. What remains is one entry in the header's existing subtitle list:

```dart
if (day.isSurface) context.l10n.trips_story_surfaceDay,
```

That slot is where an itinerary day already leads with its day type ("Dive Day", "Travel Day"), so "Surface day" reads as the same kind of label rather than a special case. A surface day's card body is empty, so the day is now nothing but its header, taking the same early exit the content-less planned day already took.

The waves icon is dropped: no other day header carries a leading icon, so keeping it would have reintroduced the asymmetry this removes.

With no second render path left, the two presentations cannot drift apart again.

## Result

```
Day 1 - Sat, May 2
Surface day

Day 2 - Sun, May 3                    (cloud) 80F
La Machaca - The Lake
```

No new strings: `trips_story_surfaceDay` already existed and simply moved slots, so no l10n work is needed.

## Tests

`trip_story_day_header_test.dart` gains a `surface day` group. The load-bearing case asserts the surface day's title `TextStyle` is **identical** to a dive day's, which tests the actual complaint rather than a proxy for it; the others cover the subtitle label and the absence of a leading icon.

Two existing header cases ("no subtitle line when there is nothing to say", "short day still fills the minimum band height") happened to build days that were incidentally surface days. They now use a siteless dive, so they keep testing the subtitle-less header they were written for.

### Two findings worth flagging

**A latent fragility in `trip_detail_checklist_test.dart`.** Its fixture is a two-day trip with no dives, so both days are surface days and the story grew ~56px taller. That pushed the checklist tile from y=799 to **y=849 in an 844px viewport**. The test relied on `scrollUntilVisible` leaving the tile on screen, but that helper stops as soon as the finder matches the widget *tree*, and slivers build children within the 250px cache extent, so the tile was "found" below the fold and the tap hit nothing. Fixed with `ensureVisible`. This was one layout shift away from breaking regardless of this change.

**A false-passing assertion in the card test.** `find.text('Surface day')` never matched anything, because the old row rendered `"Day 3 - Sat, Mar 9 - Surface day"` as a single concatenated string; `find.text` matches the whole string. It passed for the wrong reason and gave no signal. Now uses `textContaining`.

## Verification

- `flutter test` - **15710 passed**, exit 0
- `flutter analyze` (whole project) - no issues
- `dart format` - clean