### PR TITLE
Derive statistics ascent/descent rates from depth samples

### DIFF
--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -60,8 +60,16 @@ class StatisticsRepository {
   AppDatabase get _db => DatabaseService.instance.database;
   final _log = LoggerService.forClass(StatisticsRepository);
 
-  /// Smoothing window used by [getAscentDescentRates], in seconds. Matches the
-  /// per-dive calculator so both read the same shape out of a profile.
+  /// Smoothing interval used by [getAscentDescentRates], in seconds.
+  ///
+  /// Kept in sync with the per-dive calculator's configured target interval so
+  /// the two cannot drift apart on how much of a profile they smooth over. The
+  /// filters themselves differ: [AscentRateCalculator] takes an overlapping,
+  /// centred moving average over point-to-point rates (window rounded to an odd
+  /// count of samples, minimum three), while this query averages depth into
+  /// fixed non-overlapping buckets and differences consecutive bucket means.
+  /// Both suppress the same short-timescale noise; neither is a reimplementation
+  /// of the other, and their per-profile outputs are close but not identical.
   static const int _rateWindowSeconds =
       AscentRateCalculator.defaultSmoothingWindowSeconds;
 
@@ -1994,19 +2002,19 @@ class StatisticsRepository {
   /// that column (libdivecomputer reports no ascent-rate sample type), so it is
   /// null for every row and averaging it always yielded an empty section.
   ///
-  /// The derivation mirrors [AscentRateCalculator], which computes the same
-  /// quantity per-dive for the profile chart:
+  /// The derivation follows the same conventions as [AscentRateCalculator],
+  /// which computes rates per-dive for the profile chart, but smooths by a
+  /// different (cheaper, set-based) filter -- see [_rateWindowSeconds]:
   ///
-  /// - Samples are averaged into fixed [_rateWindowSeconds] windows. This is
-  ///   the SQL equivalent of the calculator's time-based smoothing: it makes
-  ///   the result independent of the computer's sample interval, and keeps
+  /// - Samples are averaged into fixed [_rateWindowSeconds] buckets, which
+  ///   makes the result independent of the computer's sample interval and keeps
   ///   depth-resolution noise from dominating (0.1 m between two 1 s samples is
   ///   already 6 m/min of pure quantisation noise).
-  /// - The rate between two windows uses their mean sample times, not the
-  ///   window width, so uneven occupancy at the edges cannot distort the
+  /// - The rate between two buckets uses their mean sample times, not the
+  ///   bucket width, so uneven occupancy at the edges cannot distort the
   ///   interval.
   /// - Positive is ascending, matching [AscentRatePoint.rateMetersPerMin].
-  /// - Windows slower than [_sustainedTransitThreshold] are excluded, so
+  /// - Buckets slower than [_sustainedTransitThreshold] are excluded, so
   ///   working a multi-level profile does not read as ascending or descending.
   ///
   /// Only primary profile rows are considered, so a dive logged by two

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart';
 
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/domain/visibility/visibility_scale.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -58,6 +59,23 @@ class DistributionSegment {
 class StatisticsRepository {
   AppDatabase get _db => DatabaseService.instance.database;
   final _log = LoggerService.forClass(StatisticsRepository);
+
+  /// Smoothing window used by [getAscentDescentRates], in seconds. Matches the
+  /// per-dive calculator so both read the same shape out of a profile.
+  static const int _rateWindowSeconds =
+      AscentRateCalculator.defaultSmoothingWindowSeconds;
+
+  /// Slowest vertical rate that counts as ascending or descending rather than
+  /// working a multi-level profile, in m/min.
+  ///
+  /// A recreational profile spends most of its windows drifting slowly around
+  /// the bottom: on a representative library, windows in the 0.5-3 m/min band
+  /// outnumber genuine transit roughly four to one. Averaging those in drags
+  /// both figures down to around 2.4 m/min, which tells a diver nothing and is
+  /// not comparable to the ascent-rate limits they are trained against. Only
+  /// counting sustained movement keeps the card answering "how fast do I
+  /// actually go up and down".
+  static const double _sustainedTransitThreshold = 3.0;
 
   /// Builds the `AND <alias>.id IN (<subquery>)` fragment + raw params for a
   /// stats filter. Empty (no-op) when the filter has no active axes.
@@ -1968,7 +1986,32 @@ class StatisticsRepository {
   // Profile Analysis Statistics
   // ============================================================================
 
-  /// Get average ascent/descent rates
+  /// Get average ascent/descent rates in m/min, or null when the filtered
+  /// dives hold no vertical movement to average.
+  ///
+  /// Rates are derived from the stored depth samples rather than read from
+  /// `dive_profiles.ascent_rate`: no download or import path ever populates
+  /// that column (libdivecomputer reports no ascent-rate sample type), so it is
+  /// null for every row and averaging it always yielded an empty section.
+  ///
+  /// The derivation mirrors [AscentRateCalculator], which computes the same
+  /// quantity per-dive for the profile chart:
+  ///
+  /// - Samples are averaged into fixed [_rateWindowSeconds] windows. This is
+  ///   the SQL equivalent of the calculator's time-based smoothing: it makes
+  ///   the result independent of the computer's sample interval, and keeps
+  ///   depth-resolution noise from dominating (0.1 m between two 1 s samples is
+  ///   already 6 m/min of pure quantisation noise).
+  /// - The rate between two windows uses their mean sample times, not the
+  ///   window width, so uneven occupancy at the edges cannot distort the
+  ///   interval.
+  /// - Positive is ascending, matching [AscentRatePoint.rateMetersPerMin].
+  /// - Windows slower than [_sustainedTransitThreshold] are excluded, so
+  ///   working a multi-level profile does not read as ascending or descending.
+  ///
+  /// Only primary profile rows are considered, so a dive logged by two
+  /// computers — or one whose original profile was demoted by an edit — is
+  /// counted once rather than interleaving two sample streams.
   Future<({double? avgAscent, double? avgDescent})> getAscentDescentRates({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
@@ -1979,12 +2022,38 @@ class StatisticsRepository {
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
+        WITH windows AS (
+          SELECT
+            p.dive_id AS dive_id,
+            p.computer_id AS computer_id,
+            p.timestamp / $_rateWindowSeconds AS window_index,
+            AVG(p.depth) AS depth,
+            AVG(p.timestamp) AS at
+          FROM dive_profiles p
+          JOIN dives d ON d.id = p.dive_id
+          WHERE p.is_primary = 1 $diverFilter ${df.clause}
+          GROUP BY p.dive_id, p.computer_id, p.timestamp / $_rateWindowSeconds
+        ),
+        paired AS (
+          SELECT
+            depth,
+            at,
+            LAG(depth) OVER w AS prev_depth,
+            LAG(at) OVER w AS prev_at
+          FROM windows
+          WINDOW w AS (PARTITION BY dive_id, computer_id ORDER BY window_index)
+        ),
+        rates AS (
+          SELECT (prev_depth - depth) * 60.0 / (at - prev_at) AS rate
+          FROM paired
+          WHERE prev_at IS NOT NULL AND at > prev_at
+        )
         SELECT
-          AVG(CASE WHEN p.ascent_rate < 0 THEN ABS(p.ascent_rate) ELSE NULL END) AS avg_ascent,
-          AVG(CASE WHEN p.ascent_rate > 0 THEN p.ascent_rate ELSE NULL END) AS avg_descent
-        FROM dive_profiles p
-        JOIN dives d ON d.id = p.dive_id
-        WHERE p.ascent_rate IS NOT NULL $diverFilter ${df.clause}
+          AVG(CASE WHEN rate >= $_sustainedTransitThreshold THEN rate END)
+            AS avg_ascent,
+          AVG(CASE WHEN rate <= -$_sustainedTransitThreshold THEN -rate END)
+            AS avg_descent
+        FROM rates
         ''', variables: params.map((p) => Variable(p)).toList()).get();
 
       if (results.isEmpty) return (avgAscent: null, avgDescent: null);

--- a/test/features/statistics/data/repositories/statistics_repository_ascent_descent_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_ascent_descent_test.dart
@@ -1,0 +1,269 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = StatisticsRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> diver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value(id),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> dive(String id, {String? diverId}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            diverId: Value(diverId),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> computer(String id) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            name: Value(id),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Inserts profile samples as (timestamp seconds, depth meters) pairs.
+  Future<void> profile(
+    String diveId,
+    List<(int, double)> samples, {
+    bool isPrimary = true,
+    String? computerId,
+  }) async {
+    await db.batch((batch) {
+      for (final (index, sample) in samples.indexed) {
+        batch.insert(
+          db.diveProfiles,
+          DiveProfilesCompanion(
+            id: Value('$diveId-${computerId ?? 'dc'}-$index'),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            timestamp: Value(sample.$1),
+            depth: Value(sample.$2),
+          ),
+        );
+      }
+    });
+  }
+
+  /// A textbook profile sampled every 15 s with exactly known rates:
+  ///   descent 0 -> 30 m over 120 s  = 15 m/min
+  ///   bottom  30 m from 135 to 600 s = 0 m/min
+  ///   ascent  30 -> 0 m over 300 s  = 6 m/min
+  List<(int, double)> textbookProfile() {
+    final samples = <(int, double)>[];
+    for (var j = 0; j <= 8; j++) {
+      samples.add((j * 15, j * 3.75));
+    }
+    for (var t = 135; t <= 600; t += 15) {
+      samples.add((t, 30.0));
+    }
+    for (var k = 1; k <= 20; k++) {
+      samples.add((600 + k * 15, 30.0 - k * 1.5));
+    }
+    return samples;
+  }
+
+  test(
+    'derives rates from depth samples when ascent_rate is never stored',
+    () async {
+      await dive('a');
+      await profile('a', textbookProfile());
+
+      final rates = await repo.getAscentDescentRates();
+
+      expect(rates.avgAscent, isNotNull);
+      expect(rates.avgDescent, isNotNull);
+    },
+  );
+
+  test('reports ascent as ascent and descent as descent', () async {
+    await dive('a');
+    await profile('a', textbookProfile());
+
+    final rates = await repo.getAscentDescentRates();
+
+    // Going shallower is the ascent (6 m/min); going deeper is the descent
+    // (15 m/min). Swapping the sign convention would invert these.
+    expect(rates.avgAscent, closeTo(6.0, 0.01));
+    expect(rates.avgDescent, closeTo(15.0, 0.01));
+  });
+
+  test('ignores level-depth samples so the bottom phase does not dilute the '
+      'averages', () async {
+    await dive('a');
+    // Same ascent and descent legs, but a bottom phase four times as long.
+    final long = <(int, double)>[];
+    for (var j = 0; j <= 8; j++) {
+      long.add((j * 15, j * 3.75));
+    }
+    for (var t = 135; t <= 2400; t += 15) {
+      long.add((t, 30.0));
+    }
+    for (var k = 1; k <= 20; k++) {
+      long.add((2400 + k * 15, 30.0 - k * 1.5));
+    }
+    await profile('a', long);
+
+    final rates = await repo.getAscentDescentRates();
+
+    expect(rates.avgAscent, closeTo(6.0, 0.01));
+    expect(rates.avgDescent, closeTo(15.0, 0.01));
+  });
+
+  test(
+    'excludes slow multi-level drift below the sustained-transit floor',
+    () async {
+      await dive('a');
+      // Descent and ascent legs as above, but the bottom phase now drifts up and
+      // down by 0.5 m every 15 s -- a real 2 m/min movement, still far short of
+      // ascending or descending. Counting it would pull the ascent average from
+      // 6 m/min down to about 4.2.
+      final drifting = <(int, double)>[];
+      for (var j = 0; j <= 8; j++) {
+        drifting.add((j * 15, j * 3.75));
+      }
+      for (var m = 0; m < 32; m++) {
+        drifting.add((135 + m * 15, m.isEven ? 29.5 : 30.0));
+      }
+      for (var k = 1; k <= 20; k++) {
+        drifting.add((600 + k * 15, 30.0 - k * 1.5));
+      }
+      await profile('a', drifting);
+
+      final rates = await repo.getAscentDescentRates();
+
+      expect(rates.avgAscent, closeTo(6.0, 0.01));
+      expect(rates.avgDescent, closeTo(15.0, 0.01));
+    },
+  );
+
+  test('counts only the primary profile of a multi-computer dive', () async {
+    await dive('a');
+    await computer('dc-primary');
+    await computer('dc-secondary');
+    await profile('a', textbookProfile(), computerId: 'dc-primary');
+    // A second computer logged the same dive twice as fast. Its samples are
+    // demoted, so they must not contribute to the averages.
+    await profile(
+      'a',
+      [for (var k = 0; k <= 20; k++) (k * 15, k * 3.0)],
+      isPrimary: false,
+      computerId: 'dc-secondary',
+    );
+
+    final rates = await repo.getAscentDescentRates();
+
+    expect(rates.avgAscent, closeTo(6.0, 0.01));
+    expect(rates.avgDescent, closeTo(15.0, 0.01));
+  });
+
+  test('returns null rates for a profile that never changes depth', () async {
+    await dive('a');
+    await profile('a', [for (var t = 0; t <= 600; t += 15) (t, 18.0)]);
+
+    final rates = await repo.getAscentDescentRates();
+
+    expect(rates.avgAscent, isNull);
+    expect(rates.avgDescent, isNull);
+  });
+
+  test('applies the statistics dive filter', () async {
+    await db
+        .into(db.tags)
+        .insert(
+          TagsCompanion(
+            id: const Value('deep'),
+            name: const Value('deep'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    await dive('a');
+    await profile('a', textbookProfile());
+    await dive('b');
+    // Twice as fast, and not carrying the tag.
+    await profile('b', [
+      for (var j = 0; j <= 4; j++) (j * 15, j * 7.5),
+      for (var k = 1; k <= 10; k++) (60 + k * 15, 30.0 - k * 3.0),
+    ]);
+    await db
+        .into(db.diveTags)
+        .insert(
+          DiveTagsCompanion(
+            id: const Value('a-deep'),
+            diveId: const Value('a'),
+            tagId: const Value('deep'),
+            createdAt: Value(now),
+          ),
+        );
+
+    final unfiltered = await repo.getAscentDescentRates();
+    expect(unfiltered.avgDescent, isNot(closeTo(15.0, 0.01)));
+
+    final filtered = await repo.getAscentDescentRates(
+      filter: const DiveFilterState(tagIds: ['deep']),
+    );
+    expect(filtered.avgAscent, closeTo(6.0, 0.01));
+    expect(filtered.avgDescent, closeTo(15.0, 0.01));
+  });
+
+  test('scopes the averages to the requested diver', () async {
+    await diver('diver-1');
+    await diver('diver-2');
+    await dive('a', diverId: 'diver-1');
+    await profile('a', textbookProfile());
+    await dive('b', diverId: 'diver-2');
+    // Diver 2 descends and ascends twice as fast.
+    await profile('b', [
+      for (var j = 0; j <= 4; j++) (j * 15, j * 7.5),
+      for (var k = 1; k <= 10; k++) (60 + k * 15, 30.0 - k * 3.0),
+    ]);
+
+    final first = await repo.getAscentDescentRates(diverId: 'diver-1');
+    expect(first.avgAscent, closeTo(6.0, 0.01));
+    expect(first.avgDescent, closeTo(15.0, 0.01));
+
+    final second = await repo.getAscentDescentRates(diverId: 'diver-2');
+    expect(second.avgAscent, closeTo(12.0, 0.01));
+    expect(second.avgDescent, closeTo(30.0, 0.01));
+  });
+}

--- a/test/features/statistics/data/repositories/statistics_repository_ascent_descent_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_ascent_descent_test.dart
@@ -66,13 +66,14 @@ void main() {
     List<(int, double)> samples, {
     bool isPrimary = true,
     String? computerId,
+    String idPrefix = 'row',
   }) async {
     await db.batch((batch) {
       for (final (index, sample) in samples.indexed) {
         batch.insert(
           db.diveProfiles,
           DiveProfilesCompanion(
-            id: Value('$diveId-${computerId ?? 'dc'}-$index'),
+            id: Value('$diveId-${computerId ?? 'dc'}-$idPrefix-$index'),
             diveId: Value(diveId),
             computerId: Value(computerId),
             isPrimary: Value(isPrimary),
@@ -175,6 +176,22 @@ void main() {
       expect(rates.avgDescent, closeTo(15.0, 0.01));
     },
   );
+
+  test('is unaffected by exact duplicate profile rows', () async {
+    await dive('a');
+    // A repeated import stores every sample twice. Point-to-point rates halve
+    // on this data (the duplicate contributes a zero-length interval), which is
+    // why getDiveById and getMergedProfile collapse duplicates before analysis.
+    // Averaging depth per time bucket weights the repeats evenly, so the
+    // bucket means -- and the rates between them -- are unchanged.
+    await profile('a', textbookProfile());
+    await profile('a', textbookProfile(), idPrefix: 'reimport');
+
+    final rates = await repo.getAscentDescentRates();
+
+    expect(rates.avgAscent, closeTo(6.0, 0.01));
+    expect(rates.avgDescent, closeTo(15.0, 0.01));
+  });
 
   test('counts only the primary profile of a multi-computer dive', () async {
     await dive('a');


### PR DESCRIPTION
## Summary

The Profile Analysis "Average Ascent & Descent Rates" card was always empty for every user.

`getAscentDescentRates` averaged `dive_profiles.ascent_rate` — **a column no code path ever populates.** libdivecomputer exposes no ascent-rate sample type, so `parsed_dive_mapper.dart` constructs `ProfileSample` without an `ascentRate` argument, and every downstream site passes that same null through (`ProfileSample` → `ProfilePointData` → `DiveProfilesCompanion`). No importer (UDDF, FIT, HealthKit) sets it either. With the query gated on `WHERE p.ascent_rate IS NOT NULL`, zero rows ever matched, both `AVG()`s returned NULL, and the UI fell through to `StatEmptyState`. Confirmed against a real library: 50,883 profile rows, 0 with a value.

A second bug sat behind the first. The SQL treated `ascent_rate < 0` as ascending, but the app's convention (`AscentRatePoint.rateMetersPerMin`, `lib/core/deco/ascent_rate_calculator.dart`) is **positive = ascending**. Had the column ever held data, ascent and descent would have rendered swapped.

Rates are now derived from the stored depth samples instead of read from the dead column.

## Changes

- `getAscentDescentRates` computes rates in SQL from `depth` + `timestamp` rather than reading `ascent_rate`.
- Samples are averaged into 15 s windows — the SQL equivalent of `AscentRateCalculator`'s time-based smoothing. Without it, depth resolution dominates: 0.1 m between two 1 s samples is already 6 m/min of pure quantisation noise.
- The rate between two windows uses their **mean sample times** (`AVG(timestamp)`) rather than the window width. With uneven samples per bucket, dividing by the width inflates every rate — 33% at 10 s sampling.
- Corrected the sign convention to positive = ascending, matching `AscentRatePoint`.
- Restricted to `is_primary = 1` and partitioned by `(dive_id, computer_id)`, so a dive logged by two computers — or one whose original profile was demoted by an edit — is counted once instead of interleaving two sample streams.
- Buckets slower than **3 m/min** are excluded as multi-level working rather than transit (see note below).
- New test file with 9 cases: derivation from depth-only profiles, sign convention, level-bottom and slow-drift exclusion, duplicate-row immunity, primary-profile scoping, diver scoping, statistics-filter plumbing, and the null-when-no-movement case.

### Rebase note (interaction with #931)

This branch originally also extracted `AscentRateCalculator.defaultSmoothingWindowSeconds`. #931 landed the **identical constant and constructor-default change** on `main` independently — needed there because callers interpreting a violation's extent must know the smoothing span. That file is now taken verbatim from `main` and has dropped out of this diff entirely; only the statistics repository and its tests remain.

#931 also collapses duplicate profile rows in `getDiveById` / `getMergedProfile`, since a repeated import stores every sample twice and halves every point-to-point smoothed rate. This query reads `dive_profiles` directly and so does not inherit that repair — but it does not need it: averaging depth per time bucket weights the repeats evenly. There is now a test pinning that, because the logbook that motivated this work carries 3402 duplicate rows.

One known limitation, unchanged by this PR: the new `profile_depth_sanitizer` runs inside `ProfileAnalysisService`, so a single corrupt depth sample is repaired for the per-dive chart but not for this aggregate. Bucket averaging dilutes such an outlier across ~7 samples and the 3 m/min floor absorbs most of the remainder, so the effect on a library-wide mean is small; worth revisiting if it ever proves visible.

### On the 3 m/min floor

This threshold is load-bearing, so it is worth stating why. Averaging *all* non-level windows produces ~2.4 m/min on a real library — technically correct and completely useless, because on multi-level recreational profiles the windows drifting 0.5–3 m/min around the bottom outnumber genuine transit roughly four to one:

| band | windows | | band | windows |
|---|---|---|---|---|
| descend >12 | 18 | | ascend 0.5–3 | 1735 |
| descend 6–12 | 121 | | ascend 3–6 | 488 |
| descend 3–6 | 421 | | ascend 6–12 | 119 |
| descend 0.5–3 | 1620 | | ascend >12 | 4 |

Two threshold-free alternatives were tried and rejected on real data, both because max depth falls mid-dive on multi-level profiles: the 90%-of-max-depth phase split gave 2.5 / 3.3 m/min, and max-depth ÷ time-to-max-depth gave 0.82 m/min. The 3 m/min floor yields 4.9 / 5.3 m/min, which is comparable to the ascent-rate limits divers are trained against.

## Test Plan

- [x] `flutter test` passes — 15,717 tests. Two full runs each failed one or two *different* tests (`file_share_handler_test`, `backup_encryption_backup_test`); both pass in isolation, neither imports the changed files, and this matches the repo's known full-suite concurrency flake whose victims move between runs.
- [x] `flutter analyze` passes — no issues.
- [x] `dart format` clean.
- [x] Verified against a real 50,883-row profile library: the card renders 4.9 m/min ascent / 5.3 m/min descent where it previously rendered the empty state.
- [x] Performance measured at 1.62M profile rows: ~590 ms. Adds no new engine requirement — the schema migrations already use window functions.

## Not included

`getTimeAtDepthRanges` and `getDecoObligationStats` in the same file do not filter `is_primary`, so they will double-count edited or multi-computer dives. That is a pre-existing latent bug, left alone here to keep this change scoped.
