### PR TITLE
Slide Settings sub-sections into view like Appearance

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -894,6 +894,21 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               child: const SettingsPage(),
             ),
             routes: [
+              // Shared detail route for settings sections that have no
+              // dedicated page of their own (About, Units, Data, ...).
+              // Deliberately a child route with a plain builder: go_router
+              // then wraps it in the platform-adaptive MaterialPage, so these
+              // sections slide in exactly like '/settings/appearance'.
+              // Rendering them by re-matching '/settings?selected=<id>'
+              // instead reused this route's NoTransitionPage and made them
+              // appear instantly.
+              GoRoute(
+                path: 'section/:sectionId',
+                name: 'settingsSection',
+                builder: (context, state) => SettingsSectionDetailPage(
+                  sectionId: state.pathParameters['sectionId']!,
+                ),
+              ),
               GoRoute(
                 path: 'storage',
                 name: 'storageSettings',

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -905,6 +905,13 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: 'section/:sectionId',
                 name: 'settingsSection',
+                // Sections that render a full page of their own would get a
+                // second app bar from the wrapper, so send deep links to the
+                // dedicated route. Returns null for genuine section content,
+                // which belongs in the wrapper.
+                redirect: (context, state) =>
+                    settingsSectionDedicatedRoutes[state
+                        .pathParameters['sectionId']],
                 builder: (context, state) => SettingsSectionDetailPage(
                   sectionId: state.pathParameters['sectionId']!,
                 ),

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -222,6 +222,23 @@ class SettingsMobileContent extends ConsumerWidget {
   }
 }
 
+/// Settings sections that render a page of their own, mapped to that page's
+/// route.
+///
+/// [SettingsSectionDetailPage] supplies a Scaffold and an AppBar, so sections
+/// whose content is itself a Scaffold with an AppBar (Diver Profile, Safety,
+/// Debug) would show two stacked app bars inside it. Appearance is listed too
+/// because it has a dedicated page, keeping that route canonical.
+///
+/// Used both by the settings list tile and by the '/settings/section/:id'
+/// route's redirect, so a deep link to that path cannot bypass it.
+const settingsSectionDedicatedRoutes = <String, String>{
+  'profile': '/settings/diver-profile',
+  'appearance': '/settings/appearance',
+  'safety': '/settings/safety',
+  'debug': '/settings/debug-logs',
+};
+
 /// Mobile detail page for a single settings section.
 ///
 /// Reached by pushing the '/settings/section/:sectionId' child route, which
@@ -384,36 +401,19 @@ class _MobileSettingsTile extends StatelessWidget {
   }
 
   void _navigateToSection(BuildContext context, String sectionId) {
-    // Navigate to the appropriate page based on section
-    switch (sectionId) {
-      case 'profile':
-        context.push('/settings/diver-profile');
-        break;
-      case 'appearance':
-        context.push('/settings/appearance');
-        break;
-      // Safety and Debug render pages that already supply their own Scaffold
-      // and AppBar, so routing them through the shared section wrapper (which
-      // supplies both as well) stacks two app bars. Both have dedicated
-      // routes -- use them.
-      case 'safety':
-        context.push('/settings/safety');
-        break;
-      case 'debug':
-        context.push('/settings/debug-logs');
-        break;
-      default:
-        // Sections without a dedicated page get the shared section route.
-        // PUSH (not go): go() replaces the location in place, leaving nothing
-        // on the stack for the system back gesture to pop, so Android closed
-        // the whole app (#647).
-        //
-        // This pushes a child route rather than '/settings?selected=<id>'.
-        // The latter re-matched the '/settings' tab root, whose pageBuilder
-        // returns a NoTransitionPage so bottom-nav tab switches do not
-        // animate -- which also robbed every pushed section of its slide-in.
-        context.push('/settings/section/$sectionId');
-    }
+    // Sections without a page of their own get the shared section route.
+    // PUSH (not go): go() replaces the location in place, leaving nothing on
+    // the stack for the system back gesture to pop, so Android closed the
+    // whole app (#647).
+    //
+    // This pushes a child route rather than '/settings?selected=<id>'. The
+    // latter re-matched the '/settings' tab root, whose pageBuilder returns a
+    // NoTransitionPage so bottom-nav tab switches do not animate -- which
+    // also robbed every pushed section of its slide-in.
+    context.push(
+      settingsSectionDedicatedRoutes[sectionId] ??
+          '/settings/section/$sectionId',
+    );
   }
 }
 

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -392,6 +392,16 @@ class _MobileSettingsTile extends StatelessWidget {
       case 'appearance':
         context.push('/settings/appearance');
         break;
+      // Safety and Debug render pages that already supply their own Scaffold
+      // and AppBar, so routing them through the shared section wrapper (which
+      // supplies both as well) stacks two app bars. Both have dedicated
+      // routes -- use them.
+      case 'safety':
+        context.push('/settings/safety');
+        break;
+      case 'debug':
+        context.push('/settings/debug-logs');
+        break;
       default:
         // Sections without a dedicated page get the shared section route.
         // PUSH (not go): go() replaces the location in place, leaving nothing

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -127,7 +127,7 @@ class SettingsPage extends ConsumerWidget {
 
     if (selectedSection != null) {
       // Show section detail page
-      return _SettingsSectionDetailPage(sectionId: selectedSection, ref: ref);
+      return SettingsSectionDetailPage(sectionId: selectedSection);
     }
 
     // Mobile: Show section list
@@ -222,15 +222,16 @@ class SettingsMobileContent extends ConsumerWidget {
   }
 }
 
-/// Mobile detail page for settings sections accessed via query params.
-class _SettingsSectionDetailPage extends ConsumerWidget {
+/// Mobile detail page for a single settings section.
+///
+/// Reached by pushing the '/settings/section/:sectionId' child route, which
+/// go_router wraps in a platform-adaptive page so the section slides in like
+/// every other sub-page. Also rendered directly by [SettingsPage] for legacy
+/// `/settings?selected=<id>` deep links.
+class SettingsSectionDetailPage extends ConsumerWidget {
   final String sectionId;
-  final WidgetRef ref;
 
-  const _SettingsSectionDetailPage({
-    required this.sectionId,
-    required this.ref,
-  });
+  const SettingsSectionDetailPage({super.key, required this.sectionId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -392,13 +393,16 @@ class _MobileSettingsTile extends StatelessWidget {
         context.push('/settings/appearance');
         break;
       default:
-        // For sections that don't have dedicated pages, show them in a
-        // detail page using query params. PUSH (not go): go() replaces the
-        // location in place, leaving nothing on the stack for the system
-        // back gesture to pop, so Android closed the whole app (#647).
-        final state = GoRouterState.of(context);
-        final currentPath = state.uri.path;
-        context.push('$currentPath?selected=$sectionId');
+        // Sections without a dedicated page get the shared section route.
+        // PUSH (not go): go() replaces the location in place, leaving nothing
+        // on the stack for the system back gesture to pop, so Android closed
+        // the whole app (#647).
+        //
+        // This pushes a child route rather than '/settings?selected=<id>'.
+        // The latter re-matched the '/settings' tab root, whose pageBuilder
+        // returns a NoTransitionPage so bottom-nav tab switches do not
+        // animate -- which also robbed every pushed section of its slide-in.
+        context.push('/settings/section/$sectionId');
     }
   }
 }

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -777,4 +777,91 @@ void main() {
       expect(await route.redirect!(capturedContext, state), isNull);
     });
   });
+
+  group('settings sections are pushed as animated child routes', () {
+    // Settings sub-sections used to navigate two different ways. Sections
+    // with a dedicated route (Appearance -> /settings/appearance) push a
+    // child GoRoute, which go_router wraps in a platform-adaptive
+    // MaterialPage, so they slide in. Sections without one (About, Units,
+    // Data, ...) pushed '/settings?selected=<id>', which re-matches the
+    // '/settings' route itself -- a bottom-nav tab root whose pageBuilder
+    // returns a NoTransitionPage. Correct for switching tabs, but it made
+    // those sections snap into place with no animation.
+    //
+    // The fix gives them a real child route. It deliberately does not make
+    // '/settings' itself animate when '?selected=' is present: the desktop
+    // master-detail pane navigates with go() (a stable pageKey), so swapping
+    // the page type under the same key would fail Page.canUpdate's
+    // runtimeType check and slide the whole split view on every click.
+    test('a section child route exists under /settings', () {
+      final route = _findRouteByName(
+        router.configuration.routes,
+        'settingsSection',
+      );
+      expect(route, isNotNull);
+      expect(route!.path, 'section/:sectionId');
+    });
+
+    test('the section route uses builder, so go_router animates it', () {
+      final route = _findRouteByName(
+        router.configuration.routes,
+        'settingsSection',
+      );
+      expect(route, isNotNull);
+      expect(
+        route!.builder,
+        isNotNull,
+        reason:
+            'builder lets go_router pick the platform-adaptive MaterialPage, '
+            'which is what makes /settings/appearance slide in.',
+      );
+      expect(
+        route.pageBuilder,
+        isNull,
+        reason:
+            'a custom pageBuilder here would risk reintroducing the '
+            'NoTransitionPage that suppressed the animation.',
+      );
+    });
+
+    testWidgets('the settings tab root itself still has no transition', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final route = _findRouteByName(router.configuration.routes, 'settings');
+      expect(route, isNotNull);
+      expect(route!.pageBuilder, isNotNull);
+
+      final page = route.pageBuilder!(
+        capturedContext,
+        GoRouterState(
+          router.configuration,
+          uri: Uri.parse('/settings'),
+          matchedLocation: '/settings',
+          fullPath: '/settings',
+          pathParameters: const {},
+          pageKey: const ValueKey('/settings'),
+        ),
+      );
+
+      expect(
+        page,
+        isA<NoTransitionPage<dynamic>>(),
+        reason:
+            '/settings is a bottom-nav destination; switching tabs must not '
+            'animate, matching every other tab root.',
+      );
+    });
+  });
 }

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -825,6 +825,64 @@ void main() {
       );
     });
 
+    testWidgets('the section route redirects ids that have a page of their '
+        'own', (tester) async {
+      // SettingsSectionDetailPage supplies a Scaffold and an AppBar, so a
+      // deep link to /settings/section/safety would stack a second app bar
+      // on top of SafetySettingsPage's. Fixing only the list tile leaves the
+      // URL reachable; the route itself has to normalize it.
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final route = _findRouteByName(
+        router.configuration.routes,
+        'settingsSection',
+      );
+      expect(route, isNotNull);
+      expect(route!.redirect, isNotNull);
+
+      Future<String?> redirectFor(String sectionId) async {
+        return route.redirect!(
+          capturedContext,
+          GoRouterState(
+            router.configuration,
+            uri: Uri.parse('/settings/section/$sectionId'),
+            matchedLocation: '/settings/section/$sectionId',
+            fullPath: '/settings/section/:sectionId',
+            pathParameters: {'sectionId': sectionId},
+            pageKey: ValueKey('/settings/section/$sectionId'),
+          ),
+        );
+      }
+
+      // Sections whose content is its own Scaffold with its own AppBar.
+      expect(await redirectFor('safety'), '/settings/safety');
+      expect(await redirectFor('debug'), '/settings/debug-logs');
+      expect(await redirectFor('profile'), '/settings/diver-profile');
+      // Has a dedicated page too, so the route stays canonical.
+      expect(await redirectFor('appearance'), '/settings/appearance');
+
+      // Genuine section content belongs in the wrapper and must not redirect.
+      expect(await redirectFor('about'), isNull);
+      expect(await redirectFor('units'), isNull);
+      expect(
+        await redirectFor('security'),
+        isNull,
+        reason:
+            'SecuritySettingsPage returns plain content and relies on the '
+            "wrapper's Scaffold for its snackbars",
+      );
+    });
+
     testWidgets('the section route passes its path parameter through', (
       tester,
     ) async {

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/safety/presentation/pages/incident_edit_page
 import 'package:submersion/features/safety/presentation/pages/incidents_list_page.dart';
 import 'package:submersion/features/safety/presentation/pages/no_fly_page.dart';
 import 'package:submersion/features/settings/presentation/pages/section_appearance_page.dart';
+import 'package:submersion/features/settings/presentation/pages/settings_page.dart';
 import 'package:submersion/features/settings/presentation/pages/column_config_page.dart';
 
 /// Finds a [GoRoute] by name in a route tree recursively.
@@ -822,6 +823,43 @@ void main() {
             'a custom pageBuilder here would risk reintroducing the '
             'NoTransitionPage that suppressed the animation.',
       );
+    });
+
+    testWidgets('the section route passes its path parameter through', (
+      tester,
+    ) async {
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final route = _findRouteByName(
+        router.configuration.routes,
+        'settingsSection',
+      );
+      expect(route, isNotNull);
+
+      final widget = route!.builder!(
+        capturedContext,
+        GoRouterState(
+          router.configuration,
+          uri: Uri.parse('/settings/section/about'),
+          matchedLocation: '/settings/section/about',
+          fullPath: '/settings/section/:sectionId',
+          pathParameters: const {'sectionId': 'about'},
+          pageKey: const ValueKey('/settings/section/about'),
+        ),
+      );
+
+      expect(widget, isA<SettingsSectionDetailPage>());
+      expect((widget as SettingsSectionDetailPage).sectionId, 'about');
     });
 
     testWidgets('the settings tab root itself still has no transition', (

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -1459,6 +1459,14 @@ void main() {
                   sectionId: state.pathParameters['sectionId']!,
                 ),
               ),
+              // Sections whose content is already a full page have their own
+              // routes; stubbed here so the tile's target is observable
+              // without pulling in their provider graphs.
+              GoRoute(
+                path: 'safety',
+                builder: (context, state) =>
+                    const Scaffold(body: Text('safety page')),
+              ),
             ],
           ),
         ],
@@ -1478,6 +1486,27 @@ void main() {
       await tester.pumpAndSettle();
       return router;
     }
+
+    testWidgets('sections whose content is already a full page go to their '
+        'own route, not the shared section wrapper', (tester) async {
+      // SettingsSectionDetailPage supplies a Scaffold and an AppBar, so a
+      // section whose content is itself a Scaffold-with-AppBar (Safety,
+      // Debug) would render two stacked app bars. Both have dedicated
+      // routes; the tile must use them, the way Profile and Appearance do.
+      final router = await pumpSettingsList(tester);
+
+      await tester.scrollUntilVisible(find.text('Safety'), 100);
+      await tester.tap(find.text('Safety'));
+      await tester.pumpAndSettle();
+
+      expect(
+        router.state.uri.toString(),
+        '/settings/safety',
+        reason:
+            'routing Safety through /settings/section/safety nests '
+            'SafetySettingsPage inside the wrapper Scaffold',
+      );
+    });
 
     testWidgets('opening a section animates it into place instead of '
         'snapping', (tester) async {

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -1440,12 +1440,26 @@ void main() {
       await tester.binding.setSurfaceSize(const Size(400, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
+      // Mirror the real route config: '/settings' is a bottom-nav tab root
+      // that must not animate when tabs are switched, and sections live on
+      // an animated child route beneath it.
       final router = GoRouter(
         initialLocation: initialLocation,
         routes: [
           GoRoute(
             path: '/settings',
-            builder: (context, state) => const SettingsPage(),
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: const SettingsPage(),
+            ),
+            routes: [
+              GoRoute(
+                path: 'section/:sectionId',
+                builder: (context, state) => SettingsSectionDetailPage(
+                  sectionId: state.pathParameters['sectionId']!,
+                ),
+              ),
+            ],
           ),
         ],
       );
@@ -1465,7 +1479,44 @@ void main() {
       return router;
     }
 
-    testWidgets('opening a query-param section pushes a poppable route so the '
+    testWidgets('opening a section animates it into place instead of '
+        'snapping', (tester) async {
+      // Appearance slid in because it pushes a child GoRoute; About, Data and
+      // the rest re-matched the '/settings' tab root, whose NoTransitionPage
+      // suppressed the animation. Every section must now animate the same
+      // way.
+      final router = await pumpSettingsList(tester);
+
+      await tester.scrollUntilVisible(find.text('Data'), 100);
+      await tester.tap(find.text('Data'));
+      await tester.pumpAndSettle();
+
+      expect(
+        router.state.uri.toString(),
+        '/settings/section/data',
+        reason:
+            'the section must be its own child route; re-matching /settings '
+            'reuses that tab root page, which never animates',
+      );
+
+      // Assert on the route rather than a frame-by-frame position: the tap
+      // ripple keeps animations running either way, so only the pushed
+      // route's own transition duration distinguishes a slide from a snap.
+      final route = ModalRoute.of(
+        tester.element(find.byType(SettingsSectionDetailPage)),
+      );
+      expect(route, isNotNull);
+      expect(
+        route!.transitionDuration,
+        greaterThan(Duration.zero),
+        reason:
+            'a NoTransitionPage route has a zero-length transition, which is '
+            'exactly the snap this fixes',
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('opening a section pushes a poppable route so the '
         'system back gesture returns to Settings instead of closing the app', (
       tester,
     ) async {


### PR DESCRIPTION
## Problem

In Settings, some sub-menus slid into view (Appearance) while others replaced the view instantly (About). All of them should slide.

## Root cause

The two groups were not styled differently — they were structurally different go_router pages.

| Section | Pushes | Page type | Transition |
| --- | --- | --- | --- |
| Appearance, Diver Profile | `/settings/appearance` — a child `GoRoute` with `builder:` | platform-adaptive `MaterialPage` | slides |
| About, Units, Data, Manage, ... | `/settings?selected=<id>` — **re-matches `/settings` itself** | `NoTransitionPage` | snaps |

`NoTransitionPage` on `/settings` is correct for a bottom-nav tab root: switching tabs must not animate. But the same `pageBuilder` was reused whenever the route was imperatively pushed as a sub-page, so every query-param section inherited "no transition."

Confirmed empirically rather than by inspection — the pushed route's `transitionDuration` was literally `0:00:00.000000`.

## Fix

Sections without a dedicated page now push a real child route, `/settings/section/:sectionId`, with a plain `builder:` so go_router wraps it in the same adaptive `MaterialPage` Appearance already gets.

- `lib/core/router/app_router.dart` — new `settingsSection` route
- `lib/features/settings/presentation/pages/settings_page.dart` — `_SettingsSectionDetailPage` promoted to public `SettingsSectionDetailPage` (dropping a dead `ref` field); `_MobileSettingsTile._navigateToSection` pushes the child route

Legacy `?selected=` deep links still render, and the desktop master-detail split view is untouched.

### Why not just swap the page type on `/settings`

Returning a `MaterialPage` from the `/settings` `pageBuilder` when `?selected=` is present looks like the smaller fix, but it would break desktop. go_router mints a **unique** `pageKey` for `push()` and reuses a **stable** one for `go()` — and the desktop master-detail pane navigates with `go()`. `Page.canUpdate` requires a matching `runtimeType`, so flipping the page type under an unchanged key would slide the entire split view on every left-pane click. The child route removes the ambiguity instead of working around it.

### Side benefit

`/settings?selected=about` produced a single-page stack, so `canPop()` was false and the app-bar back button fell back to `go('/settings')`. `/settings/section/about` makes go_router materialize the parent chain, so back pops naturally.

## Testing

- `test/core/router/app_router_test.dart` — the section child route exists and uses `builder:` (not a custom `pageBuilder`), and `/settings` itself still returns a `NoTransitionPage` so tab switches stay instant
- `test/features/settings/presentation/pages/settings_page_test.dart` — tapping a section pushes `/settings/section/data` and the resulting route has a non-zero `transitionDuration`; the `#647` helper now mirrors the real route config (tab root + child route) instead of a stub builder

The new assertion was checked for discriminating power: an initial `hasRunningAnimations` version **passed against the buggy code**, because the `ListTile` tap ripple animates either way. It was replaced with an assertion on the pushed route's `transitionDuration`, verified red before the fix and green after.

Full suite: 15,714 passed, 15 skipped, 0 failures. `flutter analyze` clean, `dart format` reports no changes.

## Note for reviewers

There is parallel in-flight work adding `lib/core/router/back_navigation.dart` with a `resolveUpLocation()` helper that unwinds a URL by dropping **one** path segment. It is not on `main`, so there is no conflict today — but once it lands, `/settings/section/about` would resolve "up" to `/settings/section`, which is not a valid route. That helper will need to drop both segments or special-case this route.
