### PR TITLE
Harden Sparkle release notes for dark mode and guard changelog output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,6 +391,9 @@ jobs:
       - name: Run beta release notes test
         run: ./scripts/release/beta_release_notes_test.sh
 
+      - name: Run changelog generator test
+        run: ./scripts/release/generate_changelog_test.sh
+
       - name: Run fastlane beta changelog test
         run: ruby scripts/release/fastlane_beta_changelog_test.rb
 

--- a/scripts/generate_release_notes_html.sh
+++ b/scripts/generate_release_notes_html.sh
@@ -27,7 +27,15 @@ cat <<HTML_TEMPLATE
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
 <style>
+  /* Explicit dark-mode opt-in. Some WKWebView versions only match the
+     prefers-color-scheme dark media query when the page declares
+     color-scheme support, and the declaration lets WebKit pick matching
+     UA defaults (form controls, scrollbars) in Sparkle's web view. */
+  :root {
+    color-scheme: light dark;
+  }
   body {
     font-family: -apple-system, "Segoe UI", Roboto, sans-serif;
     margin: 16px;

--- a/scripts/generate_release_notes_html_test.sh
+++ b/scripts/generate_release_notes_html_test.sh
@@ -26,6 +26,15 @@ echo "$BODY_RULE" | grep -q "color: #222" || fail "body text colour missing"
 echo "$BODY_RULE" | grep -q "background-color: #fff" \
   || fail "body background colour missing; dark-mode web views paint #222 text on a dark page"
 
+# The page must opt in to dark mode with a color-scheme declaration (meta tag
+# and :root CSS). Some WKWebView versions only match prefers-color-scheme: dark
+# when the page declares color-scheme support, and it keeps WebKit's UA
+# defaults consistent with the active appearance in Sparkle's web view.
+echo "$OUT" | grep -q '<meta name="color-scheme" content="light dark">' \
+  || fail "color-scheme meta tag missing; some WKWebViews need it to match the dark media query"
+echo "$OUT" | sed -n '/:root {/,/}/p' | grep -q "color-scheme: light dark" \
+  || fail ":root color-scheme declaration missing; some WKWebViews need it to match the dark media query"
+
 # Dark mode must be handled explicitly with the inverse pair, plus a visible
 # h2 border (the light #ddd border disappears on a dark background).
 DARK_RULE=$(echo "$OUT" | sed -n '/@media (prefers-color-scheme: dark)/,/^  }/p')

--- a/scripts/release/generate_changelog_test.sh
+++ b/scripts/release/generate_changelog_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tests for generate_changelog.sh --notes-only, the Sparkle/appcast release
+# notes path. Its stdout is piped into generate_release_notes_html.sh and
+# published inside the update dialog, so progress output must stay on stderr:
+# the v1.7.2.4977 appcast shipped "Changelog: 1.7.2 (commits since ...)" and
+# "Found 82 commit(s) in 7 section(s)." as the opening lines of the notes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$SCRIPT_DIR/generate_changelog.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Build a scratch repository with a tagged release and conventional commits
+# after it, mirroring the state the release workflow runs from.
+TMPREPO=$(mktemp -d)
+trap 'rm -rf "$TMPREPO"' EXIT
+(
+  cd "$TMPREPO"
+  git init -q
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "chore: initial"
+  git tag v1.0.0.1
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "feat: a new thing"
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "fix: an old thing"
+)
+
+STDOUT=$(cd "$TMPREPO" && "$GEN" --notes-only 2>/dev/null)
+STDERR=$(cd "$TMPREPO" && "$GEN" --notes-only 2>&1 >/dev/null)
+
+# Progress lines belong on stderr, never in the published notes body.
+echo "$STDOUT" | grep -qiE '^(changelog:|found |generating|nothing to generate)' \
+  && fail "progress output leaked onto --notes-only stdout"
+
+# The notes must start with the version heading, not blank filler or noise.
+[ -n "$STDOUT" ] || fail "--notes-only produced no output"
+echo "$STDOUT" | head -1 | grep -q '^## ' \
+  || fail "--notes-only does not start with the version heading"
+
+# The commit content itself must be present.
+echo "$STDOUT" | grep -q "a new thing" || fail "feat commit missing from notes"
+echo "$STDOUT" | grep -q "an old thing" || fail "fix commit missing from notes"
+
+# The progress lines still exist for humans running the script interactively.
+echo "$STDERR" | grep -q "^Changelog: " || fail "progress summary missing from stderr"
+echo "$STDERR" | grep -q "commit(s) in" || fail "commit count missing from stderr"
+
+echo "PASS: all generate_changelog tests passed"


### PR DESCRIPTION
## Summary

Follow-ups from investigating the unreadable dark-mode release notes in the v1.7.2.4977 update dialog.

The root cause was not a template bug in main: the appcast item for 1.7.2.4977 was generated on Aug 3, two days before the #849 dark-mode CSS fix merged, and release-notes HTML is frozen into each appcast item at build time. The published stable `appcast.xml` still serves that pre-fix HTML, which needs a release-asset update (separate from this PR). This PR hardens the pipeline so both classes of regression stay fixed:

- **Declare `color-scheme: light dark`** (meta tag + `:root` CSS) in `generate_release_notes_html.sh`. Verified in a WKWebView harness replicating Sparkle's setup (`_setDrawsBackground:NO`, dark-appearance window) that current macOS matches `prefers-color-scheme: dark` either way; the declaration is defense-in-depth for WKWebView versions that require the opt-in, and keeps WebKit UA defaults consistent with the active appearance.
- **Add a regression test for `generate_changelog.sh --notes-only`**: progress lines ("Changelog: ...", "Found N commit(s) ...") must stay on stderr. The leak was fixed in 69c79183601 but the Sparkle/appcast path had no test; 1.7.2.4977 shipped those lines as the opening of its release notes. Wired into CI's script-test job.

## Testing

- `./scripts/generate_release_notes_html_test.sh` (new assertions for both color-scheme declarations)
- `./scripts/release/generate_changelog_test.sh` (new; temp-repo based)
- `./scripts/release/beta_release_notes_test.sh`, `./scripts/generate_appcast_beta_test.sh` still pass
- WKWebView harness: generated HTML renders light-on-dark in dark windows, dark-on-light in light windows, and tracks live theme flips