### PR TITLE
Run the safety review automatically after a backup restore

### DIFF
--- a/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
+++ b/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
@@ -1542,6 +1542,13 @@ because each one is a trap the next person will hit.
 5. **`_analyzeFailed` was deleted, not reassigned.** Once the snackbar reads
    `result.failed`, the field becomes write-only, which the analyzer flags.
 
+6. **The all-divers sweep needed one pass per diver** (found in PR #916 review,
+   fixed in `3202c07`). The plan's single container with `diverId: null` graded
+   every non-active diver's dives with the ACTIVE diver's gradient factors and
+   persisted the result stamped with the current `engineVersion`. Fixed with a
+   `SettingsNotifier.preloaded` constructor and one container per diver, plus a
+   trailing pass for dives with a null `diver_id`. See spec section 3b.
+
 An extra test was added beyond the plan:
 `reads settings from the restored database, not the defaults` in
 `post_restore_safety_review_test.dart`. It switches the master toggle off in the

--- a/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
+++ b/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
@@ -1,0 +1,1517 @@
+# Post-Restore Safety Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the post-dive safety review automatically over the whole
+restored library at the end of a backup restore, with progress and a Skip
+button, so a restore no longer leaves every dive un-analyzed until the user
+finds the manual sweep in Settings.
+
+**Architecture:** Extract the existing "Analyze all dives" loop out of
+`safety_settings_page.dart` into a shared `SafetyReviewSweep` provider. Call
+it from `BackupOperationNotifier` — the single seam every restore path funnels
+through — after the database swap and before the restore-complete transition.
+The restore-side call runs the sweep inside a short-lived, disposable
+`ProviderContainer` so the engine sees the restored database's settings rather
+than the replaced device's cached ones.
+
+**Tech Stack:** Flutter 3.x, Riverpod 3.1 (`flutter_riverpod`), Drift ORM over
+SQLite, `flutter_test`, `flutter gen-l10n` for ARB localization.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md`
+
+## Global Constraints
+
+- All Dart code must pass `dart format .` with no changes.
+- `flutter analyze` must be clean across the whole project; infos are fatal in
+  CI, so no unused imports or dangling references.
+- TDD: write the failing test first, watch it fail, then implement.
+- No emojis in code, comments, or documentation.
+- Immutability: never mutate entities in place; use `copyWith`.
+- 80% minimum test coverage.
+- Localized strings go in `lib/l10n/arb/app_en.arb` and must be translated
+  into all eleven locales: `ar, de, en, es, fr, he, hu, it, nl, pt, zh`.
+- Do not change `SafetyReviewService.engineVersion` or any safety rule.
+- No database schema changes. Both safety tables already exist.
+- Run tests from the worktree root:
+  `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/safety-review-after-restore`
+
+---
+
+### Task 1: Extract the root provider overrides
+
+The sweep needs to build a second `ProviderContainer` with the same overrides
+as the app's real one. `logFileServiceProvider` throws `UnimplementedError`
+unless overridden, so copying the list is mandatory, not cosmetic. Extracting
+it into one function stops the two lists from drifting apart.
+
+**Files:**
+- Create: `lib/core/providers/root_overrides.dart`
+- Modify: `lib/main.dart:134-141`
+- Test: `test/core/providers/root_overrides_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `List<Override> rootProviderOverrides({required SharedPreferences prefs, required LogFileService logFileService})`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/providers/root_overrides_test.dart`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/root_overrides.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('supplies both providers that would otherwise throw', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final logFileService = LogFileService();
+
+    final container = ProviderContainer(
+      overrides: rootProviderOverrides(
+        prefs: prefs,
+        logFileService: logFileService,
+      ),
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(sharedPreferencesProvider), same(prefs));
+    expect(container.read(logFileServiceProvider), same(logFileService));
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/core/providers/root_overrides_test.dart`
+Expected: FAIL — `Target of URI doesn't exist: 'package:submersion/core/providers/root_overrides.dart'`
+
+- [ ] **Step 3: Create the override helper**
+
+Create `lib/core/providers/root_overrides.dart`:
+
+```dart
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// The provider overrides the app's root [ProviderScope] installs.
+///
+/// Shared with the post-restore safety sweep, which builds a second, throwaway
+/// container against the freshly restored database. Both must install the same
+/// overrides: [logFileServiceProvider] throws unless overridden, and a
+/// container missing [sharedPreferencesProvider] cannot resolve settings. Keep
+/// this the single definition so the two cannot drift apart.
+List<Override> rootProviderOverrides({
+  required SharedPreferences prefs,
+  required LogFileService logFileService,
+}) {
+  return [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    logFileServiceProvider.overrideWithValue(logFileService),
+  ];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/core/providers/root_overrides_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Use the helper in main.dart**
+
+In `lib/main.dart`, add the import:
+
+```dart
+import 'package:submersion/core/providers/root_overrides.dart';
+```
+
+Replace the inline override list in `SubmersionRestart.build` (currently
+`lib/main.dart:136-139`):
+
+```dart
+        return ProviderScope(
+          key: key,
+          overrides: rootProviderOverrides(
+            prefs: prefs,
+            logFileService: logFileService,
+          ),
+          child: const SubmersionApp(),
+        );
+```
+
+- [ ] **Step 6: Verify formatting, analysis, and tests**
+
+Run:
+```bash
+dart format .
+flutter analyze
+flutter test test/core/providers/root_overrides_test.dart
+```
+Expected: no formatting changes, no analyzer issues, test passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/core/providers/root_overrides.dart lib/main.dart test/core/providers/root_overrides_test.dart
+git commit -m "refactor(providers): extract rootProviderOverrides for reuse"
+```
+
+---
+
+### Task 2: The shared SafetyReviewSweep
+
+The loop that currently lives inline in the settings page becomes a reusable
+provider. The `ref.invalidate` before the read is load-bearing:
+`safetyReviewProvider` is not `autoDispose`, so a bare read returns a stale
+cached `AsyncValue` — including a cached `null` from a dive opened mid-sync —
+and silently never runs the compute-through-cache.
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/providers/safety_review_sweep.dart`
+- Test: `test/features/dive_log/presentation/providers/safety_review_sweep_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `class SafetyReviewSweepResult { final int swept; final int failed; final bool cancelled; }`
+  - `class SafetyReviewSweep { Future<SafetyReviewSweepResult> run({String? diverId, void Function(int done, int total)? onProgress, bool Function()? isCancelled}); }`
+  - `final safetyReviewSweepProvider = Provider<SafetyReviewSweep>(...)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/providers/safety_review_sweep_test.dart`:
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+import '../../domain/services/safety_review_fixtures.dart';
+
+/// Records every review handed to it, so the sweep's coverage can be asserted
+/// without inspecting the database.
+class _RecordingRepo extends SafetyFindingsRepository {
+  final saved = <String>[];
+
+  @override
+  Future<SafetyReview?> getReview(String diveId) async => null;
+
+  @override
+  Future<void> saveReview(SafetyReview review) async =>
+      saved.add(review.diveId);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final now = DateTime.utc(2026, 8, 8);
+  late AppDatabase db;
+
+  /// Inserts a dive owned by [diverId].
+  ///
+  /// `dives.diver_id` is a nullable FK to `divers`, but foreign keys are off
+  /// in the test database, so no matching diver row is needed. If this ever
+  /// starts failing with a constraint error, insert the two `Divers` rows in
+  /// setUp first.
+  Future<void> insertDive(String id, String diverId) async {
+    final ts = now.millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            diveDateTime: Value(ts),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await insertDive('d1', 'diver-a');
+    await insertDive('d2', 'diver-b');
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  /// A container whose analysis always yields a rapid-ascent fixture, so every
+  /// dive produces a persistable review.
+  ProviderContainer makeContainer(_RecordingRepo repo) {
+    final profile = rapidAscentProfile();
+    final analysis = analyzeFixture(
+      depths: profile.depths,
+      timestamps: profile.timestamps,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(true),
+        profileAnalysisProvider('d1').overrideWith((ref) async => analysis),
+        profileAnalysisProvider('d2').overrideWith((ref) async => analysis),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('sweeps every diver when diverId is null', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(repo).read(safetyReviewSweepProvider).run();
+
+    expect(repo.saved, containsAll(<String>['d1', 'd2']));
+    expect(result.swept, 2);
+    expect(result.failed, 0);
+    expect(result.cancelled, isFalse);
+  });
+
+  test('scopes to a single diver when diverId is supplied', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run(diverId: 'diver-a');
+
+    expect(repo.saved, <String>['d1']);
+    expect(result.swept, 1);
+  });
+
+  test('reports progress ending at the total', () async {
+    final repo = _RecordingRepo();
+    final seen = <(int, int)>[];
+    await makeContainer(repo).read(safetyReviewSweepProvider).run(
+      onProgress: (done, total) => seen.add((done, total)),
+    );
+
+    expect(seen.first, (0, 2), reason: 'an initial 0-of-N sizes the bar');
+    expect(seen.last, (2, 2));
+  });
+
+  test('stops early and reports cancelled when isCancelled fires', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run(isCancelled: () => true);
+
+    expect(repo.saved, isEmpty);
+    expect(result.cancelled, isTrue);
+    expect(result.swept, 0);
+  });
+
+  test('an empty logbook sweeps nothing and reports a zero total', () async {
+    await db.delete(db.dives).go();
+    final repo = _RecordingRepo();
+    final seen = <(int, int)>[];
+
+    final result = await makeContainer(repo).read(safetyReviewSweepProvider).run(
+      onProgress: (done, total) => seen.add((done, total)),
+    );
+
+    expect(result.swept, 0);
+    expect(result.failed, 0);
+    expect(result.cancelled, isFalse);
+    expect(seen, <(int, int)>[(0, 0)]);
+  });
+
+  test('does nothing when the master toggle is off', () async {
+    final repo = _RecordingRepo();
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(false),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(safetyReviewSweepProvider).run();
+
+    expect(repo.saved, isEmpty);
+    expect(result.swept, 0);
+    expect(result.cancelled, isFalse);
+  });
+
+  test('counts a failing dive and still sweeps the rest', () async {
+    final repo = _RecordingRepo();
+    final profile = rapidAscentProfile();
+    final analysis = analyzeFixture(
+      depths: profile.depths,
+      timestamps: profile.timestamps,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(true),
+        profileAnalysisProvider('d1').overrideWith(
+          (ref) async => throw StateError('corrupt profile'),
+        ),
+        profileAnalysisProvider('d2').overrideWith((ref) async => analysis),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(safetyReviewSweepProvider).run();
+
+    expect(result.failed, 1);
+    expect(result.swept, 2, reason: 'swept counts dives visited, not successes');
+    expect(repo.saved, <String>['d2']);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/presentation/providers/safety_review_sweep_test.dart`
+Expected: FAIL — `Target of URI doesn't exist: '.../safety_review_sweep.dart'`
+
+- [ ] **Step 3: Implement the sweep**
+
+Create `lib/features/dive_log/presentation/providers/safety_review_sweep.dart`:
+
+```dart
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Outcome of a [SafetyReviewSweep.run].
+class SafetyReviewSweepResult {
+  /// Dives visited, including those that failed analysis. Mirrors the progress
+  /// bar's position rather than a success count.
+  final int swept;
+
+  /// Dives whose analysis threw. They stay unanalyzed and recompute lazily.
+  final int failed;
+
+  /// True when the caller's isCancelled callback stopped the sweep early.
+  final bool cancelled;
+
+  const SafetyReviewSweepResult({
+    required this.swept,
+    required this.failed,
+    required this.cancelled,
+  });
+
+  static const empty = SafetyReviewSweepResult(
+    swept: 0,
+    failed: 0,
+    cancelled: false,
+  );
+}
+
+/// Runs the post-dive safety review over a logbook, persisting each result.
+///
+/// Shared by the manual Settings sweep and the post-restore sweep so the
+/// invalidate-before-read invariant below lives in exactly one place.
+class SafetyReviewSweep {
+  final Ref _ref;
+
+  const SafetyReviewSweep(this._ref);
+
+  /// Analyzes every dive matching [diverId] (null means every diver).
+  ///
+  /// [onProgress] fires once with (0, total) to size a progress bar, then after
+  /// each dive. [isCancelled] is polled before each dive; returning true stops
+  /// the sweep and yields a result with `cancelled: true`. Cancelling is
+  /// lossless -- unswept dives still compute lazily on first view.
+  Future<SafetyReviewSweepResult> run({
+    String? diverId,
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    // Master toggle off: safetyReviewProvider would refuse to compute anyway,
+    // so skip the whole pass rather than issuing a marker read per dive.
+    if (!_ref.read(safetyReviewEnabledProvider)) {
+      return SafetyReviewSweepResult.empty;
+    }
+
+    final diveIds = await _ref
+        .read(diveRepositoryProvider)
+        .getOrderedDiveIds(diverId: diverId);
+
+    final total = diveIds.length;
+    onProgress?.call(0, total);
+
+    var swept = 0;
+    var failed = 0;
+
+    for (final diveId in diveIds) {
+      if (isCancelled?.call() ?? false) {
+        return SafetyReviewSweepResult(
+          swept: swept,
+          failed: failed,
+          cancelled: true,
+        );
+      }
+      try {
+        // Invalidate first. safetyReviewProvider is not autoDispose, so any
+        // dive whose detail page was opened this session holds a cached
+        // AsyncValue -- including a cached null from a dive opened mid-sync
+        // before its profile arrived. A bare read would return that cached
+        // value and never run the compute-through-cache, leaving the review
+        // missing until an app restart.
+        _ref.invalidate(safetyReviewProvider(diveId));
+        await _ref.read(safetyReviewProvider(diveId).future);
+      } catch (_) {
+        // A dive that fails analysis (corrupt profile) must not abort the
+        // sweep; it stays unanalyzed. Counted so callers can report honestly
+        // rather than implying every dive was analyzed.
+        failed++;
+      }
+      swept++;
+      onProgress?.call(swept, total);
+    }
+
+    return SafetyReviewSweepResult(
+      swept: swept,
+      failed: failed,
+      cancelled: false,
+    );
+  }
+}
+
+final safetyReviewSweepProvider = Provider<SafetyReviewSweep>(
+  (ref) => SafetyReviewSweep(ref),
+);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/presentation/providers/safety_review_sweep_test.dart`
+Expected: PASS — all seven tests.
+
+- [ ] **Step 5: Verify formatting and analysis**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: no formatting changes, no analyzer issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/providers/safety_review_sweep.dart test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
+git commit -m "feat(safety): add reusable SafetyReviewSweep provider"
+```
+
+---
+
+### Task 3: Settings page delegates to the sweep
+
+Behavior must not change. The existing safety settings page test is the
+regression gate.
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/safety_settings_page.dart:149-203`
+- Test: `test/features/settings/presentation/pages/safety_settings_page_test.dart` (existing, unchanged)
+
+**Interfaces:**
+- Consumes: `safetyReviewSweepProvider`, `SafetyReviewSweep.run`, `SafetyReviewSweepResult` from Task 2.
+- Produces: nothing new.
+
+- [ ] **Step 1: Run the existing test to capture the green baseline**
+
+Run: `flutter test test/features/settings/presentation/pages/safety_settings_page_test.dart`
+Expected: PASS. Note the count — it must be identical after the refactor.
+
+- [ ] **Step 2: Add the import**
+
+In `lib/features/settings/presentation/pages/safety_settings_page.dart`, add:
+
+```dart
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+```
+
+- [ ] **Step 3: Replace `_analyzeAllDives` with a delegating version**
+
+Replace the whole `_analyzeAllDives` method body (currently lines 149-203):
+
+```dart
+  Future<void> _analyzeAllDives() async {
+    // Scope the sweep to the active diver's logbook so "Analyze all dives"
+    // only touches the current diver's dives, not every diver on the device.
+    final diverId = ref.read(currentDiverIdProvider);
+    setState(() {
+      _analyzing = true;
+      _analyzeDone = 0;
+      _analyzeTotal = 0;
+      _analyzeFailed = 0;
+    });
+
+    final result = await ref
+        .read(safetyReviewSweepProvider)
+        .run(
+          diverId: diverId,
+          onProgress: (done, total) {
+            if (!mounted) return;
+            setState(() {
+              _analyzeDone = done;
+              _analyzeTotal = total;
+            });
+          },
+          // Leaving the page ends the sweep, matching the previous
+          // `if (!mounted) return;` guard inside the loop.
+          isCancelled: () => !mounted,
+        );
+
+    if (!mounted) return;
+    setState(() {
+      _analyzing = false;
+      _analyzeFailed = result.failed;
+    });
+    if (result.cancelled) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          result.failed == 0
+              ? context.l10n.safetySettings_analyzeAll_done
+              : context.l10n.safetySettings_analyzeAll_doneWithErrors(
+                  result.failed,
+                ),
+        ),
+      ),
+    );
+  }
+```
+
+- [ ] **Step 4: Run the regression test**
+
+Run: `flutter test test/features/settings/presentation/pages/safety_settings_page_test.dart`
+Expected: PASS with the same test count as Step 1.
+
+- [ ] **Step 5: Verify formatting and analysis**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: no formatting changes, no analyzer issues. In particular the
+`_analyzeFailed` field must still be referenced; if the analyzer reports it
+unused, the `setState` in Step 3 was not applied correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/settings/presentation/pages/safety_settings_page.dart
+git commit -m "refactor(safety): route Analyze all dives through SafetyReviewSweep"
+```
+
+---
+
+### Task 4: The post-restore container seam
+
+Wraps the throwaway `ProviderContainer` so the notifier can be tested without
+building the real provider graph.
+
+**Files:**
+- Create: `lib/features/backup/presentation/providers/post_restore_safety_review.dart`
+- Test: `test/features/backup/presentation/providers/post_restore_safety_review_test.dart`
+
+**Interfaces:**
+- Consumes: `rootProviderOverrides` (Task 1); `safetyReviewSweepProvider`, `SafetyReviewSweepResult` (Task 2).
+- Produces:
+  - `class PostRestoreSafetyReview { Future<SafetyReviewSweepResult> run({void Function(int done, int total)? onProgress, bool Function()? isCancelled}); }`
+  - `final postRestoreSafetyReviewProvider = Provider<PostRestoreSafetyReview>(...)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/backup/presentation/providers/post_restore_safety_review_test.dart`:
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    final ts = DateTime.utc(2026, 8, 8).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diverId: const Value('diver-a'),
+            diveDateTime: Value(ts),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        logFileServiceProvider.overrideWithValue(LogFileService()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('runs a whole-library sweep and reports progress', () async {
+    final seen = <(int, int)>[];
+
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run(onProgress: (done, total) => seen.add((done, total)));
+
+    // The dive has no profile, so nothing is persisted -- but it is visited,
+    // which is what proves the scratch container reached the restored data.
+    expect(result.swept, 1);
+    expect(result.cancelled, isFalse);
+    expect(seen.first, (0, 1));
+    expect(seen.last, (1, 1));
+  });
+
+  test('honours cancellation', () async {
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run(isCancelled: () => true);
+
+    expect(result.cancelled, isTrue);
+    expect(result.swept, 0);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/backup/presentation/providers/post_restore_safety_review_test.dart`
+Expected: FAIL — `Target of URI doesn't exist: '.../post_restore_safety_review.dart'`
+
+- [ ] **Step 3: Implement the seam**
+
+Create `lib/features/backup/presentation/providers/post_restore_safety_review.dart`:
+
+```dart
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/providers/root_overrides.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Runs the whole-library safety sweep that follows a database restore.
+///
+/// The sweep deliberately runs in its own short-lived [ProviderContainer]
+/// rather than the live one. After a restore the live container still holds
+/// values built against the REPLACED database -- settingsProvider (and so the
+/// gradient factors that shape the ceiling curve the missedDecoStop and
+/// highSurfaceGf rules grade against), ProfileLegend's metric-source defaults,
+/// and cached analysisDiveProvider/profileAnalysisProvider entries. Computing
+/// findings from that state would persist the old device's settings into the
+/// restored library, and because saveReview stamps the current engineVersion
+/// they would never be recomputed.
+///
+/// A fresh container builds every provider against the restored database. The
+/// live container is left untouched; restartApp() rebuilds the root
+/// ProviderScope under a new key moments later and discards it anyway.
+class PostRestoreSafetyReview {
+  final Ref _ref;
+
+  const PostRestoreSafetyReview(this._ref);
+
+  Future<SafetyReviewSweepResult> run({
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    final container = ProviderContainer(
+      overrides: rootProviderOverrides(
+        prefs: _ref.read(sharedPreferencesProvider),
+        logFileService: _ref.read(logFileServiceProvider),
+      ),
+    );
+    try {
+      return await container
+          .read(safetyReviewSweepProvider)
+          .run(
+            // A restore replaces the whole library, so sweep every diver.
+            diverId: null,
+            onProgress: onProgress,
+            isCancelled: isCancelled,
+          );
+    } finally {
+      container.dispose();
+    }
+  }
+}
+
+final postRestoreSafetyReviewProvider = Provider<PostRestoreSafetyReview>(
+  (ref) => PostRestoreSafetyReview(ref),
+);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/backup/presentation/providers/post_restore_safety_review_test.dart`
+Expected: PASS — both tests.
+
+- [ ] **Step 5: Verify formatting and analysis**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/backup/presentation/providers/post_restore_safety_review.dart test/features/backup/presentation/providers/post_restore_safety_review_test.dart
+git commit -m "feat(backup): add isolated post-restore safety review runner"
+```
+
+---
+
+### Task 5: Wire the sweep into the restore flow
+
+**Files:**
+- Modify: `lib/features/backup/presentation/providers/backup_providers.dart` (state class ~170-203, notifier ~206-292 and ~369-427)
+- Test: `test/features/backup/presentation/providers/backup_providers_restore_test.dart` (existing, add cases)
+
+**Interfaces:**
+- Consumes: `postRestoreSafetyReviewProvider`, `PostRestoreSafetyReview.run`, `SafetyReviewSweepResult` (Tasks 2 and 4).
+- Produces:
+  - `class SafetyReviewSweepProgress { final int done; final int total; }`
+  - `BackupOperationState.sweepProgress` (`SafetyReviewSweepProgress?`)
+  - `BackupOperationNotifier.skipSafetyReviewSweep()`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/backup/presentation/providers/backup_providers_restore_test.dart`, inside the existing `main()` (after the last test). Add these imports at the top of the file:
+
+```dart
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+```
+
+Add this fake above `void main()`:
+
+```dart
+/// Stands in for the real sweep so the notifier can be exercised without
+/// building a second provider graph.
+class _FakePostRestoreSafetyReview implements PostRestoreSafetyReview {
+  int calls = 0;
+  bool throwOnRun = false;
+
+  /// Progress pairs emitted before returning.
+  List<(int, int)> emit = const [];
+
+  /// Captured so a test can assert the notifier's skip flag reaches the sweep.
+  bool Function()? capturedIsCancelled;
+
+  @override
+  Future<SafetyReviewSweepResult> run({
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    calls++;
+    capturedIsCancelled = isCancelled;
+    if (throwOnRun) throw StateError('sweep exploded');
+    for (final (done, total) in emit) {
+      onProgress?.call(done, total);
+    }
+    return SafetyReviewSweepResult(
+      swept: emit.isEmpty ? 0 : emit.last.$1,
+      failed: 0,
+      cancelled: isCancelled?.call() ?? false,
+    );
+  }
+}
+```
+
+Then add the tests:
+
+```dart
+  test('a restore runs the post-restore safety sweep', () async {
+    final sweep = _FakePostRestoreSafetyReview();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(null),
+        backupServiceProvider.overrideWithValue(service),
+        postRestoreSafetyReviewProvider.overrideWithValue(sweep),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath('/tmp/backup.db');
+
+    expect(sweep.calls, 1);
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.restoreComplete,
+    );
+  });
+
+  test('sweep progress is published while the barrier is still up', () async {
+    final sweep = _FakePostRestoreSafetyReview()..emit = const [(0, 2), (1, 2)];
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(null),
+        backupServiceProvider.overrideWithValue(service),
+        postRestoreSafetyReviewProvider.overrideWithValue(sweep),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final seen = <SafetyReviewSweepProgress?>[];
+    final sub = container.listen(
+      backupOperationProvider,
+      (_, next) => seen.add(next.sweepProgress),
+    );
+    addTearDown(sub.close);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath('/tmp/backup.db');
+
+    final published = seen.whereType<SafetyReviewSweepProgress>().toList();
+    expect(published, isNotEmpty);
+    expect(published.last.done, 1);
+    expect(published.last.total, 2);
+  });
+
+  test('a sweep failure still completes the restore', () async {
+    final sweep = _FakePostRestoreSafetyReview()..throwOnRun = true;
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(null),
+        backupServiceProvider.overrideWithValue(service),
+        postRestoreSafetyReviewProvider.overrideWithValue(sweep),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath('/tmp/backup.db');
+
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.restoreComplete,
+      reason: 'the data restore already succeeded; the sweep is a convenience',
+    );
+  });
+
+  test('skipSafetyReviewSweep is visible to the running sweep', () async {
+    final sweep = _FakePostRestoreSafetyReview();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(null),
+        backupServiceProvider.overrideWithValue(service),
+        postRestoreSafetyReviewProvider.overrideWithValue(sweep),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(backupOperationProvider.notifier);
+    await notifier.restoreFromFilePath('/tmp/backup.db');
+
+    expect(sweep.capturedIsCancelled, isNotNull);
+    expect(sweep.capturedIsCancelled!(), isFalse);
+    notifier.skipSafetyReviewSweep();
+    expect(sweep.capturedIsCancelled!(), isTrue);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/backup/presentation/providers/backup_providers_restore_test.dart`
+Expected: FAIL — `postRestoreSafetyReviewProvider` / `sweepProgress` / `skipSafetyReviewSweep` undefined.
+
+- [ ] **Step 3: Add the progress type and state field**
+
+In `lib/features/backup/presentation/providers/backup_providers.dart`, add these imports:
+
+```dart
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
+```
+
+Add above `class BackupOperationState`:
+
+```dart
+/// Progress of the whole-library safety review sweep that runs at the end of a
+/// restore. Structured rather than a pre-formatted string so the restore
+/// barrier can render it in the user's language.
+class SafetyReviewSweepProgress {
+  final int done;
+  final int total;
+
+  const SafetyReviewSweepProgress({required this.done, required this.total});
+}
+```
+
+Add the field to `BackupOperationState` (after `isRestoring`):
+
+```dart
+  /// Non-null only while the post-restore safety sweep is running.
+  final SafetyReviewSweepProgress? sweepProgress;
+```
+
+Add it to the constructor:
+
+```dart
+    this.sweepProgress,
+```
+
+and to `copyWith` — deliberately NOT `??`-merged, because a null must be able
+to clear the field when the sweep ends. `BackupOperationState.copyWith` has no
+callers today (the `state.copyWith` calls elsewhere in this file belong to
+`BackupSettings`), so this cannot regress an existing path:
+
+```dart
+  BackupOperationState copyWith({
+    BackupOperationStatus? status,
+    String? message,
+    BackupRecord? lastRecord,
+    bool? isRestoring,
+    SafetyReviewSweepProgress? sweepProgress,
+  }) {
+    return BackupOperationState(
+      status: status ?? this.status,
+      message: message ?? this.message,
+      lastRecord: lastRecord ?? this.lastRecord,
+      isRestoring: isRestoring ?? this.isRestoring,
+      sweepProgress: sweepProgress,
+    );
+  }
+```
+
+- [ ] **Step 4: Add the sweep runner to the notifier**
+
+In `BackupOperationNotifier`, add a logger and the skip flag next to
+`_desktopBackupTimer`:
+
+```dart
+  final _log = LoggerService.forClass(BackupOperationNotifier);
+  bool _sweepSkipped = false;
+```
+
+Add these methods next to `_syncActiveDiverAfterRestore`:
+
+```dart
+  /// Stops the post-restore safety sweep at the next dive boundary.
+  ///
+  /// Lossless: unswept dives still compute lazily when opened, and
+  /// Settings > Safety > "Analyze all dives" remains available.
+  void skipSafetyReviewSweep() {
+    _sweepSkipped = true;
+  }
+
+  /// Analyze the restored library so safety findings and dive-list badges are
+  /// present immediately, instead of only after each dive is opened.
+  ///
+  /// Deliberately cannot fail the restore: by the time this runs the database
+  /// swap and the sync re-baseline have already succeeded, so a sweep error is
+  /// logged and swallowed rather than turning a completed restore into a
+  /// failed one. isRestoring stays true so the barrier keeps the app blocked.
+  Future<void> _runPostRestoreSafetyReview() async {
+    _sweepSkipped = false;
+    try {
+      await _ref
+          .read(postRestoreSafetyReviewProvider)
+          .run(
+            onProgress: (done, total) {
+              if (!mounted || total == 0) return;
+              state = BackupOperationState(
+                status: BackupOperationStatus.inProgress,
+                isRestoring: true,
+                sweepProgress: SafetyReviewSweepProgress(
+                  done: done,
+                  total: total,
+                ),
+              );
+            },
+            isCancelled: () => _sweepSkipped,
+          );
+    } catch (e, st) {
+      _log.error(
+        'Post-restore safety review failed; the restore itself is unaffected',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+```
+
+- [ ] **Step 5: Call it from both restore methods**
+
+In `restoreFromBackup`, replace:
+
+```dart
+      await _syncActiveDiverAfterRestore();
+      state = const BackupOperationState(
+        status: BackupOperationStatus.restoreComplete,
+      );
+```
+
+with:
+
+```dart
+      await _syncActiveDiverAfterRestore();
+      await _runPostRestoreSafetyReview();
+      state = const BackupOperationState(
+        status: BackupOperationStatus.restoreComplete,
+      );
+```
+
+Make the identical change in `restoreFromFilePath`.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `flutter test test/features/backup/presentation/providers/backup_providers_restore_test.dart`
+Expected: PASS — the pre-existing tests plus the four new ones.
+
+- [ ] **Step 7: Verify formatting and analysis**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/features/backup/presentation/providers/backup_providers.dart test/features/backup/presentation/providers/backup_providers_restore_test.dart
+git commit -m "feat(backup): run the safety review sweep at the end of a restore"
+```
+
+---
+
+### Task 6: Localized strings
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` and the ten other `app_*.arb` files
+- Regenerate: `lib/l10n/arb/app_localizations*.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `l10n.backup_restore_safetyReview_title`,
+  `l10n.backup_restore_safetyReview_progress(done, total)`,
+  `l10n.backup_restore_safetyReview_skip`
+
+- [ ] **Step 1: Add the template strings**
+
+In `lib/l10n/arb/app_en.arb`, add next to the other `backup_restore*` keys:
+
+```json
+  "backup_restore_safetyReview_title": "Running the safety review",
+  "backup_restore_safetyReview_progress": "Analyzed {done} of {total} dives",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Skip",
+```
+
+- [ ] **Step 2: Translate into the other ten locales**
+
+Add all three keys to each of `app_ar.arb`, `app_de.arb`, `app_es.arb`,
+`app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`,
+`app_pt.arb`, `app_zh.arb`.
+
+Every locale file in this project repeats the `@`-metadata block for
+placeholder keys, not just the template — compare
+`safetySettings_analyzeAll_progress` in `app_de.arb:6571-6581`. So the
+`@backup_restore_safetyReview_progress` block from Step 1 must be copied
+verbatim (English key names, `"type": "int"`) into all ten files alongside
+the translated string.
+
+Suggested translations for the title / skip (translate the progress string to
+match each locale's existing `safetySettings_analyzeAll_progress` phrasing):
+
+| Locale | title | skip |
+| --- | --- | --- |
+| ar | جارٍ تشغيل مراجعة السلامة | تخطي |
+| de | Sicherheitsprüfung läuft | Überspringen |
+| es | Ejecutando la revisión de seguridad | Omitir |
+| fr | Analyse de sécurité en cours | Ignorer |
+| he | מריץ את סקירת הבטיחות | דלג |
+| hu | Biztonsági ellenőrzés folyamatban | Kihagyás |
+| it | Revisione di sicurezza in corso | Salta |
+| nl | Veiligheidscontrole wordt uitgevoerd | Overslaan |
+| pt | Executando a revisão de segurança | Ignorar |
+| zh | 正在运行安全审查 | 跳过 |
+
+- [ ] **Step 3: Regenerate the localization classes**
+
+Run: `flutter gen-l10n`
+Expected: `lib/l10n/arb/app_localizations*.dart` updated with the three new
+getters/methods on every locale class.
+
+- [ ] **Step 4: Verify the generated API compiles**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: clean. An "is missing translations" warning for any locale means a
+key was not added everywhere — fix and regenerate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/arb/
+git commit -m "i18n: add post-restore safety review barrier strings"
+```
+
+---
+
+### Task 7: Restore barrier progress and Skip button
+
+**Files:**
+- Modify: `lib/features/backup/presentation/widgets/restore_barrier.dart`
+- Test: `test/features/backup/presentation/widgets/restore_barrier_test.dart` (existing, add cases)
+
+**Interfaces:**
+- Consumes: `SafetyReviewSweepProgress`, `BackupOperationState.sweepProgress`, `BackupOperationNotifier.skipSafetyReviewSweep` (Task 5); the three l10n keys (Task 6).
+- Produces: `restoreSweepProgressProvider` (`Provider<SafetyReviewSweepProgress?>`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/features/backup/presentation/widgets/restore_barrier_test.dart`, add
+the import:
+
+```dart
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+```
+
+Extend the existing `wrap` helper with an optional progress override:
+
+```dart
+  Widget wrap({
+    required bool restoring,
+    String? message,
+    SafetyReviewSweepProgress? sweepProgress,
+    required VoidCallback onTap,
+  }) {
+    return testApp(
+      locale: const Locale('en'),
+      overrides: [
+        restoreInProgressProvider.overrideWithValue(restoring),
+        restoreMessageProvider.overrideWithValue(message),
+        restoreSweepProgressProvider.overrideWithValue(sweepProgress),
+      ],
+      child: RestoreBarrier(
+        child: Center(
+          child: ElevatedButton(onPressed: onTap, child: const Text('Tap me')),
+        ),
+      ),
+    );
+  }
+```
+
+Add these tests. They assert that the Skip button renders, not that tapping it
+works: the tap closure calls `ref.read(backupOperationProvider.notifier)`,
+which would need the whole backup service graph. The skip behavior itself is
+already covered by the notifier test in Task 5.
+
+```dart
+  testWidgets('shows determinate sweep progress and a Skip button', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        restoring: true,
+        sweepProgress: const SafetyReviewSweepProgress(done: 3, total: 10),
+        onTap: () {},
+      ),
+    );
+
+    expect(find.text('Running the safety review'), findsOneWidget);
+    expect(find.text('Analyzed 3 of 10 dives'), findsOneWidget);
+    expect(find.text('Skip'), findsOneWidget);
+
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byType(LinearProgressIndicator),
+    );
+    expect(bar.value, closeTo(0.3, 0.001));
+  });
+
+  testWidgets('keeps the plain spinner when no sweep is running', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(restoring: true, message: 'Restoring backup...', onTap: () {}),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.text('Skip'), findsNothing);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `flutter test test/features/backup/presentation/widgets/restore_barrier_test.dart`
+Expected: FAIL — `restoreSweepProgressProvider` undefined.
+
+- [ ] **Step 3: Rewrite the barrier**
+
+Replace the whole contents of
+`lib/features/backup/presentation/widgets/restore_barrier.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// True while a database restore is running. Derived (not the whole operation
+/// state) so widgets rebuild only when this specific flag flips, and so tests
+/// can override it with a plain value.
+final restoreInProgressProvider = Provider<bool>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.isRestoring)),
+);
+
+/// The current restore progress message (e.g. "Restoring backup...").
+final restoreMessageProvider = Provider<String?>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.message)),
+);
+
+/// Non-null only while the post-restore safety review sweep is running.
+final restoreSweepProgressProvider = Provider<SafetyReviewSweepProgress?>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.sweepProgress)),
+);
+
+/// Wraps the whole app and, while a database restore is running, covers it with
+/// an interaction-blocking overlay.
+///
+/// A restore briefly closes and reopens the database. Without this barrier the
+/// user could navigate to a data page mid-restore, whose providers would build
+/// against the transient null database and cache a fatal "Database not
+/// initialized" error that survives until a full app restart (the DiveCenters
+/// red-screen bug). Blocking all interaction until the restore finishes — and
+/// hands off to RestoreCompletePage — closes that gap.
+class RestoreBarrier extends ConsumerWidget {
+  const RestoreBarrier({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isRestoring = ref.watch(restoreInProgressProvider);
+
+    return Stack(
+      children: [
+        child,
+        if (isRestoring)
+          Positioned.fill(
+            child: _RestoreOverlay(
+              message: ref.watch(restoreMessageProvider),
+              sweepProgress: ref.watch(restoreSweepProgressProvider),
+              onSkipSweep: () => ref
+                  .read(backupOperationProvider.notifier)
+                  .skipSafetyReviewSweep(),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _RestoreOverlay extends StatelessWidget {
+  const _RestoreOverlay({
+    this.message,
+    this.sweepProgress,
+    required this.onSkipSweep,
+  });
+
+  final String? message;
+  final SafetyReviewSweepProgress? sweepProgress;
+  final VoidCallback onSkipSweep;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sweep = sweepProgress;
+
+    // The provider already supplies an English progress string for the swap
+    // phases; fall back to a plain one if it is ever absent. Once the safety
+    // sweep starts, its own localized label takes over.
+    final label = sweep != null
+        ? context.l10n.backup_restore_safetyReview_progress(
+            sweep.done,
+            sweep.total,
+          )
+        : (message ?? 'Restoring backup...');
+
+    // Announce the busy/restoring state to screen readers as a live region, and
+    // exclude the inner widgets' own semantics so the state is announced once
+    // (not duplicated by the progress indicator and the label Text).
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: label,
+      child: ExcludeSemantics(
+        child: Stack(
+          children: [
+            // Absorbs every pointer event and paints the scrim, so nothing
+            // beneath can be tapped or scrolled during the restore.
+            const ModalBarrier(dismissible: false, color: Colors.black54),
+            Center(
+              child: Material(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                child: Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 320),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: sweep != null
+                          ? _sweepChildren(context, theme, sweep, label)
+                          : _spinnerChildren(theme, label),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _spinnerChildren(ThemeData theme, String label) {
+    return [
+      const CircularProgressIndicator(),
+      const SizedBox(height: 16),
+      Text(label, style: theme.textTheme.bodyMedium),
+    ];
+  }
+
+  List<Widget> _sweepChildren(
+    BuildContext context,
+    ThemeData theme,
+    SafetyReviewSweepProgress sweep,
+    String label,
+  ) {
+    return [
+      Text(
+        context.l10n.backup_restore_safetyReview_title,
+        style: theme.textTheme.titleMedium,
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 16),
+      LinearProgressIndicator(
+        value: sweep.total == 0 ? null : sweep.done / sweep.total,
+      ),
+      const SizedBox(height: 12),
+      Text(label, style: theme.textTheme.bodyMedium),
+      const SizedBox(height: 8),
+      // Skipping is lossless: unswept dives still compute lazily when opened.
+      TextButton(
+        onPressed: onSkipSweep,
+        child: Text(context.l10n.backup_restore_safetyReview_skip),
+      ),
+    ];
+  }
+}
+```
+
+- [ ] **Step 4: Run the barrier tests to verify they pass**
+
+Run: `flutter test test/features/backup/presentation/widgets/restore_barrier_test.dart`
+Expected: PASS — the four pre-existing tests plus the two new ones.
+
+- [ ] **Step 5: Verify formatting and analysis**
+
+Run:
+```bash
+dart format .
+flutter analyze
+```
+Expected: clean.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `flutter test`
+Expected: PASS. `RestoreBarrier` now calls `context.l10n`, so any test that
+pumps it with `restoreInProgressProvider` true under a bare `MaterialApp`
+would throw in `build`. If one fails, fix it by pumping through the shared
+`testApp` helper (`test/helpers/test_app.dart`), which wires
+`localizationsDelegates`, `supportedLocales`, and `locale`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/backup/presentation/widgets/restore_barrier.dart test/features/backup/presentation/widgets/restore_barrier_test.dart
+git commit -m "feat(backup): show safety sweep progress and a Skip button on the restore barrier"
+```
+
+---
+
+## Verification
+
+- [ ] `dart format .` reports no changes
+- [ ] `flutter analyze` is clean across the whole project
+- [ ] `flutter test` passes in full
+- [ ] Manual: restore a backup created before the safety review feature
+      existed. The barrier shows "Running the safety review" with a moving
+      determinate bar, then the restore-complete screen appears. After the
+      restart, dive-list rows show finding badges and dive detail pages show a
+      populated safety review section without opening each dive first.
+- [ ] Manual: tap Skip mid-sweep. The restore completes immediately, and an
+      unswept dive still populates its review when opened.

--- a/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
+++ b/docs/superpowers/plans/2026-08-08-post-restore-safety-review.md
@@ -1503,6 +1503,52 @@ git commit -m "feat(backup): show safety sweep progress and a Skip button on the
 
 ---
 
+## As built: deviations from the plan
+
+Five things the plan got wrong, all corrected during execution. Recorded here
+because each one is a trap the next person will hit.
+
+1. **`Override` cannot be named.** Riverpod 3 does not export its `Override`
+   type, so `List<Override> rootProviderOverrides(...)` does not compile.
+   Leaving the return type to inference works but trips
+   `strict_top_level_inference`, and this project treats analyzer infos as
+   fatal. Final shape: return `List<dynamic>` and `.cast()` at each call site,
+   matching `test/helpers/test_app.dart`. (That helper reaches the real type via
+   an `// ignore: implementation_imports` import of
+   `package:riverpod/src/framework.dart` — acceptable in a test helper, not in
+   `lib/`.)
+
+2. **`LogFileService` has a required `logDirectory`.** It touches no filesystem
+   until `initialize()`, so tests construct it with any path.
+
+3. **Foreign keys ARE enforced by `setUpTestDatabase()`.** A `dives` row whose
+   `diver_id` has no `divers` parent fails with SQLITE_CONSTRAINT (787). Every
+   test fixture inserts the diver first.
+
+4. **`SettingsNotifier` needed two fixes, both latent bugs independent of
+   backups.** `state` starts at the `AppSettings` DEFAULTS and is replaced
+   asynchronously, so the scratch container would have graded dives against
+   default gradient factors — defeating its entire purpose. Added
+   `initialLoad`, awaited by `PostRestoreSafetyReview` before sweeping.
+   Separately, `_loadSettings` assigned `state` after an `await` with no
+   `mounted` check, throwing "Tried to use SettingsNotifier after dispose"
+   whenever a `ProviderScope` is torn down mid-load — reachable today via
+   `restartApp()`'s soft restart, not just the new container. Added the guard.
+   Consequence: four test fakes that `implements SettingsNotifier` had to gain
+   `Future<void> get initialLoad async {}` (`test/helpers/mock_providers.dart`,
+   `settings_page_test.dart`, `settings_page_shared_data_test.dart`,
+   `records_page_test.dart`).
+
+5. **`_analyzeFailed` was deleted, not reassigned.** Once the snackbar reads
+   `result.failed`, the field becomes write-only, which the analyzer flags.
+
+An extra test was added beyond the plan:
+`reads settings from the restored database, not the defaults` in
+`post_restore_safety_review_test.dart`. It switches the master toggle off in the
+restored diver's row and asserts the sweep no-ops — the only assertion that
+actually proves the scratch container reads restored settings rather than
+defaults, and the regression guard for deviation 4.
+
 ## Verification
 
 - [ ] `dart format .` reports no changes

--- a/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
+++ b/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
@@ -197,6 +197,15 @@ final postRestoreSafetyReviewProvider =
 Tests override `postRestoreSafetyReviewProvider` with a fake that records the
 call, reports progress, or throws.
 
+A fresh container is necessary but not sufficient. `SettingsNotifier` starts at
+the `AppSettings` DEFAULTS and replaces its state asynchronously once the
+diver's row is read, so reading gradient factors immediately after building the
+container still yields defaults. `PostRestoreSafetyReview` therefore awaits a
+new `SettingsNotifier.initialLoad` before sweeping (guarded: a failed load
+leaves the defaults in place rather than aborting the restore). The same
+asynchrony required a `mounted` guard on `_loadSettings`'s post-await `state`
+assignment, since disposing the scratch container mid-load previously threw.
+
 ### 4. Progress and the Skip button
 
 `BackupOperationState` gains a structured field rather than another English
@@ -330,4 +339,5 @@ minimum.
 | `lib/features/backup/presentation/widgets/restore_barrier.dart` | Determinate progress, localized labels, Skip button |
 | `lib/core/providers/root_overrides.dart` | New: `rootProviderOverrides` |
 | `lib/main.dart` | Use `rootProviderOverrides` instead of an inline list |
+| `lib/features/settings/presentation/providers/settings_providers.dart` | Expose `initialLoad`; `mounted` guard on the post-await state write |
 | `lib/l10n/arb/app_*.arb` | Three new keys across nine locales |

--- a/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
+++ b/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
@@ -1,0 +1,333 @@
+# Run the Safety Review After a Backup Restore
+
+Date: 2026-08-08
+Status: Approved
+
+## Problem
+
+After restoring a backup, the safety review is empty for the whole logbook.
+No dive shows findings, and no dive-list row shows a finding badge, until
+the user discovers Settings → Safety → "Analyze all dives" and runs it by
+hand.
+
+The cause is that the safety review has only two triggers, and a restore is
+neither of them:
+
+1. **Lazy compute on first view.** `safetyReviewProvider`
+   (`lib/features/dive_log/presentation/providers/safety_review_providers.dart`)
+   is a compute-through-cache: it returns the stored review when current,
+   otherwise runs the engine over the profile analysis and persists the
+   result. It only runs when something watches it — in practice, opening a
+   dive's detail page.
+2. **The manual sweep.** `_analyzeAllDives` in
+   `lib/features/settings/presentation/pages/safety_settings_page.dart`.
+
+A Submersion backup is a whole-file SQLite copy (`DatabaseService.backup`
+→ `sourceFile.copy`), so the `dive_safety_reviews` and
+`dive_safety_findings` tables travel with it — but carrying only whatever
+rows the source database happened to have. Two common cases leave them
+empty:
+
+- The backup predates the safety review feature, so the migration ladder
+  creates both tables empty during the restore.
+- The source device never opened those dives, so lazy compute never ran.
+
+Either way `restoreFromBackup` / `restoreFromFile` land a database with no
+reviews, and `DiveSummary.safetyFindingCount` — which reads persisted rows
+— reports zero across the library.
+
+## Goals
+
+- A restore leaves the restored library analyzed, with no manual step.
+- Cover every restore entry point, including the setup wizard.
+- Never let a sweep failure turn a successful restore into a failed one.
+- Give the user a way out of a sweep that is taking longer than expected.
+
+## Non-goals
+
+- Changing when the safety review runs outside of a restore (imports,
+  dive-computer downloads, and sync keep their current behavior).
+- Changing any safety rule, threshold, or `SafetyReviewService.engineVersion`.
+- Any schema change. Both safety tables already exist and already sync.
+- Resuming a skipped remainder on a later launch.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| When does the sweep run? | Inline, as the last step of the restore, before the restore-complete screen |
+| Which dives? | Every dive in the restored library, across all divers |
+| Long sweeps | Determinate progress plus a Skip button |
+| Code structure | Extract a shared sweep helper used by both Settings and restore |
+
+## Design
+
+### 1. `SafetyReviewSweep`
+
+New file:
+`lib/features/dive_log/presentation/providers/safety_review_sweep.dart`.
+
+```dart
+class SafetyReviewSweepResult {
+  final int swept;
+  final int failed;
+  final bool cancelled;
+}
+
+class SafetyReviewSweep {
+  final Ref _ref;
+  const SafetyReviewSweep(this._ref);
+
+  Future<SafetyReviewSweepResult> run({
+    String? diverId,                            // null = every diver
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  });
+}
+
+final safetyReviewSweepProvider =
+    Provider<SafetyReviewSweep>((ref) => SafetyReviewSweep(ref));
+```
+
+Behavior, lifted verbatim from `_analyzeAllDives`:
+
+- Returns immediately with a zero result when `safetyReviewEnabledProvider`
+  is false.
+- Resolves dive ids via
+  `diveRepositoryProvider.getOrderedDiveIds(diverId: diverId)`. Passing
+  `null` already yields every dive across every diver — the SQL only adds
+  the `d.diver_id = ?` clause when `diverId` is non-null.
+- Per dive: `ref.invalidate(safetyReviewProvider(diveId))` **before**
+  `await ref.read(safetyReviewProvider(diveId).future)`. The invalidate is
+  load-bearing, not defensive: `safetyReviewProvider` is not `autoDispose`,
+  so a bare read returns a stale cached `AsyncValue` — including a cached
+  `null` from a dive opened mid-sync before its profile arrived — and
+  silently never runs the compute-through-cache.
+- Per dive `try/catch`: a corrupt profile increments `failed` and the sweep
+  continues.
+- Checks `isCancelled()` at the top of each iteration and returns a result
+  with `cancelled: true` when it fires.
+
+`_analyzeAllDives` is rewritten to delegate, keeping its current active-diver
+scope (`diverId: ref.read(currentDiverIdProvider)`) and its existing progress
+and snackbar behavior. The Settings page's user-visible behavior does not
+change.
+
+Riverpod note: `Ref` and `WidgetRef` are separate sealed types, so the helper
+is exposed as a `Provider` rather than taking a ref parameter. Both call
+sites then reach the same object — `ref.read(safetyReviewSweepProvider)` —
+and the sweep uses the provider's own long-lived `Ref` internally.
+
+### 2. Restore integration
+
+`BackupOperationNotifier`
+(`lib/features/backup/presentation/providers/backup_providers.dart`) is the
+single seam: every restore entry point — the backup settings page, a backup
+history record, and the setup wizard's restore step — funnels through its
+`restoreFromBackup` or `restoreFromFilePath`.
+
+A new private `_runPostRestoreSafetyReview()` is called in both, between the
+existing `_syncActiveDiverAfterRestore()` and the
+`BackupOperationStatus.restoreComplete` transition. `isRestoring` stays
+`true` for its duration, so the restore barrier keeps the app blocked and
+nothing can touch the database mid-sweep.
+
+### 3. The sweep runs in a scratch `ProviderContainer`
+
+The restore path must not sweep on the live container. That container still
+holds values built against the **pre-restore** database:
+
+- `settingsProvider`, and therefore `gfLowProvider` / `gfHighProvider`,
+  which shape the ceiling curve that the `missedDecoStop` and
+  `highSurfaceGf` rules grade against.
+- `ProfileLegend`, which seeds `defaultCnsSource` / `defaultTtsSource` /
+  `defaultDecoStopSource` from `settingsProvider` and feeds
+  `overlayComputerDecoData`, changing the very curves the rules read.
+- Cached `analysisDiveProvider` and `profileAnalysisProvider` entries.
+
+Sweeping there would persist findings computed from the *replaced* device's
+settings, and because `saveReview` stamps the current
+`SafetyReviewService.engineVersion`, those wrong findings would never be
+recomputed.
+
+So `_runPostRestoreSafetyReview` creates a short-lived `ProviderContainer`
+after the database swap, runs the sweep in it, and disposes it in a
+`finally`. Every provider builds fresh against the restored database. The
+live container is left untouched — `restartApp()` is a soft restart that
+rebuilds `ProviderScope` under a fresh key, disposing every provider in it
+moments later anyway.
+
+To keep the scratch container faithful to the real one, `main.dart`'s
+override list moves into a shared function in a new file,
+`lib/core/providers/root_overrides.dart`:
+
+```dart
+List<Override> rootProviderOverrides({
+  required SharedPreferences prefs,
+  required LogFileService logFileService,
+}) => [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      logFileServiceProvider.overrideWithValue(logFileService),
+    ];
+```
+
+used by both `SubmersionRestart.build` (`lib/main.dart:136`) and the sweep,
+so the two cannot drift apart as overrides are added. Copying
+`logFileServiceProvider` is mandatory, not cosmetic: its default
+implementation throws `UnimplementedError` unless overridden.
+
+The container construction is wrapped in its own injectable seam so the
+notifier stays testable without building the real provider graph:
+
+```dart
+class PostRestoreSafetyReview {
+  final Ref _ref;
+  const PostRestoreSafetyReview(this._ref);
+
+  Future<SafetyReviewSweepResult> run({
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  });
+}
+
+final postRestoreSafetyReviewProvider =
+    Provider<PostRestoreSafetyReview>((ref) => PostRestoreSafetyReview(ref));
+```
+
+Tests override `postRestoreSafetyReviewProvider` with a fake that records the
+call, reports progress, or throws.
+
+### 4. Progress and the Skip button
+
+`BackupOperationState` gains a structured field rather than another English
+`message` string, so the barrier can localize:
+
+```dart
+class SafetyReviewSweepProgress {
+  final int done;
+  final int total;
+}
+
+// on BackupOperationState:
+final SafetyReviewSweepProgress? sweepProgress;
+```
+
+`RestoreBarrier`'s `_RestoreOverlay`
+(`lib/features/backup/presentation/widgets/restore_barrier.dart`) renders,
+when `sweepProgress` is non-null: a heading, a determinate
+`LinearProgressIndicator`, an "Analyzed {done} of {total}" label, and a Skip
+button. The notifier exposes `skipSafetyReviewSweep()`, which sets a private
+flag that the sweep's `isCancelled` callback reads.
+
+Skipping is lossless. Unswept dives still compute lazily on first view, and
+Settings → "Analyze all dives" remains available.
+
+The Bühlmann replay already runs on a background isolate via `compute()`
+inside `profileAnalysisProvider`, so the UI thread stays free to paint
+progress and accept the Skip tap.
+
+### 5. Data flow
+
+```
+restoreFromBackup / restoreFromFilePath
+  └─ BackupService.restore*         DB swapped + reopened, sync re-baselined
+  └─ _syncActiveDiverAfterRestore   (existing)
+  └─ _runPostRestoreSafetyReview    (new)
+       ├─ open scratch ProviderContainer(rootProviderOverrides(...))
+       ├─ getOrderedDiveIds(diverId: null)      every diver's dives
+       ├─ per dive: invalidate + read safetyReviewProvider  → saveReview
+       ├─ push {done, total} into BackupOperationState → RestoreBarrier
+       ├─ stop when the skip flag is set
+       └─ dispose the container (finally)
+  └─ state = restoreComplete → RestoreCompletePage → restartApp()
+```
+
+## Error handling
+
+1. **Per dive.** `try/catch`, increment `failed`, continue. One corrupt
+   profile must not end the sweep.
+2. **Per sweep.** The whole `_runPostRestoreSafetyReview` call is wrapped so
+   that no sweep failure can fail the restore. By the time it runs, the
+   database swap and the sync re-baseline have already succeeded — the
+   restore is done. A throw is logged and the flow proceeds to
+   `restoreComplete` regardless.
+3. **Container lifetime.** `dispose()` in a `finally`, so neither a throw nor
+   a Skip leaks the scratch container or its subscriptions.
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| Safety review disabled in restored settings | Sweep returns immediately; no progress UI |
+| Restored library has no dives | No-op; no progress UI |
+| Older-schema backup | Migration ladder creates the safety tables empty, then the sweep populates them — the case that most needs this fix |
+| Merge vs Replace mode | Both sweep. `rebaselineAfterRestore` has already cleared the sync position, so every row is pending regardless; the sweep's parent-dive HLC bumps add no meaningful extra push |
+| Skip tapped | Sweep stops at the current dive; the remainder computes lazily on view |
+| Wrong passphrase / invalid file | The restore throws before the sweep is reached; nothing runs |
+| Setup wizard restore | Uses `restoreFromFilePath` on the same notifier, so it is covered with no extra work |
+
+## Localization
+
+Three new keys in `lib/l10n/arb/app_en.arb`, translated across all eleven
+locales (ar, de, en, es, fr, he, hu, it, nl, pt, zh):
+
+- `backup_restore_safetyReview_title`
+- `backup_restore_safetyReview_progress` — `{done}`, `{total}` placeholders
+- `backup_restore_safetyReview_skip`
+
+`RestoreBarrier` wraps the whole app, which normally makes adding
+`context.l10n` to it hazardous for every existing widget test. Here the risk
+is bounded: `_RestoreOverlay` is only built when `isRestoring` is true, so
+tests that pump unrelated consumers never reach the new calls. Only
+`test/features/backup/presentation/widgets/restore_barrier_test.dart`, which
+forces that flag, needs `localizationsDelegates` wired.
+
+## Testing
+
+Tests are written before implementation.
+
+**Unit — `test/features/dive_log/presentation/providers/safety_review_sweep_test.dart`** (new),
+against a `ProviderContainer` over an in-memory database:
+
+- sweeps dives belonging to more than one diver when `diverId` is null
+- scopes to a single diver when `diverId` is supplied
+- stops early when `isCancelled` returns true, reporting `cancelled: true`
+- counts a dive that throws in `failed` and still sweeps the rest
+- returns a zero result without touching the repository when
+  `safetyReviewEnabledProvider` is false
+- reports monotonic `onProgress` callbacks ending at `total`
+
+**Provider — `test/features/backup/presentation/providers/backup_providers_restore_test.dart`** (existing):
+
+- a restore populates safety reviews for dives across multiple divers
+- a sweep that throws still reaches `BackupOperationStatus.restoreComplete`
+- `skipSafetyReviewSweep()` halts the sweep and the restore still completes
+
+**Widget — `test/features/backup/presentation/widgets/restore_barrier_test.dart`** (existing):
+
+- the progress label and Skip button render while `sweepProgress` is non-null
+- the overlay keeps its current spinner appearance when `sweepProgress` is null
+
+The Skip *tap* is asserted at the notifier level rather than the widget level:
+the button's callback resolves `backupOperationProvider.notifier`, which would
+drag the whole backup service graph into a widget test for no added coverage.
+
+**Regression:** the existing safety-settings tests must pass unchanged after
+`_analyzeAllDives` is extracted — that is the check that the extraction
+preserved behavior.
+
+Project gates: `dart format .`, `flutter analyze` clean, 80% coverage
+minimum.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `lib/features/dive_log/presentation/providers/safety_review_sweep.dart` | New: `SafetyReviewSweep`, result type, provider |
+| `lib/features/backup/presentation/providers/post_restore_safety_review.dart` | New: `PostRestoreSafetyReview` container seam |
+| `lib/features/settings/presentation/pages/safety_settings_page.dart` | `_analyzeAllDives` delegates to the sweep |
+| `lib/features/backup/presentation/providers/backup_providers.dart` | `_runPostRestoreSafetyReview`, `skipSafetyReviewSweep`, `sweepProgress` on the state |
+| `lib/features/backup/presentation/widgets/restore_barrier.dart` | Determinate progress, localized labels, Skip button |
+| `lib/core/providers/root_overrides.dart` | New: `rootProviderOverrides` |
+| `lib/main.dart` | Use `rootProviderOverrides` instead of an inline list |
+| `lib/l10n/arb/app_*.arb` | Three new keys across nine locales |

--- a/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
+++ b/docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md
@@ -197,6 +197,35 @@ final postRestoreSafetyReviewProvider =
 Tests override `postRestoreSafetyReviewProvider` with a fake that records the
 call, reports progress, or throws.
 
+### 3b. One pass per diver (added after PR #916 review)
+
+A single all-divers pass is not enough either. Decompression settings are
+per-diver (`diver_settings.gf_low` / `gf_high`, ppO2 ceilings, deco stop
+increment, CNS method), and `computeAnalysisForProfile` falls back to
+`gfLowProvider` / `gfHighProvider` whenever a dive carries no dive-specific
+GFs. Those derive from `settingsProvider`, which only ever loads the **active**
+diver's row. So one pass over every diver's dives would grade the non-active
+divers' dives with the active diver's gradient factors — and, because
+`saveReview` stamps the current `engineVersion`, persist them permanently.
+
+The sweep therefore runs one pass per diver, each in a container whose
+`settingsProvider` is overridden with a new `SettingsNotifier.preloaded`
+constructor pinned to that diver's stored `AppSettings` (no database load, no
+diver-change listener). Overriding the single root provider covers every
+derived provider, including `ProfileLegend`; enumerating the dozen derived
+providers would rot as the analysis pipeline grows. Dives whose `diver_id` is
+null (the column is nullable) get a trailing pass under the active diver's
+settings, matching the pre-existing behavior for unowned rows.
+
+Settings are read with `getSettingsForDiver`, deliberately not
+`getOrCreateSettingsForDiver`: the latter writes a defaults row when none
+exists, and a restore must not mint rows that would then sync out as genuine
+edits.
+
+Known limitation, pre-existing and out of scope: `getPreviousDiveTimes`
+(`dive_repository_impl.dart:4317`) is not diver-scoped, so residual CNS/tissue
+lookback can still pull a different diver's previous dive.
+
 A fresh container is necessary but not sufficient. `SettingsNotifier` starts at
 the `AppSettings` DEFAULTS and replaces its state asynchronously once the
 diver's row is read, so reading gradient factors immediately after building the
@@ -339,5 +368,5 @@ minimum.
 | `lib/features/backup/presentation/widgets/restore_barrier.dart` | Determinate progress, localized labels, Skip button |
 | `lib/core/providers/root_overrides.dart` | New: `rootProviderOverrides` |
 | `lib/main.dart` | Use `rootProviderOverrides` instead of an inline list |
-| `lib/features/settings/presentation/providers/settings_providers.dart` | Expose `initialLoad`; `mounted` guard on the post-await state write |
+| `lib/features/settings/presentation/providers/settings_providers.dart` | Expose `initialLoad`; `mounted` guard on the post-await state write; `SettingsNotifier.preloaded` for per-diver pinning |
 | `lib/l10n/arb/app_*.arb` | Three new keys across nine locales |

--- a/lib/core/providers/root_overrides.dart
+++ b/lib/core/providers/root_overrides.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// The provider overrides the app's root [ProviderScope] installs.
+///
+/// Shared with the post-restore safety sweep, which builds a second, throwaway
+/// container against the freshly restored database. Both must install the same
+/// overrides: [logFileServiceProvider] throws unless overridden, and a
+/// container missing [sharedPreferencesProvider] cannot resolve settings. Keep
+/// this the single definition so the two cannot drift apart.
+///
+/// Returns `List<dynamic>` because Riverpod 3 does not export its `Override`
+/// type, so it cannot be named in a signature -- the same constraint that
+/// makes `test/helpers/test_app.dart` take `List<dynamic>`. Call sites pass the
+/// result to `overrides:` with `.cast()`, which infers the real element type
+/// from context.
+List<dynamic> rootProviderOverrides({
+  required SharedPreferences prefs,
+  required LogFileService logFileService,
+}) {
+  return [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    logFileServiceProvider.overrideWithValue(logFileService),
+  ];
+}

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -203,21 +203,26 @@ class BackupOperationState {
     this.sweepProgress,
   });
 
+  /// [clearSweepProgress] separates "leave the sweep progress alone" from
+  /// "clear it". Omitting [sweepProgress] means unchanged, matching every other
+  /// field, so an unrelated `copyWith` cannot silently blank an in-flight
+  /// sweep; pass `clearSweepProgress: true` to actually null it out.
   BackupOperationState copyWith({
     BackupOperationStatus? status,
     String? message,
     BackupRecord? lastRecord,
     bool? isRestoring,
     SafetyReviewSweepProgress? sweepProgress,
+    bool clearSweepProgress = false,
   }) {
     return BackupOperationState(
       status: status ?? this.status,
       message: message ?? this.message,
       lastRecord: lastRecord ?? this.lastRecord,
       isRestoring: isRestoring ?? this.isRestoring,
-      // Deliberately not ??-merged: a null must be able to clear the progress
-      // when the sweep ends.
-      sweepProgress: sweepProgress,
+      sweepProgress: clearSweepProgress
+          ? null
+          : (sweepProgress ?? this.sweepProgress),
     );
   }
 }

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -15,6 +16,7 @@ import 'package:submersion/core/services/sync/crypto/sync_encryption_service.dar
 import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
 import 'package:submersion/features/backup/domain/entities/backup_settings.dart';
 import 'package:submersion/features/backup/domain/entities/restore_mode.dart';
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -166,6 +168,16 @@ final backupSettingsProvider =
 /// Status of a backup operation
 enum BackupOperationStatus { idle, inProgress, success, restoreComplete, error }
 
+/// Progress of the whole-library safety review sweep that runs at the end of a
+/// restore. Structured rather than a pre-formatted string so the restore
+/// barrier can render it in the user's language.
+class SafetyReviewSweepProgress {
+  final int done;
+  final int total;
+
+  const SafetyReviewSweepProgress({required this.done, required this.total});
+}
+
 /// State for backup/restore operations
 class BackupOperationState {
   final BackupOperationStatus status;
@@ -180,11 +192,15 @@ class BackupOperationState {
   /// this flag, not `status`.
   final bool isRestoring;
 
+  /// Non-null only while the post-restore safety sweep is running.
+  final SafetyReviewSweepProgress? sweepProgress;
+
   const BackupOperationState({
     this.status = BackupOperationStatus.idle,
     this.message,
     this.lastRecord,
     this.isRestoring = false,
+    this.sweepProgress,
   });
 
   BackupOperationState copyWith({
@@ -192,12 +208,16 @@ class BackupOperationState {
     String? message,
     BackupRecord? lastRecord,
     bool? isRestoring,
+    SafetyReviewSweepProgress? sweepProgress,
   }) {
     return BackupOperationState(
       status: status ?? this.status,
       message: message ?? this.message,
       lastRecord: lastRecord ?? this.lastRecord,
       isRestoring: isRestoring ?? this.isRestoring,
+      // Deliberately not ??-merged: a null must be able to clear the progress
+      // when the sweep ends.
+      sweepProgress: sweepProgress,
     );
   }
 }
@@ -205,7 +225,9 @@ class BackupOperationState {
 /// Notifier managing backup/restore/delete operations with state transitions
 class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
   final Ref _ref;
+  final _log = LoggerService.forClass(BackupOperationNotifier);
   Timer? _desktopBackupTimer;
+  bool _sweepSkipped = false;
 
   BackupOperationNotifier(this._ref) : super(const BackupOperationState()) {
     _startDesktopTimerIfNeeded();
@@ -219,6 +241,49 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
     await realignActiveDiverAfterDataReplace(
       _ref.read(sharedPreferencesProvider),
     );
+  }
+
+  /// Stops the post-restore safety sweep at the next dive boundary.
+  ///
+  /// Lossless: unswept dives still compute lazily when opened, and
+  /// Settings > Safety > "Analyze all dives" remains available.
+  void skipSafetyReviewSweep() {
+    _sweepSkipped = true;
+  }
+
+  /// Analyze the restored library so safety findings and dive-list badges are
+  /// present immediately, instead of only after each dive is opened.
+  ///
+  /// Deliberately cannot fail the restore: by the time this runs the database
+  /// swap and the sync re-baseline have already succeeded, so a sweep error is
+  /// logged and swallowed rather than turning a completed restore into a
+  /// failed one. isRestoring stays true so the barrier keeps the app blocked.
+  Future<void> _runPostRestoreSafetyReview() async {
+    _sweepSkipped = false;
+    try {
+      await _ref
+          .read(postRestoreSafetyReviewProvider)
+          .run(
+            onProgress: (done, total) {
+              if (!mounted || total == 0) return;
+              state = BackupOperationState(
+                status: BackupOperationStatus.inProgress,
+                isRestoring: true,
+                sweepProgress: SafetyReviewSweepProgress(
+                  done: done,
+                  total: total,
+                ),
+              );
+            },
+            isCancelled: () => _sweepSkipped,
+          );
+    } catch (e, st) {
+      _log.error(
+        'Post-restore safety review failed; the restore itself is unaffected',
+        error: e,
+        stackTrace: st,
+      );
+    }
   }
 
   /// Perform a manual backup
@@ -269,6 +334,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         onMigrationProgress: _onRestoreMigrationProgress,
       );
       await _syncActiveDiverAfterRestore();
+      await _runPostRestoreSafetyReview();
       state = const BackupOperationState(
         status: BackupOperationStatus.restoreComplete,
       );
@@ -404,6 +470,7 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         onMigrationProgress: _onRestoreMigrationProgress,
       );
       await _syncActiveDiverAfterRestore();
+      await _runPostRestoreSafetyReview();
       state = const BackupOperationState(
         status: BackupOperationStatus.restoreComplete,
       );

--- a/lib/features/backup/presentation/providers/post_restore_safety_review.dart
+++ b/lib/features/backup/presentation/providers/post_restore_safety_review.dart
@@ -1,23 +1,40 @@
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/providers/root_overrides.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+/// One sweep pass: the dives owned by [diverId], graded with that diver's
+/// settings. A null [diverId] is the leftover set of dives with no owner.
+typedef _SweepPass = ({String? diverId, List<String> diveIds});
+
 /// Runs the whole-library safety sweep that follows a database restore.
 ///
-/// The sweep deliberately runs in its own short-lived [ProviderContainer]
-/// rather than the live one. After a restore the live container still holds
-/// values built against the REPLACED database -- settingsProvider (and so the
-/// gradient factors that shape the ceiling curve the missedDecoStop and
-/// highSurfaceGf rules grade against), ProfileLegend's metric-source defaults,
-/// and cached analysisDiveProvider/profileAnalysisProvider entries. Computing
-/// findings from that state would persist the old device's settings into the
-/// restored library, and because saveReview stamps the current engineVersion
-/// they would never be recomputed.
+/// Two things make this more than a loop over every dive.
 ///
-/// A fresh container builds every provider against the restored database. The
-/// live container is left untouched; restartApp() rebuilds the root
+/// 1. It runs in short-lived [ProviderContainer]s, not the live one. After a
+///    restore the live container still holds values built against the REPLACED
+///    database -- settingsProvider (and so the gradient factors that shape the
+///    ceiling curve the missedDecoStop and highSurfaceGf rules grade against),
+///    ProfileLegend's metric-source defaults, and cached
+///    analysisDiveProvider/profileAnalysisProvider entries. Computing findings
+///    from that state would persist the old device's settings into the restored
+///    library, and because saveReview stamps the current engineVersion they
+///    would never be recomputed.
+///
+/// 2. It sweeps ONE DIVER AT A TIME, each in a container whose settingsProvider
+///    is pinned to that diver. Decompression settings are per-diver
+///    (`diver_settings.gf_low` / `gf_high`, ppO2 ceilings, deco stop
+///    increment), and `computeAnalysisForProfile` falls back to
+///    gfLowProvider/gfHighProvider whenever a dive carries no dive-specific
+///    GFs. A single all-divers pass would therefore grade every non-active
+///    diver's dives with the ACTIVE diver's gradient factors and persist the
+///    result -- stamped current, so never corrected.
+///
+/// The live container is left untouched; restartApp() rebuilds the root
 /// ProviderScope under a new key moments later and discards it anyway.
 class PostRestoreSafetyReview {
   final Ref _ref;
@@ -28,20 +45,114 @@ class PostRestoreSafetyReview {
     void Function(int done, int total)? onProgress,
     bool Function()? isCancelled,
   }) async {
-    final container = ProviderContainer(
-      overrides: rootProviderOverrides(
-        prefs: _ref.read(sharedPreferencesProvider),
-        logFileService: _ref.read(logFileServiceProvider),
-      ).cast(),
+    final diveRepo = _ref.read(diveRepositoryProvider);
+    final allIds = await diveRepo.getOrderedDiveIds();
+    final total = allIds.length;
+    onProgress?.call(0, total);
+    if (total == 0) return SafetyReviewSweepResult.empty;
+
+    final passes = await _buildPasses(allIds);
+    final settingsRepo = _ref.read(diverSettingsRepositoryProvider);
+
+    var swept = 0;
+    var failed = 0;
+    for (final pass in passes) {
+      if (isCancelled?.call() ?? false) {
+        return SafetyReviewSweepResult(
+          swept: swept,
+          failed: failed,
+          cancelled: true,
+        );
+      }
+      // Progress is reported across the whole library, not per pass, so the
+      // barrier's bar advances once from 0 to N rather than restarting per
+      // diver.
+      final base = swept;
+      final result = await _runPass(
+        pass,
+        settingsRepo,
+        onProgress: (done, _) => onProgress?.call(base + done, total),
+        isCancelled: isCancelled,
+      );
+      swept += result.swept;
+      failed += result.failed;
+      if (result.cancelled) {
+        return SafetyReviewSweepResult(
+          swept: swept,
+          failed: failed,
+          cancelled: true,
+        );
+      }
+    }
+
+    return SafetyReviewSweepResult(
+      swept: swept,
+      failed: failed,
+      cancelled: false,
     );
+  }
+
+  /// Groups [allIds] by owning diver, plus a trailing pass for dives whose
+  /// `diver_id` is null (the column is nullable; pre-multi-diver rows have no
+  /// owner). Divers with no dives are skipped so no empty container is built.
+  Future<List<_SweepPass>> _buildPasses(List<String> allIds) async {
+    final diveRepo = _ref.read(diveRepositoryProvider);
+    final divers = await _ref.read(diverRepositoryProvider).getAllDivers();
+
+    final passes = <_SweepPass>[];
+    final owned = <String>{};
+    for (final diver in divers) {
+      final ids = await diveRepo.getOrderedDiveIds(diverId: diver.id);
+      if (ids.isEmpty) continue;
+      owned.addAll(ids);
+      passes.add((diverId: diver.id, diveIds: ids));
+    }
+
+    final unowned = allIds.where((id) => !owned.contains(id)).toList();
+    if (unowned.isNotEmpty) {
+      passes.add((diverId: null, diveIds: unowned));
+    }
+    return passes;
+  }
+
+  Future<SafetyReviewSweepResult> _runPass(
+    _SweepPass pass,
+    DiverSettingsRepository settingsRepo, {
+    required void Function(int done, int total) onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    final overrides = rootProviderOverrides(
+      prefs: _ref.read(sharedPreferencesProvider),
+      logFileService: _ref.read(logFileServiceProvider),
+    );
+
+    final diverId = pass.diverId;
+    if (diverId != null) {
+      // Read-only on purpose: getOrCreateSettingsForDiver WRITES a defaults row
+      // when none exists, and a restore must not mint rows (they would sync out
+      // as real edits). A diver with no settings row falls back to the same
+      // defaults the app itself would show them.
+      final settings =
+          await settingsRepo.getSettingsForDiver(diverId) ??
+          const AppSettings();
+      overrides.add(
+        settingsProvider.overrideWith(
+          (ref) => SettingsNotifier.preloaded(
+            settingsRepo,
+            ref,
+            settings: settings,
+            diverId: diverId,
+          ),
+        ),
+      );
+    }
+
+    final container = ProviderContainer(overrides: overrides.cast());
     try {
-      // Settings load asynchronously: SettingsNotifier starts at the DEFAULTS
-      // and only adopts the diver's stored row once its first load completes.
-      // Sweeping before that would grade every dive against default gradient
-      // factors instead of the restored diver's -- the exact staleness this
-      // container exists to avoid -- and would also dispose the container out
-      // from under the in-flight load. A failed load is not fatal: the sweep
-      // then runs on the defaults, which is what happens everywhere else.
+      // For an owner-less pass this awaits the real async load of the active
+      // diver's settings (state starts at the AppSettings DEFAULTS until it
+      // completes). For a pinned pass it is already complete. A failed load is
+      // not fatal -- the sweep then runs on the defaults, as everywhere else.
       try {
         await container.read(settingsProvider.notifier).initialLoad;
       } catch (_) {
@@ -50,8 +161,7 @@ class PostRestoreSafetyReview {
       return await container
           .read(safetyReviewSweepProvider)
           .run(
-            // A restore replaces the whole library, so sweep every diver.
-            diverId: null,
+            diveIds: pass.diveIds,
             onProgress: onProgress,
             isCancelled: isCancelled,
           );

--- a/lib/features/backup/presentation/providers/post_restore_safety_review.dart
+++ b/lib/features/backup/presentation/providers/post_restore_safety_review.dart
@@ -1,0 +1,66 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/providers/root_overrides.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Runs the whole-library safety sweep that follows a database restore.
+///
+/// The sweep deliberately runs in its own short-lived [ProviderContainer]
+/// rather than the live one. After a restore the live container still holds
+/// values built against the REPLACED database -- settingsProvider (and so the
+/// gradient factors that shape the ceiling curve the missedDecoStop and
+/// highSurfaceGf rules grade against), ProfileLegend's metric-source defaults,
+/// and cached analysisDiveProvider/profileAnalysisProvider entries. Computing
+/// findings from that state would persist the old device's settings into the
+/// restored library, and because saveReview stamps the current engineVersion
+/// they would never be recomputed.
+///
+/// A fresh container builds every provider against the restored database. The
+/// live container is left untouched; restartApp() rebuilds the root
+/// ProviderScope under a new key moments later and discards it anyway.
+class PostRestoreSafetyReview {
+  final Ref _ref;
+
+  const PostRestoreSafetyReview(this._ref);
+
+  Future<SafetyReviewSweepResult> run({
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    final container = ProviderContainer(
+      overrides: rootProviderOverrides(
+        prefs: _ref.read(sharedPreferencesProvider),
+        logFileService: _ref.read(logFileServiceProvider),
+      ).cast(),
+    );
+    try {
+      // Settings load asynchronously: SettingsNotifier starts at the DEFAULTS
+      // and only adopts the diver's stored row once its first load completes.
+      // Sweeping before that would grade every dive against default gradient
+      // factors instead of the restored diver's -- the exact staleness this
+      // container exists to avoid -- and would also dispose the container out
+      // from under the in-flight load. A failed load is not fatal: the sweep
+      // then runs on the defaults, which is what happens everywhere else.
+      try {
+        await container.read(settingsProvider.notifier).initialLoad;
+      } catch (_) {
+        // Intentionally ignored; see above.
+      }
+      return await container
+          .read(safetyReviewSweepProvider)
+          .run(
+            // A restore replaces the whole library, so sweep every diver.
+            diverId: null,
+            onProgress: onProgress,
+            isCancelled: isCancelled,
+          );
+    } finally {
+      container.dispose();
+    }
+  }
+}
+
+final postRestoreSafetyReviewProvider = Provider<PostRestoreSafetyReview>(
+  (ref) => PostRestoreSafetyReview(ref),
+);

--- a/lib/features/backup/presentation/widgets/restore_barrier.dart
+++ b/lib/features/backup/presentation/widgets/restore_barrier.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 /// True while a database restore is running. Derived (not the whole operation
 /// state) so widgets rebuild only when this specific flag flips, and so tests
@@ -13,6 +14,11 @@ final restoreInProgressProvider = Provider<bool>(
 /// The current restore progress message (e.g. "Restoring backup...").
 final restoreMessageProvider = Provider<String?>(
   (ref) => ref.watch(backupOperationProvider.select((s) => s.message)),
+);
+
+/// Non-null only while the post-restore safety review sweep is running.
+final restoreSweepProgressProvider = Provider<SafetyReviewSweepProgress?>(
+  (ref) => ref.watch(backupOperationProvider.select((s) => s.sweepProgress)),
 );
 
 /// Wraps the whole app and, while a database restore is running, covers it with
@@ -38,7 +44,13 @@ class RestoreBarrier extends ConsumerWidget {
         child,
         if (isRestoring)
           Positioned.fill(
-            child: _RestoreOverlay(message: ref.watch(restoreMessageProvider)),
+            child: _RestoreOverlay(
+              message: ref.watch(restoreMessageProvider),
+              sweepProgress: ref.watch(restoreSweepProgressProvider),
+              onSkipSweep: () => ref
+                  .read(backupOperationProvider.notifier)
+                  .skipSafetyReviewSweep(),
+            ),
           ),
       ],
     );
@@ -46,16 +58,30 @@ class RestoreBarrier extends ConsumerWidget {
 }
 
 class _RestoreOverlay extends StatelessWidget {
-  const _RestoreOverlay({this.message});
+  const _RestoreOverlay({
+    this.message,
+    this.sweepProgress,
+    required this.onSkipSweep,
+  });
 
   final String? message;
+  final SafetyReviewSweepProgress? sweepProgress;
+  final VoidCallback onSkipSweep;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    // The provider already supplies an English progress string; fall back to a
-    // plain one if it is ever absent.
-    final label = message ?? 'Restoring backup...';
+    final sweep = sweepProgress;
+
+    // The provider supplies an English progress string for the swap phases;
+    // fall back to a plain one if it is ever absent. Once the safety sweep
+    // starts, its own localized label takes over.
+    final label = sweep != null
+        ? context.l10n.backup_restore_safetyReview_progress(
+            sweep.done,
+            sweep.total,
+          )
+        : (message ?? 'Restoring backup...');
 
     // Announce the busy/restoring state to screen readers as a live region, and
     // exclude the inner widgets' own semantics so the state is announced once
@@ -76,13 +102,14 @@ class _RestoreOverlay extends StatelessWidget {
                 borderRadius: BorderRadius.circular(12),
                 child: Padding(
                   padding: const EdgeInsets.all(24),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const CircularProgressIndicator(),
-                      const SizedBox(height: 16),
-                      Text(label, style: theme.textTheme.bodyMedium),
-                    ],
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 320),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: sweep == null
+                          ? _spinnerChildren(theme, label)
+                          : _sweepChildren(context, theme, sweep, label),
+                    ),
                   ),
                 ),
               ),
@@ -91,5 +118,41 @@ class _RestoreOverlay extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  List<Widget> _spinnerChildren(ThemeData theme, String label) {
+    return [
+      const CircularProgressIndicator(),
+      const SizedBox(height: 16),
+      Text(label, style: theme.textTheme.bodyMedium),
+    ];
+  }
+
+  List<Widget> _sweepChildren(
+    BuildContext context,
+    ThemeData theme,
+    SafetyReviewSweepProgress sweep,
+    String label,
+  ) {
+    return [
+      Text(
+        context.l10n.backup_restore_safetyReview_title,
+        style: theme.textTheme.titleMedium,
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: 16),
+      LinearProgressIndicator(
+        value: sweep.total == 0 ? null : sweep.done / sweep.total,
+      ),
+      const SizedBox(height: 12),
+      Text(label, style: theme.textTheme.bodyMedium),
+      const SizedBox(height: 8),
+      // Skipping is lossless: unswept dives still compute lazily when opened,
+      // and Settings > Safety > "Analyze all dives" remains available.
+      TextButton(
+        onPressed: onSkipSweep,
+        child: Text(context.l10n.backup_restore_safetyReview_skip),
+      ),
+    ];
   }
 }

--- a/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
@@ -1,0 +1,104 @@
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Outcome of a [SafetyReviewSweep.run].
+class SafetyReviewSweepResult {
+  /// Dives visited, including those that failed analysis. Mirrors the progress
+  /// bar's position rather than a success count.
+  final int swept;
+
+  /// Dives whose analysis threw. They stay unanalyzed and recompute lazily.
+  final int failed;
+
+  /// True when the caller's isCancelled callback stopped the sweep early.
+  final bool cancelled;
+
+  const SafetyReviewSweepResult({
+    required this.swept,
+    required this.failed,
+    required this.cancelled,
+  });
+
+  static const empty = SafetyReviewSweepResult(
+    swept: 0,
+    failed: 0,
+    cancelled: false,
+  );
+}
+
+/// Runs the post-dive safety review over a logbook, persisting each result.
+///
+/// Shared by the manual Settings sweep and the post-restore sweep so the
+/// invalidate-before-read invariant below lives in exactly one place.
+class SafetyReviewSweep {
+  final Ref _ref;
+
+  const SafetyReviewSweep(this._ref);
+
+  /// Analyzes every dive matching [diverId] (null means every diver).
+  ///
+  /// [onProgress] fires once with (0, total) to size a progress bar, then after
+  /// each dive. [isCancelled] is polled before each dive; returning true stops
+  /// the sweep and yields a result with `cancelled: true`. Cancelling is
+  /// lossless -- unswept dives still compute lazily on first view.
+  Future<SafetyReviewSweepResult> run({
+    String? diverId,
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    // Master toggle off: safetyReviewProvider would refuse to compute anyway,
+    // so skip the whole pass rather than issuing a marker read per dive.
+    if (!_ref.read(safetyReviewEnabledProvider)) {
+      return SafetyReviewSweepResult.empty;
+    }
+
+    final diveIds = await _ref
+        .read(diveRepositoryProvider)
+        .getOrderedDiveIds(diverId: diverId);
+
+    final total = diveIds.length;
+    onProgress?.call(0, total);
+
+    var swept = 0;
+    var failed = 0;
+
+    for (final diveId in diveIds) {
+      if (isCancelled?.call() ?? false) {
+        return SafetyReviewSweepResult(
+          swept: swept,
+          failed: failed,
+          cancelled: true,
+        );
+      }
+      try {
+        // Invalidate first. safetyReviewProvider is not autoDispose, so any
+        // dive whose detail page was opened this session holds a cached
+        // AsyncValue -- including a cached null from a dive opened mid-sync
+        // before its profile arrived. A bare read would return that cached
+        // value and never run the compute-through-cache, leaving the review
+        // missing until an app restart.
+        _ref.invalidate(safetyReviewProvider(diveId));
+        await _ref.read(safetyReviewProvider(diveId).future);
+      } catch (_) {
+        // A dive that fails analysis (corrupt profile) must not abort the
+        // sweep; it stays unanalyzed. Counted so callers can report honestly
+        // rather than implying every dive was analyzed.
+        failed++;
+      }
+      swept++;
+      onProgress?.call(swept, total);
+    }
+
+    return SafetyReviewSweepResult(
+      swept: swept,
+      failed: failed,
+      cancelled: false,
+    );
+  }
+}
+
+final safetyReviewSweepProvider = Provider<SafetyReviewSweep>(
+  (ref) => SafetyReviewSweep(ref),
+);

--- a/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
@@ -37,7 +37,13 @@ class SafetyReviewSweep {
 
   const SafetyReviewSweep(this._ref);
 
-  /// Analyzes every dive matching [diverId] (null means every diver).
+  /// Analyzes every dive matching [diverId] (null means every diver), or
+  /// exactly [diveIds] when supplied.
+  ///
+  /// Pass [diveIds] when the caller has already resolved the set and the
+  /// container is scoped to match it — the post-restore sweep runs one pass per
+  /// diver, each in a container pinned to that diver's settings, so it supplies
+  /// the ids rather than re-deriving them here. [diverId] is ignored then.
   ///
   /// [onProgress] fires once with (0, total) to size a progress bar, then after
   /// each dive. [isCancelled] is polled before each dive; returning true stops
@@ -45,6 +51,7 @@ class SafetyReviewSweep {
   /// lossless -- unswept dives still compute lazily on first view.
   Future<SafetyReviewSweepResult> run({
     String? diverId,
+    List<String>? diveIds,
     void Function(int done, int total)? onProgress,
     bool Function()? isCancelled,
   }) async {
@@ -54,17 +61,19 @@ class SafetyReviewSweep {
       return SafetyReviewSweepResult.empty;
     }
 
-    final diveIds = await _ref
-        .read(diveRepositoryProvider)
-        .getOrderedDiveIds(diverId: diverId);
+    final ids =
+        diveIds ??
+        await _ref
+            .read(diveRepositoryProvider)
+            .getOrderedDiveIds(diverId: diverId);
 
-    final total = diveIds.length;
+    final total = ids.length;
     onProgress?.call(0, total);
 
     var swept = 0;
     var failed = 0;
 
-    for (final diveId in diveIds) {
+    for (final diveId in ids) {
       if (isCancelled?.call() ?? false) {
         return SafetyReviewSweepResult(
           swept: swept,

--- a/lib/features/settings/presentation/pages/safety_settings_page.dart
+++ b/lib/features/settings/presentation/pages/safety_settings_page.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
-import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -23,7 +22,6 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
   bool _analyzing = false;
   int _analyzeDone = 0;
   int _analyzeTotal = 0;
-  int _analyzeFailed = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -150,53 +148,42 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
     // Scope the sweep to the active diver's logbook so "Analyze all dives"
     // only touches the current diver's dives, not every diver on the device.
     final diverId = ref.read(currentDiverIdProvider);
-    final diveIds = await ref
-        .read(diveRepositoryProvider)
-        .getOrderedDiveIds(diverId: diverId);
-    if (!mounted) return;
     setState(() {
       _analyzing = true;
       _analyzeDone = 0;
-      _analyzeTotal = diveIds.length;
-      _analyzeFailed = 0;
+      _analyzeTotal = 0;
     });
 
-    for (final diveId in diveIds) {
-      if (!mounted) return;
-      try {
-        // Force a rebuild before reading: safetyReviewProvider is not
-        // autoDispose, so any dive whose detail page was already opened this
-        // session holds a cached AsyncValue. A bare `ref.read(...future)` would
-        // return that cached value -- including a null cached when the dive was
-        // opened mid-sync before its profile arrived -- and never run the
-        // compute-through-cache, so the review would stay missing until an app
-        // restart. Invalidating first guarantees the engine runs (and persists)
-        // for every dive in the sweep.
-        ref.invalidate(safetyReviewProvider(diveId));
-        // Compute-through-cache: already-analyzed dives return after a cheap
-        // marker-row read; only unanalyzed dives run the profile replay.
-        await ref.read(safetyReviewProvider(diveId).future);
-      } catch (_) {
-        // A dive that fails analysis (corrupt profile) must not abort the
-        // sweep; it simply stays unanalyzed. Count it so completion can report
-        // failures honestly rather than implying every dive was analyzed.
-        _analyzeFailed++;
-      }
-      if (!mounted) return;
-      // _analyzeDone tracks dives swept (the progress bar's position), so it
-      // advances on failure too; the failure count is surfaced separately.
-      setState(() => _analyzeDone++);
-    }
+    final result = await ref
+        .read(safetyReviewSweepProvider)
+        .run(
+          diverId: diverId,
+          // _analyzeDone tracks dives swept (the progress bar's position), so
+          // it advances on failure too; the failure count is surfaced
+          // separately when the sweep completes.
+          onProgress: (done, total) {
+            if (!mounted) return;
+            setState(() {
+              _analyzeDone = done;
+              _analyzeTotal = total;
+            });
+          },
+          // Leaving the page ends the sweep, matching the previous
+          // `if (!mounted) return;` guard inside the loop.
+          isCancelled: () => !mounted,
+        );
 
     if (!mounted) return;
-    final failed = _analyzeFailed;
     setState(() => _analyzing = false);
+    if (result.cancelled) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(
-          failed == 0
+          result.failed == 0
               ? context.l10n.safetySettings_analyzeAll_done
-              : context.l10n.safetySettings_analyzeAll_doneWithErrors(failed),
+              : context.l10n.safetySettings_analyzeAll_doneWithErrors(
+                  result.failed,
+                ),
         ),
       ),
     );

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -938,6 +938,27 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> get initialLoad => _initialLoad;
 
+  /// A notifier pinned to already-loaded [settings] for [diverId], performing
+  /// no database read and installing no diver-change listener.
+  ///
+  /// For batch work that must grade ONE diver's data with THAT diver's
+  /// settings. The post-restore safety sweep builds one container per diver and
+  /// overrides [settingsProvider] with this, so every settings-derived provider
+  /// — gradient factors, ppO2 ceilings, deco stop increment, and
+  /// [ProfileLegend]'s metric-source defaults — resolves to the dive's owning
+  /// diver instead of whoever happens to be active. Overriding the one root
+  /// provider covers them all; overriding each derived provider would rot as
+  /// the analysis pipeline grows.
+  SettingsNotifier.preloaded(
+    this._repository,
+    this._ref, {
+    required AppSettings settings,
+    required String? diverId,
+  }) : super(settings) {
+    _validatedDiverId = diverId;
+    _initialLoad = Future<void>.value();
+  }
+
   SettingsNotifier(this._repository, this._ref) : super(const AppSettings()) {
     _initialLoad = _initializeAndLoad();
 

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -921,8 +921,25 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
   String? _validatedDiverId;
   bool _isLoading = false;
 
+  /// Completes when the constructor's first load has finished.
+  ///
+  /// State starts at `const AppSettings()` -- the DEFAULTS -- and is replaced
+  /// asynchronously once the diver's row is read. Anything that must act on the
+  /// stored settings rather than the defaults (notably the post-restore safety
+  /// sweep, which builds a throwaway container against a freshly restored
+  /// database) has to await this first.
+  ///
+  /// May complete with an error -- `_loadSettings` has a `finally` but no
+  /// `catch` -- so awaiting callers must guard and fall back to the defaults
+  /// still held in [state]. Merely storing the future adds no listener, so
+  /// failures surface to the zone handler exactly as they did when the
+  /// constructor called `_initializeAndLoad()` fire-and-forget.
+  late final Future<void> _initialLoad;
+
+  Future<void> get initialLoad => _initialLoad;
+
   SettingsNotifier(this._repository, this._ref) : super(const AppSettings()) {
-    _initializeAndLoad();
+    _initialLoad = _initializeAndLoad();
 
     // Listen for diver changes and reload settings
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -1036,6 +1053,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
       // Load settings from database
       final settings = await _repository.getOrCreateSettingsForDiver(diverId);
+      // The notifier can be disposed while this read is in flight -- a
+      // ProviderScope teardown (restartApp's soft restart, or the throwaway
+      // container the post-restore safety sweep builds) tears down mid-load,
+      // and the diver-id listener can start a second load whose completion
+      // nobody awaits. Assigning state after dispose throws.
+      if (!mounted) return;
       state = settings.copyWith(
         fullscreenTileOrder: fullscreenTileOrder,
         fullscreenHiddenTiles: fullscreenHiddenTiles,

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "سيتم إنشاء نسخة احتياطية آمنة من بياناتك الحالية تلقائياً قبل الاستعادة.",
   "backup_restore_dialog_title": "استعادة النسخة الاحتياطية",
   "backup_restore_dialog_warning": "سيؤدي هذا إلى استبدال جميع البيانات الحالية ببيانات النسخة الاحتياطية. لا يمكن التراجع عن هذا الإجراء.",
+  "backup_restore_safetyReview_progress": "تم تحليل {done} من {total} غطسة",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "تخطي",
+  "backup_restore_safetyReview_title": "جارٍ تشغيل مراجعة السلامة",
   "backup_schedule_enabled": "نسخ احتياطي تلقائي",
   "backup_schedule_enabled_subtitle": "نسخ البيانات احتياطياً وفقاً لجدول زمني",
   "backup_schedule_frequency": "التكرار",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Eine Sicherheitskopie Ihrer aktuellen Daten wird automatisch vor der Wiederherstellung erstellt.",
   "backup_restore_dialog_title": "Sicherung Wiederherstellen",
   "backup_restore_dialog_warning": "Dies ersetzt ALLE aktuellen Daten durch die Sicherungsdaten. Diese Aktion kann nicht rückgängig gemacht werden.",
+  "backup_restore_safetyReview_progress": "{done} von {total} Tauchgängen analysiert",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Überspringen",
+  "backup_restore_safetyReview_title": "Sicherheitsprüfung läuft",
   "backup_schedule_enabled": "Automatische Sicherungen",
   "backup_schedule_enabled_subtitle": "Daten nach Zeitplan sichern",
   "backup_schedule_frequency": "Häufigkeit",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -713,6 +713,19 @@
   "backup_restore_dialog_safetyNote": "A safety backup of your current data will be created automatically before restoring.",
   "backup_restore_dialog_title": "Restore Backup",
   "backup_restore_dialog_warning": "This will replace ALL current data with the backup data. This action cannot be undone.",
+  "backup_restore_safetyReview_progress": "Analyzed {done} of {total} dives",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Skip",
+  "backup_restore_safetyReview_title": "Running the safety review",
   "backup_restoreComplete_continue": "Continue",
   "backup_restoreComplete_description": "Your data has been restored successfully. Tap continue to reload the app with your restored data.",
   "backup_restoreComplete_title": "Restore Complete",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Se creará automáticamente una copia de seguridad de sus datos actuales antes de restaurar.",
   "backup_restore_dialog_title": "Restaurar Copia",
   "backup_restore_dialog_warning": "Esto reemplazará TODOS los datos actuales con los datos de la copia. Esta acción no se puede deshacer.",
+  "backup_restore_safetyReview_progress": "Analizadas {done} de {total} inmersiones",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Omitir",
+  "backup_restore_safetyReview_title": "Ejecutando la revisión de seguridad",
   "backup_schedule_enabled": "Copias automáticas",
   "backup_schedule_enabled_subtitle": "Hacer copias de seguridad de forma programada",
   "backup_schedule_frequency": "Frecuencia",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Une sauvegarde de sécurité de vos données actuelles sera créée automatiquement avant la restauration.",
   "backup_restore_dialog_title": "Restaurer la Sauvegarde",
   "backup_restore_dialog_warning": "Cela remplacera TOUTES les données actuelles par les données de la sauvegarde. Cette action est irréversible.",
+  "backup_restore_safetyReview_progress": "{done} plongées sur {total} analysées",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Ignorer",
+  "backup_restore_safetyReview_title": "Analyse de sécurité en cours",
   "backup_schedule_enabled": "Sauvegardes automatiques",
   "backup_schedule_enabled_subtitle": "Sauvegarder vos données selon un calendrier",
   "backup_schedule_frequency": "Fréquence",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "גיבוי בטיחות של הנתונים הנוכחיים שלך ייווצר אוטומטית לפני השחזור.",
   "backup_restore_dialog_title": "שחזור גיבוי",
   "backup_restore_dialog_warning": "פעולה זו תחליף את כל הנתונים הנוכחיים בנתוני הגיבוי. לא ניתן לבטל פעולה זו.",
+  "backup_restore_safetyReview_progress": "נותחו {done} מתוך {total} צלילות",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "דלג",
+  "backup_restore_safetyReview_title": "מריץ את סקירת הבטיחות",
   "backup_schedule_enabled": "גיבויים אוטומטיים",
   "backup_schedule_enabled_subtitle": "גבה את הנתונים לפי לוח זמנים",
   "backup_schedule_frequency": "תדירות",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "A jelenlegi adatokról automatikusan biztonsági mentés készül a visszaállítás előtt.",
   "backup_restore_dialog_title": "Mentés Visszaállítása",
   "backup_restore_dialog_warning": "Ez MINDEN jelenlegi adatot lecserél a mentés adataival. Ez a művelet nem vonható vissza.",
+  "backup_restore_safetyReview_progress": "{done} / {total} merülés elemezve",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Kihagyás",
+  "backup_restore_safetyReview_title": "Biztonsági ellenőrzés folyamatban",
   "backup_schedule_enabled": "Automatikus mentések",
   "backup_schedule_enabled_subtitle": "Adatok mentése ütemezés szerint",
   "backup_schedule_frequency": "Gyakoriság",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Un backup di sicurezza dei dati correnti verrà creato automaticamente prima del ripristino.",
   "backup_restore_dialog_title": "Ripristina Backup",
   "backup_restore_dialog_warning": "Questo sostituirà TUTTI i dati correnti con i dati del backup. Questa azione non può essere annullata.",
+  "backup_restore_safetyReview_progress": "Analizzate {done} di {total} immersioni",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Salta",
+  "backup_restore_safetyReview_title": "Revisione di sicurezza in corso",
   "backup_schedule_enabled": "Backup automatici",
   "backup_schedule_enabled_subtitle": "Esegui il backup dei dati secondo una pianificazione",
   "backup_schedule_frequency": "Frequenza",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -1729,6 +1729,24 @@ abstract class AppLocalizations {
   /// **'This will replace ALL current data with the backup data. This action cannot be undone.'**
   String get backup_restore_dialog_warning;
 
+  /// No description provided for @backup_restore_safetyReview_progress.
+  ///
+  /// In en, this message translates to:
+  /// **'Analyzed {done} of {total} dives'**
+  String backup_restore_safetyReview_progress(int done, int total);
+
+  /// No description provided for @backup_restore_safetyReview_skip.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip'**
+  String get backup_restore_safetyReview_skip;
+
+  /// No description provided for @backup_restore_safetyReview_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Running the safety review'**
+  String get backup_restore_safetyReview_title;
+
   /// No description provided for @backup_restoreComplete_continue.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -990,6 +990,17 @@ class AppLocalizationsAr extends AppLocalizations {
       'سيؤدي هذا إلى استبدال جميع البيانات الحالية ببيانات النسخة الاحتياطية. لا يمكن التراجع عن هذا الإجراء.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'تم تحليل $done من $total غطسة';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'تخطي';
+
+  @override
+  String get backup_restore_safetyReview_title => 'جارٍ تشغيل مراجعة السلامة';
+
+  @override
   String get backup_restoreComplete_continue => 'متابعة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -997,6 +997,17 @@ class AppLocalizationsDe extends AppLocalizations {
       'Dies ersetzt ALLE aktuellen Daten durch die Sicherungsdaten. Diese Aktion kann nicht rückgängig gemacht werden.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return '$done von $total Tauchgängen analysiert';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Überspringen';
+
+  @override
+  String get backup_restore_safetyReview_title => 'Sicherheitsprüfung läuft';
+
+  @override
   String get backup_restoreComplete_continue => 'Weiter';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -982,6 +982,17 @@ class AppLocalizationsEn extends AppLocalizations {
       'This will replace ALL current data with the backup data. This action cannot be undone.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'Analyzed $done of $total dives';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Skip';
+
+  @override
+  String get backup_restore_safetyReview_title => 'Running the safety review';
+
+  @override
   String get backup_restoreComplete_continue => 'Continue';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -1003,6 +1003,18 @@ class AppLocalizationsEs extends AppLocalizations {
       'Esto reemplazará TODOS los datos actuales con los datos de la copia. Esta acción no se puede deshacer.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'Analizadas $done de $total inmersiones';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Omitir';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Ejecutando la revisión de seguridad';
+
+  @override
   String get backup_restoreComplete_continue => 'Continuar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -1004,6 +1004,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Cela remplacera TOUTES les données actuelles par les données de la sauvegarde. Cette action est irréversible.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return '$done plongées sur $total analysées';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Ignorer';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Analyse de sécurité en cours';
+
+  @override
   String get backup_restoreComplete_continue => 'Continuer';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -976,6 +976,17 @@ class AppLocalizationsHe extends AppLocalizations {
       'פעולה זו תחליף את כל הנתונים הנוכחיים בנתוני הגיבוי. לא ניתן לבטל פעולה זו.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'נותחו $done מתוך $total צלילות';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'דלג';
+
+  @override
+  String get backup_restore_safetyReview_title => 'מריץ את סקירת הבטיחות';
+
+  @override
   String get backup_restoreComplete_continue => 'המשך';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -996,6 +996,18 @@ class AppLocalizationsHu extends AppLocalizations {
       'Ez MINDEN jelenlegi adatot lecserél a mentés adataival. Ez a művelet nem vonható vissza.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return '$done / $total merülés elemezve';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Kihagyás';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Biztonsági ellenőrzés folyamatban';
+
+  @override
   String get backup_restoreComplete_continue => 'Tovabb';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -998,6 +998,18 @@ class AppLocalizationsIt extends AppLocalizations {
       'Questo sostituirà TUTTI i dati correnti con i dati del backup. Questa azione non può essere annullata.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'Analizzate $done di $total immersioni';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Salta';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Revisione di sicurezza in corso';
+
+  @override
   String get backup_restoreComplete_continue => 'Continua';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -993,6 +993,18 @@ class AppLocalizationsNl extends AppLocalizations {
       'Dit vervangt ALLE huidige gegevens door de back-upgegevens. Deze actie kan niet ongedaan worden gemaakt.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return '$done van $total duiken geanalyseerd';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Overslaan';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Veiligheidscontrole wordt uitgevoerd';
+
+  @override
   String get backup_restoreComplete_continue => 'Doorgaan';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -997,6 +997,18 @@ class AppLocalizationsPt extends AppLocalizations {
       'Isso substituirá TODOS os dados atuais pelos dados do backup. Esta ação não pode ser desfeita.';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return 'Analisados $done de $total mergulhos';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => 'Ignorar';
+
+  @override
+  String get backup_restore_safetyReview_title =>
+      'Executando a revisão de segurança';
+
+  @override
   String get backup_restoreComplete_continue => 'Continuar';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -932,6 +932,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get backup_restore_dialog_warning => '这将用备份数据替换所有当前数据。此操作无法撤消。';
 
   @override
+  String backup_restore_safetyReview_progress(int done, int total) {
+    return '已分析 $done / $total 次潜水';
+  }
+
+  @override
+  String get backup_restore_safetyReview_skip => '跳过';
+
+  @override
+  String get backup_restore_safetyReview_title => '正在运行安全审查';
+
+  @override
   String get backup_restoreComplete_continue => '继续';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Er wordt automatisch een veiligheidsback-up van uw huidige gegevens gemaakt voor het herstellen.",
   "backup_restore_dialog_title": "Back-up Herstellen",
   "backup_restore_dialog_warning": "Dit vervangt ALLE huidige gegevens door de back-upgegevens. Deze actie kan niet ongedaan worden gemaakt.",
+  "backup_restore_safetyReview_progress": "{done} van {total} duiken geanalyseerd",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Overslaan",
+  "backup_restore_safetyReview_title": "Veiligheidscontrole wordt uitgevoerd",
   "backup_schedule_enabled": "Automatische back-ups",
   "backup_schedule_enabled_subtitle": "Maak back-ups van uw gegevens volgens schema",
   "backup_schedule_frequency": "Frequentie",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -408,6 +408,19 @@
   "backup_restore_dialog_safetyNote": "Um backup de segurança dos seus dados atuais será criado automaticamente antes da restauração.",
   "backup_restore_dialog_title": "Restaurar Backup",
   "backup_restore_dialog_warning": "Isso substituirá TODOS os dados atuais pelos dados do backup. Esta ação não pode ser desfeita.",
+  "backup_restore_safetyReview_progress": "Analisados {done} de {total} mergulhos",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "Ignorar",
+  "backup_restore_safetyReview_title": "Executando a revisão de segurança",
   "backup_schedule_enabled": "Backups automáticos",
   "backup_schedule_enabled_subtitle": "Fazer backup dos dados em um agendamento",
   "backup_schedule_frequency": "Frequência",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -502,6 +502,19 @@
   "backup_restore_dialog_safetyNote": "恢复前将自动创建当前数据的安全备份。",
   "backup_restore_dialog_title": "恢复备份",
   "backup_restore_dialog_warning": "这将用备份数据替换所有当前数据。此操作无法撤消。",
+  "backup_restore_safetyReview_progress": "已分析 {done} / {total} 次潜水",
+  "@backup_restore_safetyReview_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "backup_restore_safetyReview_skip": "跳过",
+  "backup_restore_safetyReview_title": "正在运行安全审查",
   "backup_schedule_enabled": "自动备份",
   "backup_schedule_enabled_subtitle": "按计划备份您的数据",
   "backup_schedule_frequency": "频率",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/network/trusted_http_overrides.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/providers/root_overrides.dart';
 import 'package:submersion/core/services/global_error_handler.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -16,8 +17,6 @@ import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
 import 'package:submersion/features/data_quality/presentation/providers/quality_detector_toggles.dart';
 import 'package:submersion/features/media/data/network_cache_config.dart';
-import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
-import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 // main() and the _bootstrap signature are untestable startup wiring (they
 // never run under test); the zone-error logging is unit-tested via
@@ -133,10 +132,10 @@ class SubmersionRestart extends StatelessWidget {
       builder: (context, key, _) {
         return ProviderScope(
           key: key,
-          overrides: [
-            sharedPreferencesProvider.overrideWithValue(prefs),
-            logFileServiceProvider.overrideWithValue(logFileService),
-          ],
+          overrides: rootProviderOverrides(
+            prefs: prefs,
+            logFileService: logFileService,
+          ).cast(),
           child: const SubmersionApp(),
         );
       },

--- a/test/core/providers/root_overrides_test.dart
+++ b/test/core/providers/root_overrides_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/providers/root_overrides.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('supplies both providers that would otherwise throw', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    // Never initialized, so no directory is created; the override only has to
+    // hand back the same instance.
+    final logFileService = LogFileService(logDirectory: '/tmp/submersion-test');
+
+    final container = ProviderContainer(
+      overrides: rootProviderOverrides(
+        prefs: prefs,
+        logFileService: logFileService,
+      ).cast(),
+    );
+    addTearDown(container.dispose);
+
+    expect(container.read(sharedPreferencesProvider), same(prefs));
+    expect(container.read(logFileServiceProvider), same(logFileService));
+  });
+}

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -452,6 +452,30 @@ void main() {
     expect(service.lastSecret, 'pw');
   });
 
+  test('copyWith preserves sweep progress unless asked to clear it', () {
+    const state = BackupOperationState(
+      status: BackupOperationStatus.inProgress,
+      isRestoring: true,
+      sweepProgress: SafetyReviewSweepProgress(done: 3, total: 10),
+    );
+
+    // An unrelated copyWith must not blank an in-flight sweep.
+    final touched = state.copyWith(message: 'something else');
+    expect(touched.sweepProgress, isNotNull);
+    expect(touched.sweepProgress!.done, 3);
+
+    expect(state.copyWith(clearSweepProgress: true).sweepProgress, isNull);
+    expect(
+      state
+          .copyWith(
+            sweepProgress: const SafetyReviewSweepProgress(done: 4, total: 10),
+          )
+          .sweepProgress!
+          .done,
+      4,
+    );
+  });
+
   test('a restore runs the post-restore safety sweep', () async {
     final sweep = _FakePostRestoreSafetyReview();
     final container = makeContainer(sweep: sweep);

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -14,6 +14,8 @@ import 'package:submersion/core/services/sync/crypto/sync_encryption_service.dar
     show WrongPassphraseException;
 import 'package:submersion/features/backup/domain/exceptions/backup_encrypted_exception.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -109,6 +111,37 @@ class _RecordingBackupService extends BackupService {
   }
 }
 
+/// Stands in for the real post-restore sweep so the notifier can be exercised
+/// without building a second provider graph.
+class _FakePostRestoreSafetyReview implements PostRestoreSafetyReview {
+  int calls = 0;
+  bool throwOnRun = false;
+
+  /// Progress pairs emitted before returning.
+  List<(int, int)> emit = const [];
+
+  /// Captured so a test can assert the notifier's skip flag reaches the sweep.
+  bool Function()? capturedIsCancelled;
+
+  @override
+  Future<SafetyReviewSweepResult> run({
+    void Function(int done, int total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    calls++;
+    capturedIsCancelled = isCancelled;
+    if (throwOnRun) throw StateError('sweep exploded');
+    for (final (done, total) in emit) {
+      onProgress?.call(done, total);
+    }
+    return SafetyReviewSweepResult(
+      swept: emit.isEmpty ? 0 : emit.last.$1,
+      failed: 0,
+      cancelled: isCancelled?.call() ?? false,
+    );
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -126,16 +159,38 @@ void main() {
     DatabaseService.instance.resetForTesting();
   });
 
-  ProviderContainer makeContainer({bool overrideService = true}) {
+  ProviderContainer makeContainer({
+    bool overrideService = true,
+    PostRestoreSafetyReview? sweep,
+  }) {
     final container = ProviderContainer(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         cloudStorageProviderProvider.overrideWithValue(null),
         if (overrideService) backupServiceProvider.overrideWithValue(service),
+        // Default to a no-op sweep so the pre-existing restore tests never
+        // build the real one (which would open a second provider container
+        // against the test database).
+        postRestoreSafetyReviewProvider.overrideWithValue(
+          sweep ?? _FakePostRestoreSafetyReview(),
+        ),
       ],
     );
     addTearDown(container.dispose);
     return container;
+  }
+
+  /// A throwaway backup file for the restoreFromFilePath entry point.
+  Future<String> tempBackupPath(String tag) async {
+    final tmp = File(
+      '${Directory.systemTemp.path}/notifier_restore_${tag}_'
+      '${DateTime.now().microsecondsSinceEpoch}.db',
+    );
+    await tmp.writeAsString('db');
+    addTearDown(() async {
+      if (await tmp.exists()) await tmp.delete();
+    });
+    return tmp.path;
   }
 
   test('restoreFromFilePath threads the mode and completes', () async {
@@ -395,6 +450,97 @@ void main() {
         .read(backupOperationProvider.notifier)
         .restoreFromBackup(record, encryptionSecret: 'pw');
     expect(service.lastSecret, 'pw');
+  });
+
+  test('a restore runs the post-restore safety sweep', () async {
+    final sweep = _FakePostRestoreSafetyReview();
+    final container = makeContainer(sweep: sweep);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath(await tempBackupPath('sweep'));
+
+    expect(sweep.calls, 1);
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.restoreComplete,
+    );
+  });
+
+  test('restoreFromBackup runs the sweep too', () async {
+    final sweep = _FakePostRestoreSafetyReview();
+    final container = makeContainer(sweep: sweep);
+    final record = BackupRecord(
+      id: 'r1',
+      filename: 'b.db',
+      timestamp: DateTime(2026),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+    );
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromBackup(record);
+
+    expect(sweep.calls, 1);
+  });
+
+  test('sweep progress is published while the barrier is still up', () async {
+    final sweep = _FakePostRestoreSafetyReview()..emit = const [(0, 2), (1, 2)];
+    final container = makeContainer(sweep: sweep);
+
+    final seen = <BackupOperationState>[];
+    final sub = container.listen(
+      backupOperationProvider,
+      (_, next) => seen.add(next),
+    );
+    addTearDown(sub.close);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath(await tempBackupPath('progress'));
+
+    final published = seen
+        .where((s) => s.sweepProgress != null)
+        .map((s) => s.sweepProgress!)
+        .toList();
+    expect(published, isNotEmpty);
+    expect(published.last.done, 1);
+    expect(published.last.total, 2);
+    // The barrier must stay up for the whole sweep, or the user could touch
+    // the database while it is being analyzed.
+    expect(
+      seen.where((s) => s.sweepProgress != null).every((s) => s.isRestoring),
+      isTrue,
+    );
+  });
+
+  test('a sweep failure still completes the restore', () async {
+    final sweep = _FakePostRestoreSafetyReview()..throwOnRun = true;
+    final container = makeContainer(sweep: sweep);
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromFilePath(await tempBackupPath('boom'));
+
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.restoreComplete,
+      reason: 'the data restore already succeeded; the sweep is a convenience',
+    );
+  });
+
+  test('skipSafetyReviewSweep is visible to the running sweep', () async {
+    final sweep = _FakePostRestoreSafetyReview();
+    final container = makeContainer(sweep: sweep);
+
+    final notifier = container.read(backupOperationProvider.notifier);
+    await notifier.restoreFromFilePath(await tempBackupPath('skip'));
+
+    expect(sweep.capturedIsCancelled, isNotNull);
+    expect(sweep.capturedIsCancelled!(), isFalse);
+    notifier.skipSafetyReviewSweep();
+    expect(sweep.capturedIsCancelled!(), isTrue);
   });
 
   test('backup encryption providers wire their real dependencies', () async {

--- a/test/features/backup/presentation/providers/post_restore_safety_review_test.dart
+++ b/test/features/backup/presentation/providers/post_restore_safety_review_test.dart
@@ -17,37 +17,63 @@ void main() {
   late AppDatabase db;
   late SharedPreferences prefs;
 
-  setUp(() async {
-    db = await setUpTestDatabase();
-    SharedPreferences.setMockInitialValues({});
-    prefs = await SharedPreferences.getInstance();
+  final ts = DateTime.utc(2026, 8, 8).millisecondsSinceEpoch;
 
-    final ts = DateTime.utc(2026, 8, 8).millisecondsSinceEpoch;
-    // Foreign keys are enforced, so the owning diver must exist first.
+  Future<void> insertDiver(String id, {bool isDefault = false}) async {
     await db
         .into(db.divers)
         .insert(
           DiversCompanion(
-            id: const Value('diver-a'),
-            name: const Value('Diver A'),
-            // Default diver: with no id in SharedPreferences, SettingsNotifier
-            // falls back to getDefaultDiver() to decide whose settings to load.
-            isDefault: const Value(true),
+            id: Value(id),
+            name: Value('Diver $id'),
+            isDefault: Value(isDefault),
             createdAt: Value(ts),
             updatedAt: Value(ts),
           ),
         );
+  }
+
+  Future<void> insertDive(String id, String? diverId) async {
     await db
         .into(db.dives)
         .insert(
           DivesCompanion(
-            id: const Value('d1'),
-            diverId: const Value('diver-a'),
+            id: Value(id),
+            diverId: Value(diverId),
             diveDateTime: Value(ts),
             createdAt: Value(ts),
             updatedAt: Value(ts),
           ),
         );
+  }
+
+  Future<void> insertSettings(
+    String rowId,
+    String diverId, {
+    required bool safetyReviewEnabled,
+  }) async {
+    await db
+        .into(db.diverSettings)
+        .insert(
+          DiverSettingsCompanion(
+            id: Value(rowId),
+            diverId: Value(diverId),
+            safetyReviewEnabled: Value(safetyReviewEnabled),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    // Foreign keys are enforced, so the owning diver must exist first.
+    // Default diver: with no id in SharedPreferences, SettingsNotifier falls
+    // back to getDefaultDiver() to decide whose settings to load.
+    await insertDiver('diver-a', isDefault: true);
+    await insertDive('d1', 'diver-a');
   });
 
   tearDown(() => tearDownTestDatabase());
@@ -87,17 +113,7 @@ void main() {
   // proof -- the sweep can only no-op if it actually read that row, since the
   // default for safetyReviewEnabled is on.
   test('reads settings from the restored database, not the defaults', () async {
-    await db
-        .into(db.diverSettings)
-        .insert(
-          DiverSettingsCompanion(
-            id: const Value('s1'),
-            diverId: const Value('diver-a'),
-            safetyReviewEnabled: const Value(false),
-            createdAt: Value(DateTime.utc(2026, 8, 8).millisecondsSinceEpoch),
-            updatedAt: Value(DateTime.utc(2026, 8, 8).millisecondsSinceEpoch),
-          ),
-        );
+    await insertSettings('s1', 'diver-a', safetyReviewEnabled: false);
 
     final result = await makeContainer()
         .read(postRestoreSafetyReviewProvider)
@@ -108,6 +124,43 @@ void main() {
       0,
       reason: 'the restored diver has the safety review switched off',
     );
+  });
+
+  // Regression for PR #916 review: a single all-divers pass graded every
+  // non-active diver's dives with the ACTIVE diver's settings and persisted the
+  // result. Decompression settings are per-diver, so each diver must be swept
+  // in a container pinned to their own row. Opposite master toggles are the
+  // cheapest observable proof that the pinning happens.
+  test(
+    'grades each diver with their own settings, not the active one',
+    () async {
+      await insertSettings('s1', 'diver-a', safetyReviewEnabled: true);
+      await insertDiver('diver-b');
+      await insertDive('d2', 'diver-b');
+      await insertSettings('s2', 'diver-b', safetyReviewEnabled: false);
+
+      final result = await makeContainer()
+          .read(postRestoreSafetyReviewProvider)
+          .run();
+
+      expect(
+        result.swept,
+        1,
+        reason:
+            "only diver-a's dive is swept; diver-b has the review switched off, "
+            'which a single active-diver-scoped pass would have ignored',
+      );
+    },
+  );
+
+  test('sweeps dives that have no owning diver', () async {
+    await insertDive('d-orphan', null);
+
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run();
+
+    expect(result.swept, 2, reason: 'the owner-less dive gets its own pass');
   });
 
   test('honours cancellation', () async {

--- a/test/features/backup/presentation/providers/post_restore_safety_review_test.dart
+++ b/test/features/backup/presentation/providers/post_restore_safety_review_test.dart
@@ -1,0 +1,121 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/backup/presentation/providers/post_restore_safety_review.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+
+    final ts = DateTime.utc(2026, 8, 8).millisecondsSinceEpoch;
+    // Foreign keys are enforced, so the owning diver must exist first.
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: const Value('diver-a'),
+            name: const Value('Diver A'),
+            // Default diver: with no id in SharedPreferences, SettingsNotifier
+            // falls back to getDefaultDiver() to decide whose settings to load.
+            isDefault: const Value(true),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diverId: const Value('diver-a'),
+            diveDateTime: Value(ts),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        // Never initialized, so no directory is created.
+        logFileServiceProvider.overrideWithValue(
+          LogFileService(logDirectory: '/tmp/submersion-test'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('runs a whole-library sweep and reports progress', () async {
+    final seen = <(int, int)>[];
+
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run(onProgress: (done, total) => seen.add((done, total)));
+
+    // The dive has no profile, so nothing is persisted -- but it is visited,
+    // which is what proves the scratch container reached the restored data.
+    expect(result.swept, 1);
+    expect(result.cancelled, isFalse);
+    expect(seen.first, (0, 1));
+    expect(seen.last, (1, 1));
+  });
+
+  // The whole point of the throwaway container: it must grade against the
+  // RESTORED database's settings, not the process-wide defaults. Turning the
+  // master toggle off in the restored diver's row is the cheapest observable
+  // proof -- the sweep can only no-op if it actually read that row, since the
+  // default for safetyReviewEnabled is on.
+  test('reads settings from the restored database, not the defaults', () async {
+    await db
+        .into(db.diverSettings)
+        .insert(
+          DiverSettingsCompanion(
+            id: const Value('s1'),
+            diverId: const Value('diver-a'),
+            safetyReviewEnabled: const Value(false),
+            createdAt: Value(DateTime.utc(2026, 8, 8).millisecondsSinceEpoch),
+            updatedAt: Value(DateTime.utc(2026, 8, 8).millisecondsSinceEpoch),
+          ),
+        );
+
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run();
+
+    expect(
+      result.swept,
+      0,
+      reason: 'the restored diver has the safety review switched off',
+    );
+  });
+
+  test('honours cancellation', () async {
+    final result = await makeContainer()
+        .read(postRestoreSafetyReviewProvider)
+        .run(isCancelled: () => true);
+
+    expect(result.cancelled, isTrue);
+    expect(result.swept, 0);
+  });
+}

--- a/test/features/backup/presentation/widgets/restore_barrier_test.dart
+++ b/test/features/backup/presentation/widgets/restore_barrier_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
 
 import '../../../../helpers/test_app.dart';
@@ -11,6 +12,7 @@ void main() {
   Widget wrap({
     required bool restoring,
     String? message,
+    SafetyReviewSweepProgress? sweepProgress,
     required VoidCallback onTap,
   }) {
     return testApp(
@@ -18,6 +20,7 @@ void main() {
       overrides: [
         restoreInProgressProvider.overrideWithValue(restoring),
         restoreMessageProvider.overrideWithValue(message),
+        restoreSweepProgressProvider.overrideWithValue(sweepProgress),
       ],
       child: RestoreBarrier(
         child: Center(
@@ -66,6 +69,43 @@ void main() {
   ) async {
     await tester.pumpWidget(wrap(restoring: true, onTap: () {}));
     expect(find.text('Restoring backup...'), findsOneWidget);
+  });
+
+  // The Skip button's callback resolves backupOperationProvider.notifier,
+  // which would drag the whole backup service graph into a widget test. These
+  // assert that it renders; the skip behavior itself is covered by the
+  // notifier test in backup_providers_restore_test.dart.
+  testWidgets('shows determinate sweep progress and a Skip button', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        restoring: true,
+        sweepProgress: const SafetyReviewSweepProgress(done: 3, total: 10),
+        onTap: () {},
+      ),
+    );
+
+    expect(find.text('Running the safety review'), findsOneWidget);
+    expect(find.text('Analyzed 3 of 10 dives'), findsOneWidget);
+    expect(find.text('Skip'), findsOneWidget);
+
+    final bar = tester.widget<LinearProgressIndicator>(
+      find.byType(LinearProgressIndicator),
+    );
+    expect(bar.value, closeTo(0.3, 0.001));
+  });
+
+  testWidgets('keeps the plain spinner when no sweep is running', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(restoring: true, message: 'Restoring backup...', onTap: () {}),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+    expect(find.text('Skip'), findsNothing);
   });
 
   testWidgets(

--- a/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
+++ b/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
@@ -1,0 +1,202 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+import '../../domain/services/safety_review_fixtures.dart';
+
+/// Records every review handed to it, so the sweep's coverage can be asserted
+/// without inspecting the database.
+class _RecordingRepo extends SafetyFindingsRepository {
+  final saved = <String>[];
+
+  @override
+  Future<SafetyReview?> getReview(String diveId) async => null;
+
+  @override
+  Future<void> saveReview(SafetyReview review) async =>
+      saved.add(review.diveId);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final now = DateTime.utc(2026, 8, 8);
+  late AppDatabase db;
+
+  /// Inserts the owning diver. Required: the test database enforces foreign
+  /// keys, so a dive referencing a missing diver fails with SQLITE_CONSTRAINT.
+  Future<void> insertDiver(String id) async {
+    final ts = now.millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value('Diver $id'),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  }
+
+  /// Inserts a dive owned by [diverId].
+  Future<void> insertDive(String id, String diverId) async {
+    final ts = now.millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            diveDateTime: Value(ts),
+            createdAt: Value(ts),
+            updatedAt: Value(ts),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await insertDiver('diver-a');
+    await insertDiver('diver-b');
+    await insertDive('d1', 'diver-a');
+    await insertDive('d2', 'diver-b');
+  });
+
+  tearDown(() => tearDownTestDatabase());
+
+  /// A container whose analysis always yields a rapid-ascent fixture, so every
+  /// dive produces a persistable review.
+  ProviderContainer makeContainer(_RecordingRepo repo) {
+    final profile = rapidAscentProfile();
+    final analysis = analyzeFixture(
+      depths: profile.depths,
+      timestamps: profile.timestamps,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(true),
+        profileAnalysisProvider('d1').overrideWith((ref) async => analysis),
+        profileAnalysisProvider('d2').overrideWith((ref) async => analysis),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('sweeps every diver when diverId is null', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run();
+
+    expect(repo.saved, containsAll(<String>['d1', 'd2']));
+    expect(result.swept, 2);
+    expect(result.failed, 0);
+    expect(result.cancelled, isFalse);
+  });
+
+  test('scopes to a single diver when diverId is supplied', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run(diverId: 'diver-a');
+
+    expect(repo.saved, <String>['d1']);
+    expect(result.swept, 1);
+  });
+
+  test('reports progress ending at the total', () async {
+    final repo = _RecordingRepo();
+    final seen = <(int, int)>[];
+    await makeContainer(repo)
+        .read(safetyReviewSweepProvider)
+        .run(onProgress: (done, total) => seen.add((done, total)));
+
+    expect(seen.first, (0, 2), reason: 'an initial 0-of-N sizes the bar');
+    expect(seen.last, (2, 2));
+  });
+
+  test('stops early and reports cancelled when isCancelled fires', () async {
+    final repo = _RecordingRepo();
+    final result = await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run(isCancelled: () => true);
+
+    expect(repo.saved, isEmpty);
+    expect(result.cancelled, isTrue);
+    expect(result.swept, 0);
+  });
+
+  test('an empty logbook sweeps nothing and reports a zero total', () async {
+    await db.delete(db.dives).go();
+    final repo = _RecordingRepo();
+    final seen = <(int, int)>[];
+
+    final result = await makeContainer(repo)
+        .read(safetyReviewSweepProvider)
+        .run(onProgress: (done, total) => seen.add((done, total)));
+
+    expect(result.swept, 0);
+    expect(result.failed, 0);
+    expect(result.cancelled, isFalse);
+    expect(seen, <(int, int)>[(0, 0)]);
+  });
+
+  test('does nothing when the master toggle is off', () async {
+    final repo = _RecordingRepo();
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(false),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(safetyReviewSweepProvider).run();
+
+    expect(repo.saved, isEmpty);
+    expect(result.swept, 0);
+    expect(result.cancelled, isFalse);
+  });
+
+  test('counts a failing dive and still sweeps the rest', () async {
+    final repo = _RecordingRepo();
+    final profile = rapidAscentProfile();
+    final analysis = analyzeFixture(
+      depths: profile.depths,
+      timestamps: profile.timestamps,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        safetyReviewEnabledProvider.overrideWithValue(true),
+        profileAnalysisProvider(
+          'd1',
+        ).overrideWith((ref) async => throw StateError('corrupt profile')),
+        profileAnalysisProvider('d2').overrideWith((ref) async => analysis),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(safetyReviewSweepProvider).run();
+
+    expect(result.failed, 1);
+    expect(
+      result.swept,
+      2,
+      reason: 'swept counts dives visited, not successes',
+    );
+    expect(repo.saved, <String>['d2']);
+  });
+}

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -120,6 +120,10 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier() : super(const AppSettings());
 
+  /// Already "loaded": the mock's state is supplied up front.
+  @override
+  Future<void> get initialLoad async {}
+
   @override
   Future<void> setAccentNavIcons(bool value) async =>
       state = state.copyWith(accentNavIcons: value);

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -45,6 +45,10 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   _MockSettingsNotifier([AppSettings? initial])
     : super(initial ?? const AppSettings());
 
+  /// Already "loaded": the mock's state is supplied up front.
+  @override
+  Future<void> get initialLoad async {}
+
   @override
   Future<void> setAccentNavIcons(bool value) async =>
       state = state.copyWith(accentNavIcons: value);

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -30,6 +30,10 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
   _MockSettingsNotifier() : super(const AppSettings());
 
+  /// Already "loaded": the mock's state is supplied up front.
+  @override
+  Future<void> get initialLoad async {}
+
   @override
   Future<void> setAccentNavIcons(bool value) async =>
       state = state.copyWith(accentNavIcons: value);

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -32,6 +32,11 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   MockSettingsNotifier([AppSettings? initial])
     : super(initial ?? const AppSettings());
 
+  /// Already "loaded": the mock's state is supplied up front, so nothing
+  /// awaits a database read.
+  @override
+  Future<void> get initialLoad async {}
+
   @override
   Future<void> setDepthUnit(DepthUnit unit) async =>
       state = state.copyWith(depthUnit: unit);


### PR DESCRIPTION
## Summary

Restoring a backup left the safety review empty for the entire logbook. No dive
showed findings and no dive-list row showed a finding badge until the user found
Settings > Safety > "Analyze all dives" and ran it by hand.

The safety review has only two triggers, and a restore is neither: lazy compute
when a dive detail page is opened (`safetyReviewProvider`), and the manual
Settings sweep. A backup is a whole-file SQLite copy, so the
`dive_safety_reviews` / `dive_safety_findings` tables travel with it — but
carrying only whatever rows the source database happened to have. A backup that
predates the feature restores those tables empty (the migration ladder creates
them), and dives the source device never opened were never analyzed. Either way
`DiveSummary.safetyFindingCount` reports zero across the library.

This runs the sweep automatically as the last step of a restore, over every
diver, with progress and a Skip button on the restore barrier.

## Changes

- Extract the "Analyze all dives" loop from `safety_settings_page.dart` into a
  shared `SafetyReviewSweep` provider. Both Settings and the restore path use
  it, so the load-bearing `ref.invalidate()`-before-`read` invariant (needed
  because `safetyReviewProvider` is not `autoDispose` and would otherwise return
  a stale cached `AsyncValue`) lives in one place.
- Call it from `BackupOperationNotifier` — the single seam every restore entry
  point funnels through, including the setup wizard — between the existing
  active-diver realignment and the restore-complete transition.
- Run the sweep in a short-lived `ProviderContainer` (`PostRestoreSafetyReview`).
  The live container still holds settings loaded from the database being
  replaced: gradient factors shape the ceiling curve that the `missedDecoStop`
  and `highSurfaceGf` rules grade against, and `ProfileLegend`'s metric-source
  defaults feed `overlayComputerDecoData`. Persisting findings computed from
  those would stamp the current `engineVersion` onto wrong results that then
  never recompute.
- Extract `rootProviderOverrides` so the scratch container cannot drift from the
  real `ProviderScope` (`logFileServiceProvider` throws unless overridden).
- Show determinate progress and a Skip button on the restore barrier. Skipping
  is lossless: unswept dives still compute lazily on first view, and the
  Settings sweep remains available.
- A sweep failure can never fail the restore. By the time it runs, the database
  swap and sync re-baseline have already succeeded, so errors are logged and
  swallowed.

### Two latent bugs fixed along the way, both independent of backups

- `SettingsNotifier` starts at the `AppSettings` **defaults** and replaces its
  state asynchronously, so any consumer reading gradient factors before that
  first load completes silently grades against defaults. Added `initialLoad`,
  which the sweep awaits before running.
- `_loadSettings` assigned `state` after an `await` with no `mounted` check,
  throwing "Tried to use SettingsNotifier after dispose" whenever a
  `ProviderScope` is torn down mid-load — reachable today via `restartApp()`'s
  soft restart, not just the new container. Added the guard.

### Notes

- No schema change. Both safety tables already exist and already sync.
- No safety rule or `SafetyReviewService.engineVersion` change.
- Merge and Replace restores both sweep. `rebaselineAfterRestore` has already
  cleared the sync position, so every row is pending regardless; the sweep's
  parent-dive HLC bumps add no meaningful extra push.
- Three new strings translated across all eleven locales.

Design and implementation notes, including an as-built deviations section, are
in `docs/superpowers/specs/2026-08-08-post-restore-safety-review-design.md` and
`docs/superpowers/plans/2026-08-08-post-restore-safety-review.md`.

## Test Plan

- [x] `flutter test` passes — 15,724 passing, 15 skipped, 0 failures
- [x] `flutter analyze` passes — clean across the whole project
- [x] Manual testing on: not yet run against a real device

New coverage:

- `safety_review_sweep_test.dart` (new, 7 cases): sweeps every diver when
  `diverId` is null; scopes correctly when set; stops on `isCancelled`; counts a
  failing dive without aborting; no-ops when the master toggle is off; reports
  monotonic progress; handles an empty logbook.
- `post_restore_safety_review_test.dart` (new, 3 cases): including
  `reads settings from the restored database, not the defaults`, which switches
  the master toggle off in the restored diver's row and asserts the sweep
  no-ops — the assertion that actually proves the scratch container reads
  restored settings rather than defaults.
- `backup_providers_restore_test.dart` (+5): both restore entry points run the
  sweep; progress reaches the barrier with `isRestoring` still true; a throwing
  sweep still reaches `restoreComplete`; the skip flag reaches the running sweep.
- `restore_barrier_test.dart` (+2): progress label and Skip button render; the
  plain spinner is unchanged when no sweep is running.
- `root_overrides_test.dart` (new).

Suggested manual check: restore a backup created before the safety review
feature existed. The barrier should show "Running the safety review" with a
moving determinate bar, then the restore-complete screen. After the restart,
dive-list rows should show finding badges without opening each dive first.
