### PR TITLE
Open the photo viewer when a home-page recent photo is tapped

### DIFF
--- a/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
+++ b/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/dashboard/presentation/providers/photo_providers.dart';
+import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Horizontal ribbon of the newest dive photos.
 class PhotoRibbonCard extends ConsumerWidget {
   const PhotoRibbonCard({super.key});
+
+  /// Opens the full-screen viewer on the photo itself, with the rest of its
+  /// dive's gallery swipeable alongside it. Pushed on the root navigator
+  /// because the dashboard sits inside the shell route, whose bottom nav
+  /// would otherwise render over the immersive viewer.
+  void _openViewer(BuildContext context, String diveId, String mediaId) {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute<void>(
+        fullscreenDialog: true,
+        builder: (_) =>
+            PhotoViewerPage(diveId: diveId, initialMediaId: mediaId),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -38,10 +52,11 @@ class PhotoRibbonCard extends ConsumerWidget {
                 separatorBuilder: (_, _) => const SizedBox(width: 8),
                 itemBuilder: (context, index) {
                   final item = photos[index];
+                  final diveId = item.diveId;
                   return InkWell(
-                    onTap: item.diveId == null
+                    onTap: diveId == null
                         ? null
-                        : () => context.push('/dives/${item.diveId}'),
+                        : () => _openViewer(context, diveId, item.id),
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: SizedBox(

--- a/test/features/dashboard/presentation/widgets/dashboard_cards_test.dart
+++ b/test/features/dashboard/presentation/widgets/dashboard_cards_test.dart
@@ -11,9 +11,12 @@ import 'package:submersion/features/dashboard/presentation/widgets/photo_ribbon_
 import 'package:submersion/features/dashboard/presentation/widgets/quick_actions_card.dart';
 import 'package:submersion/features/dashboard/presentation/widgets/year_in_review_card.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -22,8 +25,17 @@ import '../../../../helpers/mock_providers.dart';
 final _t0 = DateTime(2026, 1, 1);
 
 /// Records where a tap navigated.
-class NavSpy {
+class NavSpy extends NavigatorObserver {
   String? location;
+
+  /// Routes pushed imperatively onto the root navigator (go_router's own
+  /// route pushes arrive here too, so callers match on route type).
+  final List<Route<dynamic>> pushedRoutes = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route);
+  }
 }
 
 Future<NavSpy> pumpCard(
@@ -40,6 +52,7 @@ Future<NavSpy> pumpCard(
     },
   );
   final router = GoRouter(
+    observers: [spy],
     routes: [
       GoRoute(
         path: '/',
@@ -309,6 +322,42 @@ void main() {
       );
       expect(find.text('Recent photos'), findsOneWidget);
       expect(find.byType(ClipRRect), findsNWidgets(2));
+    });
+
+    testWidgets('tapping a photo opens the photo viewer, not the dive', (
+      tester,
+    ) async {
+      final spy = await pumpCard(
+        tester,
+        const PhotoRibbonCard(),
+        overrides: [
+          recentPhotosProvider.overrideWith(
+            (ref) async => [
+              MediaItem(
+                id: 'p1',
+                mediaType: MediaType.photo,
+                sourceType: MediaSourceType.platformGallery,
+                filePath: '/tmp/p1.jpg',
+                diveId: 'd1',
+                takenAt: _t0,
+                createdAt: _t0,
+                updatedAt: _t0,
+              ),
+            ],
+          ),
+          // The viewer resolves its own gallery from the dive; an empty list
+          // short-circuits its build before it reaches the profile providers,
+          // so this stays a navigation test rather than a viewer test.
+          mediaForDiveProvider('d1').overrideWith((ref) async => <MediaItem>[]),
+          diveProvider('d1').overrideWith((ref) async => null),
+        ],
+      );
+
+      await tester.tap(find.byType(ClipRRect).first);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PhotoViewerPage), findsOneWidget);
+      expect(spy.location, isNull);
     });
   });
 


### PR DESCRIPTION
## Summary

Tapping a thumbnail in the home page's "Recent photos" ribbon navigated to the
dive detail page instead of opening the photo. The tile now opens the
full-screen photo viewer on the photo that was tapped.

The root cause was the destination, not the navigation itself:
`photo_ribbon_card.dart` called `context.push('/dives/${item.diveId}')`, wiring
the tile as a shortcut to the dive rather than to the media item.

Two existing call sites already establish the house pattern for this —
`photo_marker_overlay.dart:114` and `trip_gallery_page.dart:420` both push
`PhotoViewerPage` as a `fullscreenDialog` `MaterialPageRoute`. The ribbon now
matches them.

One detail those call sites don't face: the dashboard sits inside the
`ShellRoute` (`app_router.dart:200`), so a shell-level push would leave the
bottom nav bar painted over a viewer that requests
`SystemUiMode.immersiveSticky` in its `initState`. The route therefore goes on
the root navigator, the same escape `surface_gps_section.dart:61` uses for its
fullscreen map.

The viewer resolves its own gallery from `mediaForDiveProvider(diveId)` and
seeds the page controller from `initialMediaId`, so the tap lands on the right
photo and the rest of that dive's media stays swipeable alongside it. The dive
detail page is still reachable from the viewer's metadata, so nothing was lost
by retargeting.

## Changes

- `photo_ribbon_card.dart`: tapping a tile pushes
  `PhotoViewerPage(diveId, initialMediaId: item.id)` on the root navigator as a
  `fullscreenDialog` route, replacing the `context.push('/dives/:id')` call. The
  now-unused `go_router` import is dropped.
- `dashboard_cards_test.dart`: `NavSpy` also extends `NavigatorObserver` and is
  wired into the harness `GoRouter`, so the shared `pumpCard` helper can observe
  imperative pushes as well as declarative go_router navigation.
- New test `tapping a photo opens the photo viewer, not the dive`, asserting
  both halves of the bug: `PhotoViewerPage` mounts, and no `/dives/d1`
  navigation occurs. It was written first and watched failing
  (`Found 0 widgets with type "PhotoViewerPage"`) before the fix.

The test stays lightweight because `photo_viewer_page.dart:120` returns early on
an empty media list, before the seven profile-related providers it otherwise
watches. Overriding `mediaForDiveProvider('d1')` to `[]` and `diveProvider('d1')`
to `null` is enough to prove the destination without standing up a test
database.

## Test Plan

- [x] `flutter test` passes — 15,710 passed. One unrelated failure,
      `backup_service_encryption_test.dart`, which passes 7/7 in isolation; it is
      a known full-suite flake and nothing here touches backup, encryption, or
      file IO.
- [x] `flutter analyze` passes (dashboard lib/test dirs clean);
      `dart format lib/ test/` reports 0 files changed.
- [x] Manual testing: not performed — this change is covered by the widget test
      above and was not run against a device or simulator.

## Out of scope

- The ribbon tile has no semantic label (`MediaItemView` renders the image
  without one, and both sibling call sites wrap their tiles in
  `Semantics(button: true, label: ...)`). Adding one requires a new ARB string
  across every locale, so it is flagged here rather than folded into a bug fix.
- Trip photo tiles (`trip_photo_section.dart:241`,
  `trip_story_day_card.dart:194`) open `/trips/$tripId/gallery`. That is
  intended and labelled as such, not the same defect.
