### PR TITLE
Resolve per-sample GPS after the profile walk, not during it

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -320,6 +320,15 @@ static void resolve_sample_locations(sample_state_t *state) {
 
     // Two different positions: the dive genuinely moved between the first and
     // last lock, so they are the entry and exit points.
+    //
+    // Exact equality is deliberate here, not an oversight. Every source
+    // quantizes to an integer before we see it -- int32 / 1e7 for Ratio, / 1e6
+    // for Halcyon and Divesoft, and an exactly-widened float32 for OSTC 4 --
+    // and this file only copies the value, so identical device bytes always
+    // produce bit-identical doubles. Equality therefore means "the device
+    // replayed the same record", which is the only case worth collapsing. A
+    // distance tolerance would instead discard real data: a shore dive exits a
+    // few metres from where it entered, and those are two genuine fixes.
     if (state->first_latitude != state->last_latitude ||
         state->first_longitude != state->last_longitude) {
         if (!state->has_field_entry) {

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -55,9 +55,18 @@ typedef struct {
     int has_pending_sample;
     unsigned int current_gasmix;  // active gas index, carried across samples
     libdc_sample_t current_sample;
-    // GPS reported as profile samples (see DC_SAMPLE_LOCATION below).
-    int has_field_location;   // DC_FIELD_LOCATION already supplied a fix
-    int sample_location_count;
+    // GPS reported as profile samples (see DC_SAMPLE_LOCATION below). Fixes
+    // are only collected here and resolved once the whole profile has been
+    // walked: which end of the dive a lone fix belongs to is knowable only
+    // relative to the profile's full length.
+    int has_field_entry;  // DC_FIELD_LOCATION already supplied the entry
+    int has_field_exit;   // ...and/or the exit
+    unsigned int location_count;
+    double first_latitude;
+    double first_longitude;
+    unsigned int first_location_time_ms;
+    double last_latitude;
+    double last_longitude;
 } sample_state_t;
 
 // ============================================================
@@ -268,29 +277,24 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.deco_tts = value->deco.tts;
         break;
     case DC_SAMPLE_LOCATION:
-        // Issue #926. The Ratio / DiveSystem iX3M and iDive families do not
-        // implement DC_FIELD_LOCATION at all; they emit each GPS fix as a
-        // profile sample instead. Promote those to the dive-level entry/exit
-        // positions the rest of the app already understands: first fix is the
-        // entry point, the most recent one the exit point. A dive with a
-        // single fix keeps its exit unset rather than mirroring the entry --
-        // a duplicated point renders as a bogus second marker on the map.
-        if (state->has_field_location) {
-            break;  // a real DC_FIELD_LOCATION is authoritative
-        }
+        // Issue #926. Most GPS-capable families -- Ratio / DiveSystem iX3M and
+        // iDive, Halcyon Symbios, OSTC 4, Divesoft Freedom -- do not implement
+        // DC_FIELD_LOCATION at all, emitting each fix as a profile sample
+        // instead. Record the first and last usable fix and the time of the
+        // first; resolve_sample_locations() turns them into the dive-level
+        // entry/exit positions once the profile length is known.
         if (!is_usable_location(value->location.latitude,
                                 value->location.longitude)) {
             break;
         }
-        if (state->sample_location_count == 0) {
-            state->dive->entry_latitude = value->location.latitude;
-            state->dive->entry_longitude = value->location.longitude;
-        } else if (value->location.latitude != state->dive->entry_latitude ||
-                   value->location.longitude != state->dive->entry_longitude) {
-            state->dive->exit_latitude = value->location.latitude;
-            state->dive->exit_longitude = value->location.longitude;
+        if (state->location_count == 0) {
+            state->first_latitude = value->location.latitude;
+            state->first_longitude = value->location.longitude;
+            state->first_location_time_ms = state->current_sample.time_ms;
         }
-        state->sample_location_count++;
+        state->last_latitude = value->location.latitude;
+        state->last_longitude = value->location.longitude;
+        state->location_count++;
         break;
     case DC_SAMPLE_EVENT:
         push_event(state->dive,
@@ -301,6 +305,52 @@ static void sample_callback(dc_sample_type_t type,
         break;
     default:
         break;
+    }
+}
+
+// Turn the per-sample GPS fixes collected during the profile walk into the
+// dive-level entry/exit positions the rest of the app consumes. Must run after
+// the final push_sample() so the profile's length is known.
+static void resolve_sample_locations(sample_state_t *state) {
+    libdc_parsed_dive_t *dive = state->dive;
+
+    if (state->location_count == 0) {
+        return;
+    }
+
+    // Two different positions: the dive genuinely moved between the first and
+    // last lock, so they are the entry and exit points.
+    if (state->first_latitude != state->last_latitude ||
+        state->first_longitude != state->last_longitude) {
+        if (!state->has_field_entry) {
+            dive->entry_latitude = state->first_latitude;
+            dive->entry_longitude = state->first_longitude;
+        }
+        if (!state->has_field_exit) {
+            dive->exit_latitude = state->last_latitude;
+            dive->exit_longitude = state->last_longitude;
+        }
+        return;
+    }
+
+    // Every fix reported the same position, so this dive has one known point
+    // rather than an entry/exit pair. Writing it to both slots would render a
+    // bogus second marker, and always calling it the entry is wrong for a
+    // receiver that only got a lock after surfacing -- a real case now that
+    // OSTC 4 and Divesoft, which log fixes anywhere in the profile, reach this
+    // code. Let its timestamp pick the end it belongs to. Either slot resolves
+    // a dive site: the matcher falls back to the exit when entry is absent.
+    unsigned int profile_end_ms = dive->sample_count > 0
+        ? dive->samples[dive->sample_count - 1].time_ms
+        : 0;
+    if (state->first_location_time_ms <= profile_end_ms / 2) {
+        if (!state->has_field_entry) {
+            dive->entry_latitude = state->first_latitude;
+            dive->entry_longitude = state->first_longitude;
+        }
+    } else if (!state->has_field_exit) {
+        dive->exit_latitude = state->first_latitude;
+        dive->exit_longitude = state->first_longitude;
     }
 }
 
@@ -356,17 +406,20 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
     // Patched libdivecomputer maps these to opening[9]/closing[9] record 9.
     // Families that report GPS per-sample instead are handled in
     // sample_callback's DC_SAMPLE_LOCATION branch.
-    int has_field_location = 0;
+    // Tracked per side: a parser that supplies only the entry via the field
+    // while reporting the exit per-sample must not lose its exit.
+    int has_field_entry = 0;
+    int has_field_exit = 0;
     dc_location_t loc = {0};
     if (dc_parser_get_field(parser, DC_FIELD_LOCATION, 0, &loc) == DC_STATUS_SUCCESS) {
         dive->entry_latitude = loc.latitude;
         dive->entry_longitude = loc.longitude;
-        has_field_location = 1;
+        has_field_entry = 1;
     }
     if (dc_parser_get_field(parser, DC_FIELD_LOCATION, 1, &loc) == DC_STATUS_SUCCESS) {
         dive->exit_latitude = loc.latitude;
         dive->exit_longitude = loc.longitude;
-        has_field_location = 1;
+        has_field_exit = 1;
     }
 
     // Extract gas mixes.
@@ -405,9 +458,11 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
     sample_state_t sample_state = {0};
     sample_state.dive = dive;
     sample_state.current_gasmix = UINT32_MAX;  // 0 is a valid gas index
-    sample_state.has_field_location = has_field_location;
+    sample_state.has_field_entry = has_field_entry;
+    sample_state.has_field_exit = has_field_exit;
     dc_parser_samples_foreach(parser, sample_callback, &sample_state);
     push_sample(&sample_state);
+    resolve_sample_locations(&sample_state);
 
     return 0;
 }

--- a/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
+++ b/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
@@ -232,7 +232,8 @@ static void test_parse_ratio_ix3m_single_fix(void) {
                                   blob, size, &result, err, sizeof(err));
     assert(rc == 0);
 
-    assert(!isnan(result.entry_latitude));
+    assert(fabs(result.entry_latitude - 36.04) < 1e-7);
+    assert(fabs(result.entry_longitude - 14.32) < 1e-7);
     assert(isnan(result.exit_latitude));
     assert(isnan(result.exit_longitude));
 
@@ -277,6 +278,86 @@ static void test_parse_ratio_ix3m_null_island_ignored(void) {
     free(blob);
 }
 
+/* A receiver that reacquires its original position after an intermediate fix
+   (A, B, A) must not leave the mid-dive position B as the exit point: the dive
+   started and ended at A, so A is the one known position and there is no
+   distinct exit. */
+static void test_parse_ratio_ix3m_returns_to_entry(void) {
+    const int a_lat_e7 = 360400000, a_lon_e7 = 143200000;
+    const int b_lat_e7 = 360900000, b_lon_e7 = 143900000;
+
+    const unsigned int nrecords = 6;
+    const unsigned int size = IX3M_HEADER_SIZE + nrecords * IX3M_APOS4_SAMPLE_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    put_u16le(blob + 1, nrecords);
+    put_u32le(blob + 0x2A, 40000000);
+
+    ix3m_put_info(blob, 0, a_lat_e7, a_lon_e7);
+    ix3m_put_sample(blob, 1, 0, 50);
+    ix3m_put_info(blob, 2, b_lat_e7, b_lon_e7);
+    ix3m_put_sample(blob, 3, 10, 120);
+    ix3m_put_info(blob, 4, a_lat_e7, a_lon_e7);
+    ix3m_put_sample(blob, 5, 20, 30);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Ratio", "iX3M 2 GPS Pro", IX3M2_GPS_PRO_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(fabs(result.entry_latitude - 36.04) < 1e-7);
+    assert(fabs(result.entry_longitude - 14.32) < 1e-7);
+    assert(isnan(result.exit_latitude));
+    assert(isnan(result.exit_longitude));
+
+    printf("PASS: test_parse_ratio_ix3m_returns_to_entry\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* A receiver that only gets a lock after surfacing yields one fix, late in the
+   profile. That is the exit position, not the entry -- storing it as the entry
+   would pin the dive at the wrong end. Site matching reads the exit when the
+   entry is absent, so the dive still resolves to a site. */
+static void test_parse_ratio_ix3m_late_fix_is_exit(void) {
+    const unsigned int nrecords = 5;
+    const unsigned int size = IX3M_HEADER_SIZE + nrecords * IX3M_APOS4_SAMPLE_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    put_u16le(blob + 1, nrecords);
+    put_u32le(blob + 0x2A, 40000000);
+
+    ix3m_put_sample(blob, 0, 0, 50);
+    ix3m_put_sample(blob, 1, 600, 180);
+    ix3m_put_sample(blob, 2, 1200, 120);
+    ix3m_put_info(blob, 3, 360400000, 143200000);
+    ix3m_put_sample(blob, 4, 1800, 10);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Ratio", "iX3M 2 GPS Pro", IX3M2_GPS_PRO_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(isnan(result.entry_latitude));
+    assert(isnan(result.entry_longitude));
+    assert(fabs(result.exit_latitude - 36.04) < 1e-7);
+    assert(fabs(result.exit_longitude - 14.32) < 1e-7);
+
+    printf("PASS: test_parse_ratio_ix3m_late_fix_is_exit\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
 int main(void) {
     test_null_args();
     test_load_fixture_missing();
@@ -285,6 +366,8 @@ int main(void) {
     test_parse_ratio_ix3m_sample_gps();
     test_parse_ratio_ix3m_single_fix();
     test_parse_ratio_ix3m_null_island_ignored();
+    test_parse_ratio_ix3m_returns_to_entry();
+    test_parse_ratio_ix3m_late_fix_is_exit();
     printf("\nAll parse_raw_dive tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Follow-up to #945, which merged before these review findings were applied.

A code-review pass over #945 found three defects, all tracing to the same
mistake: entry/exit were decided **while** the samples were still streaming,
before the profile's length was known. This collects the first and last usable
fix during the walk and resolves them once, afterwards, in a new
`resolve_sample_locations()`.

## Changes

**1. `A, B, A` left a mid-dive position as the exit.** Each fix was compared
against the entry rather than deduplicated at the end, so a receiver that
reacquired its original position after an intermediate lock left `B` — neither
the entry nor the exit — as the exit point. The dive started and ended at `A`,
so `A` is the one known position and there is no distinct exit.

**2. The first usable fix became the entry wherever it occurred.** Wrong for a
receiver that only gets a lock after surfacing, and now reachable: `hw_ostc`
(OSTC 4, GNSS on event bit `0x0400`) and `divesoft_freedom` log fixes anywhere
in the profile, and both reach this code because neither implements
`DC_FIELD_LOCATION`. A lone fix past the profile's midpoint is now stored as the
exit.

Verified this strands nothing before changing it — the concern being that
demoting a position out of `entry` could leave a dive with no matchable
coordinate at all:

- `dive_repository_impl.dart:502` — the unmatched-dives query accepts
  `entry IS NOT NULL` **OR** `exit IS NOT NULL`
- `site_matching_service.dart:123` —
  `_pointFor(dive) => dive.entryLocation ?? dive.exitLocation`

So the dive still resolves to a site; it is simply pinned at the correct end.

**3. `has_field_location` was one flag for two sides.** It was set when *either*
`DC_FIELD_LOCATION` index succeeded and suppressed the sample fallback for
*both*, so a parser supplying only the entry via the field would have had its
per-sample exit silently discarded. Now tracked per side. No parser does this
today — the single flag encoded an assumption its name did not admit to.

## Test Plan

- [x] Native suite **9/9** (`ctest`), up from 7
- [x] `flutter analyze` clean, `dart format` clean
- [x] No Dart changed

Two new cases, both of which fail against the merged #945 logic:

| Test | Asserts |
| --- | --- |
| `test_parse_ratio_ix3m_returns_to_entry` | `A, B, A` → entry `A`, exit unset (was: exit `B`) |
| `test_parse_ratio_ix3m_late_fix_is_exit` | lone fix at 30 of 30 min → exit set, entry unset (was: entry set) |

`test_parse_ratio_ix3m_single_fix` now asserts both coordinates rather than
latitude alone.

### Known gap

The `DC_FIELD_LOCATION` precedence gate is still untested. Reaching it needs a
parser implementing **both** APIs, which is `shearwater_predator` alone, and no
Shearwater fixture exists in the repo. Its field and sample paths read the same
records behind the same `GNSS_FIX_2D/3D` and `logversion >= 17` checks, so they
cannot disagree in practice — but that is an argument from inspection, not from
a test. Adding a Shearwater GNSS fixture would close it.
