### PR TITLE
Chart-anchored safety findings: lane, callout, and minimum-width highlights

### DIFF
--- a/docs/superpowers/plans/2026-08-09-safety-findings-lane.md
+++ b/docs/superpowers/plans/2026-08-09-safety-findings-lane.md
@@ -1,0 +1,1926 @@
+# Safety Findings Lane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the profile chart a first-class selection surface for safety findings: a tappable findings lane under the plot, a callout with Details/Dismiss/clear, and minimum-width highlight bands so short findings are visible.
+
+**Architecture:** All state flows through the existing `selectedSafetyFindingProvider(diveId)`; the lane and callout are a widget overlay inside `DiveProfileChart`'s Stack (the `PhotoMarkerOverlay` pattern), with lane space reserved below the plot (the `GasTimelineStrip` pattern). Pure geometry (band inflation, chip layout/clustering) lives in standalone functions unit-tested without widgets. No schema, sync, repository, or rules-engine changes.
+
+**Tech Stack:** Flutter 3.x, fl_chart, Riverpod, existing Submersion widgets/providers.
+
+**Spec:** `docs/superpowers/specs/2026-08-09-safety-findings-lane-design.md`
+
+## Global Constraints
+
+- Run every command from the worktree root: `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/safety-review-presentation` (bash cwd can reset to the main checkout between calls — verify with `pwd` before builds, codegen, and l10n generation; generated files landing in the main checkout is a known failure mode).
+- No emojis anywhere. No alarm-red styling; severity colors come only from `safetySeverityColor`.
+- All user-facing strings localized; new keys must be added to ALL 11 arb files (`app_en`, `app_ar`, `app_de`, `app_es`, `app_fr`, `app_he`, `app_hu`, `app_it`, `app_nl`, `app_pt`, `app_zh`) then `flutter gen-l10n`.
+- `dart format .` (whole project) must produce no changes before any commit.
+- Minimum highlight band width on the chart: 12 px. Minimum lane chip width: 26 px. Lane height: 24 px.
+- Existing behavior preserved: section tile tap still selects + scrolls toward the chart; retap clears; dismissed findings never in the lane; findings without a start timestamp never in the lane.
+- Immutability: never mutate passed-in lists; return new lists.
+- Commit after each task with a plain imperative message (no Co-Authored-By line, no conventional-commit prefix).
+
+---
+
+### Task 1: Minimum-width band geometry (`highlightBandSpan`)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/profile_highlight_range.dart`
+- Test: `test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart`
+
+**Interfaces:**
+- Consumes: existing `ProfileHighlightRange`, `visibleHighlightSpan` (same file).
+- Produces: `({double x1, double x2})? highlightBandSpan(ProfileHighlightRange range, {required double visibleMinX, required double visibleMaxX, required double minWidthX})` — Task 2 calls this from the chart.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new group to `test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart` (keep the existing `visibleHighlightSpan` tests untouched):
+
+```dart
+  group('highlightBandSpan', () {
+    const color = Color(0xFF000000);
+
+    test('wide range passes through unchanged', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 60,
+          endTimestamp: 120,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 10,
+      );
+      expect(span, (x1: 60.0, x2: 120.0));
+    });
+
+    test('narrow range inflates to minWidthX centered on its midpoint', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 100,
+          endTimestamp: 104,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 20,
+      );
+      expect(span, (x1: 92.0, x2: 112.0));
+    });
+
+    test('instant range inflates to minWidthX centered on the instant', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 90,
+          endTimestamp: 90,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 84.0, x2: 96.0));
+    });
+
+    test('inflation shifts right when clamped by the window start', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 2,
+          endTimestamp: 2,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 0.0, x2: 12.0));
+    });
+
+    test('inflation shifts left when clamped by the window end', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 268,
+          endTimestamp: 268,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 258.0, x2: 270.0));
+    });
+
+    test('window narrower than minWidthX returns the whole window', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 100,
+          endTimestamp: 101,
+          color: color,
+        ),
+        visibleMinX: 98,
+        visibleMaxX: 104,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 98.0, x2: 104.0));
+    });
+
+    test('range fully outside the window returns null', () {
+      final span = highlightBandSpan(
+        const ProfileHighlightRange(
+          startTimestamp: 400,
+          endTimestamp: 500,
+          color: color,
+        ),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, isNull);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart`
+Expected: FAIL — `highlightBandSpan` is not defined.
+
+- [ ] **Step 3: Implement `highlightBandSpan`**
+
+Append to `lib/features/dive_log/presentation/widgets/profile_highlight_range.dart`:
+
+```dart
+/// The drawable band for [range], inflated to at least [minWidthX] (x-axis
+/// units) so short and instant findings stay visible. Centered on the
+/// clamped span's midpoint, shifted (not shrunk) to stay inside the window;
+/// a window narrower than [minWidthX] yields the whole window. Returns null
+/// when nothing of the range is visible.
+({double x1, double x2})? highlightBandSpan(
+  ProfileHighlightRange range, {
+  required double visibleMinX,
+  required double visibleMaxX,
+  required double minWidthX,
+}) {
+  final span = visibleHighlightSpan(
+    range,
+    visibleMinX: visibleMinX,
+    visibleMaxX: visibleMaxX,
+  );
+  if (span == null) return null;
+  if (span.x2 - span.x1 >= minWidthX) return span;
+  if (visibleMaxX - visibleMinX <= minWidthX) {
+    return (x1: visibleMinX, x2: visibleMaxX);
+  }
+  final mid = (span.x1 + span.x2) / 2;
+  var x1 = mid - minWidthX / 2;
+  var x2 = mid + minWidthX / 2;
+  if (x1 < visibleMinX) {
+    x2 += visibleMinX - x1;
+    x1 = visibleMinX;
+  } else if (x2 > visibleMaxX) {
+    x1 -= x2 - visibleMaxX;
+    x2 = visibleMaxX;
+  }
+  return (x1: x1, x2: x2);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart`
+Expected: PASS (all groups).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/widgets/profile_highlight_range.dart test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart
+git commit -m "Add minimum-width highlight band geometry helper"
+```
+
+---
+
+### Task 2: Chart renders minimum-width bands (instant dashed line removed)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` (highlight builders ~`:4984-5044`, call sites ~`:2590-2600`, span computed in `_buildChart` ~`:2144`)
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart`
+
+**Interfaces:**
+- Consumes: `highlightBandSpan` (Task 1), existing `widget.highlightRange`, `_plotInsets(availableWidth, units)`, `visibleMinX`/`visibleMaxX` locals in `_buildChart`.
+- Produces: the chart's highlight vocabulary becomes "band + two edge lines" for every visible highlight, including instants. No API change.
+
+- [ ] **Step 1: Rewrite the instant-highlight test and add min-width tests**
+
+In `test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart`, REPLACE the test `'an instant highlight renders a single dashed cursor, no band'` with:
+
+```dart
+  testWidgets('an instant highlight renders a minimum-width band, no dash', (
+    tester,
+  ) async {
+    await pumpChart(
+      tester,
+      highlightRange: const ProfileHighlightRange(
+        startTimestamp: 90,
+        endTimestamp: 90,
+        color: Colors.teal,
+      ),
+    );
+    final data = chartData(tester);
+
+    final annotations = data.rangeAnnotations.verticalRangeAnnotations;
+    expect(annotations, hasLength(1));
+    expect(annotations.single.x1, lessThan(90));
+    expect(annotations.single.x2, greaterThan(90));
+
+    final lines = data.extraLinesData.verticalLines;
+    expect(lines, hasLength(2));
+    for (final line in lines) {
+      expect(line.dashArray, isNull);
+    }
+  });
+
+  testWidgets('a very short range inflates to a visible band', (tester) async {
+    await pumpChart(
+      tester,
+      highlightRange: const ProfileHighlightRange(
+        startTimestamp: 100,
+        endTimestamp: 102,
+        color: Colors.teal,
+      ),
+    );
+    final data = chartData(tester);
+
+    final annotations = data.rangeAnnotations.verticalRangeAnnotations;
+    expect(annotations, hasLength(1));
+    // 2 s of a 270 s axis is ~2-3 px at this width; the band must be wider
+    // than the raw range because the 12 px minimum kicked in.
+    expect(
+      annotations.single.x2 - annotations.single.x1,
+      greaterThan(2.0),
+    );
+    expect(data.extraLinesData.verticalLines, hasLength(2));
+  });
+```
+
+Leave the other four tests untouched — they must keep passing (the 60–120 s range is wider than the 12 px minimum at a 400 px chart width, so its exact x values are unchanged).
+
+- [ ] **Step 2: Run the file to verify the new tests fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart`
+Expected: the two new/rewritten tests FAIL (instant still renders a dashed line and no band); the others PASS.
+
+- [ ] **Step 3: Implement in the chart**
+
+In `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`:
+
+3a. Add a constant next to `gasTimelineHeight` (~`:175`):
+
+```dart
+  /// Minimum on-screen width of the safety-highlight band, in logical px.
+  /// Short and instant findings inflate to this so they stay visible.
+  static const double _minHighlightBandPx = 12.0;
+```
+
+3b. In `_buildChart`, after `visibleMaxDepth` is computed (~`:2175`), compute the span once:
+
+```dart
+    // Highlight band, inflated to a 12 px minimum so short/instant findings
+    // stay visible (spec: safety-findings-lane). Computed once and shared by
+    // the band annotation and its edge lines.
+    ({double x1, double x2})? highlightSpan;
+    if (widget.highlightRange != null) {
+      final plotInsets = _plotInsets(availableWidth, units);
+      final plotWidth = (availableWidth - plotInsets.left - plotInsets.right)
+          .clamp(1.0, double.infinity);
+      highlightSpan = highlightBandSpan(
+        widget.highlightRange!,
+        visibleMinX: visibleMinX,
+        visibleMaxX: visibleMaxX,
+        minWidthX:
+            DiveProfileChart._minHighlightBandPx *
+            (visibleMaxX - visibleMinX) /
+            plotWidth,
+      );
+    }
+```
+
+3c. Change the two call sites (~`:2590-2600`) to pass the span:
+
+```dart
+            rangeAnnotations: RangeAnnotations(
+              verticalRangeAnnotations: _buildHighlightRangeAnnotations(
+                highlightSpan,
+              ),
+            ),
+```
+
+and in `extraLinesData.verticalLines`:
+
+```dart
+                ..._buildHighlightRangeLines(highlightSpan),
+```
+
+3d. REPLACE both builders (~`:4984-5044`) with:
+
+```dart
+  /// Translucent band for the externally highlighted time range. [span] is
+  /// precomputed by [_buildChart] via [highlightBandSpan]: clamped to the
+  /// visible window and inflated to the 12 px minimum, so instants and short
+  /// ranges render the same visible band as wide ones.
+  List<VerticalRangeAnnotation> _buildHighlightRangeAnnotations(
+    ({double x1, double x2})? span,
+  ) {
+    final range = widget.highlightRange;
+    if (range == null || span == null) return [];
+    return [
+      VerticalRangeAnnotation(
+        x1: span.x1,
+        x2: span.x2,
+        color: range.color.withValues(alpha: 0.12),
+      ),
+    ];
+  }
+
+  /// Edge lines at the highlight band's (possibly inflated) edges.
+  List<VerticalLine> _buildHighlightRangeLines(
+    ({double x1, double x2})? span,
+  ) {
+    final range = widget.highlightRange;
+    if (range == null || span == null) return [];
+    return [
+      for (final x in [span.x1, span.x2])
+        VerticalLine(
+          x: x,
+          color: range.color.withValues(alpha: 0.7),
+          strokeWidth: 1,
+        ),
+    ];
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart test/features/dive_log/presentation/pages/dive_detail_page_test.dart test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart --timeout 120s`
+Expected: PASS. (The page tests exercise highlight wiring end to end; a fullscreen test asserts the carried-over highlight — an instant selection there now yields a band, which these tests don't assert against, but run them to be sure.)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Render minimum-width highlight bands for short and instant safety findings"
+```
+
+---
+
+### Task 3: Lane chip layout and clustering (pure)
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/safety_lane_layout.dart`
+- Test: `test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart`
+
+**Interfaces:**
+- Consumes: nothing project-specific (pure geometry).
+- Produces (used by Task 5's overlay):
+
+```dart
+class SafetyLaneChipPlacement {
+  final double left;            // px from the lane's left edge
+  final double width;           // px, >= minChipWidth (unless lane narrower)
+  final List<int> memberIndexes; // indexes into the caller's findings list,
+                                 // in ascending start-time order
+}
+
+List<SafetyLaneChipPlacement> layoutSafetyLaneChips({
+  required List<({double startSeconds, double endSeconds})> ranges,
+  required double visibleMinSeconds,
+  required double visibleMaxSeconds,
+  required double laneWidth,
+  double minChipWidth = 26.0,
+})
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/safety_lane_layout.dart';
+
+void main() {
+  // Lane maps a 0..1000 s window onto 500 px: 1 px per 2 s.
+  List<SafetyLaneChipPlacement> layout(
+    List<({double startSeconds, double endSeconds})> ranges, {
+    double visibleMin = 0,
+    double visibleMax = 1000,
+    double laneWidth = 500,
+  }) {
+    return layoutSafetyLaneChips(
+      ranges: ranges,
+      visibleMinSeconds: visibleMin,
+      visibleMaxSeconds: visibleMax,
+      laneWidth: laneWidth,
+    );
+  }
+
+  test('a wide range maps to a proportional chip', () {
+    final placements = layout([(startSeconds: 200.0, endSeconds: 400.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.left, 100);
+    expect(placements.single.width, 100);
+    expect(placements.single.memberIndexes, [0]);
+  });
+
+  test('a short range gets the minimum chip width, centered', () {
+    // 10 s -> 5 px extent (100..105 px), inflated to 26 px centered on
+    // the 102.5 px midpoint: left = 102.5 - 13 = 89.5.
+    final placements = layout([(startSeconds: 200.0, endSeconds: 210.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.left, closeTo(89.5, 0.01));
+    expect(placements.single.width, 26);
+  });
+
+  test('an instant range gets the minimum chip width', () {
+    final placements = layout([(startSeconds: 500.0, endSeconds: 500.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.width, 26);
+    expect(placements.single.left, closeTo(250 - 13, 0.01));
+  });
+
+  test('a chip near the lane start is clamped inside the lane', () {
+    final placements = layout([(startSeconds: 0.0, endSeconds: 0.0)]);
+    expect(placements.single.left, 0);
+    expect(placements.single.width, 26);
+  });
+
+  test('a chip near the lane end is clamped inside the lane', () {
+    final placements = layout([(startSeconds: 1000.0, endSeconds: 1000.0)]);
+    expect(placements.single.left, closeTo(500 - 26, 0.01));
+    expect(placements.single.width, 26);
+  });
+
+  test('a range outside the visible window produces no chip', () {
+    final placements = layout([
+      (startSeconds: 800.0, endSeconds: 900.0),
+    ], visibleMin: 0, visibleMax: 500);
+    expect(placements, isEmpty);
+  });
+
+  test('a range straddling the window edge is clamped to the edge', () {
+    final placements = layout([
+      (startSeconds: 400.0, endSeconds: 600.0),
+    ], visibleMin: 0, visibleMax: 500, laneWidth: 500);
+    expect(placements, hasLength(1));
+    expect(placements.single.left, 400);
+    expect(placements.single.width, 100);
+  });
+
+  test('overlapping chips merge into one cluster in start order', () {
+    // Two instants 10 s (5 px) apart: both inflate to 26 px and overlap.
+    final placements = layout([
+      (startSeconds: 510.0, endSeconds: 510.0),
+      (startSeconds: 500.0, endSeconds: 500.0),
+    ]);
+    expect(placements, hasLength(1));
+    expect(placements.single.memberIndexes, [1, 0]);
+  });
+
+  test('non-overlapping chips stay separate', () {
+    final placements = layout([
+      (startSeconds: 100.0, endSeconds: 100.0),
+      (startSeconds: 900.0, endSeconds: 900.0),
+    ]);
+    expect(placements, hasLength(2));
+  });
+
+  test('empty window or lane yields nothing', () {
+    expect(
+      layout([
+        (startSeconds: 1.0, endSeconds: 2.0),
+      ], visibleMin: 5, visibleMax: 5),
+      isEmpty,
+    );
+    expect(
+      layout([(startSeconds: 1.0, endSeconds: 2.0)], laneWidth: 0),
+      isEmpty,
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart`
+Expected: FAIL — file/function not defined.
+
+- [ ] **Step 3: Implement the layout**
+
+Create `lib/features/dive_log/presentation/widgets/safety_lane_layout.dart`:
+
+```dart
+import 'dart:math' as math;
+
+/// One tappable chip in the safety findings lane. [memberIndexes] holds the
+/// indexes (into the caller's findings list) of every finding merged into
+/// this chip, ascending by on-screen position; length > 1 marks a cluster.
+class SafetyLaneChipPlacement {
+  final double left;
+  final double width;
+  final List<int> memberIndexes;
+
+  const SafetyLaneChipPlacement({
+    required this.left,
+    required this.width,
+    required this.memberIndexes,
+  });
+}
+
+/// Maps finding time ranges onto lane pixels: clamps to the visible window,
+/// inflates every chip to [minChipWidth] (shifted to stay inside the lane),
+/// and merges chips whose extents overlap into clusters. Pure geometry so
+/// clustering behavior is unit-testable without widgets.
+List<SafetyLaneChipPlacement> layoutSafetyLaneChips({
+  required List<({double startSeconds, double endSeconds})> ranges,
+  required double visibleMinSeconds,
+  required double visibleMaxSeconds,
+  required double laneWidth,
+  double minChipWidth = 26.0,
+}) {
+  final window = visibleMaxSeconds - visibleMinSeconds;
+  if (window <= 0 || laneWidth <= 0) return const [];
+
+  final extents = <({double left, double right, int index})>[];
+  for (var i = 0; i < ranges.length; i++) {
+    final r = ranges[i];
+    if (r.endSeconds < visibleMinSeconds || r.startSeconds > visibleMaxSeconds) {
+      continue;
+    }
+    var left = ((r.startSeconds - visibleMinSeconds) / window * laneWidth)
+        .clamp(0.0, laneWidth);
+    var right = ((r.endSeconds - visibleMinSeconds) / window * laneWidth)
+        .clamp(0.0, laneWidth);
+    if (right - left < minChipWidth) {
+      final mid = (left + right) / 2;
+      left = mid - minChipWidth / 2;
+      right = mid + minChipWidth / 2;
+      if (left < 0) {
+        right -= left;
+        left = 0;
+      } else if (right > laneWidth) {
+        left -= right - laneWidth;
+        right = laneWidth;
+      }
+      left = math.max(left, 0.0);
+      right = math.min(right, laneWidth);
+    }
+    extents.add((left: left, right: right, index: i));
+  }
+  extents.sort((a, b) => a.left.compareTo(b.left));
+
+  final placements = <SafetyLaneChipPlacement>[];
+  double clusterLeft = 0;
+  double clusterRight = 0;
+  var members = <int>[];
+  for (final e in extents) {
+    if (members.isEmpty) {
+      clusterLeft = e.left;
+      clusterRight = e.right;
+      members = [e.index];
+    } else if (e.left < clusterRight) {
+      clusterRight = math.max(clusterRight, e.right);
+      members.add(e.index);
+    } else {
+      placements.add(
+        SafetyLaneChipPlacement(
+          left: clusterLeft,
+          width: clusterRight - clusterLeft,
+          memberIndexes: members,
+        ),
+      );
+      clusterLeft = e.left;
+      clusterRight = e.right;
+      members = [e.index];
+    }
+  }
+  if (members.isNotEmpty) {
+    placements.add(
+      SafetyLaneChipPlacement(
+        left: clusterLeft,
+        width: clusterRight - clusterLeft,
+        memberIndexes: members,
+      ),
+    );
+  }
+  return placements;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/dive_log/presentation/widgets/safety_lane_layout.dart test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart
+git commit -m "Add pure chip layout and clustering for the safety findings lane"
+```
+
+---
+
+### Task 4: Shared finding text/filter helpers and l10n strings
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/safety_finding_text.dart`
+- Modify: `lib/features/dive_log/presentation/widgets/safety_finding_highlight.dart`
+- Modify: `lib/features/dive_log/presentation/widgets/safety_review_section.dart`
+- Modify: all 11 `lib/l10n/arb/app_*.arb`
+- Test: `test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart`, `test/features/dive_log/presentation/widgets/safety_review_section_test.dart`
+
+**Interfaces:**
+- Consumes: `SafetyFinding`, `SafetyRuleId`, `AppLocalizations`, `UnitFormatter`, existing arb keys `safetySettings_rule_rapidAscent` / `_missedDecoStop` / `_omittedSafetyStop` / `_sawtoothProfile` / `_highSurfaceGf`, `safetyReview_findingCount` (plural-metadata template).
+- Produces (used by Tasks 5, 7, 8):
+  - `String safetyFindingTitle(SafetyFinding finding, AppLocalizations l10n, UnitFormatter units)` — the full composed title (moved verbatim from `_FindingTile._titleFor` plus its `_duration`/`_seconds` helpers).
+  - `String safetyFindingShortLabel(SafetyFinding finding, AppLocalizations l10n)` — the localized rule name (for wide chips).
+  - `List<SafetyFinding> chartSafetyFindings(SafetyReview? review, Set<String> disabledRules)` — non-dismissed, rule-enabled, start-timestamped findings sorted by start time.
+  - `profileHighlightRangeFor` now treats a null `endTimestamp` as an instant at `startTimestamp` (previously returned null).
+  - New l10n getters: `l10n.safetyReview_details`, `l10n.safetyReview_clearHighlight`, `l10n.safetyReview_findingGroupSemantics(count)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart` (match the file's existing imports/fixtures; construct findings with the real `SafetyFinding` constructor — required fields are `id`, `diveId`, `ruleId`, `severity`, `engineVersion`, `createdAt`):
+
+```dart
+  group('profileHighlightRangeFor with missing end timestamp', () {
+    test('start-only finding maps to an instant range', () {
+      final finding = SafetyFinding(
+        id: 'f1',
+        diveId: 'd1',
+        ruleId: SafetyRuleId.omittedSafetyStop,
+        severity: SafetySeverity.caution,
+        startTimestamp: 300,
+        endTimestamp: null,
+        engineVersion: 1,
+        createdAt: DateTime(2026),
+      );
+      final range = profileHighlightRangeFor(
+        finding,
+        const ColorScheme.light(),
+      );
+      expect(range, isNotNull);
+      expect(range!.startTimestamp, 300);
+      expect(range.endTimestamp, 300);
+    });
+
+    test('finding with no start timestamp maps to null', () {
+      final finding = SafetyFinding(
+        id: 'f2',
+        diveId: 'd1',
+        ruleId: SafetyRuleId.sawtoothProfile,
+        severity: SafetySeverity.info,
+        engineVersion: 1,
+        createdAt: DateTime(2026),
+      );
+      expect(
+        profileHighlightRangeFor(finding, const ColorScheme.light()),
+        isNull,
+      );
+    });
+  });
+
+  group('chartSafetyFindings', () {
+    SafetyFinding finding(
+      String id, {
+      int? start,
+      SafetyRuleId rule = SafetyRuleId.rapidAscent,
+      DateTime? dismissedAt,
+    }) {
+      return SafetyFinding(
+        id: id,
+        diveId: 'd1',
+        ruleId: rule,
+        severity: SafetySeverity.caution,
+        startTimestamp: start,
+        engineVersion: 1,
+        dismissedAt: dismissedAt,
+        createdAt: DateTime(2026),
+      );
+    }
+
+    test('filters dismissed, disabled-rule, and timestampless findings', () {
+      final review = SafetyReview(
+        diveId: 'd1',
+        engineVersion: 1,
+        reviewedAt: DateTime(2026),
+        findings: [
+          finding('keep', start: 200),
+          finding('dismissed', start: 100, dismissedAt: DateTime(2026)),
+          finding('no-time'),
+          finding(
+            'disabled',
+            start: 50,
+            rule: SafetyRuleId.sawtoothProfile,
+          ),
+          finding('earlier', start: 10),
+        ],
+      );
+      final result = chartSafetyFindings(review, {
+        SafetyRuleId.sawtoothProfile.dbValue,
+      });
+      expect(result.map((f) => f.id), ['earlier', 'keep']);
+    });
+
+    test('null review yields an empty list', () {
+      expect(chartSafetyFindings(null, const {}), isEmpty);
+    });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart`
+Expected: FAIL — `chartSafetyFindings` undefined; the start-only test fails (current code returns null).
+
+- [ ] **Step 3: Implement helpers and refactor the section**
+
+3a. In `lib/features/dive_log/presentation/widgets/safety_finding_highlight.dart`, change `profileHighlightRangeFor`'s body:
+
+```dart
+  if (finding == null) return null;
+  final start = finding.startTimestamp;
+  if (start == null) return null;
+  final end = finding.endTimestamp ?? start;
+  return ProfileHighlightRange(
+    startTimestamp: start,
+    endTimestamp: end,
+    color: safetySeverityColor(finding.severity, colorScheme),
+  );
+```
+
+Update its doc comment: a missing end timestamp now means "instant at start"; only a missing start disables highlighting. Then append:
+
+```dart
+/// The findings the profile chart's safety lane shows for [review]:
+/// non-dismissed, rule-enabled, and placeable on the time axis (start
+/// timestamp present), sorted by start time. [disabledRules] holds
+/// [SafetyRuleId.dbValue] strings (settings.safetyReviewDisabledRules).
+List<SafetyFinding> chartSafetyFindings(
+  SafetyReview? review,
+  Set<String> disabledRules,
+) {
+  if (review == null) return const [];
+  final findings = review.findings
+      .where(
+        (f) =>
+            !f.isDismissed &&
+            !disabledRules.contains(f.ruleId.dbValue) &&
+            f.startTimestamp != null,
+      )
+      .toList();
+  findings.sort((a, b) => a.startTimestamp!.compareTo(b.startTimestamp!));
+  return findings;
+}
+```
+
+3b. Create `lib/features/dive_log/presentation/widgets/safety_finding_text.dart`. Move the bodies of `_FindingTile._titleFor`, `_FindingTile._duration`, and `_FindingTile._seconds` from `safety_review_section.dart` into top-level functions, changing `finding.` field access to the parameter (keep the placeholder comments — they document sync-data edge cases):
+
+```dart
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Full composed title for a finding (rule + key numbers), shared by the
+/// safety section tiles and the chart lane callout.
+String safetyFindingTitle(
+  SafetyFinding finding,
+  AppLocalizations l10n,
+  UnitFormatter units,
+) {
+  // ... moved verbatim from _FindingTile._titleFor, with _duration()/_seconds()
+  // inlined as the private functions below ...
+}
+
+/// Localized rule name only (settings-page strings), for narrow contexts
+/// like wide lane chips.
+String safetyFindingShortLabel(SafetyFinding finding, AppLocalizations l10n) {
+  return switch (finding.ruleId) {
+    SafetyRuleId.rapidAscent => l10n.safetySettings_rule_rapidAscent,
+    SafetyRuleId.missedDecoStop => l10n.safetySettings_rule_missedDecoStop,
+    SafetyRuleId.omittedSafetyStop =>
+      l10n.safetySettings_rule_omittedSafetyStop,
+    SafetyRuleId.sawtoothProfile => l10n.safetySettings_rule_sawtoothProfile,
+    SafetyRuleId.highSurfaceGf => l10n.safetySettings_rule_highSurfaceGf,
+  };
+}
+```
+
+(The "moved verbatim" comment above is a transcription instruction for this step, not content to leave in the file: copy the exact switch expression from `safety_review_section.dart:224-252` and the two helpers at `:255-267`, renaming `_duration()` to a private `_durationOf(SafetyFinding finding)` and `_seconds` to `_formatSeconds`.)
+
+3c. In `safety_review_section.dart`: delete `_titleFor`, `_duration`, `_seconds` from `_FindingTile`; import `safety_finding_text.dart`; replace the `title:` argument with `Text(safetyFindingTitle(finding, l10n, units))` (add `final l10n = context.l10n;` already present). Change `_tapHandlerFor` to gate only on the start timestamp:
+
+```dart
+  VoidCallback? _tapHandlerFor(SafetyFinding finding) {
+    if (finding.startTimestamp == null) return null;
+    return () => _toggleSelected(finding);
+  }
+```
+
+3d. Add l10n keys. In `lib/l10n/arb/app_en.arb`, next to the existing `safetyReview_*` block (~`:7481`):
+
+```json
+  "safetyReview_details": "Details",
+  "@safetyReview_details": {
+    "description": "Link in the chart finding callout that scrolls to the full safety review section"
+  },
+  "safetyReview_clearHighlight": "Clear highlight",
+  "@safetyReview_clearHighlight": {
+    "description": "Tooltip/semantics for the button that clears the chart safety highlight"
+  },
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 safety observation} other{{count} safety observations}}",
+  "@safetyReview_findingGroupSemantics": {
+    "description": "Semantics label for a clustered chip in the chart safety lane",
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+```
+
+Add the same three keys (with the same `@`-metadata placeholder structure, mirroring how each file formats `safetyReview_findingCount`) to the other 10 arb files with these values:
+
+| File | details | clearHighlight | findingGroupSemantics (=1 / other) |
+|---|---|---|---|
+| app_ar.arb | التفاصيل | مسح التمييز | ملاحظة سلامة واحدة / {count} ملاحظات سلامة |
+| app_de.arb | Details | Hervorhebung entfernen | 1 Sicherheitshinweis / {count} Sicherheitshinweise |
+| app_es.arb | Detalles | Quitar resaltado | 1 observación de seguridad / {count} observaciones de seguridad |
+| app_fr.arb | Détails | Effacer la surbrillance | 1 observation de sécurité / {count} observations de sécurité |
+| app_he.arb | פרטים | ניקוי הדגשה | ממצא בטיחות אחד / {count} ממצאי בטיחות |
+| app_hu.arb | Részletek | Kiemelés törlése | 1 biztonsági megállapítás / {count} biztonsági megállapítás |
+| app_it.arb | Dettagli | Rimuovi evidenziazione | 1 rilievo di sicurezza / {count} rilievi di sicurezza |
+| app_nl.arb | Details | Markering wissen | 1 veiligheidsbevinding / {count} veiligheidsbevindingen |
+| app_pt.arb | Detalhes | Limpar destaque | 1 observação de segurança / {count} observações de segurança |
+| app_zh.arb | 详情 | 清除高亮 | {count} 条安全提示 (single "other" form; zh has no plural split — mirror how zh formats safetyReview_findingCount) |
+
+Then regenerate (from the worktree root — verify `pwd` first):
+
+```bash
+flutter gen-l10n
+```
+
+- [ ] **Step 4: Run tests to verify everything passes**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart test/features/dive_log/presentation/widgets/safety_review_section_test.dart --timeout 120s`
+Expected: PASS. Note: the section test `'a finding without timestamps is not tappable'` uses a finding with BOTH timestamps null, so it still passes; if any section test constructs a start-only finding and expects it inert, update that expectation (start-only findings are now tappable instants).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Extract shared safety finding text and chart-filter helpers, add callout strings"
+```
+
+---
+
+### Task 5: SafetyFindingsOverlay widget (lane chips + callout)
+
+**Files:**
+- Create: `lib/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart`
+- Create: `lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart`
+- Modify: `lib/features/dive_log/presentation/widgets/photo_marker_overlay.dart` (use the extracted recognizer)
+- Test: `test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart`
+
+**Interfaces:**
+- Consumes: `layoutSafetyLaneChips` / `SafetyLaneChipPlacement` (Task 3), `safetyFindingTitle` / `safetyFindingShortLabel` (Task 4), `safetySeverityColor`, `SafetyFinding`, `UnitFormatter`.
+- Produces (mounted by Task 6):
+
+```dart
+class SafetyFindingsOverlay extends StatelessWidget {
+  final List<SafetyFinding> findings;      // pre-filtered via chartSafetyFindings
+  final String? selectedFindingId;
+  final double visibleMinSeconds;
+  final double visibleMaxSeconds;
+  final ({double left, double top, double right, double bottom}) insets;
+  final double laneHeight;
+  final double laneBottomOffset;           // px from overlay bottom to lane bottom
+  final UnitFormatter units;
+  final void Function(SafetyFinding finding) onFindingTap;   // select/toggle
+  final void Function(SafetyFinding finding) onFindingDismiss;
+  final void Function(SafetyFinding finding)? onFindingDetails; // null hides link
+}
+```
+
+Tap contract: `onFindingTap` is a toggle request — the parent selects the finding, or clears when it is already selected. The overlay's cluster cycling builds on that: tap with none of the cluster selected reports the first member; with member *i* selected reports member *i+1*; with the last member selected reports that same last member (parent toggle clears).
+
+- [ ] **Step 1: Extract the eager tap recognizer**
+
+Create `lib/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart` by moving `_EagerTapGestureRecognizer` out of `photo_marker_overlay.dart`, renamed public, with its full doc comment:
+
+```dart
+import 'package:flutter/gestures.dart';
+
+/// A tap that wins its gesture arena the instant the pointer lifts.
+///
+/// (move the complete comment block from photo_marker_overlay.dart:11-24 here)
+class EagerTapGestureRecognizer extends TapGestureRecognizer {
+  EagerTapGestureRecognizer({super.debugOwner});
+
+  @override
+  void handlePrimaryPointer(PointerEvent event) {
+    if (event is PointerUpEvent) {
+      resolve(GestureDisposition.accepted);
+    }
+    super.handlePrimaryPointer(event);
+  }
+}
+```
+
+In `photo_marker_overlay.dart`: delete the private class, import the new file, and replace the three `_EagerTapGestureRecognizer` references with `EagerTapGestureRecognizer`.
+
+Run: `flutter test test/features/dive_log/presentation/widgets/ --timeout 120s`
+Expected: PASS (pure move).
+
+- [ ] **Step 2: Write the failing overlay tests**
+
+Create `test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_findings_overlay.dart';
+import 'package:submersion/features/settings/domain/entities/app_settings.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  SafetyFinding finding(
+    String id, {
+    required int start,
+    int? end,
+    SafetyRuleId rule = SafetyRuleId.rapidAscent,
+  }) {
+    return SafetyFinding(
+      id: id,
+      diveId: 'd1',
+      ruleId: rule,
+      severity: SafetySeverity.caution,
+      startTimestamp: start,
+      endTimestamp: end,
+      value: 14,
+      engineVersion: 1,
+      createdAt: DateTime(2026),
+    );
+  }
+
+  Future<void> pumpOverlay(
+    WidgetTester tester, {
+    required List<SafetyFinding> findings,
+    String? selectedFindingId,
+    void Function(SafetyFinding)? onTap,
+    void Function(SafetyFinding)? onDismiss,
+    void Function(SafetyFinding)? onDetails,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 300,
+            child: SafetyFindingsOverlay(
+              findings: findings,
+              selectedFindingId: selectedFindingId,
+              visibleMinSeconds: 0,
+              visibleMaxSeconds: 1000,
+              insets: (left: 48, top: 0, right: 38, bottom: 96),
+              laneHeight: 24,
+              laneBottomOffset: 36,
+              units: UnitFormatter(const AppSettings()),
+              onFindingTap: onTap ?? (_) {},
+              onFindingDismiss: onDismiss ?? (_) {},
+              onFindingDetails: onDetails,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders one chip per finding', (tester) async {
+    await pumpOverlay(
+      tester,
+      findings: [
+        finding('a', start: 100, end: 200),
+        finding('b', start: 800, end: 800),
+      ],
+    );
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-1')), findsOneWidget);
+  });
+
+  testWidgets('tapping a chip reports its finding', (tester) async {
+    SafetyFinding? tapped;
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    await tester.pump();
+    expect(tapped?.id, 'a');
+  });
+
+  testWidgets('overlapping findings cluster into one chip with a count', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [
+        finding('a', start: 500, end: 500),
+        finding('b', start: 505, end: 505),
+      ],
+    );
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-1')), findsNothing);
+    expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets('cluster tap cycles: first, next, then toggles last to clear', (
+    tester,
+  ) async {
+    final findings = [
+      finding('a', start: 500, end: 500),
+      finding('b', start: 505, end: 505),
+    ];
+    SafetyFinding? tapped;
+
+    await pumpOverlay(tester, findings: findings, onTap: (f) => tapped = f);
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'a');
+
+    await pumpOverlay(
+      tester,
+      findings: findings,
+      selectedFindingId: 'a',
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'b');
+
+    await pumpOverlay(
+      tester,
+      findings: findings,
+      selectedFindingId: 'b',
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'b'); // parent toggle clears
+  });
+
+  testWidgets('selection shows the callout with title and actions', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+      onDetails: (_) {},
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsOneWidget);
+    expect(find.text('Details'), findsOneWidget);
+    expect(find.text('Dismiss'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('callout hides the Details link when onFindingDetails is null', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+    );
+    expect(find.text('Details'), findsNothing);
+  });
+
+  testWidgets('callout actions invoke their callbacks', (tester) async {
+    SafetyFinding? cleared;
+    SafetyFinding? dismissed;
+    SafetyFinding? details;
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+      onTap: (f) => cleared = f,
+      onDismiss: (f) => dismissed = f,
+      onDetails: (f) => details = f,
+    );
+    await tester.tap(find.text('Details'));
+    expect(details?.id, 'a');
+    await tester.tap(find.text('Dismiss'));
+    expect(dismissed?.id, 'a');
+    await tester.tap(find.byIcon(Icons.close));
+    expect(cleared?.id, 'a'); // clear = toggle-tap of the selected finding
+  });
+
+  testWidgets('no callout when the selected finding is not in the lane', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'gone',
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsNothing);
+  });
+}
+```
+
+Note: if `AppSettings` has no const default constructor, build the settings object the way `UnitFormatter` tests in this repo do (check `test/core/utils/unit_formatter_test.dart` and mirror it).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart`
+Expected: FAIL — widget not defined.
+
+- [ ] **Step 4: Implement the overlay**
+
+Create `lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart`. Structure (follow `photo_marker_overlay.dart` conventions; StatelessWidget — all state lives in the parent via `selectedFindingId`):
+
+```dart
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_text.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_lane_layout.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Chart overlay hosting the safety findings lane (tappable chips below the
+/// plot) and the callout card for the selected finding. A widget layer, not
+/// an fl_chart element, so taps never enter the chart's gesture arena
+/// (PhotoMarkerOverlay precedent).
+class SafetyFindingsOverlay extends StatelessWidget {
+  // ... fields exactly as the Interfaces block above ...
+
+  static const double _chipVerticalInset = 3.0;
+  static const double _calloutMaxWidth = 280.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final laneWidth =
+            constraints.maxWidth - insets.left - insets.right;
+        if (laneWidth <= 0 || findings.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        final placements = layoutSafetyLaneChips(
+          ranges: [
+            for (final f in findings)
+              (
+                startSeconds: f.startTimestamp!.toDouble(),
+                endSeconds: (f.endTimestamp ?? f.startTimestamp!).toDouble(),
+              ),
+          ],
+          visibleMinSeconds: visibleMinSeconds,
+          visibleMaxSeconds: visibleMaxSeconds,
+          laneWidth: laneWidth,
+        );
+        if (placements.isEmpty) return const SizedBox.shrink();
+
+        final laneTop =
+            constraints.maxHeight - laneBottomOffset - laneHeight;
+
+        SafetyLaneChipPlacement? selectedPlacement;
+        if (selectedFindingId != null) {
+          for (final p in placements) {
+            if (p.memberIndexes.any(
+              (i) => findings[i].id == selectedFindingId,
+            )) {
+              selectedPlacement = p;
+              break;
+            }
+          }
+        }
+
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // Lane background strip.
+            Positioned(
+              left: insets.left,
+              top: laneTop,
+              width: laneWidth,
+              height: laneHeight,
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .surfaceContainerHighest
+                        .withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+            for (var i = 0; i < placements.length; i++)
+              Positioned(
+                key: ValueKey('safetyLaneChip-$i'),
+                left: insets.left + placements[i].left,
+                top: laneTop,
+                width: placements[i].width,
+                height: laneHeight,
+                child: _buildChip(context, placements[i]),
+              ),
+            if (selectedPlacement != null)
+              _buildCallout(
+                context,
+                selectedPlacement,
+                constraints,
+                laneTop,
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+```
+
+Implementation notes for the private builders (write them in full; keep each focused):
+
+- `_buildChip(BuildContext, SafetyLaneChipPlacement)`: resolve the cluster's severity as the most severe member (`SafetySeverity.values` order is info < caution < significant); color `safetySeverityColor(severity, colorScheme)`. Pill: `Container` inset vertically by `_chipVerticalInset`, `BorderRadius.circular((laneHeight - 2 * _chipVerticalInset) / 2)`, background color at alpha 0.9 — when any selection is active and this chip is not the selected one, drop to alpha 0.45. Selected chip gets `Border.all(color: severityColor, width: 2)`. Content row centered: `Icon(Icons.report_problem_outlined, size: 12)` for caution/significant or `Icons.info_outline` for info (same mapping as `_FindingTile._iconFor`), icon color = the tile's contrast trick: use `colorScheme.surface` for legibility on the colored pill. If `placement.width > 60` and the cluster has a single member, add the `safetyFindingShortLabel` text (`labelSmall`, ellipsized). If members > 1, add a count badge (`Text('${members.length}')` in a small circle, `colorScheme.primary` background — mirror `photo_marker_overlay.dart:269-291`). Wrap in `Semantics(button: true, label: ...)` — single member: `safetyFindingTitle(...)`; cluster: `context.l10n.safetyReview_findingGroupSemantics(members.length)`. Tap via a `RawGestureDetector` with `EagerTapGestureRecognizer` (copy `_eagerTap` from `photo_marker_overlay.dart:124-142` as a private helper) calling `_handleTap`.
+- `_handleTap(List<SafetyFinding> members)` (members = `[for (final i in placement.memberIndexes) findings[i]]`):
+
+```dart
+  void _handleTap(List<SafetyFinding> members) {
+    final selectedIdx = members.indexWhere((f) => f.id == selectedFindingId);
+    if (selectedIdx == -1) {
+      onFindingTap(members.first);
+    } else if (selectedIdx < members.length - 1) {
+      onFindingTap(members[selectedIdx + 1]);
+    } else {
+      // Last member selected: report it again so the parent toggle clears.
+      onFindingTap(members.last);
+    }
+  }
+```
+
+- `_buildCallout(context, placement, constraints, laneTop)`: the selected finding is `findings.firstWhere((f) => f.id == selectedFindingId)`. Card centered over the chip center (`insets.left + placement.left + placement.width / 2`), clamped so `[left, left + width]` stays within `[insets.left, insets.left + laneWidth]`; width `math.min(_calloutMaxWidth, laneWidth)`. `Positioned(bottom: laneBottomOffset + laneHeight + 6, ...)` with `key: const ValueKey('safetyFindingCallout')`. `Material(elevation: 6, borderRadius: BorderRadius.circular(10), color: colorScheme.surfaceContainerHigh)` containing a `Padding(8)` column: header row (severity icon + `Expanded(Text(safetyFindingTitle(finding, context.l10n, units), style: bodySmall, maxLines: 2))` + `IconButton(icon: Icon(Icons.close, size: 18), tooltip: context.l10n.safetyReview_clearHighlight, onPressed: () => onFindingTap(finding))`), then an action row: `if (onFindingDetails != null) TextButton(child: Text(context.l10n.safetyReview_details), onPressed: () => onFindingDetails!(finding))` and `TextButton(child: Text(context.l10n.safetyReview_dismiss), onPressed: () => onFindingDismiss(finding))`. All buttons use the eager-tap-safe defaults (TextButton/IconButton are fine here — they sit above the chart's detector, and the callout floats over the plot where the double-tap-zoom hold matters less; if taps feel laggy in manual testing, wrap with the eager helper, but do not block on it).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart test/features/dive_log/presentation/widgets/ --timeout 120s`
+Expected: PASS (including all existing photo-marker tests after the recognizer extraction).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Add safety findings lane overlay with chip clustering and callout"
+```
+
+---
+
+### Task 6: Mount the lane in DiveProfileChart (reservations + params)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_profile_chart.dart`
+- Test: `test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart` (new)
+
+**Interfaces:**
+- Consumes: `SafetyFindingsOverlay` (Task 5), `SafetyFinding`.
+- Produces — new optional `DiveProfileChart` parameters (used by Tasks 7 and 8):
+
+```dart
+  final List<SafetyFinding>? safetyFindings;         // pre-filtered, sorted
+  final String? selectedSafetyFindingId;
+  final void Function(SafetyFinding finding)? onSafetyFindingTap;
+  final void Function(SafetyFinding finding)? onSafetyFindingDismiss;
+  final void Function(SafetyFinding finding)? onSafetyFindingDetails;
+  static const double safetyLaneHeight = 24.0;
+```
+
+The lane renders only when `safetyFindings` is non-empty AND `onSafetyFindingTap` is non-null. Vertical order below the plot: gas strip (adjacent to plot), then safety lane, then tick labels, then axis name.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart`, reusing the pump pattern from `dive_profile_chart_highlight_test.dart` (same imports, same 10-point profile, same `MockSettingsNotifier` override):
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_findings_overlay.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+void main() {
+  final profile = List.generate(
+    10,
+    (i) => DiveProfilePoint(
+      timestamp: i * 30,
+      depth: i < 5 ? i * 3.0 : (10 - i) * 3.0,
+    ),
+  );
+
+  SafetyFinding finding(String id, {required int start, int? end}) {
+    return SafetyFinding(
+      id: id,
+      diveId: 'd1',
+      ruleId: SafetyRuleId.rapidAscent,
+      severity: SafetySeverity.caution,
+      startTimestamp: start,
+      endTimestamp: end,
+      value: 14,
+      engineVersion: 1,
+      createdAt: DateTime(2026),
+    );
+  }
+
+  Future<void> pumpChart(
+    WidgetTester tester, {
+    List<SafetyFinding>? safetyFindings,
+    String? selectedId,
+    void Function(SafetyFinding)? onTap,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 300,
+              child: DiveProfileChart(
+                profile: profile,
+                safetyFindings: safetyFindings,
+                selectedSafetyFindingId: selectedId,
+                onSafetyFindingTap: onTap ?? (safetyFindings != null ? (_) {} : null),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('no findings renders no lane overlay', (tester) async {
+    await pumpChart(tester);
+    expect(find.byType(SafetyFindingsOverlay), findsNothing);
+  });
+
+  testWidgets('findings render the lane overlay with chips', (tester) async {
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+    );
+    expect(find.byType(SafetyFindingsOverlay), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+  });
+
+  testWidgets('chip tap reaches the chart callback', (tester) async {
+    SafetyFinding? tapped;
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    await tester.pump();
+    expect(tapped?.id, 'a');
+  });
+
+  testWidgets('selected finding shows the callout above the lane', (
+    tester,
+  ) async {
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+      selectedId: 'a',
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart`
+Expected: FAIL — unknown chart parameters.
+
+- [ ] **Step 3: Implement the chart integration**
+
+All in `dive_profile_chart.dart`:
+
+3a. Add the five fields near `highlightRange` (~`:201`) with doc comments, the `safetyLaneHeight` constant near `gasTimelineHeight` (~`:175`), and the constructor parameters near `this.highlightRange` (~`:505`).
+
+3b. Add the gate next to `_hasGasStrip` (~`:2107`):
+
+```dart
+  /// Whether the safety findings lane renders. Widget-param based (no
+  /// provider read) so it is safe from both build and gesture paths.
+  bool get _hasSafetyLane =>
+      (widget.safetyFindings?.isNotEmpty ?? false) &&
+      widget.onSafetyFindingTap != null;
+```
+
+3c. Extend every bottom reservation that currently special-cases the gas strip. There are four sites; in each, add the lane height when `_hasSafetyLane`:
+
+- `bottomTitles.sideTitles.reservedSize` (~`:2321-2324`):
+
+```dart
+                  reservedSize:
+                      DiveProfileChart._bottomTickReservedSize +
+                      (_hasGasStrip ? DiveProfileChart.gasTimelineHeight : 0) +
+                      (_hasSafetyLane
+                          ? DiveProfileChart.safetyLaneHeight
+                          : 0),
+```
+
+- `SideTitleWidget space` (~`:2337-2339`):
+
+```dart
+                      space:
+                          8 +
+                          (_hasGasStrip
+                              ? DiveProfileChart.gasTimelineHeight
+                              : 0) +
+                          (_hasSafetyLane
+                              ? DiveProfileChart.safetyLaneHeight
+                              : 0),
+```
+
+- `_plotInsets` bottom (~`:1537-1542`) — same shape (note `_plotInsets` reads gas-strip visibility via `ref.read`; `_hasSafetyLane` reads only widget fields, which is safe):
+
+```dart
+      bottom:
+          DiveProfileChart._bottomAxisNameSize +
+          DiveProfileChart._bottomTickReservedSize +
+          (hasGasStrip ? DiveProfileChart.gasTimelineHeight : 0) +
+          (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
+```
+
+- Gas strip `Positioned.bottom` (~`:3435-3437`) and the cursor-extension `Positioned.bottom` (~`:3526-3528`) — the gas strip sits ABOVE the lane, so both gain the lane height:
+
+```dart
+            bottom:
+                DiveProfileChart._bottomAxisNameSize +
+                DiveProfileChart._bottomTickReservedSize +
+                (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
+```
+
+3d. Mount the overlay as the LAST child of the chart Stack, after the `PhotoMarkerOverlay` block (~`:3478`):
+
+```dart
+        // Safety findings lane + callout: a widget layer like the photo
+        // markers, occupying the extra bottom reservation added by
+        // _hasSafetyLane, directly between the gas strip (or plot) and the
+        // tick labels.
+        if (_hasSafetyLane)
+          Positioned.fill(
+            child: SafetyFindingsOverlay(
+              findings: widget.safetyFindings!,
+              selectedFindingId: widget.selectedSafetyFindingId,
+              visibleMinSeconds: visibleMinX,
+              visibleMaxSeconds: visibleMaxX,
+              insets: _plotInsets(availableWidth, units),
+              laneHeight: DiveProfileChart.safetyLaneHeight,
+              laneBottomOffset:
+                  DiveProfileChart._bottomAxisNameSize +
+                  DiveProfileChart._bottomTickReservedSize,
+              units: units,
+              onFindingTap: widget.onSafetyFindingTap!,
+              onFindingDismiss: widget.onSafetyFindingDismiss ?? (_) {},
+              onFindingDetails: widget.onSafetyFindingDetails,
+            ),
+          ),
+```
+
+The mounting site's enclosing builder must have `visibleMinX`/`visibleMaxX`/`availableWidth`/`units` in scope — it is the same Stack that mounts the gas strip and photo overlay, which already use all four.
+
+3e. Cache note: the lane is a widget layer and the highlight is `rangeAnnotations` — neither goes through `_barsCache`, so no signature changes. Do NOT add safety params to any `_barsCache` signature.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart --timeout 120s`
+Expected: PASS. Also run the broader chart tests to catch reservation regressions: `flutter test test/features/dive_log/presentation/widgets/ --timeout 300s` — expected PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Mount the safety findings lane in the dive profile chart"
+```
+
+---
+
+### Task 7: Detail page wiring (lane data, dismiss helper, Details scroll, stale-selection guard)
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/providers/safety_review_providers.dart`
+- Modify: `lib/features/dive_log/presentation/widgets/safety_review_section.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_detail_page.dart` (chart wiring ~`:1636-1741`, section builder ~`:312-319`, state class fields)
+- Test: `test/features/dive_log/presentation/pages/dive_detail_page_test.dart`, `test/features/dive_log/presentation/widgets/safety_review_section_test.dart`, `test/features/dive_log/presentation/providers/safety_review_providers_test.dart`
+
+**Interfaces:**
+- Consumes: chart params (Task 6), `chartSafetyFindings` (Task 4), `selectedSafetyFindingProvider`, `safetyReviewProvider`, `settingsProvider`, `SafetyFindingsRepository.setDismissed`.
+- Produces: `Future<void> setSafetyFindingDismissed(WidgetRef ref, {required SafetyFinding finding, required bool dismissed})` in `safety_review_providers.dart` — Task 8 reuses it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/features/dive_log/presentation/pages/dive_detail_page_test.dart`, extend the `'safety finding highlight wiring'` group (~`:1410`; reuse the group's existing dive/finding fixtures and pump helper — read the group first and follow its established setup exactly):
+
+```dart
+    testWidgets('active findings reach the chart as lane findings', (
+      tester,
+    ) async {
+      // Arrange a dive whose stored review has one active timestamped
+      // finding (the group's existing fixture does this); pump the page.
+      // Assert the chart received it:
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart).first,
+      );
+      expect(chart.safetyFindings, isNotNull);
+      expect(chart.safetyFindings!.map((f) => f.id), [/* fixture id */]);
+      expect(chart.onSafetyFindingTap, isNotNull);
+      expect(chart.onSafetyFindingDismiss, isNotNull);
+      expect(chart.onSafetyFindingDetails, isNotNull);
+    });
+
+    testWidgets('chart tap callback toggles the selection provider', (
+      tester,
+    ) async {
+      // Pump as above, grab the chart widget, invoke its callback directly
+      // (unit-testing the wiring without pixel-hunting the chip):
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart).first,
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveProfileChart).first),
+      );
+      chart.onSafetyFindingTap!(/* fixture finding */);
+      expect(
+        container.read(selectedSafetyFindingProvider(/* diveId */))?.id,
+        /* fixture id */,
+      );
+      chart.onSafetyFindingTap!(/* fixture finding */); // toggle
+      expect(
+        container.read(selectedSafetyFindingProvider(/* diveId */)),
+        isNull,
+      );
+    });
+```
+
+(The `/* fixture */` markers refer to the concrete ids/objects already defined in that test group — substitute the group's actual fixture names when writing the test; they are group-local so cannot be named here.)
+
+In `test/features/dive_log/presentation/providers/safety_review_providers_test.dart`, add coverage for the new helper (mirror the file's existing repository/container setup):
+
+```dart
+    test('setSafetyFindingDismissed clears a matching selection and persists', () async {
+      // Seed a review with finding f; select f via
+      // container.read(selectedSafetyFindingProvider(diveId).notifier).state = f;
+      // call setSafetyFindingDismissed(ref-equivalent, finding: f, dismissed: true)
+      // then assert: selection is null, repository row has dismissedAt set,
+      // safetyReviewProvider(diveId) refetch shows the finding dismissed.
+    });
+```
+
+Note: `setSafetyFindingDismissed` takes a `WidgetRef`; in a pure provider test use the section-test approach instead — if the file has no widget pump infrastructure, move this assertion into `safety_review_section_test.dart`'s dismiss group (which already pumps widgets and mocks the repository) by asserting the section still dismisses correctly after the refactor. Do not build new test infrastructure for this.
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_detail_page_test.dart --timeout 300s`
+Expected: new tests FAIL (`safetyFindings` param never set); existing tests PASS.
+
+- [ ] **Step 3: Implement**
+
+3a. In `safety_review_providers.dart`, append:
+
+```dart
+/// Dismisses or restores a finding and keeps UI state consistent: a dismissed
+/// finding can no longer be the chart selection. Persists through
+/// SafetyFindingsRepository.setDismissed, which also bumps the parent dive's
+/// HLC so the change syncs (findings tables have no HLC of their own).
+Future<void> setSafetyFindingDismissed(
+  WidgetRef ref, {
+  required SafetyFinding finding,
+  required bool dismissed,
+}) async {
+  final diveId = finding.diveId;
+  if (dismissed) {
+    final selected = ref.read(selectedSafetyFindingProvider(diveId).notifier);
+    if (selected.state?.id == finding.id) {
+      selected.state = null;
+    }
+  }
+  await ref
+      .read(safetyFindingsRepositoryProvider)
+      .setDismissed(
+        findingId: finding.id,
+        dismissed: dismissed,
+        now: DateTime.now(),
+      );
+  ref.invalidate(safetyReviewProvider(diveId));
+}
+```
+
+Add `import 'package:flutter_riverpod/flutter_riverpod.dart';` if `WidgetRef` is not already resolvable through the existing imports.
+
+3b. In `safety_review_section.dart`, replace `_setDismissed`'s body with a delegate:
+
+```dart
+  Future<void> _setDismissed(SafetyFinding finding, bool dismissed) {
+    return setSafetyFindingDismissed(
+      ref,
+      finding: finding,
+      dismissed: dismissed,
+    );
+  }
+```
+
+3c. In `dive_detail_page.dart`:
+
+- Add a state field on the page's `ConsumerState` class: `final _safetyReviewSectionKey = GlobalKey();` (next to `_profileChartExportKey`).
+- In the section builder (~`:316`), pass the key: `SafetyReviewSection(key: _safetyReviewSectionKey, diveId: dive.id)`.
+- In the chart `LayoutBuilder` (~`:1637-1643`), alongside the existing `selectedFinding` watch, add:
+
+```dart
+                final safetyReview = ref
+                    .watch(safetyReviewProvider(diveId))
+                    .value;
+                final appSettings = ref.watch(settingsProvider);
+                final laneFindings = appSettings.safetyReviewEnabled
+                    ? chartSafetyFindings(
+                        safetyReview,
+                        appSettings.safetyReviewDisabledRules,
+                      )
+                    : const <SafetyFinding>[];
+```
+
+- Pass to `DiveProfileChart` (after `highlightRange:` ~`:1727-1730`):
+
+```dart
+                        safetyFindings: laneFindings.isEmpty
+                            ? null
+                            : laneFindings,
+                        selectedSafetyFindingId: selectedFinding?.id,
+                        onSafetyFindingTap: (finding) {
+                          final notifier = ref.read(
+                            selectedSafetyFindingProvider(diveId).notifier,
+                          );
+                          notifier.state = notifier.state?.id == finding.id
+                              ? null
+                              : finding;
+                        },
+                        onSafetyFindingDismiss: (finding) =>
+                            setSafetyFindingDismissed(
+                              ref,
+                              finding: finding,
+                              dismissed: true,
+                            ),
+                        onSafetyFindingDetails: (_) =>
+                            _scrollToSafetySection(),
+```
+
+- Add the scroll method to the state class:
+
+```dart
+  /// Scrolls the page so the safety review section is visible (callout
+  /// "Details" action). The selection stays active.
+  void _scrollToSafetySection() {
+    final ctx = _safetyReviewSectionKey.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeInOutCubic,
+      alignment: 0.05,
+    );
+  }
+```
+
+- Stale-selection guard: in the page's main `build` (where other `ref.listen` calls live, or at the top of build if there are none), add:
+
+```dart
+    // A finding dismissed elsewhere (section button, another device via sync,
+    // batch re-analysis) must not stay highlighted: drop a selection whose
+    // finding no longer exists as an active row.
+    ref.listen(safetyReviewProvider(diveId), (previous, next) {
+      final review = next.value;
+      if (review == null) return;
+      final selected = ref.read(selectedSafetyFindingProvider(diveId));
+      if (selected == null) return;
+      final stillActive = review.findings.any(
+        (f) => f.id == selected.id && !f.isDismissed,
+      );
+      if (!stillActive) {
+        ref.read(selectedSafetyFindingProvider(diveId).notifier).state = null;
+      }
+    });
+```
+
+- Imports: `safety_finding.dart` (entity), `safety_finding_highlight.dart` already imported for `profileHighlightRangeFor` — `chartSafetyFindings` comes with it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/pages/dive_detail_page_test.dart test/features/dive_log/presentation/widgets/safety_review_section_test.dart test/features/dive_log/presentation/providers/safety_review_providers_test.dart --timeout 300s`
+Expected: PASS. Known trap: the detail page now watches `safetyReviewProvider` + `settingsProvider` in the chart region — if any existing page test fails on an unexpected provider state, mirror how the section's tests override the safety repository rather than adding new mocks.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Wire the safety findings lane into the dive detail page"
+```
+
+---
+
+### Task 8: Fullscreen parity
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart` (chart wiring ~`:299-410`)
+- Test: `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`
+
+**Interfaces:**
+- Consumes: chart params (Task 6), `chartSafetyFindings` (Task 4), `setSafetyFindingDismissed` (Task 7), `selectedSafetyFindingProvider`, `safetyReviewProvider`, `settingsProvider`.
+- Produces: fullscreen shows the same lane/callout; `onSafetyFindingDetails` is NOT wired there (no section exists in fullscreen — the callout hides the link, per the overlay's nullable-`onFindingDetails` contract). Selection round-trips with the detail page automatically via the shared provider family.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart`, next to the existing highlight carry-over test (~`:358`, reuse its fixtures/pump):
+
+```dart
+    testWidgets('lane findings and selection wiring reach the chart', (
+      tester,
+    ) async {
+      // Same arrangement as the carried-over-highlight test: stored review
+      // with an active timestamped finding.
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart).first,
+      );
+      expect(chart.safetyFindings, isNotNull);
+      expect(chart.onSafetyFindingTap, isNotNull);
+      expect(chart.onSafetyFindingDismiss, isNotNull);
+      expect(chart.onSafetyFindingDetails, isNull); // no section in fullscreen
+    });
+
+    testWidgets('fullscreen tap callback toggles the shared provider', (
+      tester,
+    ) async {
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart).first,
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveProfileChart).first),
+      );
+      chart.onSafetyFindingTap!(/* fixture finding */);
+      expect(
+        container.read(selectedSafetyFindingProvider(/* diveId */))?.id,
+        /* fixture id */,
+      );
+    });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `flutter test test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart --timeout 300s`
+Expected: new tests FAIL; existing PASS.
+
+- [ ] **Step 3: Implement**
+
+In `fullscreen_profile_page.dart` `build` (~`:125-155`), alongside the existing `selectedSafetyFindingProvider` watch (~`:152`):
+
+```dart
+    final safetyReview = ref.watch(safetyReviewProvider(widget.diveId)).value;
+    final appSettings = ref.watch(settingsProvider);
+    final laneFindings = appSettings.safetyReviewEnabled
+        ? chartSafetyFindings(
+            safetyReview,
+            appSettings.safetyReviewDisabledRules,
+          )
+        : const <SafetyFinding>[];
+```
+
+Add the same stale-selection `ref.listen` block as Task 7 (identical code, `widget.diveId`). Then pass to the `DiveProfileChart` (~`:299`, near `highlightRange:` ~`:396`):
+
+```dart
+                          safetyFindings: laneFindings.isEmpty
+                              ? null
+                              : laneFindings,
+                          selectedSafetyFindingId: ref
+                              .watch(
+                                selectedSafetyFindingProvider(widget.diveId),
+                              )
+                              ?.id,
+                          onSafetyFindingTap: (finding) {
+                            final notifier = ref.read(
+                              selectedSafetyFindingProvider(
+                                widget.diveId,
+                              ).notifier,
+                            );
+                            notifier.state =
+                                notifier.state?.id == finding.id
+                                ? null
+                                : finding;
+                          },
+                          onSafetyFindingDismiss: (finding) =>
+                              setSafetyFindingDismissed(
+                                ref,
+                                finding: finding,
+                                dismissed: true,
+                              ),
+```
+
+(Reuse the already-watched selected finding local if the page has one at `:152` instead of re-watching inline — match the file's existing style.) Imports: `safety_finding.dart`, `safety_finding_highlight.dart`, `safety_review_providers.dart` as needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart --timeout 300s`
+Expected: PASS, including the pre-existing carried-over-highlight test.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add -A lib test
+git commit -m "Add safety findings lane parity to the fullscreen profile"
+```
+
+---
+
+### Task 9: Full verification sweep
+
+**Files:** none new.
+
+- [ ] **Step 1: Format the whole project and verify no drift**
+
+```bash
+dart format .
+git status --short
+```
+Expected: no modified files. If files changed, commit them as "Format".
+
+- [ ] **Step 2: Analyze the whole project**
+
+```bash
+flutter analyze
+```
+Run WITHOUT piping through head/grep (piping masks the exit code). Expected: zero issues — infos are CI-fatal in this project; fix any.
+
+- [ ] **Step 3: Run the affected test tree**
+
+```bash
+flutter test test/features/dive_log/ --timeout 300s
+```
+Expected: PASS. Known flaky areas unrelated to this work (backup/media-store suites) are outside this path; if an unrelated flake appears elsewhere later in pre-push, re-run that file alone before assuming this change caused it.
+
+- [ ] **Step 4: Manual smoke check (if a macOS environment is available)**
+
+```bash
+flutter run -d macos
+```
+Open a dive that has safety findings: verify the lane appears under the chart, chips are tappable, the callout's Details scrolls to the section, Dismiss removes the chip, the ✕ clears, a tiny finding shows a visible band, and fullscreen shows the same lane. This step is observational; do not block the branch on it if no device is available.
+
+- [ ] **Step 5: Final commit if anything changed**
+
+```bash
+git status --short
+```
+Commit any stragglers with an accurate message.
+
+---
+
+## Self-review notes (already applied)
+
+- Spec coverage: lane (Tasks 3/5/6), callout with Details/Dismiss/clear (5/7), min-width bands + instant-band vocabulary (1/2), two-way section sync + tile behavior preserved (7, section untouched except refactors), fullscreen parity minus the Details link (8 — the spec's "full parity: lane, callout, and clearing" enumerates exactly what fullscreen gets; Details-to-section is a detail-page navigation and the overlay contract makes it explicitly optional), dismissed/timestampless exclusion (4), stale-selection guard (7/8), cluster cycling (3/5), no schema/sync changes (none anywhere).
+- Type consistency: `highlightBandSpan` record return matches `visibleHighlightSpan`'s; `SafetyLaneChipPlacement` names match between Task 3 and Task 5; chart param names match between Task 6 and Tasks 7/8; `setSafetyFindingDismissed` signature matches between Tasks 7 and 8.
+- Two intentionally-flagged judgment points for the executor: (a) exact fixture names inside `dive_detail_page_test.dart`'s existing group must be read from that file; (b) `AppSettings` construction in the overlay test should mirror existing `UnitFormatter` test usage.

--- a/docs/superpowers/specs/2026-08-09-safety-findings-lane-design.md
+++ b/docs/superpowers/specs/2026-08-09-safety-findings-lane-design.md
@@ -1,0 +1,209 @@
+# Safety Findings Lane: Chart-Anchored Safety Review Presentation
+
+**Date:** 2026-08-09
+**Status:** Approved design, pending implementation plan
+**Supersedes:** the interaction model of
+`2026-08-07-safety-finding-chart-highlight-design.md` (the highlight rendering
+it introduced is retained and extended; its selection/clearing model is
+replaced).
+
+## Problem
+
+The safety review presentation has two usability failures, both rooted in the
+same structural decision: selection state is written only by the
+`SafetyReviewSection` card, which sits below the profile chart and the entire
+Deco/O2 panel, one to two viewport heights away from where the selection
+renders.
+
+1. **Clearing is unintuitive and requires scrolling.** Tapping a finding tile
+   selects it and auto-scrolls the page to the chart. The only clear
+   affordances are tapping the same tile again or dismissing the finding, both
+   of which require scrolling back down. The chart itself offers no clearing
+   interaction (an explicit decision in the prior spec).
+2. **Short findings are invisible on the chart.** Two of the five safety rules
+   (`omittedSafetyStop`, `highSurfaceGf`) produce zero-width time ranges that
+   render as a single 1.5 px dashed line, indistinguishable from the playback
+   and hover cursor lines. `rapidAscent` and `missedDecoStop` findings can be
+   as short as 10 seconds, rendering as roughly 1 px of 12%-alpha fill on a
+   typical dive.
+
+## Design summary
+
+Make the chart a first-class selection surface. A findings lane under the
+profile chart holds one tappable chip per finding; tapping a chip highlights
+the finding on the chart and opens a callout with summary, Details, Dismiss,
+and clear actions. All selection and clearing happens at the chart. The
+existing safety section remains as the detailed view with two-way selection
+sync. Highlight bands gain a minimum on-screen width so short and instant
+findings are visible.
+
+Decisions made during brainstorming (each chosen from mockup alternatives):
+
+| Decision | Choice |
+|---|---|
+| Primary home of findings | Chart-anchored: findings lane under the plot |
+| Marker geometry | Dedicated lane below the plot (GasTimelineStrip idiom), not in-plot badges or top-edge flags |
+| Selected state | Callout bubble anchored to the tapped chip |
+| Callout actions | Summary text, Details link, Dismiss action, and a clear button |
+| Existing section | Kept as detail view with two-way selection sync |
+| Fullscreen chart | Full parity: lane, callout, and clearing (reverses the prior spec's "no selection UI in fullscreen") |
+
+## Components
+
+### 1. SafetyFindingsLane (new widget)
+
+A horizontal lane rendered directly below the profile chart plot area, aligned
+with the chart's time axis.
+
+- **Placement.** Follows the `GasTimelineStrip` pattern: positioned by
+  mirroring the chart's axis reservations (`leftAxisSize()`,
+  `rightAxisSize()`, bottom reservations) so chip x-positions map exactly to
+  chart time coordinates, including under zoom and pan. Chips for findings
+  outside the visible time window are hidden; chips partially in the window
+  are clamped to the window edge.
+- **Chips.** One chip per non-dismissed finding that has at least a start
+  timestamp.
+  - A finding whose time range is wide enough on screen gets a range-width
+    chip (rounded rectangle spanning start to end) with a severity icon and a
+    short rule label when the width allows.
+  - Short and instant findings get an icon-only chip with a minimum visual
+    width of 26 px. Every chip's hit target is at least 26 px wide and the
+    full lane height.
+  - Chip colors come from the existing `safetySeverityColor` mapping (muted
+    palette; no alarm red), consistent with the safety feature's tone rules.
+  - The selected chip shows a ring outline; unselected chips render at reduced
+    opacity while any selection is active.
+- **Overlap.** Chips whose on-screen extents would overlap cluster into a
+  single group chip showing a count. Tapping a group chip cycles the selection
+  through its members (each tap selects the next; after the last member, the
+  next tap clears). The exact cycle affordance may be refined during
+  implementation, but a group chip must never be un-tappable or ambiguous
+  about which finding is selected (the callout identifies it).
+- **Visibility.** The lane renders only when safety review is enabled
+  (`safetyReviewEnabledProvider`) and the dive has at least one non-dismissed
+  finding with a start timestamp. Otherwise it occupies no space.
+- **Dismissed findings** never appear in the lane. Restoring a dismissed
+  finding (via the section's "show dismissed" list) returns its chip.
+- **Findings without timestamps** cannot be placed on a time axis; they appear
+  only in the safety section, as today.
+
+### 2. Selection state and callout
+
+- **State.** The existing
+  `selectedSafetyFindingProvider(diveId)` (`StateProvider.family`) remains the
+  single source of truth. The lane becomes a second writer alongside the
+  section tiles. No new state model.
+- **Callout.** Selecting a chip opens a callout bubble anchored to it,
+  implemented as a widget overlay (the `PhotoMarkerOverlay` precedent), not an
+  fl_chart element, so it has real tap targets outside the chart's gesture
+  arena. Contents:
+  - Severity icon, localized rule name, and key numbers (for example "peak
+    14 m/min for 10 s"), respecting the active diver's units.
+  - **Details** link: scrolls the page to the finding's tile in the safety
+    section (selection stays active).
+  - **Dismiss** action: calls the existing
+    `SafetyFindingsRepository.setDismissed`, which already bumps the parent
+    dive's HLC for sync; clears the selection and removes the chip.
+  - **Clear** button (close icon): clears the selection.
+- **Clearing paths.** All co-located with the chart: tap the clear button, tap
+  the selected chip again, tap a different chip (switches), or dismiss the
+  finding. Selecting from a section tile still works and can still be cleared
+  from the chart.
+
+### 3. Chart highlight rendering changes
+
+In `DiveProfileChart`:
+
+- **Minimum band width.** `_buildHighlightRangeAnnotations` enforces a minimum
+  on-screen band width of 12 px: a range narrower than 12 px renders as a
+  12 px band centered on the range midpoint (clamped to the plot bounds).
+- **Instant findings** (start equals end), which today draw only a dashed
+  vertical line and no band, render the same minimum-width band centered on
+  the timestamp. The dashed line is dropped; the band with edge lines is the
+  single highlight vocabulary.
+- **Edge lines.** True ranges keep their two edge hairlines. For
+  minimum-width-inflated bands, edge lines sit at the inflated band edges.
+- The minimum-width calculation depends on plot pixel width, so it lives where
+  the chart already knows `availableWidth` and the visible window; the pure
+  `visibleHighlightSpan` clamp helper remains pixel-agnostic.
+
+### 4. Safety section integration (two-way sync)
+
+`SafetyReviewSection` keeps its current content and layout. Behavior:
+
+- Tile tap still toggles selection and auto-scrolls toward the chart on
+  select, exactly as today (`_toggleSelected`). This flow is acceptable now
+  because clearing no longer requires scrolling back.
+- Tile selected styling, lane chip ring, chart highlight, and callout all
+  derive from the same provider, so they can never disagree.
+- Dismiss/restore stays in the section (trailing icon buttons and the "show
+  dismissed" toggle), now duplicated by the callout's Dismiss action. Both go
+  through the same repository method.
+
+### 5. Fullscreen profile parity
+
+`FullscreenProfilePage` mounts the same lane and callout with identical
+behavior, replacing today's read-only highlight carry-over. Selection made in
+fullscreen is visible on the detail page afterward and vice versa, since both
+read the same provider.
+
+## Data flow
+
+```
+SafetyReviewSection tile tap ──┐
+SafetyFindingsLane chip tap ───┼──> selectedSafetyFindingProvider(diveId) ──> DiveProfileChart highlightRange
+Callout clear / dismiss ───────┘         │                                    SafetyFindingsLane (ring state)
+                                         │                                    SafetyReviewSection (tile state)
+                                         └────────────────────────────────>   FullscreenProfilePage
+Callout Dismiss ──> SafetyFindingsRepository.setDismissed ──> safetyReviewProvider invalidation ──> lane/section rebuild
+```
+
+No schema, sync, repository, or rules-engine changes. This is a
+presentation-layer redesign over existing state and persistence.
+
+## Error handling and edge cases
+
+- **Finding with start but no end timestamp:** treat as instant at the start
+  timestamp (minimum-width band, icon-only chip).
+- **Zoomed window excluding the selection:** the chart already omits
+  out-of-window highlights via `visibleHighlightSpan`; the lane hides the
+  chip; the callout hides with its chip. Selection state persists, so zooming
+  back restores both.
+- **Selection of a finding that becomes dismissed elsewhere** (section button,
+  sync from another device): `safetyReviewProvider` invalidation rebuilds the
+  lane; the lane clears a selection whose finding is no longer present and
+  closes the callout.
+- **Very many findings:** clustering keeps the lane legible; a group chip's
+  count communicates density.
+- **Narrow layouts:** the callout clamps to the chart width and repositions
+  its arrow; it must never overflow the screen.
+- **Render caching:** any new chart series or annotation source must supply a
+  cache signature; selection state stays excluded from the bars cache key, as
+  today.
+
+## Testing
+
+- **Rewrite** the `finding selection` group in
+  `safety_review_section_test.dart`: retap-to-clear and scroll-on-select
+  survive; assertions about "no other clear affordance" do not.
+- **Extend** `dive_profile_chart_highlight_test.dart`: minimum-width band for
+  short ranges, band (not dashed line) for instant findings, unchanged
+  rendering for wide ranges.
+- **New** widget tests for `SafetyFindingsLane`: chip positioning against the
+  time axis under zoom/pan, minimum chip width for short and instant findings,
+  overlap clustering and cycle-tap behavior, visibility gating (disabled
+  setting, no findings, all dismissed), and tap-to-toggle selection.
+- **New** callout tests: content per rule with unit formatting, Details
+  scrolls to the section, Dismiss calls the repository and clears selection,
+  clear button clears selection.
+- **Extend** `fullscreen_profile_page_test.dart`: lane renders, selection
+  works, and state round-trips with the detail page.
+- **Unchanged:** repository, provider, service, and migration tests.
+
+## Non-goals
+
+- No changes to the safety rules engine, finding generation, storage, or sync.
+- No multi-select; one finding highlighted at a time, as today.
+- No alarm-red styling or judgmental copy; the neutral tone rules from
+  `2026-07-16-safety-features-design.md` still apply.
+- No changes to the dive list safety badge.

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1683,6 +1683,15 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                         appSettings.safetyReviewDisabledRules,
                       )
                     : const <SafetyFinding>[];
+                // Gate the highlight on lane membership: with safety review
+                // (or the finding's rule) disabled neither the lane nor the
+                // section renders, so an ungated highlight would be stuck on
+                // the chart with no UI to clear it.
+                final visibleSelectedFinding =
+                    selectedFinding != null &&
+                        laneFindings.any((f) => f.id == selectedFinding.id)
+                    ? selectedFinding
+                    : null;
                 return Stack(
                   children: [
                     MouseRegion(
@@ -1767,13 +1776,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                             ? chartProfile[trackingIndex].timestamp
                             : null,
                         highlightRange: profileHighlightRangeFor(
-                          selectedFinding,
+                          visibleSelectedFinding,
                           Theme.of(context).colorScheme,
                         ),
                         safetyFindings: laneFindings.isEmpty
                             ? null
                             : laneFindings,
-                        selectedSafetyFindingId: selectedFinding?.id,
+                        selectedSafetyFindingId: visibleSelectedFinding?.id,
                         onSafetyFindingTap: (finding) {
                           final notifier = ref.read(
                             selectedSafetyFindingProvider(diveId).notifier,

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -50,6 +50,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_trac
 import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/buoyancy_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/safety_review_section.dart';
@@ -141,6 +142,20 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
   /// Key for capturing the profile chart as an image for PNG export
   final GlobalKey _profileChartExportKey = GlobalKey();
+  final GlobalKey _safetyReviewSectionKey = GlobalKey();
+
+  /// Scrolls the page so the safety review section is visible (callout
+  /// "Details" action). The selection stays active.
+  void _scrollToSafetySection() {
+    final ctx = _safetyReviewSectionKey.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeInOutCubic,
+      alignment: 0.05,
+    );
+  }
 
   /// Key for capturing the entire dive details page as an image for PNG export
   final GlobalKey _pageExportKey = GlobalKey();
@@ -238,6 +253,22 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       }
     }
 
+    // A finding dismissed elsewhere (section button, another device via sync,
+    // batch re-analysis) must not stay highlighted: drop a selection whose
+    // finding no longer exists as an active row.
+    ref.listen(safetyReviewProvider(diveId), (previous, next) {
+      final review = next.value;
+      if (review == null) return;
+      final selected = ref.read(selectedSafetyFindingProvider(diveId));
+      if (selected == null) return;
+      final stillActive = review.findings.any(
+        (f) => f.id == selected.id && !f.isDismissed,
+      );
+      if (!stillActive) {
+        ref.read(selectedSafetyFindingProvider(diveId).notifier).state = null;
+      }
+    });
+
     final diveAsync = ref.watch(diveProvider(diveId));
 
     return diveAsync.when(
@@ -313,7 +344,8 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         // The widgets collapse to nothing when empty, so plain SizedBox
         // spacers would double up; each widget owns its own spacing.
         return [
-          if (dive.profile.isNotEmpty) SafetyReviewSection(diveId: dive.id),
+          if (dive.profile.isNotEmpty)
+            SafetyReviewSection(key: _safetyReviewSectionKey, diveId: dive.id),
           LinkedIncidentsRow(diveId: dive.id),
         ];
       },
@@ -1641,6 +1673,16 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 final selectedFinding = ref.watch(
                   selectedSafetyFindingProvider(diveId),
                 );
+                final safetyReview = ref
+                    .watch(safetyReviewProvider(diveId))
+                    .value;
+                final appSettings = ref.watch(settingsProvider);
+                final laneFindings = appSettings.safetyReviewEnabled
+                    ? chartSafetyFindings(
+                        safetyReview,
+                        appSettings.safetyReviewDisabledRules,
+                      )
+                    : const <SafetyFinding>[];
                 return Stack(
                   children: [
                     MouseRegion(
@@ -1728,6 +1770,25 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                           selectedFinding,
                           Theme.of(context).colorScheme,
                         ),
+                        safetyFindings: laneFindings.isEmpty
+                            ? null
+                            : laneFindings,
+                        selectedSafetyFindingId: selectedFinding?.id,
+                        onSafetyFindingTap: (finding) {
+                          final notifier = ref.read(
+                            selectedSafetyFindingProvider(diveId).notifier,
+                          );
+                          notifier.state = notifier.state?.id == finding.id
+                              ? null
+                              : finding;
+                        },
+                        onSafetyFindingDismiss: (finding) =>
+                            setSafetyFindingDismissed(
+                              ref,
+                              finding: finding,
+                              dismissed: true,
+                            ),
+                        onSafetyFindingDetails: (_) => _scrollToSafetySection(),
                         onPointSelected: (index) {
                           ref
                                   .read(

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/dive_log/presentation/providers/gas_switch_p
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_playback_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_review_provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
@@ -151,6 +152,33 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final selectedFinding = ref.watch(
       selectedSafetyFindingProvider(widget.diveId),
     );
+    // Narrow selects (not a full settings watch): this page deliberately
+    // avoids rebuilding on unrelated settings writes.
+    final safetyReviewEnabled = ref.watch(
+      settingsProvider.select((s) => s.safetyReviewEnabled),
+    );
+    final safetyDisabledRules = ref.watch(
+      settingsProvider.select((s) => s.safetyReviewDisabledRules),
+    );
+    final safetyReview = ref.watch(safetyReviewProvider(widget.diveId)).value;
+    final laneFindings = safetyReviewEnabled
+        ? chartSafetyFindings(safetyReview, safetyDisabledRules)
+        : const <SafetyFinding>[];
+    // A finding dismissed elsewhere (callout, detail page, sync) must not
+    // stay highlighted: drop a selection with no matching active row.
+    ref.listen(safetyReviewProvider(widget.diveId), (previous, next) {
+      final review = next.value;
+      if (review == null) return;
+      final selected = ref.read(selectedSafetyFindingProvider(widget.diveId));
+      if (selected == null) return;
+      final stillActive = review.findings.any(
+        (f) => f.id == selected.id && !f.isDismissed,
+      );
+      if (!stillActive) {
+        ref.read(selectedSafetyFindingProvider(widget.diveId).notifier).state =
+            null;
+      }
+    });
     final showMaxDepthMarker = ref.watch(showMaxDepthMarkerProvider);
     final showPressureThresholdMarkers = ref.watch(
       showPressureThresholdMarkersProvider,
@@ -397,6 +425,27 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                             selectedFinding,
                             Theme.of(context).colorScheme,
                           ),
+                          safetyFindings: laneFindings.isEmpty
+                              ? null
+                              : laneFindings,
+                          selectedSafetyFindingId: selectedFinding?.id,
+                          onSafetyFindingTap: (finding) {
+                            final selectionNotifier = ref.read(
+                              selectedSafetyFindingProvider(
+                                widget.diveId,
+                              ).notifier,
+                            );
+                            selectionNotifier.state =
+                                selectionNotifier.state?.id == finding.id
+                                ? null
+                                : finding;
+                          },
+                          onSafetyFindingDismiss: (finding) =>
+                              setSafetyFindingDismissed(
+                                ref,
+                                finding: finding,
+                                dismissed: true,
+                              ),
                           onPointSelected: (index) {
                             if (index == null || index >= chartProfile.length) {
                               return;

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -164,6 +164,14 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     final laneFindings = safetyReviewEnabled
         ? chartSafetyFindings(safetyReview, safetyDisabledRules)
         : const <SafetyFinding>[];
+    // Gate the highlight on lane membership: with safety review (or the
+    // finding's rule) disabled the lane disappears, so an ungated highlight
+    // would be stuck on the chart with no UI to clear it.
+    final visibleSelectedFinding =
+        selectedFinding != null &&
+            laneFindings.any((f) => f.id == selectedFinding.id)
+        ? selectedFinding
+        : null;
     // A finding dismissed elsewhere (callout, detail page, sync) must not
     // stay highlighted: drop a selection with no matching active row.
     ref.listen(safetyReviewProvider(widget.diveId), (previous, next) {
@@ -422,13 +430,13 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                               : chartProfile.last.timestamp,
                           highlightedTimestamp: reviewTimestamp,
                           highlightRange: profileHighlightRangeFor(
-                            selectedFinding,
+                            visibleSelectedFinding,
                             Theme.of(context).colorScheme,
                           ),
                           safetyFindings: laneFindings.isEmpty
                               ? null
                               : laneFindings,
-                          selectedSafetyFindingId: selectedFinding?.id,
+                          selectedSafetyFindingId: visibleSelectedFinding?.id,
                           onSafetyFindingTap: (finding) {
                             final selectionNotifier = ref.read(
                               selectedSafetyFindingProvider(

--- a/lib/features/dive_log/presentation/providers/safety_review_providers.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_providers.dart
@@ -66,3 +66,29 @@ final safetyReviewProvider = FutureProvider.family<SafetyReview?, String>((
 /// depend on the async [safetyReviewProvider]. Not persisted.
 final selectedSafetyFindingProvider =
     StateProvider.family<SafetyFinding?, String>((ref, diveId) => null);
+
+/// Dismisses or restores a finding and keeps UI state consistent: a dismissed
+/// finding can no longer be the chart selection. Persists through
+/// [SafetyFindingsRepository.setDismissed], which also bumps the parent
+/// dive's HLC so the change syncs (findings tables have no HLC of their own).
+Future<void> setSafetyFindingDismissed(
+  WidgetRef ref, {
+  required SafetyFinding finding,
+  required bool dismissed,
+}) async {
+  final diveId = finding.diveId;
+  if (dismissed) {
+    final selected = ref.read(selectedSafetyFindingProvider(diveId).notifier);
+    if (selected.state?.id == finding.id) {
+      selected.state = null;
+    }
+  }
+  await ref
+      .read(safetyFindingsRepositoryProvider)
+      .setDismissed(
+        findingId: finding.id,
+        dismissed: dismissed,
+        now: DateTime.now(),
+      );
+  ref.invalidate(safetyReviewProvider(diveId));
+}

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -174,6 +174,10 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   /// name would start to clip.
   static const double gasTimelineHeight = 18.0;
 
+  /// Minimum on-screen width of the safety-highlight band, in logical px.
+  /// Short and instant findings inflate to this so they stay visible.
+  static const double _minHighlightBandPx = 12.0;
+
   /// fl_chart default axisNameSize used for left and right axes.
   static const double _leftRightAxisNameSize = 16.0;
 
@@ -2174,6 +2178,25 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     final visibleMinDepth = _viewport.offsetY * totalMaxDepth;
     final visibleMaxDepth = visibleMinDepth + visibleRangeY;
 
+    // Highlight band, inflated to a 12 px minimum so short/instant findings
+    // stay visible (spec: safety-findings-lane). Computed once and shared by
+    // the band annotation and its edge lines.
+    ({double x1, double x2})? highlightSpan;
+    if (widget.highlightRange != null) {
+      final plotInsets = _plotInsets(availableWidth, units);
+      final plotWidth = (availableWidth - plotInsets.left - plotInsets.right)
+          .clamp(1.0, double.infinity);
+      highlightSpan = highlightBandSpan(
+        widget.highlightRange!,
+        visibleMinX: visibleMinX,
+        visibleMaxX: visibleMaxX,
+        minWidthX:
+            DiveProfileChart._minHighlightBandPx *
+            (visibleMaxX - visibleMinX) /
+            plotWidth,
+      );
+    }
+
     // Same helper and same totalMaxDepth build() fed into the bar-cache
     // signatures, so the band the bars are drawn with can never diverge from
     // the band they are keyed on.
@@ -2589,15 +2612,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
             ),
             rangeAnnotations: RangeAnnotations(
               verticalRangeAnnotations: _buildHighlightRangeAnnotations(
-                visibleMinX,
-                visibleMaxX,
+                highlightSpan,
               ),
             ),
             extraLinesData: ExtraLinesData(
               verticalLines: [
                 ..._buildPlaybackCursor(colorScheme),
                 ..._buildHighlightCursor(colorScheme),
-                ..._buildHighlightRangeLines(visibleMinX, visibleMaxX),
+                ..._buildHighlightRangeLines(highlightSpan),
                 if (_showEvents && widget.events != null)
                   ..._buildEventVerticalLines(colorScheme),
               ],
@@ -4981,23 +5003,15 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     ];
   }
 
-  /// Translucent band for the externally highlighted time range, clamped to
-  /// the visible window (fl_chart asserts annotations stay within bounds).
-  /// Instant ranges draw no band; see [_buildHighlightRangeLines].
+  /// Translucent band for the externally highlighted time range. [span] is
+  /// precomputed by [_buildChart] via [highlightBandSpan]: clamped to the
+  /// visible window and inflated to the 12 px minimum, so instants and short
+  /// ranges render the same visible band as wide ones.
   List<VerticalRangeAnnotation> _buildHighlightRangeAnnotations(
-    double visibleMinX,
-    double visibleMaxX,
+    ({double x1, double x2})? span,
   ) {
     final range = widget.highlightRange;
-    if (range == null || range.startTimestamp == range.endTimestamp) {
-      return [];
-    }
-    final span = visibleHighlightSpan(
-      range,
-      visibleMinX: visibleMinX,
-      visibleMaxX: visibleMaxX,
-    );
-    if (span == null) return [];
+    if (range == null || span == null) return [];
     return [
       VerticalRangeAnnotation(
         x1: span.x1,
@@ -5007,39 +5021,17 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
     ];
   }
 
-  /// Edge lines for a range highlight (only the edges inside the visible
-  /// window), or the single dashed cursor for an instant highlight.
-  List<VerticalLine> _buildHighlightRangeLines(
-    double visibleMinX,
-    double visibleMaxX,
-  ) {
+  /// Edge lines at the highlight band's (possibly inflated) edges.
+  List<VerticalLine> _buildHighlightRangeLines(({double x1, double x2})? span) {
     final range = widget.highlightRange;
-    if (range == null) return [];
-    final start = range.startTimestamp.toDouble();
-    final end = range.endTimestamp.toDouble();
-
-    bool inWindow(double x) => x >= visibleMinX && x <= visibleMaxX;
-
-    if (range.startTimestamp == range.endTimestamp) {
-      if (!inWindow(start)) return [];
-      return [
-        VerticalLine(
-          x: start,
-          color: range.color,
-          strokeWidth: 1.5,
-          dashArray: [3, 3],
-        ),
-      ];
-    }
-
+    if (range == null || span == null) return [];
     return [
-      for (final x in [start, end])
-        if (inWindow(x))
-          VerticalLine(
-            x: x,
-            color: range.color.withValues(alpha: 0.7),
-            strokeWidth: 1,
-          ),
+      for (final x in [span.x1, span.x2])
+        VerticalLine(
+          x: x,
+          color: range.color.withValues(alpha: 0.7),
+          strokeWidth: 1,
+        ),
     ];
   }
 

--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/dive_log/data/services/profile_surface_lead_
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_legend_provider.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/chart_series_cache.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/deco_stop_band.dart';
@@ -30,6 +31,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/gas_colors.dar
 import 'package:submersion/features/dive_log/presentation/widgets/gas_timeline_strip.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_overlay.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_findings_overlay.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_chart_viewport.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/profile_highlight_range.dart';
@@ -200,9 +202,32 @@ class DiveProfileChart extends ConsumerStatefulWidget {
   final int? highlightedTimestamp;
 
   /// Optional time range to emphasize (e.g. the selected safety finding).
-  /// A true range renders as a translucent vertical band with edge lines;
-  /// an instant (start == end) renders as a single dashed cursor line.
+  /// Renders as a translucent vertical band with edge lines; short and
+  /// instant ranges inflate to a minimum on-screen width.
   final ProfileHighlightRange? highlightRange;
+
+  /// Safety findings shown as tappable chips in a lane below the plot.
+  /// Pre-filtered by the caller (chartSafetyFindings): non-dismissed,
+  /// rule-enabled, start-timestamped, sorted by start time. The lane renders
+  /// only when this is non-empty AND [onSafetyFindingTap] is provided.
+  final List<SafetyFinding>? safetyFindings;
+
+  /// Id of the finding whose chip shows the selected ring and callout.
+  final String? selectedSafetyFindingId;
+
+  /// Toggle request from a chip or the callout's clear button: callers
+  /// select the finding, or clear when it is already selected.
+  final void Function(SafetyFinding finding)? onSafetyFindingTap;
+
+  /// Callout "Dismiss" action.
+  final void Function(SafetyFinding finding)? onSafetyFindingDismiss;
+
+  /// Callout "Details" action (scroll to the safety section). Omit where no
+  /// detail surface exists (fullscreen); the callout hides the link.
+  final void Function(SafetyFinding finding)? onSafetyFindingDetails;
+
+  /// Height of the safety findings lane in logical pixels.
+  static const double safetyLaneHeight = 24.0;
 
   // Advanced decompression/gas curves
   /// ppO2 curve in bar
@@ -507,6 +532,11 @@ class DiveProfileChart extends ConsumerStatefulWidget {
     this.playbackTimestamp,
     this.highlightedTimestamp,
     this.highlightRange,
+    this.safetyFindings,
+    this.selectedSafetyFindingId,
+    this.onSafetyFindingTap,
+    this.onSafetyFindingDismiss,
+    this.onSafetyFindingDetails,
     this.ppO2Curve,
     this.o2SensorCurves,
     this.ppO2FromSensorAverage = false,
@@ -1540,10 +1570,9 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
           DiveProfileChart.rightAxisSize(availableWidth),
       bottom:
           DiveProfileChart._bottomAxisNameSize +
-          (hasGasStrip
-              ? DiveProfileChart._bottomTickReservedSize +
-                    DiveProfileChart.gasTimelineHeight
-              : DiveProfileChart._bottomTickReservedSize),
+          DiveProfileChart._bottomTickReservedSize +
+          (hasGasStrip ? DiveProfileChart.gasTimelineHeight : 0) +
+          (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
     );
   }
 
@@ -2106,6 +2135,12 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
       (widget.diveDurationSeconds != null && widget.diveDurationSeconds! > 0) &&
       showGas;
 
+  /// Whether the safety findings lane renders. Widget-param based (no
+  /// provider read) so it is safe from both build and gesture paths.
+  bool get _hasSafetyLane =>
+      (widget.safetyFindings?.isNotEmpty ?? false) &&
+      widget.onSafetyFindingTap != null;
+
   // ref.watch is correct here: _hasGasStrip is only read from build().
   // Gesture paths must use _gasStripVisible with ref.read (see _plotInsets).
   bool get _hasGasStrip => _gasStripVisible(
@@ -2341,10 +2376,10 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                   // push the tick labels down by the strip's height so the
                   // strip can be Positioned in the resulting gap, directly
                   // between the plot area and the time labels.
-                  reservedSize: _hasGasStrip
-                      ? DiveProfileChart._bottomTickReservedSize +
-                            DiveProfileChart.gasTimelineHeight
-                      : DiveProfileChart._bottomTickReservedSize,
+                  reservedSize:
+                      DiveProfileChart._bottomTickReservedSize +
+                      (_hasGasStrip ? DiveProfileChart.gasTimelineHeight : 0) +
+                      (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
                   interval: _calculateTimeInterval(visibleRangeX),
                   getTitlesWidget: (value, meta) {
                     // Suppress interval ticks that are too close to the max
@@ -2357,9 +2392,14 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                     final minutes = (value / 60).round();
                     return SideTitleWidget(
                       meta: meta,
-                      space: _hasGasStrip
-                          ? 8 + DiveProfileChart.gasTimelineHeight
-                          : 8,
+                      space:
+                          8 +
+                          (_hasGasStrip
+                              ? DiveProfileChart.gasTimelineHeight
+                              : 0) +
+                          (_hasSafetyLane
+                              ? DiveProfileChart.safetyLaneHeight
+                              : 0),
                       child: Text(
                         '$minutes',
                         style: Theme.of(context).textTheme.labelSmall,
@@ -3456,7 +3496,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 DiveProfileChart.rightAxisSize(availableWidth),
             bottom:
                 DiveProfileChart._bottomAxisNameSize +
-                DiveProfileChart._bottomTickReservedSize,
+                DiveProfileChart._bottomTickReservedSize +
+                (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
             height: DiveProfileChart.gasTimelineHeight,
             child: GasTimelineStrip(
               segments: widget.gasSegments!,
@@ -3496,6 +3537,28 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               visibleMaxDepth: visibleMaxDepth,
               insets: _plotInsets(availableWidth, units),
               units: units,
+            ),
+          ),
+        // Safety findings lane + callout: a widget layer like the photo
+        // markers, occupying the extra bottom reservation added by
+        // _hasSafetyLane, directly between the gas strip (or plot) and the
+        // tick labels.
+        if (_hasSafetyLane)
+          Positioned.fill(
+            child: SafetyFindingsOverlay(
+              findings: widget.safetyFindings!,
+              selectedFindingId: widget.selectedSafetyFindingId,
+              visibleMinSeconds: visibleMinX,
+              visibleMaxSeconds: visibleMaxX,
+              insets: _plotInsets(availableWidth, units),
+              laneHeight: DiveProfileChart.safetyLaneHeight,
+              laneBottomOffset:
+                  DiveProfileChart._bottomAxisNameSize +
+                  DiveProfileChart._bottomTickReservedSize,
+              units: units,
+              onFindingTap: widget.onSafetyFindingTap!,
+              onFindingDismiss: widget.onSafetyFindingDismiss ?? (_) {},
+              onFindingDetails: widget.onSafetyFindingDetails,
             ),
           ),
       ],
@@ -3547,7 +3610,8 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
                 width / 2,
             bottom:
                 DiveProfileChart._bottomAxisNameSize +
-                DiveProfileChart._bottomTickReservedSize,
+                DiveProfileChart._bottomTickReservedSize +
+                (_hasSafetyLane ? DiveProfileChart.safetyLaneHeight : 0),
             height: DiveProfileChart.gasTimelineHeight,
             width: width,
             child: IgnorePointer(child: ColoredBox(color: color)),

--- a/lib/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart
+++ b/lib/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/gestures.dart';
+
+/// A tap that wins its gesture arena the instant the pointer lifts.
+///
+/// Overlays using this render inside the chart's [GestureDetector], which
+/// handles double-tap-to-zoom. Flutter's [DoubleTapGestureRecognizer] holds
+/// the pointer's arena for [kDoubleTapTimeout] (300ms) after the first tap
+/// up, and a plain [TapGestureRecognizer] never self-accepts - it waits for
+/// the arena sweep that the hold defers. So an ordinary
+/// [GestureDetector.onTap] here lags 300ms behind the finger, and an
+/// impatient second tap lands inside the double-tap window, zooming the
+/// chart instead of acting on the marker. Resolving accepted on the up event
+/// ends the hold immediately.
+///
+/// Drags are unaffected: [PrimaryPointerGestureRecognizer] rejects this
+/// recognizer as soon as the pointer travels past `kTouchSlop`, so a pan
+/// that starts on a marker still pans the chart.
+class EagerTapGestureRecognizer extends TapGestureRecognizer {
+  EagerTapGestureRecognizer({super.debugOwner});
+
+  @override
+  void handlePrimaryPointer(PointerEvent event) {
+    if (event is PointerUpEvent) {
+      resolve(GestureDisposition.accepted);
+    }
+    super.handlePrimaryPointer(event);
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/photo_marker_overlay.dart
+++ b/lib/features/dive_log/presentation/widgets/photo_marker_overlay.dart
@@ -2,37 +2,12 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
-
-/// A tap that wins its gesture arena the instant the pointer lifts.
-///
-/// The overlay renders inside the chart's [GestureDetector], which handles
-/// double-tap-to-zoom. Flutter's [DoubleTapGestureRecognizer] holds the
-/// pointer's arena for [kDoubleTapTimeout] (300ms) after the first tap up,
-/// and a plain [TapGestureRecognizer] never self-accepts - it waits for the
-/// arena sweep that the hold defers. So an ordinary [GestureDetector.onTap]
-/// here lags 300ms behind the finger, and an impatient second tap lands
-/// inside the double-tap window, zooming the chart instead of acting on the
-/// marker. Resolving accepted on the up event ends the hold immediately.
-///
-/// Drags are unaffected: [PrimaryPointerGestureRecognizer] rejects this
-/// recognizer as soon as the pointer travels past `kTouchSlop`, so a pan
-/// that starts on a marker still pans the chart.
-class _EagerTapGestureRecognizer extends TapGestureRecognizer {
-  _EagerTapGestureRecognizer({super.debugOwner});
-
-  @override
-  void handlePrimaryPointer(PointerEvent event) {
-    if (event is PointerUpEvent) {
-      resolve(GestureDisposition.accepted);
-    }
-    super.handlePrimaryPointer(event);
-  }
-}
 
 /// Camera-icon markers over the dive profile chart at each photo's
 /// (time, depth), with a tap-to-preview thumbnail card.
@@ -41,7 +16,7 @@ class _EagerTapGestureRecognizer extends TapGestureRecognizer {
 /// its tap targets win hit-testing over the chart's pan/scrub/tooltip
 /// gestures without entering fl_chart's touch arena. The chart's own
 /// double-tap recognizer is an ancestor and does still share the arena;
-/// [_EagerTapGestureRecognizer] is what keeps these taps immediate.
+/// [EagerTapGestureRecognizer] is what keeps these taps immediate.
 class PhotoMarkerOverlay extends StatefulWidget {
   /// Time-sorted markers (see [photoMarkersFromMedia]).
   final List<PhotoChartMarker> markers;
@@ -120,7 +95,7 @@ class _PhotoMarkerOverlayState extends State<PhotoMarkerOverlay> {
     );
   }
 
-  /// [GestureDetector.onTap] equivalent backed by [_EagerTapGestureRecognizer].
+  /// [GestureDetector.onTap] equivalent backed by [EagerTapGestureRecognizer].
   Widget _eagerTap({
     Key? key,
     required HitTestBehavior behavior,
@@ -131,9 +106,9 @@ class _PhotoMarkerOverlayState extends State<PhotoMarkerOverlay> {
       key: key,
       behavior: behavior,
       gestures: {
-        _EagerTapGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<_EagerTapGestureRecognizer>(
-              () => _EagerTapGestureRecognizer(debugOwner: this),
+        EagerTapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<EagerTapGestureRecognizer>(
+              () => EagerTapGestureRecognizer(debugOwner: this),
               (recognizer) => recognizer.onTap = onTap,
             ),
       },

--- a/lib/features/dive_log/presentation/widgets/photo_marker_overlay.dart
+++ b/lib/features/dive_log/presentation/widgets/photo_marker_overlay.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';

--- a/lib/features/dive_log/presentation/widgets/profile_highlight_range.dart
+++ b/lib/features/dive_log/presentation/widgets/profile_highlight_range.dart
@@ -44,3 +44,37 @@ class ProfileHighlightRange {
   if (x1 >= x2) return null;
   return (x1: x1, x2: x2);
 }
+
+/// The drawable band for [range], inflated to at least [minWidthX] (x-axis
+/// units) so short and instant findings stay visible. Centered on the
+/// clamped span's midpoint, shifted (not shrunk) to stay inside the window;
+/// a window narrower than [minWidthX] yields the whole window. Returns null
+/// when nothing of the range is visible.
+({double x1, double x2})? highlightBandSpan(
+  ProfileHighlightRange range, {
+  required double visibleMinX,
+  required double visibleMaxX,
+  required double minWidthX,
+}) {
+  final span = visibleHighlightSpan(
+    range,
+    visibleMinX: visibleMinX,
+    visibleMaxX: visibleMaxX,
+  );
+  if (span == null) return null;
+  if (span.x2 - span.x1 >= minWidthX) return span;
+  if (visibleMaxX - visibleMinX <= minWidthX) {
+    return (x1: visibleMinX, x2: visibleMaxX);
+  }
+  final mid = (span.x1 + span.x2) / 2;
+  var x1 = mid - minWidthX / 2;
+  var x2 = mid + minWidthX / 2;
+  if (x1 < visibleMinX) {
+    x2 += visibleMinX - x1;
+    x1 = visibleMinX;
+  } else if (x2 > visibleMaxX) {
+    x1 -= x2 - visibleMaxX;
+    x2 = visibleMaxX;
+  }
+  return (x1: x1, x2: x2);
+}

--- a/lib/features/dive_log/presentation/widgets/safety_finding_highlight.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_finding_highlight.dart
@@ -15,18 +15,41 @@ Color safetySeverityColor(SafetySeverity severity, ColorScheme colorScheme) {
 }
 
 /// Maps the selected finding to the chart's highlight parameter. Returns null
-/// when nothing is selected or the finding has no profile time range.
+/// when nothing is selected or the finding has no start timestamp; a missing
+/// end timestamp is treated as an instant at the start (the chart inflates
+/// instants to a minimum-width band).
 ProfileHighlightRange? profileHighlightRangeFor(
   SafetyFinding? finding,
   ColorScheme colorScheme,
 ) {
   if (finding == null) return null;
   final start = finding.startTimestamp;
-  final end = finding.endTimestamp;
-  if (start == null || end == null) return null;
+  if (start == null) return null;
+  final end = finding.endTimestamp ?? start;
   return ProfileHighlightRange(
     startTimestamp: start,
     endTimestamp: end,
     color: safetySeverityColor(finding.severity, colorScheme),
   );
+}
+
+/// The findings the profile chart's safety lane shows for [review]:
+/// non-dismissed, rule-enabled, and placeable on the time axis (start
+/// timestamp present), sorted by start time. [disabledRules] holds
+/// [SafetyRuleId.dbValue] strings (settings.safetyReviewDisabledRules).
+List<SafetyFinding> chartSafetyFindings(
+  SafetyReview? review,
+  Set<String> disabledRules,
+) {
+  if (review == null) return const [];
+  final findings = review.findings
+      .where(
+        (f) =>
+            !f.isDismissed &&
+            !disabledRules.contains(f.ruleId.dbValue) &&
+            f.startTimestamp != null,
+      )
+      .toList();
+  findings.sort((a, b) => a.startTimestamp!.compareTo(b.startTimestamp!));
+  return findings;
 }

--- a/lib/features/dive_log/presentation/widgets/safety_finding_text.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_finding_text.dart
@@ -1,0 +1,70 @@
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Full composed title for a finding (rule + key numbers), shared by the
+/// safety section tiles and the chart lane callout.
+String safetyFindingTitle(
+  SafetyFinding finding,
+  AppLocalizations l10n,
+  UnitFormatter units,
+) {
+  // value is nullable in storage; a missing number (older/corrupt/malformed
+  // sync row) must render a neutral placeholder rather than a fabricated 0
+  // that would read as e.g. "Ascent exceeded 0/min".
+  final value = finding.value;
+  const unknown = '--';
+  return switch (finding.ruleId) {
+    SafetyRuleId.rapidAscent => l10n.safetyReview_rapidAscent_title(
+      value == null ? unknown : '${units.formatDepth(value, decimals: 0)}/min',
+      _durationOf(finding),
+    ),
+    SafetyRuleId.missedDecoStop => l10n.safetyReview_missedDecoStop_title(
+      value == null ? unknown : units.formatDepth(value),
+      _durationOf(finding),
+    ),
+    SafetyRuleId.omittedSafetyStop => l10n.safetyReview_omittedSafetyStop_title(
+      value == null ? unknown : _formatSeconds(value.round()),
+    ),
+    // Sawtooth's only detail is the cycle count; with no value there is
+    // nothing meaningful to interpolate, so fall back to the neutral rule
+    // name instead of claiming "0 repeated up-and-down depth changes".
+    SafetyRuleId.sawtoothProfile =>
+      value == null
+          ? l10n.safetySettings_rule_sawtoothProfile
+          : l10n.safetyReview_sawtoothProfile_title(value.round()),
+    SafetyRuleId.highSurfaceGf => l10n.safetyReview_highSurfaceGf_title(
+      value == null ? unknown : '${value.toStringAsFixed(0)}%',
+      // Pass a plain percentage (matching the surfaced-GF formatting) so the
+      // localized template owns every word; no baked-in English "GF" token.
+      '${units.settings.gfHigh}%',
+    ),
+  };
+}
+
+/// Localized rule name only (settings-page strings), for narrow contexts
+/// like wide lane chips.
+String safetyFindingShortLabel(SafetyFinding finding, AppLocalizations l10n) {
+  return switch (finding.ruleId) {
+    SafetyRuleId.rapidAscent => l10n.safetySettings_rule_rapidAscent,
+    SafetyRuleId.missedDecoStop => l10n.safetySettings_rule_missedDecoStop,
+    SafetyRuleId.omittedSafetyStop =>
+      l10n.safetySettings_rule_omittedSafetyStop,
+    SafetyRuleId.sawtoothProfile => l10n.safetySettings_rule_sawtoothProfile,
+    SafetyRuleId.highSurfaceGf => l10n.safetySettings_rule_highSurfaceGf,
+  };
+}
+
+String _durationOf(SafetyFinding finding) {
+  final start = finding.startTimestamp;
+  final end = finding.endTimestamp;
+  if (start == null || end == null) return '--';
+  return _formatSeconds(end - start);
+}
+
+String _formatSeconds(int totalSeconds) {
+  if (totalSeconds < 60) return '${totalSeconds}s';
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return seconds == 0 ? '${minutes}m' : '${minutes}m ${seconds}s';
+}

--- a/lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart
@@ -1,0 +1,377 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/eager_tap_gesture_recognizer.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_text.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_lane_layout.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Chart overlay hosting the safety findings lane (tappable chips below the
+/// plot) and the callout card for the selected finding. A widget layer, not
+/// an fl_chart element, so taps never enter the chart's gesture arena
+/// (PhotoMarkerOverlay precedent). Stateless: selection lives with the
+/// caller, which passes [selectedFindingId] and receives toggle requests
+/// through [onFindingTap].
+class SafetyFindingsOverlay extends StatelessWidget {
+  /// Lane findings, pre-filtered (chartSafetyFindings): non-dismissed,
+  /// rule-enabled, start-timestamped, sorted by start time.
+  final List<SafetyFinding> findings;
+
+  final String? selectedFindingId;
+
+  /// Visible time window in seconds (the chart's zoomed/panned X range).
+  final double visibleMinSeconds;
+  final double visibleMaxSeconds;
+
+  /// Reserved axis gutters around the plot rect (the chart's _plotInsets).
+  final ({double left, double top, double right, double bottom}) insets;
+
+  final double laneHeight;
+
+  /// Distance from the overlay's bottom edge to the lane's bottom edge
+  /// (the tick-label + axis-name reservation below the lane).
+  final double laneBottomOffset;
+
+  final UnitFormatter units;
+
+  /// Toggle request: the parent selects this finding, or clears when it is
+  /// already the selection.
+  final void Function(SafetyFinding finding) onFindingTap;
+
+  final void Function(SafetyFinding finding) onFindingDismiss;
+
+  /// Opens the finding's detail view (the safety review section). Null when
+  /// no detail surface exists (fullscreen); the callout hides the link.
+  final void Function(SafetyFinding finding)? onFindingDetails;
+
+  const SafetyFindingsOverlay({
+    super.key,
+    required this.findings,
+    required this.selectedFindingId,
+    required this.visibleMinSeconds,
+    required this.visibleMaxSeconds,
+    required this.insets,
+    required this.laneHeight,
+    required this.laneBottomOffset,
+    required this.units,
+    required this.onFindingTap,
+    required this.onFindingDismiss,
+    this.onFindingDetails,
+  });
+
+  static const double _chipVerticalInset = 3.0;
+  static const double _calloutMaxWidth = 280.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final laneWidth = constraints.maxWidth - insets.left - insets.right;
+        if (laneWidth <= 0 || findings.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        final placements = layoutSafetyLaneChips(
+          ranges: [
+            for (final f in findings)
+              (
+                startSeconds: f.startTimestamp!.toDouble(),
+                endSeconds: (f.endTimestamp ?? f.startTimestamp!).toDouble(),
+              ),
+          ],
+          visibleMinSeconds: visibleMinSeconds,
+          visibleMaxSeconds: visibleMaxSeconds,
+          laneWidth: laneWidth,
+        );
+        if (placements.isEmpty) return const SizedBox.shrink();
+
+        final laneTop = constraints.maxHeight - laneBottomOffset - laneHeight;
+
+        SafetyLaneChipPlacement? selectedPlacement;
+        if (selectedFindingId != null) {
+          for (final p in placements) {
+            if (p.memberIndexes.any(
+              (i) => findings[i].id == selectedFindingId,
+            )) {
+              selectedPlacement = p;
+              break;
+            }
+          }
+        }
+
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // Lane background strip.
+            Positioned(
+              left: insets.left,
+              top: laneTop,
+              width: laneWidth,
+              height: laneHeight,
+              child: IgnorePointer(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+            for (var i = 0; i < placements.length; i++)
+              Positioned(
+                key: ValueKey('safetyLaneChip-$i'),
+                left: insets.left + placements[i].left,
+                top: laneTop,
+                width: placements[i].width,
+                height: laneHeight,
+                child: _buildChip(context, placements[i]),
+              ),
+            if (selectedPlacement != null)
+              _buildCallout(context, constraints, laneWidth),
+          ],
+        );
+      },
+    );
+  }
+
+  /// [GestureDetector.onTap] equivalent backed by [EagerTapGestureRecognizer]
+  /// so chip taps land immediately despite the chart's double-tap-to-zoom
+  /// recognizer holding the arena (see PhotoMarkerOverlay).
+  Widget _eagerTap({required VoidCallback onTap, required Widget child}) {
+    return RawGestureDetector(
+      behavior: HitTestBehavior.opaque,
+      gestures: {
+        EagerTapGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<EagerTapGestureRecognizer>(
+              () => EagerTapGestureRecognizer(debugOwner: this),
+              (recognizer) => recognizer.onTap = onTap,
+            ),
+      },
+      child: child,
+    );
+  }
+
+  void _handleTap(List<SafetyFinding> members) {
+    final selectedIdx = members.indexWhere((f) => f.id == selectedFindingId);
+    if (selectedIdx == -1) {
+      onFindingTap(members.first);
+    } else if (selectedIdx < members.length - 1) {
+      onFindingTap(members[selectedIdx + 1]);
+    } else {
+      // Last member selected: report it again so the parent toggle clears.
+      onFindingTap(members.last);
+    }
+  }
+
+  IconData _iconFor(SafetySeverity severity) {
+    return switch (severity) {
+      SafetySeverity.info => Icons.info_outline,
+      SafetySeverity.caution => Icons.report_problem_outlined,
+      SafetySeverity.significant => Icons.report_problem_outlined,
+    };
+  }
+
+  Widget _buildChip(BuildContext context, SafetyLaneChipPlacement placement) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
+    final members = [for (final i in placement.memberIndexes) findings[i]];
+    // Most severe member colors the chip; enum order is info < caution <
+    // significant.
+    final severity = members
+        .map((f) => f.severity)
+        .reduce((a, b) => a.index >= b.index ? a : b);
+    final severityColor = safetySeverityColor(severity, colorScheme);
+    final isSelected =
+        selectedFindingId != null &&
+        members.any((f) => f.id == selectedFindingId);
+    final dimmed = selectedFindingId != null && !isSelected;
+
+    final semanticsLabel = members.length == 1
+        ? safetyFindingTitle(members.single, l10n, units)
+        : l10n.safetyReview_findingGroupSemantics(members.length);
+
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      child: _eagerTap(
+        onTap: () => _handleTap(members),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: _chipVerticalInset),
+          child: Container(
+            decoration: BoxDecoration(
+              color: severityColor.withValues(alpha: dimmed ? 0.45 : 0.9),
+              borderRadius: BorderRadius.circular(
+                (laneHeight - 2 * _chipVerticalInset) / 2,
+              ),
+              border: isSelected
+                  ? Border.all(color: severityColor, width: 2)
+                  : null,
+            ),
+            child: Stack(
+              clipBehavior: Clip.none,
+              alignment: Alignment.center,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      _iconFor(severity),
+                      size: 12,
+                      color: colorScheme.surface,
+                    ),
+                    if (placement.width > 60 && members.length == 1) ...[
+                      const SizedBox(width: 4),
+                      Flexible(
+                        child: Text(
+                          safetyFindingShortLabel(members.single, l10n),
+                          style: Theme.of(context).textTheme.labelSmall
+                              ?.copyWith(
+                                color: colorScheme.surface,
+                                fontWeight: FontWeight.w600,
+                              ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                    ],
+                  ],
+                ),
+                if (members.length > 1)
+                  Positioned(
+                    top: -7,
+                    right: -4,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 4,
+                        vertical: 1,
+                      ),
+                      decoration: BoxDecoration(
+                        color: colorScheme.primary,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        '${members.length}',
+                        style: TextStyle(
+                          color: colorScheme.onPrimary,
+                          fontSize: 9,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCallout(
+    BuildContext context,
+    BoxConstraints constraints,
+    double laneWidth,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
+    final finding = findings.firstWhere((f) => f.id == selectedFindingId);
+    final severityColor = safetySeverityColor(finding.severity, colorScheme);
+
+    // Re-derive the selected placement's center for anchoring; build() only
+    // calls this when a placement matched, so firstWhere cannot miss.
+    final placements = layoutSafetyLaneChips(
+      ranges: [
+        for (final f in findings)
+          (
+            startSeconds: f.startTimestamp!.toDouble(),
+            endSeconds: (f.endTimestamp ?? f.startTimestamp!).toDouble(),
+          ),
+      ],
+      visibleMinSeconds: visibleMinSeconds,
+      visibleMaxSeconds: visibleMaxSeconds,
+      laneWidth: laneWidth,
+    );
+    final placement = placements.firstWhere(
+      (p) => p.memberIndexes.any((i) => findings[i].id == selectedFindingId),
+    );
+
+    final cardWidth = math.min(_calloutMaxWidth, laneWidth);
+    final chipCenter = insets.left + placement.left + placement.width / 2;
+    final minLeft = insets.left;
+    final maxLeft = math.max(insets.left + laneWidth - cardWidth, minLeft);
+    final left = (chipCenter - cardWidth / 2).clamp(minLeft, maxLeft);
+
+    return Positioned(
+      key: const ValueKey('safetyFindingCallout'),
+      left: left,
+      width: cardWidth,
+      bottom: laneBottomOffset + laneHeight + 6,
+      child: Material(
+        elevation: 6,
+        borderRadius: BorderRadius.circular(10),
+        color: colorScheme.surfaceContainerHigh,
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 8, 4, 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Icon(
+                      _iconFor(finding.severity),
+                      size: 16,
+                      color: severityColor,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(
+                        safetyFindingTitle(finding, l10n, units),
+                        style: Theme.of(context).textTheme.bodySmall,
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    visualDensity: VisualDensity.compact,
+                    tooltip: l10n.safetyReview_clearHighlight,
+                    onPressed: () => onFindingTap(finding),
+                  ),
+                ],
+              ),
+              Row(
+                children: [
+                  if (onFindingDetails != null)
+                    TextButton(
+                      onPressed: () => onFindingDetails!(finding),
+                      child: Text(l10n.safetyReview_details),
+                    ),
+                  TextButton(
+                    onPressed: () => onFindingDismiss(finding),
+                    child: Text(l10n.safetyReview_dismiss),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_findings_overlay.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';

--- a/lib/features/dive_log/presentation/widgets/safety_lane_layout.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_lane_layout.dart
@@ -1,0 +1,98 @@
+import 'dart:math' as math;
+
+/// One tappable chip in the safety findings lane. [memberIndexes] holds the
+/// indexes (into the caller's findings list) of every finding merged into
+/// this chip, ascending by on-screen position; length > 1 marks a cluster.
+class SafetyLaneChipPlacement {
+  final double left;
+  final double width;
+  final List<int> memberIndexes;
+
+  const SafetyLaneChipPlacement({
+    required this.left,
+    required this.width,
+    required this.memberIndexes,
+  });
+}
+
+/// Maps finding time ranges onto lane pixels: clamps to the visible window,
+/// inflates every chip to [minChipWidth] (shifted to stay inside the lane),
+/// and merges chips whose extents overlap into clusters. Pure geometry so
+/// clustering behavior is unit-testable without widgets.
+List<SafetyLaneChipPlacement> layoutSafetyLaneChips({
+  required List<({double startSeconds, double endSeconds})> ranges,
+  required double visibleMinSeconds,
+  required double visibleMaxSeconds,
+  required double laneWidth,
+  double minChipWidth = 26.0,
+}) {
+  final window = visibleMaxSeconds - visibleMinSeconds;
+  if (window <= 0 || laneWidth <= 0) return const [];
+
+  final extents = <({double left, double right, int index})>[];
+  for (var i = 0; i < ranges.length; i++) {
+    final r = ranges[i];
+    if (r.endSeconds < visibleMinSeconds ||
+        r.startSeconds > visibleMaxSeconds) {
+      continue;
+    }
+    var left = ((r.startSeconds - visibleMinSeconds) / window * laneWidth)
+        .clamp(0.0, laneWidth);
+    var right = ((r.endSeconds - visibleMinSeconds) / window * laneWidth).clamp(
+      0.0,
+      laneWidth,
+    );
+    if (right - left < minChipWidth) {
+      final mid = (left + right) / 2;
+      left = mid - minChipWidth / 2;
+      right = mid + minChipWidth / 2;
+      if (left < 0) {
+        right -= left;
+        left = 0;
+      } else if (right > laneWidth) {
+        left -= right - laneWidth;
+        right = laneWidth;
+      }
+      left = math.max(left, 0.0);
+      right = math.min(right, laneWidth);
+    }
+    extents.add((left: left, right: right, index: i));
+  }
+  extents.sort((a, b) => a.left.compareTo(b.left));
+
+  final placements = <SafetyLaneChipPlacement>[];
+  double clusterLeft = 0;
+  double clusterRight = 0;
+  var members = <int>[];
+  for (final e in extents) {
+    if (members.isEmpty) {
+      clusterLeft = e.left;
+      clusterRight = e.right;
+      members = [e.index];
+    } else if (e.left < clusterRight) {
+      clusterRight = math.max(clusterRight, e.right);
+      members.add(e.index);
+    } else {
+      placements.add(
+        SafetyLaneChipPlacement(
+          left: clusterLeft,
+          width: clusterRight - clusterLeft,
+          memberIndexes: members,
+        ),
+      );
+      clusterLeft = e.left;
+      clusterRight = e.right;
+      members = [e.index];
+    }
+  }
+  if (members.isNotEmpty) {
+    placements.add(
+      SafetyLaneChipPlacement(
+        left: clusterLeft,
+        width: clusterRight - clusterLeft,
+        memberIndexes: members,
+      ),
+    );
+  }
+  return placements;
+}

--- a/lib/features/dive_log/presentation/widgets/safety_review_section.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_review_section.dart
@@ -6,8 +6,8 @@ import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/collapsible_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_highlight.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_finding_text.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
-import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Dive detail section listing the post-dive safety review findings.
@@ -111,12 +111,11 @@ class _SafetyReviewSectionState extends ConsumerState<SafetyReviewSection> {
     );
   }
 
-  /// Tap toggles chart highlighting; findings without a profile time range
-  /// (nullable in storage) have nothing to highlight and stay inert.
+  /// Tap toggles chart highlighting; findings without a start timestamp
+  /// (nullable in storage) cannot be placed on the time axis and stay inert.
+  /// A missing end timestamp is fine: the chart treats it as an instant.
   VoidCallback? _tapHandlerFor(SafetyFinding finding) {
-    if (finding.startTimestamp == null || finding.endTimestamp == null) {
-      return null;
-    }
+    if (finding.startTimestamp == null) return null;
     return () => _toggleSelected(finding);
   }
 
@@ -184,7 +183,7 @@ class _FindingTile extends StatelessWidget {
       selectedTileColor: severityColor.withValues(alpha: 0.08),
       onTap: onTap,
       leading: Icon(_iconFor(finding.severity), size: 20, color: severityColor),
-      title: Text(_titleFor(l10n)),
+      title: Text(safetyFindingTitle(finding, l10n, units)),
       subtitle: finding.startTimestamp != null && finding.endTimestamp != null
           ? Text(
               l10n.safetyReview_timeRange(
@@ -213,57 +212,6 @@ class _FindingTile extends StatelessWidget {
       SafetySeverity.caution => Icons.report_problem_outlined,
       SafetySeverity.significant => Icons.report_problem_outlined,
     };
-  }
-
-  String _titleFor(AppLocalizations l10n) {
-    // value is nullable in storage; a missing number (older/corrupt/malformed
-    // sync row) must render a neutral placeholder rather than a fabricated 0
-    // that would read as e.g. "Ascent exceeded 0/min".
-    final value = finding.value;
-    const unknown = '--';
-    return switch (finding.ruleId) {
-      SafetyRuleId.rapidAscent => l10n.safetyReview_rapidAscent_title(
-        value == null
-            ? unknown
-            : '${units.formatDepth(value, decimals: 0)}/min',
-        _duration(),
-      ),
-      SafetyRuleId.missedDecoStop => l10n.safetyReview_missedDecoStop_title(
-        value == null ? unknown : units.formatDepth(value),
-        _duration(),
-      ),
-      SafetyRuleId.omittedSafetyStop =>
-        l10n.safetyReview_omittedSafetyStop_title(
-          value == null ? unknown : _seconds(value.round()),
-        ),
-      // Sawtooth's only detail is the cycle count; with no value there is
-      // nothing meaningful to interpolate, so fall back to the neutral rule
-      // name instead of claiming "0 repeated up-and-down depth changes".
-      SafetyRuleId.sawtoothProfile =>
-        value == null
-            ? l10n.safetySettings_rule_sawtoothProfile
-            : l10n.safetyReview_sawtoothProfile_title(value.round()),
-      SafetyRuleId.highSurfaceGf => l10n.safetyReview_highSurfaceGf_title(
-        value == null ? unknown : '${value.toStringAsFixed(0)}%',
-        // Pass a plain percentage (matching the surfaced-GF formatting) so the
-        // localized template owns every word; no baked-in English "GF" token.
-        '${units.settings.gfHigh}%',
-      ),
-    };
-  }
-
-  String _duration() {
-    final start = finding.startTimestamp;
-    final end = finding.endTimestamp;
-    if (start == null || end == null) return '--';
-    return _seconds(end - start);
-  }
-
-  String _seconds(int totalSeconds) {
-    if (totalSeconds < 60) return '${totalSeconds}s';
-    final minutes = totalSeconds ~/ 60;
-    final seconds = totalSeconds % 60;
-    return seconds == 0 ? '${minutes}m' : '${minutes}m ${seconds}s';
   }
 
   String _runTime(int timestampSeconds) {

--- a/lib/features/dive_log/presentation/widgets/safety_review_section.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_review_section.dart
@@ -136,23 +136,12 @@ class _SafetyReviewSectionState extends ConsumerState<SafetyReviewSection> {
     );
   }
 
-  Future<void> _setDismissed(SafetyFinding finding, bool dismissed) async {
-    if (dismissed) {
-      final selectedNotifier = ref.read(
-        selectedSafetyFindingProvider(widget.diveId).notifier,
-      );
-      if (selectedNotifier.state?.id == finding.id) {
-        selectedNotifier.state = null;
-      }
-    }
-    await ref
-        .read(safetyFindingsRepositoryProvider)
-        .setDismissed(
-          findingId: finding.id,
-          dismissed: dismissed,
-          now: DateTime.now(),
-        );
-    ref.invalidate(safetyReviewProvider(widget.diveId));
+  Future<void> _setDismissed(SafetyFinding finding, bool dismissed) {
+    return setSafetyFindingDismissed(
+      ref,
+      finding: finding,
+      dismissed: dismissed,
+    );
   }
 }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "تجاهل",
   "safetyReview_restore": "استعادة",
+  "safetyReview_details": "التفاصيل",
+  "safetyReview_clearHighlight": "مسح التمييز",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{ملاحظة سلامة واحدة} other{{count} ملاحظات سلامة}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{إظهار ملاحظة متجاهلة واحدة} other{إظهار {count} ملاحظات متجاهلة}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Ausblenden",
   "safetyReview_restore": "Wiederherstellen",
+  "safetyReview_details": "Details",
+  "safetyReview_clearHighlight": "Hervorhebung entfernen",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 Sicherheitshinweis} other{{count} Sicherheitshinweise}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{1 Ausgeblendete anzeigen} other{{count} Ausgeblendete anzeigen}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7548,6 +7548,23 @@
   },
   "safetyReview_dismiss": "Dismiss",
   "safetyReview_restore": "Restore",
+  "safetyReview_details": "Details",
+  "@safetyReview_details": {
+    "description": "Link in the chart finding callout that scrolls to the full safety review section"
+  },
+  "safetyReview_clearHighlight": "Clear highlight",
+  "@safetyReview_clearHighlight": {
+    "description": "Tooltip/semantics for the button that clears the chart safety highlight"
+  },
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 safety observation} other{{count} safety observations}}",
+  "@safetyReview_findingGroupSemantics": {
+    "description": "Semantics label for a clustered chip in the chart safety lane",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetySettings_title": "Safety review",
   "safetySettings_entry_subtitle": "Post-dive observations and rules",
   "safetySettings_masterToggle": "Post-dive safety review",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Descartar",
   "safetyReview_restore": "Restaurar",
+  "safetyReview_details": "Detalles",
+  "safetyReview_clearHighlight": "Quitar resaltado",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observación de seguridad} other{{count} observaciones de seguridad}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{Mostrar 1 descartada} other{Mostrar {count} descartadas}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Ignorer",
   "safetyReview_restore": "Restaurer",
+  "safetyReview_details": "Détails",
+  "safetyReview_clearHighlight": "Effacer la surbrillance",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observation de sécurité} other{{count} observations de sécurité}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{Afficher 1 ignorée} other{Afficher {count} ignorées}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "התעלם",
   "safetyReview_restore": "שחזר",
+  "safetyReview_details": "פרטים",
+  "safetyReview_clearHighlight": "ניקוי הדגשה",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{ממצא בטיחות אחד} other{{count} ממצאי בטיחות}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{הצג תצפית אחת שהוסתרה} other{הצג {count} תצפיות שהוסתרו}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Elvetés",
   "safetyReview_restore": "Visszaállítás",
+  "safetyReview_details": "Részletek",
+  "safetyReview_clearHighlight": "Kiemelés törlése",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 biztonsági megállapítás} other{{count} biztonsági megállapítás}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{1 elvetett megjelenítése} other{{count} elvetett megjelenítése}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Ignora",
   "safetyReview_restore": "Ripristina",
+  "safetyReview_details": "Dettagli",
+  "safetyReview_clearHighlight": "Rimuovi evidenziazione",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 rilievo di sicurezza} other{{count} rilievi di sicurezza}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{Mostra 1 ignorata} other{Mostra {count} ignorate}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -21979,6 +21979,24 @@ abstract class AppLocalizations {
   /// **'Restore'**
   String get safetyReview_restore;
 
+  /// Link in the chart finding callout that scrolls to the full safety review section
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get safetyReview_details;
+
+  /// Tooltip/semantics for the button that clears the chart safety highlight
+  ///
+  /// In en, this message translates to:
+  /// **'Clear highlight'**
+  String get safetyReview_clearHighlight;
+
+  /// Semantics label for a clustered chip in the chart safety lane
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 safety observation} other{{count} safety observations}}'**
+  String safetyReview_findingGroupSemantics(int count);
+
   /// No description provided for @safetySettings_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -12761,6 +12761,23 @@ class AppLocalizationsAr extends AppLocalizations {
   String get safetyReview_restore => 'استعادة';
 
   @override
+  String get safetyReview_details => 'التفاصيل';
+
+  @override
+  String get safetyReview_clearHighlight => 'مسح التمييز';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ملاحظات سلامة',
+      one: 'ملاحظة سلامة واحدة',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'مراجعة السلامة';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -12977,6 +12977,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get safetyReview_restore => 'Wiederherstellen';
 
   @override
+  String get safetyReview_details => 'Details';
+
+  @override
+  String get safetyReview_clearHighlight => 'Hervorhebung entfernen';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Sicherheitshinweise',
+      one: '1 Sicherheitshinweis',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Sicherheitsüberprüfung';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -12780,6 +12780,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get safetyReview_restore => 'Restore';
 
   @override
+  String get safetyReview_details => 'Details';
+
+  @override
+  String get safetyReview_clearHighlight => 'Clear highlight';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count safety observations',
+      one: '1 safety observation',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Safety review';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -12984,6 +12984,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get safetyReview_restore => 'Restaurar';
 
   @override
+  String get safetyReview_details => 'Detalles';
+
+  @override
+  String get safetyReview_clearHighlight => 'Quitar resaltado';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observaciones de seguridad',
+      one: '1 observación de seguridad',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Revisión de seguridad';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -13033,6 +13033,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get safetyReview_restore => 'Restaurer';
 
   @override
+  String get safetyReview_details => 'Détails';
+
+  @override
+  String get safetyReview_clearHighlight => 'Effacer la surbrillance';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observations de sécurité',
+      one: '1 observation de sécurité',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Bilan de sécurité';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -12672,6 +12672,23 @@ class AppLocalizationsHe extends AppLocalizations {
   String get safetyReview_restore => 'שחזר';
 
   @override
+  String get safetyReview_details => 'פרטים';
+
+  @override
+  String get safetyReview_clearHighlight => 'ניקוי הדגשה';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ממצאי בטיחות',
+      one: 'ממצא בטיחות אחד',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'סקירת בטיחות';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -12948,6 +12948,23 @@ class AppLocalizationsHu extends AppLocalizations {
   String get safetyReview_restore => 'Visszaállítás';
 
   @override
+  String get safetyReview_details => 'Részletek';
+
+  @override
+  String get safetyReview_clearHighlight => 'Kiemelés törlése';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count biztonsági megállapítás',
+      one: '1 biztonsági megállapítás',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Biztonsági áttekintés';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -12989,6 +12989,23 @@ class AppLocalizationsIt extends AppLocalizations {
   String get safetyReview_restore => 'Ripristina';
 
   @override
+  String get safetyReview_details => 'Dettagli';
+
+  @override
+  String get safetyReview_clearHighlight => 'Rimuovi evidenziazione';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count rilievi di sicurezza',
+      one: '1 rilievo di sicurezza',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Revisione di sicurezza';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -12892,6 +12892,23 @@ class AppLocalizationsNl extends AppLocalizations {
   String get safetyReview_restore => 'Herstellen';
 
   @override
+  String get safetyReview_details => 'Details';
+
+  @override
+  String get safetyReview_clearHighlight => 'Markering wissen';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count veiligheidsbevindingen',
+      one: '1 veiligheidsbevinding',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Veiligheidscontrole';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -12992,6 +12992,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get safetyReview_restore => 'Restaurar';
 
   @override
+  String get safetyReview_details => 'Detalhes';
+
+  @override
+  String get safetyReview_clearHighlight => 'Limpar destaque';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observações de segurança',
+      one: '1 observação de segurança',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => 'Revisão de segurança';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -12387,6 +12387,23 @@ class AppLocalizationsZh extends AppLocalizations {
   String get safetyReview_restore => '恢复';
 
   @override
+  String get safetyReview_details => '详情';
+
+  @override
+  String get safetyReview_clearHighlight => '清除高亮';
+
+  @override
+  String safetyReview_findingGroupSemantics(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 条安全提示',
+      one: '1 条安全提示',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get safetySettings_title => '安全回顾';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Negeren",
   "safetyReview_restore": "Herstellen",
+  "safetyReview_details": "Details",
+  "safetyReview_clearHighlight": "Markering wissen",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 veiligheidsbevinding} other{{count} veiligheidsbevindingen}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{Toon 1 genegeerde} other{Toon {count} genegeerde}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "Dispensar",
   "safetyReview_restore": "Restaurar",
+  "safetyReview_details": "Detalhes",
+  "safetyReview_clearHighlight": "Limpar destaque",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observação de segurança} other{{count} observações de segurança}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{Mostrar 1 dispensada} other{Mostrar {count} dispensadas}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6541,6 +6541,16 @@
   },
   "safetyReview_dismiss": "忽略",
   "safetyReview_restore": "恢复",
+  "safetyReview_details": "详情",
+  "safetyReview_clearHighlight": "清除高亮",
+  "safetyReview_findingGroupSemantics": "{count, plural, =1{1 条安全提示} other{{count} 条安全提示}}",
+  "@safetyReview_findingGroupSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "safetyReview_showDismissed": "{count, plural, =1{显示 1 条已忽略} other{显示 {count} 条已忽略}}",
   "@safetyReview_showDismissed": {
     "placeholders": {

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -56,9 +56,13 @@ Widget _buildDetailPage(Dive dive, List<Override> overrides) {
 
 Future<void> _pumpDetailPage(WidgetTester tester, Dive dive) async {
   final overrides = await getBaseOverrides();
+  // Restore via addTearDown so a throwing pump cannot leak the filtered
+  // handler into later tests; the immediate restore below keeps the filter
+  // scoped to the pump itself on the happy path.
   final originalOnError = FlutterError.onError;
+  addTearDown(() => FlutterError.onError = originalOnError);
   FlutterError.onError = (d) {
-    if (d.toString().contains('overflowed')) return;
+    if (d.exceptionAsString().contains('overflowed')) return;
     originalOnError?.call(d);
   };
   await tester.pumpWidget(_buildDetailPage(dive, overrides));
@@ -1417,28 +1421,63 @@ void main() {
       ),
     );
 
+    SafetyFinding laneFinding(String diveId, {DateTime? dismissedAt}) =>
+        SafetyFinding(
+          id: 'f-lane',
+          diveId: diveId,
+          ruleId: SafetyRuleId.rapidAscent,
+          severity: SafetySeverity.caution,
+          startTimestamp: 300,
+          endTimestamp: 420,
+          value: 14.0,
+          engineVersion: 1,
+          dismissedAt: dismissedAt,
+          createdAt: DateTime.utc(2026, 8, 9),
+        );
+
+    Future<void> pumpWithReview(
+      WidgetTester tester,
+      Dive dive,
+      SafetyFinding finding,
+    ) async {
+      final overrides = await getBaseOverrides();
+      overrides.add(
+        safetyReviewProvider(dive.id).overrideWith(
+          (ref) async => SafetyReview(
+            diveId: dive.id,
+            engineVersion: 1,
+            reviewedAt: DateTime.utc(2026, 8, 9),
+            findings: [finding],
+          ),
+        ),
+      );
+      // Restore via addTearDown so a throwing pump cannot leak the filtered
+      // handler into later tests; the immediate restore below keeps the
+      // filter scoped to the pump itself on the happy path.
+      final originalOnError = FlutterError.onError;
+      addTearDown(() => FlutterError.onError = originalOnError);
+      FlutterError.onError = (d) {
+        if (d.exceptionAsString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+      await tester.pumpWidget(_buildDetailPage(dive, overrides));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      FlutterError.onError = originalOnError;
+    }
+
     testWidgets('selected finding reaches the chart as a highlight range', (
       tester,
     ) async {
       final dive = diveWithProfile();
-      await _pumpDetailPage(tester, dive);
+      final finding = laneFinding(dive.id);
+      await pumpWithReview(tester, dive, finding);
 
       final container = ProviderScope.containerOf(
         tester.element(find.byType(DiveDetailPage)),
       );
-      container
-          .read(selectedSafetyFindingProvider(dive.id).notifier)
-          .state = SafetyFinding(
-        id: 'f1',
-        diveId: dive.id,
-        ruleId: SafetyRuleId.rapidAscent,
-        severity: SafetySeverity.significant,
-        startTimestamp: 300,
-        endTimestamp: 420,
-        value: 14.0,
-        engineVersion: 1,
-        createdAt: DateTime.utc(2026, 8, 7),
-      );
+      container.read(selectedSafetyFindingProvider(dive.id).notifier).state =
+          finding;
       await tester.pump();
 
       final chart = tester.widget<DiveProfileChart>(
@@ -1459,44 +1498,31 @@ void main() {
       expect(chart.highlightRange, isNull);
     });
 
-    SafetyFinding laneFinding(String diveId) => SafetyFinding(
-      id: 'f-lane',
-      diveId: diveId,
-      ruleId: SafetyRuleId.rapidAscent,
-      severity: SafetySeverity.caution,
-      startTimestamp: 300,
-      endTimestamp: 420,
-      value: 14.0,
-      engineVersion: 1,
-      createdAt: DateTime.utc(2026, 8, 9),
-    );
-
-    Future<void> pumpWithReview(
-      WidgetTester tester,
-      Dive dive,
-      SafetyFinding finding,
+    testWidgets('a selection outside the gated lane renders no highlight', (
+      tester,
     ) async {
-      final overrides = await getBaseOverrides();
-      overrides.add(
-        safetyReviewProvider(dive.id).overrideWith(
-          (ref) async => SafetyReview(
-            diveId: dive.id,
-            engineVersion: 1,
-            reviewedAt: DateTime.utc(2026, 8, 9),
-            findings: [finding],
-          ),
-        ),
+      final dive = diveWithProfile();
+      // The stored review's only finding is dismissed, so the lane (and the
+      // section tile) hide it; the highlight must be gated off with it.
+      final dismissed = laneFinding(
+        dive.id,
+        dismissedAt: DateTime.utc(2026, 8, 9),
       );
-      final originalOnError = FlutterError.onError;
-      FlutterError.onError = (d) {
-        if (d.toString().contains('overflowed')) return;
-        originalOnError?.call(d);
-      };
-      await tester.pumpWidget(_buildDetailPage(dive, overrides));
+      await pumpWithReview(tester, dive, dismissed);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveDetailPage)),
+      );
+      container.read(selectedSafetyFindingProvider(dive.id).notifier).state =
+          dismissed;
       await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-      FlutterError.onError = originalOnError;
-    }
+
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart),
+      );
+      expect(chart.highlightRange, isNull);
+      expect(chart.selectedSafetyFindingId, isNull);
+    });
 
     testWidgets('active findings reach the chart as lane findings', (
       tester,

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -1458,5 +1458,84 @@ void main() {
       );
       expect(chart.highlightRange, isNull);
     });
+
+    SafetyFinding laneFinding(String diveId) => SafetyFinding(
+      id: 'f-lane',
+      diveId: diveId,
+      ruleId: SafetyRuleId.rapidAscent,
+      severity: SafetySeverity.caution,
+      startTimestamp: 300,
+      endTimestamp: 420,
+      value: 14.0,
+      engineVersion: 1,
+      createdAt: DateTime.utc(2026, 8, 9),
+    );
+
+    Future<void> pumpWithReview(
+      WidgetTester tester,
+      Dive dive,
+      SafetyFinding finding,
+    ) async {
+      final overrides = await getBaseOverrides();
+      overrides.add(
+        safetyReviewProvider(dive.id).overrideWith(
+          (ref) async => SafetyReview(
+            diveId: dive.id,
+            engineVersion: 1,
+            reviewedAt: DateTime.utc(2026, 8, 9),
+            findings: [finding],
+          ),
+        ),
+      );
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (d) {
+        if (d.toString().contains('overflowed')) return;
+        originalOnError?.call(d);
+      };
+      await tester.pumpWidget(_buildDetailPage(dive, overrides));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      FlutterError.onError = originalOnError;
+    }
+
+    testWidgets('active findings reach the chart as lane findings', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      await pumpWithReview(tester, dive, laneFinding(dive.id));
+
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart),
+      );
+      expect(chart.safetyFindings, isNotNull);
+      expect(chart.safetyFindings!.map((f) => f.id), ['f-lane']);
+      expect(chart.onSafetyFindingTap, isNotNull);
+      expect(chart.onSafetyFindingDismiss, isNotNull);
+      expect(chart.onSafetyFindingDetails, isNotNull);
+    });
+
+    testWidgets('chart tap callback toggles the selection provider', (
+      tester,
+    ) async {
+      final dive = diveWithProfile();
+      final finding = laneFinding(dive.id);
+      await pumpWithReview(tester, dive, finding);
+
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart),
+      );
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DiveDetailPage)),
+      );
+
+      chart.onSafetyFindingTap!(finding);
+      expect(
+        container.read(selectedSafetyFindingProvider(dive.id))?.id,
+        'f-lane',
+      );
+
+      chart.onSafetyFindingTap!(finding);
+      expect(container.read(selectedSafetyFindingProvider(dive.id)), isNull);
+    });
   });
 }

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -356,39 +356,6 @@ void main() {
     },
   );
 
-  testWidgets(
-    'selected safety finding carries into fullscreen as a highlight',
-    (tester) async {
-      await tester.pumpWidget(_wrap(_defaultOverrides()));
-      await tester.pumpAndSettle();
-
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(FullscreenProfilePage)),
-      );
-      container
-          .read(selectedSafetyFindingProvider('d1').notifier)
-          .state = SafetyFinding(
-        id: 'f1',
-        diveId: 'd1',
-        ruleId: SafetyRuleId.missedDecoStop,
-        severity: SafetySeverity.caution,
-        startTimestamp: 120,
-        endTimestamp: 240,
-        value: 2.0,
-        engineVersion: 1,
-        createdAt: DateTime.utc(2026, 8, 7),
-      );
-      await tester.pump();
-
-      final chart = tester.widget<DiveProfileChart>(
-        find.byType(DiveProfileChart),
-      );
-      expect(chart.highlightRange, isNotNull);
-      expect(chart.highlightRange!.startTimestamp, 120);
-      expect(chart.highlightRange!.endTimestamp, 240);
-    },
-  );
-
   SafetyFinding laneFinding() => SafetyFinding(
     id: 'f-lane',
     diveId: 'd1',
@@ -412,6 +379,63 @@ void main() {
       ),
     ),
   ];
+
+  testWidgets(
+    'selected safety finding carries into fullscreen as a highlight',
+    (tester) async {
+      final finding = laneFinding();
+      await tester.pumpWidget(_wrap(reviewOverrides(finding)));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(FullscreenProfilePage)),
+      );
+      container.read(selectedSafetyFindingProvider('d1').notifier).state =
+          finding;
+      await tester.pump();
+
+      final chart = tester.widget<DiveProfileChart>(
+        find.byType(DiveProfileChart),
+      );
+      expect(chart.highlightRange, isNotNull);
+      expect(chart.highlightRange!.startTimestamp, 60);
+      expect(chart.highlightRange!.endTimestamp, 120);
+    },
+  );
+
+  testWidgets('a selection outside the gated lane renders no highlight', (
+    tester,
+  ) async {
+    // The stored review has no active row for the selection (dismissed), so
+    // the lane hides it; the highlight must be gated off with it.
+    final dismissed = SafetyFinding(
+      id: 'f-lane',
+      diveId: 'd1',
+      ruleId: SafetyRuleId.rapidAscent,
+      severity: SafetySeverity.caution,
+      startTimestamp: 60,
+      endTimestamp: 120,
+      value: 14.0,
+      engineVersion: 1,
+      dismissedAt: DateTime.utc(2026, 8, 9),
+      createdAt: DateTime.utc(2026, 8, 9),
+    );
+    await tester.pumpWidget(_wrap(reviewOverrides(dismissed)));
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(FullscreenProfilePage)),
+    );
+    container.read(selectedSafetyFindingProvider('d1').notifier).state =
+        dismissed;
+    await tester.pump();
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.highlightRange, isNull);
+    expect(chart.selectedSafetyFindingId, isNull);
+  });
 
   testWidgets('lane findings and selection wiring reach the chart', (
     tester,

--- a/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
+++ b/test/features/dive_log/presentation/pages/fullscreen_profile_page_test.dart
@@ -388,4 +388,65 @@ void main() {
       expect(chart.highlightRange!.endTimestamp, 240);
     },
   );
+
+  SafetyFinding laneFinding() => SafetyFinding(
+    id: 'f-lane',
+    diveId: 'd1',
+    ruleId: SafetyRuleId.rapidAscent,
+    severity: SafetySeverity.caution,
+    startTimestamp: 60,
+    endTimestamp: 120,
+    value: 14.0,
+    engineVersion: 1,
+    createdAt: DateTime.utc(2026, 8, 9),
+  );
+
+  List<Override> reviewOverrides(SafetyFinding finding) => [
+    ..._defaultOverrides(),
+    safetyReviewProvider('d1').overrideWith(
+      (ref) async => SafetyReview(
+        diveId: 'd1',
+        engineVersion: 1,
+        reviewedAt: DateTime.utc(2026, 8, 9),
+        findings: [finding],
+      ),
+    ),
+  ];
+
+  testWidgets('lane findings and selection wiring reach the chart', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(reviewOverrides(laneFinding())));
+    await tester.pumpAndSettle();
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    expect(chart.safetyFindings, isNotNull);
+    expect(chart.safetyFindings!.map((f) => f.id), ['f-lane']);
+    expect(chart.onSafetyFindingTap, isNotNull);
+    expect(chart.onSafetyFindingDismiss, isNotNull);
+    expect(chart.onSafetyFindingDetails, isNull); // no section in fullscreen
+  });
+
+  testWidgets('fullscreen tap callback toggles the shared provider', (
+    tester,
+  ) async {
+    final finding = laneFinding();
+    await tester.pumpWidget(_wrap(reviewOverrides(finding)));
+    await tester.pumpAndSettle();
+
+    final chart = tester.widget<DiveProfileChart>(
+      find.byType(DiveProfileChart),
+    );
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(FullscreenProfilePage)),
+    );
+
+    chart.onSafetyFindingTap!(finding);
+    expect(container.read(selectedSafetyFindingProvider('d1'))?.id, 'f-lane');
+
+    chart.onSafetyFindingTap!(finding);
+    expect(container.read(selectedSafetyFindingProvider('d1')), isNull);
+  });
 }

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_highlight_test.dart
@@ -84,7 +84,7 @@ void main() {
     expect(lines.map((l) => l.x), containsAll([60.0, 120.0]));
   });
 
-  testWidgets('an instant highlight renders a single dashed cursor, no band', (
+  testWidgets('an instant highlight renders a minimum-width band, no dash', (
     tester,
   ) async {
     await pumpChart(
@@ -97,11 +97,35 @@ void main() {
     );
     final data = chartData(tester);
 
-    expect(data.rangeAnnotations.verticalRangeAnnotations, isEmpty);
+    final annotations = data.rangeAnnotations.verticalRangeAnnotations;
+    expect(annotations, hasLength(1));
+    expect(annotations.single.x1, lessThan(90));
+    expect(annotations.single.x2, greaterThan(90));
+
     final lines = data.extraLinesData.verticalLines;
-    expect(lines, hasLength(1));
-    expect(lines.single.x, 90);
-    expect(lines.single.dashArray, isNotNull);
+    expect(lines, hasLength(2));
+    for (final line in lines) {
+      expect(line.dashArray, isNull);
+    }
+  });
+
+  testWidgets('a very short range inflates to a visible band', (tester) async {
+    await pumpChart(
+      tester,
+      highlightRange: const ProfileHighlightRange(
+        startTimestamp: 100,
+        endTimestamp: 102,
+        color: Colors.teal,
+      ),
+    );
+    final data = chartData(tester);
+
+    final annotations = data.rangeAnnotations.verticalRangeAnnotations;
+    expect(annotations, hasLength(1));
+    // 2 s of a 270 s axis is ~2-3 px at this width; the band must be wider
+    // than the raw range because the 12 px minimum kicked in.
+    expect(annotations.single.x2 - annotations.single.x1, greaterThan(2.0));
+    expect(data.extraLinesData.verticalLines, hasLength(2));
   });
 
   // A finding can outlive the displayed axis: on a multi-source dive the

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_safety_lane_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_findings_overlay.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+void main() {
+  final profile = List.generate(
+    10,
+    (i) => DiveProfilePoint(
+      timestamp: i * 30,
+      depth: i < 5 ? i * 3.0 : (10 - i) * 3.0,
+    ),
+  );
+
+  SafetyFinding finding(String id, {required int start, int? end}) {
+    return SafetyFinding(
+      id: id,
+      diveId: 'd1',
+      ruleId: SafetyRuleId.rapidAscent,
+      severity: SafetySeverity.caution,
+      startTimestamp: start,
+      endTimestamp: end,
+      value: 14,
+      engineVersion: 1,
+      createdAt: DateTime(2026),
+    );
+  }
+
+  Future<void> pumpChart(
+    WidgetTester tester, {
+    List<SafetyFinding>? safetyFindings,
+    String? selectedId,
+    void Function(SafetyFinding)? onTap,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 300,
+              child: DiveProfileChart(
+                profile: profile,
+                safetyFindings: safetyFindings,
+                selectedSafetyFindingId: selectedId,
+                onSafetyFindingTap:
+                    onTap ?? (safetyFindings != null ? (_) {} : null),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('no findings renders no lane overlay', (tester) async {
+    await pumpChart(tester);
+    expect(find.byType(SafetyFindingsOverlay), findsNothing);
+  });
+
+  testWidgets('findings render the lane overlay with chips', (tester) async {
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+    );
+    expect(find.byType(SafetyFindingsOverlay), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+  });
+
+  testWidgets('chip tap reaches the chart callback', (tester) async {
+    SafetyFinding? tapped;
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    // Settle past the chart's double-tap window so its recognizer's timer
+    // resolves before the test tears the tree down.
+    await tester.pumpAndSettle();
+    expect(tapped?.id, 'a');
+  });
+
+  testWidgets('selected finding shows the callout above the lane', (
+    tester,
+  ) async {
+    await pumpChart(
+      tester,
+      safetyFindings: [finding('a', start: 60, end: 120)],
+      selectedId: 'a',
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsOneWidget);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart
+++ b/test/features/dive_log/presentation/widgets/profile_highlight_range_test.dart
@@ -75,4 +75,76 @@ void main() {
       expect(span, isNull);
     });
   });
+
+  group('highlightBandSpan', () {
+    test('wide range passes through unchanged', () {
+      final span = highlightBandSpan(
+        range(60, 120),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 10,
+      );
+      expect(span, (x1: 60.0, x2: 120.0));
+    });
+
+    test('narrow range inflates to minWidthX centered on its midpoint', () {
+      final span = highlightBandSpan(
+        range(100, 104),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 20,
+      );
+      expect(span, (x1: 92.0, x2: 112.0));
+    });
+
+    test('instant range inflates to minWidthX centered on the instant', () {
+      final span = highlightBandSpan(
+        range(90, 90),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 84.0, x2: 96.0));
+    });
+
+    test('inflation shifts right when clamped by the window start', () {
+      final span = highlightBandSpan(
+        range(2, 2),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 0.0, x2: 12.0));
+    });
+
+    test('inflation shifts left when clamped by the window end', () {
+      final span = highlightBandSpan(
+        range(268, 268),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 258.0, x2: 270.0));
+    });
+
+    test('window narrower than minWidthX returns the whole window', () {
+      final span = highlightBandSpan(
+        range(100, 101),
+        visibleMinX: 98,
+        visibleMaxX: 104,
+        minWidthX: 12,
+      );
+      expect(span, (x1: 98.0, x2: 104.0));
+    });
+
+    test('range fully outside the window returns null', () {
+      final span = highlightBandSpan(
+        range(400, 500),
+        visibleMinX: 0,
+        visibleMaxX: 270,
+        minWidthX: 12,
+      );
+      expect(span, isNull);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart
+++ b/test/features/dive_log/presentation/widgets/safety_finding_highlight_test.dart
@@ -60,9 +60,62 @@ void main() {
       expect(profileHighlightRangeFor(null, scheme), isNull);
     });
 
-    test('returns null when either timestamp is missing', () {
+    test('returns null when the start timestamp is missing', () {
       expect(profileHighlightRangeFor(finding(start: null), scheme), isNull);
-      expect(profileHighlightRangeFor(finding(end: null), scheme), isNull);
+      expect(
+        profileHighlightRangeFor(finding(start: null, end: null), scheme),
+        isNull,
+      );
+    });
+
+    test('a start-only finding maps to an instant range', () {
+      final range = profileHighlightRangeFor(finding(end: null), scheme);
+      expect(range, isNotNull);
+      expect(range!.startTimestamp, 300);
+      expect(range.endTimestamp, 300);
+    });
+  });
+
+  group('chartSafetyFindings', () {
+    SafetyFinding entry(
+      String id, {
+      int? start,
+      SafetyRuleId rule = SafetyRuleId.rapidAscent,
+      DateTime? dismissedAt,
+    }) {
+      return SafetyFinding(
+        id: id,
+        diveId: 'dive-1',
+        ruleId: rule,
+        severity: SafetySeverity.caution,
+        startTimestamp: start,
+        engineVersion: 1,
+        dismissedAt: dismissedAt,
+        createdAt: now,
+      );
+    }
+
+    test('filters dismissed, disabled-rule, and timestampless findings', () {
+      final review = SafetyReview(
+        diveId: 'dive-1',
+        engineVersion: 1,
+        reviewedAt: now,
+        findings: [
+          entry('keep', start: 200),
+          entry('dismissed', start: 100, dismissedAt: now),
+          entry('no-time'),
+          entry('disabled', start: 50, rule: SafetyRuleId.sawtoothProfile),
+          entry('earlier', start: 10),
+        ],
+      );
+      final result = chartSafetyFindings(review, {
+        SafetyRuleId.sawtoothProfile.dbValue,
+      });
+      expect(result.map((f) => f.id), ['earlier', 'keep']);
+    });
+
+    test('null review yields an empty list', () {
+      expect(chartSafetyFindings(null, const {}), isEmpty);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart
+++ b/test/features/dive_log/presentation/widgets/safety_findings_overlay_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/safety_findings_overlay.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  SafetyFinding finding(
+    String id, {
+    required int start,
+    int? end,
+    SafetyRuleId rule = SafetyRuleId.rapidAscent,
+  }) {
+    return SafetyFinding(
+      id: id,
+      diveId: 'd1',
+      ruleId: rule,
+      severity: SafetySeverity.caution,
+      startTimestamp: start,
+      endTimestamp: end,
+      value: 14,
+      engineVersion: 1,
+      createdAt: DateTime(2026),
+    );
+  }
+
+  Future<void> pumpOverlay(
+    WidgetTester tester, {
+    required List<SafetyFinding> findings,
+    String? selectedFindingId,
+    void Function(SafetyFinding)? onTap,
+    void Function(SafetyFinding)? onDismiss,
+    void Function(SafetyFinding)? onDetails,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 300,
+            child: SafetyFindingsOverlay(
+              findings: findings,
+              selectedFindingId: selectedFindingId,
+              visibleMinSeconds: 0,
+              visibleMaxSeconds: 1000,
+              insets: (left: 48, top: 0, right: 38, bottom: 96),
+              laneHeight: 24,
+              laneBottomOffset: 36,
+              units: const UnitFormatter(AppSettings()),
+              onFindingTap: onTap ?? (_) {},
+              onFindingDismiss: onDismiss ?? (_) {},
+              onFindingDetails: onDetails,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders one chip per finding', (tester) async {
+    await pumpOverlay(
+      tester,
+      findings: [
+        finding('a', start: 100, end: 200),
+        finding('b', start: 800, end: 800),
+      ],
+    );
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-1')), findsOneWidget);
+  });
+
+  testWidgets('tapping a chip reports its finding', (tester) async {
+    SafetyFinding? tapped;
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    await tester.pump();
+    expect(tapped?.id, 'a');
+  });
+
+  testWidgets('overlapping findings cluster into one chip with a count', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [
+        finding('a', start: 500, end: 500),
+        finding('b', start: 505, end: 505),
+      ],
+    );
+    expect(find.byKey(const ValueKey('safetyLaneChip-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('safetyLaneChip-1')), findsNothing);
+    expect(find.text('2'), findsOneWidget);
+  });
+
+  testWidgets('cluster tap cycles: first, next, then toggles last to clear', (
+    tester,
+  ) async {
+    final findings = [
+      finding('a', start: 500, end: 500),
+      finding('b', start: 505, end: 505),
+    ];
+    SafetyFinding? tapped;
+
+    await pumpOverlay(tester, findings: findings, onTap: (f) => tapped = f);
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'a');
+
+    await pumpOverlay(
+      tester,
+      findings: findings,
+      selectedFindingId: 'a',
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'b');
+
+    await pumpOverlay(
+      tester,
+      findings: findings,
+      selectedFindingId: 'b',
+      onTap: (f) => tapped = f,
+    );
+    await tester.tap(find.byKey(const ValueKey('safetyLaneChip-0')));
+    expect(tapped?.id, 'b'); // parent toggle clears
+  });
+
+  testWidgets('selection shows the callout with title and actions', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+      onDetails: (_) {},
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsOneWidget);
+    expect(find.text('Details'), findsOneWidget);
+    expect(find.text('Dismiss'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('callout hides the Details link when onFindingDetails is null', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+    );
+    expect(find.text('Details'), findsNothing);
+  });
+
+  testWidgets('callout actions invoke their callbacks', (tester) async {
+    SafetyFinding? cleared;
+    SafetyFinding? dismissed;
+    SafetyFinding? details;
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'a',
+      onTap: (f) => cleared = f,
+      onDismiss: (f) => dismissed = f,
+      onDetails: (f) => details = f,
+    );
+    await tester.tap(find.text('Details'));
+    expect(details?.id, 'a');
+    await tester.tap(find.text('Dismiss'));
+    expect(dismissed?.id, 'a');
+    await tester.tap(find.byIcon(Icons.close));
+    expect(cleared?.id, 'a'); // clear = toggle-tap of the selected finding
+  });
+
+  testWidgets('no callout when the selected finding is not in the lane', (
+    tester,
+  ) async {
+    await pumpOverlay(
+      tester,
+      findings: [finding('a', start: 100, end: 200)],
+      selectedFindingId: 'gone',
+    );
+    expect(find.byKey(const ValueKey('safetyFindingCallout')), findsNothing);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart
+++ b/test/features/dive_log/presentation/widgets/safety_lane_layout_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/presentation/widgets/safety_lane_layout.dart';
+
+void main() {
+  // Lane maps a 0..1000 s window onto 500 px: 1 px per 2 s.
+  List<SafetyLaneChipPlacement> layout(
+    List<({double startSeconds, double endSeconds})> ranges, {
+    double visibleMin = 0,
+    double visibleMax = 1000,
+    double laneWidth = 500,
+  }) {
+    return layoutSafetyLaneChips(
+      ranges: ranges,
+      visibleMinSeconds: visibleMin,
+      visibleMaxSeconds: visibleMax,
+      laneWidth: laneWidth,
+    );
+  }
+
+  test('a wide range maps to a proportional chip', () {
+    final placements = layout([(startSeconds: 200.0, endSeconds: 400.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.left, 100);
+    expect(placements.single.width, 100);
+    expect(placements.single.memberIndexes, [0]);
+  });
+
+  test('a short range gets the minimum chip width, centered', () {
+    // 10 s -> 5 px extent (100..105 px), inflated to 26 px centered on
+    // the 102.5 px midpoint: left = 102.5 - 13 = 89.5.
+    final placements = layout([(startSeconds: 200.0, endSeconds: 210.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.left, closeTo(89.5, 0.01));
+    expect(placements.single.width, 26);
+  });
+
+  test('an instant range gets the minimum chip width', () {
+    final placements = layout([(startSeconds: 500.0, endSeconds: 500.0)]);
+    expect(placements, hasLength(1));
+    expect(placements.single.width, 26);
+    expect(placements.single.left, closeTo(250 - 13, 0.01));
+  });
+
+  test('a chip near the lane start is clamped inside the lane', () {
+    final placements = layout([(startSeconds: 0.0, endSeconds: 0.0)]);
+    expect(placements.single.left, 0);
+    expect(placements.single.width, 26);
+  });
+
+  test('a chip near the lane end is clamped inside the lane', () {
+    final placements = layout([(startSeconds: 1000.0, endSeconds: 1000.0)]);
+    expect(placements.single.left, closeTo(500 - 26, 0.01));
+    expect(placements.single.width, 26);
+  });
+
+  test('a range outside the visible window produces no chip', () {
+    final placements = layout(
+      [(startSeconds: 800.0, endSeconds: 900.0)],
+      visibleMin: 0,
+      visibleMax: 500,
+    );
+    expect(placements, isEmpty);
+  });
+
+  test('a range straddling the window edge is clamped to the edge', () {
+    final placements = layout(
+      [(startSeconds: 400.0, endSeconds: 600.0)],
+      visibleMin: 0,
+      visibleMax: 500,
+      laneWidth: 500,
+    );
+    expect(placements, hasLength(1));
+    expect(placements.single.left, 400);
+    expect(placements.single.width, 100);
+  });
+
+  test('overlapping chips merge into one cluster in start order', () {
+    // Two instants 10 s (5 px) apart: both inflate to 26 px and overlap.
+    final placements = layout([
+      (startSeconds: 510.0, endSeconds: 510.0),
+      (startSeconds: 500.0, endSeconds: 500.0),
+    ]);
+    expect(placements, hasLength(1));
+    expect(placements.single.memberIndexes, [1, 0]);
+  });
+
+  test('non-overlapping chips stay separate', () {
+    final placements = layout([
+      (startSeconds: 100.0, endSeconds: 100.0),
+      (startSeconds: 900.0, endSeconds: 900.0),
+    ]);
+    expect(placements, hasLength(2));
+  });
+
+  test('empty window or lane yields nothing', () {
+    expect(
+      layout(
+        [(startSeconds: 1.0, endSeconds: 2.0)],
+        visibleMin: 5,
+        visibleMax: 5,
+      ),
+      isEmpty,
+    );
+    expect(
+      layout([(startSeconds: 1.0, endSeconds: 2.0)], laneWidth: 0),
+      isEmpty,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Redesigns how safety review findings are presented on the dive detail page. Previously, chart highlighting was controlled only from the safety review section 1-2 viewport heights below the chart: clearing a highlight required scrolling back down to re-tap the tile, and findings covering a short time range (10 s rapid ascents, instant omitted-stop/surface-GF findings) rendered as a ~1 px band or a lone dashed line, effectively invisible.

This PR makes the chart itself the primary selection surface:

- A **findings lane** renders directly under the profile plot (gas-timeline-strip idiom): one tappable chip per active finding, positioned on the time axis, with a guaranteed minimum chip width so a 10-second event is as findable as a 10-minute one. Overlapping chips cluster into a count badge; tapping a cluster cycles through its members.
- Tapping a chip highlights the finding on the chart and opens a **callout** with the finding summary, a Details link (scrolls to the safety section), Dismiss, and a clear button. All clearing paths are co-located with the chart: re-tap the chip, tap the clear button, select another chip, or dismiss.
- **Highlight bands enforce a 12 px minimum on-screen width**; instant findings now draw the same band instead of a dashed hairline indistinguishable from cursor lines.
- The safety review section below is unchanged as the detail view, with two-way selection sync through the existing `selectedSafetyFindingProvider`.
- The **fullscreen profile** gets full parity (lane, callout, clearing), replacing the previous read-only highlight carry-over.

No schema, sync, repository, or rules-engine changes; dismiss reuses the existing repository path including the parent-dive HLC bump. Design spec and implementation plan are included under `docs/superpowers/`.

## Changes

- Add `SafetyFindingsOverlay` (lane chips + callout) mounted in `DiveProfileChart`'s widget-layer stack, with bottom-space reservations mirroring the gas strip pattern
- Add pure `layoutSafetyLaneChips` (chip geometry, min-width, overlap clustering) and `highlightBandSpan` (minimum-width band inflation) helpers with unit tests
- Extract `EagerTapGestureRecognizer` (shared with `PhotoMarkerOverlay`) and `safetyFindingTitle`/`safetyFindingShortLabel` text helpers
- Treat findings with a start but no end timestamp as instants instead of unhighlightable
- Wire lane data and callbacks in the dive detail page (with Details scroll-to-section and a stale-selection guard for sync-driven dismissals) and the fullscreen profile page
- Add `safetyReview_details`, `safetyReview_clearHighlight`, `safetyReview_findingGroupSemantics` strings across all 11 locales

## Test Plan

- [x] `flutter test` passes (full suite; two pre-existing flaky tests pass in isolation)
- [x] `flutter analyze` passes
- [x] Manual testing on: macOS

## Screenshots

UI changes are chart-internal; screenshots to follow from manual macOS testing if needed.