### PR TITLE
Fix unreliable S3 sync on mobile networks (#942)

### DIFF
--- a/lib/core/services/cloud_storage/s3/s3_api_client.dart
+++ b/lib/core/services/cloud_storage/s3/s3_api_client.dart
@@ -62,7 +62,13 @@ class S3ApiClient {
     Duration maxRetryDelay = defaultMaxRetryDelay,
     Random? random,
     this.onRegionCorrected,
-  }) : _config = config,
+  }) : assert(maxAttempts >= 1, 'a request must be attempted at least once'),
+       assert(
+         !retryDelay.isNegative && !maxRetryDelay.isNegative,
+         'a negative backoff reaches Random.nextInt with a non-positive max '
+         'and throws RangeError',
+       ),
+       _config = config,
        _region = config.region,
        _http = httpClient ?? http.Client(),
        _now = now ?? DateTime.now,

--- a/lib/core/services/cloud_storage/s3/s3_api_client.dart
+++ b/lib/core/services/cloud_storage/s3/s3_api_client.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
 
@@ -56,17 +58,46 @@ class S3ApiClient {
     http.Client? httpClient,
     DateTime Function()? now,
     Duration retryDelay = const Duration(milliseconds: 500),
+    int maxAttempts = defaultMaxAttempts,
+    Duration maxRetryDelay = defaultMaxRetryDelay,
+    Random? random,
     this.onRegionCorrected,
   }) : _config = config,
        _region = config.region,
        _http = httpClient ?? http.Client(),
        _now = now ?? DateTime.now,
-       _retryDelay = retryDelay;
+       _retryDelay = retryDelay,
+       _maxAttempts = maxAttempts,
+       _maxRetryDelay = maxRetryDelay,
+       _random = random ?? Random();
+
+  /// Attempts per request, including the first.
+  ///
+  /// A base publish is 15+ sequential multi-megabyte PUTs (8 MiB parts), and
+  /// the manifest that commits them is written last, so a single failed part
+  /// aborts the whole sync and the next one re-uploads the base from part 0.
+  /// Two attempts 500ms apart are the same network moment on a mobile radio,
+  /// which made whole-publish success p^N and left large first syncs failing
+  /// nine times in ten (#942).
+  ///
+  /// Six attempts with the delays below span 7.75-15.5s of waiting, which is
+  /// the timescale a handover or a brief loss of signal resolves on. It does
+  /// not delay a genuinely offline device by that much per request: the sync
+  /// aborts at the FIRST request to exhaust its budget, so being offline costs
+  /// one budget, not one per part.
+  static const int defaultMaxAttempts = 6;
+
+  /// Ceiling for one backoff wait, so the exponential cannot run away on a
+  /// request that is retried to exhaustion.
+  static const Duration defaultMaxRetryDelay = Duration(seconds: 16);
 
   final S3Config _config;
   final http.Client _http;
   final DateTime Function() _now;
   final Duration _retryDelay;
+  final int _maxAttempts;
+  final Duration _maxRetryDelay;
+  final Random _random;
 
   /// Called after a server region hint led to a successful replay, so the
   /// owner can persist the corrected region.
@@ -429,6 +460,18 @@ class S3ApiClient {
     return (scheme: scheme, host: host, port: port, path: path);
   }
 
+  /// Sends [method] with up to [_maxAttempts] attempts, backing off between
+  /// them. Retries transport failures and retryable statuses (5xx, 429);
+  /// every other status is returned to the caller, which decides what it
+  /// means. A request that exhausts the budget on transport failures throws
+  /// [CloudStorageException]; one that exhausts it on a retryable status
+  /// returns that last response, so the caller still reports the real HTTP
+  /// code rather than a generic reachability message.
+  ///
+  /// Every operation routed through here is safe to repeat: the object writes
+  /// are idempotent by key, and the two multipart POSTs were already retried
+  /// before this budget existed (a duplicated session is reaped by the
+  /// stale-session sweep, orphan-prevention spec 6.1).
   Future<http.Response> _sendWithRetry(
     String method,
     String key, {
@@ -436,65 +479,91 @@ class S3ApiClient {
     Uint8List? body,
     Map<String, String> extraHeaders = const {},
   }) async {
-    try {
-      var response = await _send(
-        method,
-        key,
-        queryParams: queryParams,
-        body: body,
-        extraHeaders: extraHeaders,
-      );
-      if (response.statusCode >= 300) {
-        final corrected = await _replayWithRegionHint(
-          response,
+    Object? transportError;
+    for (var attempt = 1; ; attempt++) {
+      final lastAttempt = attempt >= _maxAttempts;
+      try {
+        var response = await _send(
           method,
           key,
-          queryParams,
-          body,
-          extraHeaders,
+          queryParams: queryParams,
+          body: body,
+          extraHeaders: extraHeaders,
         );
-        // The replay flows through the normal 5xx retry below, which now
-        // signs with the corrected region.
-        if (corrected != null) response = corrected;
+        if (response.statusCode >= 300) {
+          final corrected = await _replayWithRegionHint(
+            response,
+            method,
+            key,
+            queryParams,
+            body,
+            extraHeaders,
+          );
+          // The replay flows through the retry decision below, whose next
+          // attempt signs with the corrected region.
+          if (corrected != null) response = corrected;
+        }
+        if (lastAttempt || !_isRetryableStatus(response.statusCode)) {
+          return response;
+        }
+      } on FormatException catch (e) {
+        // A malformed endpoint is a configuration fault: retrying it can only
+        // fail the same way.
+        throw CloudStorageException(
+          'Invalid S3 endpoint configuration: ${_config.endpoint}',
+          e,
+        );
+      } on http.ClientException catch (e) {
+        transportError = e;
+      } on IOException catch (e) {
+        // Socket or TLS failure.
+        transportError = e;
+      } on TimeoutException catch (e) {
+        transportError = e;
       }
-      if (response.statusCode < 500) return response;
-    } on FormatException catch (e) {
-      throw CloudStorageException(
-        'Invalid S3 endpoint configuration: ${_config.endpoint}',
-        e,
-      );
-    } on http.ClientException {
-      // Transport failure; retry once below.
-    } on IOException {
-      // Socket or TLS failure; retry once below.
-    } on TimeoutException {
-      // Timed out; retry once below.
+      if (lastAttempt) {
+        throw CloudStorageException(
+          'Could not reach S3 endpoint ${_config.displayHost}',
+          transportError,
+        );
+      }
+      await Future<void>.delayed(_backoffFor(attempt));
     }
-    return _retry(method, key, queryParams, body, extraHeaders);
   }
 
-  Future<http.Response> _retry(
-    String method,
-    String key,
-    Map<String, String> queryParams,
-    Uint8List? body,
-    Map<String, String> extraHeaders,
-  ) async {
-    await Future<void>.delayed(_retryDelay);
-    try {
-      return await _send(
-        method,
-        key,
-        queryParams: queryParams,
-        body: body,
-        extraHeaders: extraHeaders,
-      );
-    } on Exception catch (e) {
-      throw CloudStorageException(
-        'Could not reach S3 endpoint ${_config.displayHost}',
-        e,
-      );
-    }
+  /// 5xx is a server-side fault worth repeating; 429 is the throttle signal
+  /// used by R2/B2/MinIO where AWS sends 503 SlowDown. Everything else -
+  /// including 403, 404 and the region-hint 301/400 handled above - is a
+  /// verdict about the request itself, and repeating it just burns time.
+  static bool _isRetryableStatus(int statusCode) =>
+      statusCode >= 500 || statusCode == 429;
+
+  /// Wait before the attempt after [attempt] (1-based): equal jitter, i.e. a
+  /// uniform pick from `[ceiling / 2, ceiling]`.
+  ///
+  /// The jitter decorrelates devices that hit the same throttled bucket prefix
+  /// at once, which lockstep backoff keeps colliding. The half-ceiling floor
+  /// is what full jitter would give up: the point of backing off here is to
+  /// outlast a dropout, and a run of near-zero waits would spend the whole
+  /// budget inside it.
+  Duration _backoffFor(int attempt) {
+    final ceiling = backoffCeilingFor(_retryDelay, attempt, _maxRetryDelay);
+    if (ceiling == Duration.zero) return Duration.zero;
+    final half = ceiling.inMicroseconds ~/ 2;
+    return Duration(microseconds: half + _random.nextInt(half + 1));
+  }
+
+  /// Un-jittered `base * 2^(attempt-1)`, capped at [cap]. Exposed so the
+  /// growth curve is testable without the jitter.
+  @visibleForTesting
+  static Duration backoffCeilingFor(Duration base, int attempt, Duration cap) {
+    if (base == Duration.zero) return Duration.zero;
+    // Shift the exponent, not the duration: a large attempt would otherwise
+    // overflow the microsecond product before the cap could clamp it.
+    final exponent = attempt - 1;
+    if (exponent >= 32) return cap;
+    final scaled = base * (1 << exponent);
+    return scaled > cap ? cap : scaled;
   }
 
   /// If [response] carries a region hint that differs from the effective

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -70,10 +70,7 @@ class MediaStoreWorker {
       while (true) {
         // Re-checked per entry, not once per drain: a store wipe or user
         // disconnect mid-drain must suspend the rest of the queue.
-        if (_preflight != null && !await _preflight()) {
-          _log.warning('Media store preflight failed; drain suspended');
-          return;
-        }
+        if (!await _preflightPasses()) return;
         final entry = await _queue.nextPending(DateTime.now());
         if (entry == null) break;
         if (_gate != null) {
@@ -104,6 +101,29 @@ class MediaStoreWorker {
       _running = false;
       await _armWakeup();
     }
+  }
+
+  /// Whether the drain may proceed. Null preflight admits everything.
+  ///
+  /// A preflight that throws suspends the drain exactly like one that returns
+  /// false. It reads the store marker out of the bucket, so an offline moment
+  /// or a transient S3 failure makes it throw rather than answer - and since
+  /// every drain() call site is fire-and-forget (app start, connectivity
+  /// change, the retry wakeup, enqueueAndKick), an escaping throw had no
+  /// handler and surfaced as an uncaught zone error instead of a suspended
+  /// drain (#942). Suspending is also the safe reading: the check exists to
+  /// stop transfers against a store this device may no longer be attached to,
+  /// so "could not verify" must never be treated as "verified".
+  Future<bool> _preflightPasses() async {
+    final preflight = _preflight;
+    if (preflight == null) return true;
+    try {
+      if (await preflight()) return true;
+      _log.warning('Media store preflight failed; drain suspended');
+    } on Object catch (e) {
+      _log.warning('Media store preflight could not run; drain suspended: $e');
+    }
+    return false;
   }
 
   /// Arms a single timer for the soonest deferred row, so a retry that comes

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -114,14 +114,23 @@ class MediaStoreWorker {
   /// drain (#942). Suspending is also the safe reading: the check exists to
   /// stop transfers against a store this device may no longer be attached to,
   /// so "could not verify" must never be treated as "verified".
+  ///
+  /// The throw is logged with its error and stack trace, not interpolated into
+  /// the message: catching it is what stops the crash, so the log is now the
+  /// only record of a preflight that keeps failing, and a bare string would
+  /// make that state less diagnosable than the uncaught zone error it replaced.
   Future<bool> _preflightPasses() async {
     final preflight = _preflight;
     if (preflight == null) return true;
     try {
       if (await preflight()) return true;
       _log.warning('Media store preflight failed; drain suspended');
-    } on Object catch (e) {
-      _log.warning('Media store preflight could not run; drain suspended: $e');
+    } on Object catch (e, stackTrace) {
+      _log.warning(
+        'Media store preflight could not run; drain suspended',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
     return false;
   }

--- a/test/core/services/cloud_storage/s3/s3_api_client_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_api_client_test.dart
@@ -348,6 +348,35 @@ void main() {
       }
     });
 
+    // A negative delay survives backoffCeilingFor (it is below the cap, so it
+    // is returned as-is) and reaches Random.nextInt with a non-positive max,
+    // which throws RangeError deep inside a retry. Fail at construction
+    // instead, where the misconfiguration is visible.
+    test('rejects a retry configuration that cannot produce a delay', () {
+      S3ApiClient build({
+        int maxAttempts = 6,
+        Duration retryDelay = const Duration(milliseconds: 500),
+        Duration maxRetryDelay = const Duration(seconds: 16),
+      }) => S3ApiClient(
+        minioConfig(),
+        httpClient: MockClient((_) async => http.Response('', 200)),
+        maxAttempts: maxAttempts,
+        retryDelay: retryDelay,
+        maxRetryDelay: maxRetryDelay,
+      );
+
+      expect(() => build(maxAttempts: 0), throwsA(isA<AssertionError>()));
+      expect(
+        () => build(retryDelay: const Duration(milliseconds: -1)),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => build(maxRetryDelay: const Duration(seconds: -1)),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(build, returnsNormally);
+    });
+
     // Equal jitter, not full jitter: the floor is the point. A run of
     // near-zero waits would spend the whole budget inside the dropout the
     // backoff exists to outlast.

--- a/test/core/services/cloud_storage/s3/s3_api_client_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_api_client_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -30,6 +31,19 @@ S3ApiClient clientWith(S3Config config, MockClient mock) => S3ApiClient(
   now: () => DateTime.utc(2026, 6, 9, 12),
   retryDelay: Duration.zero,
 );
+
+/// Always picks the low end of the jitter range, so a backoff test asserts
+/// the guaranteed floor rather than a random draw above it.
+class _MinJitter implements Random {
+  @override
+  int nextInt(int max) => 0;
+
+  @override
+  bool nextBool() => false;
+
+  @override
+  double nextDouble() => 0;
+}
 
 String malformedAuthBody(String expectedRegion) =>
     '<?xml version="1.0" encoding="UTF-8"?>'
@@ -235,6 +249,136 @@ void main() {
         );
       },
     );
+
+    // Issue #942: a base publish is 15+ sequential multi-megabyte PUTs. With
+    // only two attempts 500ms apart - the same network moment on a mobile
+    // radio - one routine blip aborted the whole sync, and nothing is
+    // resumable, so the next attempt re-uploaded the entire base. Success was
+    // p^N and never improved.
+    test(
+      'rides out a burst of transport errors within the attempt budget',
+      () async {
+        var calls = 0;
+        final mock = MockClient((_) async {
+          calls++;
+          if (calls < 4) throw const SocketException('network unreachable');
+          return http.Response('', 200);
+        });
+        await clientWith(
+          minioConfig(),
+          mock,
+        ).putObject('k', Uint8List.fromList([1]));
+        expect(calls, 4);
+      },
+    );
+
+    test('gives up after maxAttempts rather than retrying forever', () async {
+      var calls = 0;
+      final mock = MockClient((_) async {
+        calls++;
+        throw http.ClientException('refused');
+      });
+      final client = S3ApiClient(
+        minioConfig(),
+        httpClient: mock,
+        now: () => DateTime.utc(2026, 6, 9, 12),
+        retryDelay: Duration.zero,
+        maxAttempts: 3,
+      );
+
+      await expectLater(
+        client.getObject('k'),
+        throwsA(isA<CloudStorageException>()),
+      );
+      expect(calls, 3);
+    });
+
+    test('retries a 5xx across the whole attempt budget', () async {
+      var calls = 0;
+      final mock = MockClient((_) async {
+        calls++;
+        return http.Response('oops', calls < 4 ? 503 : 200);
+      });
+      await clientWith(
+        minioConfig(),
+        mock,
+      ).putObject('k', Uint8List.fromList([1]));
+      expect(calls, 4);
+    });
+
+    // 503 SlowDown is the AWS throttle signal and was already retried as a
+    // 5xx; R2/B2/MinIO use 429 for the same condition and it was not.
+    test('retries a 429 throttle response', () async {
+      var calls = 0;
+      final mock = MockClient((_) async {
+        calls++;
+        return http.Response('slow down', calls == 1 ? 429 : 200);
+      });
+      await clientWith(
+        minioConfig(),
+        mock,
+      ).putObject('k', Uint8List.fromList([1]));
+      expect(calls, 2);
+    });
+
+    test('backoff grows exponentially and is capped', () {
+      const base = Duration(milliseconds: 500);
+      const cap = Duration(seconds: 8);
+      Duration at(int attempt) =>
+          S3ApiClient.backoffCeilingFor(base, attempt, cap);
+
+      expect(at(1), const Duration(milliseconds: 500));
+      expect(at(2), const Duration(seconds: 1));
+      expect(at(3), const Duration(seconds: 2));
+      expect(at(4), const Duration(seconds: 4));
+      expect(at(5), cap);
+      expect(at(9), cap, reason: 'must not overflow past the cap');
+    });
+
+    test('a zero base delay stays zero at every attempt', () {
+      for (var attempt = 1; attempt <= 6; attempt++) {
+        expect(
+          S3ApiClient.backoffCeilingFor(
+            Duration.zero,
+            attempt,
+            const Duration(seconds: 8),
+          ),
+          Duration.zero,
+        );
+      }
+    });
+
+    // Equal jitter, not full jitter: the floor is the point. A run of
+    // near-zero waits would spend the whole budget inside the dropout the
+    // backoff exists to outlast.
+    test('the jittered wait never drops below half the ceiling', () async {
+      var calls = 0;
+      final mock = MockClient((_) async {
+        calls++;
+        throw http.ClientException('refused');
+      });
+      final client = S3ApiClient(
+        minioConfig(),
+        httpClient: mock,
+        now: () => DateTime.utc(2026, 6, 9, 12),
+        retryDelay: const Duration(milliseconds: 40),
+        maxAttempts: 3,
+        maxRetryDelay: const Duration(seconds: 8),
+        random: _MinJitter(),
+      );
+
+      final stopwatch = Stopwatch()..start();
+      await expectLater(
+        client.getObject('k'),
+        throwsA(isA<CloudStorageException>()),
+      );
+      stopwatch.stop();
+
+      expect(calls, 3);
+      // Ceilings 40ms then 80ms; the floor is half of each. Asserted as a
+      // lower bound only, so a loaded machine cannot flake it.
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(60));
+    });
   });
 
   group('headObject', () {

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -4,6 +4,8 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
@@ -89,6 +91,40 @@ void main() {
       expect(pipeline.processed, isEmpty);
     },
   );
+
+  // Catching the throw is what removes the stack trace that used to reach the
+  // zone handler, so this log line is now the only record of a preflight that
+  // keeps failing. It must carry the cause through LoggerService's structured
+  // error field (rendered as "| error: ..."), not interpolated into the text.
+  test('the suspended drain logs the cause as a structured error', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => throw const MediaStoreException(
+        'get smv1/store.json failed: Could not reach S3 endpoint',
+        kind: MediaStoreErrorKind.transient,
+      ),
+    );
+    addTearDown(worker.dispose);
+
+    final entries = <LogEntry>[];
+    final sub = LoggerService.logStream.listen(entries.add);
+    addTearDown(sub.cancel);
+
+    await worker.drain();
+
+    expect(
+      entries.map((e) => e.message),
+      contains(
+        allOf(
+          contains('drain suspended'),
+          contains('| error: MediaStoreException(transient)'),
+          contains('smv1/store.json'),
+        ),
+      ),
+    );
+  });
 
   test(
     'a drain suspended by a throwing preflight can run again later',

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+class _RecordingPipeline extends MediaUploadPipeline {
+  _RecordingPipeline({
+    required this.queueRef,
+    required super.mediaRepository,
+    required super.queue,
+    required super.store,
+    required super.registry,
+    required super.cache,
+  });
+
+  final MediaTransferQueueRepository queueRef;
+  final processed = <String>[];
+
+  @override
+  Future<UploadOutcome> process(MediaTransferQueueEntry entry) async {
+    processed.add(entry.mediaId);
+    await queueRef.markDone(entry.id);
+    return UploadOutcome.uploaded;
+  }
+}
+
+void main() {
+  late MediaRepository mediaRepository;
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late MediaTransferQueueRepository queue;
+  late _RecordingPipeline pipeline;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    mediaRepository = MediaRepository();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('worker_preflight');
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    pipeline = _RecordingPipeline(
+      queueRef: queue,
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: InMemoryMediaObjectStore(),
+      registry: MediaSourceResolverRegistry({}),
+      cache: MediaCacheStore(database: cacheDb, root: root),
+    );
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    if (root.existsSync()) await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  // Issue #942: preflight reads smv1/store.json from the bucket, so a network
+  // blip throws. Every drain() call site is unawaited, so the throw escaped
+  // into nothing and surfaced as "Uncaught zone error" - 25 of them in the
+  // reporter's log. Preflight's contract is to suspend the drain; a failure to
+  // determine the answer must suspend it too, not crash the zone.
+  test(
+    'a preflight that throws suspends the drain instead of escaping',
+    () async {
+      await queue.enqueueUpload(mediaId: 'm1');
+      final worker = MediaStoreWorker(
+        queue: queue,
+        pipeline: pipeline,
+        preflight: () async => throw const MediaStoreException(
+          'get smv1/store.json failed: Could not reach S3 endpoint',
+          kind: MediaStoreErrorKind.transient,
+        ),
+      );
+      addTearDown(worker.dispose);
+
+      await expectLater(worker.drain(), completes);
+      expect(pipeline.processed, isEmpty);
+    },
+  );
+
+  test(
+    'a drain suspended by a throwing preflight can run again later',
+    () async {
+      await queue.enqueueUpload(mediaId: 'm1');
+      var online = false;
+      final worker = MediaStoreWorker(
+        queue: queue,
+        pipeline: pipeline,
+        preflight: () async {
+          if (!online) {
+            throw const MediaStoreException(
+              'get smv1/store.json failed: Could not reach S3 endpoint',
+              kind: MediaStoreErrorKind.transient,
+            );
+          }
+          return true;
+        },
+      );
+      addTearDown(worker.dispose);
+
+      await worker.drain();
+      expect(pipeline.processed, isEmpty);
+
+      online = true;
+      await worker.drain();
+      expect(pipeline.processed, ['m1']);
+    },
+  );
+}


### PR DESCRIPTION
Fixes #942.

## The failure

A first sync from Android to an S3 bucket reached "Publishing changes..." and then failed with `Could not reach S3 endpoint s3.ap-southeast-2.amazonaws.com`, succeeding maybe once in ten attempts across hours and days, on both wifi and 5G, with no other sign of network interruption.

## Root cause

A base publish is a sequence of 8 MiB PUTs — the reporter's base was 14 parts, ~112 MB — and `ChangesetWriter` writes the manifest **last**, as the commit point. So a failure on part 9 of 14 leaves `hasBase == false`, and the next sync restarts the entire base from part 0 under a fresh seq. Nothing is resumable.

`S3ApiClient` gave each request exactly **two** attempts, 500 ms apart. On a mobile radio that is the same network moment, so a routine blip on any one part aborted the whole sync. Whole-publish success was therefore *p^N*: at *p* ≈ 0.85 over 15 requests that is ~10%, matching the reported 1-in-10.

## Changes

**`S3ApiClient` retry budget.** The single fixed retry becomes a bounded loop: 6 attempts per request, exponential backoff capped at 16 s, **equal jitter** (a uniform pick from `[ceiling/2, ceiling]`). The floor is deliberate — the backoff exists to outlast a handover or brief loss of signal, and full jitter could spend the whole budget inside one. Total wait spans 7.75–15.5 s per request.

Preserved behaviour:
- 4xx is still never retried; a wrong key or bucket still fails immediately.
- Region-hint replay (301 / `AuthorizationHeaderMalformed`) is unchanged, and a corrected region still signs every subsequent attempt.
- A malformed endpoint still throws the configuration error without retrying.
- A budget exhausted on a **retryable status** returns that last response, so the caller still reports the real HTTP code (`HTTP 503`) rather than the generic reachability message. Only transport exhaustion produces "Could not reach".

Added: **429** joins 5xx as retryable. R2/B2/MinIO use it for the throttle condition where AWS sends 503 SlowDown, and a burst of 15 large PUTs is exactly when a device meets it.

Being offline does not cost one budget per part — the sync aborts at the first request to exhaust its budget, so it costs one budget total.

**`MediaStoreWorker` preflight.** The reporter's log carries 25 `Uncaught zone error | MediaStoreException(transient): get smv1/store.json failed` entries. `drain()` called `_preflight()` unguarded, and every `drain()` call site is fire-and-forget (app start, connectivity change, the retry wakeup, `enqueueAndKick`), so a transient failure to read the store marker escaped with no handler. Preflight's documented contract is already "return false to suspend the drain"; a failure to *determine* the answer now suspends it too. That is also the safe reading — the check exists to stop transfers against a store this device may no longer be attached to, so "could not verify" must never be treated as "verified".

## Tests

New coverage in `s3_api_client_test.dart`: riding out a burst of transport errors within the budget, giving up at `maxAttempts`, retrying 5xx across the budget, retrying 429, the exponential-and-capped growth curve, a zero base delay staying zero, and the jitter floor. New `media_store_worker_preflight_test.dart` covers a throwing preflight suspending the drain and a later drain succeeding once the network returns; both were verified red against the unfixed worker.

`flutter analyze` clean; full suite 16051 passed, 0 failed.

## Not addressed here

- **Resumable base publish.** Uploaded parts are still discarded when a publish fails. The retry budget makes a failure far less likely, but a first sync of a large library over cellular still restarts from part 0 when one does happen. Worth a follow-up.
- **Per-request timeout.** There is still no timeout on the HTTP send, so a socket that stalls without erroring would hang. The reporter's failures took 87–330 s with variable durations, which reads as progress-then-blip rather than a hang, so there was no evidence to size a timeout against — and a wrong one would break genuinely slow connections.
- **Interactive "Test Connection"** now takes a few seconds longer to report a genuinely unreachable host, since it shares the client. A wrong key or bucket (4xx) still fails immediately. This seems right: a probe that gives up faster than the sync it predicts can report failure for a config that syncs fine.