### PR TITLE
Capture GPS reported as profile samples (fixes #926)

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -55,6 +55,9 @@ typedef struct {
     int has_pending_sample;
     unsigned int current_gasmix;  // active gas index, carried across samples
     libdc_sample_t current_sample;
+    // GPS reported as profile samples (see DC_SAMPLE_LOCATION below).
+    int has_field_location;   // DC_FIELD_LOCATION already supplied a fix
+    int sample_location_count;
 } sample_state_t;
 
 // ============================================================
@@ -115,6 +118,20 @@ static void push_sample(sample_state_t *state) {
 
     dive->samples[dive->sample_count++] = state->current_sample;
     state->has_pending_sample = 0;
+}
+
+// A dive computer with no satellite lock reports 0/0 rather than omitting the
+// record, and a corrupt record can yield values far outside the WGS84 range.
+// Either would place the dive somewhere it never happened, so both are dropped.
+static int is_usable_location(double latitude, double longitude) {
+    if (isnan(latitude) || isnan(longitude)) {
+        return 0;
+    }
+    if (latitude == 0.0 && longitude == 0.0) {
+        return 0;
+    }
+    return latitude >= -90.0 && latitude <= 90.0 &&
+           longitude >= -180.0 && longitude <= 180.0;
 }
 
 static void push_event(libdc_parsed_dive_t *dive,
@@ -250,6 +267,31 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.deco_depth = value->deco.depth;
         state->current_sample.deco_tts = value->deco.tts;
         break;
+    case DC_SAMPLE_LOCATION:
+        // Issue #926. The Ratio / DiveSystem iX3M and iDive families do not
+        // implement DC_FIELD_LOCATION at all; they emit each GPS fix as a
+        // profile sample instead. Promote those to the dive-level entry/exit
+        // positions the rest of the app already understands: first fix is the
+        // entry point, the most recent one the exit point. A dive with a
+        // single fix keeps its exit unset rather than mirroring the entry --
+        // a duplicated point renders as a bogus second marker on the map.
+        if (state->has_field_location) {
+            break;  // a real DC_FIELD_LOCATION is authoritative
+        }
+        if (!is_usable_location(value->location.latitude,
+                                value->location.longitude)) {
+            break;
+        }
+        if (state->sample_location_count == 0) {
+            state->dive->entry_latitude = value->location.latitude;
+            state->dive->entry_longitude = value->location.longitude;
+        } else if (value->location.latitude != state->dive->entry_latitude ||
+                   value->location.longitude != state->dive->entry_longitude) {
+            state->dive->exit_latitude = value->location.latitude;
+            state->dive->exit_longitude = value->location.longitude;
+        }
+        state->sample_location_count++;
+        break;
     case DC_SAMPLE_EVENT:
         push_event(state->dive,
                    state->current_sample.time_ms,
@@ -312,14 +354,19 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
 
     // Extract GPS entry/exit fixes (Shearwater Swift). flags: 0=entry, 1=exit.
     // Patched libdivecomputer maps these to opening[9]/closing[9] record 9.
+    // Families that report GPS per-sample instead are handled in
+    // sample_callback's DC_SAMPLE_LOCATION branch.
+    int has_field_location = 0;
     dc_location_t loc = {0};
     if (dc_parser_get_field(parser, DC_FIELD_LOCATION, 0, &loc) == DC_STATUS_SUCCESS) {
         dive->entry_latitude = loc.latitude;
         dive->entry_longitude = loc.longitude;
+        has_field_location = 1;
     }
     if (dc_parser_get_field(parser, DC_FIELD_LOCATION, 1, &loc) == DC_STATUS_SUCCESS) {
         dive->exit_latitude = loc.latitude;
         dive->exit_longitude = loc.longitude;
+        has_field_location = 1;
     }
 
     // Extract gas mixes.
@@ -358,6 +405,7 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
     sample_state_t sample_state = {0};
     sample_state.dive = dive;
     sample_state.current_gasmix = UINT32_MAX;  // 0 is a valid gas index
+    sample_state.has_field_location = has_field_location;
     dc_parser_samples_foreach(parser, sample_callback, &sample_state);
     push_sample(&sample_state);
 

--- a/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
+++ b/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
@@ -103,11 +103,188 @@ static void test_parse_cressi_leonardo(void) {
     free(data);
 }
 
+/* --- Ratio iX3M synthetic dive (issue #926) ------------------------------
+   The iX3M/iDive family does not implement DC_FIELD_LOCATION. It reports GPS
+   as DC_SAMPLE_LOCATION entries inside the profile stream: an "info" record
+   (type 1) carries a fix, which libdivecomputer attaches to the next real
+   sample record (type 0). This builds the smallest blob that exercises that
+   path so the wrapper's entry/exit extraction can be asserted without a
+   device. Layout constants mirror divesystem_idive_parser.c. */
+
+#define IX3M_HEADER_SIZE 0x36
+#define IX3M_APOS4_SAMPLE_SIZE 0x40
+#define IX3M_REC_SAMPLE 0
+#define IX3M_REC_INFO 1
+/* iX3M 2 GPS Pro. */
+#define IX3M2_GPS_PRO_MODEL 0x92
+
+static void put_u16le(unsigned char *p, unsigned int v) {
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+}
+
+static void put_u32le(unsigned char *p, unsigned int v) {
+    p[0] = (unsigned char)(v & 0xFF);
+    p[1] = (unsigned char)((v >> 8) & 0xFF);
+    p[2] = (unsigned char)((v >> 16) & 0xFF);
+    p[3] = (unsigned char)((v >> 24) & 0xFF);
+}
+
+/* Write a profile record of the given type at record index `idx`. */
+static unsigned char *ix3m_record(unsigned char *blob, unsigned int idx) {
+    return blob + IX3M_HEADER_SIZE + idx * IX3M_APOS4_SAMPLE_SIZE;
+}
+
+static void ix3m_put_sample(unsigned char *blob, unsigned int idx,
+                            unsigned int time_s, unsigned int depth_dm) {
+    unsigned char *rec = ix3m_record(blob, idx);
+    put_u32le(rec + 2, time_s);
+    put_u16le(rec + 6, depth_dm);
+    put_u16le(rec + 52, IX3M_REC_SAMPLE);
+}
+
+static void ix3m_put_info(unsigned char *blob, unsigned int idx,
+                          int latitude_e7, int longitude_e7) {
+    unsigned char *rec = ix3m_record(blob, idx);
+    put_u32le(rec + 40, 0);  /* altitude (mm) */
+    put_u32le(rec + 44, (unsigned int)longitude_e7);
+    put_u32le(rec + 48, (unsigned int)latitude_e7);
+    put_u16le(rec + 52, IX3M_REC_INFO);
+}
+
+/* Regression test for issue #926: GPS fixes from a Ratio iX3M arrive as
+   profile samples, not as DC_FIELD_LOCATION. The first fix must land in the
+   entry position and the last in the exit position. */
+static void test_parse_ratio_ix3m_sample_gps(void) {
+    /* Malta: entry ~36.0400 / 14.3200, exit ~36.0450 / 14.3250. */
+    const int entry_lat_e7 = 360400000;
+    const int entry_lon_e7 = 143200000;
+    const int exit_lat_e7 = 360450000;
+    const int exit_lon_e7 = 143250000;
+
+    const unsigned int nrecords = 5;
+    const unsigned int size = IX3M_HEADER_SIZE + nrecords * IX3M_APOS4_SAMPLE_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    put_u16le(blob + 1, nrecords);
+    /* Firmware >= 4.x selects the APOS4 sample size and the timezone-aware
+       datetime path; byte 48 is the timezone index and must stay even. */
+    put_u32le(blob + 0x2A, 40000000);
+
+    ix3m_put_info(blob, 0, entry_lat_e7, entry_lon_e7);
+    ix3m_put_sample(blob, 1, 0, 50);
+    ix3m_put_sample(blob, 2, 10, 120);
+    ix3m_put_info(blob, 3, exit_lat_e7, exit_lon_e7);
+    ix3m_put_sample(blob, 4, 20, 30);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Ratio", "iX3M 2 GPS Pro", IX3M2_GPS_PRO_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    if (rc != 0) {
+        fprintf(stderr, "FAIL: parse returned %d: %s\n", rc, err);
+        free(blob);
+        assert(0 && "libdc_parse_raw_dive failed for Ratio iX3M");
+    }
+
+    assert(result.sample_count == 3);
+
+    assert(!isnan(result.entry_latitude));
+    assert(!isnan(result.entry_longitude));
+    assert(fabs(result.entry_latitude - 36.04) < 1e-7);
+    assert(fabs(result.entry_longitude - 14.32) < 1e-7);
+
+    assert(!isnan(result.exit_latitude));
+    assert(!isnan(result.exit_longitude));
+    assert(fabs(result.exit_latitude - 36.045) < 1e-7);
+    assert(fabs(result.exit_longitude - 14.325) < 1e-7);
+
+    printf("PASS: test_parse_ratio_ix3m_sample_gps (entry=%.5f,%.5f exit=%.5f,%.5f)\n",
+           result.entry_latitude, result.entry_longitude,
+           result.exit_latitude, result.exit_longitude);
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* A single GPS fix must populate the entry position only. Mirroring it into
+   the exit position would render a spurious "exit point" on the map. */
+static void test_parse_ratio_ix3m_single_fix(void) {
+    const unsigned int nrecords = 3;
+    const unsigned int size = IX3M_HEADER_SIZE + nrecords * IX3M_APOS4_SAMPLE_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    put_u16le(blob + 1, nrecords);
+    put_u32le(blob + 0x2A, 40000000);
+
+    ix3m_put_info(blob, 0, 360400000, 143200000);
+    ix3m_put_sample(blob, 1, 0, 50);
+    ix3m_put_sample(blob, 2, 10, 120);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Ratio", "iX3M 2 GPS Pro", IX3M2_GPS_PRO_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(!isnan(result.entry_latitude));
+    assert(isnan(result.exit_latitude));
+    assert(isnan(result.exit_longitude));
+
+    printf("PASS: test_parse_ratio_ix3m_single_fix\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* A record with no satellite fix reports 0/0. Treating Null Island as a real
+   position would drop the dive in the Gulf of Guinea. */
+static void test_parse_ratio_ix3m_null_island_ignored(void) {
+    const unsigned int nrecords = 3;
+    const unsigned int size = IX3M_HEADER_SIZE + nrecords * IX3M_APOS4_SAMPLE_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    put_u16le(blob + 1, nrecords);
+    put_u32le(blob + 0x2A, 40000000);
+
+    ix3m_put_info(blob, 0, 0, 0);
+    ix3m_put_sample(blob, 1, 0, 50);
+    ix3m_put_sample(blob, 2, 10, 120);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Ratio", "iX3M 2 GPS Pro", IX3M2_GPS_PRO_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(isnan(result.entry_latitude));
+    assert(isnan(result.entry_longitude));
+    assert(isnan(result.exit_latitude));
+    assert(isnan(result.exit_longitude));
+
+    printf("PASS: test_parse_ratio_ix3m_null_island_ignored\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
 int main(void) {
     test_null_args();
     test_load_fixture_missing();
     test_unknown_descriptor();
     test_parse_cressi_leonardo();
+    test_parse_ratio_ix3m_sample_gps();
+    test_parse_ratio_ix3m_single_fix();
+    test_parse_ratio_ix3m_null_island_ignored();
     printf("\nAll parse_raw_dive tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #926 — a Ratio iX3M2 GPS download captured no coordinates on either
Windows/USB or Android/BLE, despite the fixes being visible on the device and
readable by Subsurface.

Root cause: **libdivecomputer exposes GPS through two unrelated APIs**, and a
parser implements one or the other, never both. Our wrapper only ever read the
dive-level field.

| API | Shape | Implemented by |
| --- | --- | --- |
| `DC_FIELD_LOCATION` | dive-level field, `flags` 0=entry / 1=exit | `shearwater_predator_parser.c` only — and only because our fork's patch re-adds it |
| `DC_SAMPLE_LOCATION` | per-sample callback inside `samples_foreach` | `divesystem_idive_parser.c` (Ratio iX3M / iDive), `halcyon_symbios_parser.c`, `hw_ostc_parser.c` (OSTC 4 GNSS), `divesoft_freedom_parser.c`, and `shearwater_predator_parser.c` |

`sample_callback` in `libdc_download.c` had no `DC_SAMPLE_LOCATION` case, so
every fix delivered that way was discarded before it reached Dart.

**This is broader than the reported device.** GPS was being dropped for every
GPS-capable computer we support except Shearwater — Ratio, Halcyon Symbios,
OSTC 4 and Divesoft Freedom all report through the sample API. The shared C
wrapper also explains why the reporter saw identical behaviour on two different
platforms and transports.

**It is also a regression, not a never-implemented feature** — see the dated
provenance below.

Nothing errored anywhere: the parsed-dive struct, the Pigeon `ParsedDive`, all
four platform NaN-to-null bridges and the site-matching flow already carried
entry/exit coordinates. The data simply never entered the pipeline, which is why
the symptom presented as "dive site: unknown" and read like a site-matching bug.

### This is a regression, and we can date it exactly

Issue #310 — same reporter, same iX3M2 — shows GPS **was** arriving previously,
with entry and exit both populated and identical. That is the signature of the
old code path: the iDive parser used to cache a single location and return it
from `DC_FIELD_LOCATION` while ignoring the `flags` argument, so our wrapper's
two calls (entry, exit) both received the same coordinate.

Upstream commit `77759ab` (2026-06-21), *"Add a new location sample to report
multiple GPS locations"*, **deleted** `DC_FIELD_LOCATION` from five parsers in
one go — `divesystem_idive`, `divesoft_freedom`, `halcyon_symbios`, `hw_ostc`
and `shearwater_predator` — and moved them all to `DC_SAMPLE_LOCATION`. Its
message notes "Currently there are no such computers left anymore," i.e.
upstream treats the field as dead.

That commit entered our tree via submodule bump `2911e9d8f62` (2026-07-15,
Perdix 3 V2 support). Our fork's patch re-added the field **for Shearwater
only**, so Shearwater kept working and masked the loss everywhere else. Verified:

```
$ git merge-base --is-ancestor 77759ab <gitlink @ 947d1b4, 2026-07-07>   # clean
$ git merge-base --is-ancestor 77759ab <gitlink @ 2911e9d, 2026-07-15>   # contains
```

Worth noting `2911e9d8f62` is the same bump that silently desynced the
hand-curated per-platform source lists. That is twice now that a libdivecomputer
bump has broken something without any build or test going red — once by removing
a source file, once by removing a parser capability the wrapper depends on. A
bump checklist that diffs parser *capabilities*, not just file adds/deletes,
would have caught both.

Upstream's direction is the sample API, so handling it is the durable path.
Shearwater now emits both, and this PR keeps the field authoritative so existing
Shearwater behaviour is bit-identical.
See `packages/libdivecomputer_plugin/patches/0001-shearwater-swift-exit-gps.patch`.

As a side effect this also **improves** on the pre-regression behaviour for
Ratio: #310 reported entry and exit as the same coordinate, whereas the sample
stream carries genuinely distinct entry and exit fixes.

## Changes

- `libdc_download.c`: handle `DC_SAMPLE_LOCATION` in `sample_callback` and
  promote per-sample fixes to the dive-level entry/exit positions the rest of
  the app already consumes — first usable fix becomes the entry point, the most
  recent one the exit point.
- A dive with a **single** fix leaves exit unset rather than mirroring entry;
  a duplicated point renders as a bogus second marker on the map (the same
  regression shape as the earlier Shearwater exit-GPS work).
- New `is_usable_location()` rejects `0/0` — the device writes a record even
  with no satellite lock — and values outside the WGS84 range. This is load
  bearing, not tidiness: without it a leading no-lock record would claim the
  entry slot and demote the real fix to exit.
- A genuine `DC_FIELD_LOCATION` still wins, tracked via `has_field_location`
  on `sample_state_t`, so the Shearwater path is untouched.
- Three regression tests in `test/native/test_parse_raw_dive.c`.

No other layer needed changes, and no Dart changed.

### Recovering already-downloaded dives

`libdc_parse_raw_dive` shares `extract_dive_fields` with the download path, and
`reparse_service.dart` writes entry/exit GPS back — so **"Re-parse raw data"
recovers coordinates for dives already in the log**, from the stored raw blob,
with no re-download. Worth telling the reporter on #926.

## Test Plan

- [x] `flutter analyze` passes (clean in the worktree)
- [x] `dart format` clean
- [x] Native suite: **8/8 pass** via `ctest` in
      `packages/libdivecomputer_plugin/test/native`
- [x] 293 `test/features/dive_computer` Dart tests pass
- [x] `flutter test` — hook skipped local tests as this push contains no Dart
      changes; CI runs the full suite

Tests were written first and confirmed failing: the two-fix case failed on
`!isnan(result.entry_latitude)` before the fix.

New cases, driven by a **synthetic iX3M blob** built from the parser's record
layout so no hardware is required:

| Test | Asserts |
| --- | --- |
| `test_parse_ratio_ix3m_sample_gps` | two fixes yield distinct entry and exit |
| `test_parse_ratio_ix3m_single_fix` | one fix sets entry, leaves exit NaN |
| `test_parse_ratio_ix3m_null_island_ignored` | a `0/0` record is ignored entirely |

Per-family tests for Halcyon / OSTC / Divesoft were deliberately skipped — they
hit the identical wrapper branch, so these three already cover the mechanism.

### Not verified, and worth flagging

- **No hardware pass.** The fixture is synthetic. It proves the wrapper handles
  the sample API correctly; it does not prove a real iX3M2 writes `REC_INFO`
  where the parser expects. A raw blob from the reporter would turn this into a
  real fixture.
- **Site assignment stays manual.** Coordinates now arrive, but a dive still
  won't self-assign a site until the user runs "Match sites" from the dive list
  overflow menu. That is pre-existing behaviour, left alone here; auto-routing
  GPS-bearing downloads into `/dives/match-sites` would be a separate change to
  a shared flow.
