### PR TITLE
Refresh the home photo ribbon when a photo is deleted

### DIFF
--- a/lib/features/dashboard/presentation/providers/photo_providers.dart
+++ b/lib/features/dashboard/presentation/providers/photo_providers.dart
@@ -3,10 +3,16 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 
-/// Newest dive photos for the dashboard ribbon. Refreshed by the
-/// dashboard's pull-to-refresh invalidation (the media repository has no
-/// change stream to self-invalidate on).
+/// Newest dive photos for the dashboard ribbon.
+///
+/// Self-invalidates on the media-table change tick so the ribbon reflects
+/// deletions, imports and syncs without a pull-to-refresh. A photo deleted
+/// from the dive gallery, the files tab, or a dive-deletion cascade removes
+/// its `media` row directly, and none of those paths knows about this
+/// dashboard provider; before the tick subscription the ribbon kept rendering
+/// the deleted photo as a dead tile until the app restarted.
 final recentPhotosProvider = FutureProvider<List<MediaItem>>((ref) async {
   final repository = ref.watch(mediaRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchMediaChanges());
   return repository.getRecentPhotos(limit: 12);
 });

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/core/utils/stream_debounce.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart'
     as domain;
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
@@ -15,6 +16,27 @@ class MediaRepository {
   final SyncRepository _syncRepository = SyncRepository();
   final _uuid = const Uuid();
   final _log = LoggerService.forClass(MediaRepository);
+
+  /// Trailing-debounce window applied to [watchMediaChanges].
+  ///
+  /// A sync applies remote changes as many per-changeset transactions, and a
+  /// bulk photo import inserts one row per file; un-coalesced, every commit
+  /// would re-invalidate every listening provider. Debouncing collapses a
+  /// write burst into a single tick that fires once writes go quiet.
+  static const changeTickDebounce = Duration(milliseconds: 300);
+
+  /// Emits whenever the `media` table changes so cross-feature providers can
+  /// refresh after a delete, an import, or a sync -- including writes that go
+  /// straight to the database and so bypass the notifier paths that invalidate
+  /// per-dive media providers.
+  ///
+  /// Scoped to `media` alone: consumers render the media rows themselves, not
+  /// the joined `media_enrichment` values, and enrichment is backfilled on
+  /// every dive-detail open (see `DiveMediaEnricher`), which would otherwise
+  /// churn listeners for data they do not display.
+  Stream<void> watchMediaChanges() => _db
+      .tableUpdates(TableUpdateQuery.onTable(_db.media))
+      .debounce(changeTickDebounce);
 
   /// Get all media for a dive, ordered by takenAt
   /// Includes enrichment data (depth, temperature) if available

--- a/test/features/dashboard/presentation/providers/photo_ribbon_reactivity_test.dart
+++ b/test/features/dashboard/presentation/providers/photo_ribbon_reactivity_test.dart
@@ -58,15 +58,34 @@ void main() {
 
   /// Polls the provider until [settled] holds, so the media-table tick ->
   /// invalidate -> rebuild round trip has a chance to run.
+  ///
+  /// The budget is derived from [MediaRepository.changeTickDebounce] rather
+  /// than hard-coded, so it stays proportionate if that window is ever
+  /// widened. Never settling fails here, naming the round trip that stalled,
+  /// instead of surfacing downstream as a bare value mismatch that reads like
+  /// a wrong query.
   Future<List<MediaItem>> pollPhotos(
     ProviderContainer container,
-    bool Function(List<MediaItem> photos) settled,
-  ) async {
-    var photos = const <MediaItem>[];
-    for (var i = 0; i < 50; i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+    bool Function(List<MediaItem> photos) settled, {
+    required String awaiting,
+  }) async {
+    const interval = Duration(milliseconds: 20);
+    final budget = MediaRepository.changeTickDebounce * 20;
+    final deadline = DateTime.now().add(budget);
+
+    var photos = await container.read(recentPhotosProvider.future);
+    while (!settled(photos) && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(interval);
       photos = await container.read(recentPhotosProvider.future);
-      if (settled(photos)) break;
+    }
+
+    if (!settled(photos)) {
+      fail(
+        'Timed out after ${budget.inMilliseconds}ms waiting for $awaiting. '
+        'The media-table tick -> invalidateSelfWhen -> rebuild round trip '
+        'never settled; recentPhotosProvider still holds '
+        '${photos.map((p) => p.filePath).toList()}.',
+      );
     }
     return photos;
   }
@@ -110,6 +129,7 @@ void main() {
     final photos = await pollPhotos(
       container,
       (p) => !p.any((item) => item.id == doomed.id),
+      awaiting: 'the deleted photo to leave the ribbon',
     );
 
     expect(
@@ -154,6 +174,7 @@ void main() {
       final photos = await pollPhotos(
         container,
         (p) => p.any((item) => item.id == imported.id),
+        awaiting: 'the newly added photo to appear on the ribbon',
       );
 
       expect(photos.map((p) => p.id).toList(), [imported.id, existing.id]);

--- a/test/features/dashboard/presentation/providers/photo_ribbon_reactivity_test.dart
+++ b/test/features/dashboard/presentation/providers/photo_ribbon_reactivity_test.dart
@@ -1,0 +1,162 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dashboard/presentation/providers/photo_providers.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Regression tests for the home-page photo ribbon showing photos that no
+/// longer exist. Deleting a photo (from the dive detail gallery, the files
+/// tab, a dive deletion cascade, or an incoming sync) removes the `media`
+/// row, but `recentPhotosProvider` is a kept-alive [FutureProvider] that used
+/// to have no change-tick subscription: it held its cached slice until
+/// pull-to-refresh or an app restart, so the deleted photo stayed on the
+/// ribbon as a dead tile.
+///
+/// The provider now self-invalidates on [MediaRepository.watchMediaChanges],
+/// the same repo-tick pattern the recent-dives card uses (issue #217).
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+  tearDown(tearDownTestDatabase);
+
+  Future<void> insertDive(String id) => db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(DateTime(2026, 1, 1).millisecondsSinceEpoch),
+          createdAt: Value(DateTime(2026, 1, 1).millisecondsSinceEpoch),
+          updatedAt: Value(DateTime(2026, 1, 1).millisecondsSinceEpoch),
+        ),
+      );
+
+  Future<MediaItem> addPhoto(
+    MediaRepository repo, {
+    required String diveId,
+    required String path,
+    required DateTime takenAt,
+  }) => repo.createMedia(
+    MediaItem(
+      id: '',
+      mediaType: MediaType.photo,
+      sourceType: MediaSourceType.platformGallery,
+      filePath: path,
+      diveId: diveId,
+      takenAt: takenAt,
+      createdAt: takenAt,
+      updatedAt: takenAt,
+    ),
+  );
+
+  /// Polls the provider until [settled] holds, so the media-table tick ->
+  /// invalidate -> rebuild round trip has a chance to run.
+  Future<List<MediaItem>> pollPhotos(
+    ProviderContainer container,
+    bool Function(List<MediaItem> photos) settled,
+  ) async {
+    var photos = const <MediaItem>[];
+    for (var i = 0; i < 50; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      photos = await container.read(recentPhotosProvider.future);
+      if (settled(photos)) break;
+    }
+    return photos;
+  }
+
+  test('recentPhotosProvider drops a photo deleted while off screen', () async {
+    await insertDive('d1');
+    final repo = MediaRepository();
+    final keep = await addPhoto(
+      repo,
+      diveId: 'd1',
+      path: '/tmp/keep.jpg',
+      takenAt: DateTime(2026, 3, 1),
+    );
+    final doomed = await addPhoto(
+      repo,
+      diveId: 'd1',
+      path: '/tmp/doomed.jpg',
+      takenAt: DateTime(2026, 3, 2),
+    );
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // Dashboard on screen: an active listener builds the ribbon's provider,
+    // exactly like PhotoRibbonCard watching recentPhotosProvider.
+    final onScreen = container.listen(recentPhotosProvider, (_, _) {});
+    final initial = await container.read(recentPhotosProvider.future);
+    expect(initial.map((p) => p.id).toList(), [
+      doomed.id,
+      keep.id,
+    ], reason: 'newest first, before the delete');
+
+    // User leaves the dashboard for the dive detail page and deletes a photo.
+    onScreen.close();
+    await repo.deleteMedia(doomed.id);
+
+    // User returns to the dashboard: the ribbon re-subscribes.
+    final backOnScreen = container.listen(recentPhotosProvider, (_, _) {});
+    addTearDown(backOnScreen.close);
+
+    final photos = await pollPhotos(
+      container,
+      (p) => !p.any((item) => item.id == doomed.id),
+    );
+
+    expect(
+      photos.map((p) => p.id).toList(),
+      [keep.id],
+      reason:
+          'A photo deleted while the dashboard was off screen must be gone '
+          'from the home-page ribbon on return, not left as a dead tile.',
+    );
+  });
+
+  test(
+    'recentPhotosProvider picks up a photo added while off screen',
+    () async {
+      await insertDive('d1');
+      final repo = MediaRepository();
+      final existing = await addPhoto(
+        repo,
+        diveId: 'd1',
+        path: '/tmp/existing.jpg',
+        takenAt: DateTime(2026, 3, 1),
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final onScreen = container.listen(recentPhotosProvider, (_, _) {});
+      expect(await container.read(recentPhotosProvider.future), hasLength(1));
+      onScreen.close();
+
+      // An import or an incoming sync writes a newer photo straight to the DB.
+      final imported = await addPhoto(
+        repo,
+        diveId: 'd1',
+        path: '/tmp/imported.jpg',
+        takenAt: DateTime(2026, 3, 2),
+      );
+
+      final backOnScreen = container.listen(recentPhotosProvider, (_, _) {});
+      addTearDown(backOnScreen.close);
+
+      final photos = await pollPhotos(
+        container,
+        (p) => p.any((item) => item.id == imported.id),
+      );
+
+      expect(photos.map((p) => p.id).toList(), [imported.id, existing.id]);
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Deleting a photo left it on the home page's "recent photos" ribbon as a dead tile until pull-to-refresh or an app restart.

`recentPhotosProvider` was a kept-alive `FutureProvider` with no change subscription — its own doc comment said so: *"the media repository has no change stream to self-invalidate on."* Its only refresh trigger was the dashboard's pull-to-refresh.

Meanwhile `MediaListNotifier._invalidateRelatedProviders` invalidates five dive-scoped providers and never the dashboard one. Point-fixing that notifier would not have been enough: photos are also removed via the files tab, the URL tab, and the dive-deletion cascade, plus incoming sync — which writes the database directly and bypasses every notifier path.

## Fix

Give `MediaRepository` the change-tick stream every other repository in the codebase already has, and subscribe the dashboard provider to it.

- **`MediaRepository.watchMediaChanges()`** — Drift `tableUpdates` on the `media` table, trailing-debounced 300ms. The debounce mirrors `DiveRepositoryImpl.changeTickDebounce` and exists for the same reason: a sync applies remote changes as many per-changeset transactions and a bulk import inserts one row per file, so un-coalesced ticks would re-invalidate listeners on every intermediate commit.
- **`recentPhotosProvider`** — `ref.invalidateSelfWhen(repository.watchMediaChanges())`.

Because the trigger is at the database level, one subscription covers every delete path, plus imports and sync.

This is the same cure applied to the recent-dives card in #217, where the home tab went stale after a dive-computer import wrote the `dives` table directly.

### Scoping note

The tick watches `media` alone, not the joined `media_enrichment`. The ribbon renders only thumbnails from the media rows, never the enrichment values (depth/temperature), and `DiveMediaEnricher` backfills enrichment on every dive-detail open — including it would churn the dashboard for data it does not display.

## Tests

New `photo_ribbon_reactivity_test.dart`, modelled on the #217 regression test. Both cases drop the listener before the write and re-subscribe after, reproducing the real sequence (the user is on the dive detail page when the delete happens, then returns home) and exercising the paused/`onResume` branch of `invalidateSelfWhen`:

- a photo deleted while the dashboard is off screen is gone from the ribbon on return
- a photo added while the dashboard is off screen appears on return

Both were confirmed failing before the fix and passing after.

## Verification

- `flutter test` — 15993 passed, 0 failures
- `flutter analyze` — no issues
- `dart format` — clean

## Not addressed

A photo deleted from the **device's photo gallery** (rather than in-app) is marked `isOrphaned` instead of deleted, and `getRecentPhotos` has no orphan filter, so it will still occupy a ribbon slot with a broken thumbnail. Retaining the row looks deliberate — it is a log entry, and `SubscriptionPoller` can flip it back when a manifest entry reappears — so whether the ribbon should skip orphans is a separate product decision.
