### PR TITLE
Refresh stale ios/Podfile.lock

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -102,6 +102,9 @@ PODS:
     - Flutter
   - libdivecomputer_plugin (0.1.0):
     - Flutter
+  - local_auth_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - native_exif (0.8.0):
     - Flutter
   - ObjectBox (4.4.1)
@@ -131,31 +134,14 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.52.0):
-    - sqlite3/common (= 3.52.0)
-  - sqlite3/common (3.52.0)
-  - sqlite3/dbstatvtab (3.52.0):
-    - sqlite3/common
-  - sqlite3/fts5 (3.52.0):
-    - sqlite3/common
-  - sqlite3/math (3.52.0):
-    - sqlite3/common
-  - sqlite3/perf-threadsafe (3.52.0):
-    - sqlite3/common
-  - sqlite3/rtree (3.52.0):
-    - sqlite3/common
-  - sqlite3/session (3.52.0):
-    - sqlite3/common
-  - sqlite3_flutter_libs (0.0.1):
+  - SQLCipher (4.10.0):
+    - SQLCipher/standard (= 4.10.0)
+  - SQLCipher/common (4.10.0)
+  - SQLCipher/standard (4.10.0):
+    - SQLCipher/common
+  - sqlcipher_flutter_libs (0.0.1):
     - Flutter
-    - FlutterMacOS
-    - sqlite3 (~> 3.52.0)
-    - sqlite3/dbstatvtab
-    - sqlite3/fts5
-    - sqlite3/math
-    - sqlite3/perf-threadsafe
-    - sqlite3/rtree
-    - sqlite3/session
+    - SQLCipher (~> 4.10.0)
   - submersion_ocr (0.1.0):
     - Flutter
     - FlutterMacOS
@@ -189,6 +175,7 @@ DEPENDENCIES:
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - libdivecomputer_plugin (from `.symlinks/plugins/libdivecomputer_plugin/ios`)
+  - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - native_exif (from `.symlinks/plugins/native_exif/ios`)
   - objectbox_flutter_libs (from `.symlinks/plugins/objectbox_flutter_libs/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -199,7 +186,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
-  - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+  - sqlcipher_flutter_libs (from `.symlinks/plugins/sqlcipher_flutter_libs/ios`)
   - submersion_ocr (from `.symlinks/plugins/submersion_ocr/darwin`)
   - submersion_transcoder (from `.symlinks/plugins/submersion_transcoder/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -219,7 +206,7 @@ SPEC REPOS:
     - ObjectBox
     - PromisesObjC
     - SDWebImage
-    - sqlite3
+    - SQLCipher
     - SwiftyGif
 
 EXTERNAL SOURCES:
@@ -257,6 +244,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   libdivecomputer_plugin:
     :path: ".symlinks/plugins/libdivecomputer_plugin/ios"
+  local_auth_darwin:
+    :path: ".symlinks/plugins/local_auth_darwin/darwin"
   native_exif:
     :path: ".symlinks/plugins/native_exif/ios"
   objectbox_flutter_libs:
@@ -277,8 +266,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
-  sqlite3_flutter_libs:
-    :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+  sqlcipher_flutter_libs:
+    :path: ".symlinks/plugins/sqlcipher_flutter_libs/ios"
   submersion_ocr:
     :path: ".symlinks/plugins/submersion_ocr/darwin"
   submersion_transcoder:
@@ -316,6 +305,7 @@ SPEC CHECKSUMS:
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   libdivecomputer_plugin: 5876d08dd98fc04a06421cbaa7ad70e4c01d3f94
+  local_auth_darwin: c3ee6cce0a8d56be34c8ccb66ba31f7f180aaebb
   native_exif: fe0a79e4115f2d7cd084ba206e4933d8a5ed7bde
   ObjectBox: 7da4aceb5013d041bfafdbc6d744a26918b09757
   objectbox_flutter_libs: 09b1dec1b4cd27bf1a5f9bae7ccaa7e43588bf31
@@ -329,8 +319,8 @@ SPEC CHECKSUMS:
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
-  sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
+  SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
+  sqlcipher_flutter_libs: ae224763b087bffb3a5955fe295a1c460d458cb1
   submersion_ocr: c16e8aa86fee22293c92688fcf97c5293b6b159f
   submersion_transcoder: c0bc7bb59ce039c73dcd24cb7797b390cfd2dab6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4


### PR DESCRIPTION
## Summary

The committed `ios/Podfile.lock` had drifted from the project's actual dependency set. It still pinned `sqlite3_flutter_libs` / `sqlite3 3.52.0` even though the project moved to `sqlcipher_flutter_libs` (SQLCipher 4.10.0), and it was missing `local_auth_darwin` entirely.

`macos/Podfile.lock` already reflects both, so only the iOS lock was stale. The two platforms' lockfiles are generated independently and drift apart whenever `pod install` is run for one and not the other — the same failure mode as a stale per-platform `Pods.xcodeproj`.

Spotted while working on #291 (PR #949), where running `pod install --project-directory=ios` produced this diff as an unrelated side effect. Reverted there to keep that PR focused; fixed here instead.

## Changes

- Regenerated `ios/Podfile.lock` via `pod install --project-directory=ios`.

Lockfile only. No source, plugin, podspec or `Podfile` changes — the `PODFILE CHECKSUM` line is unchanged, and `libdivecomputer_plugin`'s spec checksum is byte-identical to the one on `main`.

## Test Plan

- [x] Regenerated on a clean worktree branched from `origin/main`, so the result depends on nothing else in flight
- [x] **Converged**: running `pod install` again over the regenerated file leaves it byte-identical, so this is a fixed point rather than a moving target
- [x] `flutter build ios --no-codesign` succeeds with the new lockfile
- [x] `flutter test` / `flutter analyze` not run locally for this branch — the change contains no Dart, and CI covers both

## Notes

No version bumps or dependency changes are introduced here: every version recorded is what CocoaPods already resolves today from the current `pubspec.yaml` and `Podfile`. This only makes the committed lockfile match reality, restoring the reproducibility the file exists to provide.
