### PR TITLE
Fix macOS USB-serial dive computer downloads denied by App Sandbox (#291)

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -27,6 +27,8 @@
 	<true/>
 	<key>com.apple.security.device.bluetooth</key>
 	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -25,6 +25,8 @@
 	</array>
 	<key>com.apple.security.device.bluetooth</key>
 	<true/>
+	<key>com.apple.security.device.serial</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -407,8 +407,12 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
         if candidates.count == 1 {
             let port = candidates[0]
             let stream = SerialIoStream()
-            guard stream.open(path: port) else {
-                reportError(code: "connect_failed", message: "Failed to open serial port: \(port)")
+            if let failure = stream.open(path: port) {
+                NativeLogger.e("DiveComputerHost", category: "SER",
+                    "Failed to open \(port) (errno=\(failure.errnoValue)): \(failure.reason)")
+                reportError(
+                    code: "connect_failed",
+                    message: "Failed to open serial port \(port): \(failure.reason)")
                 return
             }
             NativeLogger.i("DiveComputerHost", category: "SER", "Opened serial port: \(port)")
@@ -440,8 +444,10 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             diveBufferLock.unlock()
 
             let stream = SerialIoStream()
-            guard stream.open(path: port) else {
-                probeLog += "  \(port): failed to open\n"
+            if let failure = stream.open(path: port) {
+                NativeLogger.e("DiveComputerHost", category: "SER",
+                    "Failed to open \(port) (errno=\(failure.errnoValue)): \(failure.reason)")
+                probeLog += "  \(port): \(failure.reason)\n"
                 continue
             }
             anyOpened = true

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialIoStream.swift
@@ -14,9 +14,20 @@ class SerialIoStream {
         close()
     }
 
-    func open(path: String, baudRate: speed_t = 9600) -> Bool {
-        fileDescriptor = Darwin.open(path, O_RDWR | O_NOCTTY | O_NONBLOCK)
-        guard fileDescriptor >= 0 else { return false }
+    /// Opens and configures the port. Returns `nil` on success, or the reason
+    /// the open was refused.
+    ///
+    /// The failure is returned rather than collapsed to a Bool so callers can
+    /// log why. A sandboxed macOS build missing
+    /// `com.apple.security.device.serial` is denied here with EPERM even though
+    /// the port enumerated fine moments earlier (issue #291).
+    func open(path: String, baudRate: speed_t = 9600) -> SerialOpenFailure? {
+        switch openSerialPort(path: path) {
+        case .failure(let failure):
+            return failure
+        case .success(let fd):
+            fileDescriptor = fd
+        }
 
         // Configure serial port.
         var options = termios()
@@ -33,7 +44,7 @@ class SerialIoStream {
         let flags = fcntl(fileDescriptor, F_GETFL)
         _ = fcntl(fileDescriptor, F_SETFL, flags & ~O_NONBLOCK)
 
-        return true
+        return nil
     }
 
     func close() {

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialPortOpener.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialPortOpener.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Why a serial callout device could not be opened.
+///
+/// Carries the raw `errno` alongside an actionable description. The errno is
+/// kept because the numeric value is what makes a bug report diagnosable when
+/// the prose turns out to be wrong.
+struct SerialOpenFailure: Equatable {
+    let errnoValue: Int32
+    let reason: String
+}
+
+/// Result of opening a serial callout device: an owned file descriptor the
+/// caller must close, or a failure describing why the open was refused.
+enum SerialOpenResult {
+    case success(Int32)
+    case failure(SerialOpenFailure)
+}
+
+/// Translates an `errno` from `open(2)` on a `/dev/cu.*` device into text a
+/// user can act on.
+///
+/// The EPERM case is the reason this function exists. On macOS the App Sandbox
+/// splits serial access in two: IOKit enumeration
+/// (`SerialPortEnumerator.enumerateUsbSerialPaths`) is always permitted, but
+/// `open(2)` on the resulting device node is denied with EPERM unless the app
+/// declares `com.apple.security.device.serial`. The app therefore reports the
+/// exact port path it just discovered and then fails to open it, which reads as
+/// a cable or driver fault. Issue #291 (Suunto Vyper Air over an FTDI cable)
+/// spent two months being diagnosed as a driver problem for exactly this
+/// reason, because the old code discarded errno and logged only "Failed to open
+/// serial port".
+func serialOpenFailureReason(errnoValue: Int32) -> String {
+    let systemText = String(cString: strerror(errnoValue))
+    switch errnoValue {
+    case EPERM:
+        return "\(systemText): macOS denied access to the serial port. This "
+            + "build is missing the serial-port entitlement "
+            + "(com.apple.security.device.serial)."
+    case EACCES:
+        return "\(systemText): the current user does not have permission to "
+            + "open this serial device."
+    case EBUSY:
+        return "\(systemText): the port is already open in another application."
+    case ENOENT:
+        return "\(systemText): the port no longer exists. Was the cable "
+            + "unplugged?"
+    default:
+        return systemText
+    }
+}
+
+/// Opens a serial callout device for dive-computer I/O.
+///
+/// Uses the flags libdivecomputer's own POSIX serial backend uses: `O_NOCTTY`
+/// so the port never becomes the controlling terminal, and `O_NONBLOCK` so the
+/// open returns immediately instead of waiting on carrier detect. The caller
+/// switches the descriptor back to blocking mode after configuring the line.
+func openSerialPort(path: String) -> SerialOpenResult {
+    let fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK)
+    guard fd >= 0 else {
+        // Capture errno before anything else can perturb it.
+        let code = errno
+        return .failure(
+            SerialOpenFailure(
+                errnoValue: code, reason: serialOpenFailureReason(errnoValue: code)))
+    }
+    return .success(fd)
+}

--- a/packages/libdivecomputer_plugin/darwin/Tests/SerialPortOpenerTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/SerialPortOpenerTests/main.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+// Standalone test runner for SerialPortOpener (no XCTest: the LibDCDarwin
+// package cannot build under SwiftPM because it depends on Flutter modules only
+// present in the CocoaPods build). Run via darwin/run_native_tests.sh.
+//
+// Covers issue #291: a sandboxed macOS build without
+// com.apple.security.device.serial is denied open(2) on /dev/cu.* with EPERM,
+// but the old code returned a bare Bool, so the log only ever said "Failed to
+// open serial port" with no reason. These tests pin the errno -> reason mapping
+// and the fd/failure contract.
+
+var failures = 0
+
+func expect(_ condition: Bool, _ message: String, line: Int = #line) {
+    if condition {
+        print("PASS: \(message)")
+    } else {
+        print("FAIL: \(message) (main.swift:\(line))")
+        failures += 1
+    }
+}
+
+// 1. EPERM is the sandbox denial. It must name the entitlement cause, because
+//    a plain "Operation not permitted" reads as a driver/cable fault and sent
+//    issue #291 down a two-month dead end.
+let epermReason = serialOpenFailureReason(errnoValue: EPERM)
+expect(epermReason.lowercased().contains("permitted"),
+       "EPERM reason states the operation was not permitted")
+expect(epermReason.lowercased().contains("entitlement"),
+       "EPERM reason names the missing macOS serial entitlement")
+
+// 2. Distinct, actionable text for the other realistic open(2) failures, so
+//    they are never confused with the sandbox case.
+expect(serialOpenFailureReason(errnoValue: EBUSY).lowercased().contains("another"),
+       "EBUSY reason points at another application holding the port")
+expect(serialOpenFailureReason(errnoValue: ENOENT).lowercased().contains("no longer"),
+       "ENOENT reason suggests the port vanished (cable unplugged)")
+expect(!serialOpenFailureReason(errnoValue: EACCES).isEmpty,
+       "EACCES reason is non-empty")
+
+// 3. Every mapped reason is distinguishable from the others.
+let mapped = [EPERM, EACCES, EBUSY, ENOENT].map {
+    serialOpenFailureReason(errnoValue: $0)
+}
+expect(Set(mapped).count == mapped.count,
+       "each mapped errno produces a distinct reason")
+
+// 4. An unmapped errno still yields the system description rather than an
+//    empty string (fail-informative, never fail-silent).
+let unmapped = serialOpenFailureReason(errnoValue: EDOM)
+expect(!unmapped.isEmpty, "unmapped errno falls back to a non-empty description")
+expect(unmapped.contains(String(cString: strerror(EDOM))),
+       "unmapped errno includes the strerror text")
+
+// 5. Success path: /dev/null accepts the same open(2) flags a serial callout
+//    device does, and exists on every machine (including CI runners with no
+//    serial hardware attached).
+switch openSerialPort(path: "/dev/null") {
+case .success(let fd):
+    expect(fd >= 0, "opening /dev/null yields a valid descriptor")
+    close(fd)
+case .failure(let failure):
+    expect(false, "opening /dev/null should succeed (got \(failure.reason))")
+}
+
+// 6. Failure path carries the real errno, not just a boolean.
+switch openSerialPort(path: "/dev/cu.submersion-nonexistent-291") {
+case .success(let fd):
+    close(fd)
+    expect(false, "a nonexistent port must not open")
+case .failure(let failure):
+    expect(failure.errnoValue == ENOENT,
+           "a nonexistent port reports ENOENT, not a bare failure")
+    expect(!failure.reason.isEmpty, "the failure carries a human-readable reason")
+}
+
+if failures == 0 {
+    print("\nAll SerialPortOpener tests passed.")
+    exit(0)
+} else {
+    print("\n\(failures) SerialPortOpener test(s) failed.")
+    exit(1)
+}

--- a/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
+++ b/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
@@ -41,3 +41,12 @@ swiftc -o "$BUILD_DIR/serial_read_loop_tests" \
     Tests/SerialReadLoopTests/main.swift
 
 "$BUILD_DIR/serial_read_loop_tests"
+
+# SerialPortOpener errno-reporting tests (issue #291): open(2) failures must
+# carry the real errno and an actionable reason, so a sandbox denial (EPERM) is
+# distinguishable from a busy port or an unplugged cable. Pure POSIX logic.
+swiftc -o "$BUILD_DIR/serial_port_opener_tests" \
+    Sources/LibDCDarwin/SerialPortOpener.swift \
+    Tests/SerialPortOpenerTests/main.swift
+
+"$BUILD_DIR/serial_port_opener_tests"

--- a/packages/libdivecomputer_plugin/ios/Classes/SerialPortOpener.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/SerialPortOpener.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/SerialPortOpener.swift

--- a/packages/libdivecomputer_plugin/macos/Classes/SerialPortOpener.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/SerialPortOpener.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/SerialPortOpener.swift

--- a/test/macos_entitlements_test.dart
+++ b/test/macos_entitlements_test.dart
@@ -1,56 +1,136 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:xml/xml.dart';
+
+/// Maps each top-level entitlement key to the element name of its value
+/// (`true`, `false`, `array`, `string`, ...).
+///
+/// Parsed structurally rather than matched as text: asserting only that a
+/// `<key>` is present would pass for a key explicitly set to `<false/>`, which
+/// is exactly how a build turns a capability OFF (see
+/// `ReleaseNoSandbox.entitlements`, which disables the sandbox that way). These
+/// files also carry XML comments between entries, which a whitespace-based
+/// pattern would trip over but `childElements` skips.
+Map<String, String> entitlementValueTypes(String plistXml) {
+  final dict = XmlDocument.parse(plistXml).rootElement.getElement('dict');
+  if (dict == null) return const {};
+
+  final types = <String, String>{};
+  final children = dict.childElements.toList();
+  for (var i = 0; i + 1 < children.length; i++) {
+    if (children[i].name.local != 'key') continue;
+    final value = children[i + 1];
+    // A key immediately followed by another key is malformed; skip rather than
+    // record a bogus value type.
+    if (value.name.local == 'key') continue;
+    types[children[i].innerText.trim()] = value.name.local;
+  }
+  return types;
+}
 
 /// Guards the macOS entitlements the app needs at runtime.
 ///
-/// These are plain-file assertions rather than platform tests so they run on
-/// the Linux CI/coverage host: an entitlement can only be verified by the OS on
-/// a signed, sandboxed macOS build, which CI does not execute. A missing key is
-/// invisible until a real user plugs in real hardware, so the file itself is
-/// the regression surface.
+/// These are file assertions rather than platform tests so they run on the
+/// Linux CI/coverage host: an entitlement is only enforced by the OS on a
+/// signed, sandboxed macOS build talking to real hardware, which CI never does.
+/// A missing or disabled key is invisible until a user plugs in a cable, so the
+/// file itself is the only regression surface CI can see.
 void main() {
-  /// The sandboxed macOS builds. `ReleaseNoSandbox.entitlements` is
-  /// deliberately excluded: it sets `com.apple.security.app-sandbox` to false,
-  /// so sandbox hardware entitlements are inert there.
+  /// The sandboxed macOS builds. `ReleaseNoSandbox.entitlements` is handled
+  /// separately: it disables the sandbox, so sandbox hardware entitlements are
+  /// inert there.
   const sandboxedEntitlements = <String>[
     'macos/Runner/DebugProfile.entitlements',
     'macos/Runner/Release.entitlements',
   ];
+  const noSandboxEntitlements = 'macos/Runner/ReleaseNoSandbox.entitlements';
 
-  String read(String path) {
+  Map<String, String> typesOf(String path) {
     final file = File(path);
     expect(file.existsSync(), isTrue, reason: '$path is missing');
-    return file.readAsStringSync();
+    return entitlementValueTypes(file.readAsStringSync());
   }
+
+  group('entitlementValueTypes', () {
+    // These fixtures prove the assertions below actually assert something: a
+    // key set to <false/> must NOT read as enabled.
+    const plist = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>enabled.capability</key>
+	<true/>
+	<!-- a comment between entries, as the real files have -->
+	<key>disabled.capability</key>
+	<false/>
+	<key>list.capability</key>
+	<array>
+		<string>one</string>
+	</array>
+</dict>
+</plist>
+''';
+
+    test('distinguishes an enabled key from one explicitly set to false', () {
+      final types = entitlementValueTypes(plist);
+      expect(types['enabled.capability'], 'true');
+      expect(types['disabled.capability'], 'false');
+    });
+
+    test('reads past interleaved comments and non-boolean values', () {
+      final types = entitlementValueTypes(plist);
+      expect(types['list.capability'], 'array');
+      expect(types.keys, hasLength(3));
+    });
+
+    test('reports absent keys as null', () {
+      expect(entitlementValueTypes(plist)['never.declared'], isNull);
+    });
+  });
 
   group('macOS sandboxed entitlements', () {
     for (final path in sandboxedEntitlements) {
-      test('$path declares the serial-port entitlement (issue #291)', () {
-        // Without com.apple.security.device.serial, a sandboxed app is denied
-        // open(2) on /dev/cu.* with EPERM, so every USB-serial dive computer
-        // download fails with "Failed to open serial port". IOKit enumeration
-        // is NOT gated the same way, so the port is still discovered and the
-        // failure looks like a driver problem rather than a permission one.
+      test('$path enables the serial-port entitlement (issue #291)', () {
+        // Without com.apple.security.device.serial set to true, a sandboxed app
+        // is denied open(2) on /dev/cu.* with EPERM, so every USB-serial dive
+        // computer download fails with "Failed to open serial port". IOKit
+        // enumeration is NOT gated the same way, so the port is still
+        // discovered and the failure looks like a driver or cable problem
+        // rather than a permission one.
         expect(
-          read(path),
-          contains('<key>com.apple.security.device.serial</key>'),
+          typesOf(path)['com.apple.security.device.serial'],
+          'true',
           reason:
               'Sandboxed macOS builds cannot open /dev/cu.* serial devices '
-              'without com.apple.security.device.serial. Removing it silently '
-              'breaks all USB-cable dive computer downloads (issue #291).',
+              'without com.apple.security.device.serial. Removing it, or '
+              'setting it to false, silently breaks all USB-cable dive '
+              'computer downloads (issue #291).',
         );
       });
 
       test('$path keeps the sandbox enabled', () {
-        // Sanity anchor for the test above: if a build ever turns the sandbox
-        // off, the serial assertion stops meaning what it claims to mean.
+        // Anchor for the assertion above: if a build ever turns the sandbox
+        // off, the serial entitlement stops meaning what it claims to mean.
         expect(
-          read(path),
-          contains('<key>com.apple.security.app-sandbox</key>'),
+          typesOf(path)['com.apple.security.app-sandbox'],
+          'true',
           reason: '$path is expected to be a sandboxed build',
         );
       });
     }
+
+    test('$noSandboxEntitlements is genuinely unsandboxed', () {
+      // Documents why the file is excluded above: with the sandbox off, serial
+      // access needs no entitlement. If this ever became a sandboxed build it
+      // would need com.apple.security.device.serial too.
+      expect(
+        typesOf(noSandboxEntitlements)['com.apple.security.app-sandbox'],
+        'false',
+        reason:
+            'ReleaseNoSandbox is excluded from the serial-entitlement check '
+            'only because it disables the sandbox',
+      );
+    });
   });
 }

--- a/test/macos_entitlements_test.dart
+++ b/test/macos_entitlements_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the macOS entitlements the app needs at runtime.
+///
+/// These are plain-file assertions rather than platform tests so they run on
+/// the Linux CI/coverage host: an entitlement can only be verified by the OS on
+/// a signed, sandboxed macOS build, which CI does not execute. A missing key is
+/// invisible until a real user plugs in real hardware, so the file itself is
+/// the regression surface.
+void main() {
+  /// The sandboxed macOS builds. `ReleaseNoSandbox.entitlements` is
+  /// deliberately excluded: it sets `com.apple.security.app-sandbox` to false,
+  /// so sandbox hardware entitlements are inert there.
+  const sandboxedEntitlements = <String>[
+    'macos/Runner/DebugProfile.entitlements',
+    'macos/Runner/Release.entitlements',
+  ];
+
+  String read(String path) {
+    final file = File(path);
+    expect(file.existsSync(), isTrue, reason: '$path is missing');
+    return file.readAsStringSync();
+  }
+
+  group('macOS sandboxed entitlements', () {
+    for (final path in sandboxedEntitlements) {
+      test('$path declares the serial-port entitlement (issue #291)', () {
+        // Without com.apple.security.device.serial, a sandboxed app is denied
+        // open(2) on /dev/cu.* with EPERM, so every USB-serial dive computer
+        // download fails with "Failed to open serial port". IOKit enumeration
+        // is NOT gated the same way, so the port is still discovered and the
+        // failure looks like a driver problem rather than a permission one.
+        expect(
+          read(path),
+          contains('<key>com.apple.security.device.serial</key>'),
+          reason:
+              'Sandboxed macOS builds cannot open /dev/cu.* serial devices '
+              'without com.apple.security.device.serial. Removing it silently '
+              'breaks all USB-cable dive computer downloads (issue #291).',
+        );
+      });
+
+      test('$path keeps the sandbox enabled', () {
+        // Sanity anchor for the test above: if a build ever turns the sandbox
+        // off, the serial assertion stops meaning what it claims to mean.
+        expect(
+          read(path),
+          contains('<key>com.apple.security.app-sandbox</key>'),
+          reason: '$path is expected to be a sandboxed build',
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #291. USB-serial dive computer downloads were impossible on sandboxed macOS builds: the app enumerated the cable's port correctly and then failed to open it, reporting `Failed to open serial port: /dev/cu.usbserial-XXXX` for every model.

The App Sandbox gates serial access in **two independent places**:

- **Enumeration** via IOKit (`SerialPortEnumerator.enumerateUsbSerialPaths` → `IOServiceGetMatchingServices`) needs **no** hardware entitlement.
- **`open(2)` on the resulting `/dev/cu.*` node** is denied with **EPERM** unless the app declares `com.apple.security.device.serial`.

`Release.entitlements` and `DebugProfile.entitlements` never declared it — it was missed when serial-over-USB shipped in #334 / #364 (`git log` on `Release.entitlements` shows no commits from that work). Because enumeration still worked, the app named the exact port it had just discovered and then failed to open it, which reads as a cable or FTDI-driver fault rather than a permission one. That is why #291 spent months being investigated as an Apple Silicon FTDI driver issue.

`com.apple.security.device.serial` is a plain App Sandbox hardware entitlement, **not** a restricted one: it requires no provisioning-profile entry and no Apple approval, so Mac App Store distribution is unaffected.

**Scope of the bug:** sandboxed builds only. The Developer ID / DMG build (`ReleaseNoSandbox.entitlements`) runs with the sandbox disabled and could always download over USB. A quick triage signal: if a macOS user's log shows iCloud working, they are on a sandboxed build, so serial was broken for them.

### Root cause verified empirically

One binary calling `open(path, O_RDWR|O_NOCTTY|O_NONBLOCK)` — the exact flags `SerialIoStream` uses — signed three ways:

| Build | Result |
| --- | --- |
| Signed, no sandbox | `OPEN OK` |
| Sandboxed, **without** `device.serial` (shipped config) | `errno=1 EPERM "Operation not permitted"` |
| Sandboxed, **with** `device.serial` | `OPEN OK` |

## Changes

- Add `com.apple.security.device.serial` to `macos/Runner/Release.entitlements` and `macos/Runner/DebugProfile.entitlements`. `ReleaseNoSandbox.entitlements` is deliberately untouched: sandbox hardware entitlements are inert when the sandbox is off.
- New `SerialPortOpener.swift` (pure POSIX, no libdc types) returning `SerialOpenFailure { errnoValue, reason }`. `SerialIoStream.open` previously returned a bare `Bool` and **discarded `errno`**, so the log could only ever say "Failed to open serial port" with no cause — the reason this took so long to diagnose. The mapping gives distinct, actionable text for EPERM (names the missing entitlement), EBUSY, ENOENT and EACCES, and falls back to `strerror` rather than an empty string.
- `SerialIoStream.open` now returns the failure instead of a `Bool`; both call sites in `DiveComputerHostApiImpl` (single-port and multi-port probe) log the errno and include the reason in the reported error and the probe log.
- Follows the existing `SerialReadLoop.swift` pattern — pure logic in its own file so `swiftc` can compile it standalone, since `SerialIoStream` itself is untestable in isolation (it references `libdc_io_callbacks_t`).
- Symlinked the new source into both `ios/Classes/` and `macos/Classes/` and re-ran `pod install` per platform, per the shared-darwin-source ritual.

### Tests

- `test/macos_entitlements_test.dart` — guards the entitlement as a plain file assertion so it runs on the Linux CI/coverage host. An entitlement is only enforced by the OS on a signed, sandboxed macOS build against real hardware, so the file itself is the only regression surface CI can see. Includes a sanity anchor asserting the builds are still sandboxed, so the assertion cannot silently stop meaning what it claims.
- `darwin/Tests/SerialPortOpenerTests` — errno-to-reason mapping, distinctness of the mapped reasons, non-empty fallback for unmapped errnos, and the fd/failure contract (`/dev/null` for the success path so it passes on CI runners with no serial hardware). Wired into `darwin/run_native_tests.sh`.

## Test Plan

- [x] `flutter test` passes — 16046 passed, 15 skipped
- [x] `flutter analyze` passes — no issues
- [x] `dart format .` clean
- [x] `darwin/run_native_tests.sh` — all native suites pass
- [x] `flutter build macos` and `flutter build ios --no-codesign` both succeed
- [x] Shipped bundle verified: `codesign -d --entitlements` on the built `Submersion.app` reports `com.apple.security.device.serial => true` alongside `app-sandbox => true`
- [ ] Manual testing on: macOS with a real USB-serial dive computer cable (issue reporter has a Suunto Vyper Air on an FTDI cable and can confirm on the next release)

## Notes

Unrelated pre-existing drift spotted while running `pod install`: the committed `ios/Podfile.lock` is stale — it still lists `sqlite3_flutter_libs` although the project uses `sqlcipher_flutter_libs`, and it is missing `local_auth_darwin`. `macos/Podfile.lock` is in sync. Reverted here to keep this PR focused; worth a separate fix.
