### PR TITLE
Implement Terminal I/O credit handshake for Heinrichs Weikamp BLE

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -415,6 +415,19 @@ class BleIoStream(
                 // released for a write that did not take one.
                 if (creditTopUpInFlight) {
                     creditTopUpInFlight = false
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        // Only now is the module known to hold the grant.
+                        credits += TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD
+                        NativeLogger.d(TAG, "BLE",
+                            "Terminal I/O: credits acknowledged (balance=$credits)")
+                    } else {
+                        // Leave the balance uncredited so the next packet
+                        // retries rather than stalling on credits the module
+                        // never received.
+                        NativeLogger.w(TAG, "BLE",
+                            "Terminal I/O: credit grant not acknowledged" +
+                                " status=$status; will retry")
+                    }
                     gattOperation.release()
                     return
                 }
@@ -544,10 +557,17 @@ class BleIoStream(
         // Commit the grant only when the request was accepted; otherwise the
         // balance must stay as it is so the next packet asks again.
         if (g.writeCharacteristic(creditsChar)) {
+            // Do NOT count the grant yet. writeCharacteristic() reporting true
+            // only means Android accepted the request; the write can still
+            // fail at the ATT layer, and counting credits the module never
+            // received leaves the balance permanently above the refill
+            // threshold -- the module falls silent, no packets arrive to
+            // decrement it, and the transfer stalls for good. The balance may
+            // run understated in the meantime, which only costs an early
+            // refill.
             creditTopUpInFlight = true
-            credits += grant
             NativeLogger.d(TAG, "BLE",
-                "Terminal I/O: granted $grant more credits (balance=$credits)")
+                "Terminal I/O: requesting $grant more credits (balance=$credits)")
         } else {
             // No completion callback is coming, so release the gate here.
             gattOperation.release()

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -184,6 +184,23 @@ class BleIoStream(
             } else {
                 connected = false
                 lastDisconnectStatus = status
+                // A credit top-up that was accepted before the link dropped
+                // never gets its completion callback, so its permit would be
+                // held for the life of this object. Every later command write
+                // would then wait on the gate instead of failing fast -- and
+                // libdivecomputer passes a negative timeout for "no timeout",
+                // which write() maps to Long.MAX_VALUE, so the wait would be
+                // indefinite rather than merely slow. Clear the flag before
+                // releasing so a late callback cannot release it a second
+                // time; Semaphore has no permit ceiling, and an over-release
+                // would silently destroy the mutual exclusion the gate exists
+                // for. Both callbacks arrive on the same GATT callback thread,
+                // so this check and the one in onCharacteristicWrite cannot
+                // interleave.
+                if (creditTopUpInFlight) {
+                    creditTopUpInFlight = false
+                    gattOperation.release()
+                }
                 NativeLogger.d(TAG, "BLE", "onConnectionStateChange: disconnected status=$status")
                 connectSemaphore.release()
             }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -133,6 +133,9 @@ class BleIoStream(
     // Set while a mid-transfer top-up holds the GATT gate. Only touched on the
     // GATT callback thread.
     private var creditTopUpInFlight = false
+    // Set once the opening grant is confirmed; top-ups stay suppressed until
+    // then so they cannot race the setup write.
+    private var creditsOpen = false
     // GATT status of the most recent command write, so writeLocked() can fail
     // a write the peripheral rejected instead of reporting it as sent.
     private var lastWriteStatus = BluetoothGatt.GATT_SUCCESS
@@ -446,6 +449,7 @@ class BleIoStream(
                     setupStep = SetupStep.NONE
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         credits = TIO_INITIAL_GRANT
+                        creditsOpen = true
                         NativeLogger.d(TAG, "BLE",
                             "Terminal I/O: bridge open (credits=$credits)")
                     } else if (creditsRequired) {
@@ -557,6 +561,14 @@ class BleIoStream(
     private fun replenishCredits() {
         val creditsChar = creditsWriteCharacteristic ?: return
         val g = gatt ?: return
+
+        // Nothing until the opening grant has been confirmed. Notifications go
+        // live before that write is issued -- the u-blox service streams with
+        // no credits at all -- and a refill requested in that window would put
+        // a second credit write on the wire alongside the opening one. Their
+        // completions are indistinguishable here, so the setup step and the
+        // top-up would be mis-attributed to each other.
+        if (!creditsOpen) return
 
         if (credits > 0) credits--
         if (credits > TIO_REFILL_THRESHOLD) return
@@ -880,6 +892,7 @@ class BleIoStream(
         creditsNotifyCharacteristic = null
         credits = 0
         creditsRequired = false
+        creditsOpen = false
         creditTopUpInFlight = false
         setupStep = SetupStep.NONE
     }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -130,10 +130,21 @@ class BleIoStream(
     // Whether a failed opening grant is fatal (Telit) or falls back to running
     // without flow control (u-blox, where it is optional).
     private var creditsRequired = false
+    // Set while a mid-transfer top-up holds the GATT gate. Only touched on the
+    // GATT callback thread.
+    private var creditTopUpInFlight = false
     private var setupStep = SetupStep.NONE
 
     private val readQueue = LinkedBlockingQueue<ByteArray>()
     private val writeSemaphore = Semaphore(0)
+    // One permit, held from the moment a GATT write is issued until its
+    // completion callback arrives. Android's BluetoothGatt carries a single
+    // busy flag and rejects writeCharacteristic() while any operation is
+    // pending, so command writes and credit top-ups must not overlap.
+    // Acquired with a timeout on the download thread; only ever tryAcquire()d
+    // on the callback thread, which must stay free to deliver the completion
+    // that releases it.
+    private val gattOperation = Semaphore(1)
     private val connectSemaphore = Semaphore(0)
     private var connected = false
     private var readBuffer = ByteArray(0)
@@ -381,6 +392,15 @@ class BleIoStream(
             // command write that is still in flight and desynchronise the
             // protocol.
             if (characteristic.uuid == creditsWriteCharacteristic?.uuid) {
+                // A mid-transfer top-up owns the GATT gate; release it before
+                // anything else can want it. Tracked by its own flag rather
+                // than inferred from setupStep, so the permit can never be
+                // released for a write that did not take one.
+                if (creditTopUpInFlight) {
+                    creditTopUpInFlight = false
+                    gattOperation.release()
+                    return
+                }
                 if (setupStep == SetupStep.INITIAL_CREDITS) {
                     setupStep = SetupStep.NONE
                     if (status == BluetoothGatt.GATT_SUCCESS) {
@@ -484,17 +504,28 @@ class BleIoStream(
         if (credits > 0) credits--
         if (credits > TIO_REFILL_THRESHOLD) return
 
+        // Never preempt a command write. Android permits one GATT operation in
+        // flight and rejects the loser, and a rejected command write fails the
+        // whole download, so credit maintenance always yields. tryAcquire and
+        // never a blocking acquire: this runs on the GATT callback thread,
+        // which must stay free to deliver the completion that frees the gate.
+        // Skipping is cheap -- there are TIO_REFILL_THRESHOLD packets of slack
+        // and the next one retries.
+        if (!gattOperation.tryAcquire()) return
+
         val grant = TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD
         creditsChar.value = byteArrayOf(grant.toByte())
         creditsChar.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-        // Android permits one GATT operation in flight, so a top-up issued
-        // while a command write is pending is refused. Commit the grant only
-        // when the request was accepted; otherwise the next packet retries,
-        // with TIO_REFILL_THRESHOLD packets of slack to recover within.
+        // Commit the grant only when the request was accepted; otherwise the
+        // balance must stay as it is so the next packet asks again.
         if (g.writeCharacteristic(creditsChar)) {
+            creditTopUpInFlight = true
             credits += grant
             NativeLogger.d(TAG, "BLE",
                 "Terminal I/O: granted $grant more credits (balance=$credits)")
+        } else {
+            // No completion callback is coming, so release the gate here.
+            gattOperation.release()
         }
     }
 
@@ -695,6 +726,32 @@ class BleIoStream(
         }
 
         NativeLogger.d(TAG, "BLE", "write: ${data.size} bytes, timeout=$timeoutMs")
+
+        // Claim the GATT gate for the whole request/completion cycle so a
+        // credit top-up cannot be in flight when this write is issued. Android
+        // rejects writeCharacteristic() outright while another operation is
+        // pending, and a rejected command write fails the download with no
+        // retry -- unlike a rejected credit write, which simply waits for the
+        // next packet. Blocking here is safe: this is the libdivecomputer
+        // download thread, not the callback thread that releases the gate.
+        val timeout = if (timeoutMs < 0) Long.MAX_VALUE else timeoutMs.toLong()
+        if (!gattOperation.tryAcquire(timeout, TimeUnit.MILLISECONDS)) {
+            NativeLogger.e(TAG, "BLE", "write: timed out waiting for GATT to be free")
+            return -1
+        }
+        try {
+            return writeLocked(char, g, data, timeout)
+        } finally {
+            gattOperation.release()
+        }
+    }
+
+    private fun writeLocked(
+        char: BluetoothGattCharacteristic,
+        g: BluetoothGatt,
+        data: ByteArray,
+        timeout: Long
+    ): Int {
         char.value = data
         // Use WRITE_NO_RESPONSE when supported. Many BLE dive computers
         // (including Shearwater) only process WRITE_NO_RESPONSE at the
@@ -717,7 +774,6 @@ class BleIoStream(
         // Android BLE only allows one GATT operation at a time;
         // without this wait, a subsequent write would fail because
         // the previous one is still in flight.
-        val timeout = if (timeoutMs < 0) Long.MAX_VALUE else timeoutMs.toLong()
         if (!writeSemaphore.tryAcquire(timeout, TimeUnit.MILLISECONDS)) return -1
 
         return data.size
@@ -740,6 +796,7 @@ class BleIoStream(
         creditsNotifyCharacteristic = null
         credits = 0
         creditsRequired = false
+        creditTopUpInFlight = false
         setupStep = SetupStep.NONE
     }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -810,6 +810,16 @@ class BleIoStream(
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
         }
 
+        // Discard any permit left behind by an earlier write that timed out
+        // before its completion callback arrived. Without this, that stale
+        // permit satisfies this write's wait immediately: write() would report
+        // success while the write was still in flight, and the finally block
+        // would hand back the GATT gate, letting the next command write be
+        // issued on top of an operation Android still considers pending --
+        // which it then rejects, failing the download. darwin drains the same
+        // semaphore for the same reason before a with-response write.
+        writeSemaphore.drainPermits()
+
         if (!g.writeCharacteristic(char)) {
             NativeLogger.e(TAG, "BLE", "write: writeCharacteristic() returned false")
             return -1

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -20,14 +20,61 @@ import java.util.concurrent.TimeUnit
 // Client Characteristic Configuration Descriptor UUID for enabling notifications.
 private val CCCD_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 
+// Telit/Stollmann Terminal I/O (TIO), service 0xFEFB.
+//
+// Heinrichs Weikamp computers built on the Telit (formerly Stollmann)
+// BlueMod+SR module -- the OSTC 2/3/4/Sport/cR/Plus family -- expose their
+// serial bridge behind this service with credit-based flow control (Telit
+// "TIO Implementation Guide" r04). The module carries no UART data until the
+// client subscribes to UART Credits TX and grants initial credits on UART
+// Credits RX, and it spends one credit per notification, so the balance must
+// also be topped up while a transfer runs. Without the handshake the first
+// command write fails and libdivecomputer reports "Failed to send the
+// command" (issue #923, OSTC4).
+//
+// Subsurface implements the same handshake in core/qt-ble.cpp across the two
+// Heinrichs Weikamp module families, and both are handled here: Telit (0xFEFB,
+// four characteristics, credits mandatory) and the u-blox serial service
+// (...d701, two characteristics, credits optional -- the OSTC nano downloads
+// today with no handshake at all, #280/#394, so a rejected grant there falls
+// back to running without flow control instead of failing a working device).
+// Mirrors darwin's BleCharacteristicSelector + TerminalIoCreditPolicy.
+private val TIO_SERVICE_UUID = UUID.fromString("0000fefb-0000-1000-8000-00805f9b34fb")
+private val TIO_DATA_RX_UUID = UUID.fromString("00000001-0000-1000-8000-008025000000")
+private val TIO_DATA_TX_UUID = UUID.fromString("00000002-0000-1000-8000-008025000000")
+private val TIO_CREDITS_RX_UUID = UUID.fromString("00000003-0000-1000-8000-008025000000")
+private val TIO_CREDITS_TX_UUID = UUID.fromString("00000004-0000-1000-8000-008025000000")
+
+// u-blox serial service: one characteristic carries data in both directions
+// and one carries credits in both directions.
+private val UBLOX_SERVICE_UUID = UUID.fromString("2456e1b9-26e2-8f83-e744-f34f01e9d701")
+private val UBLOX_DATA_UUID = UUID.fromString("2456e1b9-26e2-8f83-e744-f34f01e9d703")
+private val UBLOX_CREDITS_UUID = UUID.fromString("2456e1b9-26e2-8f83-e744-f34f01e9d704")
+
+// Opening credit grant. 0xFF is reserved by the TIO protocol, so 254 is the
+// largest value that means "credits" rather than a control code.
+private const val TIO_INITIAL_GRANT = 254
+// Balance at or below which the client tops the module back up.
+private const val TIO_REFILL_THRESHOLD = 32
+
 // Preferred UUIDs for characteristic selection scoring (matching Darwin BleIoStream).
 // These ensure devices like Aqualung/Oceanic select the correct write and notify
 // characteristics when the service has multiple write-capable chars.
 private val PREFERRED_SERVICE_UUIDS = setOf(
-    UUID.fromString("cb3c4555-d670-4670-bc20-b61dbc851e9a")
+    UUID.fromString("cb3c4555-d670-4670-bc20-b61dbc851e9a"),
+    // Biased so the serial bridge always beats the Stollmann vendor service
+    // the same devices also advertise, which can tie on raw score.
+    TIO_SERVICE_UUID,
+    UBLOX_SERVICE_UUID
 )
 private val PREFERRED_WRITE_UUIDS = setOf(
     UUID.fromString("6606ab42-89d5-4a00-a8ce-4eb5e1414ee0"),
+    // Telit UART Data RX. Raw scoring already prefers it over UART Credits RX,
+    // but commands written to the credits characteristic would be silently
+    // swallowed, so the pair is pinned rather than left to the heuristic.
+    TIO_DATA_RX_UUID,
+    // u-blox FIFO, pinned over the credits characteristic for the same reason.
+    UBLOX_DATA_UUID,
     // Halcyon Symbios: the app writes commands to the device's Rx endpoint
     // (00000101). Both Symbios characteristics advertise read+write+indicate and
     // tie on raw score, so a preferred UUID is required to tell them apart. The
@@ -38,6 +85,11 @@ private val PREFERRED_WRITE_UUIDS = setOf(
 )
 private val PREFERRED_NOTIFY_UUIDS = setOf(
     UUID.fromString("a60b8e5c-b267-44d7-9764-837caf96489e"),
+    // Telit UART Data TX (see PREFERRED_WRITE_UUIDS).
+    TIO_DATA_TX_UUID,
+    // u-blox FIFO carries data in both directions, so it is the notify
+    // candidate as well as the write one.
+    UBLOX_DATA_UUID,
     // Halcyon Symbios: the device transmits replies on its Tx endpoint
     // (00000201) via indications; the app writes commands on 00000101 (see
     // PREFERRED_WRITE_UUIDS and issue #288).
@@ -61,8 +113,24 @@ class BleIoStream(
         private const val TAG = "BleIoStream"
     }
 
+    // Which step of the connection handshake is in flight. Telit Terminal I/O
+    // devices subscribe to UART Credits TX, then UART Data TX, then grant
+    // initial credits; everything else only does the DATA_NOTIFY step. Android
+    // permits one GATT operation at a time, so these must be chained through
+    // their completion callbacks rather than issued together.
+    private enum class SetupStep { NONE, CREDITS_NOTIFY, DATA_NOTIFY, INITIAL_CREDITS }
+
     private var gatt: BluetoothGatt? = null
     private var writeCharacteristic: BluetoothGattCharacteristic? = null
+    private var notifyCharacteristic: BluetoothGattCharacteristic? = null
+    // UART Credits RX/TX, non-null only on Telit Terminal I/O devices.
+    private var creditsWriteCharacteristic: BluetoothGattCharacteristic? = null
+    private var creditsNotifyCharacteristic: BluetoothGattCharacteristic? = null
+    private var credits = 0
+    // Whether a failed opening grant is fatal (Telit) or falls back to running
+    // without flow control (u-blox, where it is optional).
+    private var creditsRequired = false
+    private var setupStep = SetupStep.NONE
 
     private val readQueue = LinkedBlockingQueue<ByteArray>()
     private val writeSemaphore = Semaphore(0)
@@ -130,6 +198,9 @@ class BleIoStream(
             var bestServiceScore = -1
             var bestWrite: BluetoothGattCharacteristic? = null
             var bestNotify: BluetoothGattCharacteristic? = null
+            var bestCreditsWrite: BluetoothGattCharacteristic? = null
+            var bestCreditsNotify: BluetoothGattCharacteristic? = null
+            var bestCreditsRequired = false
 
             for (service in gatt.services) {
                 NativeLogger.d(TAG, "BLE", "Service: ${service.uuid}")
@@ -178,39 +249,67 @@ class BleIoStream(
                         bestServiceScore = score
                         bestWrite = serviceWrite
                         bestNotify = serviceNotify
+                        // Only run the handshake on a complete known layout, so
+                        // every other device keeps today's plain write/notify
+                        // path. Telit needs all four UART characteristics;
+                        // u-blox needs its data and credits pair.
+                        val tioCreditsRx = service.getCharacteristic(TIO_CREDITS_RX_UUID)
+                        val tioCreditsTx = service.getCharacteristic(TIO_CREDITS_TX_UUID)
+                        val ubloxCredits = service.getCharacteristic(UBLOX_CREDITS_UUID)
+                        if (tioCreditsRx != null && tioCreditsTx != null &&
+                            service.getCharacteristic(TIO_DATA_RX_UUID) != null &&
+                            service.getCharacteristic(TIO_DATA_TX_UUID) != null
+                        ) {
+                            bestCreditsWrite = tioCreditsRx
+                            bestCreditsNotify = tioCreditsTx
+                            bestCreditsRequired = true
+                        } else if (ubloxCredits != null &&
+                            service.getCharacteristic(UBLOX_DATA_UUID) != null
+                        ) {
+                            bestCreditsWrite = ubloxCredits
+                            bestCreditsNotify = ubloxCredits
+                            bestCreditsRequired = false
+                        } else {
+                            bestCreditsWrite = null
+                            bestCreditsNotify = null
+                            bestCreditsRequired = false
+                        }
                     }
                 }
             }
 
-            var startedDescriptorWrite = false
+            var startedSetup = false
             if (bestWrite != null && bestNotify != null) {
                 NativeLogger.d(TAG, "BLE", "Data service selected (score=$bestServiceScore)")
                 NativeLogger.d(TAG, "BLE", "  write=${bestWrite.uuid} notify=${bestNotify.uuid}")
                 writeCharacteristic = bestWrite
-                gatt.setCharacteristicNotification(bestNotify, true)
-                val descriptor = bestNotify.getDescriptor(CCCD_UUID)
-                NativeLogger.d(TAG, "BLE", "  CCCD descriptor: ${descriptor?.uuid ?: "NULL"}")
-                if (descriptor != null) {
-                    // Use ENABLE_INDICATION_VALUE for INDICATE-only chars,
-                    // ENABLE_NOTIFICATION_VALUE otherwise.
-                    descriptor.value = if (
-                        bestNotify.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY == 0 &&
-                        bestNotify.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0
-                    ) {
-                        BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
-                    } else {
-                        BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                    }
-                    startedDescriptorWrite = gatt.writeDescriptor(descriptor)
-                    NativeLogger.d(TAG, "BLE", "  writeDescriptor returned: $startedDescriptorWrite")
+                notifyCharacteristic = bestNotify
+                creditsWriteCharacteristic = bestCreditsWrite
+                creditsNotifyCharacteristic = bestCreditsNotify
+                creditsRequired = bestCreditsRequired
+
+                // Terminal I/O subscribes to Credits TX before Data TX (Telit
+                // TIO Implementation Guide r04 sections 6.4 and 6.2, and the
+                // same order in Subsurface's qt-ble.cpp). The payload is never
+                // consumed, but the module keeps the UART bridge closed until
+                // the subscription exists.
+                val creditsNotify = bestCreditsNotify
+                startedSetup = if (creditsNotify != null) {
+                    NativeLogger.d(TAG, "BLE",
+                        "  Credit flow control detected" +
+                            " (${if (bestCreditsRequired) "Telit, required" else "u-blox, optional"}):" +
+                            " creditsRx=${bestCreditsWrite?.uuid} creditsTx=${creditsNotify.uuid}")
+                    subscribeToNotifications(gatt, creditsNotify, SetupStep.CREDITS_NOTIFY)
+                } else {
+                    subscribeToNotifications(gatt, bestNotify, SetupStep.DATA_NOTIFY)
                 }
             }
 
-            // If a CCCD descriptor write was started, wait for
-            // onDescriptorWrite before signalling ready. Otherwise
-            // the download may call writeCharacteristic while the
-            // descriptor write is still in flight, which silently fails.
-            if (!startedDescriptorWrite) {
+            // If a setup operation was started, wait for its completion
+            // callback before signalling ready. Otherwise the download may
+            // call writeCharacteristic while the descriptor write is still in
+            // flight, which silently fails.
+            if (!startedSetup) {
                 connectSemaphore.release()
             }
         }
@@ -221,8 +320,32 @@ class BleIoStream(
             status: Int
         ) {
             NativeLogger.d(TAG, "BLE", "onDescriptorWrite: ${descriptor.uuid} status=$status")
-            // CCCD write completed; notification subscription is active
-            // on the remote device and GATT is free for I/O.
+            val completed = setupStep
+            setupStep = SetupStep.NONE
+            val ok = status == BluetoothGatt.GATT_SUCCESS
+
+            // Credits TX is live; Data TX comes next, and the initial credit
+            // grant after that.
+            if (completed == SetupStep.CREDITS_NOTIFY && (ok || !creditsRequired)) {
+                if (!ok) abandonCreditFlowControl("credits subscription failed status=$status")
+                val notify = notifyCharacteristic
+                if (notify != null &&
+                    subscribeToNotifications(gatt, notify, SetupStep.DATA_NOTIFY)
+                ) {
+                    return
+                }
+            } else if (completed == SetupStep.DATA_NOTIFY && ok) {
+                if (creditsWriteCharacteristic == null) {
+                    // No credit flow control on this device, or already
+                    // abandoned: GATT is free for I/O.
+                } else if (grantInitialCredits(gatt)) {
+                    return
+                } else if (!creditsRequired) {
+                    abandonCreditFlowControl("initial credit write rejected")
+                }
+            }
+
+            // Nothing further in flight; GATT is free for I/O.
             connectSemaphore.release()
         }
 
@@ -234,7 +357,7 @@ class BleIoStream(
             value: ByteArray
         ) {
             NativeLogger.d(TAG, "BLE", "onCharacteristicChanged(API33+): ${value.size} bytes")
-            readQueue.offer(value)
+            onNotification(characteristic, value)
         }
 
         // Pre-API 33 fallback: notification data is on characteristic.value.
@@ -245,7 +368,7 @@ class BleIoStream(
         ) {
             val value = characteristic.value ?: return
             NativeLogger.d(TAG, "BLE", "onCharacteristicChanged(legacy): ${value.size} bytes")
-            readQueue.offer(value)
+            onNotification(characteristic, value)
         }
 
         override fun onCharacteristicWrite(
@@ -253,7 +376,125 @@ class BleIoStream(
             characteristic: BluetoothGattCharacteristic,
             status: Int
         ) {
+            // Credit grants share this callback with command writes but not
+            // their semaphore: releasing writeSemaphore here would free a
+            // command write that is still in flight and desynchronise the
+            // protocol.
+            if (characteristic.uuid == creditsWriteCharacteristic?.uuid) {
+                if (setupStep == SetupStep.INITIAL_CREDITS) {
+                    setupStep = SetupStep.NONE
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        credits = TIO_INITIAL_GRANT
+                        NativeLogger.d(TAG, "BLE",
+                            "Terminal I/O: bridge open (credits=$credits)")
+                    } else if (creditsRequired) {
+                        NativeLogger.e(TAG, "BLE",
+                            "Terminal I/O: initial credit grant failed status=$status")
+                    } else {
+                        abandonCreditFlowControl(
+                            "initial credit grant failed status=$status")
+                    }
+                    connectSemaphore.release()
+                }
+                return
+            }
             writeSemaphore.release()
+        }
+    }
+
+    // Route one notification, ignoring anything that is not the selected data
+    // characteristic. UART Credits TX carries no application data; injecting
+    // its indications into the read queue would corrupt the protocol stream.
+    private fun onNotification(
+        characteristic: BluetoothGattCharacteristic,
+        value: ByteArray
+    ) {
+        val notify = notifyCharacteristic
+        if (notify != null && characteristic.uuid != notify.uuid) return
+        readQueue.offer(value)
+        replenishCredits()
+    }
+
+    // Give up on credit flow control and run the connection without it.
+    //
+    // Only reachable for u-blox, whose serial service treats flow control as
+    // optional and already works with no handshake at all (#280, #394). A
+    // Telit bridge carries nothing without credits, so its failures are fatal
+    // and never come here.
+    private fun abandonCreditFlowControl(reason: String) {
+        NativeLogger.w(TAG, "BLE",
+            "Terminal I/O: $reason; continuing without credit flow control")
+        creditsWriteCharacteristic = null
+        creditsNotifyCharacteristic = null
+    }
+
+    // Subscribe to a characteristic and record which setup step is now in
+    // flight. Returns true if the descriptor write was accepted.
+    private fun subscribeToNotifications(
+        gatt: BluetoothGatt,
+        characteristic: BluetoothGattCharacteristic,
+        step: SetupStep
+    ): Boolean {
+        gatt.setCharacteristicNotification(characteristic, true)
+        val descriptor = characteristic.getDescriptor(CCCD_UUID)
+        NativeLogger.d(TAG, "BLE", "  CCCD descriptor: ${descriptor?.uuid ?: "NULL"}")
+        if (descriptor == null) return false
+
+        // Use ENABLE_INDICATION_VALUE for INDICATE-only chars (which is what
+        // UART Credits TX is), ENABLE_NOTIFICATION_VALUE otherwise.
+        descriptor.value = if (
+            characteristic.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY == 0 &&
+            characteristic.properties and BluetoothGattCharacteristic.PROPERTY_INDICATE != 0
+        ) {
+            BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+        } else {
+            BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+        }
+        setupStep = step
+        val started = gatt.writeDescriptor(descriptor)
+        NativeLogger.d(TAG, "BLE", "  writeDescriptor returned: $started")
+        if (!started) setupStep = SetupStep.NONE
+        return started
+    }
+
+    // Write the opening credit grant to UART Credits RX. Returns true if the
+    // write was accepted, in which case onCharacteristicWrite finishes setup.
+    private fun grantInitialCredits(gatt: BluetoothGatt): Boolean {
+        val creditsChar = creditsWriteCharacteristic ?: return false
+        NativeLogger.d(TAG, "BLE",
+            "Terminal I/O: granting $TIO_INITIAL_GRANT initial credits")
+        creditsChar.value = byteArrayOf(TIO_INITIAL_GRANT.toByte())
+        creditsChar.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        setupStep = SetupStep.INITIAL_CREDITS
+        val started = gatt.writeCharacteristic(creditsChar)
+        if (!started) {
+            setupStep = SetupStep.NONE
+            NativeLogger.e(TAG, "BLE", "Terminal I/O: initial credit write rejected")
+        }
+        return started
+    }
+
+    // Account for one received packet and top the module back up when its
+    // balance runs low, so a multi-thousand-notification logbook dump does not
+    // stall once the opening grant is spent.
+    private fun replenishCredits() {
+        val creditsChar = creditsWriteCharacteristic ?: return
+        val g = gatt ?: return
+
+        if (credits > 0) credits--
+        if (credits > TIO_REFILL_THRESHOLD) return
+
+        val grant = TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD
+        creditsChar.value = byteArrayOf(grant.toByte())
+        creditsChar.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+        // Android permits one GATT operation in flight, so a top-up issued
+        // while a command write is pending is refused. Commit the grant only
+        // when the request was accepted; otherwise the next packet retries,
+        // with TIO_REFILL_THRESHOLD packets of slack to recover within.
+        if (g.writeCharacteristic(creditsChar)) {
+            credits += grant
+            NativeLogger.d(TAG, "BLE",
+                "Terminal I/O: granted $grant more credits (balance=$credits)")
         }
     }
 
@@ -272,8 +513,12 @@ class BleIoStream(
             NativeLogger.e(TAG, "BLE", "connectAndDiscover: semaphore timeout")
             return false
         }
-        val ok = connected && writeCharacteristic != null
-        NativeLogger.d(TAG, "BLE", "connectAndDiscover: connected=$connected writeChar=${writeCharacteristic?.uuid} result=$ok")
+        // A Terminal I/O module keeps its UART bridge closed until credits are
+        // granted, so a failed handshake means the first command write would
+        // fail rather than the download merely being slow (issue #923).
+        val terminalIoReady = creditsWriteCharacteristic == null || credits > 0
+        val ok = connected && writeCharacteristic != null && terminalIoReady
+        NativeLogger.d(TAG, "BLE", "connectAndDiscover: connected=$connected writeChar=${writeCharacteristic?.uuid} credits=$credits result=$ok")
         return ok
     }
 
@@ -491,6 +736,11 @@ class BleIoStream(
         gatt?.disconnect()
         gatt?.close()
         gatt = null
+        creditsWriteCharacteristic = null
+        creditsNotifyCharacteristic = null
+        credits = 0
+        creditsRequired = false
+        setupStep = SetupStep.NONE
     }
 
     override fun onPinCodeRequired(address: String): String {

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -448,6 +448,13 @@ class BleIoStream(
                 }
                 return
             }
+            // Only the selected command characteristic drives writeSemaphore.
+            // Matching positively rather than "anything that is not credits"
+            // matters once the u-blox fallback has cleared the credit
+            // characteristics: a late completion for an abandoned credit
+            // grant would otherwise fall through and wake a command write
+            // that is still in flight.
+            if (characteristic.uuid != writeCharacteristic?.uuid) return
             writeSemaphore.release()
         }
     }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -444,6 +444,14 @@ class BleIoStream(
     private fun abandonCreditFlowControl(reason: String) {
         NativeLogger.w(TAG, "BLE",
             "Terminal I/O: $reason; continuing without credit flow control")
+        // Stop the local stack forwarding credit indications we would only
+        // discard. This is a local call with no GATT operation behind it, so
+        // it cannot collide with the setup chain or the write gate. The CCCD
+        // disable that would also stop the module transmitting is deliberately
+        // not chained here: it would need another setup step on a path that
+        // only runs when a u-blox module rejects the grant, and the callbacks
+        // are already filtered out by onNotification.
+        creditsNotifyCharacteristic?.let { gatt?.setCharacteristicNotification(it, false) }
         creditsWriteCharacteristic = null
         creditsNotifyCharacteristic = null
     }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -133,6 +133,9 @@ class BleIoStream(
     // Set while a mid-transfer top-up holds the GATT gate. Only touched on the
     // GATT callback thread.
     private var creditTopUpInFlight = false
+    // GATT status of the most recent command write, so writeLocked() can fail
+    // a write the peripheral rejected instead of reporting it as sent.
+    private var lastWriteStatus = BluetoothGatt.GATT_SUCCESS
     private var setupStep = SetupStep.NONE
 
     private val readQueue = LinkedBlockingQueue<ByteArray>()
@@ -201,6 +204,14 @@ class BleIoStream(
                     creditTopUpInFlight = false
                     gattOperation.release()
                 }
+                // A command write in flight gets no completion callback once
+                // the link is down either. libdivecomputer's negative "no
+                // timeout" maps to Long.MAX_VALUE, so its wait would never
+                // end; wake it with a failure status so it returns -1. A
+                // permit left unconsumed here is harmless because every write
+                // drains the semaphore before issuing.
+                lastWriteStatus = BluetoothGatt.GATT_FAILURE
+                writeSemaphore.release()
                 NativeLogger.d(TAG, "BLE", "onConnectionStateChange: disconnected status=$status")
                 connectSemaphore.release()
             }
@@ -455,6 +466,7 @@ class BleIoStream(
             // grant would otherwise fall through and wake a command write
             // that is still in flight.
             if (characteristic.uuid != writeCharacteristic?.uuid) return
+            lastWriteStatus = status
             writeSemaphore.release()
         }
     }
@@ -826,6 +838,7 @@ class BleIoStream(
         // which it then rejects, failing the download. darwin drains the same
         // semaphore for the same reason before a with-response write.
         writeSemaphore.drainPermits()
+        lastWriteStatus = BluetoothGatt.GATT_SUCCESS
 
         if (!g.writeCharacteristic(char)) {
             NativeLogger.e(TAG, "BLE", "write: writeCharacteristic() returned false")
@@ -837,6 +850,15 @@ class BleIoStream(
         // without this wait, a subsequent write would fail because
         // the previous one is still in flight.
         if (!writeSemaphore.tryAcquire(timeout, TimeUnit.MILLISECONDS)) return -1
+
+        // A write the peripheral rejected must be reported as a failure.
+        // Returning data.size regardless would tell libdivecomputer the
+        // command went out, leaving it waiting for a reply that can never
+        // come. darwin already fails the write on lastWriteError.
+        if (lastWriteStatus != BluetoothGatt.GATT_SUCCESS) {
+            NativeLogger.e(TAG, "BLE", "write: failed status=$lastWriteStatus")
+            return -1
+        }
 
         return data.size
     }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleCharacteristicSelector.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleCharacteristicSelector.swift
@@ -30,6 +30,26 @@ enum BleCharacteristicSelector {
         let characteristics: [Characteristic]
     }
 
+    /// The credit characteristics of the selected service, as positions in the
+    /// same input the write/notify indices address.
+    struct TerminalIoCredits: Equatable {
+        /// Credits RX: the client writes its credit grants here.
+        let writeIndex: Int
+        /// Credits TX: the server indicates its own credits here. The client
+        /// must subscribe even though the payload is not consumed -- a Telit
+        /// module keeps the UART bridge closed until it is. On the u-blox
+        /// serial service both roles are the same characteristic.
+        let notifyIndex: Int
+        /// Whether a failed handshake should fail the connection.
+        ///
+        /// True for Telit, whose bridge carries nothing at all until credits
+        /// are granted. False for u-blox, where flow control is optional: the
+        /// OSTC nano downloads today with no handshake whatsoever (#280,
+        /// #394), so a rejected grant there falls back to running without
+        /// credits rather than breaking a device that already works.
+        let required: Bool
+    }
+
     /// The chosen write/notify pair, identified by position in the input.
     ///
     /// Indices (rather than UUIDs) are returned so the caller resolves the
@@ -41,10 +61,75 @@ enum BleCharacteristicSelector {
         let writeIndex: Int
         let notifyIndex: Int
         let score: Int
+        /// Non-nil only when the selected service exposes the full 4-characteristic
+        /// Telit layout, in which case the caller must run the credit handshake.
+        let terminalIoCredits: TerminalIoCredits?
     }
+
+    // MARK: - Telit/Stollmann Terminal I/O (TIO)
+    //
+    // Heinrichs Weikamp computers built on the Telit (formerly Stollmann)
+    // BlueMod+SR module -- the OSTC 2/3/4/Sport/cR/Plus family -- expose a
+    // serial bridge behind service 0xFEFB that uses credit-based flow control
+    // (Telit "TIO Implementation Guide" r04). The bridge does not carry data
+    // until the client subscribes to UART Credits TX and grants initial
+    // credits on UART Credits RX, so a plain write/notify pair is not enough:
+    // the first command write fails and libdivecomputer reports "Failed to
+    // send the command" (issue #923, OSTC4 on Windows).
+    //
+    // Subsurface implements the same handshake in core/qt-ble.cpp, applying it
+    // to every Heinrichs Weikamp device across two module families, and both
+    // are handled here:
+    //
+    //  - Telit (service 0xFEFB, four characteristics). Credits are mandatory:
+    //    the bridge carries nothing until they are granted.
+    //  - u-blox serial service (0x...d701, two characteristics: one carries
+    //    data in both directions, one carries credits in both directions).
+    //    Flow control there is optional -- the OSTC nano downloads today with
+    //    no handshake at all (#280, #394) -- so a rejected grant falls back to
+    //    running without credits instead of failing a working device. See the
+    //    `required` flag on TerminalIoCredits.
+    //
+    // The credits the module indicates back on Credits TX -- its budget for
+    // what the client may send -- are subscribed to but not consumed or
+    // accounted for, matching Subsurface. Commands are a handful of bytes sent
+    // rarely, so that budget is never the constraint in practice; the
+    // subscription exists because the module requires it before opening the
+    // bridge at all.
+
+    /// 16-bit service 0xFEFB in its 128-bit form.
+    static let terminalIoServiceUUID = CBUUID(
+        string: "0000FEFB-0000-1000-8000-00805F9B34FB")
+    /// UART Data RX: the client writes commands here (write-without-response).
+    static let terminalIoDataRxUUID = CBUUID(
+        string: "00000001-0000-1000-8000-008025000000")
+    /// UART Data TX: the server notifies replies here.
+    static let terminalIoDataTxUUID = CBUUID(
+        string: "00000002-0000-1000-8000-008025000000")
+    /// UART Credits RX: the client writes credit grants here (with response).
+    static let terminalIoCreditsRxUUID = CBUUID(
+        string: "00000003-0000-1000-8000-008025000000")
+    /// UART Credits TX: the server indicates its credits here.
+    static let terminalIoCreditsTxUUID = CBUUID(
+        string: "00000004-0000-1000-8000-008025000000")
+
+    /// u-blox serial service, the other Heinrichs Weikamp module family.
+    static let ubloxServiceUUID = CBUUID(
+        string: "2456E1B9-26E2-8F83-E744-F34F01E9D701")
+    /// u-blox FIFO: one characteristic carries data in both directions.
+    static let ubloxDataUUID = CBUUID(
+        string: "2456E1B9-26E2-8F83-E744-F34F01E9D703")
+    /// u-blox credits: one characteristic carries credits in both directions.
+    static let ubloxCreditsUUID = CBUUID(
+        string: "2456E1B9-26E2-8F83-E744-F34F01E9D704")
 
     static let preferredServiceUUIDs: Set<CBUUID> = [
         CBUUID(string: "CB3C4555-D670-4670-BC20-B61DBC851E9A"),
+        // Telit Terminal I/O. Biased so the serial bridge always beats the
+        // Stollmann vendor service the same devices also advertise, whose
+        // characteristics can tie on raw score and win on discovery order.
+        terminalIoServiceUUID,
+        ubloxServiceUUID,
     ]
 
     static let preferredWriteUUIDs: Set<CBUUID> = [
@@ -59,6 +144,14 @@ enum BleCharacteristicSelector {
         // the device accepts at the ATT layer but never answers -- so downloads
         // timed out with result=-7 (issue #288).
         CBUUID(string: "00000101-8C3B-4F2C-A59E-8C08224F3253"),
+        // Telit UART Data RX. Raw scoring already prefers it over UART Credits
+        // RX (write-without-response +4 beats write +2), but commands written
+        // to the credits characteristic would be silently swallowed, so the
+        // pair is pinned rather than left to the heuristic.
+        terminalIoDataRxUUID,
+        // u-blox FIFO, pinned over the credits characteristic for the same
+        // reason: both are writable and would otherwise tie on raw score.
+        ubloxDataUUID,
     ]
 
     static let preferredNotifyUUIDs: Set<CBUUID> = [
@@ -67,7 +160,41 @@ enum BleCharacteristicSelector {
         // (00000201) via indications; the app writes commands on 00000101 (see
         // preferredWriteUUIDs and issue #288).
         CBUUID(string: "00000201-8C3B-4F2C-A59E-8C08224F3253"),
+        // Telit UART Data TX (see preferredWriteUUIDs).
+        terminalIoDataTxUUID,
+        // u-blox FIFO carries data in both directions, so it is the notify
+        // candidate as well as the write one.
+        ubloxDataUUID,
     ]
+
+    /// Locate the credit characteristics in a service.
+    ///
+    /// Returns nil unless a complete known layout is present, so the handshake
+    /// is only attempted on the two module families it was written for and
+    /// every other device keeps today's plain write/notify behaviour.
+    static func terminalIoCredits(in service: Service) -> TerminalIoCredits? {
+        func index(of uuid: CBUUID) -> Int? {
+            service.characteristics.firstIndex { $0.uuid == uuid }
+        }
+
+        // Telit: four separate UART characteristics, credits mandatory.
+        if index(of: terminalIoDataRxUUID) != nil,
+            index(of: terminalIoDataTxUUID) != nil,
+            let creditsWrite = index(of: terminalIoCreditsRxUUID),
+            let creditsNotify = index(of: terminalIoCreditsTxUUID) {
+            return TerminalIoCredits(
+                writeIndex: creditsWrite, notifyIndex: creditsNotify, required: true)
+        }
+
+        // u-blox: one data characteristic and one credits characteristic, each
+        // used in both directions. Flow control is optional here.
+        if index(of: ubloxDataUUID) != nil, let credits = index(of: ubloxCreditsUUID) {
+            return TerminalIoCredits(
+                writeIndex: credits, notifyIndex: credits, required: false)
+        }
+
+        return nil
+    }
 
     /// Score a write candidate, or nil if the characteristic cannot be written.
     static func writeScore(_ characteristic: Characteristic) -> Int? {
@@ -131,7 +258,8 @@ enum BleCharacteristicSelector {
                 serviceIndex: serviceIndex,
                 writeIndex: write.index,
                 notifyIndex: notify.index,
-                score: serviceScore
+                score: serviceScore,
+                terminalIoCredits: terminalIoCredits(in: service)
             )
         }
         return best

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -43,6 +43,8 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     private var creditsWriteCharacteristic: CBCharacteristic?
     private var creditsNotifyCharacteristic: CBCharacteristic?
     private var creditsRequired = false
+    /// Grant awaiting its write confirmation, for mid-transfer top-ups only.
+    private var pendingTopUpGrant: UInt8?
     private var creditPolicy = TerminalIoCreditPolicy()
     private var discoveredServices: [(service: CBService, characteristics: [CBCharacteristic])] = []
     private var remainingServiceDiscoveries = 0
@@ -140,6 +142,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         creditsWriteCharacteristic = nil
         creditsNotifyCharacteristic = nil
         creditsRequired = false
+        pendingTopUpGrant = nil
         creditPolicy = TerminalIoCreditPolicy()
         lastCreditWriteError = nil
         hasSeenNotify = false
@@ -285,19 +288,21 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     ///
     /// Called on the CoreBluetooth delegate queue, so the write is issued
     /// without waiting for its confirmation: blocking this queue starves
-    /// notification delivery and loses bytes (issue #394). CoreBluetooth
-    /// queues the write reliably, so the balance is credited here rather than
-    /// on confirmation -- a failure is reported by didWriteValueFor.
+    /// notification delivery and loses bytes (issue #394). The balance is
+    /// therefore credited later, in didWriteValueFor, once the module has
+    /// actually acknowledged the grant -- counting it here would overstate the
+    /// balance whenever a write failed, and an overstated balance stalls the
+    /// transfer permanently (see TerminalIoCreditPolicy).
     private func replenishCredits() {
         guard let creditsChar = creditsWriteCharacteristic,
             let grant = creditPolicy.packetReceived()
         else { return }
 
+        pendingTopUpGrant = grant
         peripheral.writeValue(Data([grant]), for: creditsChar, type: .withResponse)
-        creditPolicy.grantAccepted(grant)
-        let balance = creditPolicy.credits
         NativeLogger.d("BleIoStream", category: "BLE",
-            "Terminal I/O: granted \(grant) more credits (balance=\(balance))")
+            "Terminal I/O: requesting \(grant) more credits"
+                + " (balance=\(self.creditPolicy.credits))")
     }
 
     // MARK: - C Callback Implementations
@@ -746,6 +751,23 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         // write that is still in flight and desynchronise the protocol.
         if let credits = creditsWriteCharacteristic,
             characteristic.uuid == credits.uuid {
+            // A mid-transfer top-up has no waiter; settle it against the
+            // policy here. Only now is the module known to hold the grant.
+            if let grant = pendingTopUpGrant {
+                pendingTopUpGrant = nil
+                if error == nil {
+                    creditPolicy.grantAccepted(grant)
+                    NativeLogger.d("BleIoStream", category: "BLE",
+                        "Terminal I/O: \(grant) credits acknowledged"
+                            + " (balance=\(self.creditPolicy.credits))")
+                } else {
+                    // Leave the balance uncredited so the next packet retries.
+                    creditPolicy.grantFailed()
+                    NativeLogger.w("BleIoStream", category: "BLE",
+                        "Terminal I/O: credit grant not acknowledged; will retry")
+                }
+                return
+            }
             lastCreditWriteError = error
             creditSemaphore.signal()
             return

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -15,6 +15,17 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         string: "6606AB42-89D5-4A00-A8CE-4EB5E1414EE0"
     )
     private static let notifySettleDelaySeconds: TimeInterval = 0.3
+    /// Bound on the opening credit grant.
+    ///
+    /// Deliberately fixed rather than derived from `timeoutMs`. This runs
+    /// inside connectAndDiscover, before libdivecomputer has been handed the
+    /// iostream callbacks, so `set_timeout` cannot have been called yet and
+    /// `timeoutMs` is still its 10000 ms initialiser -- the two are the same
+    /// number. Following the caller's timeout would also let libdivecomputer's
+    /// negative "no timeout" (mapped to `.distantFuture` on the I/O path) hang
+    /// connection setup indefinitely. The neighbouring setup waits are bounded
+    /// the same way: 15 s to connect, 10 s to discover.
+    private static let creditGrantTimeoutSeconds: DispatchTimeInterval = .seconds(10)
     private static let bleIoctlType: UInt32 = UInt32(Character("b").asciiValue!)
     private static let bleIoctlGetNameNumber: UInt32 = 0
     private static let bleIoctlGetPinCodeNumber: UInt32 = 1
@@ -239,7 +250,8 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
                 + " \(creditsChar.uuid.uuidString)")
         peripheral.writeValue(Data([amount]), for: creditsChar, type: .withResponse)
 
-        if creditSemaphore.wait(timeout: .now() + .seconds(10)) == .timedOut {
+        if creditSemaphore.wait(
+            timeout: .now() + Self.creditGrantTimeoutSeconds) == .timedOut {
             return creditGrantFailed("timed out granting initial credits")
         }
         if let error = lastCreditWriteError {

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -263,6 +263,19 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         NativeLogger.w("BleIoStream", category: "BLE",
             "Terminal I/O: \(reason); continuing without credit flow control")
         creditsWriteCharacteristic = nil
+
+        // Unsubscribe rather than merely ignoring the credit indications. The
+        // point is not the discarded delegate callbacks but that the module
+        // stops transmitting them at all: this fallback exists for the OSTC
+        // nano, whose downloads are already lost to a saturated delegate queue
+        // and BLE link (#394), so spending neither airtime nor queue time on a
+        // channel we have given up on matters.
+        if let creditsNotify = creditsNotifyCharacteristic {
+            if creditsNotify.isNotifying {
+                peripheral.setNotifyValue(false, for: creditsNotify)
+            }
+            creditsNotifyCharacteristic = nil
+        }
         return true
     }
 
@@ -769,8 +782,9 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             // A failed credits subscription is survivable on u-blox, whose
             // flow control is optional; on Telit it is the end of the road.
             if step == .creditsNotify, !creditsRequired {
+                // creditGrantFailed clears the credit characteristics; the
+                // subscription never came up here, so it has nothing to undo.
                 _ = creditGrantFailed(failure)
-                creditsNotifyCharacteristic = nil
                 subscribeToDataNotifications()
                 return
             }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -773,6 +773,18 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             return
         }
 
+        // Only the selected command characteristic drives writeSemaphore.
+        // Matching positively rather than "anything that is not credits"
+        // matters once the u-blox fallback has cleared the credit
+        // characteristics: a late completion for a timed-out credit grant
+        // would otherwise fall through here and wake a command write that is
+        // still in flight, desynchronising the protocol.
+        guard let dataCharacteristic = writeCharacteristic,
+            characteristic.uuid == dataCharacteristic.uuid
+        else {
+            return
+        }
+
         lastWriteError = error
         writeSemaphore.signal()
     }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -258,7 +258,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             return creditGrantFailed(
                 "initial credit grant failed: \(error.localizedDescription)")
         }
-        creditPolicy.grantAccepted(amount)
+        creditPolicy.opened(with: amount)
         NativeLogger.d("BleIoStream", category: "BLE",
             "Terminal I/O: bridge open (credits=\(self.creditPolicy.credits))")
         return true

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -28,8 +28,22 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     let peripheral: CBPeripheral
     private let centralManager: CBCentralManager
 
+    /// Which subscription the discovery state machine is waiting on. Telit
+    /// Terminal I/O devices subscribe to UART Credits TX before UART Data TX;
+    /// everything else goes straight to `.dataNotify`.
+    private enum NotifySetupStep {
+        case idle
+        case creditsNotify
+        case dataNotify
+    }
+
     private var writeCharacteristic: CBCharacteristic?
     private var notifyCharacteristic: CBCharacteristic?
+    /// UART Credits RX/TX, non-nil only for Telit Terminal I/O devices.
+    private var creditsWriteCharacteristic: CBCharacteristic?
+    private var creditsNotifyCharacteristic: CBCharacteristic?
+    private var creditsRequired = false
+    private var creditPolicy = TerminalIoCreditPolicy()
     private var discoveredServices: [(service: CBService, characteristics: [CBCharacteristic])] = []
     private var remainingServiceDiscoveries = 0
     private var discoverySignaled = false
@@ -37,14 +51,16 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     private let packetBuffer = PacketReadBuffer()
     private let writeSemaphore = DispatchSemaphore(value: 0)
     private let writeReadySemaphore = DispatchSemaphore(value: 0)
+    private let creditSemaphore = DispatchSemaphore(value: 0)
     private let connectSemaphore = DispatchSemaphore(value: 0)
     private let discoverSemaphore = DispatchSemaphore(value: 0)
 
     private var timeoutMs: Int = 10000
     private var connectError: Error?
     private var isReady = false
-    private var waitingForNotifyEnable = false
+    private var notifySetupStep: NotifySetupStep = .idle
     private var lastWriteError: Error?
+    private var lastCreditWriteError: Error?
     private var hasSeenNotify = false
     private var writeWithoutResponsePreferred = false
     private var consecutiveReadTimeouts = 0
@@ -115,12 +131,17 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
 
         connectError = nil
         isReady = false
-        waitingForNotifyEnable = false
+        notifySetupStep = .idle
         discoverySignaled = false
         remainingServiceDiscoveries = 0
         discoveredServices.removeAll()
         writeCharacteristic = nil
         notifyCharacteristic = nil
+        creditsWriteCharacteristic = nil
+        creditsNotifyCharacteristic = nil
+        creditsRequired = false
+        creditPolicy = TerminalIoCreditPolicy()
+        lastCreditWriteError = nil
         hasSeenNotify = false
         writeWithoutResponsePreferred = false
         consecutiveReadTimeouts = 0
@@ -183,6 +204,13 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             centralManager.cancelPeripheralConnection(peripheral)
             return false
         }
+        // A Telit Terminal I/O module keeps its UART bridge closed until the
+        // client grants initial credits, so the first command write would fail
+        // outright without this (issue #923).
+        if !grantInitialCredits() {
+            centralManager.cancelPeripheralConnection(peripheral)
+            return false
+        }
         Thread.sleep(forTimeInterval: Self.notifySettleDelaySeconds)
         NativeLogger.d("BleIoStream", category: "BLE",
             "Post-notify settle delay complete (\(Int(Self.notifySettleDelaySeconds * 1000)) ms)")
@@ -190,6 +218,73 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             "Discovery ready (write=\(self.writeCharacteristic?.uuid.uuidString ?? "nil")"
                 + " notify=\(self.notifyCharacteristic?.uuid.uuidString ?? "nil"))")
         return true
+    }
+
+    // MARK: - Terminal I/O credits
+
+    /// Write the opening credit grant to Credits RX and wait for the
+    /// confirmation. A no-op (success) on devices with no credit
+    /// characteristics.
+    private func grantInitialCredits() -> Bool {
+        guard let creditsChar = creditsWriteCharacteristic else { return true }
+
+        let amount = TerminalIoCreditPolicy.initialGrant
+        drainSemaphore(creditSemaphore)
+        lastCreditWriteError = nil
+        NativeLogger.d("BleIoStream", category: "BLE",
+            "Terminal I/O: granting \(amount) initial credits on"
+                + " \(creditsChar.uuid.uuidString)")
+        peripheral.writeValue(Data([amount]), for: creditsChar, type: .withResponse)
+
+        if creditSemaphore.wait(timeout: .now() + .seconds(10)) == .timedOut {
+            return creditGrantFailed("timed out granting initial credits")
+        }
+        if let error = lastCreditWriteError {
+            return creditGrantFailed(
+                "initial credit grant failed: \(error.localizedDescription)")
+        }
+        creditPolicy.grantAccepted(amount)
+        NativeLogger.d("BleIoStream", category: "BLE",
+            "Terminal I/O: bridge open (credits=\(self.creditPolicy.credits))")
+        return true
+    }
+
+    /// Decide what a failed opening grant means for this module family.
+    ///
+    /// A Telit bridge carries nothing without credits, so the connection is
+    /// dead. The u-blox serial service treats flow control as optional and
+    /// already works with no handshake at all, so drop back to that rather
+    /// than fail a device that would otherwise download fine.
+    private func creditGrantFailed(_ reason: String) -> Bool {
+        if creditsRequired {
+            NativeLogger.e("BleIoStream", category: "BLE", "Terminal I/O: \(reason)")
+            return false
+        }
+        NativeLogger.w("BleIoStream", category: "BLE",
+            "Terminal I/O: \(reason); continuing without credit flow control")
+        creditsWriteCharacteristic = nil
+        return true
+    }
+
+    /// Account for one received packet and top the module back up when its
+    /// balance runs low, so a multi-thousand-notification logbook dump does
+    /// not stall once the opening grant is spent.
+    ///
+    /// Called on the CoreBluetooth delegate queue, so the write is issued
+    /// without waiting for its confirmation: blocking this queue starves
+    /// notification delivery and loses bytes (issue #394). CoreBluetooth
+    /// queues the write reliably, so the balance is credited here rather than
+    /// on confirmation -- a failure is reported by didWriteValueFor.
+    private func replenishCredits() {
+        guard let creditsChar = creditsWriteCharacteristic,
+            let grant = creditPolicy.packetReceived()
+        else { return }
+
+        peripheral.writeValue(Data([grant]), for: creditsChar, type: .withResponse)
+        creditPolicy.grantAccepted(grant)
+        let balance = creditPolicy.credits
+        NativeLogger.d("BleIoStream", category: "BLE",
+            "Terminal I/O: granted \(grant) more credits (balance=\(balance))")
     }
 
     // MARK: - C Callback Implementations
@@ -614,6 +709,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         // the download loses bytes (issue #394). append() is O(1) and the log
         // is dispatched off this queue by NativeLogger.
         packetBuffer.append(value)
+        replenishCredits()
         NativeLogger.d("BleIoStream", category: "BLE",
             "notify \(characteristic.uuid.uuidString)"
                 + " bytes=\(value.count)"
@@ -623,7 +719,6 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral,
                      didWriteValueFor characteristic: CBCharacteristic,
                      error: Error?) {
-        lastWriteError = error
         if let error {
             NativeLogger.e("BleIoStream", category: "BLE",
                 "didWriteValue error for \(characteristic.uuid.uuidString):"
@@ -632,33 +727,67 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
             NativeLogger.d("BleIoStream", category: "BLE",
                 "didWriteValue ok for \(characteristic.uuid.uuidString)")
         }
+
+        // Credit grants share this callback with command writes but not their
+        // semaphore: signalling writeSemaphore here would release a command
+        // write that is still in flight and desynchronise the protocol.
+        if let credits = creditsWriteCharacteristic,
+            characteristic.uuid == credits.uuid {
+            lastCreditWriteError = error
+            creditSemaphore.signal()
+            return
+        }
+
+        lastWriteError = error
         writeSemaphore.signal()
     }
 
     func peripheral(_ peripheral: CBPeripheral,
                     didUpdateNotificationStateFor characteristic: CBCharacteristic,
                     error: Error?) {
-        guard let notify = notifyCharacteristic, characteristic.uuid == notify.uuid else {
-            return
+        let expected: CBCharacteristic?
+        switch notifySetupStep {
+        case .idle: return
+        case .creditsNotify: expected = creditsNotifyCharacteristic
+        case .dataNotify: expected = notifyCharacteristic
         }
-        guard waitingForNotifyEnable else { return }
-        waitingForNotifyEnable = false
+        guard let expected, characteristic.uuid == expected.uuid else { return }
 
+        let step = notifySetupStep
+        notifySetupStep = .idle
+
+        let failure: String?
         if let error {
+            failure = "failed enabling notify: \(error.localizedDescription)"
+        } else if !characteristic.isNotifying {
+            failure = "notify not active"
+        } else {
+            failure = nil
+        }
+
+        if let failure {
+            // A failed credits subscription is survivable on u-blox, whose
+            // flow control is optional; on Telit it is the end of the road.
+            if step == .creditsNotify, !creditsRequired {
+                _ = creditGrantFailed(failure)
+                creditsNotifyCharacteristic = nil
+                subscribeToDataNotifications()
+                return
+            }
             NativeLogger.e("BleIoStream", category: "BLE",
-                "Failed enabling notify for \(characteristic.uuid.uuidString):"
-                    + " \(error.localizedDescription)")
+                "\(failure) for \(characteristic.uuid.uuidString)")
             signalDiscoveryReady()
             return
         }
-        if !characteristic.isNotifying {
-            NativeLogger.w("BleIoStream", category: "BLE",
-                "Notify not active for \(characteristic.uuid.uuidString)")
-            signalDiscoveryReady()
-            return
-        }
+
         NativeLogger.d("BleIoStream", category: "BLE",
             "Notify enabled for \(characteristic.uuid.uuidString)")
+
+        if step == .creditsNotify {
+            // Credits TX is live; Data TX comes next.
+            subscribeToDataNotifications()
+            return
+        }
         isReady = true
         signalDiscoveryReady()
     }
@@ -696,6 +825,16 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
 
         writeCharacteristic = writeChar
         notifyCharacteristic = notifyChar
+        if let credits = selection.terminalIoCredits {
+            creditsWriteCharacteristic = entry.characteristics[credits.writeIndex]
+            creditsNotifyCharacteristic = entry.characteristics[credits.notifyIndex]
+            creditsRequired = credits.required
+            NativeLogger.d("BleIoStream", category: "BLE",
+                "Credit flow control detected"
+                    + " (\(credits.required ? "Telit, required" : "u-blox, optional")):"
+                    + " creditsRx=\(entry.characteristics[credits.writeIndex].uuid.uuidString)"
+                    + " creditsTx=\(entry.characteristics[credits.notifyIndex].uuid.uuidString)")
+        }
         writeWithoutResponsePreferred = initialWriteWithoutResponsePreference(for: writeChar)
         NativeLogger.d("BleIoStream", category: "BLE",
             "Selected write=\(writeChar.uuid.uuidString)"
@@ -707,12 +846,28 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         NativeLogger.d("BleIoStream", category: "BLE",
             "Initial write mode preference:"
                 + " \(preferWithoutResponse ? "withoutResponse" : "withResponse")")
+        // Terminal I/O requires UART Credits TX to be subscribed before UART
+        // Data TX (Telit TIO Implementation Guide r04 sections 6.4 and 6.2,
+        // and the same order in Subsurface's qt-ble.cpp).
+        if let creditsNotify = creditsNotifyCharacteristic, !creditsNotify.isNotifying {
+            notifySetupStep = .creditsNotify
+            peripheral.setNotifyValue(true, for: creditsNotify)
+            return
+        }
+        subscribeToDataNotifications()
+    }
+
+    private func subscribeToDataNotifications() {
+        guard let notifyChar = notifyCharacteristic else {
+            signalDiscoveryReady()
+            return
+        }
         if notifyChar.isNotifying {
             isReady = true
             signalDiscoveryReady()
             return
         }
-        waitingForNotifyEnable = true
+        notifySetupStep = .dataNotify
         peripheral.setNotifyValue(true, for: notifyChar)
     }
 }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
@@ -14,41 +14,64 @@ import Foundation
 /// PacketReadBuffer and BleCharacteristicSelector are. The Windows, Linux and
 /// Android transports carry line-by-line equivalents.
 ///
-/// Deliberate deviations from Subsurface's core/qt-ble.cpp, which is otherwise
-/// the reference for this handshake:
+/// The balance is only ever credited once the module has *confirmed* it
+/// received a grant, and a grant already in flight suppresses further ones.
+/// The invariant that buys is that the balance may be understated but never
+/// overstated, and the two errors are not symmetric:
 ///
-///  - Subsurface credits its counter when the GATT write is *confirmed* and
-///    refills on `hw_credit == MINIMAL`. An exact-equality test cannot recover
-///    if a decrement is ever missed, so the refill here triggers on `<=`.
-///  - A refill is only committed once the transport reports that the platform
-///    accepted the write request. A rejected request (Android permits one GATT
-///    operation in flight at a time, so a top-up can collide with a command
-///    write) leaves the balance untouched and the next packet asks again --
-///    there are `refillThreshold` packets of slack to retry within.
+///  - Understated: a refill goes out slightly early. Harmless -- the module
+///    caps its own balance and the spare credits are simply unused.
+///  - Overstated: the client believes the module can still send when it
+///    cannot. The module falls silent, no further packets arrive to decrement
+///    the balance, so no refill is ever triggered and the transfer stalls for
+///    good.
+///
+/// Crediting when the platform merely *accepts* the write request would
+/// produce exactly that overstatement, because acceptance is local: Android
+/// reports success from `writeCharacteristic()` and can still fail the write
+/// at the ATT layer afterwards.
+///
+/// Deliberate deviation from Subsurface's core/qt-ble.cpp, otherwise the
+/// reference for this handshake: it refills on `hw_credit == MINIMAL`, an
+/// exact-equality test that cannot recover if a decrement is ever missed, so
+/// the refill here triggers on `<=`.
 struct TerminalIoCreditPolicy {
     /// Opening grant. 0xFF is reserved by the TIO protocol, so 254 is the
     /// largest value that means "credits" rather than a control code.
     static let initialGrant: UInt8 = 254
     /// Balance at or below which the client tops the module back up.
     static let refillThreshold = 32
+    /// Size of a mid-transfer refill.
+    static let refillAmount = UInt8(Int(initialGrant) - refillThreshold)
 
     private(set) var credits = 0
+    private(set) var grantInFlight = false
 
-    /// Record the opening grant, once the transport has written it.
+    /// Record a grant the module has confirmed receiving.
     mutating func grantAccepted(_ amount: UInt8) {
+        grantInFlight = false
         credits += Int(amount)
+    }
+
+    /// Record that a grant never reached the module, so the next packet can
+    /// ask again. The balance is left alone precisely because these credits
+    /// were never counted in the first place.
+    mutating func grantFailed() {
+        grantInFlight = false
     }
 
     /// Account for one received packet.
     ///
-    /// Returns the number of credits the caller must now write to UART Credits
-    /// RX, or nil while the balance is still healthy. The returned grant is not
-    /// applied until the caller reports success via `grantAccepted`.
+    /// Returns the number of credits the caller must now write to Credits RX,
+    /// or nil while the balance is healthy or a grant is already outstanding.
+    /// The returned grant is not counted until the caller confirms it via
+    /// `grantAccepted`.
     mutating func packetReceived() -> UInt8? {
         if credits > 0 {
             credits -= 1
         }
-        guard credits <= Self.refillThreshold else { return nil }
-        return UInt8(Int(Self.initialGrant) - Self.refillThreshold)
+        guard !grantInFlight, credits <= Self.refillThreshold else { return nil }
+        grantInFlight = true
+        return Self.refillAmount
     }
 }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Credit accounting for the Telit/Stollmann Terminal I/O (TIO) profile used
+/// by the Heinrichs Weikamp BlueMod+SR devices (issue #923).
+///
+/// The module will not send a byte over the UART bridge until the client has
+/// granted it credits, and it spends one credit per notification. A single
+/// opening grant therefore only covers the first `initialGrant` packets: an
+/// OSTC logbook dump is thousands of notifications, so the client has to top
+/// the balance up while the transfer runs.
+///
+/// Kept as a dependency-free value type (Foundation only) so it can be
+/// compiled and unit-tested standalone via run_native_tests.sh, the same way
+/// PacketReadBuffer and BleCharacteristicSelector are. The Windows, Linux and
+/// Android transports carry line-by-line equivalents.
+///
+/// Deliberate deviations from Subsurface's core/qt-ble.cpp, which is otherwise
+/// the reference for this handshake:
+///
+///  - Subsurface credits its counter when the GATT write is *confirmed* and
+///    refills on `hw_credit == MINIMAL`. An exact-equality test cannot recover
+///    if a decrement is ever missed, so the refill here triggers on `<=`.
+///  - A refill is only committed once the transport reports that the platform
+///    accepted the write request. A rejected request (Android permits one GATT
+///    operation in flight at a time, so a top-up can collide with a command
+///    write) leaves the balance untouched and the next packet asks again --
+///    there are `refillThreshold` packets of slack to retry within.
+struct TerminalIoCreditPolicy {
+    /// Opening grant. 0xFF is reserved by the TIO protocol, so 254 is the
+    /// largest value that means "credits" rather than a control code.
+    static let initialGrant: UInt8 = 254
+    /// Balance at or below which the client tops the module back up.
+    static let refillThreshold = 32
+
+    private(set) var credits = 0
+
+    /// Record the opening grant, once the transport has written it.
+    mutating func grantAccepted(_ amount: UInt8) {
+        credits += Int(amount)
+    }
+
+    /// Account for one received packet.
+    ///
+    /// Returns the number of credits the caller must now write to UART Credits
+    /// RX, or nil while the balance is still healthy. The returned grant is not
+    /// applied until the caller reports success via `grantAccepted`.
+    mutating func packetReceived() -> UInt8? {
+        if credits > 0 {
+            credits -= 1
+        }
+        guard credits <= Self.refillThreshold else { return nil }
+        return UInt8(Int(Self.initialGrant) - Self.refillThreshold)
+    }
+}

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift
@@ -46,8 +46,25 @@ struct TerminalIoCreditPolicy {
 
     private(set) var credits = 0
     private(set) var grantInFlight = false
+    /// Whether the opening grant has been confirmed.
+    private(set) var isOpen = false
 
-    /// Record a grant the module has confirmed receiving.
+    /// Record the confirmed opening grant, which starts credit accounting.
+    ///
+    /// Nothing is requested before this, because notifications are already
+    /// live by the time the opening grant is written -- the u-blox service in
+    /// particular streams with no credits at all. A refill requested in that
+    /// window would race the opening grant: two credit writes would be
+    /// outstanding on the same characteristic, their completions are
+    /// indistinguishable to the transport, and the balance would end up
+    /// counting both.
+    mutating func opened(with amount: UInt8) {
+        isOpen = true
+        grantInFlight = false
+        credits += Int(amount)
+    }
+
+    /// Record a mid-transfer grant the module has confirmed receiving.
     mutating func grantAccepted(_ amount: UInt8) {
         grantInFlight = false
         credits += Int(amount)
@@ -70,7 +87,9 @@ struct TerminalIoCreditPolicy {
         if credits > 0 {
             credits -= 1
         }
-        guard !grantInFlight, credits <= Self.refillThreshold else { return nil }
+        guard isOpen, !grantInFlight, credits <= Self.refillThreshold else {
+            return nil
+        }
         grantInFlight = true
         return Self.refillAmount
     }

--- a/packages/libdivecomputer_plugin/darwin/Tests/BleCharacteristicSelectorTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/BleCharacteristicSelectorTests/main.swift
@@ -208,6 +208,161 @@ do {
            "higher-score: later notify candidate replaces the earlier one")
 }
 
+// 9. Heinrichs Weikamp OSTC4 (issue #923). The real GATT table enumerated from
+// the reporter's device: the Telit/Stollmann Terminal I/O service alongside the
+// Stollmann vendor service. The transport must land on the TIO service, write
+// commands to UART Data RX, listen on UART Data TX, and surface the credit
+// characteristics so the caller can run the handshake that opens the UART
+// bridge. Without the handshake the first command write fails and
+// libdivecomputer reports "Failed to send the command".
+do {
+    let tioService = "0000FEFB-0000-1000-8000-00805F9B34FB"
+    let dataRx = "00000001-0000-1000-8000-008025000000"
+    let dataTx = "00000002-0000-1000-8000-008025000000"
+    let creditsRx = "00000003-0000-1000-8000-008025000000"
+    let creditsTx = "00000004-0000-1000-8000-008025000000"
+    let vendorService = "53544D54-4552-494F-5345-525631303030"
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: tioService),
+            characteristics: [
+                char(dataRx, [.writeWithoutResponse]),
+                char(dataTx, [.notify]),
+                char(creditsRx, [.write]),
+                char(creditsTx, [.indicate]),
+            ]
+        ),
+        // The vendor service ties on raw score (writeNoResponse+notify = 8) and
+        // would win on discovery order if the TIO service were not preferred.
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: vendorService),
+            characteristics: [
+                char("53544D01-4552-494F-5345-525631303030", [.writeWithoutResponse]),
+                char("53544D02-4552-494F-5345-525631303030", [.notify]),
+            ]
+        ),
+    ]
+    let selection = BleCharacteristicSelector.select(services: services)
+    let result = resolve(services, selection)
+    expect(result?.serviceIndex == 0, "ostc4: Terminal I/O service selected over the vendor service")
+    expect(result?.write == CBUUID(string: dataRx), "ostc4: commands go to UART Data RX")
+    expect(result?.notify == CBUUID(string: dataTx), "ostc4: replies arrive on UART Data TX")
+    expect(selection?.terminalIoCredits?.writeIndex == 2, "ostc4: UART Credits RX located")
+    expect(selection?.terminalIoCredits?.notifyIndex == 3, "ostc4: UART Credits TX located")
+    expect(selection?.terminalIoCredits?.required == true,
+           "ostc4: Telit credits are mandatory (bridge stays closed without them)")
+}
+
+// 10. Discovery order must not decide it: the same two services in the reverse
+// order still select the Terminal I/O service.
+do {
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "53544D54-4552-494F-5345-525631303030"),
+            characteristics: [
+                char("53544D01-4552-494F-5345-525631303030", [.writeWithoutResponse]),
+                char("53544D02-4552-494F-5345-525631303030", [.notify]),
+            ]
+        ),
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "0000FEFB-0000-1000-8000-00805F9B34FB"),
+            characteristics: [
+                char("00000001-0000-1000-8000-008025000000", [.writeWithoutResponse]),
+                char("00000002-0000-1000-8000-008025000000", [.notify]),
+                char("00000003-0000-1000-8000-008025000000", [.write]),
+                char("00000004-0000-1000-8000-008025000000", [.indicate]),
+            ]
+        ),
+    ]
+    let selection = BleCharacteristicSelector.select(services: services)
+    expect(selection?.serviceIndex == 1,
+           "ostc4-reordered: Terminal I/O service wins regardless of discovery order")
+    expect(selection?.terminalIoCredits != nil,
+           "ostc4-reordered: credit characteristics still located")
+}
+
+// 11. Devices with no credit characteristics must be left exactly as they
+// were: no handshake, so every currently-working device stays on today's
+// plain write/notify path.
+do {
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "0000ffe0-0000-1000-8000-00805f9b34fb"),
+            characteristics: [char("0000ffe1-0000-1000-8000-00805f9b34fb",
+                                   [.writeWithoutResponse, .notify])]
+        )
+    ]
+    expect(BleCharacteristicSelector.select(services: services)?.terminalIoCredits == nil,
+           "non-TIO: no credit handshake requested")
+}
+
+// 12. A partial Telit layout -- data characteristics with no credit pair, and
+// not u-blox either -- is an unknown shape and must not trigger a handshake.
+do {
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "0000FEFB-0000-1000-8000-00805F9B34FB"),
+            characteristics: [
+                char("00000001-0000-1000-8000-008025000000", [.writeWithoutResponse]),
+                char("00000002-0000-1000-8000-008025000000", [.notify]),
+            ]
+        )
+    ]
+    expect(BleCharacteristicSelector.select(services: services)?.terminalIoCredits == nil,
+           "partial-TIO: incomplete characteristic set does not trigger the handshake")
+}
+
+// 13. u-blox serial service: one characteristic carries data in both
+// directions and one carries credits in both directions, so the write and
+// notify roles collapse onto the same index on each side. Credits are
+// OPTIONAL here -- a device on this service (the OSTC nano, #280/#394)
+// downloads today with no handshake at all, so a rejected grant must be able
+// to fall back rather than fail the connection.
+do {
+    let ubloxData = "2456E1B9-26E2-8F83-E744-F34F01E9D703"
+    let ubloxCredits = "2456E1B9-26E2-8F83-E744-F34F01E9D704"
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "2456E1B9-26E2-8F83-E744-F34F01E9D701"),
+            characteristics: [
+                char(ubloxData, [.writeWithoutResponse, .notify]),
+                char(ubloxCredits, [.write, .indicate]),
+            ]
+        )
+    ]
+    let selection = BleCharacteristicSelector.select(services: services)
+    let result = resolve(services, selection)
+    expect(result?.write == CBUUID(string: ubloxData), "ublox: commands go to the FIFO characteristic")
+    expect(result?.notify == CBUUID(string: ubloxData), "ublox: replies arrive on the same FIFO characteristic")
+    expect(selection?.terminalIoCredits?.writeIndex == 1, "ublox: credits characteristic located for writes")
+    expect(selection?.terminalIoCredits?.notifyIndex == 1, "ublox: same characteristic used for credit indications")
+    expect(selection?.terminalIoCredits?.required == false,
+           "ublox: credits are optional, so a failed grant can fall back")
+}
+
+// 14. The u-blox credits characteristic must never be mistaken for the data
+// characteristic. Here credits advertise write-without-response + notify --
+// the top raw score on both sides -- so only the preferred-UUID pin on the
+// FIFO keeps commands off the credits endpoint.
+do {
+    let ubloxData = "2456E1B9-26E2-8F83-E744-F34F01E9D703"
+    let ubloxCredits = "2456E1B9-26E2-8F83-E744-F34F01E9D704"
+    let services = [
+        BleCharacteristicSelector.Service(
+            uuid: CBUUID(string: "2456E1B9-26E2-8F83-E744-F34F01E9D701"),
+            characteristics: [
+                char(ubloxCredits, [.writeWithoutResponse, .notify]),
+                char(ubloxData, [.write, .indicate]),
+            ]
+        )
+    ]
+    let result = resolve(services, BleCharacteristicSelector.select(services: services))
+    expect(result?.write == CBUUID(string: ubloxData),
+           "ublox-pin: FIFO wins the write role despite the lower raw score")
+    expect(result?.notify == CBUUID(string: ubloxData),
+           "ublox-pin: FIFO wins the notify role despite the lower raw score")
+}
+
 if failures == 0 {
     print("All BleCharacteristicSelector tests passed.")
     exit(0)

--- a/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+// Standalone test runner for TerminalIoCreditPolicy (no XCTest: the
+// LibDCDarwin package cannot build under SwiftPM because it depends on Flutter
+// modules only present in the CocoaPods build). Run via run_native_tests.sh.
+
+var failures = 0
+
+func expect(_ condition: Bool, _ message: String, line: Int = #line) {
+    if condition {
+        print("PASS: \(message)")
+    } else {
+        print("FAIL: \(message) (main.swift:\(line))")
+        failures += 1
+    }
+}
+
+/// Feed `count` packets through the policy, committing every refill the way a
+/// transport whose writes all succeed would. Returns the grants requested.
+func drain(_ policy: inout TerminalIoCreditPolicy, packets count: Int) -> [UInt8] {
+    var grants: [UInt8] = []
+    for _ in 0..<count {
+        if let grant = policy.packetReceived() {
+            grants.append(grant)
+            policy.grantAccepted(grant)
+        }
+    }
+    return grants
+}
+
+// 1. The opening grant is 254, not 255: 0xFF is a reserved TIO control value.
+do {
+    expect(TerminalIoCreditPolicy.initialGrant == 254,
+           "initial grant is 254 (0xFF is reserved by the TIO protocol)")
+}
+
+// 2. A fresh policy has no credits until the opening grant is committed. This
+// is what keeps the transport from believing the bridge is open before the
+// initial write to UART Credits RX has actually gone out.
+do {
+    var policy = TerminalIoCreditPolicy()
+    expect(policy.credits == 0, "fresh policy starts at zero credits")
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    expect(policy.credits == 254, "opening grant credits the balance")
+}
+
+// 3. Packets below the threshold cost a credit but ask for nothing.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    let grants = drain(&policy, packets: 100)
+    expect(grants.isEmpty, "no refill requested while the balance is healthy")
+    expect(policy.credits == 154, "each packet spends exactly one credit")
+}
+
+// 4. The refill fires at the threshold and restores the full balance, so a
+// long transfer never runs the module dry. 254 - 32 = 222 credits are granted
+// when 32 remain.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    let grants = drain(&policy, packets: 222)
+    expect(grants == [222], "one refill of 222 requested on reaching the threshold")
+    expect(policy.credits == 254, "refill restores the full balance")
+}
+
+// 5. Regression for the real failure mode: an OSTC logbook dump is thousands
+// of notifications. A one-shot grant would stall after 254; the policy must
+// keep topping up and never let the balance reach zero.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    var minimumSeen = Int.max
+    var refills = 0
+    for _ in 0..<5000 {
+        if let grant = policy.packetReceived() {
+            refills += 1
+            policy.grantAccepted(grant)
+        }
+        minimumSeen = min(minimumSeen, policy.credits)
+    }
+    expect(refills > 20, "long transfer refills repeatedly (got \(refills))")
+    expect(minimumSeen > 0, "balance never reaches zero (low-water \(minimumSeen))")
+}
+
+// 6. A refill the platform rejected is not committed, and the next packet asks
+// again. Android allows one GATT operation in flight, so a top-up issued while
+// a command write is pending can be refused; the balance must not drift as if
+// the credits had been granted.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    _ = drain(&policy, packets: 221)
+    let first = policy.packetReceived()  // reaches the threshold, not committed
+    expect(first == 222, "refill requested at the threshold")
+    expect(policy.credits == 32, "a rejected refill leaves the balance untouched")
+    let second = policy.packetReceived()
+    expect(second == 222, "the next packet asks for the refill again")
+    policy.grantAccepted(second ?? 0)
+    expect(policy.credits == 253, "the accepted retry credits the balance")
+}
+
+// 7. The counter cannot go negative even if more packets arrive than were paid
+// for (a stale notification delivered before the opening grant, say), so the
+// refill amount always stays a valid UInt8.
+do {
+    var policy = TerminalIoCreditPolicy()
+    let grants = (0..<10).map { _ in policy.packetReceived() }
+    expect(grants.allSatisfy { $0 == 222 }, "un-granted packets still request a refill")
+    expect(policy.credits == 0, "balance floors at zero rather than going negative")
+}
+
+if failures == 0 {
+    print("All TerminalIoCreditPolicy tests passed.")
+    exit(0)
+} else {
+    print("\(failures) TerminalIoCreditPolicy test(s) FAILED.")
+    exit(1)
+}

--- a/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
@@ -40,14 +40,14 @@ do {
 do {
     var policy = TerminalIoCreditPolicy()
     expect(policy.credits == 0, "fresh policy starts at zero credits")
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     expect(policy.credits == 254, "opening grant credits the balance")
 }
 
 // 3. Packets below the threshold cost a credit but ask for nothing.
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     let grants = drain(&policy, packets: 100)
     expect(grants.isEmpty, "no refill requested while the balance is healthy")
     expect(policy.credits == 154, "each packet spends exactly one credit")
@@ -58,7 +58,7 @@ do {
 // when 32 remain.
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     let grants = drain(&policy, packets: 222)
     expect(grants == [222], "one refill of 222 requested on reaching the threshold")
     expect(policy.credits == 254, "refill restores the full balance")
@@ -69,7 +69,7 @@ do {
 // keep topping up and never let the balance reach zero.
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     var minimumSeen = Int.max
     var refills = 0
     for _ in 0..<5000 {
@@ -89,7 +89,7 @@ do {
 // layer afterwards, so "accepted" is not "received".
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     _ = drain(&policy, packets: 221)
     let first = policy.packetReceived()  // reaches the threshold
     expect(first == 222, "refill requested at the threshold")
@@ -109,7 +109,7 @@ do {
 // module's real one so a refill is always eventually triggered.
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     _ = drain(&policy, packets: 222)  // one confirmed refill, balance back to 254
     var moduleBalance = 254
 
@@ -133,7 +133,7 @@ do {
 // be handed credits twice and the balance would overshoot.
 do {
     var policy = TerminalIoCreditPolicy()
-    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
     _ = drain(&policy, packets: 221)
     expect(policy.packetReceived() == 222, "first refill requested")
     expect(policy.packetReceived() == nil, "no second refill while one is outstanding")
@@ -142,15 +142,24 @@ do {
     expect(policy.credits == 252, "only the one confirmed grant is counted")
 }
 
-// 9. The counter cannot go negative even if more packets arrive than were paid
-// for (a stale notification delivered before the opening grant, say), so the
-// refill amount always stays a valid UInt8.
+// 9. Nothing is requested before the opening grant is confirmed. Notifications
+// are already live by the time that grant is written -- the u-blox service in
+// particular streams with no credits at all -- so packets can arrive during
+// the window. A refill requested there would put a second credit write on the
+// wire alongside the opening one; their completions are indistinguishable to
+// the transport, so it would mis-attribute them and count both grants.
 do {
     var policy = TerminalIoCreditPolicy()
-    let first = policy.packetReceived()
-    expect(first == 222, "an un-granted packet requests a refill")
-    for _ in 0..<9 { _ = policy.packetReceived() }
+    let grants = (0..<10).map { _ in policy.packetReceived() }
+    expect(grants.allSatisfy { $0 == nil },
+           "no refill is requested before the opening grant is confirmed")
     expect(policy.credits == 0, "balance floors at zero rather than going negative")
+    expect(!policy.grantInFlight, "no grant is left marked outstanding")
+
+    // Once opened, accounting proceeds normally despite those early packets.
+    policy.opened(with: TerminalIoCreditPolicy.initialGrant)
+    expect(policy.credits == 254, "opening grant credits the balance as usual")
+    expect(policy.packetReceived() == nil, "and refills resume their normal schedule")
 }
 
 if failures == 0 {

--- a/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/TerminalIoCreditPolicyTests/main.swift
@@ -83,30 +83,73 @@ do {
     expect(minimumSeen > 0, "balance never reaches zero (low-water \(minimumSeen))")
 }
 
-// 6. A refill the platform rejected is not committed, and the next packet asks
-// again. Android allows one GATT operation in flight, so a top-up issued while
-// a command write is pending can be refused; the balance must not drift as if
-// the credits had been granted.
+// 6. A refill that never reached the module must not be counted, and once the
+// caller reports the failure the next packet asks again. Android reports
+// success from writeCharacteristic() and can still fail the write at the ATT
+// layer afterwards, so "accepted" is not "received".
 do {
     var policy = TerminalIoCreditPolicy()
     policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
     _ = drain(&policy, packets: 221)
-    let first = policy.packetReceived()  // reaches the threshold, not committed
+    let first = policy.packetReceived()  // reaches the threshold
     expect(first == 222, "refill requested at the threshold")
-    expect(policy.credits == 32, "a rejected refill leaves the balance untouched")
+    expect(policy.credits == 32, "an unconfirmed refill is not counted")
+    policy.grantFailed()
     let second = policy.packetReceived()
-    expect(second == 222, "the next packet asks for the refill again")
+    expect(second == 222, "after a reported failure the next packet asks again")
     policy.grantAccepted(second ?? 0)
-    expect(policy.credits == 253, "the accepted retry credits the balance")
+    expect(policy.credits == 253, "the confirmed retry credits the balance")
 }
 
-// 7. The counter cannot go negative even if more packets arrive than were paid
+// 7. Regression for the stall this whole policy exists to avoid. If a failed
+// grant were counted as delivered, the balance would sit far above the
+// threshold while the module's real balance ran out; the module would fall
+// silent, no further packets would arrive to decrement the balance, and no
+// refill would ever be issued again. The balance must stay at or below the
+// module's real one so a refill is always eventually triggered.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    _ = drain(&policy, packets: 222)  // one confirmed refill, balance back to 254
+    var moduleBalance = 254
+
+    // Every subsequent refill fails to reach the module.
+    for _ in 0..<254 {
+        moduleBalance -= 1
+        if let grant = policy.packetReceived() {
+            _ = grant  // the write is issued but never reaches the module
+            policy.grantFailed()
+        }
+        expect(policy.credits <= moduleBalance,
+               "balance never exceeds the module's real credits")
+        if moduleBalance <= 0 { break }
+    }
+    expect(policy.packetReceived() != nil,
+           "a refill is still being requested rather than silently stalling")
+}
+
+// 8. Only one grant is outstanding at a time: a second packet arriving before
+// the first grant is confirmed must not request another, or the module would
+// be handed credits twice and the balance would overshoot.
+do {
+    var policy = TerminalIoCreditPolicy()
+    policy.grantAccepted(TerminalIoCreditPolicy.initialGrant)
+    _ = drain(&policy, packets: 221)
+    expect(policy.packetReceived() == 222, "first refill requested")
+    expect(policy.packetReceived() == nil, "no second refill while one is outstanding")
+    expect(policy.packetReceived() == nil, "still suppressed on the next packet")
+    policy.grantAccepted(TerminalIoCreditPolicy.refillAmount)
+    expect(policy.credits == 252, "only the one confirmed grant is counted")
+}
+
+// 9. The counter cannot go negative even if more packets arrive than were paid
 // for (a stale notification delivered before the opening grant, say), so the
 // refill amount always stays a valid UInt8.
 do {
     var policy = TerminalIoCreditPolicy()
-    let grants = (0..<10).map { _ in policy.packetReceived() }
-    expect(grants.allSatisfy { $0 == 222 }, "un-granted packets still request a refill")
+    let first = policy.packetReceived()
+    expect(first == 222, "an un-granted packet requests a refill")
+    for _ in 0..<9 { _ = policy.packetReceived() }
     expect(policy.credits == 0, "balance floors at zero rather than going negative")
 }
 

--- a/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
+++ b/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
@@ -22,6 +22,15 @@ swiftc -o "$BUILD_DIR/ble_characteristic_selector_tests" \
 
 "$BUILD_DIR/ble_characteristic_selector_tests"
 
+# Telit Terminal I/O credit accounting (issue #923). The OSTC4's BlueMod+SR
+# module keeps its UART bridge closed until the client grants credits, and
+# spends one per notification, so the balance has to be topped up mid-transfer.
+swiftc -o "$BUILD_DIR/terminal_io_credit_policy_tests" \
+    Sources/LibDCDarwin/TerminalIoCreditPolicy.swift \
+    Tests/TerminalIoCreditPolicyTests/main.swift
+
+"$BUILD_DIR/terminal_io_credit_policy_tests"
+
 # SerialPortEnumerator pure-logic tests (USB-serial port classification and
 # candidate selection for the Mares Puck Pro / serial-over-USB download path).
 # -framework IOKit satisfies the IOKit references in enumerateUsbSerialPaths();

--- a/packages/libdivecomputer_plugin/ios/Classes/TerminalIoCreditPolicy.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/TerminalIoCreditPolicy.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -151,6 +151,11 @@ struct BleCreditBalance {
     GMutex mutex;
     gint credits;
     gboolean grant_in_flight;
+    // Set once the opening grant is confirmed. Top-ups stay suppressed until
+    // then: notifications go live before that write is issued, and a refill
+    // requested in the window would put a second credit write on the wire
+    // beside it and count both grants.
+    gboolean open;
 };
 
 static struct BleCreditBalance* credit_balance_new(void) {
@@ -174,10 +179,12 @@ static void credit_balance_unref(struct BleCreditBalance* balance) {
 }
 
 // Set the balance to a known value, for setup and teardown.
-static void credit_balance_set(struct BleCreditBalance* balance, gint credits) {
+static void credit_balance_set(struct BleCreditBalance* balance, gint credits,
+                               gboolean open) {
     g_mutex_lock(&balance->mutex);
     balance->credits = credits;
     balance->grant_in_flight = FALSE;
+    balance->open = open;
     g_mutex_unlock(&balance->mutex);
 }
 
@@ -204,7 +211,7 @@ static void abandon_credit_flow_control(BleIoStream* stream,
     g_warning("BleIoStream: Terminal I/O: %s; "
               "continuing without credit flow control", reason);
     g_clear_pointer(&stream->credits_write_path, g_free);
-    credit_balance_set(stream->credits, 0);
+    credit_balance_set(stream->credits, 0, FALSE);
 
     // Unsubscribe rather than merely ignoring the credit indications, so the
     // module stops transmitting on a channel we have given up on and its
@@ -240,7 +247,7 @@ static gboolean grant_initial_credits(BleIoStream* stream) {
     }
     if (result) g_variant_unref(result);
 
-    credit_balance_set(stream->credits, TIO_INITIAL_GRANT);
+    credit_balance_set(stream->credits, TIO_INITIAL_GRANT, TRUE);
     return TRUE;
 }
 
@@ -277,6 +284,10 @@ static void replenish_credits(BleIoStream* stream) {
     // Take the decrement, the check and the claim as one unit, so two packets
     // arriving together cannot both start a grant.
     g_mutex_lock(&balance->mutex);
+    if (!balance->open) {
+        g_mutex_unlock(&balance->mutex);
+        return;
+    }
     if (balance->credits > 0) balance->credits--;
     if (balance->grant_in_flight || balance->credits > TIO_REFILL_THRESHOLD) {
         g_mutex_unlock(&balance->mutex);
@@ -915,7 +926,7 @@ void ble_io_stream_close(BleIoStream* stream) {
             "org.bluez.GattCharacteristic1", "StopNotify",
             NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL);
     }
-    credit_balance_set(stream->credits, 0);
+    credit_balance_set(stream->credits, 0, FALSE);
     stream->credits_required = FALSE;
 
     if (stream->connection && stream->properties_sub > 0) {

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -157,6 +157,17 @@ static void abandon_credit_flow_control(BleIoStream* stream,
               "continuing without credit flow control", reason);
     g_clear_pointer(&stream->credits_write_path, g_free);
     stream->terminal_io_credits = 0;
+
+    // Unsubscribe rather than merely ignoring the credit indications, so the
+    // module stops transmitting on a channel we have given up on and its
+    // airtime goes to the data stream instead.
+    if (stream->connection && stream->credits_notify_path) {
+        g_dbus_connection_call(
+            stream->connection, "org.bluez", stream->credits_notify_path,
+            "org.bluez.GattCharacteristic1", "StopNotify",
+            NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL, NULL);
+        g_clear_pointer(&stream->credits_notify_path, g_free);
+    }
 }
 
 // Write the opening credit grant to Credits RX. A no-op (success) on devices
@@ -478,8 +489,9 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
                           "failed: %s", error->message);
                 return FALSE;
             }
-            abandon_credit_flow_control(stream, error->message);
+            // The subscription never came up, so there is nothing to stop.
             g_clear_pointer(&stream->credits_notify_path, g_free);
+            abandon_credit_flow_control(stream, error->message);
         }
     }
 

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -210,7 +210,13 @@ static void abandon_credit_flow_control(BleIoStream* stream,
                                         const gchar* reason) {
     g_warning("BleIoStream: Terminal I/O: %s; "
               "continuing without credit flow control", reason);
-    g_clear_pointer(&stream->credits_write_path, g_free);
+
+    // Closing the balance is what stops replenish_credits, and it is done
+    // under the balance mutex. credits_write_path is deliberately NOT freed
+    // here: this runs on the download thread while replenish_credits may be
+    // reading that pointer on the thread dispatching PropertiesChanged, so
+    // freeing it would be a use-after-free. It costs one short string to keep
+    // it until ble_io_stream_free, which runs after everything has stopped.
     credit_balance_set(stream->credits, 0, FALSE);
 
     // Unsubscribe rather than merely ignoring the credit indications, so the
@@ -277,10 +283,13 @@ static void on_credit_grant_complete(GObject* source, GAsyncResult* result,
 }
 
 static void replenish_credits(BleIoStream* stream) {
-    if (!stream->credits_write_path) return;
-
     struct BleCreditBalance* balance = stream->credits;
 
+    // The mutex-guarded `open` flag is the only gate, checked before
+    // credits_write_path is touched at all. Testing the pointer first would
+    // race the download thread, which is why that pointer is never freed
+    // while a connection is live -- see abandon_credit_flow_control.
+    //
     // Take the decrement, the check and the claim as one unit, so two packets
     // arriving together cannot both start a grant.
     g_mutex_lock(&balance->mutex);

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -141,8 +141,14 @@ static gboolean has_flag(GDBusConnection* conn, const gchar* char_path,
 // completion. Refcounted because a grant issued moments before teardown
 // completes after the stream is gone, and the callback must still be able to
 // settle the balance without touching freed memory.
+// The balance is reached from two thread contexts: the download thread runs
+// the opening grant and teardown, while the PropertiesChanged handler and the
+// grant completion are dispatched on whichever thread iterates the main
+// context. The mutex covers every access, and the decrement/check/claim
+// sequence is taken as a unit so two packets cannot both start a grant.
 struct BleCreditBalance {
     gint ref_count;
+    GMutex mutex;
     gint credits;
     gboolean grant_in_flight;
 };
@@ -150,6 +156,7 @@ struct BleCreditBalance {
 static struct BleCreditBalance* credit_balance_new(void) {
     struct BleCreditBalance* balance = g_new0(struct BleCreditBalance, 1);
     balance->ref_count = 1;
+    g_mutex_init(&balance->mutex);
     return balance;
 }
 
@@ -160,7 +167,18 @@ static struct BleCreditBalance* credit_balance_ref(
 }
 
 static void credit_balance_unref(struct BleCreditBalance* balance) {
-    if (g_atomic_int_dec_and_test(&balance->ref_count)) g_free(balance);
+    if (g_atomic_int_dec_and_test(&balance->ref_count)) {
+        g_mutex_clear(&balance->mutex);
+        g_free(balance);
+    }
+}
+
+// Set the balance to a known value, for setup and teardown.
+static void credit_balance_set(struct BleCreditBalance* balance, gint credits) {
+    g_mutex_lock(&balance->mutex);
+    balance->credits = credits;
+    balance->grant_in_flight = FALSE;
+    g_mutex_unlock(&balance->mutex);
 }
 
 // Build the (ay, a{sv}) argument tuple for GattCharacteristic1.WriteValue
@@ -186,7 +204,7 @@ static void abandon_credit_flow_control(BleIoStream* stream,
     g_warning("BleIoStream: Terminal I/O: %s; "
               "continuing without credit flow control", reason);
     g_clear_pointer(&stream->credits_write_path, g_free);
-    stream->credits->credits = 0;
+    credit_balance_set(stream->credits, 0);
 
     // Unsubscribe rather than merely ignoring the credit indications, so the
     // module stops transmitting on a channel we have given up on and its
@@ -222,7 +240,7 @@ static gboolean grant_initial_credits(BleIoStream* stream) {
     }
     if (result) g_variant_unref(result);
 
-    stream->credits->credits = TIO_INITIAL_GRANT;
+    credit_balance_set(stream->credits, TIO_INITIAL_GRANT);
     return TRUE;
 }
 
@@ -237,13 +255,15 @@ static void on_credit_grant_complete(GObject* source, GAsyncResult* result,
     GVariant* reply = g_dbus_connection_call_finish(
         G_DBUS_CONNECTION(source), result, &error);
 
+    g_mutex_lock(&balance->mutex);
     balance->grant_in_flight = FALSE;
+    if (!error) balance->credits += TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
+    g_mutex_unlock(&balance->mutex);
+
     if (error) {
         // Leave the balance uncredited so the next packet retries.
         g_warning("BleIoStream: Terminal I/O credit grant not acknowledged: %s",
                   error->message);
-    } else {
-        balance->credits += TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
     }
     if (reply) g_variant_unref(reply);
     credit_balance_unref(balance);
@@ -253,12 +273,19 @@ static void replenish_credits(BleIoStream* stream) {
     if (!stream->credits_write_path) return;
 
     struct BleCreditBalance* balance = stream->credits;
+
+    // Take the decrement, the check and the claim as one unit, so two packets
+    // arriving together cannot both start a grant.
+    g_mutex_lock(&balance->mutex);
     if (balance->credits > 0) balance->credits--;
-    if (balance->grant_in_flight) return;
-    if (balance->credits > TIO_REFILL_THRESHOLD) return;
+    if (balance->grant_in_flight || balance->credits > TIO_REFILL_THRESHOLD) {
+        g_mutex_unlock(&balance->mutex);
+        return;
+    }
+    balance->grant_in_flight = TRUE;
+    g_mutex_unlock(&balance->mutex);
 
     const guint8 grant = TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
-    balance->grant_in_flight = TRUE;
     // Asynchronous: this runs on the thread dispatching PropertiesChanged, and
     // a synchronous call here would stall notification delivery during a bulk
     // logbook dump. The balance is credited in the completion rather than
@@ -888,7 +915,7 @@ void ble_io_stream_close(BleIoStream* stream) {
             "org.bluez.GattCharacteristic1", "StopNotify",
             NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL);
     }
-    stream->credits->credits = 0;
+    credit_balance_set(stream->credits, 0);
     stream->credits_required = FALSE;
 
     if (stream->connection && stream->properties_sub > 0) {

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -217,6 +217,7 @@ static void abandon_credit_flow_control(BleIoStream* stream,
     // reading that pointer on the thread dispatching PropertiesChanged, so
     // freeing it would be a use-after-free. It costs one short string to keep
     // it until ble_io_stream_free, which runs after everything has stopped.
+    stream->credits_abandoned = TRUE;
     credit_balance_set(stream->credits, 0, FALSE);
 
     // Unsubscribe rather than merely ignoring the credit indications, so the
@@ -232,9 +233,10 @@ static void abandon_credit_flow_control(BleIoStream* stream,
 }
 
 // Write the opening credit grant to Credits RX. A no-op (success) on devices
-// with no credit characteristics.
+// with no credit characteristics, or where the fallback has already been
+// taken.
 static gboolean grant_initial_credits(BleIoStream* stream) {
-    if (!stream->credits_write_path) return TRUE;
+    if (!stream->credits_write_path || stream->credits_abandoned) return TRUE;
 
     g_autoptr(GError) error = NULL;
     GVariant* result = g_dbus_connection_call_sync(
@@ -937,6 +939,7 @@ void ble_io_stream_close(BleIoStream* stream) {
     }
     credit_balance_set(stream->credits, 0, FALSE);
     stream->credits_required = FALSE;
+    stream->credits_abandoned = FALSE;
 
     if (stream->connection && stream->properties_sub > 0) {
         g_dbus_connection_signal_unsubscribe(

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -63,6 +63,9 @@ static const guint32 BLE_IOCTL_GET_PINCODE_NR = 1;
 static const guint32 BLE_IOCTL_ACCESSCODE_NR = 2;
 static const guint32 DIRECTION_INPUT = 1;
 
+static struct BleCreditBalance* credit_balance_new(void);
+static void credit_balance_unref(struct BleCreditBalance* balance);
+
 BleIoStream* ble_io_stream_new(void) {
     BleIoStream* stream = g_new0(BleIoStream, 1);
     g_mutex_init(&stream->read_mutex);
@@ -76,6 +79,7 @@ BleIoStream* ble_io_stream_new(void) {
     stream->device_address = NULL;
     stream->on_pin_code_required = NULL;
     stream->pin_callback_data = NULL;
+    stream->credits = credit_balance_new();
     return stream;
 }
 
@@ -133,6 +137,32 @@ static gboolean has_flag(GDBusConnection* conn, const gchar* char_path,
     return found;
 }
 
+// Credit balance shared between the stream and any in-flight grant
+// completion. Refcounted because a grant issued moments before teardown
+// completes after the stream is gone, and the callback must still be able to
+// settle the balance without touching freed memory.
+struct BleCreditBalance {
+    gint ref_count;
+    gint credits;
+    gboolean grant_in_flight;
+};
+
+static struct BleCreditBalance* credit_balance_new(void) {
+    struct BleCreditBalance* balance = g_new0(struct BleCreditBalance, 1);
+    balance->ref_count = 1;
+    return balance;
+}
+
+static struct BleCreditBalance* credit_balance_ref(
+    struct BleCreditBalance* balance) {
+    g_atomic_int_inc(&balance->ref_count);
+    return balance;
+}
+
+static void credit_balance_unref(struct BleCreditBalance* balance) {
+    if (g_atomic_int_dec_and_test(&balance->ref_count)) g_free(balance);
+}
+
 // Build the (ay, a{sv}) argument tuple for GattCharacteristic1.WriteValue
 // carrying a single byte and no options.
 static GVariant* make_single_byte_write_args(guint8 byte) {
@@ -156,7 +186,7 @@ static void abandon_credit_flow_control(BleIoStream* stream,
     g_warning("BleIoStream: Terminal I/O: %s; "
               "continuing without credit flow control", reason);
     g_clear_pointer(&stream->credits_write_path, g_free);
-    stream->terminal_io_credits = 0;
+    stream->credits->credits = 0;
 
     // Unsubscribe rather than merely ignoring the credit indications, so the
     // module stops transmitting on a channel we have given up on and its
@@ -192,29 +222,55 @@ static gboolean grant_initial_credits(BleIoStream* stream) {
     }
     if (result) g_variant_unref(result);
 
-    stream->terminal_io_credits = TIO_INITIAL_GRANT;
+    stream->credits->credits = TIO_INITIAL_GRANT;
     return TRUE;
 }
 
 // Account for one received packet and top the module back up when its balance
 // runs low, so a multi-thousand-notification logbook dump does not stall once
 // the opening grant is spent.
+// Settle a grant once BlueZ reports whether the module received it.
+static void on_credit_grant_complete(GObject* source, GAsyncResult* result,
+                                     gpointer user_data) {
+    struct BleCreditBalance* balance = (struct BleCreditBalance*)user_data;
+    g_autoptr(GError) error = NULL;
+    GVariant* reply = g_dbus_connection_call_finish(
+        G_DBUS_CONNECTION(source), result, &error);
+
+    balance->grant_in_flight = FALSE;
+    if (error) {
+        // Leave the balance uncredited so the next packet retries.
+        g_warning("BleIoStream: Terminal I/O credit grant not acknowledged: %s",
+                  error->message);
+    } else {
+        balance->credits += TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
+    }
+    if (reply) g_variant_unref(reply);
+    credit_balance_unref(balance);
+}
+
 static void replenish_credits(BleIoStream* stream) {
     if (!stream->credits_write_path) return;
 
-    if (stream->terminal_io_credits > 0) stream->terminal_io_credits--;
-    if (stream->terminal_io_credits > TIO_REFILL_THRESHOLD) return;
+    struct BleCreditBalance* balance = stream->credits;
+    if (balance->credits > 0) balance->credits--;
+    if (balance->grant_in_flight) return;
+    if (balance->credits > TIO_REFILL_THRESHOLD) return;
 
     const guint8 grant = TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
-    // Fire-and-forget: this runs on the thread dispatching PropertiesChanged,
-    // and a synchronous call here would stall notification delivery during a
-    // bulk logbook dump.
+    balance->grant_in_flight = TRUE;
+    // Asynchronous: this runs on the thread dispatching PropertiesChanged, and
+    // a synchronous call here would stall notification delivery during a bulk
+    // logbook dump. The balance is credited in the completion rather than
+    // here, because counting credits the module never received leaves the
+    // balance permanently above the refill threshold -- the module falls
+    // silent, no packets arrive to decrement it, and the transfer stalls.
     g_dbus_connection_call(
         stream->connection, "org.bluez", stream->credits_write_path,
         "org.bluez.GattCharacteristic1", "WriteValue",
         make_single_byte_write_args(grant),
-        NULL, G_DBUS_CALL_FLAGS_NONE, stream->timeout_ms, NULL, NULL, NULL);
-    stream->terminal_io_credits += grant;
+        NULL, G_DBUS_CALL_FLAGS_NONE, stream->timeout_ms, NULL,
+        on_credit_grant_complete, credit_balance_ref(balance));
 }
 
 // PropertiesChanged signal handler for GATT notifications.
@@ -832,7 +888,7 @@ void ble_io_stream_close(BleIoStream* stream) {
             "org.bluez.GattCharacteristic1", "StopNotify",
             NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL);
     }
-    stream->terminal_io_credits = 0;
+    stream->credits->credits = 0;
     stream->credits_required = FALSE;
 
     if (stream->connection && stream->properties_sub > 0) {
@@ -869,6 +925,7 @@ void ble_io_stream_free(BleIoStream* stream) {
     g_free(stream->notify_path);
     g_free(stream->credits_write_path);
     g_free(stream->credits_notify_path);
+    if (stream->credits) credit_balance_unref(stream->credits);
     g_free(stream->device_name);
     g_mutex_clear(&stream->pin_mutex);
     g_cond_clear(&stream->pin_cond);

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.c
@@ -22,6 +22,41 @@ static const char* HALCYON_SYMBIOS_TX_UUID =
 static const char* HALCYON_SYMBIOS_RX_UUID =
     "00000101-8c3b-4f2c-a59e-8c08224f3253";
 
+// Telit/Stollmann Terminal I/O (TIO), service 0xFEFB.
+//
+// Heinrichs Weikamp computers built on the Telit (formerly Stollmann)
+// BlueMod+SR module -- the OSTC 2/3/4/Sport/cR/Plus family -- expose their
+// serial bridge behind this service with credit-based flow control (Telit
+// "TIO Implementation Guide" r04). The module carries no UART data until the
+// client subscribes to UART Credits TX and grants initial credits on UART
+// Credits RX, and it spends one credit per notification, so the balance must
+// also be topped up while a transfer runs. Without the handshake the first
+// command write fails and libdivecomputer reports "Failed to send the
+// command" (issue #923, OSTC4).
+//
+// Subsurface implements the same handshake in core/qt-ble.cpp across the two
+// Heinrichs Weikamp module families, and both are handled here: Telit (0xFEFB,
+// four characteristics, credits mandatory) and the u-blox serial service
+// (...d701, two characteristics, credits optional -- the OSTC nano downloads
+// today with no handshake at all, #280/#394, so a rejected grant there falls
+// back to running without flow control instead of failing a working device).
+// Mirrors darwin's BleCharacteristicSelector + TerminalIoCreditPolicy.
+static const char* TIO_DATA_RX_UUID = "00000001-0000-1000-8000-008025000000";
+static const char* TIO_DATA_TX_UUID = "00000002-0000-1000-8000-008025000000";
+static const char* TIO_CREDITS_RX_UUID = "00000003-0000-1000-8000-008025000000";
+static const char* TIO_CREDITS_TX_UUID = "00000004-0000-1000-8000-008025000000";
+
+// u-blox serial service: one characteristic carries data in both directions
+// and one carries credits in both directions.
+static const char* UBLOX_DATA_UUID = "2456e1b9-26e2-8f83-e744-f34f01e9d703";
+static const char* UBLOX_CREDITS_UUID = "2456e1b9-26e2-8f83-e744-f34f01e9d704";
+
+// Opening credit grant. 0xFF is reserved by the TIO protocol, so 254 is the
+// largest value that means "credits" rather than a control code.
+#define TIO_INITIAL_GRANT 254
+// Balance at or below which the client tops the module back up.
+#define TIO_REFILL_THRESHOLD 32
+
 static const guint32 BLE_IOCTL_TYPE = 'b';
 static const guint32 BLE_IOCTL_GET_NAME = 0;
 static const guint32 BLE_IOCTL_GET_PINCODE_NR = 1;
@@ -98,6 +133,79 @@ static gboolean has_flag(GDBusConnection* conn, const gchar* char_path,
     return found;
 }
 
+// Build the (ay, a{sv}) argument tuple for GattCharacteristic1.WriteValue
+// carrying a single byte and no options.
+static GVariant* make_single_byte_write_args(guint8 byte) {
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("ay"));
+    g_variant_builder_add(&builder, "y", byte);
+
+    GVariantBuilder opts;
+    g_variant_builder_init(&opts, G_VARIANT_TYPE("a{sv}"));
+
+    return g_variant_new("(@aya{sv})", g_variant_builder_end(&builder), &opts);
+}
+
+// Give up on credit flow control and run the connection without it.
+//
+// Only reachable for u-blox, whose serial service treats flow control as
+// optional and already works with no handshake at all (#280, #394). A Telit
+// bridge carries nothing without credits, so its failures are fatal.
+static void abandon_credit_flow_control(BleIoStream* stream,
+                                        const gchar* reason) {
+    g_warning("BleIoStream: Terminal I/O: %s; "
+              "continuing without credit flow control", reason);
+    g_clear_pointer(&stream->credits_write_path, g_free);
+    stream->terminal_io_credits = 0;
+}
+
+// Write the opening credit grant to Credits RX. A no-op (success) on devices
+// with no credit characteristics.
+static gboolean grant_initial_credits(BleIoStream* stream) {
+    if (!stream->credits_write_path) return TRUE;
+
+    g_autoptr(GError) error = NULL;
+    GVariant* result = g_dbus_connection_call_sync(
+        stream->connection, "org.bluez", stream->credits_write_path,
+        "org.bluez.GattCharacteristic1", "WriteValue",
+        make_single_byte_write_args(TIO_INITIAL_GRANT),
+        NULL, G_DBUS_CALL_FLAGS_NONE, stream->timeout_ms, NULL, &error);
+    if (error) {
+        if (stream->credits_required) {
+            g_warning("BleIoStream: Terminal I/O initial credit grant "
+                      "failed: %s", error->message);
+            return FALSE;
+        }
+        abandon_credit_flow_control(stream, error->message);
+        return TRUE;
+    }
+    if (result) g_variant_unref(result);
+
+    stream->terminal_io_credits = TIO_INITIAL_GRANT;
+    return TRUE;
+}
+
+// Account for one received packet and top the module back up when its balance
+// runs low, so a multi-thousand-notification logbook dump does not stall once
+// the opening grant is spent.
+static void replenish_credits(BleIoStream* stream) {
+    if (!stream->credits_write_path) return;
+
+    if (stream->terminal_io_credits > 0) stream->terminal_io_credits--;
+    if (stream->terminal_io_credits > TIO_REFILL_THRESHOLD) return;
+
+    const guint8 grant = TIO_INITIAL_GRANT - TIO_REFILL_THRESHOLD;
+    // Fire-and-forget: this runs on the thread dispatching PropertiesChanged,
+    // and a synchronous call here would stall notification delivery during a
+    // bulk logbook dump.
+    g_dbus_connection_call(
+        stream->connection, "org.bluez", stream->credits_write_path,
+        "org.bluez.GattCharacteristic1", "WriteValue",
+        make_single_byte_write_args(grant),
+        NULL, G_DBUS_CALL_FLAGS_NONE, stream->timeout_ms, NULL, NULL, NULL);
+    stream->terminal_io_credits += grant;
+}
+
 // PropertiesChanged signal handler for GATT notifications.
 static void on_properties_changed(GDBusConnection* connection,
                                   const gchar* sender_name,
@@ -146,6 +254,10 @@ static void on_properties_changed(GDBusConnection* connection,
         g_queue_push_tail(stream->read_chunks, chunk);
         g_cond_signal(&stream->read_cond);
         g_mutex_unlock(&stream->read_mutex);
+
+        // Each packet the module sends costs it one credit; top it back up
+        // before the balance runs out or the transfer stalls part-way.
+        replenish_credits(stream);
     }
 
     g_variant_unref(value_var);
@@ -205,6 +317,15 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
     int best_notify_score = -1;
     gchar* best_write_path = NULL;
     gchar* best_notify_path = NULL;
+    // Telit Terminal I/O members, if this device exposes them. BlueZ lists
+    // characteristics flat under the device path rather than grouped by
+    // service, so they are matched by UUID across the whole device.
+    gchar* tio_data_rx_path = NULL;
+    gchar* tio_data_tx_path = NULL;
+    gchar* tio_credits_rx_path = NULL;
+    gchar* tio_credits_tx_path = NULL;
+    gchar* ublox_data_path = NULL;
+    gchar* ublox_credits_path = NULL;
 
     GVariantIter obj_iter;
     g_variant_iter_init(&obj_iter, objects);
@@ -237,6 +358,26 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
         }
         const gchar* uuid = g_variant_get_string(uuid_var, NULL);
 
+        if (g_ascii_strcasecmp(uuid, TIO_DATA_RX_UUID) == 0) {
+            g_free(tio_data_rx_path);
+            tio_data_rx_path = g_strdup(obj_path);
+        } else if (g_ascii_strcasecmp(uuid, TIO_DATA_TX_UUID) == 0) {
+            g_free(tio_data_tx_path);
+            tio_data_tx_path = g_strdup(obj_path);
+        } else if (g_ascii_strcasecmp(uuid, TIO_CREDITS_RX_UUID) == 0) {
+            g_free(tio_credits_rx_path);
+            tio_credits_rx_path = g_strdup(obj_path);
+        } else if (g_ascii_strcasecmp(uuid, TIO_CREDITS_TX_UUID) == 0) {
+            g_free(tio_credits_tx_path);
+            tio_credits_tx_path = g_strdup(obj_path);
+        } else if (g_ascii_strcasecmp(uuid, UBLOX_DATA_UUID) == 0) {
+            g_free(ublox_data_path);
+            ublox_data_path = g_strdup(obj_path);
+        } else if (g_ascii_strcasecmp(uuid, UBLOX_CREDITS_UUID) == 0) {
+            g_free(ublox_credits_path);
+            ublox_credits_path = g_strdup(obj_path);
+        }
+
         // Score as write candidate.
         gboolean can_write = has_flag(stream->connection, obj_path, "write");
         gboolean can_write_no_rsp =
@@ -245,8 +386,12 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
             int ws = 0;
             if (can_write_no_rsp) ws += 4;
             if (can_write) ws += 2;
+            // Telit UART Data RX is pinned so commands can never land on UART
+            // Credits RX, which would swallow them silently.
             if (g_ascii_strcasecmp(uuid, PREFERRED_WRITE_UUID) == 0 ||
-                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_RX_UUID) == 0) {
+                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_RX_UUID) == 0 ||
+                g_ascii_strcasecmp(uuid, TIO_DATA_RX_UUID) == 0 ||
+                g_ascii_strcasecmp(uuid, UBLOX_DATA_UUID) == 0) {
                 ws += 1000;
             }
             if (ws > best_write_score) {
@@ -264,8 +409,12 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
             int ns = 0;
             if (can_notify) ns += 4;
             if (can_indicate) ns += 2;
+            // Telit UART Data TX is pinned so the data stream is never taken
+            // from UART Credits TX (see the write side above).
             if (g_ascii_strcasecmp(uuid, PREFERRED_NOTIFY_UUID) == 0 ||
-                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_TX_UUID) == 0) {
+                g_ascii_strcasecmp(uuid, HALCYON_SYMBIOS_TX_UUID) == 0 ||
+                g_ascii_strcasecmp(uuid, TIO_DATA_TX_UUID) == 0 ||
+                g_ascii_strcasecmp(uuid, UBLOX_DATA_UUID) == 0) {
                 ns += 1000;
             }
             if (ns > best_notify_score) {
@@ -281,6 +430,27 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
     }
     g_variant_unref(objects);
 
+    // Only run the handshake on a complete known layout, so every other device
+    // keeps today's plain write/notify behaviour. Telit needs all four UART
+    // characteristics; u-blox needs its data and credits pair, and uses the
+    // same characteristic for both credit directions.
+    if (tio_data_rx_path && tio_data_tx_path && tio_credits_rx_path &&
+        tio_credits_tx_path) {
+        stream->credits_write_path = g_steal_pointer(&tio_credits_rx_path);
+        stream->credits_notify_path = g_steal_pointer(&tio_credits_tx_path);
+        stream->credits_required = TRUE;
+    } else if (ublox_data_path && ublox_credits_path) {
+        stream->credits_write_path = g_strdup(ublox_credits_path);
+        stream->credits_notify_path = g_strdup(ublox_credits_path);
+        stream->credits_required = FALSE;
+    }
+    g_free(tio_data_rx_path);
+    g_free(tio_data_tx_path);
+    g_free(tio_credits_rx_path);
+    g_free(tio_credits_tx_path);
+    g_free(ublox_data_path);
+    g_free(ublox_credits_path);
+
     if (!best_write_path || !best_notify_path) {
         g_warning("BleIoStream: No suitable GATT characteristics found");
         g_free(best_write_path);
@@ -290,6 +460,28 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
 
     stream->write_path = best_write_path;
     stream->notify_path = best_notify_path;
+
+    // Terminal I/O subscribes to UART Credits TX before UART Data TX (Telit
+    // TIO Implementation Guide r04 sections 6.4 and 6.2, and the same order in
+    // Subsurface's qt-ble.cpp). The indications are never consumed -- no
+    // PropertiesChanged subscription is registered for this path -- but the
+    // module keeps the UART bridge closed until StartNotify has been called.
+    if (stream->credits_notify_path) {
+        g_clear_error(&error);
+        g_dbus_connection_call_sync(
+            stream->connection, "org.bluez", stream->credits_notify_path,
+            "org.bluez.GattCharacteristic1", "StartNotify",
+            NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+        if (error) {
+            if (stream->credits_required) {
+                g_warning("BleIoStream: Terminal I/O credits StartNotify "
+                          "failed: %s", error->message);
+                return FALSE;
+            }
+            abandon_credit_flow_control(stream, error->message);
+            g_clear_pointer(&stream->credits_notify_path, g_free);
+        }
+    }
 
     // Subscribe to PropertiesChanged on the notify characteristic.
     stream->properties_sub = g_dbus_connection_signal_subscribe(
@@ -310,7 +502,10 @@ gboolean ble_io_stream_connect(BleIoStream* stream,
         return FALSE;
     }
 
-    return TRUE;
+    // A Terminal I/O module keeps its UART bridge closed until the client
+    // grants initial credits, so the first command write would fail outright
+    // without this (issue #923).
+    return grant_initial_credits(stream);
 }
 
 // -- C callback implementations --
@@ -619,6 +814,15 @@ void ble_io_stream_close(BleIoStream* stream) {
             NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL);
     }
 
+    if (stream->connection && stream->credits_notify_path) {
+        g_dbus_connection_call_sync(
+            stream->connection, "org.bluez", stream->credits_notify_path,
+            "org.bluez.GattCharacteristic1", "StopNotify",
+            NULL, NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, NULL);
+    }
+    stream->terminal_io_credits = 0;
+    stream->credits_required = FALSE;
+
     if (stream->connection && stream->properties_sub > 0) {
         g_dbus_connection_signal_unsubscribe(
             stream->connection, stream->properties_sub);
@@ -651,6 +855,8 @@ void ble_io_stream_free(BleIoStream* stream) {
     g_free(stream->device_path);
     g_free(stream->write_path);
     g_free(stream->notify_path);
+    g_free(stream->credits_write_path);
+    g_free(stream->credits_notify_path);
     g_free(stream->device_name);
     g_mutex_clear(&stream->pin_mutex);
     g_cond_clear(&stream->pin_cond);

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.h
@@ -22,7 +22,9 @@ typedef struct {
     // characteristic serves both roles.
     gchar* credits_write_path;   // Credits RX (client -> module)
     gchar* credits_notify_path;  // Credits TX (module -> client)
-    gint terminal_io_credits;
+    // Credit balance, refcounted so the asynchronous grant completion can
+    // settle it even if this stream is freed first.
+    struct BleCreditBalance* credits;
     // Whether a failed opening grant is fatal (Telit) or falls back to running
     // without flow control (u-blox, where it is optional).
     gboolean credits_required;

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.h
@@ -17,6 +17,16 @@ typedef struct {
     gchar* notify_path;    // GATT characteristic object path for notify
     guint properties_sub;  // PropertiesChanged signal subscription
 
+    // Terminal I/O credit flow control. Both paths are NULL unless the device
+    // exposes a complete Telit or u-blox layout. On u-blox the same
+    // characteristic serves both roles.
+    gchar* credits_write_path;   // Credits RX (client -> module)
+    gchar* credits_notify_path;  // Credits TX (module -> client)
+    gint terminal_io_credits;
+    // Whether a failed opening grant is fatal (Telit) or falls back to running
+    // without flow control (u-blox, where it is optional).
+    gboolean credits_required;
+
     GMutex read_mutex;
     GCond read_cond;
     // Queue of GByteArray*, one entry per GATT notification.

--- a/packages/libdivecomputer_plugin/linux/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/linux/ble_io_stream.h
@@ -28,6 +28,11 @@ typedef struct {
     // Whether a failed opening grant is fatal (Telit) or falls back to running
     // without flow control (u-blox, where it is optional).
     gboolean credits_required;
+    // Set once the fallback has been taken, so no further credit work is
+    // attempted. Distinct from the balance's `open` flag, which is also FALSE
+    // before the opening grant and so cannot say whether one is still wanted.
+    // Only touched on the download thread, during connect.
+    gboolean credits_abandoned;
 
     GMutex read_mutex;
     GCond read_cond;

--- a/packages/libdivecomputer_plugin/macos/Classes/TerminalIoCreditPolicy.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/TerminalIoCreditPolicy.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/TerminalIoCreditPolicy.swift

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -440,8 +440,11 @@ void BleIoStream::OnCharacteristicValueChanged(
     GattValueChangedEventArgs const& args) {
     // UART Credits TX shares this handler with UART Data TX but carries no
     // application data: injecting its indications into the read queue would
-    // corrupt the protocol stream.
-    if (notify_characteristic_ &&
+    // corrupt the protocol stream. The check is unconditional -- revoking the
+    // ValueChanged token does not wait for handlers already running, so a late
+    // one can arrive after Close() has cleared the characteristic, and a null
+    // characteristic must reject everything rather than accept everything.
+    if (!notify_characteristic_ ||
         sender.AttributeHandle() != notify_characteristic_.AttributeHandle()) {
         return;
     }

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -354,6 +354,7 @@ bool BleIoStream::GrantInitialCredits() {
     {
         std::lock_guard<std::mutex> lock(credits_->mutex);
         credits_->credits = kTerminalIoInitialGrant;
+        credits_->open = true;
     }
     return true;
 }
@@ -377,6 +378,7 @@ void BleIoStream::ReleaseCreditCharacteristics() {
     credits_write_characteristic_ = nullptr;
     credits_->credits = 0;
     credits_->grant_in_flight = false;
+    credits_->open = false;
 }
 
 void BleIoStream::ReplenishCredits() {
@@ -388,6 +390,7 @@ void BleIoStream::ReplenishCredits() {
     {
         std::lock_guard<std::mutex> lock(credits->mutex);
         if (!credits_write_characteristic_) return;
+        if (!credits->open) return;
         if (credits->credits > 0) credits->credits--;
         if (credits->grant_in_flight) return;
         if (credits->credits > kTerminalIoRefillThreshold) return;

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -319,6 +319,10 @@ bool BleIoStream::DiscoverCharacteristics() {
         return false;
     }
 
+    // Publish the handle before subscribing, so the first callback already
+    // has something to match against.
+    notify_attribute_handle_.store(notify_characteristic_.AttributeHandle(),
+                                   std::memory_order_release);
     notify_token_ = notify_characteristic_.ValueChanged(
         {this, &BleIoStream::OnCharacteristicValueChanged});
 
@@ -443,12 +447,17 @@ void BleIoStream::OnCharacteristicValueChanged(
     GattValueChangedEventArgs const& args) {
     // UART Credits TX shares this handler with UART Data TX but carries no
     // application data: injecting its indications into the read queue would
-    // corrupt the protocol stream. The check is unconditional -- revoking the
-    // ValueChanged token does not wait for handlers already running, so a late
-    // one can arrive after Close() has cleared the characteristic, and a null
-    // characteristic must reject everything rather than accept everything.
-    if (!notify_characteristic_ ||
-        sender.AttributeHandle() != notify_characteristic_.AttributeHandle()) {
+    // corrupt the protocol stream.
+    //
+    // Compared against a cached handle rather than notify_characteristic_.
+    // Revoking the ValueChanged token does not wait for handlers already
+    // running, so this can be executing while Close() clears that member on
+    // the download thread; reading the WinRT object here would be a data race.
+    // Close() zeroes the handle first, and zero rejects everything, so a late
+    // callback is dropped rather than mis-routed.
+    const uint16_t expected_handle =
+        notify_attribute_handle_.load(std::memory_order_acquire);
+    if (expected_handle == 0 || sender.AttributeHandle() != expected_handle) {
         return;
     }
 
@@ -487,6 +496,10 @@ libdc_io_callbacks_t BleIoStream::MakeCallbacks() {
 void BleIoStream::Close() {
     ReleaseCreditCharacteristics();
     credits_required_ = false;
+    // Retire the handle before touching the characteristic, so any handler
+    // already running stops accepting data before the object it would
+    // otherwise have read is torn down.
+    notify_attribute_handle_.store(0, std::memory_order_release);
     if (notify_characteristic_) {
         notify_characteristic_.ValueChanged(notify_token_);
         try {

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -274,11 +274,21 @@ bool BleIoStream::DiscoverCharacteristics() {
                 : GattClientCharacteristicConfigurationDescriptorValue::
                       Indicate;
 
-        auto credits_cccd_result =
-            credits_notify_characteristic_
-                .WriteClientCharacteristicConfigurationDescriptorAsync(
-                    credits_cccd_value)
-                .get();
+        // .get() throws if the link drops mid-setup. The outer try in
+        // ConnectAndDiscover would catch it, but that fails the whole
+        // connection -- which is wrong for u-blox, whose fallback exists
+        // precisely so an optional handshake cannot break a working device.
+        // Treat a throw exactly like a non-Success status instead.
+        auto credits_cccd_result = GattCommunicationStatus::Unreachable;
+        try {
+            credits_cccd_result =
+                credits_notify_characteristic_
+                    .WriteClientCharacteristicConfigurationDescriptorAsync(
+                        credits_cccd_value)
+                    .get();
+        } catch (...) {
+            credits_cccd_result = GattCommunicationStatus::Unreachable;
+        }
         if (credits_cccd_result != GattCommunicationStatus::Success) {
             if (credits_required_) return false;
             // u-blox flow control is optional; fall back to running without it
@@ -342,8 +352,8 @@ bool BleIoStream::GrantInitialCredits() {
     }
 
     {
-        std::lock_guard<std::mutex> lock(credits_mutex_);
-        terminal_io_credits_ = kTerminalIoInitialGrant;
+        std::lock_guard<std::mutex> lock(credits_->mutex);
+        credits_->credits = kTerminalIoInitialGrant;
     }
     return true;
 }
@@ -363,36 +373,65 @@ void BleIoStream::ReleaseCreditCharacteristics() {
         }
         credits_notify_characteristic_ = nullptr;
     }
-    std::lock_guard<std::mutex> lock(credits_mutex_);
+    std::lock_guard<std::mutex> lock(credits_->mutex);
     credits_write_characteristic_ = nullptr;
-    terminal_io_credits_ = 0;
+    credits_->credits = 0;
+    credits_->grant_in_flight = false;
 }
 
 void BleIoStream::ReplenishCredits() {
-    std::lock_guard<std::mutex> lock(credits_mutex_);
-    if (!credits_write_characteristic_) return;
-
-    if (terminal_io_credits_ > 0) terminal_io_credits_--;
-    if (terminal_io_credits_ > kTerminalIoRefillThreshold) return;
-
+    auto credits = credits_;
     const uint8_t grant = static_cast<uint8_t>(kTerminalIoInitialGrant -
                                                kTerminalIoRefillThreshold);
+    GattCharacteristic characteristic{nullptr};
+
+    {
+        std::lock_guard<std::mutex> lock(credits->mutex);
+        if (!credits_write_characteristic_) return;
+        if (credits->credits > 0) credits->credits--;
+        if (credits->grant_in_flight) return;
+        if (credits->credits > kTerminalIoRefillThreshold) return;
+        credits->grant_in_flight = true;
+        characteristic = credits_write_characteristic_;
+    }
+    // The lock is released before the write is issued: Completed() runs the
+    // handler inline when the operation has already finished, and the handler
+    // takes this same non-recursive mutex.
+
     try {
         auto writer = DataWriter();
         writer.WriteByte(grant);
         // Fire-and-forget: this runs on the notification thread, and blocking
         // it on the write result would stall notification delivery during a
-        // bulk logbook dump. The async operation owns its own lifetime and the
-        // completion handler captures nothing, so it stays valid even if this
-        // stream is torn down first.
-        auto operation =
-            credits_write_characteristic_.WriteValueWithResultAsync(
-                writer.DetachBuffer(), GattWriteOption::WriteWithResponse);
-        operation.Completed([](auto const&, auto const&) {});
-        terminal_io_credits_ += grant;
+        // bulk logbook dump.
+        auto operation = characteristic.WriteValueWithResultAsync(
+            writer.DetachBuffer(), GattWriteOption::WriteWithResponse);
+        // The balance is credited only once the module acknowledges the
+        // grant. Counting it now would overstate the balance whenever a write
+        // failed, and an overstated balance stalls the transfer for good: the
+        // module falls silent, no notifications arrive to decrement it, and no
+        // refill is ever issued again.
+        //
+        // The handler captures the shared balance rather than `this`, so it
+        // stays safe if the async operation outlives this stream.
+        operation.Completed([credits, grant](auto const& op, auto const&) {
+            bool acknowledged = false;
+            try {
+                acknowledged =
+                    op.GetResults().Status() == GattCommunicationStatus::Success;
+            } catch (...) {
+                acknowledged = false;
+            }
+            std::lock_guard<std::mutex> lock(credits->mutex);
+            credits->grant_in_flight = false;
+            if (acknowledged) credits->credits += grant;
+        });
     } catch (...) {
-        // Leave the balance untouched; the next notification retries. There
-        // are kTerminalIoRefillThreshold packets of slack to recover within.
+        // Nothing was queued, so no completion is coming; leave the balance
+        // alone and let the next notification retry. There are
+        // kTerminalIoRefillThreshold packets of slack to recover within.
+        std::lock_guard<std::mutex> lock(credits->mutex);
+        credits->grant_in_flight = false;
     }
 }
 

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -33,6 +33,53 @@ const winrt::guid BleIoStream::kHalcyonSymbiosRxUuid{
     0x00000101, 0x8C3B, 0x4F2C,
     {0xA5, 0x9E, 0x8C, 0x08, 0x22, 0x4F, 0x32, 0x53}};
 
+// Telit/Stollmann Terminal I/O (TIO), service 0xFEFB.
+//
+// Heinrichs Weikamp computers built on the Telit (formerly Stollmann)
+// BlueMod+SR module -- the OSTC 2/3/4/Sport/cR/Plus family -- expose their
+// serial bridge behind this service with credit-based flow control (Telit
+// "TIO Implementation Guide" r04). The module carries no UART data until the
+// client subscribes to UART Credits TX and grants initial credits on UART
+// Credits RX, and it spends one credit per notification, so the balance must
+// also be topped up while a transfer runs. Without the handshake the very
+// first command write fails and libdivecomputer reports "Failed to send the
+// command" (issue #923, OSTC4).
+//
+// Subsurface implements the same handshake in core/qt-ble.cpp across the two
+// Heinrichs Weikamp module families, and both are handled here: Telit (0xFEFB,
+// four characteristics, credits mandatory) and the u-blox serial service
+// (...d701, two characteristics, credits optional -- the OSTC nano downloads
+// today with no handshake at all, #280/#394, so a rejected grant there falls
+// back to running without flow control instead of failing a working device).
+// Mirrors darwin's BleCharacteristicSelector + TerminalIoCreditPolicy.
+const winrt::guid BleIoStream::kTerminalIoServiceUuid{
+    0x0000FEFB, 0x0000, 0x1000,
+    {0x80, 0x00, 0x00, 0x80, 0x5F, 0x9B, 0x34, 0xFB}};
+const winrt::guid BleIoStream::kTerminalIoDataRxUuid{
+    0x00000001, 0x0000, 0x1000,
+    {0x80, 0x00, 0x00, 0x80, 0x25, 0x00, 0x00, 0x00}};
+const winrt::guid BleIoStream::kTerminalIoDataTxUuid{
+    0x00000002, 0x0000, 0x1000,
+    {0x80, 0x00, 0x00, 0x80, 0x25, 0x00, 0x00, 0x00}};
+const winrt::guid BleIoStream::kTerminalIoCreditsRxUuid{
+    0x00000003, 0x0000, 0x1000,
+    {0x80, 0x00, 0x00, 0x80, 0x25, 0x00, 0x00, 0x00}};
+const winrt::guid BleIoStream::kTerminalIoCreditsTxUuid{
+    0x00000004, 0x0000, 0x1000,
+    {0x80, 0x00, 0x00, 0x80, 0x25, 0x00, 0x00, 0x00}};
+
+// u-blox serial service: one characteristic carries data in both directions
+// and one carries credits in both directions.
+const winrt::guid BleIoStream::kUbloxServiceUuid{
+    0x2456E1B9, 0x26E2, 0x8F83,
+    {0xE7, 0x44, 0xF3, 0x4F, 0x01, 0xE9, 0xD7, 0x01}};
+const winrt::guid BleIoStream::kUbloxDataUuid{
+    0x2456E1B9, 0x26E2, 0x8F83,
+    {0xE7, 0x44, 0xF3, 0x4F, 0x01, 0xE9, 0xD7, 0x03}};
+const winrt::guid BleIoStream::kUbloxCreditsUuid{
+    0x2456E1B9, 0x26E2, 0x8F83,
+    {0xE7, 0x44, 0xF3, 0x4F, 0x01, 0xE9, 0xD7, 0x04}};
+
 static constexpr uint32_t kBleIoctlType = 'b';
 static constexpr uint32_t kBleIoctlGetName = 0;
 static constexpr uint32_t kBleIoctlGetPinCode = 1;
@@ -83,6 +130,9 @@ bool BleIoStream::DiscoverCharacteristics() {
         int score = -1;
         GattCharacteristic write{nullptr};
         GattCharacteristic notify{nullptr};
+        GattCharacteristic credits_write{nullptr};
+        GattCharacteristic credits_notify{nullptr};
+        bool credits_required = false;
     };
     Candidate best;
 
@@ -98,9 +148,23 @@ bool BleIoStream::DiscoverCharacteristics() {
         int best_write_score = -1;
         GattCharacteristic best_notify{nullptr};
         int best_notify_score = -1;
+        // Terminal I/O members of this service, if it is a TIO service.
+        GattCharacteristic tio_data_rx{nullptr};
+        GattCharacteristic tio_data_tx{nullptr};
+        GattCharacteristic tio_credits_rx{nullptr};
+        GattCharacteristic tio_credits_tx{nullptr};
+        GattCharacteristic ublox_data{nullptr};
+        GattCharacteristic ublox_credits{nullptr};
 
         for (auto const& ch : chars_result.Characteristics()) {
             auto props = ch.CharacteristicProperties();
+
+            if (ch.Uuid() == kTerminalIoDataRxUuid) tio_data_rx = ch;
+            if (ch.Uuid() == kTerminalIoDataTxUuid) tio_data_tx = ch;
+            if (ch.Uuid() == kTerminalIoCreditsRxUuid) tio_credits_rx = ch;
+            if (ch.Uuid() == kTerminalIoCreditsTxUuid) tio_credits_tx = ch;
+            if (ch.Uuid() == kUbloxDataUuid) ublox_data = ch;
+            if (ch.Uuid() == kUbloxCreditsUuid) ublox_credits = ch;
 
             // Evaluate as write candidate.
             if ((props & GattCharacteristicProperties::Write) !=
@@ -119,7 +183,9 @@ bool BleIoStream::DiscoverCharacteristics() {
                     ws += 2;
                 }
                 if (ch.Uuid() == kPreferredWriteUuid ||
-                    ch.Uuid() == kHalcyonSymbiosRxUuid) {
+                    ch.Uuid() == kHalcyonSymbiosRxUuid ||
+                    ch.Uuid() == kTerminalIoDataRxUuid ||
+                    ch.Uuid() == kUbloxDataUuid) {
                     ws += 1000;
                 }
                 if (ws > best_write_score) {
@@ -143,7 +209,9 @@ bool BleIoStream::DiscoverCharacteristics() {
                     ns += 2;
                 }
                 if (ch.Uuid() == kPreferredNotifyUuid ||
-                    ch.Uuid() == kHalcyonSymbiosTxUuid) {
+                    ch.Uuid() == kHalcyonSymbiosTxUuid ||
+                    ch.Uuid() == kTerminalIoDataTxUuid ||
+                    ch.Uuid() == kUbloxDataUuid) {
                     ns += 1000;
                 }
                 if (ns > best_notify_score) {
@@ -156,12 +224,30 @@ bool BleIoStream::DiscoverCharacteristics() {
         if (!best_write || !best_notify) continue;
 
         int service_score = best_write_score + best_notify_score;
-        if (service.Uuid() == kPreferredServiceUuid) {
+        if (service.Uuid() == kPreferredServiceUuid ||
+            service.Uuid() == kTerminalIoServiceUuid ||
+            service.Uuid() == kUbloxServiceUuid) {
             service_score += 1000;
         }
 
+        // Only run the handshake on a complete known layout, so every other
+        // device keeps today's plain write/notify behaviour. Telit needs all
+        // four UART characteristics; u-blox needs its data and credits pair.
+        GattCharacteristic credits_write{nullptr};
+        GattCharacteristic credits_notify{nullptr};
+        bool credits_required = false;
+        if (tio_data_rx && tio_data_tx && tio_credits_rx && tio_credits_tx) {
+            credits_write = tio_credits_rx;
+            credits_notify = tio_credits_tx;
+            credits_required = true;
+        } else if (ublox_data && ublox_credits) {
+            credits_write = ublox_credits;
+            credits_notify = ublox_credits;
+        }
+
         if (service_score > best.score) {
-            best = {service_score, best_write, best_notify};
+            best = {service_score, best_write, best_notify, credits_write,
+                    credits_notify, credits_required};
         }
     }
 
@@ -169,6 +255,41 @@ bool BleIoStream::DiscoverCharacteristics() {
 
     write_characteristic_ = best.write;
     notify_characteristic_ = best.notify;
+    credits_write_characteristic_ = best.credits_write;
+    credits_notify_characteristic_ = best.credits_notify;
+    credits_required_ = best.credits_required;
+
+    // Terminal I/O subscribes to UART Credits TX before UART Data TX (Telit
+    // TIO Implementation Guide r04 sections 6.4 and 6.2, and the same order in
+    // Subsurface's qt-ble.cpp). The payload is not consumed, but the module
+    // keeps the UART bridge closed until the subscription exists.
+    if (credits_notify_characteristic_) {
+        // Telit's UART Credits TX indicates; the u-blox credits characteristic
+        // notifies. Pick from the advertised properties rather than assuming.
+        auto credits_cccd_value =
+            ((credits_notify_characteristic_.CharacteristicProperties() &
+              GattCharacteristicProperties::Notify) !=
+             GattCharacteristicProperties::None)
+                ? GattClientCharacteristicConfigurationDescriptorValue::Notify
+                : GattClientCharacteristicConfigurationDescriptorValue::
+                      Indicate;
+
+        auto credits_cccd_result =
+            credits_notify_characteristic_
+                .WriteClientCharacteristicConfigurationDescriptorAsync(
+                    credits_cccd_value)
+                .get();
+        if (credits_cccd_result != GattCommunicationStatus::Success) {
+            if (credits_required_) return false;
+            // u-blox flow control is optional; fall back to running without it
+            // rather than failing a device that works today.
+            credits_notify_characteristic_ = nullptr;
+            credits_write_characteristic_ = nullptr;
+        } else {
+            credits_notify_token_ = credits_notify_characteristic_.ValueChanged(
+                {this, &BleIoStream::OnCharacteristicValueChanged});
+        }
+    }
 
     // Enable notifications.
     auto cccd_value =
@@ -191,12 +312,82 @@ bool BleIoStream::DiscoverCharacteristics() {
     notify_token_ = notify_characteristic_.ValueChanged(
         {this, &BleIoStream::OnCharacteristicValueChanged});
 
+    return GrantInitialCredits();
+}
+
+bool BleIoStream::GrantInitialCredits() {
+    if (!credits_write_characteristic_) return true;
+
+    bool granted = false;
+    try {
+        auto writer = DataWriter();
+        writer.WriteByte(kTerminalIoInitialGrant);
+        auto result =
+            credits_write_characteristic_
+                .WriteValueWithResultAsync(writer.DetachBuffer(),
+                                           GattWriteOption::WriteWithResponse)
+                .get();
+        granted = result.Status() == GattCommunicationStatus::Success;
+    } catch (...) {
+        granted = false;
+    }
+
+    if (!granted) {
+        // A Telit bridge carries nothing without credits, so the connection is
+        // dead. u-blox flow control is optional and the service already works
+        // with no handshake at all, so fall back to that instead.
+        if (credits_required_) return false;
+        std::lock_guard<std::mutex> lock(credits_mutex_);
+        credits_write_characteristic_ = nullptr;
+        return true;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(credits_mutex_);
+        terminal_io_credits_ = kTerminalIoInitialGrant;
+    }
     return true;
 }
 
+void BleIoStream::ReplenishCredits() {
+    std::lock_guard<std::mutex> lock(credits_mutex_);
+    if (!credits_write_characteristic_) return;
+
+    if (terminal_io_credits_ > 0) terminal_io_credits_--;
+    if (terminal_io_credits_ > kTerminalIoRefillThreshold) return;
+
+    const uint8_t grant = static_cast<uint8_t>(kTerminalIoInitialGrant -
+                                               kTerminalIoRefillThreshold);
+    try {
+        auto writer = DataWriter();
+        writer.WriteByte(grant);
+        // Fire-and-forget: this runs on the notification thread, and blocking
+        // it on the write result would stall notification delivery during a
+        // bulk logbook dump. The async operation owns its own lifetime and the
+        // completion handler captures nothing, so it stays valid even if this
+        // stream is torn down first.
+        auto operation =
+            credits_write_characteristic_.WriteValueWithResultAsync(
+                writer.DetachBuffer(), GattWriteOption::WriteWithResponse);
+        operation.Completed([](auto const&, auto const&) {});
+        terminal_io_credits_ += grant;
+    } catch (...) {
+        // Leave the balance untouched; the next notification retries. There
+        // are kTerminalIoRefillThreshold packets of slack to recover within.
+    }
+}
+
 void BleIoStream::OnCharacteristicValueChanged(
-    GattCharacteristic const&,
+    GattCharacteristic const& sender,
     GattValueChangedEventArgs const& args) {
+    // UART Credits TX shares this handler with UART Data TX but carries no
+    // application data: injecting its indications into the read queue would
+    // corrupt the protocol stream.
+    if (notify_characteristic_ &&
+        sender.AttributeHandle() != notify_characteristic_.AttributeHandle()) {
+        return;
+    }
+
     auto reader = DataReader::FromBuffer(args.CharacteristicValue());
     uint32_t length = reader.UnconsumedBufferLength();
     if (length == 0) return;
@@ -209,6 +400,10 @@ void BleIoStream::OnCharacteristicValueChanged(
         read_chunks_.push_back(std::move(data));
     }
     read_cv_.notify_one();
+
+    // Each packet the module sends costs it one credit; top it back up before
+    // the balance runs out or the transfer stalls part-way through.
+    ReplenishCredits();
 }
 
 libdc_io_callbacks_t BleIoStream::MakeCallbacks() {
@@ -226,6 +421,24 @@ libdc_io_callbacks_t BleIoStream::MakeCallbacks() {
 }
 
 void BleIoStream::Close() {
+    if (credits_notify_characteristic_) {
+        credits_notify_characteristic_.ValueChanged(credits_notify_token_);
+        try {
+            credits_notify_characteristic_
+                .WriteClientCharacteristicConfigurationDescriptorAsync(
+                    GattClientCharacteristicConfigurationDescriptorValue::
+                        None)
+                .get();
+        } catch (...) {
+        }
+        credits_notify_characteristic_ = nullptr;
+    }
+    {
+        std::lock_guard<std::mutex> lock(credits_mutex_);
+        credits_write_characteristic_ = nullptr;
+        terminal_io_credits_ = 0;
+    }
+    credits_required_ = false;
     if (notify_characteristic_) {
         notify_characteristic_.ValueChanged(notify_token_);
         try {

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -337,8 +337,7 @@ bool BleIoStream::GrantInitialCredits() {
         // dead. u-blox flow control is optional and the service already works
         // with no handshake at all, so fall back to that instead.
         if (credits_required_) return false;
-        std::lock_guard<std::mutex> lock(credits_mutex_);
-        credits_write_characteristic_ = nullptr;
+        ReleaseCreditCharacteristics();
         return true;
     }
 
@@ -347,6 +346,26 @@ bool BleIoStream::GrantInitialCredits() {
         terminal_io_credits_ = kTerminalIoInitialGrant;
     }
     return true;
+}
+
+void BleIoStream::ReleaseCreditCharacteristics() {
+    // Unsubscribe rather than merely ignoring the credit indications, so the
+    // module stops transmitting on a channel we have given up on and its
+    // airtime goes to the data stream instead.
+    if (credits_notify_characteristic_) {
+        credits_notify_characteristic_.ValueChanged(credits_notify_token_);
+        try {
+            credits_notify_characteristic_
+                .WriteClientCharacteristicConfigurationDescriptorAsync(
+                    GattClientCharacteristicConfigurationDescriptorValue::None)
+                .get();
+        } catch (...) {
+        }
+        credits_notify_characteristic_ = nullptr;
+    }
+    std::lock_guard<std::mutex> lock(credits_mutex_);
+    credits_write_characteristic_ = nullptr;
+    terminal_io_credits_ = 0;
 }
 
 void BleIoStream::ReplenishCredits() {
@@ -421,23 +440,7 @@ libdc_io_callbacks_t BleIoStream::MakeCallbacks() {
 }
 
 void BleIoStream::Close() {
-    if (credits_notify_characteristic_) {
-        credits_notify_characteristic_.ValueChanged(credits_notify_token_);
-        try {
-            credits_notify_characteristic_
-                .WriteClientCharacteristicConfigurationDescriptorAsync(
-                    GattClientCharacteristicConfigurationDescriptorValue::
-                        None)
-                .get();
-        } catch (...) {
-        }
-        credits_notify_characteristic_ = nullptr;
-    }
-    {
-        std::lock_guard<std::mutex> lock(credits_mutex_);
-        credits_write_characteristic_ = nullptr;
-        terminal_io_credits_ = 0;
-    }
+    ReleaseCreditCharacteristics();
     credits_required_ = false;
     if (notify_characteristic_) {
         notify_characteristic_.ValueChanged(notify_token_);

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -87,6 +87,8 @@ class BleIoStream {
   // ble_io_stream.cc and darwin's BleCharacteristicSelector.
   bool GrantInitialCredits();
   void ReplenishCredits();
+  // Unsubscribe from and forget the credit characteristics.
+  void ReleaseCreditCharacteristics();
 
   // Known service/characteristic UUIDs for dive computers.
   static const winrt::guid kPreferredServiceUuid;

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -1,6 +1,7 @@
 #ifndef BLE_IO_STREAM_H_
 #define BLE_IO_STREAM_H_
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -125,6 +126,13 @@ class BleIoStream {
   winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
       GattCharacteristic notify_characteristic_{nullptr};
   winrt::event_token notify_token_;
+  // ATT handle of the data notify characteristic, cached so the notification
+  // thread can identify a callback's source without reading
+  // notify_characteristic_ -- Close() clears that member concurrently, and
+  // revoking the ValueChanged token does not wait for handlers already
+  // running, so reading the WinRT object from the callback would be a data
+  // race. Zero means "no characteristic selected", which rejects everything.
+  std::atomic<uint16_t> notify_attribute_handle_{0};
   // UART Credits RX/TX, non-null only on Telit Terminal I/O devices.
   winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
       GattCharacteristic credits_write_characteristic_{nullptr};

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -133,12 +134,21 @@ class BleIoStream {
   // Whether a failed opening grant is fatal (Telit) or falls back to running
   // without flow control (u-blox, where it is optional).
   bool credits_required_ = false;
-  // Credit balance. WinRT can dispatch ValueChanged on several thread-pool
-  // threads at once, so the decrement/check/grant sequence is guarded as a
-  // unit: two concurrent refills would credit the balance twice and later
-  // suppress a top-up the module actually needed.
-  std::mutex credits_mutex_;
-  int terminal_io_credits_ = 0;
+  // Credit balance, held behind a shared_ptr so the fire-and-forget grant
+  // completion can settle it without capturing `this`: the async operation may
+  // outlive this stream, and the balance must survive that long to be updated
+  // safely.
+  //
+  // WinRT can dispatch ValueChanged on several thread-pool threads at once, so
+  // the decrement/check/grant sequence is guarded as a unit: two concurrent
+  // refills would hand the module credits twice.
+  struct CreditBalance {
+    std::mutex mutex;
+    int credits = 0;
+    bool grant_in_flight = false;
+  };
+  std::shared_ptr<CreditBalance> credits_ =
+      std::make_shared<CreditBalance>();
 
   std::mutex read_mutex_;
   std::condition_variable read_cv_;

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -146,6 +146,11 @@ class BleIoStream {
     std::mutex mutex;
     int credits = 0;
     bool grant_in_flight = false;
+    // Set once the opening grant is confirmed. Top-ups stay suppressed until
+    // then: notifications go live before that write is issued, and a refill
+    // requested in the window would put a second credit write on the wire
+    // beside it and count both grants.
+    bool open = false;
   };
   std::shared_ptr<CreditBalance> credits_ =
       std::make_shared<CreditBalance>();

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.h
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.h
@@ -83,12 +83,31 @@ class BleIoStream {
       winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
           GattValueChangedEventArgs const& args);
 
+  // Telit/Stollmann Terminal I/O credit handshake. See the block comment in
+  // ble_io_stream.cc and darwin's BleCharacteristicSelector.
+  bool GrantInitialCredits();
+  void ReplenishCredits();
+
   // Known service/characteristic UUIDs for dive computers.
   static const winrt::guid kPreferredServiceUuid;
   static const winrt::guid kPreferredWriteUuid;
   static const winrt::guid kPreferredNotifyUuid;
   static const winrt::guid kHalcyonSymbiosTxUuid;
   static const winrt::guid kHalcyonSymbiosRxUuid;
+  static const winrt::guid kTerminalIoServiceUuid;
+  static const winrt::guid kTerminalIoDataRxUuid;
+  static const winrt::guid kTerminalIoDataTxUuid;
+  static const winrt::guid kTerminalIoCreditsRxUuid;
+  static const winrt::guid kTerminalIoCreditsTxUuid;
+  static const winrt::guid kUbloxServiceUuid;
+  static const winrt::guid kUbloxDataUuid;
+  static const winrt::guid kUbloxCreditsUuid;
+
+  // Opening credit grant. 0xFF is reserved by the TIO protocol, so 254 is the
+  // largest value that means "credits" rather than a control code.
+  static constexpr uint8_t kTerminalIoInitialGrant = 254;
+  // Balance at or below which the client tops the module back up.
+  static constexpr int kTerminalIoRefillThreshold = 32;
 
   winrt::Windows::Devices::Bluetooth::BluetoothLEDevice device_{nullptr};
   // Held for the connection's lifetime to keep a throughput-optimized
@@ -103,6 +122,21 @@ class BleIoStream {
   winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
       GattCharacteristic notify_characteristic_{nullptr};
   winrt::event_token notify_token_;
+  // UART Credits RX/TX, non-null only on Telit Terminal I/O devices.
+  winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
+      GattCharacteristic credits_write_characteristic_{nullptr};
+  winrt::Windows::Devices::Bluetooth::GenericAttributeProfile::
+      GattCharacteristic credits_notify_characteristic_{nullptr};
+  winrt::event_token credits_notify_token_;
+  // Whether a failed opening grant is fatal (Telit) or falls back to running
+  // without flow control (u-blox, where it is optional).
+  bool credits_required_ = false;
+  // Credit balance. WinRT can dispatch ValueChanged on several thread-pool
+  // threads at once, so the decrement/check/grant sequence is guarded as a
+  // unit: two concurrent refills would credit the balance twice and later
+  // suppress a top-up the module actually needed.
+  std::mutex credits_mutex_;
+  int terminal_io_credits_ = 0;
 
   std::mutex read_mutex_;
   std::condition_variable read_cv_;


### PR DESCRIPTION
Fixes #923.

> **Confirmed on hardware** by @mr-glubschi on 2026-08-10: PR build `8687cbf` on Windows 11, against the OSTC4 from #923 (RTE 3.7, hwOS 1.7.5) that previously failed every attempt. The device connects, identifies as OSTC 4, and the full logbook downloads — 4 dives, ~1700–1800 profile points each, tanks included — with no `[LDC]` errors in the debug log.

## Problem

The OSTC4 connects and completes service discovery, then fails the very first command write with libdivecomputer's `Failed to send the command`.

Its Telit/Stollmann **BlueMod+SR** module exposes the serial bridge behind service `0xFEFB` using **Terminal I/O**, a credit-based flow-control profile. The module carries no UART data until the client subscribes to indications on *UART Credits TX* and writes an initial credit grant to *UART Credits RX*. None of the four BLE transports had any notion of credits, so the bridge was never opened and the first write hit a closed pipe.

The module also spends one credit per notification, so a single opening grant would only cover the first 254 packets. An OSTC logbook dump is thousands of notifications, so the balance is topped back up mid-transfer — 222 more once 32 remain — matching Subsurface's `core/qt-ble.cpp`.

## Scope

Both Heinrichs Weikamp module families are handled, with deliberately different failure semantics:

| Family | Layout | Credits | On handshake failure |
| --- | --- | --- | --- |
| Telit | `0xFEFB`, four UART characteristics | Mandatory | Connection fails — the bridge carries nothing without them |
| u-blox | `…d701`, one data + one credits characteristic, each used in both directions | Optional | **Falls back** to running without flow control |

That asymmetry is the safety story. Devices on the u-blox serial service download today with **no handshake at all** (#280, #394), so flow control there is evidently off or permissive. Making a failed u-blox grant non-fatal means the new code cannot break a device that already works. Devices exposing neither layout are untouched and keep today's plain write/notify path — there are regression tests asserting exactly that.

## Related defects fixed

Adding a second subscription exposed real problems in the existing transports that had only ever had one:

- **Notification handlers accepted values from any characteristic**, so credit indications would have been injected straight into the protocol read stream. Windows now compares `AttributeHandle`; Android filters by the selected data characteristic.
- **Write-completion callbacks released the data-write semaphore unconditionally**, so a credit write would have freed a command write still in flight. darwin and Android now route credit completions to their own path.
- **Android permits one GATT operation in flight**, so the three setup steps are chained through their completion callbacks, and a mid-transfer top-up the stack refuses is retried on the next packet rather than counted as granted.
- **WinRT can dispatch `ValueChanged` on several thread-pool threads**, so the credit decrement/check/grant sequence is guarded as a unit — two concurrent refills would inflate the balance above the module's real one and later suppress a top-up it needed.

Additionally, `0xFEFB` and the u-blox service are now preferred services, and the data characteristics pinned as preferred write/notify, so the Stollmann vendor service these devices also advertise cannot win on discovery order, and commands can never land on a credits endpoint.

## Structure

Credit detection lives in `BleCharacteristicSelector` and the accounting in a new `TerminalIoCreditPolicy`, so both are unit-tested standalone via `run_native_tests.sh` — the same factoring already used for `PacketReadBuffer`. Windows, Linux and Android carry line-by-line equivalents inline, as they do for the existing selection logic.

## Verification

- **Darwin Swift tests**: 82 assertions pass, including the reporter's exact GATT table from the issue, the same table in reverse discovery order, both u-blox layouts, and two regressions asserting non-TIO devices request no handshake.
- **C wrapper tests**: 8/8.
- **Dart suite**: 16042 passed, 15 skipped. `flutter analyze` clean, `dart format` clean.
- **Compiled locally**: macOS app build and Android debug APK.
- **Not compiled locally**: Windows and Linux — no toolchain on the dev machine, so those rely on this workflow's build jobs.

## What still needs confirming

The Telit path is confirmed on hardware (see above). The **u-blox path is not**: that device family now performs a handshake where it previously did none, with the soft fallback as its safety net, so an OSTC nano regression pass is worth having before this ships.

