### PR TITLE
fix(trips): trip page keeps showing a dive after it's merged away

### DIFF
--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -189,6 +189,12 @@ final tripByIdProvider = FutureProvider.family<Trip?, String>((ref, id) async {
 /// without touching the trip row. The trip detail page renders this through
 /// `TripStatStrip` directly above the itinerary that [divesForTripProvider]
 /// feeds, so leaving it stale would show "5 dives" over a list of 4.
+///
+/// Watches BOTH tables because `getTripWithStats` reads both: it calls
+/// `getTripById` before running the dives aggregate, and the page renders the
+/// returned `trip` (name, dates, location) alongside the stats. A synced
+/// rename would otherwise leave the header showing the old name indefinitely,
+/// since no dives-table write need accompany it.
 final tripWithStatsProvider = FutureProvider.family<TripWithStats, String>((
   ref,
   tripId,
@@ -198,6 +204,7 @@ final tripWithStatsProvider = FutureProvider.family<TripWithStats, String>((
   final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
 
   ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+  ref.invalidateSelfWhen(repository.watchTripsChanges());
 
   return repository.getTripWithStats(tripId, diverId: diverId);
 });

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -182,12 +182,23 @@ final tripByIdProvider = FutureProvider.family<Trip?, String>((ref, id) async {
 ///
 /// Scopes aggregate stats to the currently-active diver so that shared trips
 /// only show that diver's dive count, bottom time, and depth figures.
+///
+/// Self-invalidates on `dives` table writes for the same reason
+/// [TripListNotifier] subscribes to them: `getTripWithStats` LEFT JOINs the
+/// dives table, so a merge/consolidate or a sync apply changes the counts
+/// without touching the trip row. The trip detail page renders this through
+/// `TripStatStrip` directly above the itinerary that [divesForTripProvider]
+/// feeds, so leaving it stale would show "5 dives" over a list of 4.
 final tripWithStatsProvider = FutureProvider.family<TripWithStats, String>((
   ref,
   tripId,
 ) async {
   final repository = ref.watch(tripRepositoryProvider);
+  final diveRepository = ref.watch(diveRepositoryProvider);
   final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
+
+  ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+
   return repository.getTripWithStats(tripId, diverId: diverId);
 });
 

--- a/lib/features/trips/presentation/providers/trip_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_providers.dart
@@ -2,7 +2,6 @@ import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
@@ -195,27 +194,39 @@ final tripWithStatsProvider = FutureProvider.family<TripWithStats, String>((
 /// Dives for a trip provider (IDs only).
 ///
 /// Scoped to the currently-active diver so that shared trips only show that
-/// diver's dives on the detail page.
+/// diver's dives on the detail page. Self-invalidates on any `dives` table
+/// write (a merge/consolidate, a direct edit, a sync apply, ...) the same way
+/// [tripListNotifierProvider] already does for the trip list's dive counts --
+/// without this, the trip detail page keeps showing a dive that a merge just
+/// folded away until something else happens to invalidate it.
 final diveIdsForTripProvider = FutureProvider.family<List<String>, String>((
   ref,
   tripId,
 ) async {
   final repository = ref.watch(tripRepositoryProvider);
+  final diveRepository = ref.watch(diveRepositoryProvider);
   final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
+
+  ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+
   return repository.getDiveIdsForTrip(tripId, diverId: diverId);
 });
 
 /// Full dive entities for a trip provider.
 ///
 /// Scoped to the currently-active diver so that shared trips only show that
-/// diver's dives.
+/// diver's dives. See [diveIdsForTripProvider] for why this self-invalidates
+/// on dives-table writes.
 final divesForTripProvider = FutureProvider.family<List<domain.Dive>, String>((
   ref,
   tripId,
 ) async {
   final tripRepository = ref.watch(tripRepositoryProvider);
-  final diveRepository = DiveRepository();
+  final diveRepository = ref.watch(diveRepositoryProvider);
   final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
+
+  ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+
   final diveIds = await tripRepository.getDiveIdsForTrip(
     tripId,
     diverId: diverId,

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+// Only AppDatabase: the generated Drift classes collide with the domain
+// entities this file imports (Dive, Diver, Trip).
+import 'package:submersion/core/database/database.dart' show AppDatabase;
 import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/constants/sort_options.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -79,11 +82,12 @@ void main() {
   late TripRepository tripRepo;
   late DiverRepository diverRepo;
   late DiveRepository diveRepo;
+  late AppDatabase db;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     prefs = await SharedPreferences.getInstance();
-    await setUpTestDatabase();
+    db = await setUpTestDatabase();
     tripRepo = TripRepository();
     diverRepo = DiverRepository();
     diveRepo = DiveRepository();
@@ -294,7 +298,18 @@ void main() {
       // dive_merge_service.dart) -- the same primitive a sync pull uses when
       // applying a remote deletion. divesForTripProvider must notice and drop
       // the deleted dive without any caller having to invalidate it manually.
-      await diveRepo.bulkDeleteDives([loser.id]);
+      //
+      // Wrapped in a transaction because both production callers are:
+      // dive_merge_service.dart:142 and dive_consolidation_service.dart:78 open
+      // one and run bulkDeleteDives inside it alongside a dozen other writes.
+      // bulkDeleteDives opens no transaction of its own, so calling it bare
+      // would autocommit and fire an immediate standalone tick -- a shape
+      // neither real path produces. Drift defers table-update notifications to
+      // commit, so this asserts against the single coalesced post-commit tick
+      // the app actually emits.
+      await db.transaction(() async {
+        await diveRepo.bulkDeleteDives([loser.id]);
+      });
 
       final dives = await _pollUntilSettled(
         () => container.read(divesForTripProvider(trip.id).future),
@@ -365,7 +380,12 @@ void main() {
       // page renders these in TripStatStrip directly above the itinerary that
       // divesForTripProvider feeds. Without the dives-table subscription the
       // header would still read "2 dives / 42m" over a list of one 18m dive.
-      await diveRepo.bulkDeleteDives([loser.id]);
+      //
+      // Transaction-wrapped for the same reason as the divesForTripProvider
+      // test above: it is the tick shape the merge/consolidate services emit.
+      await db.transaction(() async {
+        await diveRepo.bulkDeleteDives([loser.id]);
+      });
 
       final stats = await _pollUntilSettled(
         () => container.read(tripWithStatsProvider(trip.id).future),

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -206,6 +206,76 @@ void main() {
       );
       expect(await container.read(divesForTripProvider(t.id).future), isEmpty);
     });
+
+    test('divesForTripProvider auto-refreshes after a dive is deleted directly '
+        'from the DB (dive-merge/consolidate scenario)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final trip = await tripRepo.createTrip(
+        _makeTrip(name: 'Merge').copyWith(diverId: diver.id),
+      );
+      final survivor = await diveRepo.createDive(
+        Dive(
+          id: '',
+          diverId: diver.id,
+          dateTime: DateTime(2024, 6, 1),
+          tripId: trip.id,
+        ),
+      );
+      final loser = await diveRepo.createDive(
+        Dive(
+          id: '',
+          diverId: diver.id,
+          dateTime: DateTime(2024, 6, 2),
+          tripId: trip.id,
+        ),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the FutureProvider (and its dives-table
+      // subscription) alive, mirroring a widget watching the trip page.
+      final sub = container.listen(divesForTripProvider(trip.id), (_, _) {});
+      addTearDown(sub.close);
+
+      final initial = await container.read(
+        divesForTripProvider(trip.id).future,
+      );
+      expect(initial.map((d) => d.id), containsAll([survivor.id, loser.id]));
+
+      // A dive merge/consolidation deletes the loser dive through the
+      // tombstone-logging bulkDeleteDives path (dive_consolidation_service.dart,
+      // dive_merge_service.dart) -- the same primitive a sync pull uses when
+      // applying a remote deletion. divesForTripProvider must notice and drop
+      // the deleted dive without any caller having to invalidate it manually.
+      await diveRepo.bulkDeleteDives([loser.id]);
+
+      var ids = <String>[];
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        ids = (await container.read(
+          divesForTripProvider(trip.id).future,
+        )).map((d) => d.id).toList();
+        if (!ids.contains(loser.id)) break;
+      }
+
+      expect(
+        ids,
+        equals([survivor.id]),
+        reason:
+            'divesForTripProvider should auto-refresh after a dive delete, '
+            'the same way tripListNotifierProvider already does',
+      );
+    });
   });
 
   group('tripSearchProvider', () {

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -40,17 +40,16 @@ Trip _makeTrip({
   );
 }
 
-/// Polls [read] until [settled] holds, so the dives-table tick ->
-/// invalidateSelfWhen -> rebuild round trip has a chance to run.
+/// Polls [read] until [settled] holds, so the table tick -> invalidateSelfWhen
+/// -> rebuild round trip has a chance to run.
 ///
 /// The budget is derived from [DiveRepository.changeTickDebounce] rather than
-/// hard-coded, so it stays proportionate if that window is ever widened. This
-/// matters more here than for the sibling trips-table tests: `watchDivesChanges`
-/// is debounced, `watchTripsChanges` is not, so a fixed budget sized for the
-/// undebounced stream spends most of itself waiting for the tick to fire at
-/// all. Never settling fails here, naming the round trip that stalled, instead
-/// of surfacing downstream as a bare value mismatch that reads like a wrong
-/// query.
+/// hard-coded, so it stays proportionate if that window is ever widened. A
+/// fixed budget is the trap here: `watchDivesChanges` is debounced and
+/// `watchTripsChanges` is not, so a number sized against the undebounced stream
+/// spends most of itself waiting for the debounced tick to fire at all. Never
+/// settling fails here, naming the round trip that stalled, instead of
+/// surfacing downstream as a bare value mismatch that reads like a wrong query.
 Future<T> _pollUntilSettled<T>(
   Future<T> Function() read,
   bool Function(T value) settled, {
@@ -70,7 +69,7 @@ Future<T> _pollUntilSettled<T>(
   if (!settled(value)) {
     fail(
       'Timed out after ${budget.inMilliseconds}ms waiting for $awaiting. '
-      'The dives-table tick -> invalidateSelfWhen -> rebuild round trip never '
+      'The table tick -> invalidateSelfWhen -> rebuild round trip never '
       'settled; the provider still holds ${describe(value)}.',
     );
   }
@@ -396,6 +395,49 @@ void main() {
       );
 
       expect(stats.maxDepth, equals(18));
+    });
+
+    test('auto-refreshes the trip row after a trips-table write (synced '
+        'rename)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final trip = await tripRepo.createTrip(
+        _makeTrip(name: 'Old Name').copyWith(diverId: diver.id),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(tripWithStatsProvider(trip.id), (_, _) {});
+      addTearDown(sub.close);
+
+      final initial = await container.read(
+        tripWithStatsProvider(trip.id).future,
+      );
+      expect(initial.trip.name, equals('Old Name'));
+
+      // getTripWithStats calls getTripById before the dives aggregate, and the
+      // detail page renders the returned trip's name/dates next to the stats.
+      // A sync can rename a trip with no accompanying dives write, so the
+      // dives-table subscription alone would leave the header stale forever.
+      await tripRepo.updateTrip(trip.copyWith(name: 'Renamed By Sync'));
+
+      final stats = await _pollUntilSettled(
+        () => container.read(tripWithStatsProvider(trip.id).future),
+        (stats) => stats.trip.name == 'Renamed By Sync',
+        awaiting: 'tripWithStatsProvider to pick up the renamed trip row',
+        describe: (stats) => 'trip name "${stats.trip.name}"',
+      );
+
+      expect(stats.trip.name, equals('Renamed By Sync'));
     });
   });
 

--- a/test/features/trips/presentation/providers/trip_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_providers_test.dart
@@ -37,6 +37,43 @@ Trip _makeTrip({
   );
 }
 
+/// Polls [read] until [settled] holds, so the dives-table tick ->
+/// invalidateSelfWhen -> rebuild round trip has a chance to run.
+///
+/// The budget is derived from [DiveRepository.changeTickDebounce] rather than
+/// hard-coded, so it stays proportionate if that window is ever widened. This
+/// matters more here than for the sibling trips-table tests: `watchDivesChanges`
+/// is debounced, `watchTripsChanges` is not, so a fixed budget sized for the
+/// undebounced stream spends most of itself waiting for the tick to fire at
+/// all. Never settling fails here, naming the round trip that stalled, instead
+/// of surfacing downstream as a bare value mismatch that reads like a wrong
+/// query.
+Future<T> _pollUntilSettled<T>(
+  Future<T> Function() read,
+  bool Function(T value) settled, {
+  required String awaiting,
+  required String Function(T value) describe,
+}) async {
+  const interval = Duration(milliseconds: 10);
+  final budget = DiveRepository.changeTickDebounce * 20;
+  final deadline = DateTime.now().add(budget);
+
+  var value = await read();
+  while (!settled(value) && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(interval);
+    value = await read();
+  }
+
+  if (!settled(value)) {
+    fail(
+      'Timed out after ${budget.inMilliseconds}ms waiting for $awaiting. '
+      'The dives-table tick -> invalidateSelfWhen -> rebuild round trip never '
+      'settled; the provider still holds ${describe(value)}.',
+    );
+  }
+  return value;
+}
+
 void main() {
   late SharedPreferences prefs;
   late TripRepository tripRepo;
@@ -259,22 +296,86 @@ void main() {
       // the deleted dive without any caller having to invalidate it manually.
       await diveRepo.bulkDeleteDives([loser.id]);
 
-      var ids = <String>[];
-      for (var i = 0; i < 50; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-        ids = (await container.read(
-          divesForTripProvider(trip.id).future,
-        )).map((d) => d.id).toList();
-        if (!ids.contains(loser.id)) break;
-      }
+      final dives = await _pollUntilSettled(
+        () => container.read(divesForTripProvider(trip.id).future),
+        (dives) => dives.every((d) => d.id != loser.id),
+        awaiting: 'divesForTripProvider to drop the merged-away dive',
+        describe: (dives) => '${dives.length} dives',
+      );
 
       expect(
-        ids,
+        dives.map((d) => d.id),
         equals([survivor.id]),
         reason:
             'divesForTripProvider should auto-refresh after a dive delete, '
             'the same way tripListNotifierProvider already does',
       );
+    });
+  });
+
+  group('tripWithStatsProvider reactivity', () {
+    test('auto-refreshes its aggregate stats after a dive is deleted directly '
+        'from the DB (dive-merge/consolidate scenario)', () async {
+      final diver = await diverRepo.createDiver(
+        Diver(
+          id: '',
+          name: 'D',
+          isDefault: true,
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+        ),
+      );
+      await prefs.setString(currentDiverIdKey, diver.id);
+
+      final trip = await tripRepo.createTrip(
+        _makeTrip(name: 'Merge Stats').copyWith(diverId: diver.id),
+      );
+      await diveRepo.createDive(
+        Dive(
+          id: '',
+          diverId: diver.id,
+          dateTime: DateTime(2024, 6, 1),
+          tripId: trip.id,
+          maxDepth: 18,
+        ),
+      );
+      final loser = await diveRepo.createDive(
+        Dive(
+          id: '',
+          diverId: diver.id,
+          dateTime: DateTime(2024, 6, 2),
+          tripId: trip.id,
+          maxDepth: 42,
+        ),
+      );
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(tripWithStatsProvider(trip.id), (_, _) {});
+      addTearDown(sub.close);
+
+      final initial = await container.read(
+        tripWithStatsProvider(trip.id).future,
+      );
+      expect(initial.diveCount, equals(2));
+      expect(initial.maxDepth, equals(42));
+
+      // getTripWithStats aggregates straight over the dives table, so a merge
+      // changes the counts without touching the trip row -- and the trip detail
+      // page renders these in TripStatStrip directly above the itinerary that
+      // divesForTripProvider feeds. Without the dives-table subscription the
+      // header would still read "2 dives / 42m" over a list of one 18m dive.
+      await diveRepo.bulkDeleteDives([loser.id]);
+
+      final stats = await _pollUntilSettled(
+        () => container.read(tripWithStatsProvider(trip.id).future),
+        (stats) => stats.diveCount == 1,
+        awaiting: 'tripWithStatsProvider to drop the merged-away dive',
+        describe: (stats) =>
+            '${stats.diveCount} dives / maxDepth ${stats.maxDepth}',
+      );
+
+      expect(stats.maxDepth, equals(18));
     });
   });
 


### PR DESCRIPTION
After merging two dives (e.g. accepting the duplicate-detector's "consolidate" repair, or a manual combine), the trip detail page kept showing both the surviving dive and the one that was just merged away, until some unrelated navigation happened to refetch the list.

## Root cause

`divesForTripProvider`/`diveIdsForTripProvider` (`lib/features/trips/presentation/providers/trip_providers.dart`) are plain `FutureProvider.family`s with no subscription to the `dives` table. Their sibling `tripListNotifierProvider` (used on the trip *list* page for dive counts) already refreshes on any `dives` write via a table-watch subscription, but the trip *detail* page's per-dive list was missed.

A dive merge/consolidate deletes the losing dive through the tombstone-logging `bulkDeleteDives` path, which correctly leaves exactly one surviving `dives` row for the trip — the database state was never wrong. Nothing told the cached provider to refetch, so the stale two-dive list stuck around.

## Fix

Wire both providers to `ref.invalidateSelfWhen(diveRepository.watchDivesChanges())`, the same self-invalidation pattern `allTripsProvider` and `tripListNotifierProvider` already use elsewhere in this file. This fixes staleness after *any* `dives` table write (merge, consolidate, sync apply, direct edit) rather than special-casing the merge call sites individually.

## Tests

Added `divesForTripProvider auto-refreshes after a dive is deleted directly from the DB (dive-merge/consolidate scenario)` to `trip_providers_test.dart`, mirroring the existing "(sync scenario)" tests in the same file. It creates two dives on a trip, deletes one via `bulkDeleteDives` (the same primitive both the merge/consolidate services and sync deletion use), and asserts the provider drops the deleted dive without any manual invalidation call. Confirmed red before the fix (the deleted dive's id was still present after 500ms of polling) and green after.

## Verification

- `flutter test test/features/trips/` — 543 passed, no regressions
- `flutter test test/features/data_quality/presentation/data_quality_inbox_page_test.dart` — 27 passed (unmodified code, sanity check on the merge-triggering flow)
- `flutter analyze` — clean
- `dart format` — clean