### PR TITLE
Align statistics chart grid lines with their y-axis labels

### DIFF
--- a/lib/features/statistics/presentation/widgets/chart_axis.dart
+++ b/lib/features/statistics/presentation/widgets/chart_axis.dart
@@ -1,0 +1,157 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+/// A chart y-axis whose bounds and tick step are chosen together.
+///
+/// fl_chart spaces grid lines by `FlGridData.horizontalInterval` and side
+/// titles by `SideTitles.interval`, and each independently falls back to its
+/// own heuristic when left null. Deriving both from one [ChartAxis] is what
+/// keeps a grid line under every label: fl_chart walks both sequences from
+/// the same zero baseline, so an identical interval over bounds that are
+/// whole multiples of it yields identical tick values.
+@immutable
+class ChartAxis {
+  const ChartAxis({
+    required this.min,
+    required this.max,
+    required this.interval,
+  });
+
+  /// Lower bound of the axis. Always a whole multiple of [interval].
+  final double min;
+
+  /// Upper bound of the axis. Always a whole multiple of [interval].
+  final double max;
+
+  /// Spacing between ticks. Feed this to both the grid and the side titles.
+  final double interval;
+
+  /// Builds an axis covering [values] with about a tenth of the span as
+  /// headroom at each end, then widened to whole [interval] steps.
+  ///
+  /// An all-positive series never gets a negative axis, so a chart of rates
+  /// or depths does not sprout a meaningless sub-zero band.
+  factory ChartAxis.forTrend(Iterable<double> values, {int targetTicks = 4}) {
+    final points = values.toList(growable: false);
+    if (points.isEmpty) {
+      return _snapped(0, 1, targetTicks: targetTicks, wholeSteps: false);
+    }
+
+    final lowest = points.reduce(math.min);
+    final highest = points.reduce(math.max);
+    final span = highest - lowest;
+    // A flat series has no span of its own but still needs a band to draw in.
+    final effectiveSpan = span > 0
+        ? span
+        : (highest.abs() > 0 ? highest.abs() * 0.2 : 1.0);
+    final headroom = effectiveSpan * 0.1;
+
+    return _snapped(
+      lowest >= 0 ? math.max(0.0, lowest - headroom) : lowest - headroom,
+      highest + headroom,
+      targetTicks: targetTicks,
+      wholeSteps: false,
+    );
+  }
+
+  /// Builds an axis for a bar chart of counts: anchored at zero and stepping
+  /// in whole units, since a count of 2.5 dives is not a thing to label.
+  factory ChartAxis.forCounts(double maxCount, {int targetTicks = 4}) {
+    return _snapped(
+      0,
+      maxCount > 0 ? maxCount * 1.1 : 1.0,
+      targetTicks: targetTicks,
+      wholeSteps: true,
+    );
+  }
+
+  /// Nice-number steps within one order of magnitude. Counts skip 2.5.
+  static const _fractionalSteps = <double>[1, 2, 2.5, 5, 10];
+  static const _wholeSteps = <double>[1, 2, 5, 10];
+
+  /// Widening [lower]/[upper] onto tick boundaries can add up to two extra
+  /// segments; beyond that the axis is crowded and the step moves up a rung.
+  static const _extraSegmentBudget = 2;
+
+  static ChartAxis _snapped(
+    double lower,
+    double upper, {
+    required int targetTicks,
+    required bool wholeSteps,
+  }) {
+    var interval = _niceInterval(
+      (upper - lower) / targetTicks,
+      wholeSteps: wholeSteps,
+    );
+    var min = _floorTo(lower, interval);
+    var max = _ceilTo(upper, interval);
+
+    while ((max - min) / interval > targetTicks + _extraSegmentBudget) {
+      final wider = _nextStepUp(interval, wholeSteps: wholeSteps);
+      if (wider <= interval) break;
+      interval = wider;
+      min = _floorTo(lower, interval);
+      max = _ceilTo(upper, interval);
+    }
+
+    return ChartAxis(
+      min: min,
+      max: max > min ? max : min + interval,
+      interval: interval,
+    );
+  }
+
+  /// Rounds [rough] to the nearest 1, 2, (2.5,) 5 or 10 times a power of ten.
+  static double _niceInterval(double rough, {required bool wholeSteps}) {
+    if (!rough.isFinite || rough <= 0) return 1;
+
+    final magnitude = _magnitudeOf(rough);
+    final normalized = rough / magnitude;
+    final steps = wholeSteps ? _wholeSteps : _fractionalSteps;
+    final step = steps.reduce(
+      (a, b) => (normalized - a).abs() <= (normalized - b).abs() ? a : b,
+    );
+    final interval = step * magnitude;
+
+    return wholeSteps ? math.max(1.0, interval.roundToDouble()) : interval;
+  }
+
+  static double _nextStepUp(double interval, {required bool wholeSteps}) {
+    final magnitude = _magnitudeOf(interval);
+    final normalized = interval / magnitude;
+    final steps = wholeSteps ? _wholeSteps : _fractionalSteps;
+    for (final step in steps) {
+      if (step > normalized * (1 + _epsilon)) return step * magnitude;
+    }
+    return 10 * magnitude;
+  }
+
+  static double _magnitudeOf(double value) {
+    if (!value.isFinite || value <= 0) return 1;
+    return math.pow(10, (math.log(value) / math.ln10).floor()).toDouble();
+  }
+
+  /// Relative slack so a value already sitting on a tick is not pushed a whole
+  /// step outward by binary-fraction error (14.7 / 0.1 is 146.99999999999997).
+  static const _epsilon = 1e-9;
+
+  static double _floorTo(double value, double interval) =>
+      (value / interval + _epsilon).floorToDouble() * interval;
+
+  static double _ceilTo(double value, double interval) =>
+      (value / interval - _epsilon).ceilToDouble() * interval;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ChartAxis &&
+      other.min == min &&
+      other.max == max &&
+      other.interval == interval;
+
+  @override
+  int get hashCode => Object.hash(min, max, interval);
+
+  @override
+  String toString() => 'ChartAxis(min: $min, max: $max, interval: $interval)';
+}

--- a/lib/features/statistics/presentation/widgets/stat_charts.dart
+++ b/lib/features/statistics/presentation/widgets/stat_charts.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+import 'package:submersion/features/statistics/presentation/widgets/chart_axis.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// A reusable line chart for trend data
@@ -57,17 +58,9 @@ class TrendLineChart extends StatelessWidget {
     }
 
     final color = lineColor ?? Theme.of(context).colorScheme.primary;
-    final values = data.map((d) => d.value).toList();
-    final rawMinY = values.reduce((a, b) => a < b ? a : b);
-    final rawMaxY = values.reduce((a, b) => a > b ? a : b);
-    // Ensure we have a valid range even when all values are the same
-    final range = rawMaxY - rawMinY;
-    final effectiveRange = range > 0
-        ? range
-        : (rawMaxY.abs() > 0 ? rawMaxY.abs() * 0.2 : 1.0);
-    final padding = effectiveRange * 0.1;
-    final minY = rawMinY;
-    final maxY = rawMaxY;
+    // One axis drives the bounds, the grid lines and the labels, so the lines
+    // land under the numbers instead of between them (issue #219).
+    final axis = ChartAxis.forTrend(data.map((d) => d.value));
 
     return Semantics(
       label: yAxisLabel != null
@@ -80,10 +73,8 @@ class TrendLineChart extends StatelessWidget {
         height: height,
         child: LineChart(
           LineChartData(
-            minY: minY > 0
-                ? (minY - padding).clamp(0, double.infinity)
-                : minY - padding,
-            maxY: maxY + padding,
+            minY: axis.min,
+            maxY: axis.max,
             lineTouchData: LineTouchData(
               touchTooltipData: LineTouchTooltipData(
                 getTooltipItems: (touchedSpots) {
@@ -142,6 +133,7 @@ class TrendLineChart extends StatelessWidget {
                 sideTitles: SideTitles(
                   showTitles: true,
                   reservedSize: 50,
+                  interval: axis.interval,
                   getTitlesWidget: (value, meta) {
                     final formatter = yAxisFormatter ?? valueFormatter;
                     return Text(
@@ -162,7 +154,7 @@ class TrendLineChart extends StatelessWidget {
             gridData: FlGridData(
               show: true,
               drawVerticalLine: false,
-              horizontalInterval: effectiveRange / 4,
+              horizontalInterval: axis.interval,
               getDrawingHorizontalLine: (value) => FlLine(
                 color: Theme.of(context).colorScheme.outlineVariant,
                 strokeWidth: 1,
@@ -442,10 +434,16 @@ class CategoryBarChart extends StatelessWidget {
     required double maxCount,
     required bool useCompactXLabels,
   }) {
+    // Whole-number steps shared by the grid and the labels: the left titles
+    // render nothing for a fractional value, so a 2.5 step would otherwise
+    // leave unlabelled lines (issue #219).
+    final axis = ChartAxis.forCounts(maxCount);
+
     return BarChart(
       BarChartData(
         alignment: BarChartAlignment.spaceAround,
-        maxY: maxCount + (maxCount * 0.1),
+        minY: axis.min,
+        maxY: axis.max,
         barTouchData: BarTouchData(
           touchTooltipData: BarTouchTooltipData(
             getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -506,6 +504,7 @@ class CategoryBarChart extends StatelessWidget {
               showTitles: true,
               // Room for up to 4-digit right-aligned integers.
               reservedSize: 44,
+              interval: axis.interval,
               getTitlesWidget: (value, meta) {
                 if (value != value.roundToDouble()) {
                   return const Text('');
@@ -532,7 +531,7 @@ class CategoryBarChart extends StatelessWidget {
         gridData: FlGridData(
           show: true,
           drawVerticalLine: false,
-          horizontalInterval: maxCount > 0 ? maxCount / 4 : 1,
+          horizontalInterval: axis.interval,
           getDrawingHorizontalLine: (value) => FlLine(
             color: Theme.of(context).colorScheme.outlineVariant,
             strokeWidth: 1,

--- a/test/features/statistics/data/repositories/statistics_repository_sac_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_sac_test.dart
@@ -571,6 +571,40 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // SAC By Tank Role: the two units are genuinely different calculations
+  // ---------------------------------------------------------------------------
+
+  group('SAC by tank role across units', () {
+    // Issues #160 and #219: the card once read one query for both settings,
+    // so switching bar/min to L/min swapped the unit label while leaving the
+    // number untouched (1.6 bar/min became 1.6 L/min).
+    test('volume and pressure roles report different magnitudes', () async {
+      await insertDiveWithTank(
+        id: 'dive-units',
+        bottomTimeSeconds: 35 * 60,
+        runtimeSeconds: 42 * 60,
+        avgDepth: 20.0,
+        startPressure: 200,
+        endPressure: 50,
+        tankRole: 'backGas',
+        volume: 12.0,
+      );
+
+      final pressureByRole = await repository.getSacPressureByTankRole();
+      final volumeByRole = await repository.getSacVolumeByTankRole();
+
+      // 150 bar over 42 min at 3 ata.
+      expect(pressureByRole['backGas']!, closeTo(150 / 42 / 3, 0.01));
+      // The same drop through a 12 L cylinder is an order of magnitude larger
+      // in litres, so the displayed number must move when the unit does.
+      expect(
+        volumeByRole['backGas']!,
+        greaterThan(pressureByRole['backGas']! * 5),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Bottom Time Trend (uses bottom_time column directly)
   // ---------------------------------------------------------------------------
 

--- a/test/features/statistics/presentation/widgets/chart_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/chart_axis_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/statistics/presentation/widgets/chart_axis.dart';
+
+// Issue #219: the statistics trend charts drew grid lines on one interval and
+// labelled the left axis on another, so the tick lines sat between the values.
+// ChartAxis is the single source of truth both sides now read from.
+
+/// True when [value] sits on a tick of [interval] measured from zero, which is
+/// the baseline fl_chart anchors both grid lines and side titles to.
+bool _isOnTick(double value, double interval) {
+  final steps = value / interval;
+  return (steps - steps.roundToDouble()).abs() < 1e-9;
+}
+
+void main() {
+  group('ChartAxis.forTrend', () {
+    test('bounds land on whole interval steps', () {
+      final axis = ChartAxis.forTrend(const [12.4, 15.1, 13.8, 18.2, 16.0]);
+
+      expect(axis.interval, greaterThan(0));
+      expect(_isOnTick(axis.min, axis.interval), isTrue);
+      expect(_isOnTick(axis.max, axis.interval), isTrue);
+    });
+
+    test('keeps every data point inside the axis', () {
+      const values = [12.4, 15.1, 13.8, 18.2, 16.0];
+      final axis = ChartAxis.forTrend(values);
+
+      expect(
+        axis.min,
+        lessThanOrEqualTo(values.reduce((a, b) => a < b ? a : b)),
+      );
+      expect(
+        axis.max,
+        greaterThanOrEqualTo(values.reduce((a, b) => a > b ? a : b)),
+      );
+    });
+
+    test('picks a human-readable step rather than range/4', () {
+      // Range 6.0 over four ticks is 1.5 exactly; 2.0 reads better.
+      final axis = ChartAxis.forTrend(const [10.0, 16.0]);
+      expect(axis.interval, 2.0);
+      expect(axis.min, 8.0);
+      expect(axis.max, 18.0);
+    });
+
+    test('never drops below zero for all-positive data', () {
+      final axis = ChartAxis.forTrend(const [0.4, 0.9, 1.2]);
+      expect(axis.min, greaterThanOrEqualTo(0.0));
+    });
+
+    test('allows negative bounds when the data goes negative', () {
+      final axis = ChartAxis.forTrend(const [-4.0, 6.0]);
+      expect(axis.min, lessThan(0));
+      expect(_isOnTick(axis.min, axis.interval), isTrue);
+    });
+
+    test('gives a flat series a usable range around the value', () {
+      final axis = ChartAxis.forTrend(const [15.0, 15.0, 15.0]);
+
+      expect(axis.max, greaterThan(axis.min));
+      expect(axis.min, lessThanOrEqualTo(15.0));
+      expect(axis.max, greaterThanOrEqualTo(15.0));
+      expect(_isOnTick(axis.interval, axis.interval), isTrue);
+    });
+
+    test('gives an all-zero series a usable range', () {
+      final axis = ChartAxis.forTrend(const [0.0, 0.0]);
+
+      expect(axis.min, 0.0);
+      expect(axis.max, greaterThan(0.0));
+      expect(axis.interval, greaterThan(0));
+    });
+
+    test('handles sub-unit SAC pressure values without collapsing', () {
+      // bar/min SAC lives well under 1; the interval must scale down with it.
+      final axis = ChartAxis.forTrend(const [0.52, 0.61, 0.58, 0.74]);
+
+      expect(axis.interval, lessThan(0.5));
+      expect(axis.max, greaterThanOrEqualTo(0.74));
+      expect(_isOnTick(axis.max, axis.interval), isTrue);
+    });
+  });
+
+  group('ChartAxis.forCounts', () {
+    test('anchors at zero and steps in whole dives', () {
+      final axis = ChartAxis.forCounts(10);
+
+      expect(axis.min, 0.0);
+      expect(axis.interval, axis.interval.roundToDouble());
+      expect(axis.interval, greaterThanOrEqualTo(1));
+      expect(axis.max, greaterThanOrEqualTo(10));
+      expect(_isOnTick(axis.max, axis.interval), isTrue);
+    });
+
+    test('never produces a fractional step for small counts', () {
+      for (var maxCount = 1; maxCount <= 12; maxCount++) {
+        final axis = ChartAxis.forCounts(maxCount.toDouble());
+        expect(
+          axis.interval,
+          axis.interval.roundToDouble(),
+          reason: 'maxCount $maxCount produced a fractional interval',
+        );
+        expect(axis.max, greaterThanOrEqualTo(maxCount.toDouble()));
+      }
+    });
+
+    test('stays valid for an empty chart', () {
+      final axis = ChartAxis.forCounts(0);
+
+      expect(axis.min, 0.0);
+      expect(axis.max, greaterThan(0.0));
+      expect(axis.interval, greaterThan(0));
+    });
+  });
+}

--- a/test/features/statistics/presentation/widgets/stat_charts_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/stat_charts_axis_test.dart
@@ -1,0 +1,160 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+import 'package:submersion/features/statistics/presentation/widgets/stat_charts.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+// Issue #219: the SAC rate trend plot drew its horizontal grid lines on
+// gridData.horizontalInterval while leaving SideTitles.interval null, so
+// fl_chart labelled the left axis on its own getEfficientInterval sequence.
+// The lines and the numbers were computed from different steps and visibly
+// did not line up. Both sides must now share one interval, and the axis
+// bounds must sit on that interval so every line carries a label.
+
+final _sacTrend = [
+  for (final (index, value) in const [12.4, 15.1, 13.8, 18.2, 16.0].indexed)
+    TrendDataPoint(
+      date: DateTime(2024, index + 1),
+      value: value,
+      label: 'M${index + 1}',
+    ),
+];
+
+/// Values are anchored to zero, the baseline fl_chart iterates both grid lines
+/// and side titles from.
+bool _isOnTick(double value, double interval) {
+  final steps = value / interval;
+  return (steps - steps.roundToDouble()).abs() < 1e-9;
+}
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Center(child: SizedBox(width: 400, height: 300, child: child)),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('TrendLineChart axis', () {
+    testWidgets('grid lines and left labels share one interval', (
+      tester,
+    ) async {
+      await _pump(tester, TrendLineChart(data: _sacTrend));
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final gridInterval = data.gridData.horizontalInterval;
+      final labelInterval = data.titlesData.leftTitles.sideTitles.interval;
+
+      expect(gridInterval, isNotNull);
+      expect(labelInterval, isNotNull);
+      expect(labelInterval, gridInterval);
+    });
+
+    testWidgets('axis bounds sit on the shared interval', (tester) async {
+      await _pump(tester, TrendLineChart(data: _sacTrend));
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final interval = data.gridData.horizontalInterval!;
+
+      expect(_isOnTick(data.minY, interval), isTrue);
+      expect(_isOnTick(data.maxY, interval), isTrue);
+    });
+
+    testWidgets('every rendered left label lands on a grid line', (
+      tester,
+    ) async {
+      final labelledValues = <double>[];
+      await _pump(
+        tester,
+        TrendLineChart(
+          data: _sacTrend,
+          yAxisFormatter: (value) {
+            labelledValues.add(value);
+            return value.toStringAsFixed(1);
+          },
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final interval = data.gridData.horizontalInterval!;
+
+      expect(labelledValues, isNotEmpty);
+      for (final value in labelledValues) {
+        expect(
+          _isOnTick(value, interval),
+          isTrue,
+          reason: '$value is not a multiple of the $interval grid interval',
+        );
+      }
+    });
+
+    testWidgets('keeps the whole series inside the axis', (tester) async {
+      await _pump(tester, TrendLineChart(data: _sacTrend));
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+
+      expect(data.minY, lessThanOrEqualTo(12.4));
+      expect(data.maxY, greaterThanOrEqualTo(18.2));
+    });
+
+    testWidgets('survives a flat series', (tester) async {
+      await _pump(
+        tester,
+        TrendLineChart(
+          data: [
+            TrendDataPoint(date: DateTime(2024), value: 15.0, label: 'Jan'),
+            TrendDataPoint(date: DateTime(2024, 2), value: 15.0, label: 'Feb'),
+          ],
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+
+      expect(data.maxY, greaterThan(data.minY));
+      expect(data.gridData.horizontalInterval, greaterThan(0));
+    });
+  });
+
+  group('CategoryBarChart axis', () {
+    const counts = <({String label, int count})>[
+      (label: 'Reef', count: 10),
+      (label: 'Wreck', count: 6),
+      (label: 'Cave', count: 3),
+    ];
+
+    testWidgets('grid lines and left labels share one interval', (
+      tester,
+    ) async {
+      await _pump(tester, const CategoryBarChart(data: counts));
+
+      final data = tester.widget<BarChart>(find.byType(BarChart)).data;
+      final gridInterval = data.gridData.horizontalInterval;
+      final labelInterval = data.titlesData.leftTitles.sideTitles.interval;
+
+      expect(gridInterval, isNotNull);
+      expect(labelInterval, gridInterval);
+    });
+
+    testWidgets('steps in whole counts so every line is labelled', (
+      tester,
+    ) async {
+      await _pump(tester, const CategoryBarChart(data: counts));
+
+      final data = tester.widget<BarChart>(find.byType(BarChart)).data;
+      final interval = data.gridData.horizontalInterval!;
+
+      // The left titles render nothing for fractional values, so a fractional
+      // interval would leave unlabelled lines.
+      expect(interval, interval.roundToDouble());
+      expect(data.maxY, greaterThanOrEqualTo(10));
+      expect(_isOnTick(data.maxY, interval), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #219.

The issue had two halves. The first — "SAC by tank role" showing the same number
with a swapped unit label — was already fixed on `main` by e1936c4158d, the fix
for the duplicate #160, which split the card's query into
`getSacVolumeByTankRole` and `getSacPressureByTankRole`. This PR adds the
missing regression guard for it and fixes the second half, which is still live.

That second half: the SAC trend plot's horizontal grid lines do not line up with
the y-axis numbers. The cause is an fl_chart API trap rather than a math error.
Grid spacing and label spacing are configured independently and each falls back
to its own heuristic when left null:

- grid: `gridData.horizontalInterval ?? getEfficientInterval(viewSize.height, verticalDiff)`
- labels: `sideTitles.interval ?? getEfficientInterval(axisViewSize, axisMax - axisMin)`

`TrendLineChart` set the first and not the second, so the two sides computed
different tick sequences. On a SAC trend of 12.4 to 18.2 the lines fell every
1.45 while the labels sat at 11.82, 14, 16 and 18. Compounding it, the grid
interval came from the raw data range while the axis actually spanned
`min - padding … max + padding`, so it did not divide the visible axis evenly
either.

`CategoryBarChart` carries the same defect (`maxCount / 4`, frequently
fractional, against left titles that render nothing for a non-integer value, so
some lines get no label at all). It is fixed here too — same one-line
misconfiguration, same statistics screens — but it is outside the reported
symptom and can be dropped if you would rather keep the diff to the SAC chart.

`MultiTrendLineChart` is deliberately untouched: it sets neither interval, so
both sides already share the same fallback and are aligned.

## Changes

- New `ChartAxis` (`lib/features/statistics/presentation/widgets/chart_axis.dart`)
  derives axis bounds, grid interval and label interval together. fl_chart
  anchors both sequences at `getBestInitialIntervalValue(..., baseline: 0)`, so
  one shared interval over bounds that are whole multiples of it provably emits
  identical tick values — that invariant is what the tests assert, not pixel
  positions.
- The step comes from a 1/2/2.5/5 x 10^k nice-number ladder and moves up a rung
  when snapping bounds outward would crowd the axis. Snapping inflates the tick
  count: a 0.05 step over a snapped 0.45-0.80 axis yields 8 grid lines on a
  200 px chart. A plain `range / 4` cannot express that.
- `TrendLineChart` and `CategoryBarChart` now feed both the grid and the side
  titles from that one axis.
- Regression test asserting SAC by tank role returns genuinely different
  magnitudes per unit: 150 bar over 42 min at 3 ata is 1.19 bar/min, while the
  same drop through a 12 L cylinder is an order of magnitude larger in litres.

## Test Plan

- [x] `flutter test` passes — 16082 passed, 15 skipped, 0 failed
- [x] `flutter analyze` passes — no issues
- [x] `dart format .` clean
- [x] 11 `ChartAxis` unit tests and 7 chart widget tests; 5 of the widget tests
      were confirmed failing against `main` before the fix
- [ ] Manual testing on: not run on device; verified by rendering the chart to
      an image in a widget test (below) plus the automated suite

## Screenshots

No device screenshots. The chart was rendered headless in a widget test to check
the geometry, but that environment has no font loaded, so the tick values are
more legible written out than shown. Measured, not estimated, for the SAC trend
12.4, 15.1, 13.8, 18.2, 16.0, 14.3 in a 420x240 box:

**Before** — axis 11.82 to 18.78, grid interval 1.45

- grid lines: 13.05, 14.50, 15.95, 17.40
- labels: 11.82, 12, 13, 14, 15, 16, 17, 18, 18.78

Nine labels, four lines, and not one label sits on a line.

**After** — axis 10 to 20, interval 2

- grid lines: 12, 14, 16, 18
- labels: 10, 12, 14, 16, 18, 20

Every line carries a label; 10 and 20 label the plot edges.
