### PR TITLE
Fix Android profile chart touch UX: pan when zoomed, instant scrubbing, overlap cleanup

### DIFF
--- a/docs/superpowers/plans/2026-08-08-android-profile-chart-ux.md
+++ b/docs/superpowers/plans/2026-08-08-android-profile-chart-ux.md
@@ -1,0 +1,333 @@
+# Android Profile Chart UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the dive profile chart usable on Android touch: one-finger pan when zoomed, reliable two-finger pinch/pan, instant (no 300 ms pause) scrubbing, event labels that stop hiding the dive tail, and a fullscreen readout card that defaults to an empty corner.
+
+**Architecture:** Touch gestures move off Flutter's default arena racing. A translucent overlay stacked directly above the `LineChart` hosts a custom `ChartTouchClaimRecognizer` that (a) claims a second touch pointer immediately (pinch/two-finger pan always wins) and (b) claims a one-finger drag past slop when the viewport is zoomed ("drag to pan" becomes true on touch). All gesture math stays in the existing passive `Listener` (pointer map, pinch cumulative-vs-snapshot, mouse pan). The `GestureDetector` with `onScale*`/`onDoubleTap*` is deleted; double-tap-to-zoom is re-detected manually from `PointerEvent.timeStamp` (no `DoubleTapGestureRecognizer`, hence no 300 ms arena hold, no pending timers in tests). Event labels get a pure placement function (below-the-curve anchoring, edge flip, collision push-down/drop). The fullscreen `DraggableReadoutCard` default corner is chosen by a pure occupancy function over the normalized profile.
+
+**Tech Stack:** Flutter, fl_chart 1.1.1, flutter_test. No new dependencies.
+
+## Global Constraints
+
+- All Dart code passes `dart format` unchanged; `flutter analyze` clean (infos are fatal in CI — whole-project analyze).
+- No emojis in code/comments/docs. Immutability preferred. Many small files (200–400 lines typical).
+- Unit-display code must respect active diver unit settings (not touched here; placements are pixel-space).
+- Do not add new Riverpod providers consumed by the chart/legend (breaks ~all consumer tests — see memory `new-provider-dep`).
+- Commit after each task (plan commits are pre-authorized). No Claude attribution in commits/PR bodies.
+- Existing behavior preserved: desktop mouse pan/hover/wheel, trackpad recognizer, one-finger scrub at zoom 1, long-press scrub, tap tooltip, double-tap zoom toggle.
+- Behavior deliberately removed: double-tap-and-hold pan (superseded by one-finger pan-when-zoomed; it misclassified fast tap-then-drag scrubs — the reported bug).
+
+## Root causes being fixed (verified against code)
+
+1. `dive_profile_chart.dart:1887-1958` — `GestureDetector.onDoubleTap` holds every tap's arena 300 ms (UI pause; delayed tooltip); `onDoubleTapDown` sets `_doubleTapHold`, so a fast tap-then-drag becomes a viewport pan (no-op at zoom 1) instead of a scrub.
+2. Two-finger pinch/pan (`onScaleUpdate`) must out-race fl_chart's internal `PanGestureRecognizer` (`render_base_chart.dart:139-144`, innermost so it wins ties); loses whenever one finger moves before the second lands.
+3. Zoom hint (`diveLog_profile_zoomHint`) says "drag to pan" but one-finger touch drag always scrubs.
+4. Event `VerticalLineLabel`s pinned to plot top (= surface = end-of-dive tail), centered, no collision handling (`_buildEventVerticalLines`, `dive_profile_chart.dart:5051-5092`); ascent events cluster at dive end.
+5. `DraggableReadoutCard.defaultFraction = Offset(1, 0)` (top-right) sits exactly on the ascent tail.
+
+---
+
+### Task 1: `chartDragIntent` gains `isZoomed`, loses `doubleTapHold`
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart:84-101`
+- Test: `test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart`
+
+**Interfaces:**
+- Produces: `ChartDragIntent chartDragIntent({required PointerDeviceKind kind, required int pointerCount, required bool isZoomed})` — touch+1 pointer: `scrub` when not zoomed, `pan` when zoomed; any 2+ pointers: `zoomPan`; non-touch single pointer: `pan`.
+
+- [ ] **Step 1:** Rewrite the `chartDragIntent` tests: replace every `doubleTapHold:` argument with `isZoomed:`; keep the pointer-kind matrix; add cases `touch+1+isZoomed:false => scrub`, `touch+1+isZoomed:true => pan`, `mouse+1 (either zoom) => pan`, `any kind +2 pointers => zoomPan`.
+- [ ] **Step 2:** Run `flutter test test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart` — expect compile failure (named param mismatch).
+- [ ] **Step 3:** Change the function:
+
+```dart
+ChartDragIntent chartDragIntent({
+  required PointerDeviceKind kind,
+  required int pointerCount,
+  required bool isZoomed,
+}) {
+  if (pointerCount >= 2) return ChartDragIntent.zoomPan;
+  if (kind != PointerDeviceKind.touch) return ChartDragIntent.pan;
+  return isZoomed ? ChartDragIntent.pan : ChartDragIntent.scrub;
+}
+```
+
+(The chart call site is fixed in Task 3; it will not compile until then — acceptable inside the same branch, but to keep every commit green, update the single call site in `dive_profile_chart.dart:1970-1975` in this task too, passing `isZoomed: _viewport.isZoomed` and adding a temporary `&& !_doubleTapHold` nothing — no: simply pass `isZoomed: _viewport.isZoomed` and leave `_doubleTapHold` unused until Task 3 removes it.)
+- [ ] **Step 4:** Run the viewport test file + `flutter analyze` on the two files. Expect pass (an unused-field info for `_doubleTapHold` would be fatal — silence by keeping the field read in `onPointerUp` reset until Task 3, which it already is).
+- [ ] **Step 5:** Commit: `refactor: chartDragIntent keys on viewport zoom, not double-tap hold`
+
+### Task 2: `ChartTouchClaimRecognizer`
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/chart_touch_recognizer.dart`
+- Test: `test/features/dive_log/presentation/widgets/chart_touch_recognizer_test.dart`
+
+**Interfaces:**
+- Produces: `class ChartTouchClaimRecognizer extends OneSequenceGestureRecognizer` with constructor `({required ValueGetter<bool> isZoomed, Object? debugOwner})`, settable `VoidCallback? onClaimed; VoidCallback? onReleased;`. Touch-only. Claims: 2nd pointer down → accept immediately; single pointer move past `computeHitSlop` while `isZoomed()` was true at pointer-down → accept. Rejects on up/cancel without acceptance so taps/long-presses pass through.
+
+- [ ] **Step 1:** Write widget tests using a harness that mirrors the real stacking: a `Stack` with (bottom) a `RawGestureDetector` owning a plain `PanGestureRecognizer` counting wins (stand-in for fl_chart, deeper = registers first when hit first) and (top) a translucent `RawGestureDetector` hosting `ChartTouchClaimRecognizer`. Cases:
+  1. zoomed=true, one-finger drag past slop → `onClaimed` fired, stand-in pan never started;
+  2. zoomed=false, one-finger drag → stand-in pan wins, no claim;
+  3. zoomed=false, two-finger down (second finger lands after first already moved 30 px) → claim fired (the async-finger case that broke on device);
+  4. tap (down/up, no move) with zoomed=true → no claim; stand-in tap recognizer (add a `TapGestureRecognizer` to the bottom detector) fires;
+  5. `onReleased` fires when the last pointer lifts after a claim.
+- [ ] **Step 2:** Run the new test file — expect failure (class missing).
+- [ ] **Step 3:** Implement (~120 lines):
+
+```dart
+class ChartTouchClaimRecognizer extends OneSequenceGestureRecognizer {
+  ChartTouchClaimRecognizer({required this.isZoomed, Object? debugOwner})
+      : super(debugOwner: debugOwner,
+              supportedDevices: {PointerDeviceKind.touch});
+  final ValueGetter<bool> isZoomed;
+  VoidCallback? onClaimed;
+  VoidCallback? onReleased;
+  final Map<int, Offset> _downPositions = {};
+  bool _claimed = false;
+  bool _zoomedAtFirstDown = false;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    startTrackingPointer(event.pointer, event.transform);
+    if (_downPositions.isEmpty) _zoomedAtFirstDown = isZoomed();
+    _downPositions[event.pointer] = event.position;
+    if (_downPositions.length == 2 && !_claimed) {
+      resolve(GestureDisposition.accepted);
+    }
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (event is PointerMoveEvent &&
+        !_claimed &&
+        _downPositions.length == 1 &&
+        _zoomedAtFirstDown) {
+      final start = _downPositions[event.pointer];
+      if (start != null &&
+          (event.position - start).distance >
+              computeHitSlop(event.kind, gestureSettings)) {
+        resolve(GestureDisposition.accepted);
+      }
+    } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+      if (!_claimed) resolve(GestureDisposition.rejected);
+      _downPositions.remove(event.pointer);
+      stopTrackingPointer(event.pointer);
+    }
+  }
+
+  @override
+  void acceptGesture(int pointer) {
+    if (!_claimed) { _claimed = true; onClaimed?.call(); }
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    final wasClaimed = _claimed;
+    _claimed = false;
+    _downPositions.clear();
+    if (wasClaimed) onReleased?.call();
+  }
+
+  @override
+  String get debugDescription => 'chart touch claim';
+}
+```
+
+- [ ] **Step 4:** Run test file; iterate until green.
+- [ ] **Step 5:** Commit: `feat: arena-winning touch claim recognizer for the profile chart`
+
+### Task 3: Chart integration — new touch model
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (state fields ~800-840; `_buildInteractiveChart` 1839-2059; `touchCallback` 2625; plot `Stack` 2251)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart` (new file; keeps the giant existing test file from growing)
+
+**Interfaces:**
+- Consumes: Task 1 `chartDragIntent(isZoomed:)`, Task 2 recognizer.
+- Produces: touch model — 1-finger: scrub (zoom 1) / pan (zoomed, claimed); 2-finger: pinch zoom + pan always; double-tap: zoom toggle (manual, `PointerEvent.timeStamp`-based); long-press: scrub at any zoom; tap: tooltip with no 300 ms delay. Desktop unchanged.
+
+- [ ] **Step 1:** Write failing widget tests (new file, reuse `_buildChart`-style harness from the existing chart test: `MaterialApp > Scaffold > SizedBox(400x300) > DiveProfileChart(profile: …, onPointSelected: …)`; helper `LineChartData chartData(t)`):
+  1. **fast tap-then-drag scrubs** (the reported bug): `tapAt(center)`, `pump(50ms)`, `startGesture(center)`, move +40 px in 4 steps → `onPointSelected` fired with non-null during the drag AND `chartData.minX == 0` (no pan/zoom happened);
+  2. **single tap selects with no 300 ms wait**: `tapAt`, `pump()` (one frame) → selection callback observed (previously required pumping past the double-tap window);
+  3. **double-tap zooms, double-tap again resets**: two `tapAt` 100 ms apart → visible X span shrinks; repeat → back to full span; no "Timer still pending" without extra pumps;
+  4. **two-finger pinch always zooms**: `startGesture(p1)`, move it 30 px (fl_chart pan would have won the old race), then `startGesture(p2)`, spread both by 40 px → X span shrinks;
+  5. **two-finger drag pans when zoomed**: wheel-zoom in first (existing `sendEventToBinding(PointerScrollEvent)` pattern), then two-finger parallel move → `minX` changes, zoom unchanged (within tolerance);
+  6. **one-finger drag pans when zoomed**: wheel-zoom in, drag one touch pointer left → `minX` increases; `onPointSelected` NOT called with a new index during the drag;
+  7. **one-finger drag still scrubs at zoom 1**: drag → selection fires, `minX` stays 0;
+  8. **double-tap over the right-axis metric selector strip does not zoom**: pump chart with a right-axis metric active, double-tap inside the right 50 px strip → X span unchanged;
+  9. **long-press then drag scrubs while zoomed** (no pan): zoom in, `startGesture`, `pump(600ms)` hold, then move → selection fires, `minX` unchanged.
+- [ ] **Step 2:** Run new test file — failures expected on 1, 4, 5, 6, 8 (and 2's timing assert).
+- [ ] **Step 3:** Implement in `dive_profile_chart.dart`:
+  - Delete fields `_doubleTapHold`, `_startFocalPoint`, `_lastTapDownLocal`; add:
+
+```dart
+// All touch pointers currently down, by pointer id, in chart-local coords.
+final Map<int, Offset> _touchPositions = {};
+// True while ChartTouchClaimRecognizer has won the arena for a touch drag.
+bool _touchDragClaimed = false;
+// Two-finger gesture bookkeeping (cumulative against _gestureStartViewport).
+List<int> _pinchPointers = const [];
+double _pinchStartDistance = 1;
+Offset _pinchStartFocal = Offset.zero;
+// Manual double-tap detection off PointerEvent.timeStamp (no recognizer, so
+// no 300 ms arena hold and no pending timers in tests).
+Duration? _lastTapUpStamp;
+Offset _lastTapUpPosition = Offset.zero;
+Duration _tapDownStamp = Duration.zero;
+Offset _tapDownPosition = Offset.zero;
+bool _tapMoved = false;
+bool _doubleTapArmed = false;
+// Whether the right-axis metric selector strip is active this build; taps
+// there cycle metrics and must not arm double-tap zoom.
+bool _rightAxisSelectorActive = false;
+```
+
+  - Remove the `GestureDetector` wrapper (`onScaleStart/onScaleUpdate/onDoubleTapDown/onDoubleTap`) — `RawGestureDetector` (trackpad) now directly wraps the `Listener`.
+  - In the plot `Stack` (2251), insert directly after `LineChart`:
+
+```dart
+Positioned.fill(
+  child: RawGestureDetector(
+    behavior: HitTestBehavior.translucent,
+    gestures: {
+      ChartTouchClaimRecognizer:
+          GestureRecognizerFactoryWithHandlers<ChartTouchClaimRecognizer>(
+        () => ChartTouchClaimRecognizer(
+          isZoomed: () => _viewport.isZoomed,
+          debugOwner: this,
+        ),
+        (r) => r
+          ..onClaimed = (() => _touchDragClaimed = true)
+          ..onReleased = (() => _touchDragClaimed = false),
+      ),
+    },
+  ),
+),
+```
+
+  (Overlay must live in `_buildChart`'s Stack, which is below the selector/gas-strip/photo overlays — they keep tap priority.)
+  - `Listener.onPointerDown`: keep count/kind/lastLocal updates; for `kind == touch` add position to `_touchPositions`; on second touch pointer call `_beginPinch` (snapshot viewport, `_pinchPointers = first two ids`, start distance ≥ 1, start focal midpoint; clear selection via `widget.onPointSelected?.call(null)`; `_tapMoved = true`; `_doubleTapArmed = false`); on first pointer set `_tapDownStamp/_tapDownPosition/_tapMoved=false` and arm double-tap when `_lastTapUpStamp != null && event.timeStamp - _lastTapUpStamp! < kDoubleTapTimeout && (event.localPosition - _lastTapUpPosition).distance <= kDoubleTapSlop && !_inRightAxisSelector(event.localPosition, constraints.biggest)`.
+  - `Listener.onPointerMove`: update `_touchPositions`; slop check → `_tapMoved = true; _doubleTapArmed = false`; then
+
+```dart
+final intent = chartDragIntent(
+  kind: _activePointerKind,
+  pointerCount: _activePointerCount,
+  isZoomed: _viewport.isZoomed,
+);
+if (intent == ChartDragIntent.zoomPan &&
+    _activePointerKind == PointerDeviceKind.touch) {
+  _updatePinch(constraints, units);
+  return;
+}
+if (intent != ChartDragIntent.pan) return;
+if (_activePointerKind == PointerDeviceKind.touch && !_touchDragClaimed) {
+  return; // long-press scrub owns this drag
+}
+// existing pan math unchanged
+```
+
+  - `_updatePinch`: recompute the two tracked pointers' distance/midpoint; `scale = dist / _pinchStartDistance`; `vp = _gestureStartViewport.zoomedAt(focal(startFocal), scale)` then `pannedBy(-(midNow - startFocal)/plot/vp.zoom)` — the exact math currently in `onScaleUpdate` (1903-1934), with `_pinchStartFocal` replacing `_startFocalPoint`.
+  - `Listener.onPointerUp` (touch): remove from `_touchPositions`; if a pinch pointer lifted and ≥2 remain re-`_beginPinch` with the new pair, else clear `_pinchPointers`; single-tap bookkeeping: if `!_tapMoved`: if `_doubleTapArmed` → `_toggleDoubleTapZoom(_tapDownPosition)` (old `onDoubleTap` body, 1940-1958, with the tap position parameter) and `_lastTapUpStamp = null`; else `_lastTapUpStamp = event.timeStamp; _lastTapUpPosition = event.localPosition`. `onPointerCancel`: same cleanup, no tap logic.
+  - `_inRightAxisSelector(Offset p, Size box)` → `_rightAxisSelectorActive && p.dx >= box.width - 50 && p.dy <= box.height - 30`; set `_rightAxisSelectorActive = effectiveRightAxisMetric != null` where `_buildChart` computes it.
+  - `touchCallback` first line: `if (_activePointerCount >= 2) return;` (fl_chart may still own finger 1 mid-pinch; its scrub must not fight the pinch).
+- [ ] **Step 4:** Run the new gesture test file, then the full existing chart test files (`dive_profile_chart_test.dart`, `dive_profile_panel_test.dart`, `fullscreen_profile_page_test.dart`, `photo_marker_overlay_test.dart`). Fix fallout (e.g. tests that pumped past the old double-tap window).
+- [ ] **Step 5:** Commit: `fix: reliable touch pan/pinch and instant scrubbing on the profile chart`
+
+### Task 4: Event label placement (pure)
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/profile_event_labels.dart`
+- Test: `test/features/dive_log/presentation/widgets/profile_event_labels_test.dart`
+
+**Interfaces:**
+- Produces:
+
+```dart
+class EventLabelSpec {
+  final double xPx;      // event line x within the plot rect
+  final double anchorYPx;// profile depth pixel at the event time
+  final double textWidth;
+  final double textHeight;
+  const EventLabelSpec({required this.xPx, required this.anchorYPx,
+      required this.textWidth, required this.textHeight});
+}
+
+enum EventLabelAnchor { center, leftOfLine, rightOfLine }
+
+class EventLabelPlacement {
+  final bool showText;
+  final double topPx;
+  final EventLabelAnchor anchor;
+  const EventLabelPlacement({required this.showText, required this.topPx,
+      required this.anchor});
+}
+
+List<EventLabelPlacement> placeEventLabels(
+  List<EventLabelSpec> specs, {
+  required double plotWidth,
+  required double plotHeight,
+  double gap = 4,
+})
+```
+
+Rules: label top = `anchorYPx + gap` clamped to `[0, plotHeight - textHeight]` (below the curve point, off the surface tail); anchor flips `leftOfLine` when the centered extent would cross `plotWidth`, `rightOfLine` when it would cross 0; greedy left-to-right collision resolution pushes an overlapping label down in `textHeight + 2` steps; if it cannot fit above `plotHeight` it also retries fully above the anchor (`anchorYPx - gap - textHeight`, stepping up); if neither fits → `showText: false` (the dashed line still marks the event).
+
+- [ ] **Step 1:** Unit tests: single label sits at `anchorYPx + gap`; bottom clamp; near-right-edge spec flips `leftOfLine`; near-left flips `rightOfLine`; two overlapping specs → second pushed below first (no rect intersection); crowded column (5 specs same x/anchor, small plot) → later ones `showText: false`; output length always equals input length; order preserved.
+- [ ] **Step 2:** Run — fails (file missing).
+- [ ] **Step 3:** Implement pure function + rect helpers (no Flutter imports beyond `dart:ui` `Rect`).
+- [ ] **Step 4:** Run — pass.
+- [ ] **Step 5:** Commit: `feat: collision-aware dive event label placement`
+
+### Task 5: Wire event labels into the chart
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (`_buildEventVerticalLines` 5051-5092 and its call site ~2601)
+- Test: extend `test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart`? No — create `test/features/dive_log/presentation/widgets/dive_profile_chart_event_labels_test.dart`
+
+**Interfaces:**
+- Consumes: `placeEventLabels` (Task 4).
+- Produces: `_buildEventVerticalLines(colorScheme, {required double availableWidth, required UnitFormatter units, required double visibleMinX, required double visibleMaxX, required double visibleMinDepth, required double visibleMaxDepth})`.
+
+- [ ] **Step 1:** Widget tests: build a 20-min profile with three ascent-phase events in the last 90 s (classic tail cluster) on a 400×300 surface:
+  1. every rendered `VerticalLineLabel` has `padding.top > 0` (no label pinned to the surface line);
+  2. no two shown labels' rects intersect (recompute rects from padding/alignment + `TextPainter` width the same way the wiring does);
+  3. an event 5 s before dive end gets `alignment == Alignment.topLeft` (flipped off the right edge);
+  4. two events 3 s apart (sub-pixel at this width) → only the more severe one keeps `show: true`;
+  5. events for a toggled-off computer still excluded (existing behavior, quick regression assert).
+- [ ] **Step 2:** Run — fails.
+- [ ] **Step 3:** Implement wiring: pixel-dedupe (`minSpacingPx = 24`, keep highest severity, tie → later timestamp); depth interpolation helper over `widget.profile` for `anchorYPx` (`yPx = (depth - visibleMinDepth) / (visibleMaxDepth - visibleMinDepth) * plotH`, clamped); `TextPainter` measurement at the label style (fontSize 9); map placements to `VerticalLineLabel`: `center → Alignment.topCenter, EdgeInsets.only(top: topPx)`; `leftOfLine → Alignment.topLeft, EdgeInsets.only(top: topPx, right: 4)`; `rightOfLine → Alignment.topRight, EdgeInsets.only(top: topPx, left: 4)`; `show: placement.showText`. Events outside the visible X window keep `show: false` (clipped anyway). Plot geometry from `_plotInsets(availableWidth, units)`.
+- [ ] **Step 4:** Run new file + `dive_profile_chart_test.dart` event groups.
+- [ ] **Step 5:** Commit: `fix: event labels no longer bury the end-of-dive profile tail`
+
+### Task 6: Fullscreen readout card default corner
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/readout_card_placement.dart`
+- Modify: `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart:423-446`, `lib/features/dive_log/presentation/widgets/draggable_readout_card.dart` (doc only)
+- Test: `test/features/dive_log/presentation/widgets/readout_card_placement_test.dart`, extend `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`
+
+**Interfaces:**
+- Produces: `Offset leastOccupiedReadoutCorner(List<Offset> normalizedProfile)` — input points normalized to x∈[0,1] time, y∈[0,1] depth (0 = surface/top). Counts points inside four corner windows (width 0.45, height 0.4); returns the fraction offset of the emptiest corner; ties prefer top-right, then top-left, bottom-right, bottom-left (preserves today's default when all else equal).
+
+- [ ] **Step 1:** Unit tests: empty list → `Offset(1, 0)`; a typical dive shape (fast descent, long deep bottom, ascent tail to top-right) → NOT top-right (expect bottom-right); all-shallow profile hugging the top → a bottom corner; occupancy tie → top-right.
+- [ ] **Step 2:** Fullscreen page test: with no saved position and the standard test profile, the card's initial `FractionalOffset` equals `leastOccupiedReadoutCorner(...)` of that profile (assert via the card's `Align` alignment after pump); with a saved position, saved still wins (existing test keeps passing).
+- [ ] **Step 3:** Run — fails.
+- [ ] **Step 4:** Implement the pure function; in the fullscreen page, where `initialFraction` currently falls back to `DraggableReadoutCard.defaultFraction`, compute the fallback with `leastOccupiedReadoutCorner` from the dive profile samples (normalize by dive duration / max depth).
+- [ ] **Step 5:** Run both test files.
+- [ ] **Step 6:** Commit: `fix: fullscreen readout card defaults to the emptiest chart corner`
+
+### Task 7: Whole-project verification
+
+- [ ] `dart format .` (whole project — memory `format-all`).
+- [ ] `flutter analyze` whole project; zero issues (infos fatal).
+- [ ] Run the full affected test set: `flutter test test/features/dive_log/` (generous timeout; some hosts are slow — memory `timeout`).
+- [ ] Commit any format fixes: `style: format`.
+- [ ] Note in PR: Android on-device verification pending (gesture arena behavior is now deterministic and widget-tested, but pinch feel / hint discoverability should be confirmed on hardware).
+
+## Self-review notes
+
+- Spec coverage: complaint 1 → Tasks 1-3 (one-finger pan zoomed + reliable two-finger); complaint 2 → Task 3 (no arena hold, no tap-then-drag misclassification); complaint 3 → Tasks 4-6.
+- Type consistency: `ChartTouchClaimRecognizer` callbacks used in Task 3 match Task 2; `EventLabelSpec/Placement` names match between Tasks 4 and 5; `chartDragIntent(isZoomed:)` matches Tasks 1 and 3.
+- Known accepted trade-offs: double-tapping a photo marker now also zooms the chart (previously the marker's eager tap recognizer starved the chart's double-tap); double-tap-hold pan removed.

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_log/data/services/gas_usage_segments_se
 import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
 import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/readout_card_placement.dart';
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/domain/services/source_name_resolver.dart';
 import 'package:submersion/features/dive_log/presentation/providers/active_source_provider.dart';
@@ -66,6 +67,34 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
   void _onTooltipData(List<TooltipRow>? rows) {
     if (rows == null || rows.isEmpty) return; // sticky: keep last values
     setState(() => _readoutRows = rows);
+  }
+
+  /// Memoized default corner for the readout card, recomputed only when the
+  /// profile identity changes (the page rebuilds per playback tick).
+  Offset? _autoCorner;
+  List<DiveProfilePoint>? _autoCornerProfile;
+
+  /// Default readout-card corner: the chart corner the profile occupies
+  /// least (a saved dragged position always overrides this). Strided
+  /// sampling keeps this O(200) regardless of profile size.
+  Offset _defaultCardCorner(List<DiveProfilePoint> profile) {
+    if (!identical(profile, _autoCornerProfile)) {
+      _autoCornerProfile = profile;
+      final maxT = profile.isEmpty
+          ? 0.0
+          : profile
+                .map((p) => p.timestamp)
+                .reduce((a, b) => a > b ? a : b)
+                .toDouble();
+      final maxD = profile.fold(0.0, (m, p) => m > p.depth ? m : p.depth);
+      final stride = profile.length <= 200 ? 1 : profile.length ~/ 200;
+      _autoCorner = leastOccupiedReadoutCorner([
+        if (maxT > 0 && maxD > 0)
+          for (var i = 0; i < profile.length; i += stride)
+            Offset(profile[i].timestamp / maxT, profile[i].depth / maxD),
+      ]);
+    }
+    return _autoCorner!;
   }
 
   @override
@@ -436,7 +465,7 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                                 settings.fullscreenReadoutCardX!,
                                 settings.fullscreenReadoutCardY!,
                               )
-                            : null,
+                            : _defaultCardCorner(chartProfile),
                         onDragEnd: (fraction) => ref
                             .read(settingsProvider.notifier)
                             .setFullscreenReadoutCardPosition(

--- a/lib/features/dive_log/presentation/widgets/chart_touch_recognizer.dart
+++ b/lib/features/dive_log/presentation/widgets/chart_touch_recognizer.dart
@@ -48,7 +48,11 @@ class ChartTouchClaimRecognizer extends OneSequenceGestureRecognizer {
     startTrackingPointer(event.pointer, event.transform);
     if (_downPositions.isEmpty) _zoomedAtFirstDown = isZoomed();
     _downPositions[event.pointer] = event.position;
-    if (_downPositions.length == 2 && !_claimed) {
+    // Every pointer joins its own fresh arena, so each one landing into a
+    // multi-touch gesture must be resolved explicitly - including pointers
+    // joining an already-claimed drag or pinch (resolve() only touches
+    // still-pending entries, so repeating it is safe).
+    if (_downPositions.length >= 2) {
       resolve(GestureDisposition.accepted);
     }
   }

--- a/lib/features/dive_log/presentation/widgets/chart_touch_recognizer.dart
+++ b/lib/features/dive_log/presentation/widgets/chart_touch_recognizer.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+
+/// Claims the touch gestures on the dive profile chart that fl_chart's
+/// internal recognizers must not win:
+///
+///  - a second touch pointer landing (pinch / two-finger pan) is claimed
+///    immediately, so the pinch works even when the first finger already
+///    moved and fl_chart's pan recognizer owns that pointer's arena;
+///  - a single-finger drag past touch slop is claimed when [isZoomed]
+///    returned true at pointer-down, making "drag to pan" real on touch.
+///
+/// Hosted on a translucent overlay stacked directly above the [LineChart]:
+/// hit-testing reaches the overlay first, so this recognizer joins each
+/// pointer's arena before fl_chart's recognizers and wins ties
+/// deterministically (arena membership order follows hit-test order).
+///
+/// Taps and long-presses are deliberately NOT claimed: a single pointer that
+/// lifts without exceeding slop is resolved rejected here, letting
+/// fl_chart's tap recognizer win the sweep (tooltip on tap), and a
+/// long-press that fires before slop is exceeded takes the arena first
+/// (long-press scrubbing keeps working while zoomed).
+///
+/// This recognizer only ever claims the arena; the gesture math itself lives
+/// in the chart's passive [Listener], which sees every pointer event
+/// regardless of arena outcomes. [onClaimed]/[onReleased] tell the chart
+/// whether a touch drag is currently claimed (i.e. safe to pan).
+class ChartTouchClaimRecognizer extends OneSequenceGestureRecognizer {
+  ChartTouchClaimRecognizer({required this.isZoomed, super.debugOwner})
+    : super(supportedDevices: {PointerDeviceKind.touch});
+
+  /// Sampled at first pointer-down; a gesture keeps the meaning it started
+  /// with even if the viewport zoom changes mid-gesture.
+  final ValueGetter<bool> isZoomed;
+
+  /// Fired once when the recognizer wins an arena (drag pan or pinch).
+  VoidCallback? onClaimed;
+
+  /// Fired when the last tracked pointer lifts after a claim.
+  VoidCallback? onReleased;
+
+  final Map<int, Offset> _downPositions = {};
+  bool _claimed = false;
+  bool _zoomedAtFirstDown = false;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    startTrackingPointer(event.pointer, event.transform);
+    if (_downPositions.isEmpty) _zoomedAtFirstDown = isZoomed();
+    _downPositions[event.pointer] = event.position;
+    if (_downPositions.length == 2 && !_claimed) {
+      resolve(GestureDisposition.accepted);
+    }
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (event is PointerMoveEvent &&
+        !_claimed &&
+        _downPositions.length == 1 &&
+        _zoomedAtFirstDown) {
+      final start = _downPositions[event.pointer];
+      if (start != null &&
+          (event.position - start).distance >
+              computeHitSlop(event.kind, gestureSettings)) {
+        resolve(GestureDisposition.accepted);
+      }
+    } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+      // A pointer lifting before any claim is not ours: resolve rejected so
+      // the arena sweep can hand the tap to fl_chart immediately.
+      if (!_claimed) resolve(GestureDisposition.rejected);
+      _downPositions.remove(event.pointer);
+      stopTrackingPointer(event.pointer);
+    }
+  }
+
+  @override
+  void acceptGesture(int pointer) {
+    if (!_claimed) {
+      _claimed = true;
+      onClaimed?.call();
+    }
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {
+    final wasClaimed = _claimed;
+    _claimed = false;
+    _downPositions.clear();
+    if (wasClaimed) onReleased?.call();
+  }
+
+  @override
+  String get debugDescription => 'chart touch claim';
+}

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1909,9 +1909,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 _activePointerCount++;
                 _activePointerKind = event.kind;
                 _lastPointerLocal = event.localPosition;
-                if (event.kind != PointerDeviceKind.touch) return;
-                _touchPositions[event.pointer] = event.localPosition;
-                if (_touchPositions.length == 1) {
+                if (event.kind == PointerDeviceKind.touch) {
+                  _touchPositions[event.pointer] = event.localPosition;
+                }
+                // Tap bookkeeping is kind-agnostic: a mouse double-click
+                // zooms exactly like a touch double-tap.
+                if (_activePointerCount == 1) {
                   _tapDownPosition = event.localPosition;
                   _tapMoved = false;
                   final lastUp = _lastTapUpStamp;
@@ -1933,12 +1936,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 _lastPointerLocal = event.localPosition;
                 if (event.kind == PointerDeviceKind.touch) {
                   _touchPositions[event.pointer] = event.localPosition;
-                  if (!_tapMoved &&
-                      (event.localPosition - _tapDownPosition).distance >
-                          kTouchSlop) {
-                    _tapMoved = true;
-                    _doubleTapArmed = false;
-                  }
+                }
+                if (!_tapMoved &&
+                    (event.localPosition - _tapDownPosition).distance >
+                        kTouchSlop) {
+                  _tapMoved = true;
+                  _doubleTapArmed = false;
                 }
                 if (prev == null) return;
                 final intent = chartDragIntent(
@@ -1979,14 +1982,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               onPointerUp: (event) {
                 if (_activePointerCount > 0) _activePointerCount--;
                 _lastPointerLocal = null;
-                if (event.kind != PointerDeviceKind.touch) return;
-                _touchPositions.remove(event.pointer);
-                if (_pinchPointers.contains(event.pointer)) {
-                  _touchPositions.length >= 2
-                      ? _beginPinch()
-                      : _pinchPointers = const [];
+                if (event.kind == PointerDeviceKind.touch) {
+                  _touchPositions.remove(event.pointer);
+                  if (_pinchPointers.contains(event.pointer)) {
+                    _touchPositions.length >= 2
+                        ? _beginPinch()
+                        : _pinchPointers = const [];
+                  }
                 }
-                if (_touchPositions.isEmpty && !_tapMoved) {
+                if (_activePointerCount == 0 && !_tapMoved) {
                   if (_doubleTapArmed) {
                     _doubleTapArmed = false;
                     _lastTapUpStamp = null;

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -33,6 +33,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_l
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_overlay.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/profile_event_labels.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_highlight_range.dart';
 import 'package:submersion/core/ui/trackpad_zoom_recognizer.dart';
 
@@ -2051,6 +2052,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   context,
                   units,
                   availableWidth: constraints.maxWidth,
+                  availableHeight: constraints.maxHeight,
                   hasTemperatureData: hasTemperatureData,
                   hasPressureData: hasPressureData,
                   hasHeartRateData: hasHeartRateData,
@@ -2244,6 +2246,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     BuildContext context,
     UnitFormatter units, {
     required double availableWidth,
+    required double availableHeight,
     required bool hasTemperatureData,
     required bool hasPressureData,
     required bool hasHeartRateData,
@@ -2698,7 +2701,16 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 ..._buildHighlightCursor(colorScheme),
                 ..._buildHighlightRangeLines(visibleMinX, visibleMaxX),
                 if (_showEvents && widget.events != null)
-                  ..._buildEventVerticalLines(colorScheme),
+                  ..._buildEventVerticalLines(
+                    colorScheme,
+                    availableWidth: availableWidth,
+                    availableHeight: availableHeight,
+                    units: units,
+                    visibleMinX: visibleMinX,
+                    visibleMaxX: visibleMaxX,
+                    visibleMinDepth: visibleMinDepth,
+                    visibleMaxDepth: visibleMaxDepth,
+                  ),
               ],
             ),
             lineTouchData: LineTouchData(
@@ -5179,7 +5191,47 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   /// Groups events by timestamp and shows only the most severe event at each
   /// timestamp to avoid overlapping labels. Lines are colored by severity:
   /// info = primary, warning = orange, alert = red.
-  List<VerticalLine> _buildEventVerticalLines(ColorScheme colorScheme) {
+  /// Linearly interpolated profile depth (meters) at [timestamp] seconds.
+  /// Binary search keeps this O(log n) per event, cheap enough to run on
+  /// every pan/zoom rebuild.
+  double _depthAtTimestamp(double timestamp) {
+    final profile = widget.profile;
+    if (profile.isEmpty) return 0;
+    if (timestamp <= profile.first.timestamp) return profile.first.depth;
+    if (timestamp >= profile.last.timestamp) return profile.last.depth;
+    var lo = 0;
+    var hi = profile.length - 1;
+    while (hi - lo > 1) {
+      final mid = (lo + hi) ~/ 2;
+      if (profile[mid].timestamp <= timestamp) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+    }
+    final a = profile[lo];
+    final b = profile[hi];
+    final span = (b.timestamp - a.timestamp).toDouble();
+    if (span <= 0) return a.depth;
+    final f = (timestamp - a.timestamp) / span;
+    return a.depth + (b.depth - a.depth) * f;
+  }
+
+  /// Minimum pixel spacing between event lines before the less severe of the
+  /// pair is dropped entirely (line and label). At phone plot widths a few
+  /// seconds is sub-pixel; drawing both just paints noise.
+  static const double _eventMinSpacingPx = 24;
+
+  List<VerticalLine> _buildEventVerticalLines(
+    ColorScheme colorScheme, {
+    required double availableWidth,
+    required double availableHeight,
+    required UnitFormatter units,
+    required double visibleMinX,
+    required double visibleMaxX,
+    required double visibleMinDepth,
+    required double visibleMaxDepth,
+  }) {
     final events = widget.events;
     if (events == null || events.isEmpty) return [];
 
@@ -5200,26 +5252,131 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       }
     }
 
-    return byTimestamp.values.map((event) {
-      final color = _eventSeverityColor(event.severity, colorScheme);
-      return VerticalLine(
-        x: event.timestamp.toDouble(),
-        color: color,
-        strokeWidth: 1,
-        dashArray: [3, 3],
-        label: VerticalLineLabel(
-          show: true,
-          alignment: Alignment.topCenter,
-          padding: const EdgeInsets.only(bottom: 2),
-          style: TextStyle(
-            color: color,
-            fontSize: 9,
-            backgroundColor: colorScheme.surface.withValues(alpha: 0.8),
-          ),
-          labelResolver: (line) => event.displayName,
+    // Plot-rect pixel geometry, mirroring the insets fl_chart reserves.
+    final insets = _plotInsets(availableWidth, units);
+    final plotW = (availableWidth - insets.left - insets.right).clamp(
+      1.0,
+      double.infinity,
+    );
+    final plotH = (availableHeight - insets.top - insets.bottom).clamp(
+      1.0,
+      double.infinity,
+    );
+    final rangeX = (visibleMaxX - visibleMinX).clamp(1e-9, double.infinity);
+    final rangeY = (visibleMaxDepth - visibleMinDepth).clamp(
+      1e-9,
+      double.infinity,
+    );
+    double xPx(num t) => (t - visibleMinX) / rangeX * plotW;
+
+    // Pixel-space dedupe: events landing within _eventMinSpacingPx of an
+    // already kept neighbour keep only the most severe of the pair.
+    final ordered = byTimestamp.values.toList()
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    final kept = <ProfileEvent>[];
+    for (final event in ordered) {
+      if (kept.isNotEmpty &&
+          (xPx(event.timestamp) - xPx(kept.last.timestamp)).abs() <
+              _eventMinSpacingPx) {
+        if (event.severity.index > kept.last.severity.index) {
+          kept[kept.length - 1] = event;
+        }
+      } else {
+        kept.add(event);
+      }
+    }
+
+    // Collision-aware label placement for the events inside the visible
+    // window: anchored below the profile depth at the event's time (free
+    // water instead of the surface tail), flipped off the plot edges, and
+    // hidden when there is genuinely no room (see placeEventLabels).
+    const labelStyle = TextStyle(fontSize: 9);
+    final inWindow = <int>[];
+    final specs = <EventLabelSpec>[];
+    for (var i = 0; i < kept.length; i++) {
+      final t = kept[i].timestamp.toDouble();
+      if (t < visibleMinX || t > visibleMaxX) continue;
+      final painter = TextPainter(
+        text: TextSpan(text: kept[i].displayName, style: labelStyle),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final anchorY =
+          ((_depthAtTimestamp(t) - visibleMinDepth) / rangeY * plotH).clamp(
+            0.0,
+            plotH,
+          );
+      inWindow.add(i);
+      specs.add(
+        EventLabelSpec(
+          xPx: xPx(t),
+          anchorYPx: anchorY,
+          textWidth: painter.width,
+          textHeight: painter.height,
         ),
       );
-    }).toList();
+      painter.dispose();
+    }
+    final placements = placeEventLabels(
+      specs,
+      plotWidth: plotW,
+      plotHeight: plotH,
+    );
+    final placementByEvent = <int, EventLabelPlacement>{
+      for (var j = 0; j < inWindow.length; j++) inWindow[j]: placements[j],
+    };
+
+    return [
+      for (var i = 0; i < kept.length; i++)
+        _eventVerticalLine(kept[i], placementByEvent[i], colorScheme),
+    ];
+  }
+
+  VerticalLine _eventVerticalLine(
+    ProfileEvent event,
+    EventLabelPlacement? placement,
+    ColorScheme colorScheme,
+  ) {
+    final color = _eventSeverityColor(event.severity, colorScheme);
+    // fl_chart lays the label out inside
+    // Rect.fromLTRB(x - padding.right - textWidth, padding.top,
+    //               x + padding.left, ...):
+    // topCenter with zero horizontal padding centres the text on the line,
+    // topLeft puts its right edge padding.right left of the line, topRight
+    // its left edge padding.left right of the line. padding.top is the pixel
+    // offset from the plot top; placements are computed in the same space.
+    final alignment = switch (placement?.anchor) {
+      EventLabelAnchor.leftOfLine => Alignment.topLeft,
+      EventLabelAnchor.rightOfLine => Alignment.topRight,
+      _ => Alignment.topCenter,
+    };
+    final padding = switch (placement?.anchor) {
+      EventLabelAnchor.leftOfLine => EdgeInsets.only(
+        top: placement?.topPx ?? 0,
+        right: 4,
+      ),
+      EventLabelAnchor.rightOfLine => EdgeInsets.only(
+        top: placement?.topPx ?? 0,
+        left: 4,
+      ),
+      _ => EdgeInsets.only(top: placement?.topPx ?? 0),
+    };
+    return VerticalLine(
+      x: event.timestamp.toDouble(),
+      color: color,
+      strokeWidth: 1,
+      dashArray: [3, 3],
+      label: VerticalLineLabel(
+        show: placement?.showText ?? false,
+        alignment: alignment,
+        padding: padding,
+        style: TextStyle(
+          color: color,
+          fontSize: 9,
+          backgroundColor: colorScheme.surface.withValues(alpha: 0.8),
+        ),
+        labelResolver: (line) => event.displayName,
+      ),
+    );
   }
 
   /// Returns the color for an event based on its severity level.

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -844,6 +844,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   bool _tapMoved = false;
   bool _doubleTapArmed = false;
 
+  // Whether the right-axis metric selector strip is rendered this build.
+  // Set in _buildChart alongside effectiveRightAxisMetric; a double-tap
+  // whose second tap lands in the strip must not zoom (the strip's own tap
+  // opens the metric menu).
+  bool _rightAxisSelectorActive = false;
+
   // Index of the last sample reported via hover, to de-dupe onPointSelected.
   int? _lastHoverIndex;
 
@@ -1922,7 +1928,11 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                       lastUp != null &&
                       event.timeStamp - lastUp < kDoubleTapTimeout &&
                       (event.localPosition - _lastTapUpPosition).distance <=
-                          kDoubleTapSlop;
+                          kDoubleTapSlop &&
+                      !_inRightAxisSelector(
+                        event.localPosition,
+                        constraints.biggest,
+                      );
                 } else {
                   _doubleTapArmed = false;
                   _tapMoved = true;
@@ -2069,6 +2079,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       },
     );
   }
+
+  /// Whether [localPosition] falls inside the right-axis metric selector's
+  /// tap strip (mirrors the Positioned overlay in _buildChart: right 50 px,
+  /// excluding the bottom 30 px axis band). A second tap there is a
+  /// selector interaction, not a chart double-tap.
+  bool _inRightAxisSelector(Offset localPosition, Size box) =>
+      _rightAxisSelectorActive &&
+      localPosition.dx >= box.width - 50 &&
+      localPosition.dy <= box.height - 30;
 
   // Arena outcome callbacks from ChartTouchClaimRecognizer. Only event
   // handlers read the flag, so no rebuild is needed. Claiming also parks the
@@ -2315,6 +2334,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final rightAxisRange = effectiveRightAxisMetric != null
         ? _getMetricRange(effectiveRightAxisMetric, units)
         : null;
+    _rightAxisSelectorActive = effectiveRightAxisMetric != null;
 
     // Pressure bounds from multi-tank pressure data
     double? minPressure, maxPressure;
@@ -5302,6 +5322,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       if (t < visibleMinX || t > visibleMaxX) continue;
       final painter = TextPainter(
         text: TextSpan(text: kept[i].displayName, style: labelStyle),
+        // Deliberately LTR regardless of locale: fl_chart's painter lays
+        // vertical-line labels out with TextDirection.ltr
+        // (axis_chart_painter.dart), and this measurement must match the
+        // width it will actually paint with.
         textDirection: TextDirection.ltr,
       )..layout();
       final anchorY =
@@ -5325,45 +5349,40 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       plotWidth: plotW,
       plotHeight: plotH,
     );
-    final placementByEvent = <int, EventLabelPlacement>{
-      for (var j = 0; j < inWindow.length; j++) inWindow[j]: placements[j],
+    final labelByEvent = <int, (EventLabelSpec, EventLabelPlacement)>{
+      for (var j = 0; j < inWindow.length; j++)
+        inWindow[j]: (specs[j], placements[j]),
     };
 
     return [
       for (var i = 0; i < kept.length; i++)
-        _eventVerticalLine(kept[i], placementByEvent[i], colorScheme),
+        _eventVerticalLine(kept[i], labelByEvent[i], colorScheme),
     ];
   }
 
   VerticalLine _eventVerticalLine(
     ProfileEvent event,
-    EventLabelPlacement? placement,
+    (EventLabelSpec, EventLabelPlacement)? label,
     ColorScheme colorScheme,
   ) {
+    final spec = label?.$1;
+    final placement = label?.$2;
     final color = _eventSeverityColor(event.severity, colorScheme);
     // fl_chart lays the label out inside
     // Rect.fromLTRB(x - padding.right - textWidth, padding.top,
-    //               x + padding.left, ...):
-    // topCenter with zero horizontal padding centres the text on the line,
-    // topLeft puts its right edge padding.right left of the line, topRight
-    // its left edge padding.left right of the line. padding.top is the pixel
-    // offset from the plot top; placements are computed in the same space.
-    final alignment = switch (placement?.anchor) {
-      EventLabelAnchor.leftOfLine => Alignment.topLeft,
-      EventLabelAnchor.rightOfLine => Alignment.topRight,
-      _ => Alignment.topCenter,
-    };
-    final padding = switch (placement?.anchor) {
-      EventLabelAnchor.leftOfLine => EdgeInsets.only(
-        top: placement?.topPx ?? 0,
-        right: 4,
-      ),
-      EventLabelAnchor.rightOfLine => EdgeInsets.only(
-        top: placement?.topPx ?? 0,
-        left: 4,
-      ),
-      _ => EdgeInsets.only(top: placement?.topPx ?? 0),
-    };
+    //               x + padding.left, ...)
+    // and Alignment.topLeft draws the text with its top-left corner at
+    // (rect.left, rect.top). Solving rect.left == placement.leftPx gives
+    // padding.right = xPx - leftPx - textWidth, which may be negative for a
+    // label centred on (or clamped across) the line - fl_chart's painter is
+    // pure arithmetic, so negative padding is well-defined here. padding.top
+    // is the pixel offset from the plot top; placements share that space.
+    final padding = placement == null || spec == null
+        ? EdgeInsets.zero
+        : EdgeInsets.only(
+            top: placement.topPx,
+            right: spec.xPx - placement.leftPx - spec.textWidth,
+          );
     return VerticalLine(
       x: event.timestamp.toDouble(),
       color: color,
@@ -5371,7 +5390,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       dashArray: [3, 3],
       label: VerticalLineLabel(
         show: placement?.showText ?? false,
-        alignment: alignment,
+        alignment: Alignment.topLeft,
         padding: padding,
         style: TextStyle(
           color: color,

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -1970,7 +1970,7 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   final intent = chartDragIntent(
                     kind: _activePointerKind,
                     pointerCount: _activePointerCount,
-                    doubleTapHold: _doubleTapHold,
+                    isZoomed: _viewport.isZoomed || _doubleTapHold,
                   );
                   if (intent != ChartDragIntent.pan) return;
                   setState(() {

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -22,6 +22,7 @@ import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_legend_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/chart_series_cache.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/chart_touch_recognizer.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/deco_stop_band.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_legend.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_decimator.dart';
@@ -805,10 +806,6 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
   // Snapshot of the viewport at the start of a continuous gesture; continuous
   // gestures report cumulative scale/pan, so we apply them against this.
   ProfileChartViewport _gestureStartViewport = ProfileChartViewport.reset;
-  Offset _startFocalPoint = Offset.zero;
-
-  // Local position of the most recent (double-)tap, for tap-anchored zoom.
-  Offset _lastTapDownLocal = Offset.zero;
 
   // Active pointer kind, corrected on the first real pointer event. Chooses
   // pan-vs-scrub for single-pointer drags and is set by trackpad gestures.
@@ -818,11 +815,33 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       ? PointerDeviceKind.touch
       : PointerDeviceKind.mouse;
 
-  // Cursor position at the start of a trackpad pan/zoom gesture.
+  // All touch pointers currently down, by pointer id, in chart-local coords.
+  // Fed by the passive Listener, which sees every event regardless of who
+  // wins the gesture arena; the two-finger pinch math reads from here.
+  final Map<int, Offset> _touchPositions = {};
 
-  // True between a double-tap-down and the finger lifting; lets a held-finger
-  // drag pan instead of scrub.
-  bool _doubleTapHold = false;
+  // True while ChartTouchClaimRecognizer holds the arena for a touch drag.
+  // The Listener only pans a touch drag when claimed, so a long-press scrub
+  // (which wins the arena before any movement) is never fought by a pan.
+  bool _touchDragClaimed = false;
+
+  // The two pointer ids driving the current two-finger gesture, plus its
+  // start geometry. Cumulative scale/pan is applied against
+  // _gestureStartViewport, never the live viewport (no compounding).
+  List<int> _pinchPointers = const [];
+  double _pinchStartDistance = 1;
+  Offset _pinchStartFocal = Offset.zero;
+
+  // Manual double-tap detection off PointerEvent.timeStamp. Replaces a
+  // DoubleTapGestureRecognizer, which held every tap's arena for 300 ms and
+  // delayed fl_chart's tap/pan resolution (tooltip lag; fast tap-then-drag
+  // misclassified). Timestamps are monotonic on real devices; flutter_test
+  // must pass explicit timeStamp values.
+  Duration? _lastTapUpStamp;
+  Offset _lastTapUpPosition = Offset.zero;
+  Offset _tapDownPosition = Offset.zero;
+  bool _tapMoved = false;
+  bool _doubleTapArmed = false;
 
   // Index of the last sample reported via hover, to de-dupe onPointSelected.
   int? _lastHoverIndex;
@@ -1884,22 +1903,60 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     (recognizer) => recognizer.onZoom = zoomAt,
                   ),
             },
-            child: GestureDetector(
-              onScaleStart: (details) {
-                _gestureStartViewport = _viewport;
-                _startFocalPoint = details.localFocalPoint;
+            child: Listener(
+              onPointerDown: (event) {
+                _activePointerCount++;
+                _activePointerKind = event.kind;
+                _lastPointerLocal = event.localPosition;
+                if (event.kind != PointerDeviceKind.touch) return;
+                _touchPositions[event.pointer] = event.localPosition;
+                if (_touchPositions.length == 1) {
+                  _tapDownPosition = event.localPosition;
+                  _tapMoved = false;
+                  final lastUp = _lastTapUpStamp;
+                  _doubleTapArmed =
+                      lastUp != null &&
+                      event.timeStamp - lastUp < kDoubleTapTimeout &&
+                      (event.localPosition - _lastTapUpPosition).distance <=
+                          kDoubleTapSlop;
+                } else {
+                  _doubleTapArmed = false;
+                  _tapMoved = true;
+                  if (_touchPositions.length == 2) {
+                    _beginPinch();
+                  }
+                }
               },
-              onScaleUpdate: (details) {
-                // Single-pointer drags are handled by Listener.onPointerMove
-                // (mouse pan) and fl_chart's own recognizer (touch scrub); they
-                // never reach onScaleUpdate, which only ever fires for a pinch.
-                if (details.pointerCount < 2) return;
-
-                // Trackpad pinch/scroll is handled by the
-                // TrackpadZoomGestureRecognizer (reliable cursor anchor); touch
-                // focal points are correct, so touch pinch is handled here.
-                if (_activePointerKind != PointerDeviceKind.touch) return;
-
+              onPointerMove: (event) {
+                final prev = _lastPointerLocal;
+                _lastPointerLocal = event.localPosition;
+                if (event.kind == PointerDeviceKind.touch) {
+                  _touchPositions[event.pointer] = event.localPosition;
+                  if (!_tapMoved &&
+                      (event.localPosition - _tapDownPosition).distance >
+                          kTouchSlop) {
+                    _tapMoved = true;
+                    _doubleTapArmed = false;
+                  }
+                }
+                if (prev == null) return;
+                final intent = chartDragIntent(
+                  kind: _activePointerKind,
+                  pointerCount: _activePointerCount,
+                  isZoomed: _viewport.isZoomed,
+                );
+                if (intent == ChartDragIntent.zoomPan &&
+                    _activePointerKind == PointerDeviceKind.touch) {
+                  _updatePinch(constraints, units);
+                  return;
+                }
+                if (intent != ChartDragIntent.pan) return;
+                // A touch drag only pans once the claim recognizer has won
+                // the arena; a long-press scrub keeps the drag otherwise.
+                if (_activePointerKind == PointerDeviceKind.touch &&
+                    !_touchDragClaimed) {
+                  return;
+                }
                 setState(() {
                   final box = constraints.biggest;
                   final insets = _plotInsets(constraints.maxWidth, units);
@@ -1911,145 +1968,93 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     1.0,
                     double.infinity,
                   );
-                  final focal = chartFocalFraction(
-                    _startFocalPoint,
-                    box,
-                    left: insets.left,
-                    right: insets.right,
-                    top: insets.top,
-                    bottom: insets.bottom,
+                  final d = event.localPosition - prev;
+                  _viewport = _viewport.pannedBy(
+                    -d.dx / plotW / _viewport.zoom,
+                    -d.dy / plotH / _viewport.zoom,
                   );
-                  // scale is cumulative from gesture start -> apply to snapshot.
-                  var vp = _gestureStartViewport.zoomedAt(
-                    focal.fx,
-                    focal.fy,
-                    details.scale,
-                  );
-                  final panPx = details.localFocalPoint - _startFocalPoint;
-                  vp = vp.pannedBy(
-                    -panPx.dx / plotW / vp.zoom,
-                    -panPx.dy / plotH / vp.zoom,
-                  );
-                  _viewport = vp;
                 });
               },
-              onDoubleTapDown: (details) {
-                _lastTapDownLocal = details.localPosition;
-                _doubleTapHold = true;
-              },
-              onDoubleTap: () {
-                _doubleTapHold = false;
-                setState(() {
-                  if (_viewport.isZoomed) {
-                    _viewport = ProfileChartViewport.reset;
+              onPointerUp: (event) {
+                if (_activePointerCount > 0) _activePointerCount--;
+                _lastPointerLocal = null;
+                if (event.kind != PointerDeviceKind.touch) return;
+                _touchPositions.remove(event.pointer);
+                if (_pinchPointers.contains(event.pointer)) {
+                  _touchPositions.length >= 2
+                      ? _beginPinch()
+                      : _pinchPointers = const [];
+                }
+                if (_touchPositions.isEmpty && !_tapMoved) {
+                  if (_doubleTapArmed) {
+                    _doubleTapArmed = false;
+                    _lastTapUpStamp = null;
+                    _toggleDoubleTapZoom(_tapDownPosition, constraints, units);
                   } else {
+                    _lastTapUpStamp = event.timeStamp;
+                    _lastTapUpPosition = event.localPosition;
+                  }
+                }
+              },
+              onPointerCancel: (event) {
+                if (_activePointerCount > 0) _activePointerCount--;
+                _lastPointerLocal = null;
+                _touchPositions.remove(event.pointer);
+                if (_pinchPointers.contains(event.pointer)) {
+                  _touchPositions.length >= 2
+                      ? _beginPinch()
+                      : _pinchPointers = const [];
+                }
+                _doubleTapArmed = false;
+              },
+              // Trackpad two-finger scroll/pinch is handled by the
+              // TrackpadZoomGestureRecognizer above (it wins the gesture arena so
+              // it cannot also scroll the enclosing page).
+              onPointerSignal: (event) {
+                if (event is PointerScrollEvent) {
+                  setState(() {
                     final box = constraints.biggest;
                     final insets = _plotInsets(constraints.maxWidth, units);
                     final focal = chartFocalFraction(
-                      _lastTapDownLocal,
+                      event.localPosition,
                       box,
                       left: insets.left,
                       right: insets.right,
                       top: insets.top,
                       bottom: insets.bottom,
                     );
-                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
-                  }
-                });
-              },
-              child: Listener(
-                onPointerDown: (event) {
-                  _activePointerCount++;
-                  _activePointerKind = event.kind;
-                  _lastPointerLocal = event.localPosition;
-                },
-                onPointerMove: (event) {
-                  final prev = _lastPointerLocal;
-                  _lastPointerLocal = event.localPosition;
-                  if (prev == null) return;
-                  final intent = chartDragIntent(
-                    kind: _activePointerKind,
-                    pointerCount: _activePointerCount,
-                    isZoomed: _viewport.isZoomed || _doubleTapHold,
-                  );
-                  if (intent != ChartDragIntent.pan) return;
-                  setState(() {
-                    final box = constraints.biggest;
-                    final insets = _plotInsets(constraints.maxWidth, units);
-                    final plotW = (box.width - insets.left - insets.right)
-                        .clamp(1.0, double.infinity);
-                    final plotH = (box.height - insets.top - insets.bottom)
-                        .clamp(1.0, double.infinity);
-                    final d = event.localPosition - prev;
-                    _viewport = _viewport.pannedBy(
-                      -d.dx / plotW / _viewport.zoom,
-                      -d.dy / plotH / _viewport.zoom,
-                    );
+                    final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
+                    _viewport = _viewport.zoomedAt(focal.fx, focal.fy, factor);
                   });
-                },
-                onPointerUp: (event) {
-                  if (_activePointerCount > 0) _activePointerCount--;
-                  _lastPointerLocal = null;
-                  _doubleTapHold = false;
-                },
-                onPointerCancel: (event) {
-                  if (_activePointerCount > 0) _activePointerCount--;
-                  _lastPointerLocal = null;
-                  _doubleTapHold = false;
-                },
-                // Trackpad two-finger scroll/pinch is handled by the
-                // TrackpadZoomGestureRecognizer above (it wins the gesture arena so
-                // it cannot also scroll the enclosing page).
-                onPointerSignal: (event) {
-                  if (event is PointerScrollEvent) {
-                    setState(() {
-                      final box = constraints.biggest;
-                      final insets = _plotInsets(constraints.maxWidth, units);
-                      final focal = chartFocalFraction(
-                        event.localPosition,
-                        box,
-                        left: insets.left,
-                        right: insets.right,
-                        top: insets.top,
-                        bottom: insets.bottom,
-                      );
-                      final factor = event.scrollDelta.dy < 0 ? 1.1 : 1 / 1.1;
-                      _viewport = _viewport.zoomedAt(
-                        focal.fx,
-                        focal.fy,
-                        factor,
-                      );
-                    });
+                }
+              },
+              onPointerHover: (event) {
+                _activePointerKind = PointerDeviceKind.mouse;
+                final idx = _hoverIndex(
+                  event.localPosition,
+                  constraints.biggest,
+                  _plotInsets(constraints.maxWidth, units),
+                );
+                if (idx != _lastHoverIndex) {
+                  _lastHoverIndex = idx;
+                  widget.onPointSelected?.call(idx);
+                }
+              },
+              child: MouseRegion(
+                onExit: (_) {
+                  if (_lastHoverIndex != null) {
+                    _lastHoverIndex = null;
+                    widget.onPointSelected?.call(null);
                   }
                 },
-                onPointerHover: (event) {
-                  _activePointerKind = PointerDeviceKind.mouse;
-                  final idx = _hoverIndex(
-                    event.localPosition,
-                    constraints.biggest,
-                    _plotInsets(constraints.maxWidth, units),
-                  );
-                  if (idx != _lastHoverIndex) {
-                    _lastHoverIndex = idx;
-                    widget.onPointSelected?.call(idx);
-                  }
-                },
-                child: MouseRegion(
-                  onExit: (_) {
-                    if (_lastHoverIndex != null) {
-                      _lastHoverIndex = null;
-                      widget.onPointSelected?.call(null);
-                    }
-                  },
-                  child: _buildChart(
-                    context,
-                    units,
-                    availableWidth: constraints.maxWidth,
-                    hasTemperatureData: hasTemperatureData,
-                    hasPressureData: hasPressureData,
-                    hasHeartRateData: hasHeartRateData,
-                    totalMaxDepth: totalMaxDepth,
-                  ),
+                child: _buildChart(
+                  context,
+                  units,
+                  availableWidth: constraints.maxWidth,
+                  hasTemperatureData: hasTemperatureData,
+                  hasPressureData: hasPressureData,
+                  hasHeartRateData: hasHeartRateData,
+                  totalMaxDepth: totalMaxDepth,
                 ),
               ),
             ),
@@ -2057,6 +2062,100 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
         );
       },
     );
+  }
+
+  // Arena outcome callbacks from ChartTouchClaimRecognizer. Only event
+  // handlers read the flag, so no rebuild is needed. Claiming also parks the
+  // tooltip: fl_chart emits a selection at pointer-down (pan-down/tap
+  // deadline) but is rejected mid-gesture once the claim wins, so it never
+  // sends the touch-end event that would clear that selection.
+  void _onTouchDragClaimed() {
+    _touchDragClaimed = true;
+    widget.onPointSelected?.call(null);
+  }
+
+  void _onTouchDragReleased() => _touchDragClaimed = false;
+
+  /// Snapshots the start of a two-finger gesture: the two driving pointers,
+  /// their separation and midpoint, and the viewport the cumulative
+  /// scale/pan is applied against. Re-invoked when the driving pair changes
+  /// (a third finger replacing a lifted one) so the gesture re-anchors
+  /// instead of jumping. Also parks the tooltip: fl_chart may still own the
+  /// first pointer's arena and would keep scrubbing under the pinch.
+  void _beginPinch() {
+    _pinchPointers = _touchPositions.keys.take(2).toList(growable: false);
+    final p0 = _touchPositions[_pinchPointers[0]]!;
+    final p1 = _touchPositions[_pinchPointers[1]]!;
+    _pinchStartDistance = (p0 - p1).distance.clamp(1.0, double.infinity);
+    _pinchStartFocal = (p0 + p1) / 2;
+    _gestureStartViewport = _viewport;
+    widget.onPointSelected?.call(null);
+  }
+
+  /// Applies the live two-finger scale/pan against the gesture-start
+  /// snapshot: zoom by the separation ratio anchored at the start focal
+  /// point, then pan by the focal point's movement.
+  void _updatePinch(BoxConstraints constraints, UnitFormatter units) {
+    if (_pinchPointers.length < 2) return;
+    final p0 = _touchPositions[_pinchPointers[0]];
+    final p1 = _touchPositions[_pinchPointers[1]];
+    if (p0 == null || p1 == null) return;
+    setState(() {
+      final box = constraints.biggest;
+      final insets = _plotInsets(constraints.maxWidth, units);
+      final plotW = (box.width - insets.left - insets.right).clamp(
+        1.0,
+        double.infinity,
+      );
+      final plotH = (box.height - insets.top - insets.bottom).clamp(
+        1.0,
+        double.infinity,
+      );
+      final focal = chartFocalFraction(
+        _pinchStartFocal,
+        box,
+        left: insets.left,
+        right: insets.right,
+        top: insets.top,
+        bottom: insets.bottom,
+      );
+      final scale =
+          (p0 - p1).distance.clamp(1.0, double.infinity) / _pinchStartDistance;
+      var vp = _gestureStartViewport.zoomedAt(focal.fx, focal.fy, scale);
+      final panPx = (p0 + p1) / 2 - _pinchStartFocal;
+      vp = vp.pannedBy(
+        -panPx.dx / plotW / vp.zoom,
+        -panPx.dy / plotH / vp.zoom,
+      );
+      _viewport = vp;
+    });
+  }
+
+  /// Double-tap toggle: zoom 2x anchored at the tap, or reset when already
+  /// zoomed. Invoked by the manual timestamp-based double-tap detection in
+  /// the Listener (see the field comments on _lastTapUpStamp).
+  void _toggleDoubleTapZoom(
+    Offset localPosition,
+    BoxConstraints constraints,
+    UnitFormatter units,
+  ) {
+    setState(() {
+      if (_viewport.isZoomed) {
+        _viewport = ProfileChartViewport.reset;
+      } else {
+        final box = constraints.biggest;
+        final insets = _plotInsets(constraints.maxWidth, units);
+        final focal = chartFocalFraction(
+          localPosition,
+          box,
+          left: insets.left,
+          right: insets.right,
+          top: insets.top,
+          bottom: insets.bottom,
+        );
+        _viewport = _viewport.zoomedAt(focal.fx, focal.fy, 2.0);
+      }
+    });
   }
 
   Widget _buildEmptyState(BuildContext context) {
@@ -2623,6 +2722,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 ];
               },
               touchCallback: (event, response) {
+                // During a two-finger gesture fl_chart may still own the
+                // first pointer's arena (its pan won before the second
+                // finger landed) and would keep scrubbing under the pinch;
+                // the pinch owns the interaction, so ignore its events. The
+                // same applies while a one-finger pan drag is claimed.
+                if (_activePointerCount >= 2 || _touchDragClaimed) return;
                 final isTouchEnd =
                     event is FlPointerExitEvent ||
                     event is FlLongPressEnd ||
@@ -3388,6 +3493,32 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           // (verticalLines lerp by index, and cursor lines shift the
           // indices), and smearing bars while panning. Render immediately.
           duration: Duration.zero,
+        ),
+        // Touch claim overlay. Stacked directly above the LineChart so it is
+        // hit-tested first: its recognizer joins each pointer's arena before
+        // fl_chart's internal pan/tap/long-press recognizers and therefore
+        // wins ties. Translucent, so fl_chart still receives every pointer
+        // (taps, long-press scrubs) that the recognizer does not claim. The
+        // interactive overlays stacked above (metric selector, photo
+        // markers) keep their priority over this layer.
+        Positioned.fill(
+          child: RawGestureDetector(
+            behavior: HitTestBehavior.translucent,
+            gestures: {
+              ChartTouchClaimRecognizer:
+                  GestureRecognizerFactoryWithHandlers<
+                    ChartTouchClaimRecognizer
+                  >(
+                    () => ChartTouchClaimRecognizer(
+                      isZoomed: () => _viewport.isZoomed,
+                      debugOwner: this,
+                    ),
+                    (recognizer) => recognizer
+                      ..onClaimed = _onTouchDragClaimed
+                      ..onReleased = _onTouchDragReleased,
+                  ),
+            },
+          ),
         ),
         // Right axis tap overlay for metric selection
         if (effectiveRightAxisMetric != null)

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -2005,7 +2005,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     _doubleTapArmed = false;
                     _lastTapUpStamp = null;
                     _toggleDoubleTapZoom(_tapDownPosition, constraints, units);
-                  } else {
+                  } else if (!_inRightAxisSelector(
+                    event.localPosition,
+                    constraints.biggest,
+                  )) {
+                    // Selector-strip taps belong to the metric menu; they
+                    // neither arm (see onPointerDown) nor seed a double-tap.
                     _lastTapUpStamp = event.timeStamp;
                     _lastTapUpPosition = event.localPosition;
                   }

--- a/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_chart_viewport.dart
@@ -85,17 +85,17 @@ class ProfileChartViewport {
 enum ChartDragIntent { pan, scrub, zoomPan, none }
 
 /// Decides the meaning of an in-progress gesture from the active pointer kind,
-/// the pointer count, and whether a double-tap-hold is active. Keying off the
+/// the pointer count, and whether the viewport is zoomed in. Keying off the
 /// pointer kind (not the platform) is what lets one-finger touch keep scrubbing
-/// while a mouse drag pans.
+/// while a mouse drag pans. A zoomed viewport flips one-finger touch from
+/// scrub to pan ("drag to pan", matching the on-screen zoom hint); scrubbing
+/// while zoomed remains available via tap and long-press drag.
 ChartDragIntent chartDragIntent({
   required PointerDeviceKind kind,
   required int pointerCount,
-  required bool doubleTapHold,
+  required bool isZoomed,
 }) {
   if (pointerCount >= 2) return ChartDragIntent.zoomPan;
-  if (doubleTapHold) return ChartDragIntent.pan;
-  return kind == PointerDeviceKind.touch
-      ? ChartDragIntent.scrub
-      : ChartDragIntent.pan;
+  if (kind != PointerDeviceKind.touch) return ChartDragIntent.pan;
+  return isZoomed ? ChartDragIntent.pan : ChartDragIntent.scrub;
 }

--- a/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:ui';
 
 /// Geometry of one event label candidate, in plot-rect pixel space.
@@ -94,7 +95,9 @@ List<EventLabelPlacement> placeEventLabels(
       left = spec.xPx - spec.textWidth / 2;
     }
 
-    final maxTop = plotHeight - spec.textHeight;
+    // Floor at 0: a transient layout can hand us a plot shorter than the
+    // text, and clamp() throws when its bounds are inverted.
+    final maxTop = math.max(0.0, plotHeight - spec.textHeight);
     bool collides(double top) {
       final rect = Rect.fromLTWH(left, top, spec.textWidth, spec.textHeight);
       return placedRects.any(rect.overlaps);

--- a/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
@@ -1,0 +1,144 @@
+import 'dart:ui';
+
+/// Geometry of one event label candidate, in plot-rect pixel space.
+class EventLabelSpec {
+  /// Pixel x of the event's vertical line within the plot rect.
+  final double xPx;
+
+  /// Pixel y of the profile depth at the event's time. Labels are anchored
+  /// just below this point: the free water column under the curve, instead
+  /// of the plot top where the surface (and the end-of-dive ascent tail)
+  /// lives.
+  final double anchorYPx;
+
+  final double textWidth;
+  final double textHeight;
+
+  const EventLabelSpec({
+    required this.xPx,
+    required this.anchorYPx,
+    required this.textWidth,
+    required this.textHeight,
+  });
+}
+
+/// Which side of the event line the label text sits on.
+enum EventLabelAnchor { center, leftOfLine, rightOfLine }
+
+/// Where (and whether) one event label is drawn. Placement i corresponds to
+/// spec i of the input.
+class EventLabelPlacement {
+  /// False when no collision-free slot exists; the event's vertical line is
+  /// still drawn, only the text is dropped.
+  final bool showText;
+
+  /// Pixel y of the label's top edge within the plot rect.
+  final double topPx;
+
+  final EventLabelAnchor anchor;
+
+  const EventLabelPlacement({
+    required this.showText,
+    required this.topPx,
+    required this.anchor,
+  });
+}
+
+/// Vertical clearance between stacked labels.
+const double _labelStackGap = 2;
+
+/// Horizontal clearance between a flipped label and its event line,
+/// mirrored by the chart-side EdgeInsets when mapping to VerticalLineLabel.
+const double _lineGap = 4;
+
+/// Places event labels below their profile-depth anchor with collision
+/// avoidance, replacing the previous fixed top-of-plot pinning that buried
+/// the shallow end-of-dive tail under a pile of ascent-event labels.
+///
+/// Rules, applied per label scanning left to right:
+///  - horizontal: centered on the event line; flipped fully left/right of
+///    the line when the centered extent would cross a plot edge;
+///  - vertical: `anchorYPx + gap` (just below the curve point), clamped
+///    into the plot; while the rect intersects an already-placed label it
+///    is stepped downward, and if it runs off the bottom the search retries
+///    upward from just above the anchor;
+///  - if neither direction has room, the text is hidden (`showText: false`)
+///    rather than stacked over the profile.
+List<EventLabelPlacement> placeEventLabels(
+  List<EventLabelSpec> specs, {
+  required double plotWidth,
+  required double plotHeight,
+  double gap = 4,
+}) {
+  final placements = List<EventLabelPlacement?>.filled(specs.length, null);
+  final placedRects = <Rect>[];
+
+  // Scan in x order so pushed-down labels cascade predictably, but write
+  // results back to the input index.
+  final order = List<int>.generate(specs.length, (i) => i)
+    ..sort((a, b) => specs[a].xPx.compareTo(specs[b].xPx));
+
+  for (final i in order) {
+    final spec = specs[i];
+
+    final EventLabelAnchor anchor;
+    final double left;
+    if (spec.xPx + spec.textWidth / 2 > plotWidth) {
+      anchor = EventLabelAnchor.leftOfLine;
+      left = spec.xPx - spec.textWidth - _lineGap;
+    } else if (spec.xPx - spec.textWidth / 2 < 0) {
+      anchor = EventLabelAnchor.rightOfLine;
+      left = spec.xPx + _lineGap;
+    } else {
+      anchor = EventLabelAnchor.center;
+      left = spec.xPx - spec.textWidth / 2;
+    }
+
+    final maxTop = plotHeight - spec.textHeight;
+    bool collides(double top) {
+      final rect = Rect.fromLTWH(left, top, spec.textWidth, spec.textHeight);
+      return placedRects.any(rect.overlaps);
+    }
+
+    double? resolvedTop;
+    // Downward from just below the anchor.
+    var top = (spec.anchorYPx + gap).clamp(0.0, maxTop);
+    while (top <= maxTop) {
+      if (!collides(top)) {
+        resolvedTop = top;
+        break;
+      }
+      top += spec.textHeight + _labelStackGap;
+    }
+    // Upward from just above the anchor.
+    if (resolvedTop == null) {
+      top = (spec.anchorYPx - gap - spec.textHeight).clamp(0.0, maxTop);
+      while (top >= 0) {
+        if (!collides(top)) {
+          resolvedTop = top;
+          break;
+        }
+        top -= spec.textHeight + _labelStackGap;
+      }
+    }
+
+    if (resolvedTop == null) {
+      placements[i] = EventLabelPlacement(
+        showText: false,
+        topPx: (spec.anchorYPx + gap).clamp(0.0, maxTop),
+        anchor: anchor,
+      );
+    } else {
+      placements[i] = EventLabelPlacement(
+        showText: true,
+        topPx: resolvedTop,
+        anchor: anchor,
+      );
+      placedRects.add(
+        Rect.fromLTWH(left, resolvedTop, spec.textWidth, spec.textHeight),
+      );
+    }
+  }
+
+  return placements.cast<EventLabelPlacement>();
+}

--- a/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_event_labels.dart
@@ -23,9 +23,6 @@ class EventLabelSpec {
   });
 }
 
-/// Which side of the event line the label text sits on.
-enum EventLabelAnchor { center, leftOfLine, rightOfLine }
-
 /// Where (and whether) one event label is drawn. Placement i corresponds to
 /// spec i of the input.
 class EventLabelPlacement {
@@ -36,20 +33,23 @@ class EventLabelPlacement {
   /// Pixel y of the label's top edge within the plot rect.
   final double topPx;
 
-  final EventLabelAnchor anchor;
+  /// Pixel x of the label's left edge within the plot rect. Centered on the
+  /// event line by default, shifted fully to one side of the line near a
+  /// plot edge, and always clamped so the text stays inside the plot even
+  /// when a long localized string barely fits.
+  final double leftPx;
 
   const EventLabelPlacement({
     required this.showText,
     required this.topPx,
-    required this.anchor,
+    required this.leftPx,
   });
 }
 
 /// Vertical clearance between stacked labels.
 const double _labelStackGap = 2;
 
-/// Horizontal clearance between a flipped label and its event line,
-/// mirrored by the chart-side EdgeInsets when mapping to VerticalLineLabel.
+/// Horizontal clearance between a flipped label and its event line.
 const double _lineGap = 4;
 
 /// Places event labels below their profile-depth anchor with collision
@@ -58,7 +58,9 @@ const double _lineGap = 4;
 ///
 /// Rules, applied per label scanning left to right:
 ///  - horizontal: centered on the event line; flipped fully left/right of
-///    the line when the centered extent would cross a plot edge;
+///    the line when the centered extent would cross a plot edge, and then
+///    clamped into the plot (a string wider than the remaining space slides
+///    inward rather than clipping);
 ///  - vertical: `anchorYPx + gap` (just below the curve point), clamped
 ///    into the plot; while the rect intersects an already-placed label it
 ///    is stepped downward, and if it runs off the bottom the search retries
@@ -82,18 +84,17 @@ List<EventLabelPlacement> placeEventLabels(
   for (final i in order) {
     final spec = specs[i];
 
-    final EventLabelAnchor anchor;
-    final double left;
+    final double desiredLeft;
     if (spec.xPx + spec.textWidth / 2 > plotWidth) {
-      anchor = EventLabelAnchor.leftOfLine;
-      left = spec.xPx - spec.textWidth - _lineGap;
+      desiredLeft = spec.xPx - spec.textWidth - _lineGap;
     } else if (spec.xPx - spec.textWidth / 2 < 0) {
-      anchor = EventLabelAnchor.rightOfLine;
-      left = spec.xPx + _lineGap;
+      desiredLeft = spec.xPx + _lineGap;
     } else {
-      anchor = EventLabelAnchor.center;
-      left = spec.xPx - spec.textWidth / 2;
+      desiredLeft = spec.xPx - spec.textWidth / 2;
     }
+    final left = desiredLeft
+        .clamp(0.0, math.max(0.0, plotWidth - spec.textWidth))
+        .toDouble();
 
     // Floor at 0: a transient layout can hand us a plot shorter than the
     // text, and clamp() throws when its bounds are inverted.
@@ -129,13 +130,13 @@ List<EventLabelPlacement> placeEventLabels(
       placements[i] = EventLabelPlacement(
         showText: false,
         topPx: (spec.anchorYPx + gap).clamp(0.0, maxTop),
-        anchor: anchor,
+        leftPx: left,
       );
     } else {
       placements[i] = EventLabelPlacement(
         showText: true,
         topPx: resolvedTop,
-        anchor: anchor,
+        leftPx: left,
       );
       placedRects.add(
         Rect.fromLTWH(left, resolvedTop, spec.textWidth, spec.textHeight),

--- a/lib/features/dive_log/presentation/widgets/readout_card_placement.dart
+++ b/lib/features/dive_log/presentation/widgets/readout_card_placement.dart
@@ -40,7 +40,19 @@ Offset leastOccupiedReadoutCorner(List<Offset> normalizedProfile) {
       _cornerWidthFraction,
       _cornerHeightFraction,
     );
-    final count = normalizedProfile.where(window.contains).length;
+    // Inclusive on all edges: Rect.contains excludes right/bottom, but
+    // normalized profiles always hold exact 1.0 values (the last sample's
+    // time, the max-depth sample), which must count toward the right and
+    // bottom corner windows.
+    final count = normalizedProfile
+        .where(
+          (p) =>
+              p.dx >= window.left &&
+              p.dx <= window.right &&
+              p.dy >= window.top &&
+              p.dy <= window.bottom,
+        )
+        .length;
     if (count < bestCount) {
       bestCount = count;
       best = corner;

--- a/lib/features/dive_log/presentation/widgets/readout_card_placement.dart
+++ b/lib/features/dive_log/presentation/widgets/readout_card_placement.dart
@@ -1,0 +1,50 @@
+import 'dart:ui';
+
+/// Corner windows used to measure how much of the profile lives in each
+/// corner of the chart. Sized generously (45% x 40%) so a card up to roughly
+/// a third of the chart wide counts the curve it would actually cover.
+const double _cornerWidthFraction = 0.45;
+const double _cornerHeightFraction = 0.4;
+
+/// Picks the fullscreen readout card's default corner: the one whose corner
+/// window contains the fewest profile points.
+///
+/// [normalizedProfile] holds the dive profile as offsets normalized to the
+/// chart: x = time fraction (0..1), y = depth fraction (0 = surface/top,
+/// 1 = max depth/bottom) - the same orientation the chart draws.
+///
+/// Returns a [FractionalOffset]-style corner: (1, 0) top-right, (0, 0)
+/// top-left, (1, 1) bottom-right, (0, 1) bottom-left. Ties prefer top-right
+/// (the historical default), then top-left, bottom-right, bottom-left.
+///
+/// A typical dive is deep through the middle and shallow at both ends, so
+/// this usually lands on a bottom corner - away from the end-of-dive ascent
+/// tail that the old fixed top-right default sat on. A saved user-dragged
+/// position always takes precedence over this default (see the fullscreen
+/// page wiring).
+Offset leastOccupiedReadoutCorner(List<Offset> normalizedProfile) {
+  const corners = <Offset>[
+    Offset(1, 0), // top-right: historical default, wins ties
+    Offset(0, 0), // top-left
+    Offset(1, 1), // bottom-right
+    Offset(0, 1), // bottom-left
+  ];
+  if (normalizedProfile.isEmpty) return corners.first;
+
+  var best = corners.first;
+  var bestCount = 1 << 30;
+  for (final corner in corners) {
+    final window = Rect.fromLTWH(
+      corner.dx == 0 ? 0 : 1 - _cornerWidthFraction,
+      corner.dy == 0 ? 0 : 1 - _cornerHeightFraction,
+      _cornerWidthFraction,
+      _cornerHeightFraction,
+    );
+    final count = normalizedProfile.where(window.contains).length;
+    if (count < bestCount) {
+      bestCount = count;
+      best = corner;
+    }
+  }
+  return best;
+}

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -182,6 +182,51 @@ void main() {
     expect(cardRect.bottom, greaterThan(chartRect.center.dy));
   });
 
+  testWidgets('without a saved position the card defaults to the corner the '
+      'profile occupies least', (tester) async {
+    // Fast descent, long deep bottom, ascent tail rising into the top-right:
+    // the old fixed top-right default sat exactly on that tail. For this
+    // shape the emptiest corner window is the bottom-left (the fast descent
+    // leaves it almost immediately).
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1, 10),
+      profile: List.generate(61, (i) {
+        final t = i * 10;
+        final double depth;
+        if (t < 90) {
+          depth = 30.0 * t / 90;
+        } else if (t < 450) {
+          depth = 30;
+        } else {
+          depth = 30.0 * (600 - t) / 150;
+        }
+        return DiveProfilePoint(timestamp: t, depth: depth, temperature: 20);
+      }),
+    );
+    final overrides = _defaultOverrides()
+      ..removeAt(1)
+      ..insert(1, diveProvider(dive.id).overrideWith((ref) async => dive));
+    await tester.pumpWidget(_wrap(overrides));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<DraggableReadoutCard>(find.byType(DraggableReadoutCard))
+          .initialFraction,
+      const Offset(0, 1),
+      reason: 'the card must seed at the least occupied corner',
+    );
+    final chartRect = tester.getRect(find.byType(DiveProfileChart));
+    final cardRect = tester.getRect(find.byKey(const ValueKey('readout-card')));
+    expect(
+      cardRect.left,
+      lessThan(chartRect.center.dx),
+      reason: 'the card must avoid the occupied top-right corner',
+    );
+    expect(cardRect.top, greaterThan(chartRect.center.dy));
+  });
+
   testWidgets('chart fills most of the screen height', (tester) async {
     tester.view.physicalSize = const Size(1200, 900);
     tester.view.devicePixelRatio = 1.0;

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -186,8 +186,9 @@ void main() {
       'profile occupies least', (tester) async {
     // Fast descent, long deep bottom, ascent tail rising into the top-right:
     // the old fixed top-right default sat exactly on that tail. For this
-    // shape the emptiest corner window is the bottom-left (the fast descent
-    // leaves it almost immediately).
+    // shape the emptiest corner window is the top-left - the fast descent
+    // leaves it almost immediately, while the max-depth bottom line (which
+    // normalizes to exactly y = 1.0) fills both bottom corner windows.
     final dive = Dive(
       id: 'd1',
       dateTime: DateTime(2026, 1, 1, 10),
@@ -214,7 +215,7 @@ void main() {
       tester
           .widget<DraggableReadoutCard>(find.byType(DraggableReadoutCard))
           .initialFraction,
-      const Offset(0, 1),
+      const Offset(0, 0),
       reason: 'the card must seed at the least occupied corner',
     );
     final chartRect = tester.getRect(find.byType(DiveProfileChart));
@@ -224,7 +225,7 @@ void main() {
       lessThan(chartRect.center.dx),
       reason: 'the card must avoid the occupied top-right corner',
     );
-    expect(cardRect.top, greaterThan(chartRect.center.dy));
+    expect(cardRect.top, lessThan(chartRect.center.dy));
   });
 
   testWidgets('chart fills most of the screen height', (tester) async {

--- a/test/features/dive_log/presentation/widgets/chart_touch_recognizer_test.dart
+++ b/test/features/dive_log/presentation/widgets/chart_touch_recognizer_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/chart_touch_recognizer.dart';
+
+/// Harness mirroring the real chart stacking: a bottom layer owning plain
+/// pan/tap recognizers (stand-ins for fl_chart's internal recognizers, which
+/// normally win arena ties because they are hit-tested first) and a
+/// translucent overlay above it hosting [ChartTouchClaimRecognizer]. The
+/// overlay is hit first, so the claim recognizer joins each pointer's arena
+/// before the stand-ins - exactly the production arrangement.
+class _Harness extends StatelessWidget {
+  const _Harness({
+    required this.isZoomed,
+    required this.onClaimed,
+    required this.onReleased,
+    required this.onStandInPanStart,
+    required this.onStandInTap,
+  });
+
+  final ValueGetter<bool> isZoomed;
+  final VoidCallback onClaimed;
+  final VoidCallback onReleased;
+  final VoidCallback onStandInPanStart;
+  final VoidCallback onStandInTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: RawGestureDetector(
+              gestures: {
+                PanGestureRecognizer:
+                    GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+                      () => PanGestureRecognizer(),
+                      (r) => r.onStart = (_) => onStandInPanStart(),
+                    ),
+                TapGestureRecognizer:
+                    GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+                      () => TapGestureRecognizer(),
+                      (r) => r.onTap = onStandInTap,
+                    ),
+              },
+              child: Container(color: const Color(0xFF000000)),
+            ),
+          ),
+          Positioned.fill(
+            child: RawGestureDetector(
+              behavior: HitTestBehavior.translucent,
+              gestures: {
+                ChartTouchClaimRecognizer:
+                    GestureRecognizerFactoryWithHandlers<
+                      ChartTouchClaimRecognizer
+                    >(
+                      () => ChartTouchClaimRecognizer(isZoomed: isZoomed),
+                      (r) => r
+                        ..onClaimed = onClaimed
+                        ..onReleased = onReleased,
+                    ),
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void main() {
+  late int claims;
+  late int releases;
+  late int standInPans;
+  late int standInTaps;
+  var zoomed = false;
+
+  Widget harness() => _Harness(
+    isZoomed: () => zoomed,
+    onClaimed: () => claims++,
+    onReleased: () => releases++,
+    onStandInPanStart: () => standInPans++,
+    onStandInTap: () => standInTaps++,
+  );
+
+  setUp(() {
+    claims = 0;
+    releases = 0;
+    standInPans = 0;
+    standInTaps = 0;
+    zoomed = false;
+  });
+
+  testWidgets('zoomed one-finger drag past slop is claimed; the stand-in '
+      'pan never starts', (tester) async {
+    zoomed = true;
+    await tester.pumpWidget(harness());
+
+    final gesture = await tester.startGesture(const Offset(200, 200));
+    await gesture.moveBy(const Offset(30, 0));
+    await tester.pump();
+    expect(claims, 1);
+    expect(standInPans, 0);
+
+    await gesture.up();
+    await tester.pump();
+    expect(releases, 1);
+  });
+
+  testWidgets('unzoomed one-finger drag is not claimed; the stand-in pan '
+      'wins (scrub path preserved)', (tester) async {
+    await tester.pumpWidget(harness());
+
+    final gesture = await tester.startGesture(const Offset(200, 200));
+    // Past kPanSlop (36), the threshold a competing PanGestureRecognizer
+    // needs before it accepts.
+    await gesture.moveBy(const Offset(50, 0));
+    await tester.pump();
+    expect(claims, 0);
+    expect(standInPans, 1);
+
+    await gesture.up();
+    await tester.pump();
+    expect(releases, 0);
+  });
+
+  testWidgets('second finger landing after the first already moved is still '
+      'claimed (the async-finger pinch case)', (tester) async {
+    await tester.pumpWidget(harness());
+
+    final first = await tester.startGesture(const Offset(150, 200));
+    await first.moveBy(const Offset(50, 0)); // stand-in pan wins pointer 1
+    await tester.pump();
+    expect(standInPans, 1);
+
+    final second = await tester.startGesture(const Offset(250, 200));
+    await tester.pump();
+    expect(claims, 1, reason: 'pointer 2 must be claimed immediately');
+
+    await first.up();
+    await second.up();
+    await tester.pump();
+    expect(releases, 1);
+  });
+
+  testWidgets('a tap is never claimed, even while zoomed; the stand-in tap '
+      'fires', (tester) async {
+    zoomed = true;
+    await tester.pumpWidget(harness());
+
+    await tester.tapAt(const Offset(200, 200));
+    await tester.pump();
+    expect(claims, 0);
+    expect(standInTaps, 1);
+  });
+
+  testWidgets('mouse drags are ignored entirely (desktop pan path is the '
+      'passive listener, not this recognizer)', (tester) async {
+    zoomed = true;
+    await tester.pumpWidget(harness());
+
+    final gesture = await tester.startGesture(
+      const Offset(200, 200),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(50, 0));
+    await tester.pump();
+    expect(claims, 0);
+    expect(standInPans, 1);
+
+    await gesture.up();
+    await tester.pump();
+  });
+}

--- a/test/features/dive_log/presentation/widgets/chart_touch_recognizer_test.dart
+++ b/test/features/dive_log/presentation/widgets/chart_touch_recognizer_test.dart
@@ -145,6 +145,30 @@ void main() {
     expect(releases, 1);
   });
 
+  testWidgets('a second finger joining an already-claimed drag is resolved '
+      'too; the stand-in pan never engages', (tester) async {
+    zoomed = true;
+    await tester.pumpWidget(harness());
+
+    // One-finger drag past slop: claimed (pan-while-zoomed).
+    final first = await tester.startGesture(const Offset(150, 200));
+    await first.moveBy(const Offset(30, 0));
+    await tester.pump();
+    expect(claims, 1);
+
+    // Second finger lands into the claimed gesture and moves: its own arena
+    // must be resolved for us, so the stand-in pan can never win it.
+    final second = await tester.startGesture(const Offset(250, 200));
+    await second.moveBy(const Offset(50, 0));
+    await tester.pump();
+    expect(standInPans, 0);
+
+    await first.up();
+    await second.up();
+    await tester.pump();
+    expect(releases, 1);
+  });
+
   testWidgets('a tap is never claimed, even while zoomed; the stand-in tap '
       'fires', (tester) async {
     zoomed = true;

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_event_labels_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_event_labels_test.dart
@@ -1,0 +1,206 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Event-label placement on the rendered chart: labels are anchored below
+/// the profile depth at the event time (not pinned to the plot top where the
+/// end-of-dive tail lives), flipped inward at the right edge, staggered when
+/// they would overlap, and pixel-deduped when events are seconds apart.
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 20-minute dive: descend, bottom time, ascend with a shallow tail at the
+/// end (the classic shape whose tail the old top-pinned labels buried).
+List<DiveProfilePoint> _makeProfile() {
+  return List.generate(41, (i) {
+    final t = i * 30; // 0..1200 s
+    final double depth;
+    if (t < 180) {
+      depth = 30.0 * t / 180; // descent
+    } else if (t < 900) {
+      depth = 30; // bottom
+    } else if (t < 1110) {
+      depth = 30.0 * (1110 - t) / 210; // ascent
+    } else {
+      depth = 4; // shallow safety-stop tail
+    }
+    return DiveProfilePoint(timestamp: t, depth: depth);
+  });
+}
+
+ProfileEvent _event(
+  int timestamp,
+  ProfileEventType type, {
+  EventSeverity severity = EventSeverity.info,
+}) => ProfileEvent(
+  id: 'e$timestamp',
+  diveId: 'd1',
+  timestamp: timestamp,
+  eventType: type,
+  severity: severity,
+  createdAt: DateTime(2026),
+);
+
+Widget _buildChart(List<ProfileEvent> events) {
+  return ProviderScope(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 300,
+          child: DiveProfileChart(profile: _makeProfile(), events: events),
+        ),
+      ),
+    ),
+  );
+}
+
+List<VerticalLine> _eventLines(WidgetTester tester) {
+  final data = tester.widget<LineChart>(find.byType(LineChart).first).data;
+  // Event lines are the dashed ones; cursor/highlight lines are not dashed.
+  return data.extraLinesData.verticalLines
+      .where((l) => l.dashArray != null)
+      .toList();
+}
+
+void main() {
+  testWidgets('labels anchor below the profile depth, never pinned to the '
+      'surface line', (tester) async {
+    await tester.pumpWidget(
+      _buildChart([
+        _event(300, ProfileEventType.maxDepth),
+        _event(930, ProfileEventType.ascentStart),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    final lines = _eventLines(tester);
+    expect(lines, hasLength(2));
+    for (final line in lines) {
+      expect(line.label.show, isTrue);
+      expect(
+        line.label.padding.resolve(TextDirection.ltr).top,
+        greaterThan(0),
+        reason: 'labels must sit below the curve, not on the plot top edge',
+      );
+    }
+  });
+
+  testWidgets('tail-cluster labels near the dive end stay inside the plot '
+      'and do not overlap each other', (tester) async {
+    await tester.pumpWidget(
+      _buildChart([
+        _event(900, ProfileEventType.ascentStart),
+        _event(
+          1020,
+          ProfileEventType.ascentRateWarning,
+          severity: EventSeverity.warning,
+        ),
+        _event(1140, ProfileEventType.safetyStopStart),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    final lines = _eventLines(tester);
+    expect(lines, hasLength(3));
+
+    // Reconstruct label rects the same way the chart maps placements.
+    final rects = <Rect>[];
+    final data = tester.widget<LineChart>(find.byType(LineChart).first).data;
+    final chartSize = tester.getSize(find.byType(LineChart).first);
+    for (final line in lines) {
+      if (!line.label.show) continue;
+      final text = line.label.labelResolver(line);
+      final painter = TextPainter(
+        text: TextSpan(text: text, style: const TextStyle(fontSize: 9)),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final padding = line.label.padding.resolve(TextDirection.ltr);
+      // Approximate x from the data-space fraction; exact plot insets are
+      // irrelevant for an overlap check between labels.
+      final xFrac = (line.x - data.minX) / (data.maxX - data.minX);
+      final x = xFrac * chartSize.width;
+      final double left;
+      if (line.label.alignment == Alignment.topLeft) {
+        left = x - padding.right - painter.width;
+      } else if (line.label.alignment == Alignment.topRight) {
+        left = x + padding.left;
+      } else {
+        left = x - painter.width / 2;
+      }
+      rects.add(
+        Rect.fromLTWH(left, padding.top, painter.width, painter.height),
+      );
+      painter.dispose();
+    }
+    for (var i = 0; i < rects.length; i++) {
+      for (var j = i + 1; j < rects.length; j++) {
+        expect(
+          rects[i].overlaps(rects[j]),
+          isFalse,
+          reason: 'labels $i and $j must not overlap',
+        );
+      }
+    }
+  });
+
+  testWidgets('an event at the very end flips its label left of the line '
+      'instead of clipping at the right edge', (tester) async {
+    await tester.pumpWidget(
+      _buildChart([_event(1195, ProfileEventType.safetyStopEnd)]),
+    );
+    await tester.pumpAndSettle();
+
+    final lines = _eventLines(tester);
+    expect(lines, hasLength(1));
+    expect(lines.first.label.alignment, Alignment.topLeft);
+  });
+
+  testWidgets('events seconds apart collapse to the most severe one', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _buildChart([
+        _event(1000, ProfileEventType.ascentStart),
+        _event(
+          1003,
+          ProfileEventType.ascentRateWarning,
+          severity: EventSeverity.warning,
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    final lines = _eventLines(tester);
+    expect(
+      lines,
+      hasLength(1),
+      reason: '3 s apart is sub-pixel at phone widths; keep one line',
+    );
+    expect(lines.first.x, 1003.0, reason: 'the warning outranks the info');
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_event_labels_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_event_labels_test.dart
@@ -141,17 +141,12 @@ void main() {
       )..layout();
       final padding = line.label.padding.resolve(TextDirection.ltr);
       // Approximate x from the data-space fraction; exact plot insets are
-      // irrelevant for an overlap check between labels.
+      // irrelevant for an overlap check between labels. All labels use
+      // Alignment.topLeft with the horizontal position encoded in
+      // padding.right (drawn left edge = x - padding.right - textWidth).
       final xFrac = (line.x - data.minX) / (data.maxX - data.minX);
       final x = xFrac * chartSize.width;
-      final double left;
-      if (line.label.alignment == Alignment.topLeft) {
-        left = x - padding.right - painter.width;
-      } else if (line.label.alignment == Alignment.topRight) {
-        left = x + padding.left;
-      } else {
-        left = x - painter.width / 2;
-      }
+      final left = x - padding.right - painter.width;
       rects.add(
         Rect.fromLTWH(left, padding.top, painter.width, painter.height),
       );
@@ -177,7 +172,15 @@ void main() {
 
     final lines = _eventLines(tester);
     expect(lines, hasLength(1));
-    expect(lines.first.label.alignment, Alignment.topLeft);
+    // The drawn left edge is x - padding.right - textWidth; a label pushed
+    // fully left of its line carries padding.right >= the flip gap, instead
+    // of the centered layout's negative padding (-textWidth / 2).
+    final padding = lines.first.label.padding.resolve(TextDirection.ltr);
+    expect(
+      padding.right,
+      greaterThanOrEqualTo(4),
+      reason: 'the label text must sit left of the line, not centered on it',
+    );
   });
 
   testWidgets('events seconds apart collapse to the most severe one', (

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
@@ -1,0 +1,410 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Touch interaction model tests for the profile chart:
+///  - one-finger drag scrubs at zoom 1 and pans when zoomed;
+///  - two-finger pinch/pan always wins the arena (even when the first finger
+///    already moved, which used to hand the gesture to fl_chart's pan);
+///  - double-tap zoom is detected manually from event timestamps, so a
+///    plain tap resolves instantly (no 300 ms double-tap arena hold);
+///  - long-press drag still scrubs while zoomed.
+///
+/// Gestures are driven with explicit `timeStamp:` values because flutter_test
+/// defaults every pointer event to Duration.zero, which would make any two
+/// taps look simultaneous to the timestamp-based double-tap detector.
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+List<DiveProfilePoint> _makeProfile({int points = 20}) {
+  return List.generate(
+    points,
+    (i) => DiveProfilePoint(
+      timestamp: i * 30,
+      depth: (i < points / 2 ? i * 3.0 : (points - i) * 3.0),
+    ),
+  );
+}
+
+Widget _buildChart({void Function(int? index)? onPointSelected}) {
+  return ProviderScope(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 400,
+          height: 300,
+          child: DiveProfileChart(
+            profile: _makeProfile(),
+            onPointSelected: onPointSelected,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+LineChartData _chartData(WidgetTester tester) =>
+    tester.widget<LineChart>(find.byType(LineChart).first).data;
+
+double _visibleSpan(WidgetTester tester) {
+  final data = _chartData(tester);
+  return data.maxX - data.minX;
+}
+
+/// Mouse-wheel zoom in at the chart center (existing, already-working path)
+/// used to arrange a zoomed viewport for the touch pan/scrub tests.
+Future<void> _wheelZoomIn(WidgetTester tester, {int clicks = 4}) async {
+  final center = tester.getCenter(find.byType(LineChart).first);
+  for (var i = 0; i < clicks; i++) {
+    await tester.sendEventToBinding(
+      PointerScrollEvent(position: center, scrollDelta: const Offset(0, -100)),
+    );
+    await tester.pump();
+  }
+}
+
+/// Ignores RenderFlex overflow noise from the zoom hint row on the small
+/// 400x300 test surface.
+void _ignoreOverflowErrors() {
+  final origOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    if (details.toString().contains('overflowed')) return;
+    origOnError?.call(details);
+  };
+  addTearDown(() => FlutterError.onError = origOnError);
+}
+
+void main() {
+  testWidgets('fast tap-then-drag scrubs instead of panning (the reported '
+      'Android bug)', (tester) async {
+    final selections = <int?>[];
+    await tester.pumpWidget(_buildChart(onPointSelected: selections.add));
+    await tester.pumpAndSettle();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+
+    // First tap.
+    final tap = await tester.createGesture();
+    await tap.down(center, timeStamp: Duration.zero);
+    await tap.up(timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
+
+    // Second touch lands 100 ms later (inside the double-tap window) and
+    // immediately slides: this must scrub, not arm a double-tap or pan.
+    selections.clear();
+    final drag = await tester.createGesture();
+    await drag.down(center, timeStamp: const Duration(milliseconds: 140));
+    for (var i = 1; i <= 4; i++) {
+      await drag.moveBy(
+        const Offset(15, 0),
+        timeStamp: Duration(milliseconds: 140 + i * 16),
+      );
+      await tester.pump();
+    }
+    expect(
+      selections.whereType<int>(),
+      isNotEmpty,
+      reason: 'the drag must scrub (select points) despite following a tap',
+    );
+
+    await drag.up(timeStamp: const Duration(milliseconds: 300));
+    await tester.pump();
+
+    final data = _chartData(tester);
+    expect(data.minX, 0.0, reason: 'no pan/zoom may result from the drag');
+    expect(_visibleSpan(tester), 570.0, reason: 'zoom must stay at 1x');
+  });
+
+  testWidgets('a single tap reports a selection without waiting out a '
+      'double-tap window', (tester) async {
+    final selections = <int?>[];
+    await tester.pumpWidget(_buildChart(onPointSelected: selections.add));
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(tester.getCenter(find.byType(LineChart).first));
+    // A single frame, no 300 ms wait: the tap must already have resolved.
+    await tester.pump();
+    expect(
+      selections,
+      isNotEmpty,
+      reason: 'fl_chart tap events must fire as soon as the finger lifts',
+    );
+  });
+
+  testWidgets('double-tap zooms in and a second double-tap resets', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final fullSpan = _visibleSpan(tester);
+
+    Future<void> doubleTap(Duration base) async {
+      final g1 = await tester.createGesture();
+      await g1.down(center, timeStamp: base);
+      await g1.up(timeStamp: base + const Duration(milliseconds: 40));
+      await tester.pump();
+      final g2 = await tester.createGesture();
+      await g2.down(
+        center,
+        timeStamp: base + const Duration(milliseconds: 140),
+      );
+      await g2.up(timeStamp: base + const Duration(milliseconds: 180));
+      await tester.pump();
+    }
+
+    await doubleTap(Duration.zero);
+    expect(
+      _visibleSpan(tester),
+      lessThan(fullSpan),
+      reason: 'double-tap must zoom in',
+    );
+
+    await doubleTap(const Duration(seconds: 2));
+    expect(
+      _visibleSpan(tester),
+      fullSpan,
+      reason: 'double-tap while zoomed must reset',
+    );
+  });
+
+  testWidgets('two slow taps do not zoom', (tester) async {
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final fullSpan = _visibleSpan(tester);
+
+    final g1 = await tester.createGesture();
+    await g1.down(center, timeStamp: Duration.zero);
+    await g1.up(timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
+    // Outside kDoubleTapTimeout (300 ms).
+    final g2 = await tester.createGesture();
+    await g2.down(center, timeStamp: const Duration(milliseconds: 500));
+    await g2.up(timeStamp: const Duration(milliseconds: 540));
+    await tester.pump();
+
+    expect(_visibleSpan(tester), fullSpan);
+  });
+
+  testWidgets('two-finger pinch zooms even when the first finger already '
+      'moved (async-finger case)', (tester) async {
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    final chartTopLeft = tester.getTopLeft(find.byType(LineChart).first);
+    final p1Start = chartTopLeft + const Offset(120, 150);
+    final p2Start = chartTopLeft + const Offset(220, 150);
+    final fullSpan = _visibleSpan(tester);
+
+    final p1 = await tester.createGesture();
+    await p1.down(p1Start, timeStamp: Duration.zero);
+    // First finger drifts 50 px before the second lands: fl_chart's pan
+    // recognizer wins this pointer's arena (a scrub starts). The pinch must
+    // still work.
+    await p1.moveBy(
+      const Offset(50, 0),
+      timeStamp: const Duration(milliseconds: 50),
+    );
+    await tester.pump();
+
+    final p2 = await tester.createGesture();
+    await p2.down(p2Start, timeStamp: const Duration(milliseconds: 80));
+    await tester.pump();
+
+    // Spread: distance grows from 150 px to 270 px.
+    await p1.moveBy(
+      const Offset(-60, 0),
+      timeStamp: const Duration(milliseconds: 120),
+    );
+    await p2.moveBy(
+      const Offset(60, 0),
+      timeStamp: const Duration(milliseconds: 120),
+    );
+    await tester.pump();
+
+    expect(
+      _visibleSpan(tester),
+      lessThan(fullSpan),
+      reason: 'the pinch must zoom in regardless of finger landing order',
+    );
+
+    await p1.up(timeStamp: const Duration(milliseconds: 200));
+    await p2.up(timeStamp: const Duration(milliseconds: 200));
+    await tester.pump();
+  });
+
+  testWidgets('two-finger parallel drag pans the zoomed viewport without '
+      'changing zoom', (tester) async {
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+    await _wheelZoomIn(tester);
+
+    final before = _chartData(tester);
+    final span = before.maxX - before.minX;
+    final chartTopLeft = tester.getTopLeft(find.byType(LineChart).first);
+
+    final p1 = await tester.createGesture();
+    final p2 = await tester.createGesture();
+    await p1.down(
+      chartTopLeft + const Offset(150, 150),
+      timeStamp: Duration.zero,
+    );
+    await p2.down(
+      chartTopLeft + const Offset(250, 150),
+      timeStamp: Duration.zero,
+    );
+    await tester.pump();
+    for (var i = 1; i <= 3; i++) {
+      final t = Duration(milliseconds: i * 16);
+      await p1.moveBy(const Offset(-20, 0), timeStamp: t);
+      await p2.moveBy(const Offset(-20, 0), timeStamp: t);
+      await tester.pump();
+    }
+    await p1.up(timeStamp: const Duration(milliseconds: 100));
+    await p2.up(timeStamp: const Duration(milliseconds: 100));
+    await tester.pump();
+
+    final after = _chartData(tester);
+    expect(
+      after.minX,
+      greaterThan(before.minX),
+      reason: 'dragging both fingers left must pan the window right',
+    );
+    expect(
+      (after.maxX - after.minX),
+      closeTo(span, span * 0.01),
+      reason: 'a parallel drag must not change the zoom level',
+    );
+  });
+
+  testWidgets('one-finger drag pans when zoomed (drag to pan, as the hint '
+      'promises) and does not scrub', (tester) async {
+    _ignoreOverflowErrors();
+    final selections = <int?>[];
+    await tester.pumpWidget(_buildChart(onPointSelected: selections.add));
+    await tester.pumpAndSettle();
+    await _wheelZoomIn(tester);
+
+    final before = _chartData(tester);
+    selections.clear();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final drag = await tester.createGesture();
+    await drag.down(center, timeStamp: Duration.zero);
+    for (var i = 1; i <= 4; i++) {
+      await drag.moveBy(
+        const Offset(-15, 0),
+        timeStamp: Duration(milliseconds: i * 16),
+      );
+      await tester.pump();
+    }
+    await drag.up(timeStamp: const Duration(milliseconds: 120));
+    await tester.pump();
+
+    final after = _chartData(tester);
+    expect(
+      after.minX,
+      greaterThan(before.minX),
+      reason: 'a one-finger drag on a zoomed chart must pan',
+    );
+    // fl_chart emits one selection at finger-down (pan-down/tap deadline)
+    // before the claim wins the arena; what matters is that the claim clears
+    // it and no stale scrub selection survives the pan.
+    expect(
+      selections.lastOrNull,
+      isNull,
+      reason: 'no stale scrub selection may survive a claimed pan drag',
+    );
+  });
+
+  testWidgets('one-finger drag still scrubs at zoom 1', (tester) async {
+    final selections = <int?>[];
+    await tester.pumpWidget(_buildChart(onPointSelected: selections.add));
+    await tester.pumpAndSettle();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final drag = await tester.createGesture();
+    await drag.down(center, timeStamp: Duration.zero);
+    for (var i = 1; i <= 4; i++) {
+      await drag.moveBy(
+        const Offset(15, 0),
+        timeStamp: Duration(milliseconds: i * 16),
+      );
+      await tester.pump();
+    }
+    await drag.up(timeStamp: const Duration(milliseconds: 120));
+    await tester.pump();
+
+    expect(selections.whereType<int>(), isNotEmpty);
+    expect(_chartData(tester).minX, 0.0);
+  });
+
+  testWidgets('long-press drag scrubs while zoomed instead of panning', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    final selections = <int?>[];
+    await tester.pumpWidget(_buildChart(onPointSelected: selections.add));
+    await tester.pumpAndSettle();
+    await _wheelZoomIn(tester);
+
+    final before = _chartData(tester);
+    selections.clear();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final press = await tester.createGesture();
+    await press.down(center, timeStamp: Duration.zero);
+    // Hold past the long-press timeout: fl_chart's long-press recognizer
+    // takes the arena before our claim recognizer sees any movement.
+    await tester.pump(const Duration(milliseconds: 600));
+    for (var i = 1; i <= 4; i++) {
+      await press.moveBy(
+        const Offset(15, 0),
+        timeStamp: Duration(milliseconds: 600 + i * 16),
+      );
+      await tester.pump();
+    }
+    await press.up(timeStamp: const Duration(milliseconds: 800));
+    await tester.pump();
+
+    expect(
+      selections.whereType<int>(),
+      isNotEmpty,
+      reason: 'a long-press drag must keep scrubbing while zoomed',
+    );
+    expect(
+      _chartData(tester).minX,
+      before.minX,
+      reason: 'the long-press scrub must not pan the viewport',
+    );
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
@@ -34,17 +34,24 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-List<DiveProfilePoint> _makeProfile({int points = 20}) {
+List<DiveProfilePoint> _makeProfile({
+  int points = 20,
+  bool temperature = false,
+}) {
   return List.generate(
     points,
     (i) => DiveProfilePoint(
       timestamp: i * 30,
       depth: (i < points / 2 ? i * 3.0 : (points - i) * 3.0),
+      temperature: temperature ? 20.0 - i * 0.1 : null,
     ),
   );
 }
 
-Widget _buildChart({void Function(int? index)? onPointSelected}) {
+Widget _buildChart({
+  void Function(int? index)? onPointSelected,
+  bool temperature = false,
+}) {
   return ProviderScope(
     overrides: [
       settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
@@ -57,7 +64,7 @@ Widget _buildChart({void Function(int? index)? onPointSelected}) {
           width: 400,
           height: 300,
           child: DiveProfileChart(
-            profile: _makeProfile(),
+            profile: _makeProfile(temperature: temperature),
             onPointSelected: onPointSelected,
           ),
         ),
@@ -213,6 +220,48 @@ void main() {
     await tester.pump();
 
     expect(_visibleSpan(tester), lessThan(fullSpan));
+  });
+
+  testWidgets('a second tap landing on the right-axis metric selector strip '
+      'does not zoom the chart', (tester) async {
+    await tester.pumpWidget(_buildChart(temperature: true));
+    await tester.pumpAndSettle();
+
+    // The strip only exists when a right-axis metric is active.
+    expect(
+      find.byWidgetPredicate(
+        (w) =>
+            w is Semantics && w.properties.label == 'Change right axis metric',
+      ),
+      findsOneWidget,
+    );
+
+    final chartTopRight = tester.getTopRight(find.byType(LineChart).first);
+    final fullSpan = _visibleSpan(tester);
+
+    // First tap on the plot just left of the strip, second tap inside the
+    // strip within the double-tap window and slop: the second tap belongs
+    // to the selector (it opens the metric menu), not a chart double-tap.
+    final g1 = await tester.createGesture();
+    await g1.down(
+      chartTopRight + const Offset(-90, 60),
+      timeStamp: Duration.zero,
+    );
+    await g1.up(timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
+    final g2 = await tester.createGesture();
+    await g2.down(
+      chartTopRight + const Offset(-25, 60),
+      timeStamp: const Duration(milliseconds: 140),
+    );
+    await g2.up(timeStamp: const Duration(milliseconds: 180));
+    await tester.pumpAndSettle();
+
+    expect(
+      _visibleSpan(tester),
+      fullSpan,
+      reason: 'a selector-strip tap must never double as a chart double-tap',
+    );
   });
 
   testWidgets('two slow taps do not zoom', (tester) async {

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
@@ -193,6 +193,28 @@ void main() {
     );
   });
 
+  testWidgets('a mouse double-click zooms too (desktop parity)', (
+    tester,
+  ) async {
+    _ignoreOverflowErrors();
+    await tester.pumpWidget(_buildChart());
+    await tester.pumpAndSettle();
+
+    final center = tester.getCenter(find.byType(LineChart).first);
+    final fullSpan = _visibleSpan(tester);
+
+    final g1 = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await g1.down(center, timeStamp: Duration.zero);
+    await g1.up(timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
+    final g2 = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await g2.down(center, timeStamp: const Duration(milliseconds: 140));
+    await g2.up(timeStamp: const Duration(milliseconds: 180));
+    await tester.pump();
+
+    expect(_visibleSpan(tester), lessThan(fullSpan));
+  });
+
   testWidgets('two slow taps do not zoom', (tester) async {
     await tester.pumpWidget(_buildChart());
     await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_gestures_test.dart
@@ -264,6 +264,41 @@ void main() {
     );
   });
 
+  testWidgets('a selector-strip tap does not seed a double-tap for a '
+      'following plot tap', (tester) async {
+    await tester.pumpWidget(_buildChart(temperature: true));
+    await tester.pumpAndSettle();
+
+    final chartTopRight = tester.getTopRight(find.byType(LineChart).first);
+    final fullSpan = _visibleSpan(tester);
+
+    // First tap inside the strip (opens the metric menu), second tap on the
+    // plot nearby within the double-tap window: must not zoom. In the real
+    // app the modal menu blocks the second tap anyway; this pins the
+    // bookkeeping so the model does not depend on that.
+    final g1 = await tester.createGesture();
+    await g1.down(
+      chartTopRight + const Offset(-25, 60),
+      timeStamp: Duration.zero,
+    );
+    await g1.up(timeStamp: const Duration(milliseconds: 40));
+    await tester.pump();
+    // Dismiss the menu the strip tap opened before tapping the plot.
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+
+    final g2 = await tester.createGesture();
+    await g2.down(
+      chartTopRight + const Offset(-90, 60),
+      timeStamp: const Duration(milliseconds: 140),
+    );
+    await g2.up(timeStamp: const Duration(milliseconds: 180));
+    await tester.pump();
+
+    expect(_visibleSpan(tester), fullSpan);
+  });
+
   testWidgets('two slow taps do not zoom', (tester) async {
     await tester.pumpWidget(_buildChart());
     await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -3509,10 +3509,8 @@ void main() {
     });
   });
 
-  group('double-tap-hold pan', () {
-    testWidgets('double-tap then hold-drag pans a zoomed-in chart', (
-      tester,
-    ) async {
+  group('touch pan while zoomed', () {
+    testWidgets('tap then drag pans a zoomed-in chart', (tester) async {
       await tester.pumpWidget(_buildChart(profile: _makeProfile(points: 20)));
       await tester.pumpAndSettle();
       final chart = find.byType(LineChart).first;
@@ -3534,15 +3532,20 @@ void main() {
       await tester.pump();
       final zoomed = tester.widget<LineChart>(chart).data;
 
-      // First tap (quick) then a second touch that is held and dragged.
+      // A quick tap followed by a one-finger drag: the drag is claimed after
+      // touch slop and pans. Incremental moves mirror a real pointer stream
+      // (the claim consumes the slop distance of the first move).
       await tester.tapAt(center, kind: PointerDeviceKind.touch);
       await tester.pump(const Duration(milliseconds: 50));
-      final hold = await tester.startGesture(
+      final drag = await tester.startGesture(
         center,
         kind: PointerDeviceKind.touch,
       );
-      await hold.moveBy(const Offset(-60, 0));
-      await hold.up();
+      for (var i = 0; i < 4; i++) {
+        await drag.moveBy(const Offset(-15, 0));
+        await tester.pump();
+      }
+      await drag.up();
       await tester.pumpAndSettle();
 
       final panned = tester.widget<LineChart>(chart).data;

--- a/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_chart_viewport_test.dart
@@ -164,49 +164,53 @@ void main() {
   group('chartDragIntent', () {
     test('two or more pointers always zoom+pan', () {
       for (final k in [PointerDeviceKind.touch, PointerDeviceKind.mouse]) {
+        for (final zoomed in [false, true]) {
+          expect(
+            chartDragIntent(kind: k, pointerCount: 2, isZoomed: zoomed),
+            ChartDragIntent.zoomPan,
+          );
+        }
+      }
+    });
+
+    test('single mouse/trackpad pointer pans regardless of zoom', () {
+      for (final zoomed in [false, true]) {
         expect(
-          chartDragIntent(kind: k, pointerCount: 2, doubleTapHold: false),
-          ChartDragIntent.zoomPan,
+          chartDragIntent(
+            kind: PointerDeviceKind.mouse,
+            pointerCount: 1,
+            isZoomed: zoomed,
+          ),
+          ChartDragIntent.pan,
+        );
+        expect(
+          chartDragIntent(
+            kind: PointerDeviceKind.trackpad,
+            pointerCount: 1,
+            isZoomed: zoomed,
+          ),
+          ChartDragIntent.pan,
         );
       }
     });
 
-    test('single mouse/trackpad pointer pans', () {
-      expect(
-        chartDragIntent(
-          kind: PointerDeviceKind.mouse,
-          pointerCount: 1,
-          doubleTapHold: false,
-        ),
-        ChartDragIntent.pan,
-      );
-      expect(
-        chartDragIntent(
-          kind: PointerDeviceKind.trackpad,
-          pointerCount: 1,
-          doubleTapHold: false,
-        ),
-        ChartDragIntent.pan,
-      );
-    });
-
-    test('single touch pointer scrubs', () {
+    test('single touch pointer scrubs at zoom 1', () {
       expect(
         chartDragIntent(
           kind: PointerDeviceKind.touch,
           pointerCount: 1,
-          doubleTapHold: false,
+          isZoomed: false,
         ),
         ChartDragIntent.scrub,
       );
     });
 
-    test('single touch pointer pans during double-tap-hold', () {
+    test('single touch pointer pans when zoomed', () {
       expect(
         chartDragIntent(
           kind: PointerDeviceKind.touch,
           pointerCount: 1,
-          doubleTapHold: true,
+          isZoomed: true,
         ),
         ChartDragIntent.pan,
       );

--- a/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
@@ -20,29 +20,9 @@ void main() {
     textHeight: textHeight,
   );
 
-  /// Reconstructs the pixel rect a placement produces, mirroring the
-  /// chart-side mapping (center / left-of-line / right-of-line with a 4 px
-  /// gap to the event line).
-  Rect rectOf(EventLabelSpec s, EventLabelPlacement p) {
-    switch (p.anchor) {
-      case EventLabelAnchor.center:
-        return Rect.fromLTWH(
-          s.xPx - s.textWidth / 2,
-          p.topPx,
-          s.textWidth,
-          s.textHeight,
-        );
-      case EventLabelAnchor.leftOfLine:
-        return Rect.fromLTWH(
-          s.xPx - s.textWidth - 4,
-          p.topPx,
-          s.textWidth,
-          s.textHeight,
-        );
-      case EventLabelAnchor.rightOfLine:
-        return Rect.fromLTWH(s.xPx + 4, p.topPx, s.textWidth, s.textHeight);
-    }
-  }
+  /// The pixel rect a placement produces.
+  Rect rectOf(EventLabelSpec s, EventLabelPlacement p) =>
+      Rect.fromLTWH(p.leftPx, p.topPx, s.textWidth, s.textHeight);
 
   test(
     'a lone label sits just below its depth anchor, centered on the line',
@@ -55,7 +35,7 @@ void main() {
       expect(placements, hasLength(1));
       expect(placements.first.showText, isTrue);
       expect(placements.first.topPx, 64); // anchor + default 4 px gap
-      expect(placements.first.anchor, EventLabelAnchor.center);
+      expect(placements.first.leftPx, 110); // xPx - textWidth / 2
     },
   );
 
@@ -75,7 +55,22 @@ void main() {
       plotWidth: plotWidth,
       plotHeight: plotHeight,
     );
-    expect(placements.first.anchor, EventLabelAnchor.leftOfLine);
+    expect(placements.first.leftPx, 290 - 80 - 4); // xPx - textWidth - gap
+  });
+
+  test('a label wider than the space left of the line clamps inside the '
+      'plot instead of underflowing', () {
+    final placements = placeEventLabels(
+      [spec(xPx: 295, anchorYPx: 40, textWidth: 293)],
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements.first.leftPx, greaterThanOrEqualTo(0));
+    expect(
+      placements.first.leftPx + 293,
+      lessThanOrEqualTo(plotWidth),
+      reason: 'the label must stay fully inside the plot',
+    );
   });
 
   test('a label whose centered text would cross the left edge flips right '
@@ -85,7 +80,7 @@ void main() {
       plotWidth: plotWidth,
       plotHeight: plotHeight,
     );
-    expect(placements.first.anchor, EventLabelAnchor.rightOfLine);
+    expect(placements.first.leftPx, 10 + 4); // xPx + gap
   });
 
   test('overlapping labels are pushed apart vertically', () {
@@ -180,7 +175,7 @@ void main() {
     expect(placements, hasLength(3));
     // Placement i corresponds to spec i (order preserved even though the
     // algorithm scans left to right internally).
-    expect(placements[0].anchor, EventLabelAnchor.center);
+    expect(placements[0].leftPx, 250 - 40); // centered on its line
     expect(placements[1].topPx, greaterThanOrEqualTo(180));
     expect(placements[2].topPx, greaterThanOrEqualTo(100));
   });

--- a/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
@@ -1,0 +1,177 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/profile_event_labels.dart';
+
+void main() {
+  const plotWidth = 300.0;
+  const plotHeight = 200.0;
+
+  EventLabelSpec spec({
+    required double xPx,
+    required double anchorYPx,
+    double textWidth = 80,
+    double textHeight = 12,
+  }) => EventLabelSpec(
+    xPx: xPx,
+    anchorYPx: anchorYPx,
+    textWidth: textWidth,
+    textHeight: textHeight,
+  );
+
+  /// Reconstructs the pixel rect a placement produces, mirroring the
+  /// chart-side mapping (center / left-of-line / right-of-line with a 4 px
+  /// gap to the event line).
+  Rect rectOf(EventLabelSpec s, EventLabelPlacement p) {
+    switch (p.anchor) {
+      case EventLabelAnchor.center:
+        return Rect.fromLTWH(
+          s.xPx - s.textWidth / 2,
+          p.topPx,
+          s.textWidth,
+          s.textHeight,
+        );
+      case EventLabelAnchor.leftOfLine:
+        return Rect.fromLTWH(
+          s.xPx - s.textWidth - 4,
+          p.topPx,
+          s.textWidth,
+          s.textHeight,
+        );
+      case EventLabelAnchor.rightOfLine:
+        return Rect.fromLTWH(s.xPx + 4, p.topPx, s.textWidth, s.textHeight);
+    }
+  }
+
+  test(
+    'a lone label sits just below its depth anchor, centered on the line',
+    () {
+      final placements = placeEventLabels(
+        [spec(xPx: 150, anchorYPx: 60)],
+        plotWidth: plotWidth,
+        plotHeight: plotHeight,
+      );
+      expect(placements, hasLength(1));
+      expect(placements.first.showText, isTrue);
+      expect(placements.first.topPx, 64); // anchor + default 4 px gap
+      expect(placements.first.anchor, EventLabelAnchor.center);
+    },
+  );
+
+  test('a label near the bottom clamps inside the plot', () {
+    final placements = placeEventLabels(
+      [spec(xPx: 150, anchorYPx: plotHeight - 2)],
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements.first.topPx, plotHeight - 12); // plotHeight - textHeight
+  });
+
+  test('a label whose centered text would cross the right edge flips left '
+      'of the line', () {
+    final placements = placeEventLabels(
+      [spec(xPx: 290, anchorYPx: 40)],
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements.first.anchor, EventLabelAnchor.leftOfLine);
+  });
+
+  test('a label whose centered text would cross the left edge flips right '
+      'of the line', () {
+    final placements = placeEventLabels(
+      [spec(xPx: 10, anchorYPx: 40)],
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements.first.anchor, EventLabelAnchor.rightOfLine);
+  });
+
+  test('overlapping labels are pushed apart vertically', () {
+    final specs = [
+      spec(xPx: 140, anchorYPx: 50),
+      spec(xPx: 160, anchorYPx: 50),
+    ];
+    final placements = placeEventLabels(
+      specs,
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements.every((p) => p.showText), isTrue);
+    final r0 = rectOf(specs[0], placements[0]);
+    final r1 = rectOf(specs[1], placements[1]);
+    expect(r0.overlaps(r1), isFalse);
+  });
+
+  test('a crowded column hides labels that cannot fit instead of stacking '
+      'them on the profile', () {
+    final specs = List.generate(
+      8,
+      (_) => spec(xPx: 150, anchorYPx: 90, textHeight: 30),
+    );
+    final placements = placeEventLabels(
+      specs,
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements, hasLength(8));
+    expect(
+      placements.where((p) => !p.showText),
+      isNotEmpty,
+      reason: 'a 200 px plot cannot hold 8 stacked 30 px labels',
+    );
+    // The shown ones still never overlap.
+    final shown = [
+      for (var i = 0; i < specs.length; i++)
+        if (placements[i].showText) rectOf(specs[i], placements[i]),
+    ];
+    for (var i = 0; i < shown.length; i++) {
+      for (var j = i + 1; j < shown.length; j++) {
+        expect(shown[i].overlaps(shown[j]), isFalse);
+      }
+    }
+  });
+
+  test('labels that cannot go below the anchor are placed above it', () {
+    // Anchor at the very bottom, with an existing label already occupying
+    // the clamped bottom slot: the second label must land above the anchor.
+    final specs = [
+      spec(xPx: 150, anchorYPx: plotHeight - 2),
+      spec(xPx: 152, anchorYPx: plotHeight - 2),
+    ];
+    final placements = placeEventLabels(
+      specs,
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements[1].showText, isTrue);
+    expect(
+      placements[1].topPx,
+      lessThan(placements[0].topPx),
+      reason: 'no room below the anchor, so the label must move above',
+    );
+    final r0 = rectOf(specs[0], placements[0]);
+    final r1 = rectOf(specs[1], placements[1]);
+    expect(r0.overlaps(r1), isFalse);
+  });
+
+  test('output length and order always match the input', () {
+    final specs = [
+      spec(xPx: 250, anchorYPx: 20),
+      spec(xPx: 50, anchorYPx: 180),
+      spec(xPx: 150, anchorYPx: 100),
+    ];
+    final placements = placeEventLabels(
+      specs,
+      plotWidth: plotWidth,
+      plotHeight: plotHeight,
+    );
+    expect(placements, hasLength(3));
+    // Placement i corresponds to spec i (order preserved even though the
+    // algorithm scans left to right internally).
+    expect(placements[0].anchor, EventLabelAnchor.center);
+    expect(placements[1].topPx, greaterThanOrEqualTo(180));
+    expect(placements[2].topPx, greaterThanOrEqualTo(100));
+  });
+}

--- a/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_event_labels_test.dart
@@ -156,6 +156,16 @@ void main() {
     expect(r0.overlaps(r1), isFalse);
   });
 
+  test('a plot shorter than the text does not throw (transient layouts)', () {
+    final placements = placeEventLabels(
+      [spec(xPx: 150, anchorYPx: 4, textHeight: 12)],
+      plotWidth: plotWidth,
+      plotHeight: 8,
+    );
+    expect(placements, hasLength(1));
+    expect(placements.first.topPx, 0);
+  });
+
   test('output length and order always match the input', () {
     final specs = [
       spec(xPx: 250, anchorYPx: 20),

--- a/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
+++ b/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/dive_log/presentation/widgets/readout_card_placement.dart';

--- a/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
+++ b/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
@@ -38,6 +38,26 @@ void main() {
     expect(corner.dy, 1.0, reason: 'the top edge is fully occupied');
   });
 
+  test('points exactly on the 1.0 edges count toward the right/bottom '
+      'corner windows', () {
+    // A cluster parked exactly at the bottom-right edge (the last sample of
+    // a dive ending at max depth normalizes to exactly (1, 1)) plus a few
+    // interior points elsewhere. Exclusive edge handling would count the
+    // bottom-right window as empty and park the card on the cluster.
+    final profile = <Offset>[
+      for (var i = 0; i < 10; i++) const Offset(1, 1),
+      const Offset(0.1, 0.9),
+      const Offset(0.2, 0.85),
+      const Offset(0.1, 0.1),
+    ];
+    final corner = leastOccupiedReadoutCorner(profile);
+    expect(
+      corner,
+      const Offset(1, 0),
+      reason: 'top-right holds nothing; bottom-right holds the edge cluster',
+    );
+  });
+
   test('ties prefer top-right (the historical default)', () {
     // A single point dead center occupies no corner window.
     final corner = leastOccupiedReadoutCorner(const [Offset(0.5, 0.5)]);

--- a/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
+++ b/test/features/dive_log/presentation/widgets/readout_card_placement_test.dart
@@ -1,0 +1,48 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/readout_card_placement.dart';
+
+void main() {
+  test('an empty profile keeps the historical top-right default', () {
+    expect(leastOccupiedReadoutCorner(const []), const Offset(1, 0));
+  });
+
+  test('a typical dive (descent, deep bottom, ascent tail to top-right) '
+      'avoids the top-right corner', () {
+    // Normalized: x = time fraction, y = depth fraction (0 = surface/top).
+    final profile = <Offset>[
+      for (var i = 0; i <= 100; i++)
+        Offset(
+          i / 100,
+          i < 15
+              ? i /
+                    15 // descent
+              : i < 75
+              ? 1 // deep bottom
+              : (100 - i) / 25, // ascent tail rising into the top-right
+        ),
+    ];
+    final corner = leastOccupiedReadoutCorner(profile);
+    expect(
+      corner,
+      isNot(const Offset(1, 0)),
+      reason: 'the ascent tail occupies the top-right corner window',
+    );
+  });
+
+  test('an all-shallow profile hugging the top picks a bottom corner', () {
+    final profile = <Offset>[
+      for (var i = 0; i <= 100; i++) Offset(i / 100, 0.05),
+    ];
+    final corner = leastOccupiedReadoutCorner(profile);
+    expect(corner.dy, 1.0, reason: 'the top edge is fully occupied');
+  });
+
+  test('ties prefer top-right (the historical default)', () {
+    // A single point dead center occupies no corner window.
+    final corner = leastOccupiedReadoutCorner(const [Offset(0.5, 0.5)]);
+    expect(corner, const Offset(1, 0));
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the rough dive-profile chart experience on Android touch:

- **Zoomed chart would not scroll.** The zoom hint says "drag to pan", but a one-finger drag always scrubbed, and the two-finger pan/pinch path had to out-race fl_chart's internal `PanGestureRecognizer` in the gesture arena (innermost recognizer wins ties), so it failed whenever one finger moved before the second landed.
- **Scrubbing was sporadic with a noticeable pause.** The chart's `DoubleTapGestureRecognizer` held every tap's arena for 300 ms (delayed tooltip), and a fast tap-then-drag set the old `_doubleTapHold` flag, classifying the drag as a viewport pan - a no-op at 1x zoom, so the scrub just did not happen.
- **Overlays crowded the chart.** Event labels were pinned to the top of the plot - which on a depth chart is the surface, exactly where the end-of-dive ascent tail lives and where ascent/safety-stop events cluster - with no collision handling. The fullscreen readout card defaulted to top-right, the same tail region.

## Changes

- New `ChartTouchClaimRecognizer` on a translucent overlay stacked directly above the `LineChart`: hit-tested first, it joins each pointer's arena before fl_chart's recognizers and wins deterministically. It claims a second touch pointer immediately (pinch/two-finger pan works regardless of finger landing order) and claims a one-finger drag past slop while zoomed (drag-to-pan on touch, matching the hint). Taps and long-presses pass through, so tap tooltips and long-press scrubbing (including while zoomed) are preserved.
- Removed the `DoubleTapGestureRecognizer` and its 300 ms arena hold; double-tap/double-click zoom is detected manually from `PointerEvent.timeStamp` for all pointer kinds. Fast tap-then-drag now scrubs; nested tap targets (photo markers, right-axis metric selector) respond instantly. The redundant double-tap-hold pan gesture was removed.
- Two-finger pinch/pan math moved into the passive `Listener` (cumulative against a gesture-start snapshot); `touchCallback` is gated during claimed/multi-touch gestures so fl_chart cannot scrub under a pinch or leave a stale tooltip after a claimed pan.
- `chartDragIntent` now keys on viewport zoom instead of the removed hold flag.
- New pure `placeEventLabels`: event labels anchor just below the profile depth at the event time, flip inward at plot edges, stagger vertically on collision, hide when nothing fits, and events within 24 px keep only the most severe.
- New pure `leastOccupiedReadoutCorner`: the fullscreen readout card defaults to the chart corner the profile occupies least; a saved dragged position still always wins.

## Test Plan

- [x] `flutter test` passes (full suite; one pre-existing known-flaky backup test failed in the full run and passes in isolation)
- [x] `flutter analyze` passes
- [x] Manual testing on: Android hardware pending - pinch feel and pan ergonomics should be confirmed on-device (arena behavior is deterministic and covered by ~30 new widget tests, including previously untestable two-finger pinch)

## Screenshots

Interaction-behavior changes only; no static visual changes beyond event-label positions, which depend on live profile data.