### PR TITLE
Feat/trim dives

### DIFF
--- a/lib/features/dive_log/data/services/profile_editing_service.dart
+++ b/lib/features/dive_log/data/services/profile_editing_service.dart
@@ -338,4 +338,36 @@ class ProfileEditingService {
 
     return result;
   }
+
+  /// Trim trailing zero-depth points from the profile, keeping the last one.
+  ///
+  /// Removes all consecutive points with depth 0 from the end of the profile,
+  /// but preserves the last zero-depth point to mark the surface.
+  /// Returns the original profile if it has fewer than 2 points.
+  List<DiveProfilePoint> trimEndZeros(List<DiveProfilePoint> profile) {
+    if (profile.length < 2) return List.of(profile);
+
+    // Find the index of the last non-zero point
+    int lastNonZeroIndex = -1;
+    for (int i = profile.length - 1; i >= 0; i--) {
+      if (profile[i].depth != 0) {
+        lastNonZeroIndex = i;
+        break;
+      }
+    }
+
+    // If all points are zero, keep at least the last one
+    if (lastNonZeroIndex == -1) {
+      return [profile.last];
+    }
+
+    // Keep all points up to and including the first zero after the last non-zero
+    // to preserve at least one zero-depth point
+    if (lastNonZeroIndex < profile.length - 1) {
+      return profile.sublist(0, lastNonZeroIndex + 2);
+    }
+
+    // No trailing zeros exist
+    return List.of(profile);
+  }
 }

--- a/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
@@ -7,7 +7,7 @@ import 'package:submersion/features/dive_log/domain/entities/outlier_result.dart
 import 'package:submersion/features/dive_log/domain/entities/profile_waypoint.dart';
 
 /// Editor modes for the profile editor.
-enum EditorMode { select, smooth, outlier, draw }
+enum EditorMode { select, smooth, outlier, draw, trim }
 
 /// State for the profile editor session.
 class ProfileEditorState extends Equatable {
@@ -272,4 +272,13 @@ class ProfileEditorNotifier extends StateNotifier<ProfileEditorState> {
     );
     state = state.copyWith(editedProfile: generated, hasChanges: true);
   }
+
+  /// Trim trailing zero-depth points from the profile, keeping the last one.
+  void trimEndZeros() {
+    if (state.editedProfile.isEmpty) return;
+
+    _pushUndo();
+    final trimmed = _service.trimEndZeros(state.editedProfile);
+    state = state.copyWith(editedProfile: trimmed, hasChanges: true);
+  }  
 }

--- a/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
@@ -275,13 +275,13 @@ class ProfileEditorNotifier extends StateNotifier<ProfileEditorState> {
 
   /// Trim trailing zero-depth points from the profile, keeping the last one.
   void trimEndZeros() {
-    final profile = state.editedProfile;
-    if (profile.length < 2) return;
+    final profile = state.editedProfile;
+    if (profile.length < 2) return;
 
-    final trimmed = _service.trimEndZeros(profile);
-    if (trimmed.length == profile.length) return;
-
+    final trimmed = _service.trimEndZeros(profile);
+    if (trimmed.length == profile.length) return;
+
     _pushUndo();
     state = state.copyWith(editedProfile: trimmed, hasChanges: true);
-  }
+  }
 }

--- a/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_editor_provider.dart
@@ -275,10 +275,13 @@ class ProfileEditorNotifier extends StateNotifier<ProfileEditorState> {
 
   /// Trim trailing zero-depth points from the profile, keeping the last one.
   void trimEndZeros() {
-    if (state.editedProfile.isEmpty) return;
+    final profile = state.editedProfile;
+    if (profile.length < 2) return;
 
+    final trimmed = _service.trimEndZeros(profile);
+    if (trimmed.length == profile.length) return;
+
     _pushUndo();
-    final trimmed = _service.trimEndZeros(state.editedProfile);
     state = state.copyWith(editedProfile: trimmed, hasChanges: true);
-  }  
+  }
 }

--- a/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_edit
 /// - Smooth: window size selection and apply buttons
 /// - Outlier: detect and remove outlier controls
 /// - Draw: waypoint management and profile generation
+/// - Trim: profile trimming controls
 class EditorContextPanel extends StatefulWidget {
   final EditorMode mode;
   final ProfileEditorNotifier notifier;
@@ -45,6 +46,7 @@ class _EditorContextPanelState extends State<EditorContextPanel> {
         EditorMode.smooth => _buildSmoothPanel(context),
         EditorMode.outlier => _buildOutlierPanel(context),
         EditorMode.draw => _buildDrawPanel(context),
+        EditorMode.trim => _buildTrimPanel(context),
       },
     );
   }
@@ -253,4 +255,29 @@ class _EditorContextPanelState extends State<EditorContextPanel> {
       ],
     );
   }
+
+Widget _buildTrimPanel(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Trim Mode', style: Theme.of(context).textTheme.titleSmall),
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Text(
+            'Trim profile endpoints',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        FilledButton.tonalIcon(
+          onPressed: () => widget.notifier.trimEndZeros(),
+          icon: const Icon(Icons.content_cut, size: 18),
+          label: const Text('Trim End'),
+        ),
+      ],
+    );
+  }  
 }

--- a/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
@@ -256,7 +256,7 @@ class _EditorContextPanelState extends State<EditorContextPanel> {
     );
   }
 
-Widget _buildTrimPanel(BuildContext context) {
+  Widget _buildTrimPanel(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,

--- a/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
+++ b/lib/features/dive_log/presentation/widgets/editor_context_panel.dart
@@ -256,7 +256,7 @@ class _EditorContextPanelState extends State<EditorContextPanel> {
     );
   }
 
-  Widget _buildTrimPanel(BuildContext context) {
+  Widget _buildTrimPanel(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -279,5 +279,5 @@ class _EditorContextPanelState extends State<EditorContextPanel> {
         ),
       ],
     );
-  }  
+  }
 }

--- a/lib/features/dive_log/presentation/widgets/editor_toolbar.dart
+++ b/lib/features/dive_log/presentation/widgets/editor_toolbar.dart
@@ -4,8 +4,8 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_edit
 
 /// Mode selector toolbar for the profile editor.
 ///
-/// Displays a segmented button with four editing modes:
-/// Select, Smooth, Outlier, and Draw.
+/// Displays a segmented button with five editing modes:
+/// Select, Smooth, Outlier, Draw, and Trim.
 class EditorToolbar extends StatelessWidget {
   final EditorMode mode;
   final void Function(EditorMode) onModeChanged;
@@ -41,6 +41,11 @@ class EditorToolbar extends StatelessWidget {
             value: EditorMode.draw,
             icon: Icon(Icons.draw),
             label: Text('Draw'),
+          ),
+          ButtonSegment(
+            value: EditorMode.trim,
+            icon: Icon(Icons.content_cut),
+            label: Text('Trim'),
           ),
         ],
         selected: {mode},

--- a/test/features/dive_log/data/services/profile_editing_service_test.dart
+++ b/test/features/dive_log/data/services/profile_editing_service_test.dart
@@ -406,4 +406,81 @@ void main() {
       expect(profile.first.depth, 10.0);
     });
   });
+
+  group('trimEndZeros', () {
+    test('removes multiple trailing zero-depth points, keeps exactly one', () {
+      final profile = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 60, depth: 20.0),
+        const DiveProfilePoint(timestamp: 120, depth: 0.0),
+        const DiveProfilePoint(timestamp: 180, depth: 0.0),
+        const DiveProfilePoint(timestamp: 240, depth: 0.0),
+      ];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, 3);
+      expect(trimmed.last.depth, 0.0);
+      expect(trimmed.last.timestamp, 120);
+    });
+
+    test('does not modify profile with no trailing zeros', () {
+      final profile = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 60, depth: 20.0),
+        const DiveProfilePoint(timestamp: 120, depth: 5.0),
+      ];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, profile.length);
+      expect(trimmed.last.timestamp, 120);
+      expect(trimmed.last.depth, 5.0);
+    });
+
+    test('does not remove the single trailing zero', () {
+      final profile = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 60, depth: 18.0),
+        const DiveProfilePoint(timestamp: 120, depth: 0.0),
+      ];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, profile.length);
+    });
+
+    test('returns only last point when all depths are zero', () {
+      final profile = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 10, depth: 0.0),
+        const DiveProfilePoint(timestamp: 20, depth: 0.0),
+      ];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, 1);
+      expect(trimmed.first.timestamp, 20);
+    });
+
+    test('returns original profile for empty input', () {
+      final trimmed = service.trimEndZeros([]);
+      expect(trimmed, isEmpty);
+    });
+
+    test('returns original profile for single point', () {
+      final profile = [const DiveProfilePoint(timestamp: 0, depth: 0.0)];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, 1);
+    });
+
+    test('preserves all non-trailing content unchanged', () {
+      final profile = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 30, depth: 10.0),
+        const DiveProfilePoint(timestamp: 60, depth: 30.0),
+        const DiveProfilePoint(timestamp: 90, depth: 0.0),
+        const DiveProfilePoint(timestamp: 120, depth: 0.0),
+        const DiveProfilePoint(timestamp: 150, depth: 0.0),
+      ];
+      final trimmed = service.trimEndZeros(profile);
+      expect(trimmed.length, 4);
+      expect(trimmed[0].timestamp, 0);
+      expect(trimmed[1].timestamp, 30);
+      expect(trimmed[2].timestamp, 60);
+      expect(trimmed[3].timestamp, 90);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/providers/profile_editor_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_editor_provider_test.dart
@@ -68,4 +68,58 @@ void main() {
     notifier.clearSelectedRange();
     expect(notifier.state.selectedRange, isNull);
   });
+
+  group('trimEndZeros', () {
+    test('is no-op for profiles shorter than two points', () {
+      final shortNotifier = ProfileEditorNotifier(
+        originalProfile: const [DiveProfilePoint(timestamp: 0, depth: 0.0)],
+        editingService: ProfileEditingService(),
+      );
+
+      shortNotifier.trimEndZeros();
+
+      expect(shortNotifier.state.editedProfile.length, 1);
+      expect(shortNotifier.state.undoStack, isEmpty);
+      expect(shortNotifier.state.hasChanges, isFalse);
+    });
+
+    test('trims trailing zeros, creates undo entry, and marks changes', () {
+      final profileWithTrailingZeros = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 60, depth: 20.0),
+        const DiveProfilePoint(timestamp: 120, depth: 0.0),
+        const DiveProfilePoint(timestamp: 180, depth: 0.0),
+        const DiveProfilePoint(timestamp: 240, depth: 0.0),
+      ];
+      final trimNotifier = ProfileEditorNotifier(
+        originalProfile: profileWithTrailingZeros,
+        editingService: ProfileEditingService(),
+      );
+
+      trimNotifier.trimEndZeros();
+
+      expect(trimNotifier.state.editedProfile.length, 3);
+      expect(trimNotifier.state.editedProfile.last.timestamp, 120);
+      expect(trimNotifier.state.undoStack.length, 1);
+      expect(trimNotifier.state.hasChanges, isTrue);
+    });
+
+    test('is no-op when profile does not change after trim', () {
+      final profileWithoutExtraTrailingZeros = [
+        const DiveProfilePoint(timestamp: 0, depth: 0.0),
+        const DiveProfilePoint(timestamp: 60, depth: 18.0),
+        const DiveProfilePoint(timestamp: 120, depth: 0.0),
+      ];
+      final trimNotifier = ProfileEditorNotifier(
+        originalProfile: profileWithoutExtraTrailingZeros,
+        editingService: ProfileEditingService(),
+      );
+
+      trimNotifier.trimEndZeros();
+
+      expect(trimNotifier.state.editedProfile, profileWithoutExtraTrailingZeros);
+      expect(trimNotifier.state.undoStack, isEmpty);
+      expect(trimNotifier.state.hasChanges, isFalse);
+    });
+  });
 }

--- a/test/features/dive_log/presentation/providers/profile_editor_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_editor_provider_test.dart
@@ -117,7 +117,10 @@ void main() {
 
       trimNotifier.trimEndZeros();
 
-      expect(trimNotifier.state.editedProfile, profileWithoutExtraTrailingZeros);
+      expect(
+        trimNotifier.state.editedProfile,
+        profileWithoutExtraTrailingZeros,
+      );
       expect(trimNotifier.state.undoStack, isEmpty);
       expect(trimNotifier.state.hasChanges, isFalse);
     });

--- a/test/features/dive_log/presentation/widgets/editor_context_panel_test.dart
+++ b/test/features/dive_log/presentation/widgets/editor_context_panel_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/profile_editing_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_editor_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/editor_context_panel.dart';
+
+class _TrackingProfileEditorNotifier extends ProfileEditorNotifier {
+  int trimEndZerosCallCount = 0;
+
+  _TrackingProfileEditorNotifier()
+    : super(
+        originalProfile: const [
+          DiveProfilePoint(timestamp: 0, depth: 10.0),
+          DiveProfilePoint(timestamp: 60, depth: 0.0),
+          DiveProfilePoint(timestamp: 120, depth: 0.0),
+        ],
+        editingService: ProfileEditingService(),
+      );
+
+  @override
+  void trimEndZeros() {
+    trimEndZerosCallCount += 1;
+  }
+}
+
+void main() {
+  testWidgets('trim mode renders controls and invokes trim action', (
+    tester,
+  ) async {
+    final notifier = _TrackingProfileEditorNotifier();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EditorContextPanel(mode: EditorMode.trim, notifier: notifier),
+        ),
+      ),
+    );
+
+    expect(find.text('Trim Mode'), findsOneWidget);
+    expect(find.text('Trim profile endpoints'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Trim End'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Trim End'));
+
+    expect(notifier.trimEndZerosCallCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds a function to trim dive profiles in the profile editor. The trim will remove all trailing zeros but the last one from the profile.

## Changes

- Added trim function to dive profile editor.

## Test Plan

- [X] `flutter test` passes
-- 8 tests are failing, but none of them is related to the changes.
- [X] `flutter analyze` passes
- [X] Manual testing on: Windows

## Screenshots

<img width="1084" height="675" alt="Submersion_TrimDive" src="https://github.com/user-attachments/assets/7defefcf-a31c-4579-a018-4e29ee0f5d5b" />
