### PR TITLE
Log every BLE scan skip so unsupported computers are visible (#123)

### DIFF
--- a/lib/features/dive_computer/presentation/providers/discovery_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/discovery_providers.dart
@@ -192,12 +192,17 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
         category: LogCategory.bluetooth,
       );
       await _service.startDiscovery(pigeon.TransportType.ble);
-    } catch (e) {
+    } catch (e, stackTrace) {
       _discoveryLog.error(
         'Failed to start BLE scan',
         category: LogCategory.bluetooth,
         error: e,
+        stackTrace: stackTrace,
       );
+      // Cancel the event subscription so stray events from the native side
+      // cannot mutate state after a synchronous start failure.
+      _discoverySubscription?.cancel();
+      _discoverySubscription = null;
       state = state.copyWith(
         isScanning: false,
         errorMessage: 'Failed to start scanning: $e',

--- a/lib/features/dive_computer/presentation/providers/discovery_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/discovery_providers.dart
@@ -121,6 +121,14 @@ class DiscoveryState {
 /// Steps in the device discovery wizard.
 enum DiscoveryStep { scan, select, pair, confirm, download, summary }
 
+/// Logger for the scan lifecycle.
+///
+/// The native scanner reports the devices it sees, but only this layer knows
+/// that a scan was requested at all. Without these entries a submitted debug
+/// log cannot distinguish "the user never scanned" from "the scan started and
+/// found nothing" from "permissions were refused" (issue #123).
+const _discoveryLog = LoggerService('Discovery');
+
 /// Notifier for managing the discovery wizard state.
 ///
 /// Uses DiveComputerService for BLE discovery via libdivecomputer's
@@ -154,6 +162,10 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
             .toList();
 
         if (denied.isNotEmpty) {
+          _discoveryLog.warning(
+            'Scan blocked: Bluetooth permissions denied (${denied.join(', ')})',
+            category: LogCategory.bluetooth,
+          );
           state = state.copyWith(
             isScanning: false,
             errorMessage:
@@ -175,8 +187,17 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
         _onDeviceDiscovered,
       );
 
+      _discoveryLog.info(
+        'Starting BLE scan for dive computers',
+        category: LogCategory.bluetooth,
+      );
       await _service.startDiscovery(pigeon.TransportType.ble);
     } catch (e) {
+      _discoveryLog.error(
+        'Failed to start BLE scan',
+        category: LogCategory.bluetooth,
+        error: e,
+      );
       state = state.copyWith(
         isScanning: false,
         errorMessage: 'Failed to start scanning: $e',
@@ -191,6 +212,11 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
     // Deduplicate by address
     if (existing.any((d) => d.address == device.address)) return;
 
+    _discoveryLog.info(
+      'Discovered ${device.name} (${device.address}) '
+      'as ${pigeonDevice.vendor} ${pigeonDevice.product}',
+      category: LogCategory.bluetooth,
+    );
     state = state.copyWith(discoveredDevices: [...existing, device]);
   }
 
@@ -199,6 +225,11 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
     _discoverySubscription?.cancel();
     _discoverySubscription = null;
     await _service.stopDiscovery();
+    _discoveryLog.info(
+      'Stopped BLE scan; '
+      '${state.discoveredDevices.length} supported device(s) found',
+      category: LogCategory.bluetooth,
+    );
     state = state.copyWith(isScanning: false);
   }
 

--- a/lib/features/dive_computer/presentation/providers/discovery_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/discovery_providers.dart
@@ -135,12 +135,25 @@ const _discoveryLog = LoggerService('Discovery');
 /// native platform backends. Accumulates discovered devices in state.
 class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
   final pigeon.DiveComputerService _service;
+
+  /// Whether this platform gates BLE scanning behind runtime permissions.
+  ///
+  /// Only Android does. Injectable because a refused permission is one of the
+  /// likelier reasons a scan finds nothing, and the branch that reports it is
+  /// otherwise unreachable in tests, which run where `Platform.isAndroid` is
+  /// false (issue #123).
+  final bool _requiresRuntimePermissions;
+
   StreamSubscription<pigeon.DiscoveredDevice>? _discoverySubscription;
   StreamSubscription<void>? _discoveryCompleteSubscription;
 
-  DiscoveryNotifier({required pigeon.DiveComputerService service})
-    : _service = service,
-      super(const DiscoveryState()) {
+  DiscoveryNotifier({
+    required pigeon.DiveComputerService service,
+    bool? requiresRuntimePermissions,
+  }) : _service = service,
+       _requiresRuntimePermissions =
+           requiresRuntimePermissions ?? Platform.isAndroid,
+       super(const DiscoveryState()) {
     _discoveryCompleteSubscription = _service.discoveryComplete.listen((_) {
       state = state.copyWith(isScanning: false);
     });
@@ -150,7 +163,7 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
   Future<void> startScan() async {
     try {
       // Request Bluetooth permissions on Android before scanning.
-      if (Platform.isAndroid) {
+      if (_requiresRuntimePermissions) {
         final statuses = await [
           Permission.bluetoothScan,
           Permission.bluetoothConnect,

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
@@ -64,6 +64,22 @@ class BleScanDiagnostics {
         // Not a valid "address|name" key, so it cannot collide with a device.
         private const val ADDRESSLESS_KEY = "<addressless>"
 
+        /**
+         * The usable advertised name for a scan result, or null if the device
+         * supplied none.
+         *
+         * A zero-length Complete Local Name AD field surfaces as `""` rather
+         * than being omitted, and the cached [android.bluetooth.BluetoothDevice]
+         * name can be empty too. Both must count as absent: an empty string
+         * would be matched against the descriptor table as an empty prefix,
+         * logged as a nameless `(...)`, and -- because the dedupe key is
+         * `address|name` -- would collide with the key used for devices that
+         * advertised no name at all.
+         */
+        fun resolveName(scanRecordName: String?, deviceName: String?): String? =
+            scanRecordName?.takeIf { it.isNotEmpty() }
+                ?: deviceName?.takeIf { it.isNotEmpty() }
+
         // Mirrors android.bluetooth.le.ScanCallback. Duplicated rather than
         // referenced so this class stays free of Android imports.
         const val SCAN_FAILED_ALREADY_STARTED = 1

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
@@ -1,0 +1,94 @@
+package com.submersion.libdivecomputer
+
+// Builds the debug-log messages for BLE advertisements that the scanner
+// declines to surface, and rate-limits them to one line per distinct
+// sighting (issue #123).
+//
+// Android redelivers an advertisement packet every scan interval, so the
+// raw callback fires many times per second per device. Without the
+// bookkeeping here, logging every skipped device would flood the log file
+// and rotate away the very lines a bug report needs. Without logging them
+// at all -- the previous behaviour -- an unsupported dive computer left no
+// trace whatsoever, and the owner of a Suunto Ocean could not produce the
+// advertised name that adding a descriptor requires.
+//
+// Framework-free so it can run as a JVM unit test; the Android scan-result
+// types are not constructible outside an instrumented test.
+class BleScanDiagnostics {
+
+    // Keyed by address *and* name: a peripheral that omits its local name
+    // from the initial advertisement and supplies it in the scan response
+    // must log a second time, once the name is known.
+    private val loggedSightings = mutableSetOf<String>()
+
+    /** Clears per-session state so a new scan logs every device again. */
+    fun reset() {
+        loggedSightings.clear()
+    }
+
+    /**
+     * Message for a device whose advertised [name] matched no descriptor,
+     * or null if this sighting was already logged during this scan.
+     */
+    fun describeUnmatched(address: String, name: String, rssi: Int): String? {
+        if (!loggedSightings.add("$address|$name")) return null
+        return "Unmatched device $address ($name) rssi=$rssi"
+    }
+
+    /**
+     * Message for a device that advertised no readable name, or null if
+     * this sighting was already logged during this scan.
+     *
+     * These cannot be matched at all: libdivecomputer identifies BLE dive
+     * computers by name prefix, so a nameless advertisement is unusable
+     * even when it comes from a supported model.
+     */
+    fun describeUnnamed(address: String, rssi: Int): String? {
+        if (!loggedSightings.add("$address|")) return null
+        return "Unnamed device $address rssi=$rssi (no advertised name; cannot match descriptor)"
+    }
+
+    /**
+     * Message for an advertisement that carried no device address, or null
+     * if one was already reported during this scan.
+     *
+     * There is no per-device key to deduplicate these on, so they are
+     * collapsed to a single line per scan rather than left unthrottled.
+     */
+    fun describeAddressless(): String? {
+        if (!loggedSightings.add(ADDRESSLESS_KEY)) return null
+        return "Skipped advertisement with no device address"
+    }
+
+    companion object {
+        // Not a valid "address|name" key, so it cannot collide with a device.
+        private const val ADDRESSLESS_KEY = "<addressless>"
+
+        // Mirrors android.bluetooth.le.ScanCallback. Duplicated rather than
+        // referenced so this class stays free of Android imports.
+        const val SCAN_FAILED_ALREADY_STARTED = 1
+        const val SCAN_FAILED_APPLICATION_REGISTRATION_FAILED = 2
+        const val SCAN_FAILED_INTERNAL_ERROR = 3
+        const val SCAN_FAILED_FEATURE_UNSUPPORTED = 4
+        const val SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES = 5
+        const val SCAN_FAILED_SCANNING_TOO_FREQUENTLY = 6
+
+        /** Human-readable reason for a ScanCallback.onScanFailed code. */
+        fun describeScanFailure(errorCode: Int): String = when (errorCode) {
+            SCAN_FAILED_ALREADY_STARTED ->
+                "scan already started"
+            SCAN_FAILED_APPLICATION_REGISTRATION_FAILED ->
+                "app could not be registered with the Bluetooth stack"
+            SCAN_FAILED_INTERNAL_ERROR ->
+                "internal Bluetooth stack error"
+            SCAN_FAILED_FEATURE_UNSUPPORTED ->
+                "BLE scanning unsupported on this device"
+            SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES ->
+                "out of Bluetooth hardware resources"
+            SCAN_FAILED_SCANNING_TOO_FREQUENTLY ->
+                "scanning started too frequently; Android is throttling scans"
+            else ->
+                "unknown scan failure (code $errorCode)"
+        }
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
@@ -5,60 +5,104 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
 import android.content.Context
 
 // Transport bitmask values matching libdc_wrapper.h.
 private const val LIBDC_TRANSPORT_BLE = 1 shl 5
 
+private const val TAG = "BleScanner"
+
 // Scans for BLE dive computers using Android's BluetoothLeScanner
 // and matches discovered devices against libdivecomputer's descriptor database.
 // Bluetooth permissions are requested at the Dart layer before these methods are called.
+//
+// Every path that declines to surface a device logs why (issue #123). An
+// unsupported model is indistinguishable from a dead scan otherwise, which
+// is what stalled the Suunto Ocean report: the owner was asked for the
+// "Unmatched device" line twice and could not produce it, because the
+// branches ahead of it all returned silently.
 @SuppressLint("MissingPermission")
 class BleScanner(private val context: Context) {
     private var scanCallback: ScanCallback? = null
     private val seenAddresses = mutableSetOf<String>()
-    private val loggedUnmatched = mutableSetOf<String>()
+    private val diagnostics = BleScanDiagnostics()
 
     var onDeviceDiscovered: ((DiscoveredDevice) -> Unit)? = null
     var onComplete: (() -> Unit)? = null
 
     fun start() {
         seenAddresses.clear()
-        loggedUnmatched.clear()
+        diagnostics.reset()
+
         val bluetoothManager =
-            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
-        val adapter = bluetoothManager.adapter ?: return
-        val scanner = adapter.bluetoothLeScanner ?: return
+            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        if (bluetoothManager == null) {
+            NativeLogger.e(TAG, "BLE", "Scan aborted: no Bluetooth service on this device")
+            onComplete?.invoke()
+            return
+        }
+
+        val adapter = bluetoothManager.adapter
+        if (adapter == null) {
+            NativeLogger.e(TAG, "BLE", "Scan aborted: device has no Bluetooth adapter")
+            onComplete?.invoke()
+            return
+        }
+
+        // A disabled adapter yields a null scanner, which previously looked
+        // identical to a scan that simply found nothing.
+        val scanner = adapter.bluetoothLeScanner
+        if (scanner == null) {
+            val state = if (adapter.state == BluetoothAdapter.STATE_OFF) {
+                "Bluetooth is turned off"
+            } else {
+                "adapter state=${adapter.state}"
+            }
+            NativeLogger.e(TAG, "BLE", "Scan aborted: no BLE scanner ($state)")
+            onComplete?.invoke()
+            return
+        }
 
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
-                val address = result.device.address ?: return
+                val address = result.device.address
+                if (address == null) {
+                    diagnostics.describeAddressless()?.let {
+                        NativeLogger.d(TAG, "BLE", it)
+                    }
+                    return
+                }
                 if (seenAddresses.contains(address)) return
 
-                val name = result.scanRecord?.deviceName
-                    ?: result.device.name
-                    ?: return
+                val rssi = result.rssi
+
+                // Peripherals may advertise without a local name and only
+                // supply one in the scan response, so a null here is not
+                // necessarily permanent -- later packets are re-evaluated.
+                val name = result.scanRecord?.deviceName ?: result.device.name
+                if (name == null) {
+                    diagnostics.describeUnnamed(address, rssi)?.let {
+                        NativeLogger.d(TAG, "BLE", it)
+                    }
+                    return
+                }
 
                 val info = DescriptorInfo()
                 val matched = LibdcWrapper.nativeDescriptorMatch(
                     name, LIBDC_TRANSPORT_BLE, info
                 )
                 if (!matched) {
-                    // onScanResult redelivers every advertisement packet, so
-                    // log each unmatched device only once per scan session.
-                    if (loggedUnmatched.add(address)) {
-                        NativeLogger.d(
-                            "BleScanner", "BLE",
-                            "Unmatched device $address ($name)"
-                        )
+                    diagnostics.describeUnmatched(address, name, rssi)?.let {
+                        NativeLogger.d(TAG, "BLE", it)
                     }
                     return
                 }
 
                 seenAddresses.add(address)
-                NativeLogger.d(
-                    "BleScanner", "BLE",
-                    "Matched device $address ($name) -> " +
+                NativeLogger.i(
+                    TAG, "BLE",
+                    "Matched device $address ($name) rssi=$rssi -> " +
                         "${info.vendor} ${info.product} (${info.model})"
                 )
 
@@ -74,12 +118,27 @@ class BleScanner(private val context: Context) {
             }
 
             override fun onScanFailed(errorCode: Int) {
+                NativeLogger.e(
+                    TAG, "BLE",
+                    "Scan failed: ${BleScanDiagnostics.describeScanFailure(errorCode)}"
+                )
                 onComplete?.invoke()
             }
         }
 
         scanCallback = callback
-        scanner.startScan(callback)
+
+        // The no-argument startScan overload uses SCAN_MODE_LOW_POWER, whose
+        // low duty cycle can take tens of seconds to notice a peripheral --
+        // or miss it for the length of a scan. This scan is short-lived,
+        // foreground, and user-initiated, which is exactly what LOW_LATENCY
+        // is for; vendor apps scan the same way.
+        val settings = ScanSettings.Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .build()
+
+        NativeLogger.i(TAG, "BLE", "Starting BLE scan (mode=low latency)")
+        scanner.startScan(null, settings, callback)
     }
 
     fun stop() {
@@ -87,7 +146,13 @@ class BleScanner(private val context: Context) {
             context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
         val scanner = bluetoothManager.adapter?.bluetoothLeScanner ?: return
 
-        scanCallback?.let { scanner.stopScan(it) }
+        scanCallback?.let {
+            scanner.stopScan(it)
+            NativeLogger.i(
+                TAG, "BLE",
+                "Stopped BLE scan; ${seenAddresses.size} supported device(s) found"
+            )
+        }
         scanCallback = null
         onComplete?.invoke()
     }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
@@ -78,9 +78,12 @@ class BleScanner(private val context: Context) {
                 val rssi = result.rssi
 
                 // Peripherals may advertise without a local name and only
-                // supply one in the scan response, so a null here is not
-                // necessarily permanent -- later packets are re-evaluated.
-                val name = result.scanRecord?.deviceName ?: result.device.name
+                // supply one in the scan response, so an absent name here is
+                // not necessarily permanent -- later packets are re-evaluated.
+                val name = BleScanDiagnostics.resolveName(
+                    result.scanRecord?.deviceName,
+                    result.device.name
+                )
                 if (name == null) {
                     diagnostics.describeUnnamed(address, rssi)?.let {
                         NativeLogger.d(TAG, "BLE", it)
@@ -138,7 +141,23 @@ class BleScanner(private val context: Context) {
             .build()
 
         NativeLogger.i(TAG, "BLE", "Starting BLE scan (mode=low latency)")
-        scanner.startScan(null, settings, callback)
+        try {
+            scanner.startScan(null, settings, callback)
+        } catch (e: Exception) {
+            // The adapter can be switched off between the null check above and
+            // this call, and revoked permissions surface here too. Nothing is
+            // registered when this throws, so drop the callback rather than
+            // leave it for the next start() to overwrite. The exception still
+            // propagates: DiveComputerHostApiImpl turns it into the error the
+            // user sees.
+            scanCallback = null
+            NativeLogger.e(
+                TAG, "BLE",
+                "Scan could not be started: ${e.javaClass.simpleName}: ${e.message}"
+            )
+            onComplete?.invoke()
+            throw e
+        }
     }
 
     // Always releases the callback and signals completion, including when the
@@ -156,11 +175,24 @@ class BleScanner(private val context: Context) {
 
         if (callback != null) {
             if (scanner != null) {
-                scanner.stopScan(callback)
-                NativeLogger.i(
-                    TAG, "BLE",
-                    "Stopped BLE scan; ${seenAddresses.size} supported device(s) found"
-                )
+                // stopScan throws in some adapter state transitions. Letting it
+                // escape would skip onComplete below and, because the Dart
+                // stopScan() clears isScanning only after awaiting this call,
+                // strand the wizard on "scanning" -- the failure this change
+                // exists to remove. Report it and finish the teardown.
+                try {
+                    scanner.stopScan(callback)
+                    NativeLogger.i(
+                        TAG, "BLE",
+                        "Stopped BLE scan; ${seenAddresses.size} supported device(s) found"
+                    )
+                } catch (e: Exception) {
+                    NativeLogger.w(
+                        TAG, "BLE",
+                        "Stopping the BLE scan failed: " +
+                            "${e.javaClass.simpleName}: ${e.message}"
+                    )
+                }
             } else {
                 NativeLogger.w(
                     TAG, "BLE",

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanner.kt
@@ -141,19 +141,34 @@ class BleScanner(private val context: Context) {
         scanner.startScan(null, settings, callback)
     }
 
+    // Always releases the callback and signals completion, including when the
+    // system scanner has become unreachable -- Bluetooth switched off during a
+    // scan makes bluetoothLeScanner null. Returning early there would strand
+    // scanCallback, and the next start() would overwrite it while the old
+    // registration was still outstanding.
     fun stop() {
-        val bluetoothManager =
-            context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager ?: return
-        val scanner = bluetoothManager.adapter?.bluetoothLeScanner ?: return
-
-        scanCallback?.let {
-            scanner.stopScan(it)
-            NativeLogger.i(
-                TAG, "BLE",
-                "Stopped BLE scan; ${seenAddresses.size} supported device(s) found"
-            )
-        }
+        val callback = scanCallback
         scanCallback = null
+
+        val scanner = (context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)
+            ?.adapter
+            ?.bluetoothLeScanner
+
+        if (callback != null) {
+            if (scanner != null) {
+                scanner.stopScan(callback)
+                NativeLogger.i(
+                    TAG, "BLE",
+                    "Stopped BLE scan; ${seenAddresses.size} supported device(s) found"
+                )
+            } else {
+                NativeLogger.w(
+                    TAG, "BLE",
+                    "Stopped BLE scan without unregistering: Bluetooth became unavailable"
+                )
+            }
+        }
+
         onComplete?.invoke()
     }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -165,7 +165,12 @@ class DiveComputerHostApiImpl(
         // BleScanner identifies devices via LibdcWrapper.nativeDescriptorMatch on
         // the (async) scan-result thread. Bail with a clear error if the native
         // library never loaded, rather than crashing there (issue #318).
-        if (!nativeLibraryReady()) return
+        // Signal completion on the way out so the scan UI stops spinning
+        // instead of waiting for results that can never arrive (issue #123).
+        if (!nativeLibraryReady()) {
+            mainHandler.post { flutterApi.onDiscoveryComplete { } }
+            return
+        }
 
         val scanner = BleScanner(context)
         scanner.onDeviceDiscovered = { device ->

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
@@ -1,0 +1,140 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// JVM tests for the BLE scan diagnostics used by BleScanner (issue #123).
+//
+// A Suunto Ocean owner was asked twice for the "Unmatched device" log line
+// and could not produce it, because every failure mode ahead of that line
+// returned silently. These tests pin the behaviour that makes an
+// unsupported -- or unnamed -- dive computer visible in the debug log.
+class BleScanDiagnosticsTest {
+
+    @Test
+    fun unmatchedNamedDeviceIsDescribedWithAddressAndName() {
+        val diagnostics = BleScanDiagnostics()
+
+        val message = diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62)
+
+        assertNotNull(message)
+        assertTrue(message!!.contains("AA:BB:CC:DD:EE:FF"))
+        assertTrue(message.contains("Suunto Ocean"))
+        assertTrue(message.contains("-62"))
+    }
+
+    @Test
+    fun repeatedAdvertisementsFromTheSameDeviceAreLoggedOnce() {
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62))
+        assertNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -63))
+        assertNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -58))
+    }
+
+    @Test
+    fun differentDevicesAreEachLogged() {
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62))
+        assertNotNull(diagnostics.describeUnmatched("11:22:33:44:55:66", "Some Watch", -70))
+    }
+
+    @Test
+    fun unnamedDeviceIsStillLoggedWithItsAddress() {
+        val diagnostics = BleScanDiagnostics()
+
+        val message = diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -62)
+
+        assertNotNull(message)
+        assertTrue(message!!.contains("AA:BB:CC:DD:EE:FF"))
+        assertTrue(message.contains("-62"))
+    }
+
+    @Test
+    fun unnamedDeviceIsLoggedAgainOnceItsNameBecomesKnown() {
+        // Many peripherals omit the local name from the initial advertisement
+        // and only supply it in the scan response. Suppressing the later,
+        // named sighting would hide the one string a descriptor patch needs.
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -62))
+        assertNotNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62))
+    }
+
+    @Test
+    fun unnamedSightingsAreThemselvesDeduplicated() {
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -62))
+        assertNull(diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -64))
+    }
+
+    @Test
+    fun addresslessAdvertisementsAreReportedOncePerSession() {
+        // These cannot be deduplicated per device, so an unthrottled line
+        // would flood the log file and rotate away the useful entries.
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeAddressless())
+        assertNull(diagnostics.describeAddressless())
+
+        diagnostics.reset()
+        assertNotNull(diagnostics.describeAddressless())
+    }
+
+    @Test
+    fun addresslessReportingDoesNotSuppressRealDevices() {
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeAddressless())
+        assertNotNull(diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -62))
+        assertNotNull(
+            diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62)
+        )
+    }
+
+    @Test
+    fun resetAllowsANewScanSessionToLogTheSameDeviceAgain() {
+        val diagnostics = BleScanDiagnostics()
+        assertNotNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62))
+
+        diagnostics.reset()
+
+        assertNotNull(diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62))
+    }
+
+    @Test
+    fun knownScanFailureCodesAreDescribedInWords() {
+        assertTrue(
+            BleScanDiagnostics.describeScanFailure(BleScanDiagnostics.SCAN_FAILED_ALREADY_STARTED)
+                .contains("already started", ignoreCase = true)
+        )
+        assertTrue(
+            BleScanDiagnostics.describeScanFailure(
+                BleScanDiagnostics.SCAN_FAILED_FEATURE_UNSUPPORTED
+            ).contains("unsupported", ignoreCase = true)
+        )
+        assertTrue(
+            BleScanDiagnostics.describeScanFailure(
+                BleScanDiagnostics.SCAN_FAILED_SCANNING_TOO_FREQUENTLY
+            ).contains("too frequently", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun unknownScanFailureCodeKeepsTheRawValue() {
+        assertTrue(BleScanDiagnostics.describeScanFailure(42).contains("42"))
+    }
+
+    @Test
+    fun scanFailureDescriptionsAreDistinct() {
+        val codes = listOf(1, 2, 3, 4, 5, 6)
+        val descriptions = codes.map { BleScanDiagnostics.describeScanFailure(it) }
+
+        assertEquals(codes.size, descriptions.toSet().size)
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
@@ -108,6 +108,46 @@ class BleScanDiagnosticsTest {
     }
 
     @Test
+    fun scanRecordNameIsPreferredOverTheCachedDeviceName() {
+        assertEquals(
+            "Suunto Ocean",
+            BleScanDiagnostics.resolveName("Suunto Ocean", "stale cached name")
+        )
+    }
+
+    @Test
+    fun cachedDeviceNameIsUsedWhenTheAdvertisementCarriesNone() {
+        assertEquals("Suunto D5", BleScanDiagnostics.resolveName(null, "Suunto D5"))
+    }
+
+    @Test
+    fun emptyNamesCountAsAbsent() {
+        // A zero-length Complete Local Name AD field is reported as "" rather
+        // than omitted. Treating it as a real name would match an empty prefix
+        // against the descriptor table and log a nameless "(...)" line.
+        assertNull(BleScanDiagnostics.resolveName("", ""))
+        assertNull(BleScanDiagnostics.resolveName(null, ""))
+        assertNull(BleScanDiagnostics.resolveName("", null))
+    }
+
+    @Test
+    fun anEmptyScanRecordNameFallsBackToTheDeviceName() {
+        assertEquals("Suunto D5", BleScanDiagnostics.resolveName("", "Suunto D5"))
+    }
+
+    @Test
+    fun anAbsentNameDoesNotCollideWithAnEmptyOne() {
+        // Both used to produce the dedupe key "<address>|", so whichever
+        // arrived first silently suppressed the other.
+        val diagnostics = BleScanDiagnostics()
+
+        assertNotNull(diagnostics.describeUnnamed("AA:BB:CC:DD:EE:FF", -62))
+        assertNotNull(
+            diagnostics.describeUnmatched("AA:BB:CC:DD:EE:FF", "Suunto Ocean", -62)
+        )
+    }
+
+    @Test
     fun knownScanFailureCodesAreDescribedInWords() {
         assertTrue(
             BleScanDiagnostics.describeScanFailure(BleScanDiagnostics.SCAN_FAILED_ALREADY_STARTED)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1555,7 +1555,7 @@ packages:
     source: hosted
     version: "0.1.3+5"
   permission_handler_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: permission_handler_platform_interface
       sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -151,6 +151,7 @@ dev_dependencies:
   mockito: ^5.6.1
   plugin_platform_interface: ^2.1.8
   path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests
+  permission_handler_platform_interface: ^4.3.0  # mock BLE scan permission grants
   flutter_web_auth_2_platform_interface: ^5.0.0  # mock auth in redirect-capture test
   fake_async: ^1.3.3  # synthetic clock + Timer driving for unit tests
 

--- a/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
+++ b/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
@@ -82,6 +82,32 @@ void main() {
       expect(notifier.state.errorMessage, isNotNull);
     });
 
+    test(
+      'drops the device subscription when starting discovery throws',
+      () async {
+        // The subscription is opened before startDiscovery is awaited, so a
+        // synchronous failure would otherwise leave it live and let a stray
+        // native event populate the list under an error message.
+        hostApi.startDiscoveryError = StateError('adapter unavailable');
+        await notifier.startScan();
+        await settle();
+
+        service.onDeviceDiscovered(
+          pigeon.DiscoveredDevice(
+            vendor: 'Suunto',
+            product: 'D5',
+            model: 2,
+            address: 'AA:BB:CC:DD:EE:FF',
+            name: 'Suunto D5',
+            transport: pigeon.TransportType.ble,
+          ),
+        );
+        await settle();
+
+        expect(notifier.state.discoveredDevices, isEmpty);
+      },
+    );
+
     test('logs a Bluetooth entry when a scan stops', () async {
       await notifier.startScan();
       await settle();

--- a/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
+++ b/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
@@ -57,7 +57,7 @@ void main() {
 
     // LoggerService publishes through a broadcast controller, so listeners
     // are notified on a later microtask than the call that logged.
-    Future<void> settle() => Future<void>.delayed(Duration.zero);
+    Future<void> settle() => pumpEventQueue();
 
     test('logs a Bluetooth entry when a scan starts', () async {
       await notifier.startScan();

--- a/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
+++ b/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
+
+/// Host API stub that records discovery calls without touching a platform
+/// channel. Extends the generated class so only the two methods the
+/// discovery flow uses need overriding.
+class _FakeHostApi extends pigeon.DiveComputerHostApi {
+  bool startDiscoveryCalled = false;
+  bool stopDiscoveryCalled = false;
+  Object? startDiscoveryError;
+
+  @override
+  Future<void> startDiscovery(pigeon.TransportType transport) async {
+    startDiscoveryCalled = true;
+    final error = startDiscoveryError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<void> stopDiscovery() async {
+    stopDiscoveryCalled = true;
+  }
+}
+
+void main() {
+  // Issue #123: a Suunto Ocean owner enabled debug mode, ran a scan, and
+  // submitted a log containing no Bluetooth lines at all, because the scan
+  // path emitted none. These tests pin the boundary logging that makes a
+  // scan attempt visible in a submitted debug log.
+  group('DiscoveryNotifier scan logging', () {
+    late _FakeHostApi hostApi;
+    late pigeon.DiveComputerService service;
+    late DiscoveryNotifier notifier;
+    late List<LogEntry> captured;
+    late StreamSubscription<LogEntry> subscription;
+
+    setUp(() {
+      hostApi = _FakeHostApi();
+      service = pigeon.DiveComputerService(hostApi: hostApi);
+      notifier = DiscoveryNotifier(service: service);
+      captured = [];
+      subscription = LoggerService.logStream.listen(captured.add);
+    });
+
+    tearDown(() async {
+      await subscription.cancel();
+      notifier.dispose();
+    });
+
+    List<LogEntry> bluetoothEntries() =>
+        captured.where((e) => e.category == LogCategory.bluetooth).toList();
+
+    // LoggerService publishes through a broadcast controller, so listeners
+    // are notified on a later microtask than the call that logged.
+    Future<void> settle() => Future<void>.delayed(Duration.zero);
+
+    test('logs a Bluetooth entry when a scan starts', () async {
+      await notifier.startScan();
+      await settle();
+
+      expect(hostApi.startDiscoveryCalled, isTrue);
+      expect(bluetoothEntries(), isNotEmpty);
+    });
+
+    test('logs a Bluetooth error when starting discovery throws', () async {
+      hostApi.startDiscoveryError = StateError('adapter unavailable');
+
+      await notifier.startScan();
+      await settle();
+
+      final errors = bluetoothEntries()
+          .where((e) => e.level == LogLevel.error)
+          .toList();
+      expect(errors, isNotEmpty);
+      expect(errors.first.message, contains('adapter unavailable'));
+      expect(notifier.state.isScanning, isFalse);
+      expect(notifier.state.errorMessage, isNotNull);
+    });
+
+    test('logs a Bluetooth entry when a scan stops', () async {
+      await notifier.startScan();
+      await settle();
+      captured.clear();
+
+      await notifier.stopScan();
+      await settle();
+
+      expect(hostApi.stopDiscoveryCalled, isTrue);
+      expect(bluetoothEntries(), isNotEmpty);
+    });
+
+    test('logs each device the native scanner surfaces', () async {
+      await notifier.startScan();
+      await settle();
+      captured.clear();
+
+      service.onDeviceDiscovered(
+        pigeon.DiscoveredDevice(
+          vendor: 'Suunto',
+          product: 'D5',
+          model: 2,
+          address: 'AA:BB:CC:DD:EE:FF',
+          name: 'Suunto D5',
+          transport: pigeon.TransportType.ble,
+        ),
+      );
+      await settle();
+
+      expect(notifier.state.discoveredDevices, hasLength(1));
+      final messages = bluetoothEntries().map((e) => e.message).join('\n');
+      expect(messages, contains('Suunto D5'));
+    });
+  });
+}

--- a/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
+++ b/test/features/dive_computer/presentation/providers/discovery_scan_logging_test.dart
@@ -2,9 +2,26 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
+
+/// Permission backend that answers without a platform channel. Only
+/// [requestPermissions] is overridden; the rest of the interface throws by
+/// default and is not reached by the discovery flow.
+class _FakePermissionHandler extends PermissionHandlerPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePermissionHandler(this.response);
+
+  final Map<Permission, PermissionStatus> response;
+
+  @override
+  Future<Map<Permission, PermissionStatus>> requestPermissions(
+    List<Permission> permissions,
+  ) async => response;
+}
 
 /// Host API stub that records discovery calls without touching a platform
 /// channel. Extends the generated class so only the two methods the
@@ -107,6 +124,58 @@ void main() {
         expect(notifier.state.discoveredDevices, isEmpty);
       },
     );
+
+    group('runtime permission gate', () {
+      late PermissionHandlerPlatform original;
+
+      setUp(() => original = PermissionHandlerPlatform.instance);
+      tearDown(() => PermissionHandlerPlatform.instance = original);
+
+      DiscoveryNotifier gatedNotifier() {
+        final gated = DiscoveryNotifier(
+          service: service,
+          requiresRuntimePermissions: true,
+        );
+        addTearDown(gated.dispose);
+        return gated;
+      }
+
+      test('logs and blocks the scan when a permission is refused', () async {
+        PermissionHandlerPlatform.instance = _FakePermissionHandler({
+          Permission.bluetoothScan: PermissionStatus.denied,
+          Permission.bluetoothConnect: PermissionStatus.granted,
+        });
+        final gated = gatedNotifier();
+
+        await gated.startScan();
+        await settle();
+
+        expect(hostApi.startDiscoveryCalled, isFalse);
+        expect(gated.state.isScanning, isFalse);
+        expect(gated.state.errorMessage, isNotNull);
+
+        final warnings = bluetoothEntries()
+            .where((e) => e.level == LogLevel.warning)
+            .toList();
+        expect(warnings, isNotEmpty);
+        expect(warnings.first.message, contains('denied'));
+      });
+
+      test('proceeds to scan once every permission is granted', () async {
+        PermissionHandlerPlatform.instance = _FakePermissionHandler({
+          Permission.bluetoothScan: PermissionStatus.granted,
+          Permission.bluetoothConnect: PermissionStatus.granted,
+        });
+        final gated = gatedNotifier();
+
+        await gated.startScan();
+        await settle();
+
+        expect(hostApi.startDiscoveryCalled, isTrue);
+        expect(gated.state.isScanning, isTrue);
+        expect(gated.state.errorMessage, isNull);
+      });
+    });
 
     test('logs a Bluetooth entry when a scan stops', () async {
       await notifier.startScan();


### PR DESCRIPTION
## Summary

Issue #123 (Suunto Ocean not connecting on Android) stalled for six weeks because the reporter was twice asked for the log line `BleScanner: Unmatched device <addr> (<name>)` and could never produce it. That was not their fault: every branch ahead of that line returned silently, so an empty debug log was indistinguishable from "the user never scanned".

There are two independent problems on the issue. This PR fixes the second one, which is what blocks diagnosing the first.

**1. The Suunto Ocean is in no descriptor table.** BLE matching runs through `dc_filter_suunto` in libdivecomputer's `src/descriptor.c`, which *prefix*-matches exactly four strings: `EON Steel`, `EON Core`, `Suunto D5`, `EON Steel Black`. The Ocean matches none, so it is discarded before reaching the device list. Re-verified against upstream `master` on 2026-08-10 — still no Ocean entry there either. **This PR does not attempt to add it**: the advertised name is unknown, a wrong prefix fails silently, and a *right* prefix on an incompatible protocol would yield failed or corrupt downloads rather than an honest "unsupported". Both need confirmation against real hardware.

**2. The scan path was unobservable.** Fixed here.

| Location | Previous behaviour |
| --- | --- |
| `BleScanner.start()` | no Bluetooth service / no adapter / null scanner (Bluetooth off) — three unlogged `return`s, none firing `onComplete`, so the wizard span on "scanning" forever |
| `onScanResult` | null address, and **null name**, returned bare — an advertisement with no readable name vanished entirely |
| `onScanFailed` | error code discarded |
| `startBleDiscovery` | native-library-missing path left the spinner running |
| Dart `startScan` | no logging at all, including on permission denial |

After this change, one scan with the Ocean awake produces the exact advertised name a descriptor patch needs.

## Changes

- **`BleScanDiagnostics.kt` (new)** — framework-free helper that builds the skip messages, rate-limits them to one line per `address|name` sighting, and maps `SCAN_FAILED_*` codes to readable text. Keyed on the name as well as the address so a peripheral that omits its local name from the initial advertisement still logs again once the scan response supplies one; that later line carries the string we actually need. Follows the existing `BondPolicy` idiom — `ScanResult`/`BluetoothManager` cannot be constructed off-device, so the decision logic is extracted to keep it JVM-testable.
- **`BleScanner.kt`** — every skip logs address, name (or an explicit "no advertised name"), and RSSI; scan failures report a reason; the three abort paths log and fire `onComplete` so the spinner stops. Matched devices moved from DEBUG to INFO so they survive a raised severity filter.
- **`BleScanner.kt`** — scanning now uses `SCAN_MODE_LOW_LATENCY` instead of the no-argument `startScan` overload's `SCAN_MODE_LOW_POWER`, whose low duty cycle can miss a peripheral for the length of a scan. This is a short-lived, foreground, user-initiated scan.
- **`DiveComputerHostApiImpl.kt`** — the native-library-unavailable path signals discovery completion instead of hanging.
- **`discovery_providers.dart`** — logs scan start/stop, permission denial (previously entirely silent), start failures, and each discovered device.

## Test Plan

- [x] `flutter test` passes — 16046 passed, 15 skipped, 0 failures
- [x] `flutter analyze` passes — No issues found
- [x] `dart format lib/ test/ packages/` — 3397 files, 0 changed
- [x] `BleScanDiagnosticsTest` (JVM, 12 tests) — `tests="12" skipped="0" failures="0" errors="0"`
- [x] `BondPolicyTest` regression — passing
- [x] `discovery_scan_logging_test.dart` (new, 4 tests) — passing
- [ ] Manual testing on: Android with a real Suunto Ocean — **needs the reporter**, see #123

## Notes for reviewers

Three adjacent findings, none addressed here:

1. **CI does not run the plugin's Kotlin unit tests.** No workflow references `testDebugUnitTest`, so `BondPolicyTest`, `SerialReadBufferTest`, and now `BleScanDiagnosticsTest` only ever run by hand.
2. **The plugin manifest declares `BLUETOOTH_SCAN` without `neverForLocation`** while the app manifest declares it with. The merger should preserve the app's flag (the library declares no conflicting attribute), so this was not treated as causal — but it is a latent Android 12+ scan-delivery hazard, and the new logging will expose it if it ever bites.
3. **Worktrees cannot run these Kotlin tests out of the box** — `android/gradlew` is gitignored, and Kotlin 1.8.22 cannot parse a JDK 26 version string. Ran under Android Studio's bundled JDK 21 with the wrapper copied in.
