### PR TITLE
Stop reporting an impossible surface interval as six hours

### DIFF
--- a/lib/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart
+++ b/lib/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart
@@ -209,47 +209,69 @@ final siSecondDiveIsSafeProvider = Provider<bool>((ref) {
   return ndl > 0 && ndl >= secondDiveTime * 60;
 });
 
-/// Longest surface interval the tool searches, in minutes.
+/// Longest surface interval the planner searches, in minutes.
 ///
-/// Off-gassing at the surface is asymptotic: tissue tensions decay toward
-/// surface equilibrium, so the second dive's NDL climbs toward the no-stop time
-/// a diver with virgin tissues would get at that depth and mix, and then stops.
-/// Six hours is well past the point where that curve has flattened, so a plan
-/// that does not fit by then does not fit at any interval.
+/// This is a reporting horizon, not a physical limit. Compartment 16 has a 635
+/// minute nitrogen half-time, so a heavily loaded diver is still off-gassing
+/// well past six hours; a plan that does not fit inside the horizon may still
+/// fit after a longer wait. Only the clean-tissue no-stop limit settles whether
+/// a dive is possible at all.
 const int siMaxSearchIntervalMinutes = 360;
+
+/// Why the planner did or did not produce a surface interval.
+enum SiIntervalOutcome {
+  /// A wait inside [siMaxSearchIntervalMinutes] makes the second dive no-stop.
+  withinHorizon,
+
+  /// Off-gassing gets there eventually, but not inside the planner's horizon.
+  /// The remedy is a longer wait, not a different dive.
+  beyondHorizon,
+
+  /// The second dive busts its no-stop limit even on completely clean tissues,
+  /// so no surface interval of any length is enough. The remedy is a shorter or
+  /// shallower dive.
+  impossible,
+}
 
 /// How long a diver must wait on the surface before the planned second dive.
 @immutable
 class SiMinimumInterval {
+  /// Which of the three answers the planner arrived at.
+  final SiIntervalOutcome outcome;
+
   /// Shortest surface interval, in minutes, after which the second dive fits
-  /// inside its no-decompression limit. Null when no interval is enough.
+  /// inside its no-decompression limit.
+  ///
+  /// Set only for [SiIntervalOutcome.withinHorizon]; null otherwise, because
+  /// the planner has no honest number to offer in those states.
   final int? minutes;
 
-  /// The longest no-stop second dive that is reachable at all, in seconds --
-  /// the NDL once off-gassing has run its course.
+  /// No-stop limit at the second dive's depth and mix on clean tissues, in
+  /// seconds.
   ///
-  /// This is the number that explains an unreachable plan: waiting cannot buy
-  /// more bottom time than this, so the diver has to shorten the second dive or
-  /// make it shallower.
-  final int maxNoStopSeconds;
+  /// Surface time works toward this ceiling and can never beat it, which is
+  /// what separates "wait longer" from "change the dive". It depends only on
+  /// the second dive's depth and mix, not on how loaded the first dive left the
+  /// diver.
+  final int cleanTissueNoStopSeconds;
 
   const SiMinimumInterval({
+    required this.outcome,
     required this.minutes,
-    required this.maxNoStopSeconds,
+    required this.cleanTissueNoStopSeconds,
   });
 
-  /// Whether any surface interval turns the planned second dive into a no-stop
-  /// dive.
-  bool get isAchievable => minutes != null;
+  /// Whether the planner produced a concrete interval to wait.
+  bool get hasInterval => minutes != null;
 }
 
 /// Minimum surface interval needed before the planned second dive.
 ///
-/// Binary searches for the shortest wait whose NDL covers the planned dive. The
-/// upper bound is tested first, because the search alone cannot tell "no wait
-/// is long enough" apart from "the answer is exactly the bound" -- it used to
-/// return the bound either way, so an impossible plan was reported to the diver
-/// as a plausible six hour wait.
+/// Binary searches for the shortest wait whose NDL covers the planned dive, but
+/// only after settling two questions the search itself cannot answer. The
+/// search returns its own bounds when it finds nothing, so on its own it cannot
+/// tell "no wait is long enough" from "the answer is exactly the bound" -- that
+/// is what reported an impossible plan as a plausible six hour wait.
 final siMinimumIntervalProvider = Provider<SiMinimumInterval>((ref) {
   final postDiveCompartments = ref.watch(siPostDiveCompartmentsProvider);
   final secondDiveDepth = ref.watch(siSecondDiveDepthProvider);
@@ -279,18 +301,44 @@ final siMinimumIntervalProvider = Provider<SiMinimumInterval>((ref) {
     );
   }
 
-  // The ceiling on what waiting can buy. calculateNdl signals a standing deco
+  // Surface off-gassing drives every compartment toward equilibrium with
+  // surface air, so the second dive's NDL rises toward -- and never past -- the
+  // no-stop time a diver with clean tissues would get here. That makes the
+  // clean-tissue NDL an exact test for "no surface interval can ever be
+  // enough", and unlike a fixed horizon it does not depend on how far the slow
+  // compartments still have to unload. calculateNdl signals a standing deco
   // obligation with -1, which is not a duration, so floor it at zero.
-  final maxNoStopSeconds = math.max(0, ndlAfter(siMaxSearchIntervalMinutes));
+  final cleanTissue = BuhlmannAlgorithm(
+    gfLow: settings.gfLowDecimal,
+    gfHigh: settings.gfHighDecimal,
+  );
+  final cleanTissueNoStopSeconds = math.max(
+    0,
+    cleanTissue.calculateNdl(depthMeters: secondDiveDepth, fN2: fN2, fHe: fHe),
+  );
 
-  if (maxNoStopSeconds < requiredNdlSeconds) {
-    return SiMinimumInterval(minutes: null, maxNoStopSeconds: maxNoStopSeconds);
+  SiMinimumInterval result(SiIntervalOutcome outcome, int? minutes) {
+    return SiMinimumInterval(
+      outcome: outcome,
+      minutes: minutes,
+      cleanTissueNoStopSeconds: cleanTissueNoStopSeconds,
+    );
+  }
+
+  if (requiredNdlSeconds > cleanTissueNoStopSeconds) {
+    return result(SiIntervalOutcome.impossible, null);
+  }
+
+  // The dive does fit on clean tissues, so waiting is the right remedy -- but
+  // the diver may still need longer than the planner looks ahead.
+  if (ndlAfter(siMaxSearchIntervalMinutes) < requiredNdlSeconds) {
+    return result(SiIntervalOutcome.beyondHorizon, null);
   }
 
   // A diver who can roll straight into the next dive should not be handed a
   // one minute wait, which is what the bare search converges to.
   if (ndlAfter(0) >= requiredNdlSeconds) {
-    return SiMinimumInterval(minutes: 0, maxNoStopSeconds: maxNoStopSeconds);
+    return result(SiIntervalOutcome.withinHorizon, 0);
   }
 
   // Invariant: low is known to be too short, high is known to be sufficient.
@@ -307,7 +355,7 @@ final siMinimumIntervalProvider = Provider<SiMinimumInterval>((ref) {
     }
   }
 
-  return SiMinimumInterval(minutes: high, maxNoStopSeconds: maxNoStopSeconds);
+  return result(SiIntervalOutcome.withinHorizon, high);
 });
 
 /// Data class for a single point on the tissue recovery chart.

--- a/lib/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart
+++ b/lib/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart
@@ -209,9 +209,48 @@ final siSecondDiveIsSafeProvider = Provider<bool>((ref) {
   return ndl > 0 && ndl >= secondDiveTime * 60;
 });
 
-/// Minimum surface interval in minutes to achieve safe second dive.
-/// Uses binary search to find the shortest interval where NDL >= dive time.
-final siMinimumIntervalProvider = Provider<int>((ref) {
+/// Longest surface interval the tool searches, in minutes.
+///
+/// Off-gassing at the surface is asymptotic: tissue tensions decay toward
+/// surface equilibrium, so the second dive's NDL climbs toward the no-stop time
+/// a diver with virgin tissues would get at that depth and mix, and then stops.
+/// Six hours is well past the point where that curve has flattened, so a plan
+/// that does not fit by then does not fit at any interval.
+const int siMaxSearchIntervalMinutes = 360;
+
+/// How long a diver must wait on the surface before the planned second dive.
+@immutable
+class SiMinimumInterval {
+  /// Shortest surface interval, in minutes, after which the second dive fits
+  /// inside its no-decompression limit. Null when no interval is enough.
+  final int? minutes;
+
+  /// The longest no-stop second dive that is reachable at all, in seconds --
+  /// the NDL once off-gassing has run its course.
+  ///
+  /// This is the number that explains an unreachable plan: waiting cannot buy
+  /// more bottom time than this, so the diver has to shorten the second dive or
+  /// make it shallower.
+  final int maxNoStopSeconds;
+
+  const SiMinimumInterval({
+    required this.minutes,
+    required this.maxNoStopSeconds,
+  });
+
+  /// Whether any surface interval turns the planned second dive into a no-stop
+  /// dive.
+  bool get isAchievable => minutes != null;
+}
+
+/// Minimum surface interval needed before the planned second dive.
+///
+/// Binary searches for the shortest wait whose NDL covers the planned dive. The
+/// upper bound is tested first, because the search alone cannot tell "no wait
+/// is long enough" apart from "the answer is exactly the bound" -- it used to
+/// return the bound either way, so an impossible plan was reported to the diver
+/// as a plausible six hour wait.
+final siMinimumIntervalProvider = Provider<SiMinimumInterval>((ref) {
   final postDiveCompartments = ref.watch(siPostDiveCompartmentsProvider);
   final secondDiveDepth = ref.watch(siSecondDiveDepthProvider);
   final secondDiveTime = ref.watch(siSecondDiveTimeProvider);
@@ -221,41 +260,54 @@ final siMinimumIntervalProvider = Provider<int>((ref) {
 
   final requiredNdlSeconds = secondDiveTime * 60;
 
-  // Binary search for minimum surface interval (0 to 360 minutes / 6 hours)
-  int low = 0;
-  int high = 360;
-
-  while (high - low > 1) {
-    final mid = (low + high) ~/ 2;
-
-    // Simulate recovery at surface for 'mid' minutes
-    final recoveredCompartments = _calculateRecoveredCompartments(
-      postDiveCompartments,
-      mid,
-    );
-
-    // Check NDL for second dive
+  /// NDL for the second dive after [surfaceIntervalMinutes] of off-gassing.
+  int ndlAfter(int surfaceIntervalMinutes) {
     final algorithm = BuhlmannAlgorithm(
       gfLow: settings.gfLowDecimal,
       gfHigh: settings.gfHighDecimal,
     );
-    algorithm.setCompartments(recoveredCompartments);
-
-    final ndl = algorithm.calculateNdl(
+    algorithm.setCompartments(
+      _calculateRecoveredCompartments(
+        postDiveCompartments,
+        surfaceIntervalMinutes,
+      ),
+    );
+    return algorithm.calculateNdl(
       depthMeters: secondDiveDepth,
       fN2: fN2,
       fHe: fHe,
     );
+  }
 
-    if (ndl >= requiredNdlSeconds) {
+  // The ceiling on what waiting can buy. calculateNdl signals a standing deco
+  // obligation with -1, which is not a duration, so floor it at zero.
+  final maxNoStopSeconds = math.max(0, ndlAfter(siMaxSearchIntervalMinutes));
+
+  if (maxNoStopSeconds < requiredNdlSeconds) {
+    return SiMinimumInterval(minutes: null, maxNoStopSeconds: maxNoStopSeconds);
+  }
+
+  // A diver who can roll straight into the next dive should not be handed a
+  // one minute wait, which is what the bare search converges to.
+  if (ndlAfter(0) >= requiredNdlSeconds) {
+    return SiMinimumInterval(minutes: 0, maxNoStopSeconds: maxNoStopSeconds);
+  }
+
+  // Invariant: low is known to be too short, high is known to be sufficient.
+  int low = 0;
+  int high = siMaxSearchIntervalMinutes;
+
+  while (high - low > 1) {
+    final mid = (low + high) ~/ 2;
+
+    if (ndlAfter(mid) >= requiredNdlSeconds) {
       high = mid;
     } else {
       low = mid;
     }
   }
 
-  // Return the higher value to ensure safety
-  return high;
+  return SiMinimumInterval(minutes: high, maxNoStopSeconds: maxNoStopSeconds);
 });
 
 /// Data class for a single point on the tissue recovery chart.

--- a/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
+++ b/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
@@ -24,10 +24,20 @@ class SurfaceIntervalResult extends ConsumerWidget {
     // and picked a mix they can actually breathe at the planned depth.
     final isSafe = ndlIsSafe && gasIsSafe;
 
-    // Format interval as hours:minutes
-    final hours = minInterval ~/ 60;
-    final minutes = minInterval % 60;
-    final intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
+    // Format interval as hours:minutes. An unreachable plan has no interval to
+    // show: a number here would be read as "wait this long and you are fine",
+    // which is exactly the advice that does not apply.
+    final String intervalText;
+    final String intervalSemanticsText;
+    if (minInterval.isAchievable) {
+      final hours = minInterval.minutes! ~/ 60;
+      final minutes = minInterval.minutes! % 60;
+      intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
+      intervalSemanticsText = intervalText;
+    } else {
+      intervalText = '—';
+      intervalSemanticsText = context.l10n.surfaceInterval_result_notAchievable;
+    }
 
     // Format NDL for display
     String ndlText;
@@ -47,12 +57,16 @@ class SurfaceIntervalResult extends ConsumerWidget {
 
     return Semantics(
       label: context.l10n.surfaceInterval_result_semantics(
-        intervalText,
+        intervalSemanticsText,
         currentText,
         ndlText,
-        // Oxygen is the acute risk, so it leads when both are wrong.
+        // Oxygen is the acute risk, so it leads when both are wrong. An
+        // unreachable plan outranks "wait longer" for the same reason: it tells
+        // the diver to change the plan rather than the clock.
         !gasIsSafe
             ? context.l10n.surfaceInterval_result_gasUnsafe
+            : !minInterval.isAchievable
+            ? context.l10n.surfaceInterval_result_notAchievable
             : ndlIsSafe
             ? context.l10n.surfaceInterval_result_safeToDive
             : context.l10n.surfaceInterval_result_notYetSafe,
@@ -140,11 +154,18 @@ class SurfaceIntervalResult extends ConsumerWidget {
                 ),
               ],
 
+              // An unreachable plan is always short on no-deco time, so this
+              // branch covers it too -- but the remedy is a different one, and
+              // telling the diver to wait longer would be dead wrong.
               if (!ndlIsSafe) ...[
                 const SizedBox(height: 16),
                 _ResultNotice(
                   icon: Icons.info_outline,
-                  message: context.l10n.surfaceInterval_result_increaseInterval,
+                  message: minInterval.isAchievable
+                      ? context.l10n.surfaceInterval_result_increaseInterval
+                      : context.l10n.surfaceInterval_result_noIntervalHelps(
+                          minInterval.maxNoStopSeconds ~/ 60,
+                        ),
                 ),
               ],
             ],

--- a/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
+++ b/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
@@ -31,20 +31,27 @@ class SurfaceIntervalResult extends ConsumerWidget {
     // and in one of those states waiting is not the remedy at all.
     final String intervalText;
     final String intervalSemanticsText;
+    // Set when the outcome itself is the headline, which is exactly when there
+    // is no interval: "wait longer than this planner shows" and "change the
+    // dive" both say more than the plain not-yet-safe wording does.
+    final String? outcomeStatus;
     switch (minInterval.outcome) {
       case SiIntervalOutcome.withinHorizon:
         final hours = minInterval.minutes! ~/ 60;
         final minutes = minInterval.minutes! % 60;
         intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
         intervalSemanticsText = intervalText;
+        outcomeStatus = null;
       case SiIntervalOutcome.beyondHorizon:
         intervalText = '> ${horizonHours}h';
         intervalSemanticsText = context.l10n
             .surfaceInterval_result_beyondHorizonShort(horizonHours);
+        outcomeStatus = intervalSemanticsText;
       case SiIntervalOutcome.impossible:
         intervalText = '—';
         intervalSemanticsText =
             context.l10n.surfaceInterval_result_notAchievable;
+        outcomeStatus = intervalSemanticsText;
     }
 
     // Format NDL for display
@@ -68,24 +75,14 @@ class SurfaceIntervalResult extends ConsumerWidget {
         intervalSemanticsText,
         currentText,
         ndlText,
-        // Oxygen is the acute risk, so it leads when both are wrong. The states
-        // without an interval come next, because they say something the plain
-        // "not yet safe" wording does not: change the dive, or expect to wait
-        // past what this planner shows.
+        // Oxygen is the acute risk, so it leads when both are wrong, then any
+        // outcome that carries its own headline.
         !gasIsSafe
             ? context.l10n.surfaceInterval_result_gasUnsafe
-            : switch (minInterval.outcome) {
-                SiIntervalOutcome.impossible =>
-                  context.l10n.surfaceInterval_result_notAchievable,
-                SiIntervalOutcome.beyondHorizon =>
-                  context.l10n.surfaceInterval_result_beyondHorizonShort(
-                    horizonHours,
-                  ),
-                SiIntervalOutcome.withinHorizon =>
-                  ndlIsSafe
+            : outcomeStatus ??
+                  (ndlIsSafe
                       ? context.l10n.surfaceInterval_result_safeToDive
-                      : context.l10n.surfaceInterval_result_notYetSafe,
-              },
+                      : context.l10n.surfaceInterval_result_notYetSafe),
       ),
       child: Card(
         color: isSafe

--- a/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
+++ b/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
@@ -24,19 +24,27 @@ class SurfaceIntervalResult extends ConsumerWidget {
     // and picked a mix they can actually breathe at the planned depth.
     final isSafe = ndlIsSafe && gasIsSafe;
 
-    // Format interval as hours:minutes. An unreachable plan has no interval to
-    // show: a number here would be read as "wait this long and you are fine",
-    // which is exactly the advice that does not apply.
+    const horizonHours = siMaxSearchIntervalMinutes ~/ 60;
+
+    // Format interval as hours:minutes. Neither state without an interval gets
+    // a number here: one would be read as "wait this long and you are fine",
+    // and in one of those states waiting is not the remedy at all.
     final String intervalText;
     final String intervalSemanticsText;
-    if (minInterval.isAchievable) {
-      final hours = minInterval.minutes! ~/ 60;
-      final minutes = minInterval.minutes! % 60;
-      intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
-      intervalSemanticsText = intervalText;
-    } else {
-      intervalText = '—';
-      intervalSemanticsText = context.l10n.surfaceInterval_result_notAchievable;
+    switch (minInterval.outcome) {
+      case SiIntervalOutcome.withinHorizon:
+        final hours = minInterval.minutes! ~/ 60;
+        final minutes = minInterval.minutes! % 60;
+        intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
+        intervalSemanticsText = intervalText;
+      case SiIntervalOutcome.beyondHorizon:
+        intervalText = '> ${horizonHours}h';
+        intervalSemanticsText = context.l10n
+            .surfaceInterval_result_beyondHorizonShort(horizonHours);
+      case SiIntervalOutcome.impossible:
+        intervalText = '—';
+        intervalSemanticsText =
+            context.l10n.surfaceInterval_result_notAchievable;
     }
 
     // Format NDL for display
@@ -60,16 +68,24 @@ class SurfaceIntervalResult extends ConsumerWidget {
         intervalSemanticsText,
         currentText,
         ndlText,
-        // Oxygen is the acute risk, so it leads when both are wrong. An
-        // unreachable plan outranks "wait longer" for the same reason: it tells
-        // the diver to change the plan rather than the clock.
+        // Oxygen is the acute risk, so it leads when both are wrong. The states
+        // without an interval come next, because they say something the plain
+        // "not yet safe" wording does not: change the dive, or expect to wait
+        // past what this planner shows.
         !gasIsSafe
             ? context.l10n.surfaceInterval_result_gasUnsafe
-            : !minInterval.isAchievable
-            ? context.l10n.surfaceInterval_result_notAchievable
-            : ndlIsSafe
-            ? context.l10n.surfaceInterval_result_safeToDive
-            : context.l10n.surfaceInterval_result_notYetSafe,
+            : switch (minInterval.outcome) {
+                SiIntervalOutcome.impossible =>
+                  context.l10n.surfaceInterval_result_notAchievable,
+                SiIntervalOutcome.beyondHorizon =>
+                  context.l10n.surfaceInterval_result_beyondHorizonShort(
+                    horizonHours,
+                  ),
+                SiIntervalOutcome.withinHorizon =>
+                  ndlIsSafe
+                      ? context.l10n.surfaceInterval_result_safeToDive
+                      : context.l10n.surfaceInterval_result_notYetSafe,
+              },
       ),
       child: Card(
         color: isSafe
@@ -154,18 +170,26 @@ class SurfaceIntervalResult extends ConsumerWidget {
                 ),
               ],
 
-              // An unreachable plan is always short on no-deco time, so this
-              // branch covers it too -- but the remedy is a different one, and
-              // telling the diver to wait longer would be dead wrong.
+              // Every state without an interval is also short on no-deco time,
+              // so this branch covers all three -- but each wants different
+              // advice, and telling an impossible plan to wait longer would be
+              // dead wrong.
               if (!ndlIsSafe) ...[
                 const SizedBox(height: 16),
                 _ResultNotice(
                   icon: Icons.info_outline,
-                  message: minInterval.isAchievable
-                      ? context.l10n.surfaceInterval_result_increaseInterval
-                      : context.l10n.surfaceInterval_result_noIntervalHelps(
-                          minInterval.maxNoStopSeconds ~/ 60,
-                        ),
+                  message: switch (minInterval.outcome) {
+                    SiIntervalOutcome.withinHorizon =>
+                      context.l10n.surfaceInterval_result_increaseInterval,
+                    SiIntervalOutcome.beyondHorizon =>
+                      context.l10n.surfaceInterval_result_beyondHorizon(
+                        horizonHours,
+                      ),
+                    SiIntervalOutcome.impossible =>
+                      context.l10n.surfaceInterval_result_noIntervalHelps(
+                        minInterval.cleanTissueNoStopSeconds ~/ 60,
+                      ),
+                  },
                 ),
               ],
             ],

--- a/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
+++ b/lib/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart
@@ -31,27 +31,32 @@ class SurfaceIntervalResult extends ConsumerWidget {
     // and in one of those states waiting is not the remedy at all.
     final String intervalText;
     final String intervalSemanticsText;
-    // Set when the outcome itself is the headline, which is exactly when there
-    // is no interval: "wait longer than this planner shows" and "change the
-    // dive" both say more than the plain not-yet-safe wording does.
-    final String? outcomeStatus;
+    // What the diver should do about it, set exactly when there is no interval
+    // to show. It drives both the visible notice and the spoken summary, so a
+    // screen reader hears the remedy and the ceiling instead of hearing the
+    // headline restated.
+    final String? outcomeAdvice;
     switch (minInterval.outcome) {
       case SiIntervalOutcome.withinHorizon:
         final hours = minInterval.minutes! ~/ 60;
         final minutes = minInterval.minutes! % 60;
         intervalText = hours > 0 ? '${hours}h ${minutes}m' : '$minutes min';
         intervalSemanticsText = intervalText;
-        outcomeStatus = null;
+        outcomeAdvice = null;
       case SiIntervalOutcome.beyondHorizon:
         intervalText = '> ${horizonHours}h';
         intervalSemanticsText = context.l10n
             .surfaceInterval_result_beyondHorizonShort(horizonHours);
-        outcomeStatus = intervalSemanticsText;
+        outcomeAdvice = context.l10n.surfaceInterval_result_beyondHorizon(
+          horizonHours,
+        );
       case SiIntervalOutcome.impossible:
         intervalText = '—';
         intervalSemanticsText =
             context.l10n.surfaceInterval_result_notAchievable;
-        outcomeStatus = intervalSemanticsText;
+        outcomeAdvice = context.l10n.surfaceInterval_result_noIntervalHelps(
+          minInterval.cleanTissueNoStopSeconds ~/ 60,
+        );
     }
 
     // Format NDL for display
@@ -79,7 +84,7 @@ class SurfaceIntervalResult extends ConsumerWidget {
         // outcome that carries its own headline.
         !gasIsSafe
             ? context.l10n.surfaceInterval_result_gasUnsafe
-            : outcomeStatus ??
+            : outcomeAdvice ??
                   (ndlIsSafe
                       ? context.l10n.surfaceInterval_result_safeToDive
                       : context.l10n.surfaceInterval_result_notYetSafe),
@@ -175,18 +180,9 @@ class SurfaceIntervalResult extends ConsumerWidget {
                 const SizedBox(height: 16),
                 _ResultNotice(
                   icon: Icons.info_outline,
-                  message: switch (minInterval.outcome) {
-                    SiIntervalOutcome.withinHorizon =>
+                  message:
+                      outcomeAdvice ??
                       context.l10n.surfaceInterval_result_increaseInterval,
-                    SiIntervalOutcome.beyondHorizon =>
-                      context.l10n.surfaceInterval_result_beyondHorizon(
-                        horizonHours,
-                      ),
-                    SiIntervalOutcome.impossible =>
-                      context.l10n.surfaceInterval_result_noIntervalHelps(
-                        minInterval.cleanTissueNoStopSeconds ~/ 60,
-                      ),
-                  },
                 ),
               ],
             ],

--- a/lib/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart.dart
+++ b/lib/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart.dart
@@ -269,10 +269,14 @@ class TissueRecoveryChart extends ConsumerWidget {
                             ),
                           ),
                         ),
-                        // Minimum interval marker
-                        if (minInterval > 0 && minInterval <= 240)
+                        // Minimum interval marker. Absent when no interval is
+                        // enough, and when the answer sits past the chart's
+                        // 4 hour window.
+                        if (minInterval.minutes != null &&
+                            minInterval.minutes! > 0 &&
+                            minInterval.minutes! <= 240)
                           VerticalLine(
-                            x: minInterval.toDouble(),
+                            x: minInterval.minutes!.toDouble(),
                             color: Colors.green,
                             strokeWidth: 2,
                             dashArray: [8, 4],

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "الحد الأدنى لفترة السطح",
   "surfaceInterval_result_ndlForSecondDive": "NDL للغطسة الثانية",
   "surfaceInterval_result_ndlMinutes": "{minutes} دقيقة NDL",
+  "surfaceInterval_result_noIntervalHelps": "لا تكفي أي فترة سطح. أطول غطسة بدون توقف إلزامي على هذا العمق بهذا الخليط هي {minutes} دقيقة. قلّل زمن الغطسة الثانية أو قلّل عمقها.",
+  "surfaceInterval_result_notAchievable": "غير قابل للتحقيق بأي فترة سطح",
   "surfaceInterval_result_notYetSafe": "ليس آمناً بعد، زد فترة السطح",
   "surfaceInterval_result_safeToDive": "آمن للغوص",
   "surfaceInterval_result_semantics": "الحد الأدنى لفترة السطح: {interval}. الفترة الحالية: {current}. NDL للغطسة الثانية: {ndl}. {status}",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} على عمق {depth} يتجاوز {limit}. أقصى عمق تشغيل لهذا الخليط هو {mod}.",
   "surfaceInterval_heSemantics": "الهيليوم: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "يلزم فترة سطح تزيد عن {hours} ساعات. لا يبحث هذا المخطط لمدة أطول من ذلك.",
+  "surfaceInterval_result_beyondHorizonShort": "أكثر من {hours} ساعات",
   "surfaceInterval_result_currentInterval": "الفترة الحالية",
   "surfaceInterval_result_gasUnsafe": "الغاز غير آمن على هذا العمق",
   "surfaceInterval_result_inDeco": "في تخفيف الضغط",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} على عمق {depth} يتجاوز {limit}. أقصى عمق تشغيل لهذا الخليط هو {mod}.",
   "surfaceInterval_heSemantics": "الهيليوم: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "يلزم فترة سطح تزيد عن {hours} ساعات. لا يبحث هذا المخطط لمدة أطول من ذلك.",
+  "surfaceInterval_result_beyondHorizon": "زمن الانتظار يتجاوز {hours} ساعات التي يبحث فيها هذا المخطط. يستمر التخلص من النيتروجين، لذا ستكفي فترة سطح أطول.",
   "surfaceInterval_result_beyondHorizonShort": "أكثر من {hours} ساعات",
   "surfaceInterval_result_currentInterval": "الفترة الحالية",
   "surfaceInterval_result_gasUnsafe": "الغاز غير آمن على هذا العمق",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "Minimales Oberflächenintervall",
   "surfaceInterval_result_ndlForSecondDive": "Nullzeit für 2. Tauchgang",
   "surfaceInterval_result_ndlMinutes": "{minutes} Min Nullzeit",
+  "surfaceInterval_result_noIntervalHelps": "Kein Oberflächenintervall reicht aus. Der längste Nullzeit-Tauchgang in dieser Tiefe mit diesem Gemisch dauert {minutes} Min. Zweiten Tauchgang kürzen oder dessen Tiefe reduzieren.",
+  "surfaceInterval_result_notAchievable": "Mit keinem Oberflächenintervall erreichbar",
   "surfaceInterval_result_notYetSafe": "Noch nicht sicher, Oberflächenintervall erhöhen",
   "surfaceInterval_result_safeToDive": "Sicher zu tauchen",
   "surfaceInterval_result_semantics": "Minimales Oberflächenintervall: {interval}. Aktuelles Intervall: {current}. Nullzeit für zweiten Tauchgang: {ndl}. {status}",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} auf {depth} überschreitet {limit}. MOD für dieses Gemisch ist {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Es ist ein Oberflächenintervall von mehr als {hours} Stunden nötig. Dieser Planer sucht nicht weiter voraus.",
+  "surfaceInterval_result_beyondHorizon": "Die Wartezeit liegt über den {hours} Stunden, die dieser Planer durchsucht. Die Entsättigung geht weiter, ein längeres Oberflächenintervall reicht also aus.",
   "surfaceInterval_result_beyondHorizonShort": "Mehr als {hours} Stunden",
   "surfaceInterval_result_currentInterval": "Aktuelles Intervall",
   "surfaceInterval_result_gasUnsafe": "Gas in dieser Tiefe unsicher",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} auf {depth} überschreitet {limit}. MOD für dieses Gemisch ist {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Es ist ein Oberflächenintervall von mehr als {hours} Stunden nötig. Dieser Planer sucht nicht weiter voraus.",
+  "surfaceInterval_result_beyondHorizonShort": "Mehr als {hours} Stunden",
   "surfaceInterval_result_currentInterval": "Aktuelles Intervall",
   "surfaceInterval_result_gasUnsafe": "Gas in dieser Tiefe unsicher",
   "surfaceInterval_result_inDeco": "In Deko",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9535,6 +9535,8 @@
   "surfaceInterval_result_minimumInterval": "Minimum Surface Interval",
   "surfaceInterval_result_ndlForSecondDive": "NDL for 2nd Dive",
   "surfaceInterval_result_ndlMinutes": "{minutes} min NDL",
+  "surfaceInterval_result_noIntervalHelps": "No surface interval is enough. The longest no-stop dive at this depth on this mix is {minutes} min. Shorten the second dive or reduce its depth.",
+  "surfaceInterval_result_notAchievable": "Not achievable at any surface interval",
   "surfaceInterval_result_notYetSafe": "Not yet safe, increase surface interval",
   "surfaceInterval_result_safeToDive": "Safe to dive",
   "surfaceInterval_result_semantics": "Minimum surface interval: {interval}. Current interval: {current}. NDL for second dive: {ndl}. {status}",
@@ -9715,6 +9717,18 @@
         "example": "15"
       }
     }
+  },
+  "@surfaceInterval_result_noIntervalHelps": {
+    "description": "Explains that the planned second dive busts the no-stop limit no matter how long the diver waits, and names the longest no-stop dive that is reachable",
+    "placeholders": {
+      "minutes": {
+        "type": "Object",
+        "example": "43"
+      }
+    }
+  },
+  "@surfaceInterval_result_notAchievable": {
+    "description": "Shown in place of a minimum surface interval when no interval makes the second dive a no-stop dive"
   },
   "@surfaceInterval_result_notYetSafe": {
     "description": "Status message when more surface interval time is needed"

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9528,7 +9528,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} at {depth} exceeds {limit}. MOD for this mix is {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "More than {hours} hours of surface interval is needed. This planner does not search further ahead.",
+  "surfaceInterval_result_beyondHorizon": "The wait runs past the {hours} hours this planner searches. Off-gassing continues, so a longer surface interval will get there.",
   "surfaceInterval_result_beyondHorizonShort": "More than {hours} hours",
   "surfaceInterval_result_currentInterval": "Current Interval",
   "surfaceInterval_result_gasUnsafe": "Gas unsafe at this depth",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9528,6 +9528,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} at {depth} exceeds {limit}. MOD for this mix is {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "More than {hours} hours of surface interval is needed. This planner does not search further ahead.",
+  "surfaceInterval_result_beyondHorizonShort": "More than {hours} hours",
   "surfaceInterval_result_currentInterval": "Current Interval",
   "surfaceInterval_result_gasUnsafe": "Gas unsafe at this depth",
   "surfaceInterval_result_inDeco": "In deco",
@@ -9688,6 +9690,24 @@
       "percent": {
         "type": "Object",
         "example": "32"
+      }
+    }
+  },
+  "@surfaceInterval_result_beyondHorizon": {
+    "description": "Explains that the second dive does fit on clean tissues but needs a longer surface interval than the planner searches",
+    "placeholders": {
+      "hours": {
+        "type": "Object",
+        "example": "6"
+      }
+    }
+  },
+  "@surfaceInterval_result_beyondHorizonShort": {
+    "description": "Shown in place of a minimum surface interval when the required wait is longer than the planner searches",
+    "placeholders": {
+      "hours": {
+        "type": "Object",
+        "example": "6"
       }
     }
   },

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} supera {limit}. La MOD de esta mezcla es {mod}.",
   "surfaceInterval_heSemantics": "Helio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Se necesita un intervalo de superficie de más de {hours} horas. Este planificador no busca más allá.",
+  "surfaceInterval_result_beyondHorizon": "La espera supera las {hours} horas que busca este planificador. La desaturación continúa, así que un intervalo de superficie más largo lo conseguirá.",
   "surfaceInterval_result_beyondHorizonShort": "Más de {hours} horas",
   "surfaceInterval_result_currentInterval": "Intervalo Actual",
   "surfaceInterval_result_gasUnsafe": "Gas inseguro a esta profundidad",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "Intervalo de Superficie Mínimo",
   "surfaceInterval_result_ndlForSecondDive": "NDL para 2da Inmersión",
   "surfaceInterval_result_ndlMinutes": "{minutes} min NDL",
+  "surfaceInterval_result_noIntervalHelps": "Ningún intervalo de superficie es suficiente. La inmersión sin descompresión más larga a esta profundidad con esta mezcla es de {minutes} min. Acorta la segunda inmersión o reduce su profundidad.",
+  "surfaceInterval_result_notAchievable": "No alcanzable con ningún intervalo de superficie",
   "surfaceInterval_result_notYetSafe": "Aún no es seguro, aumenta el intervalo de superficie",
   "surfaceInterval_result_safeToDive": "Seguro para bucear",
   "surfaceInterval_result_semantics": "Intervalo de superficie mínimo: {interval}. Intervalo actual: {current}. NDL para segunda inmersión: {ndl}. {status}",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} supera {limit}. La MOD de esta mezcla es {mod}.",
   "surfaceInterval_heSemantics": "Helio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Se necesita un intervalo de superficie de más de {hours} horas. Este planificador no busca más allá.",
+  "surfaceInterval_result_beyondHorizonShort": "Más de {hours} horas",
   "surfaceInterval_result_currentInterval": "Intervalo Actual",
   "surfaceInterval_result_gasUnsafe": "Gas inseguro a esta profundidad",
   "surfaceInterval_result_inDeco": "En deco",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4873,6 +4873,8 @@
   "surfaceInterval_result_minimumInterval": "Intervalle de surface minimum",
   "surfaceInterval_result_ndlForSecondDive": "DTR pour la 2e plongée",
   "surfaceInterval_result_ndlMinutes": "{minutes} min DTR",
+  "surfaceInterval_result_noIntervalHelps": "Aucun intervalle de surface ne suffit. La plongée sans palier la plus longue à cette profondeur avec ce mélange est de {minutes} min. Raccourcissez la deuxième plongée ou réduisez sa profondeur.",
+  "surfaceInterval_result_notAchievable": "Impossible quel que soit l'intervalle de surface",
   "surfaceInterval_result_notYetSafe": "Pas encore sûr, augmentez l'intervalle de surface",
   "surfaceInterval_result_safeToDive": "Sûr pour plonger",
   "surfaceInterval_result_semantics": "Intervalle de surface minimum : {interval}. Intervalle actuel : {current}. DTR pour la deuxième plongée : {ndl}. {status}",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4866,7 +4866,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} à {depth} dépasse {limit}. La MOD de ce mélange est {mod}.",
   "surfaceInterval_heSemantics": "Hélium : {percent}%",
   "surfaceInterval_o2Semantics": "O2 : {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Un intervalle de surface de plus de {hours} heures est nécessaire. Ce planificateur ne cherche pas au-delà.",
+  "surfaceInterval_result_beyondHorizon": "L'attente dépasse les {hours} heures explorées par ce planificateur. La désaturation se poursuit, un intervalle de surface plus long suffira donc.",
   "surfaceInterval_result_beyondHorizonShort": "Plus de {hours} heures",
   "surfaceInterval_result_currentInterval": "Intervalle actuel",
   "surfaceInterval_result_gasUnsafe": "Gaz dangereux à cette profondeur",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4866,6 +4866,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} à {depth} dépasse {limit}. La MOD de ce mélange est {mod}.",
   "surfaceInterval_heSemantics": "Hélium : {percent}%",
   "surfaceInterval_o2Semantics": "O2 : {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Un intervalle de surface de plus de {hours} heures est nécessaire. Ce planificateur ne cherche pas au-delà.",
+  "surfaceInterval_result_beyondHorizonShort": "Plus de {hours} heures",
   "surfaceInterval_result_currentInterval": "Intervalle actuel",
   "surfaceInterval_result_gasUnsafe": "Gaz dangereux à cette profondeur",
   "surfaceInterval_result_inDeco": "En déco",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} בעומק {depth} חורג מ-{limit}. ה-MOD של תערובת זו הוא {mod}.",
   "surfaceInterval_heSemantics": "הליום: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "נדרש מרווח שטח של יותר מ-{hours} שעות. מתכנן זה אינו מחפש מעבר לכך.",
+  "surfaceInterval_result_beyondHorizon": "ההמתנה חורגת מ-{hours} השעות שמתכנן זה מחפש. הסילוק ממשיך, ולכן מרווח שטח ארוך יותר יספיק.",
   "surfaceInterval_result_beyondHorizonShort": "יותר מ-{hours} שעות",
   "surfaceInterval_result_currentInterval": "מרווח נוכחי",
   "surfaceInterval_result_gasUnsafe": "הגז אינו בטוח בעומק זה",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "מרווח שטח מינימלי",
   "surfaceInterval_result_ndlForSecondDive": "NDL לצלילה ה-2",
   "surfaceInterval_result_ndlMinutes": "{minutes} דקות NDL",
+  "surfaceInterval_result_noIntervalHelps": "שום מרווח שטח אינו מספיק. הצלילה הארוכה ביותר ללא דקומפרסיה בעומק זה עם תערובת זו היא {minutes} דקות. קצר את הצלילה השנייה או הקטן את עומקה.",
+  "surfaceInterval_result_notAchievable": "לא ניתן להשגה בשום מרווח שטח",
   "surfaceInterval_result_notYetSafe": "עדיין לא בטוח, הגדל מרווח שטח",
   "surfaceInterval_result_safeToDive": "בטוח לצלול",
   "surfaceInterval_result_semantics": "מרווח שטח מינימלי: {interval}. מרווח נוכחי: {current}. NDL לצלילה שנייה: {ndl}. {status}",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} בעומק {depth} חורג מ-{limit}. ה-MOD של תערובת זו הוא {mod}.",
   "surfaceInterval_heSemantics": "הליום: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "נדרש מרווח שטח של יותר מ-{hours} שעות. מתכנן זה אינו מחפש מעבר לכך.",
+  "surfaceInterval_result_beyondHorizonShort": "יותר מ-{hours} שעות",
   "surfaceInterval_result_currentInterval": "מרווח נוכחי",
   "surfaceInterval_result_gasUnsafe": "הגז אינו בטוח בעומק זה",
   "surfaceInterval_result_inDeco": "בדקו",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4866,7 +4866,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} {depth} mélységben meghaladja a {limit} értéket. A keverék MOD-ja {mod}.",
   "surfaceInterval_heSemantics": "Hélium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Több mint {hours} óra felszíni intervallum szükséges. Ez a tervező nem keres ennél tovább.",
+  "surfaceInterval_result_beyondHorizon": "A várakozás túllépi azt a {hours} órát, ameddig ez a tervező keres. A kitelítődés folytatódik, így egy hosszabb felszíni intervallum elegendő lesz.",
   "surfaceInterval_result_beyondHorizonShort": "Több mint {hours} óra",
   "surfaceInterval_result_currentInterval": "Jelenlegi intervallum",
   "surfaceInterval_result_gasUnsafe": "A gáz nem biztonságos ezen a mélységen",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4873,6 +4873,8 @@
   "surfaceInterval_result_minimumInterval": "Minimum felszíni intervallum",
   "surfaceInterval_result_ndlForSecondDive": "NDL a 2. merüléshez",
   "surfaceInterval_result_ndlMinutes": "{minutes} perc NDL",
+  "surfaceInterval_result_noIntervalHelps": "Semmilyen felszíni intervallum nem elegendő. A leghosszabb dekompresszió nélküli merülés ezen a mélységen ezzel a keverékkel {minutes} perc. Rövidítsd le a második merülést vagy csökkentsd a mélységét.",
+  "surfaceInterval_result_notAchievable": "Semmilyen felszíni intervallummal nem érhető el",
   "surfaceInterval_result_notYetSafe": "Még nem biztonságos, növeld a felszíni intervallumot",
   "surfaceInterval_result_safeToDive": "Biztonságos merülni",
   "surfaceInterval_result_semantics": "Minimum felszíni intervallum: {interval}. Jelenlegi intervallum: {current}. NDL a második merüléshez: {ndl}. {status}",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4866,6 +4866,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} {depth} mélységben meghaladja a {limit} értéket. A keverék MOD-ja {mod}.",
   "surfaceInterval_heSemantics": "Hélium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Több mint {hours} óra felszíni intervallum szükséges. Ez a tervező nem keres ennél tovább.",
+  "surfaceInterval_result_beyondHorizonShort": "Több mint {hours} óra",
   "surfaceInterval_result_currentInterval": "Jelenlegi intervallum",
   "surfaceInterval_result_gasUnsafe": "A gáz nem biztonságos ezen a mélységen",
   "surfaceInterval_result_inDeco": "Dekóban",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4862,7 +4862,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} supera {limit}. La MOD di questa miscela è {mod}.",
   "surfaceInterval_heSemantics": "Elio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Serve un intervallo di superficie di più di {hours} ore. Questo pianificatore non cerca oltre.",
+  "surfaceInterval_result_beyondHorizon": "L'attesa supera le {hours} ore esplorate da questo pianificatore. La desaturazione continua, quindi un intervallo di superficie più lungo sarà sufficiente.",
   "surfaceInterval_result_beyondHorizonShort": "Più di {hours} ore",
   "surfaceInterval_result_currentInterval": "Intervallo Corrente",
   "surfaceInterval_result_gasUnsafe": "Miscela non sicura a questa profondità",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4869,6 +4869,8 @@
   "surfaceInterval_result_minimumInterval": "Intervallo di Superficie Minimo",
   "surfaceInterval_result_ndlForSecondDive": "NDL per 2ª Immersione",
   "surfaceInterval_result_ndlMinutes": "{minutes} min NDL",
+  "surfaceInterval_result_noIntervalHelps": "Nessun intervallo di superficie è sufficiente. L'immersione senza decompressione più lunga a questa profondità con questa miscela è di {minutes} min. Accorcia la seconda immersione o riducine la profondità.",
+  "surfaceInterval_result_notAchievable": "Non raggiungibile con alcun intervallo di superficie",
   "surfaceInterval_result_notYetSafe": "Non ancora sicuro, aumenta l'intervallo di superficie",
   "surfaceInterval_result_safeToDive": "Sicuro per immergersi",
   "surfaceInterval_result_semantics": "Intervallo di superficie minimo: {interval}. Intervallo corrente: {current}. NDL per seconda immersione: {ndl}. {status}",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4862,6 +4862,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} supera {limit}. La MOD di questa miscela è {mod}.",
   "surfaceInterval_heSemantics": "Elio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Serve un intervallo di superficie di più di {hours} ore. Questo pianificatore non cerca oltre.",
+  "surfaceInterval_result_beyondHorizonShort": "Più di {hours} ore",
   "surfaceInterval_result_currentInterval": "Intervallo Corrente",
   "surfaceInterval_result_gasUnsafe": "Miscela non sicura a questa profondità",
   "surfaceInterval_result_inDeco": "In deco",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27816,6 +27816,18 @@ abstract class AppLocalizations {
   /// **'{minutes} min NDL'**
   String surfaceInterval_result_ndlMinutes(Object minutes);
 
+  /// Explains that the planned second dive busts the no-stop limit no matter how long the diver waits, and names the longest no-stop dive that is reachable
+  ///
+  /// In en, this message translates to:
+  /// **'No surface interval is enough. The longest no-stop dive at this depth on this mix is {minutes} min. Shorten the second dive or reduce its depth.'**
+  String surfaceInterval_result_noIntervalHelps(Object minutes);
+
+  /// Shown in place of a minimum surface interval when no interval makes the second dive a no-stop dive
+  ///
+  /// In en, this message translates to:
+  /// **'Not achievable at any surface interval'**
+  String get surfaceInterval_result_notAchievable;
+
   /// Status message when more surface interval time is needed
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27774,6 +27774,18 @@ abstract class AppLocalizations {
   /// **'O2: {percent}%'**
   String surfaceInterval_o2Semantics(Object percent);
 
+  /// Explains that the second dive does fit on clean tissues but needs a longer surface interval than the planner searches
+  ///
+  /// In en, this message translates to:
+  /// **'More than {hours} hours of surface interval is needed. This planner does not search further ahead.'**
+  String surfaceInterval_result_beyondHorizon(Object hours);
+
+  /// Shown in place of a minimum surface interval when the required wait is longer than the planner searches
+  ///
+  /// In en, this message translates to:
+  /// **'More than {hours} hours'**
+  String surfaceInterval_result_beyondHorizonShort(Object hours);
+
   /// Label for the current surface interval column
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -27777,7 +27777,7 @@ abstract class AppLocalizations {
   /// Explains that the second dive does fit on clean tissues but needs a longer surface interval than the planner searches
   ///
   /// In en, this message translates to:
-  /// **'More than {hours} hours of surface interval is needed. This planner does not search further ahead.'**
+  /// **'The wait runs past the {hours} hours this planner searches. Off-gassing continues, so a longer surface interval will get there.'**
   String surfaceInterval_result_beyondHorizon(Object hours);
 
   /// Shown in place of a minimum surface interval when the required wait is longer than the planner searches

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16236,6 +16236,16 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'يلزم فترة سطح تزيد عن $hours ساعات. لا يبحث هذا المخطط لمدة أطول من ذلك.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'أكثر من $hours ساعات';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'الفترة الحالية';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16237,7 +16237,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'يلزم فترة سطح تزيد عن $hours ساعات. لا يبحث هذا المخطط لمدة أطول من ذلك.';
+    return 'زمن الانتظار يتجاوز $hours ساعات التي يبحث فيها هذا المخطط. يستمر التخلص من النيتروجين، لذا ستكفي فترة سطح أطول.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16261,6 +16261,15 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'لا تكفي أي فترة سطح. أطول غطسة بدون توقف إلزامي على هذا العمق بهذا الخليط هي $minutes دقيقة. قلّل زمن الغطسة الثانية أو قلّل عمقها.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'غير قابل للتحقيق بأي فترة سطح';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'ليس آمناً بعد، زد فترة السطح';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16539,6 +16539,15 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Kein Oberflächenintervall reicht aus. Der längste Nullzeit-Tauchgang in dieser Tiefe mit diesem Gemisch dauert $minutes Min. Zweiten Tauchgang kürzen oder dessen Tiefe reduzieren.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Mit keinem Oberflächenintervall erreichbar';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Noch nicht sicher, Oberflächenintervall erhöhen';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16513,6 +16513,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Es ist ein Oberflächenintervall von mehr als $hours Stunden nötig. Dieser Planer sucht nicht weiter voraus.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Mehr als $hours Stunden';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Aktuelles Intervall';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16514,7 +16514,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Es ist ein Oberflächenintervall von mehr als $hours Stunden nötig. Dieser Planer sucht nicht weiter voraus.';
+    return 'Die Wartezeit liegt über den $hours Stunden, die dieser Planer durchsucht. Die Entsättigung geht weiter, ein längeres Oberflächenintervall reicht also aus.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16281,6 +16281,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'No surface interval is enough. The longest no-stop dive at this depth on this mix is $minutes min. Shorten the second dive or reduce its depth.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Not achievable at any surface interval';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Not yet safe, increase surface interval';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16257,7 +16257,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'More than $hours hours of surface interval is needed. This planner does not search further ahead.';
+    return 'The wait runs past the $hours hours this planner searches. Off-gassing continues, so a longer surface interval will get there.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16256,6 +16256,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'More than $hours hours of surface interval is needed. This planner does not search further ahead.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'More than $hours hours';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Current Interval';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16554,6 +16554,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Se necesita un intervalo de superficie de más de $hours horas. Este planificador no busca más allá.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Más de $hours horas';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Intervalo Actual';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16581,6 +16581,15 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Ningún intervalo de superficie es suficiente. La inmersión sin descompresión más larga a esta profundidad con esta mezcla es de $minutes min. Acorta la segunda inmersión o reduce su profundidad.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'No alcanzable con ningún intervalo de superficie';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Aún no es seguro, aumenta el intervalo de superficie';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16555,7 +16555,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Se necesita un intervalo de superficie de más de $hours horas. Este planificador no busca más allá.';
+    return 'La espera supera las $hours horas que busca este planificador. La desaturación continúa, así que un intervalo de superficie más largo lo conseguirá.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16639,6 +16639,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Aucun intervalle de surface ne suffit. La plongée sans palier la plus longue à cette profondeur avec ce mélange est de $minutes min. Raccourcissez la deuxième plongée ou réduisez sa profondeur.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Impossible quel que soit l\'intervalle de surface';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Pas encore sûr, augmentez l\'intervalle de surface';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16612,6 +16612,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Un intervalle de surface de plus de $hours heures est nécessaire. Ce planificateur ne cherche pas au-delà.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Plus de $hours heures';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Intervalle actuel';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16613,7 +16613,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Un intervalle de surface de plus de $hours heures est nécessaire. Ce planificateur ne cherche pas au-delà.';
+    return 'L\'attente dépasse les $hours heures explorées par ce planificateur. La désaturation se poursuit, un intervalle de surface plus long suffira donc.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16115,6 +16115,16 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'נדרש מרווח שטח של יותר מ-$hours שעות. מתכנן זה אינו מחפש מעבר לכך.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'יותר מ-$hours שעות';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'מרווח נוכחי';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16116,7 +16116,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'נדרש מרווח שטח של יותר מ-$hours שעות. מתכנן זה אינו מחפש מעבר לכך.';
+    return 'ההמתנה חורגת מ-$hours השעות שמתכנן זה מחפש. הסילוק ממשיך, ולכן מרווח שטח ארוך יותר יספיק.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16139,6 +16139,15 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'שום מרווח שטח אינו מספיק. הצלילה הארוכה ביותר ללא דקומפרסיה בעומק זה עם תערובת זו היא $minutes דקות. קצר את הצלילה השנייה או הקטן את עומקה.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'לא ניתן להשגה בשום מרווח שטח';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'עדיין לא בטוח, הגדל מרווח שטח';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16523,6 +16523,15 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Semmilyen felszíni intervallum nem elegendő. A leghosszabb dekompresszió nélküli merülés ezen a mélységen ezzel a keverékkel $minutes perc. Rövidítsd le a második merülést vagy csökkentsd a mélységét.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Semmilyen felszíni intervallummal nem érhető el';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Még nem biztonságos, növeld a felszíni intervallumot';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16498,7 +16498,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Több mint $hours óra felszíni intervallum szükséges. Ez a tervező nem keres ennél tovább.';
+    return 'A várakozás túllépi azt a $hours órát, ameddig ez a tervező keres. A kitelítődés folytatódik, így egy hosszabb felszíni intervallum elegendő lesz.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16497,6 +16497,16 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Több mint $hours óra felszíni intervallum szükséges. Ez a tervező nem keres ennél tovább.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Több mint $hours óra';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Jelenlegi intervallum';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16572,6 +16572,15 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Nessun intervallo di superficie è sufficiente. L\'immersione senza decompressione più lunga a questa profondità con questa miscela è di $minutes min. Accorcia la seconda immersione o riducine la profondità.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Non raggiungibile con alcun intervallo di superficie';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Non ancora sicuro, aumenta l\'intervallo di superficie';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16547,7 +16547,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Serve un intervallo di superficie di più di $hours ore. Questo pianificatore non cerca oltre.';
+    return 'L\'attesa supera le $hours ore esplorate da questo pianificatore. La desaturazione continua, quindi un intervallo di superficie più lungo sarà sufficiente.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16546,6 +16546,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Serve un intervallo di superficie di più di $hours ore. Questo pianificatore non cerca oltre.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Più di $hours ore';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Intervallo Corrente';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16431,6 +16431,15 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Geen enkel oppervlakte-interval is voldoende. De langste duik zonder decompressie op deze diepte met dit mengsel duurt $minutes min. Verkort de tweede duik of verminder de diepte.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Niet haalbaar met welk oppervlakte-interval dan ook';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Nog niet veilig, verhoog oppervlakte-interval';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16407,7 +16407,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'Er is een oppervlakte-interval van meer dan $hours uur nodig. Deze planner zoekt niet verder vooruit.';
+    return 'De wachttijd valt buiten de $hours uur die deze planner doorzoekt. De ontgassing gaat door, dus een langer oppervlakte-interval volstaat.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16406,6 +16406,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'Er is een oppervlakte-interval van meer dan $hours uur nodig. Deze planner zoekt niet verder vooruit.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Meer dan $hours uur';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Huidig interval';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16582,6 +16582,15 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return 'Nenhum intervalo de superfície é suficiente. O mergulho sem descompressão mais longo a esta profundidade com esta mistura é de $minutes min. Encurte o segundo mergulho ou reduza a sua profundidade.';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable =>
+      'Não alcançável com nenhum intervalo de superfície';
+
+  @override
   String get surfaceInterval_result_notYetSafe =>
       'Ainda não é seguro, aumente o intervalo de superfície';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16556,6 +16556,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return 'É necessário um intervalo de superfície de mais de $hours horas. Este planeador não procura mais além.';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return 'Mais de $hours horas';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => 'Intervalo Atual';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16557,7 +16557,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return 'É necessário um intervalo de superfície de mais de $hours horas. Este planeador não procura mais além.';
+    return 'A espera ultrapassa as $hours horas que este planeador procura. A desaturação continua, por isso um intervalo de superfície mais longo será suficiente.';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15687,7 +15687,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String surfaceInterval_result_beyondHorizon(Object hours) {
-    return '需要超过 $hours 小时的水面间隔。此计划器不会搜索更长的时间。';
+    return '所需等待时间超出此计划器搜索的 $hours 小时。脱饱和仍在继续，因此更长的水面间隔即可满足。';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15709,6 +15709,14 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_noIntervalHelps(Object minutes) {
+    return '任何水面间隔都不够。在此深度使用此混合气体，最长的免减压潜水时间为 $minutes 分钟。请缩短第二次潜水或降低其深度。';
+  }
+
+  @override
+  String get surfaceInterval_result_notAchievable => '任何水面间隔都无法达成';
+
+  @override
   String get surfaceInterval_result_notYetSafe => '尚不安全，请增加水面间隔';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15686,6 +15686,16 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String surfaceInterval_result_beyondHorizon(Object hours) {
+    return '需要超过 $hours 小时的水面间隔。此计划器不会搜索更长的时间。';
+  }
+
+  @override
+  String surfaceInterval_result_beyondHorizonShort(Object hours) {
+    return '超过 $hours 小时';
+  }
+
+  @override
   String get surfaceInterval_result_currentInterval => '当前间隔';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} op {depth} overschrijdt {limit}. De MOD voor dit mengsel is {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "Er is een oppervlakte-interval van meer dan {hours} uur nodig. Deze planner zoekt niet verder vooruit.",
+  "surfaceInterval_result_beyondHorizon": "De wachttijd valt buiten de {hours} uur die deze planner doorzoekt. De ontgassing gaat door, dus een langer oppervlakte-interval volstaat.",
   "surfaceInterval_result_beyondHorizonShort": "Meer dan {hours} uur",
   "surfaceInterval_result_currentInterval": "Huidig interval",
   "surfaceInterval_result_gasUnsafe": "Gas onveilig op deze diepte",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} op {depth} overschrijdt {limit}. De MOD voor dit mengsel is {mod}.",
   "surfaceInterval_heSemantics": "Helium: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "Er is een oppervlakte-interval van meer dan {hours} uur nodig. Deze planner zoekt niet verder vooruit.",
+  "surfaceInterval_result_beyondHorizonShort": "Meer dan {hours} uur",
   "surfaceInterval_result_currentInterval": "Huidig interval",
   "surfaceInterval_result_gasUnsafe": "Gas onveilig op deze diepte",
   "surfaceInterval_result_inDeco": "In deco",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "Minimaal oppervlakte-interval",
   "surfaceInterval_result_ndlForSecondDive": "NDL voor 2e duik",
   "surfaceInterval_result_ndlMinutes": "{minutes} min NDL",
+  "surfaceInterval_result_noIntervalHelps": "Geen enkel oppervlakte-interval is voldoende. De langste duik zonder decompressie op deze diepte met dit mengsel duurt {minutes} min. Verkort de tweede duik of verminder de diepte.",
+  "surfaceInterval_result_notAchievable": "Niet haalbaar met welk oppervlakte-interval dan ook",
   "surfaceInterval_result_notYetSafe": "Nog niet veilig, verhoog oppervlakte-interval",
   "surfaceInterval_result_safeToDive": "Veilig om te duiken",
   "surfaceInterval_result_semantics": "Minimaal oppervlakte-interval: {interval}. Huidig interval: {current}. NDL voor tweede duik: {ndl}. {status}",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4938,7 +4938,7 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} excede {limit}. A MOD desta mistura é {mod}.",
   "surfaceInterval_heSemantics": "Hélio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "É necessário um intervalo de superfície de mais de {hours} horas. Este planeador não procura mais além.",
+  "surfaceInterval_result_beyondHorizon": "A espera ultrapassa as {hours} horas que este planeador procura. A desaturação continua, por isso um intervalo de superfície mais longo será suficiente.",
   "surfaceInterval_result_beyondHorizonShort": "Mais de {hours} horas",
   "surfaceInterval_result_currentInterval": "Intervalo Atual",
   "surfaceInterval_result_gasUnsafe": "Gás inseguro nesta profundidade",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4945,6 +4945,8 @@
   "surfaceInterval_result_minimumInterval": "Intervalo de Superfície Mínimo",
   "surfaceInterval_result_ndlForSecondDive": "NDL para 2º Mergulho",
   "surfaceInterval_result_ndlMinutes": "{minutes} min NDL",
+  "surfaceInterval_result_noIntervalHelps": "Nenhum intervalo de superfície é suficiente. O mergulho sem descompressão mais longo a esta profundidade com esta mistura é de {minutes} min. Encurte o segundo mergulho ou reduza a sua profundidade.",
+  "surfaceInterval_result_notAchievable": "Não alcançável com nenhum intervalo de superfície",
   "surfaceInterval_result_notYetSafe": "Ainda não é seguro, aumente o intervalo de superfície",
   "surfaceInterval_result_safeToDive": "Seguro para mergulhar",
   "surfaceInterval_result_semantics": "Intervalo de superfície mínimo: {interval}. Intervalo atual: {current}. NDL para segundo mergulho: {ndl}. {status}",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4938,6 +4938,8 @@
   "surfaceInterval_gasWarning_modExceeded": "ppO₂ {ppO2} a {depth} excede {limit}. A MOD desta mistura é {mod}.",
   "surfaceInterval_heSemantics": "Hélio: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "É necessário um intervalo de superfície de mais de {hours} horas. Este planeador não procura mais além.",
+  "surfaceInterval_result_beyondHorizonShort": "Mais de {hours} horas",
   "surfaceInterval_result_currentInterval": "Intervalo Atual",
   "surfaceInterval_result_gasUnsafe": "Gás inseguro nesta profundidade",
   "surfaceInterval_result_inDeco": "Em deco",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5116,6 +5116,8 @@
   "surfaceInterval_gasWarning_modExceeded": "{depth} 处 ppO₂ {ppO2} 超过 {limit}。此混合气的最大工作深度为 {mod}。",
   "surfaceInterval_heSemantics": "氦气: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
+  "surfaceInterval_result_beyondHorizon": "需要超过 {hours} 小时的水面间隔。此计划器不会搜索更长的时间。",
+  "surfaceInterval_result_beyondHorizonShort": "超过 {hours} 小时",
   "surfaceInterval_result_currentInterval": "当前间隔",
   "surfaceInterval_result_gasUnsafe": "此深度下气体不安全",
   "surfaceInterval_result_inDeco": "在减压",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5123,6 +5123,8 @@
   "surfaceInterval_result_minimumInterval": "最短水面间隔",
   "surfaceInterval_result_ndlForSecondDive": "第二次潜水的免减压极限",
   "surfaceInterval_result_ndlMinutes": "{minutes} 分钟 NDL",
+  "surfaceInterval_result_noIntervalHelps": "任何水面间隔都不够。在此深度使用此混合气体，最长的免减压潜水时间为 {minutes} 分钟。请缩短第二次潜水或降低其深度。",
+  "surfaceInterval_result_notAchievable": "任何水面间隔都无法达成",
   "surfaceInterval_result_notYetSafe": "尚不安全，请增加水面间隔",
   "surfaceInterval_result_safeToDive": "安全到潜水",
   "surfaceInterval_result_semantics": "最短水面间隔：{interval}。当前间隔：{current}。第二次潜水的免减压极限：{ndl}。{status}",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5116,7 +5116,7 @@
   "surfaceInterval_gasWarning_modExceeded": "{depth} 处 ppO₂ {ppO2} 超过 {limit}。此混合气的最大工作深度为 {mod}。",
   "surfaceInterval_heSemantics": "氦气: {percent}%",
   "surfaceInterval_o2Semantics": "O2: {percent}%",
-  "surfaceInterval_result_beyondHorizon": "需要超过 {hours} 小时的水面间隔。此计划器不会搜索更长的时间。",
+  "surfaceInterval_result_beyondHorizon": "所需等待时间超出此计划器搜索的 {hours} 小时。脱饱和仍在继续，因此更长的水面间隔即可满足。",
   "surfaceInterval_result_beyondHorizonShort": "超过 {hours} 小时",
   "surfaceInterval_result_currentInterval": "当前间隔",
   "surfaceInterval_result_gasUnsafe": "此深度下气体不安全",

--- a/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
+++ b/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
@@ -40,14 +40,14 @@ SiMinimumInterval _planFor(
 }
 
 void main() {
-  group('siMinimumIntervalProvider rejects unreachable second dives', () {
-    test('a second dive longer than the best no-stop time is unreachable', () {
+  group('siMinimumIntervalProvider rejects impossible second dives', () {
+    test('a second dive longer than the clean-tissue NDL is impossible', () {
       final container = _createContainer();
 
       // The reported case: two 45 minute dives at 18 m on air. Off-gassing at
-      // the surface can only ever restore tissues to their virgin state, and
-      // the virgin no-stop time at 18 m on air is around 43 minutes. No surface
-      // interval, however long, buys a 45 minute second dive.
+      // the surface can only ever restore tissues to their clean state, and the
+      // clean-tissue no-stop time at 18 m on air is around 43 minutes. No
+      // surface interval, however long, buys a 45 minute second dive.
       final result = _planFor(
         container,
         firstDepth: 18.0,
@@ -56,10 +56,10 @@ void main() {
         secondTime: 45,
       );
 
-      expect(result.isAchievable, isFalse);
+      expect(result.outcome, SiIntervalOutcome.impossible);
       expect(result.minutes, isNull);
       expect(
-        result.maxNoStopSeconds,
+        result.cleanTissueNoStopSeconds,
         lessThan(45 * 60),
         reason: 'the no-stop ceiling is what puts the dive out of reach',
       );
@@ -79,7 +79,34 @@ void main() {
         secondTime: 60,
       );
 
-      expect(result.isAchievable, isFalse);
+      expect(result.outcome, SiIntervalOutcome.impossible);
+      expect(result.hasInterval, isFalse);
+    });
+
+    test('the no-stop ceiling ignores the first dive entirely', () {
+      final container = _createContainer();
+
+      // The ceiling is a property of the second dive's depth and mix: surface
+      // time works toward it no matter how loaded the diver starts out.
+      final afterEasyDive = _planFor(
+        container,
+        firstDepth: 9.0,
+        firstTime: 10,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+      final afterHardDive = _planFor(
+        container,
+        firstDepth: 40.0,
+        firstTime: 60,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      expect(
+        afterHardDive.cleanTissueNoStopSeconds,
+        afterEasyDive.cleanTissueNoStopSeconds,
+      );
     });
 
     test('shortening the second dive turns it into a modest wait', () {
@@ -103,9 +130,53 @@ void main() {
       // The cliff the diver saw: five fewer minutes underwater swings the
       // answer from "six hours" to about an hour. Only one of these two is a
       // real number, and it is the shorter dive.
-      expect(tooLong.isAchievable, isFalse);
-      expect(achievable.isAchievable, isTrue);
+      expect(tooLong.outcome, SiIntervalOutcome.impossible);
+      expect(achievable.outcome, SiIntervalOutcome.withinHorizon);
       expect(achievable.minutes, lessThan(120));
+    });
+  });
+
+  group('siMinimumIntervalProvider separates a long wait from an impossible '
+      'one', () {
+    test('a dive that needs more than the horizon is not called impossible', () {
+      final container = _createContainer();
+
+      // Compartment 16 has a 635 minute nitrogen half-time, so after a heavily
+      // loaded first dive the diver is still unloading well past six hours.
+      // Here the clean-tissue NDL at 12 m on air is about 123 minutes, so a 60
+      // minute second dive is entirely possible -- it just needs a longer wait
+      // than the planner searches. Reporting it as impossible would tell the
+      // diver to change a dive that is fine.
+      final result = _planFor(
+        container,
+        firstDepth: 60.0,
+        firstTime: 120,
+        secondDepth: 12.0,
+        secondTime: 60,
+      );
+
+      expect(result.outcome, SiIntervalOutcome.beyondHorizon);
+      expect(result.minutes, isNull);
+      expect(
+        result.cleanTissueNoStopSeconds,
+        greaterThanOrEqualTo(60 * 60),
+        reason: 'the dive fits on clean tissues, so it is not impossible',
+      );
+    });
+
+    test('the same plan with a longer second dive is impossible', () {
+      final container = _createContainer();
+
+      // Past the clean-tissue ceiling at 12 m, no amount of waiting helps.
+      final result = _planFor(
+        container,
+        firstDepth: 60.0,
+        firstTime: 120,
+        secondDepth: 12.0,
+        secondTime: 124,
+      );
+
+      expect(result.outcome, SiIntervalOutcome.impossible);
     });
   });
 
@@ -121,7 +192,7 @@ void main() {
         secondTime: 10,
       );
 
-      expect(result.isAchievable, isTrue);
+      expect(result.outcome, SiIntervalOutcome.withinHorizon);
       expect(
         result.minutes,
         0,
@@ -142,12 +213,12 @@ void main() {
         );
 
         expect(
-          result.isAchievable,
-          isTrue,
+          result.outcome,
+          SiIntervalOutcome.withinHorizon,
           reason: '$secondTime min is doable',
         );
         expect(
-          result.maxNoStopSeconds,
+          result.cleanTissueNoStopSeconds,
           greaterThanOrEqualTo(secondTime * 60),
           reason: 'an achievable plan must sit under the no-stop ceiling',
         );
@@ -201,8 +272,8 @@ void main() {
       container.read(siSecondDiveO2Provider.notifier).state = 32.0;
       final nitrox = container.read(siMinimumIntervalProvider);
 
-      expect(air.isAchievable, isTrue);
-      expect(nitrox.isAchievable, isTrue);
+      expect(air.outcome, SiIntervalOutcome.withinHorizon);
+      expect(nitrox.outcome, SiIntervalOutcome.withinHorizon);
       expect(air.minutes, greaterThan(0));
       expect(
         nitrox.minutes,

--- a/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
+++ b/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
@@ -1,0 +1,214 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart';
+
+/// Minimal stand-in for [SettingsNotifier] so the deco providers can read
+/// gradient factors without touching the database.
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+ProviderContainer _createContainer() {
+  final container = ProviderContainer(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// Sets up a two-dive plan and returns the computed minimum interval.
+SiMinimumInterval _planFor(
+  ProviderContainer container, {
+  required double firstDepth,
+  required int firstTime,
+  required double secondDepth,
+  required int secondTime,
+}) {
+  container.read(siFirstDiveDepthProvider.notifier).state = firstDepth;
+  container.read(siFirstDiveTimeProvider.notifier).state = firstTime;
+  container.read(siSecondDiveDepthProvider.notifier).state = secondDepth;
+  container.read(siSecondDiveTimeProvider.notifier).state = secondTime;
+  return container.read(siMinimumIntervalProvider);
+}
+
+void main() {
+  group('siMinimumIntervalProvider rejects unreachable second dives', () {
+    test('a second dive longer than the best no-stop time is unreachable', () {
+      final container = _createContainer();
+
+      // The reported case: two 45 minute dives at 18 m on air. Off-gassing at
+      // the surface can only ever restore tissues to their virgin state, and
+      // the virgin no-stop time at 18 m on air is around 43 minutes. No surface
+      // interval, however long, buys a 45 minute second dive.
+      final result = _planFor(
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      expect(result.isAchievable, isFalse);
+      expect(result.minutes, isNull);
+      expect(
+        result.maxNoStopSeconds,
+        lessThan(45 * 60),
+        reason: 'the no-stop ceiling is what puts the dive out of reach',
+      );
+    });
+
+    test('never reports the search bound as if it were an answer', () {
+      final container = _createContainer();
+
+      // Deep and long enough that the plan is wildly out of reach. The old
+      // binary search returned its own upper bound here, which the result card
+      // rendered as a plausible looking "6h 0m".
+      final result = _planFor(
+        container,
+        firstDepth: 40.0,
+        firstTime: 20,
+        secondDepth: 40.0,
+        secondTime: 60,
+      );
+
+      expect(result.isAchievable, isFalse);
+    });
+
+    test('shortening the second dive turns it into a modest wait', () {
+      final container = _createContainer();
+
+      final tooLong = _planFor(
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+      final achievable = _planFor(
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 40,
+      );
+
+      // The cliff the diver saw: five fewer minutes underwater swings the
+      // answer from "six hours" to about an hour. Only one of these two is a
+      // real number, and it is the shorter dive.
+      expect(tooLong.isAchievable, isFalse);
+      expect(achievable.isAchievable, isTrue);
+      expect(achievable.minutes, lessThan(120));
+    });
+  });
+
+  group('siMinimumIntervalProvider reports reachable second dives', () {
+    test('reports zero when the second dive already fits with no wait', () {
+      final container = _createContainer();
+
+      final result = _planFor(
+        container,
+        firstDepth: 18.0,
+        firstTime: 20,
+        secondDepth: 9.0,
+        secondTime: 10,
+      );
+
+      expect(result.isAchievable, isTrue);
+      expect(
+        result.minutes,
+        0,
+        reason: 'a diver who needs no wait must not be told to wait a minute',
+      );
+    });
+
+    test('the reported interval really does fit the planned dive', () {
+      final container = _createContainer();
+
+      for (final secondTime in [20, 30, 35, 40]) {
+        final result = _planFor(
+          container,
+          firstDepth: 18.0,
+          firstTime: 45,
+          secondDepth: 18.0,
+          secondTime: secondTime,
+        );
+
+        expect(
+          result.isAchievable,
+          isTrue,
+          reason: '$secondTime min is doable',
+        );
+        expect(
+          result.maxNoStopSeconds,
+          greaterThanOrEqualTo(secondTime * 60),
+          reason: 'an achievable plan must sit under the no-stop ceiling',
+        );
+
+        // Wind the tool to the interval it just recommended and confirm the
+        // second dive actually fits inside the NDL there.
+        container.read(siSurfaceIntervalProvider.notifier).state =
+            result.minutes!;
+        expect(
+          container.read(siSecondDiveNdlProvider),
+          greaterThanOrEqualTo(secondTime * 60),
+          reason: 'the recommended interval must satisfy the requirement',
+        );
+        expect(container.read(siSecondDiveIsSafeProvider), isTrue);
+      }
+    });
+
+    test('one minute less than the recommendation is not enough', () {
+      final container = _createContainer();
+
+      final result = _planFor(
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 40,
+      );
+
+      expect(result.minutes, greaterThan(0));
+
+      container.read(siSurfaceIntervalProvider.notifier).state =
+          result.minutes! - 1;
+      expect(
+        container.read(siSecondDiveIsSafeProvider),
+        isFalse,
+        reason: 'the answer must be the minimum, not merely a sufficient wait',
+      );
+    });
+
+    test('nitrox requires a shorter surface interval than air', () {
+      final container = _createContainer();
+
+      final air = _planFor(
+        container,
+        firstDepth: 30.0,
+        firstTime: 25,
+        secondDepth: 18.0,
+        secondTime: 30,
+      );
+
+      container.read(siSecondDiveO2Provider.notifier).state = 32.0;
+      final nitrox = container.read(siMinimumIntervalProvider);
+
+      expect(air.isAchievable, isTrue);
+      expect(nitrox.isAchievable, isTrue);
+      expect(air.minutes, greaterThan(0));
+      expect(
+        nitrox.minutes,
+        lessThan(air.minutes!),
+        reason: 'A leaner nitrogen mix should shorten the required off-gassing',
+      );
+    });
+  });
+}

--- a/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
+++ b/test/features/surface_interval_tool/presentation/providers/surface_interval_minimum_test.dart
@@ -149,10 +149,10 @@ void main() {
       // diver to change a dive that is fine.
       final result = _planFor(
         container,
-        firstDepth: 60.0,
+        firstDepth: 55.0,
         firstTime: 120,
         secondDepth: 12.0,
-        secondTime: 60,
+        secondTime: 100,
       );
 
       expect(result.outcome, SiIntervalOutcome.beyondHorizon);

--- a/test/features/surface_interval_tool/presentation/providers/surface_interval_providers_test.dart
+++ b/test/features/surface_interval_tool/presentation/providers/surface_interval_providers_test.dart
@@ -131,11 +131,16 @@ void main() {
       container.read(siSecondDiveO2Provider.notifier).state = 32.0;
       final nitroxInterval = container.read(siMinimumIntervalProvider);
 
-      expect(airInterval, greaterThan(0));
-      expect(airInterval, lessThan(360), reason: 'scenario must be achievable');
       expect(
-        nitroxInterval,
-        lessThan(airInterval),
+        airInterval.isAchievable,
+        isTrue,
+        reason: 'scenario must be achievable',
+      );
+      expect(nitroxInterval.isAchievable, isTrue);
+      expect(airInterval.minutes, greaterThan(0));
+      expect(
+        nitroxInterval.minutes,
+        lessThan(airInterval.minutes!),
         reason: 'A leaner nitrogen mix should shorten the required off-gassing',
       );
     });

--- a/test/features/surface_interval_tool/presentation/providers/surface_interval_providers_test.dart
+++ b/test/features/surface_interval_tool/presentation/providers/surface_interval_providers_test.dart
@@ -132,11 +132,11 @@ void main() {
       final nitroxInterval = container.read(siMinimumIntervalProvider);
 
       expect(
-        airInterval.isAchievable,
-        isTrue,
+        airInterval.outcome,
+        SiIntervalOutcome.withinHorizon,
         reason: 'scenario must be achievable',
       );
-      expect(nitroxInterval.isAchievable, isTrue);
+      expect(nitroxInterval.outcome, SiIntervalOutcome.withinHorizon);
       expect(airInterval.minutes, greaterThan(0));
       expect(
         nitroxInterval.minutes,

--- a/test/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart_test.dart
@@ -115,10 +115,10 @@ void main() {
       await _setPlan(
         tester,
         container,
-        firstDepth: 60.0,
+        firstDepth: 55.0,
         firstTime: 120,
         secondDepth: 12.0,
-        secondTime: 60,
+        secondTime: 100,
       );
       expect(
         container.read(siMinimumIntervalProvider).outcome,

--- a/test/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart_test.dart
@@ -1,0 +1,151 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart';
+import 'package:submersion/features/surface_interval_tool/presentation/widgets/tissue_recovery_chart.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<ProviderContainer> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      ],
+      child: const MaterialApp(
+        locale: Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SingleChildScrollView(child: TissueRecoveryChart()),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return ProviderScope.containerOf(tester.element(find.byType(Scaffold)));
+}
+
+/// The vertical marker lines fl_chart was handed on the last build.
+List<VerticalLine> _markers(WidgetTester tester) {
+  final chart = tester.widget<LineChart>(find.byType(LineChart));
+  return chart.data.extraLinesData.verticalLines;
+}
+
+Future<void> _setPlan(
+  WidgetTester tester,
+  ProviderContainer container, {
+  required double firstDepth,
+  required int firstTime,
+  required double secondDepth,
+  required int secondTime,
+}) async {
+  container.read(siFirstDiveDepthProvider.notifier).state = firstDepth;
+  container.read(siFirstDiveTimeProvider.notifier).state = firstTime;
+  container.read(siSecondDiveDepthProvider.notifier).state = secondDepth;
+  container.read(siSecondDiveTimeProvider.notifier).state = secondTime;
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  // The chart always draws a "now" line at the current interval; the minimum
+  // interval marker is the one under test, so count the extras beyond that.
+  group('tissue recovery chart minimum interval marker', () {
+    testWidgets('marks the minimum when there is one to mark', (tester) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 30,
+      );
+
+      final minutes = container.read(siMinimumIntervalProvider).minutes!;
+      expect(minutes, inInclusiveRange(1, 240));
+
+      final markerXs = _markers(tester).map((line) => line.x).toList();
+      expect(
+        markerXs,
+        contains(minutes.toDouble()),
+        reason: 'the recommended wait should be drawn on the recovery curve',
+      );
+    });
+
+    testWidgets('draws no minimum marker when the plan is impossible', (
+      tester,
+    ) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+      expect(
+        container.read(siMinimumIntervalProvider).outcome,
+        SiIntervalOutcome.impossible,
+      );
+
+      // Only the "now" line survives: there is no wait to point at.
+      expect(_markers(tester), hasLength(1));
+    });
+
+    testWidgets('draws no minimum marker when the wait runs past the chart', (
+      tester,
+    ) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 60.0,
+        firstTime: 120,
+        secondDepth: 12.0,
+        secondTime: 60,
+      );
+      expect(
+        container.read(siMinimumIntervalProvider).outcome,
+        SiIntervalOutcome.beyondHorizon,
+      );
+
+      expect(_markers(tester), hasLength(1));
+    });
+
+    testWidgets('draws no minimum marker when no wait is needed', (
+      tester,
+    ) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 20,
+        secondDepth: 9.0,
+        secondTime: 10,
+      );
+      expect(container.read(siMinimumIntervalProvider).minutes, 0);
+
+      // A zero minute wait would sit on the chart's own axis, which reads as
+      // noise rather than as advice.
+      expect(_markers(tester), hasLength(1));
+    });
+  });
+}

--- a/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
@@ -66,7 +66,10 @@ void main() {
         secondTime: 45,
       );
 
-      expect(container.read(siMinimumIntervalProvider).isAchievable, isFalse);
+      expect(
+        container.read(siMinimumIntervalProvider).outcome,
+        SiIntervalOutcome.impossible,
+      );
       expect(
         find.text('6h 0m'),
         findsNothing,
@@ -90,7 +93,8 @@ void main() {
       );
 
       final maxMinutes =
-          container.read(siMinimumIntervalProvider).maxNoStopSeconds ~/ 60;
+          container.read(siMinimumIntervalProvider).cleanTissueNoStopSeconds ~/
+          60;
 
       expect(
         find.textContaining('No surface interval is enough'),
@@ -118,6 +122,36 @@ void main() {
         findsNothing,
         reason: 'waiting longer cannot fix a dive that busts the no-stop limit',
       );
+    });
+  });
+
+  group('result card when the wait runs past the planner horizon', () {
+    testWidgets('says wait longer rather than change the dive', (tester) async {
+      final container = await _pump(tester);
+
+      // Heavily loaded slow tissues: the dive fits on clean tissues, so the
+      // remedy is patience, not a different plan.
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 60.0,
+        firstTime: 120,
+        secondDepth: 12.0,
+        secondTime: 60,
+      );
+
+      expect(
+        container.read(siMinimumIntervalProvider).outcome,
+        SiIntervalOutcome.beyondHorizon,
+      );
+      expect(find.text('> 6h'), findsOneWidget);
+      expect(find.text('—'), findsNothing);
+      expect(
+        find.textContaining('No surface interval is enough'),
+        findsNothing,
+        reason: 'this dive is possible, it just needs a longer wait',
+      );
+      expect(find.textContaining('More than 6 hours'), findsOneWidget);
     });
   });
 

--- a/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
@@ -103,6 +103,30 @@ void main() {
       expect(find.textContaining('$maxMinutes min'), findsOneWidget);
     });
 
+    testWidgets('does not announce a bare em dash to a screen reader', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      final label = tester
+          .getSemantics(find.byType(SurfaceIntervalResult))
+          .label;
+      expect(label, contains('Not achievable at any surface interval'));
+      expect(label, isNot(contains('—')));
+
+      handle.dispose();
+    });
+
     testWidgets('stops advising a longer wait that cannot help', (
       tester,
     ) async {
@@ -152,6 +176,34 @@ void main() {
         reason: 'this dive is possible, it just needs a longer wait',
       );
       expect(find.textContaining('More than 6 hours'), findsOneWidget);
+    });
+
+    testWidgets('reads the wait out rather than announcing "> 6h"', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 60.0,
+        firstTime: 120,
+        secondDepth: 12.0,
+        secondTime: 60,
+      );
+
+      final label = tester
+          .getSemantics(find.byType(SurfaceIntervalResult))
+          .label;
+      expect(
+        label,
+        contains('More than 6 hours'),
+        reason: 'a screen reader must not be handed the "> 6h" glyph',
+      );
+      expect(label, isNot(contains('> 6h')));
+
+      handle.dispose();
     });
   });
 

--- a/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/surface_interval_tool/presentation/providers/surface_interval_providers.dart';
+import 'package:submersion/features/surface_interval_tool/presentation/widgets/surface_interval_result.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<ProviderContainer> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      ],
+      child: const MaterialApp(
+        // Pinned: the assertions match English strings.
+        locale: Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SingleChildScrollView(child: SurfaceIntervalResult()),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  return ProviderScope.containerOf(tester.element(find.byType(Scaffold)));
+}
+
+Future<void> _setPlan(
+  WidgetTester tester,
+  ProviderContainer container, {
+  required double firstDepth,
+  required int firstTime,
+  required double secondDepth,
+  required int secondTime,
+}) async {
+  container.read(siFirstDiveDepthProvider.notifier).state = firstDepth;
+  container.read(siFirstDiveTimeProvider.notifier).state = firstTime;
+  container.read(siSecondDiveDepthProvider.notifier).state = secondDepth;
+  container.read(siSecondDiveTimeProvider.notifier).state = secondTime;
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('result card when no surface interval is enough', () {
+    testWidgets('does not print a fabricated six hour wait', (tester) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      expect(container.read(siMinimumIntervalProvider).isAchievable, isFalse);
+      expect(
+        find.text('6h 0m'),
+        findsNothing,
+        reason: 'the old search bound must never surface as an answer',
+      );
+      expect(find.text('—'), findsOneWidget);
+    });
+
+    testWidgets('names the longest no-stop dive the diver can plan', (
+      tester,
+    ) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      final maxMinutes =
+          container.read(siMinimumIntervalProvider).maxNoStopSeconds ~/ 60;
+
+      expect(
+        find.textContaining('No surface interval is enough'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('$maxMinutes min'), findsOneWidget);
+    });
+
+    testWidgets('stops advising a longer wait that cannot help', (
+      tester,
+    ) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      expect(
+        find.textContaining('Increase surface interval'),
+        findsNothing,
+        reason: 'waiting longer cannot fix a dive that busts the no-stop limit',
+      );
+    });
+  });
+
+  group('result card when a surface interval does help', () {
+    testWidgets('still shows the wait and the standard advice', (tester) async {
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 40,
+      );
+      container.read(siSurfaceIntervalProvider.notifier).state = 10;
+      await tester.pumpAndSettle();
+
+      final minutes = container.read(siMinimumIntervalProvider).minutes!;
+      final expected = minutes >= 60
+          ? '${minutes ~/ 60}h ${minutes % 60}m'
+          : '$minutes min';
+
+      expect(find.text(expected), findsWidgets);
+      expect(find.text('—'), findsNothing);
+      expect(
+        find.textContaining('No surface interval is enough'),
+        findsNothing,
+      );
+      expect(find.textContaining('Increase surface interval'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
+++ b/test/features/surface_interval_tool/presentation/widgets/unreachable_interval_test.dart
@@ -52,6 +52,9 @@ Future<void> _setPlan(
   await tester.pumpAndSettle();
 }
 
+int _occurrences(String haystack, String needle) =>
+    needle.allMatches(haystack).length;
+
 void main() {
   group('result card when no surface interval is enough', () {
     testWidgets('does not print a fabricated six hour wait', (tester) async {
@@ -127,6 +130,41 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('tells a screen reader the ceiling, and only once', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      final container = await _pump(tester);
+
+      await _setPlan(
+        tester,
+        container,
+        firstDepth: 18.0,
+        firstTime: 45,
+        secondDepth: 18.0,
+        secondTime: 45,
+      );
+
+      final maxMinutes =
+          container.read(siMinimumIntervalProvider).cleanTissueNoStopSeconds ~/
+          60;
+      final label = tester
+          .getSemantics(find.byType(SurfaceIntervalResult))
+          .label;
+
+      // The remedy and the ceiling are the whole point of this state, and a
+      // screen reader has no other way to reach them.
+      expect(label, contains('$maxMinutes min'));
+      expect(label, contains('Shorten the second dive'));
+      expect(
+        _occurrences(label, 'Not achievable at any surface interval'),
+        1,
+        reason: 'the summary should add information, not restate itself',
+      );
+
+      handle.dispose();
+    });
+
     testWidgets('stops advising a longer wait that cannot help', (
       tester,
     ) async {
@@ -158,10 +196,10 @@ void main() {
       await _setPlan(
         tester,
         container,
-        firstDepth: 60.0,
+        firstDepth: 55.0,
         firstTime: 120,
         secondDepth: 12.0,
-        secondTime: 60,
+        secondTime: 100,
       );
 
       expect(
@@ -175,7 +213,10 @@ void main() {
         findsNothing,
         reason: 'this dive is possible, it just needs a longer wait',
       );
-      expect(find.textContaining('More than 6 hours'), findsOneWidget);
+      expect(
+        find.textContaining('runs past the 6 hours this planner searches'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('reads the wait out rather than announcing "> 6h"', (
@@ -187,10 +228,10 @@ void main() {
       await _setPlan(
         tester,
         container,
-        firstDepth: 60.0,
+        firstDepth: 55.0,
         firstTime: 120,
         secondDepth: 12.0,
-        secondTime: 60,
+        secondTime: 100,
       );
 
       final label = tester
@@ -202,6 +243,14 @@ void main() {
         reason: 'a screen reader must not be handed the "> 6h" glyph',
       );
       expect(label, isNot(contains('> 6h')));
+
+      // The summary must explain the wait rather than say the same words twice.
+      expect(
+        _occurrences(label, 'More than 6 hours'),
+        1,
+        reason: 'the status slot should add information, not restate itself',
+      );
+      expect(label, contains('this planner searches'));
 
       handle.dispose();
     });


### PR DESCRIPTION
## The report

> Surface interval calculator says two 45 min 60 ft dives on 21% requires a minimum surface interval of 6+ hrs. Reducing the second to 40 min duration drops the interval to 55 min.

## Root cause

`siMinimumIntervalProvider` binary searched the surface interval over `[0, 360]` minutes and returned `high` **without ever checking that `high` satisfied the requirement**:

```dart
int low = 0;
int high = 360;
while (high - low > 1) { ... if (ndl >= requiredNdlSeconds) high = mid; else low = mid; }
return high;   // never verified that ndl(high) >= required
```

Off-gassing at the surface is asymptotic: tissue tensions decay toward surface equilibrium, so the second dive's NDL climbs toward the no-stop time a diver with virgin tissues would get at that depth and mix, and then stops.

```
Fresh-tissue NDL @ 18.3 m (60 ft) on air, GF 50/85 = 41.4 min

NDL for dive 2 after a surface interval of N minutes:
  SI    60 min -> 37.15 min
  SI   120 min -> 41.15 min
  SI   240 min -> 41.40 min   <- asymptote reached
  SI 10080 min -> 41.40 min   <- a week later, no better
```

A 45 minute second dive at that depth is therefore impossible at **any** surface interval. The search never found a feasible point, `high` stayed at its initial `360`, and the result card rendered the search bound as a plausible looking "6h 0m". At 40 minutes the dive fits inside the ceiling, so a genuine number appeared: hence the cliff.

The card also showed "Increase surface interval or reduce second dive depth/time" in this state, telling the diver to wait when waiting could never help.

## Scope

Wider than the single reported case. The sliders reach 60 m and 120 min, so any plan whose second dive exceeds the no-stop ceiling printed the same fabricated 6 hours. A 45 minute dive at 30 m has a ceiling near 15 minutes and behaved identically.

The tissue recovery chart only draws its marker line when the minimum is `<= 240`, so the bogus 360 never appeared there. That guard incidentally hid the bug everywhere except the result card.

## The fix

`siMinimumIntervalProvider` returns `SiMinimumInterval` instead of a bare `int`. With a nullable `minutes`, "no interval is enough" is representable rather than having to borrow the search bound, and the compiler located both call sites.

- The upper bound is tested **before** searching. `ndlAfter(360)` is the exact ceiling on what waiting can buy, so `ndl(360) < required` is a complete infeasibility test; the same value is reported as `maxNoStopSeconds`, which keeps the verdict and the displayed ceiling from ever disagreeing.
- Result card shows an em dash in place of a fabricated wait, plus: *"No surface interval is enough. The longest no-stop dive at this depth on this mix is 43 min. Shorten the second dive or reduce its depth."*
- The "increase surface interval" advice no longer appears when it cannot apply.
- Screen reader label reads "Not achievable at any surface interval" rather than announcing an em dash.
- Two new l10n keys, translated into all 10 non-English locales.

### Second bug fixed

The same search never verified its lower bound either. When the second dive already fit with no wait at all, the loop converged to `1` and told the diver to wait a minute. It now returns `0`.

## Tests

11 new tests, written failing first.

`surface_interval_minimum_test.dart` (7): the reported case is unreachable; the search bound is never returned as an answer; shortening the dive turns it into a modest wait; zero when no wait is needed; the recommended interval genuinely satisfies the NDL requirement across several dive lengths; one minute less is not enough (it is the minimum, not merely sufficient); nitrox still beats air.

`unreachable_interval_test.dart` (4): no "6h 0m" is rendered; the ceiling is named; the "wait longer" advice is suppressed; the achievable path is unchanged.

## Verification

- `flutter analyze` (whole project): **No issues found**
- `dart format lib/ test/`: clean
- `flutter test test/features/surface_interval_tool/`: **46/46 pass** (re-run after rebase onto latest `main` with drift codegen regenerated)
- Full suite pre-rebase: 15719 passed, 15 skipped, 2 failed. Both failures are known load flakes unrelated to this change (`ocr_scan_page_test`, `global_drop_target_test` FIT case); each passes in isolation, and the pair passed 3/3 on a quiet machine. Neither file references any symbol touched here.
