### PR TITLE
Fix stale equipment-set caches after deleting gear (#819)

### DIFF
--- a/lib/features/equipment/data/repositories/equipment_set_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_set_repository_impl.dart
@@ -4,7 +4,9 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/core/utils/stream_debounce.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_set.dart'
     as domain;
 import 'package:submersion/features/equipment/domain/entities/equipment_set_geofence.dart'
@@ -16,6 +18,71 @@ class EquipmentSetRepository {
   final SyncRepository _syncRepository = SyncRepository();
   final _uuid = const Uuid();
   final _equipmentRepo = EquipmentRepository();
+  final _log = LoggerService.forClass(EquipmentSetRepository);
+
+  /// Debounce for [watchSetChanges] so a multi-changeset sync refreshes the
+  /// set surfaces once on the settled DB state instead of once per commit
+  /// (mirrors DiveRepository.changeTickDebounce).
+  static const changeTickDebounce = Duration(milliseconds: 300);
+
+  /// Emits whenever anything an equipment set renders changes, so the
+  /// set providers can self-invalidate after ANY write -- including a sync or
+  /// an import applying changes straight to the DB, which bypasses the
+  /// notifier paths that invalidate caches on local edits.
+  ///
+  /// Watches the hydration sources, not just `equipment_sets`:
+  /// - `equipment_set_items` -- membership. This is also the target of drift's
+  ///   generated `WritePropagation` for the `equipment` ON DELETE CASCADE, so
+  ///   deleting a gear item ticks here even though the DELETE statement only
+  ///   named `equipment` (see `streamUpdateRules` in database.g.dart).
+  /// - `equipment` -- [getSetById] with `includeItems` hydrates full items, and
+  ///   the cascade propagation above is delete-only, so a RENAME of a member
+  ///   only surfaces if this table is watched directly.
+  /// - `equipment_set_geofences` -- hydrated by the set detail/edit providers.
+  ///
+  /// Without this, deleting a gear item left every cached set carrying the dead
+  /// id; the edit form then re-inserted it and the save died on the FK
+  /// (issue #819).
+  Stream<void> watchSetChanges() => _db
+      .tableUpdates(
+        TableUpdateQuery.allOf([
+          TableUpdateQuery.onTable(_db.equipmentSets),
+          TableUpdateQuery.onTable(_db.equipmentSetItems),
+          TableUpdateQuery.onTable(_db.equipment),
+          TableUpdateQuery.onTable(_db.equipmentSetGeofences),
+        ]),
+      )
+      .debounce(changeTickDebounce);
+
+  /// The subset of [ids] that still has an `equipment` row, preserving order.
+  ///
+  /// A caller can legitimately hold ids that no longer exist: SQLite cascades
+  /// the junction rows away the instant a gear item is deleted, but an
+  /// in-memory equipment set -- or an edit form already on screen -- keeps its
+  /// snapshot of the membership. Inserting such an id fails the
+  /// foreign key and aborts the entire save (issue #819), so drop it instead.
+  ///
+  /// Deliberately NOT `InsertMode.insertOrIgnore`: this is a foreign-key
+  /// violation rather than a uniqueness conflict, and ignoring it would hide
+  /// the drop entirely. The set is the diver's data and must still save, but a
+  /// silent prune would also mask a genuine provider-staleness regression --
+  /// hence the warning.
+  Future<List<String>> _liveEquipmentIds(String setId, List<String> ids) async {
+    if (ids.isEmpty) return const [];
+    final rows = await (_db.select(
+      _db.equipment,
+    )..where((t) => t.id.isIn(ids))).get();
+    final live = rows.map((r) => r.id).toSet();
+    final kept = ids.where(live.contains).toList();
+    if (kept.length != ids.length) {
+      final missing = ids.where((id) => !live.contains(id));
+      _log.warning(
+        'Equipment set $setId: dropping ${ids.length - kept.length} member(s) '
+        'whose equipment no longer exists (${missing.join(', ')})',
+      );
+    }
+    return kept;
+  }
 
   /// Get all equipment sets
   Future<List<domain.EquipmentSet>> getAllSets({String? diverId}) async {
@@ -67,39 +134,50 @@ class EquipmentSetRepository {
     return rows.map((r) => r.equipmentId).toList();
   }
 
-  /// Create a new equipment set
+  /// Create a new equipment set.
+  ///
+  /// The set row and its membership are one logical write, so they share a
+  /// transaction: a failing member insert must not leave a named set behind
+  /// with a partial roster. Sync bookkeeping runs after the commit so a
+  /// rollback leaves no stray pending markers (mirrors DivePlanRepository).
   Future<domain.EquipmentSet> createSet(domain.EquipmentSet set) async {
     final id = set.id.isEmpty ? _uuid.v4() : set.id;
     final now = DateTime.now().millisecondsSinceEpoch;
+    late final List<String> members;
 
-    await _db
-        .into(_db.equipmentSets)
-        .insert(
-          EquipmentSetsCompanion(
-            id: Value(id),
-            diverId: Value(set.diverId),
-            name: Value(set.name),
-            description: Value(set.description),
-            createdAt: Value(now),
-            updatedAt: Value(now),
-          ),
-        );
+    await _db.transaction(() async {
+      await _db
+          .into(_db.equipmentSets)
+          .insert(
+            EquipmentSetsCompanion(
+              id: Value(id),
+              diverId: Value(set.diverId),
+              name: Value(set.name),
+              description: Value(set.description),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+
+      members = await _liveEquipmentIds(id, set.equipmentIds);
+      for (final equipmentId in members) {
+        await _db
+            .into(_db.equipmentSetItems)
+            .insert(
+              EquipmentSetItemsCompanion(
+                setId: Value(id),
+                equipmentId: Value(equipmentId),
+              ),
+            );
+      }
+    });
+
     await _syncRepository.markRecordPending(
       entityType: 'equipmentSets',
       recordId: id,
       localUpdatedAt: now,
     );
-
-    // Add equipment items to set
-    for (final equipmentId in set.equipmentIds) {
-      await _db
-          .into(_db.equipmentSetItems)
-          .insert(
-            EquipmentSetItemsCompanion(
-              setId: Value(id),
-              equipmentId: Value(equipmentId),
-            ),
-          );
+    for (final equipmentId in members) {
       await _syncRepository.markRecordPending(
         entityType: 'equipmentSetItems',
         recordId: '$id|$equipmentId',
@@ -110,56 +188,88 @@ class EquipmentSetRepository {
 
     return set.copyWith(
       id: id,
+      equipmentIds: members,
       createdAt: DateTime.fromMillisecondsSinceEpoch(now),
       updatedAt: DateTime.fromMillisecondsSinceEpoch(now),
     );
   }
 
-  /// Update an equipment set
+  /// Update an equipment set.
+  ///
+  /// Membership is reconciled as a DIFF rather than delete-all-then-reinsert.
+  /// The old shape had two defects this flow hits hard: it was untransacted, so
+  /// a failing re-insert left the set empty with every member already
+  /// tombstoned (issue #819); and it tombstoned + re-marked every member on
+  /// every save even when nothing changed, which is the churn the
+  /// contradicted-key handling in SyncService exists to absorb. Diffing removes
+  /// both. Mirrors the composite-PK junction handling in
+  /// DivePlanRepository.updatePlan, including running sync bookkeeping only
+  /// after the transaction commits.
   Future<void> updateSet(domain.EquipmentSet set) async {
     final now = DateTime.now().millisecondsSinceEpoch;
+    final added = <String>[];
+    final removed = <String>[];
 
-    await (_db.update(
-      _db.equipmentSets,
-    )..where((t) => t.id.equals(set.id))).write(
-      EquipmentSetsCompanion(
-        name: Value(set.name),
-        description: Value(set.description),
-        updatedAt: Value(now),
-      ),
-    );
+    await _db.transaction(() async {
+      await (_db.update(
+        _db.equipmentSets,
+      )..where((t) => t.id.equals(set.id))).write(
+        EquipmentSetsCompanion(
+          name: Value(set.name),
+          description: Value(set.description),
+          updatedAt: Value(now),
+        ),
+      );
+
+      final desired = (await _liveEquipmentIds(
+        set.id,
+        set.equipmentIds,
+      )).toSet();
+      final existing =
+          (await (_db.select(
+                _db.equipmentSetItems,
+              )..where((t) => t.setId.equals(set.id))).get())
+              .map((r) => r.equipmentId)
+              .toSet();
+
+      added.addAll(desired.difference(existing));
+      removed.addAll(existing.difference(desired));
+
+      for (final equipmentId in added) {
+        await _db
+            .into(_db.equipmentSetItems)
+            .insert(
+              EquipmentSetItemsCompanion(
+                setId: Value(set.id),
+                equipmentId: Value(equipmentId),
+              ),
+              mode: InsertMode.insertOrIgnore,
+            );
+      }
+      for (final equipmentId in removed) {
+        await (_db.delete(_db.equipmentSetItems)..where(
+              (t) => t.setId.equals(set.id) & t.equipmentId.equals(equipmentId),
+            ))
+            .go();
+      }
+    });
+
     await _syncRepository.markRecordPending(
       entityType: 'equipmentSets',
       recordId: set.id,
       localUpdatedAt: now,
     );
-
-    // Update equipment items: delete and re-insert
-    final existingItems = await (_db.select(
-      _db.equipmentSetItems,
-    )..where((t) => t.setId.equals(set.id))).get();
-    await (_db.delete(
-      _db.equipmentSetItems,
-    )..where((t) => t.setId.equals(set.id))).go();
-    for (final item in existingItems) {
-      await _syncRepository.logDeletion(
-        entityType: 'equipmentSetItems',
-        recordId: '${item.setId}|${item.equipmentId}',
-      );
-    }
-    for (final equipmentId in set.equipmentIds) {
-      await _db
-          .into(_db.equipmentSetItems)
-          .insert(
-            EquipmentSetItemsCompanion(
-              setId: Value(set.id),
-              equipmentId: Value(equipmentId),
-            ),
-          );
+    for (final equipmentId in added) {
       await _syncRepository.markRecordPending(
         entityType: 'equipmentSetItems',
         recordId: '${set.id}|$equipmentId',
         localUpdatedAt: now,
+      );
+    }
+    for (final equipmentId in removed) {
+      await _syncRepository.logDeletion(
+        entityType: 'equipmentSetItems',
+        recordId: '${set.id}|$equipmentId',
       );
     }
     SyncEventBus.notifyLocalChange();

--- a/lib/features/equipment/presentation/pages/equipment_set_edit_page.dart
+++ b/lib/features/equipment/presentation/pages/equipment_set_edit_page.dart
@@ -57,9 +57,35 @@ class _EquipmentSetEditPageState extends ConsumerState<EquipmentSetEditPage> {
     _geofences = List.of(set.geofences);
   }
 
+  /// Drops selections whose equipment has been deleted since the form opened.
+  ///
+  /// [_initializeFromSet] seeds the selection once. If a gear item is deleted
+  /// while this page is on screen -- by a sync, or from the equipment tab --
+  /// its checkbox disappears but the id stays selected, so it can be neither
+  /// seen nor un-checked, and the save would re-insert a dangling foreign key
+  /// (issue #819). The repository prunes such ids as well, but only at write
+  /// time; doing it here keeps the rendered membership honest.
+  ///
+  /// An id is kept when the freshly loaded [set] still lists it. Retired gear
+  /// renders no checkbox yet is legitimately a member, and a set may reference
+  /// gear that [allEquipmentProvider] (diver-scoped) does not return -- neither
+  /// may be silently dropped.
+  void _pruneDeletedSelections(
+    EquipmentSet set,
+    List<EquipmentItem>? everyEquipment,
+  ) {
+    if (everyEquipment == null) return;
+    final known = {...everyEquipment.map((e) => e.id), ...set.equipmentIds};
+    _selectedEquipmentIds.retainWhere(known.contains);
+  }
+
   @override
   Widget build(BuildContext context) {
     final allEquipmentAsync = ref.watch(activeEquipmentProvider);
+    // Existence check for _pruneDeletedSelections. Deliberately not
+    // activeEquipmentProvider: retired gear still belongs to a set, it just
+    // gets no checkbox.
+    final everyEquipment = ref.watch(allEquipmentProvider).valueOrNull;
 
     if (widget.isEditing) {
       final setAsync = ref.watch(equipmentSetProvider(widget.setId!));
@@ -76,6 +102,7 @@ class _EquipmentSetEditPageState extends ConsumerState<EquipmentSetEditPage> {
             );
           }
           _initializeFromSet(set);
+          _pruneDeletedSelections(set, everyEquipment);
           return _buildForm(context, allEquipmentAsync, set);
         },
         loading: () => Scaffold(

--- a/lib/features/equipment/presentation/providers/equipment_set_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_set_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -10,29 +12,45 @@ final equipmentSetRepositoryProvider = Provider<EquipmentSetRepository>((ref) {
   return EquipmentSetRepository();
 });
 
-/// All equipment sets provider
+/// All equipment sets provider.
+///
+/// Self-invalidates on [EquipmentSetRepository.watchSetChanges] so a set's
+/// membership never outlives the gear it points at -- deleting an equipment
+/// item cascades its junction rows away, and a cached set carrying the dead id
+/// used to break the next save (issue #819). The stream also covers writes that
+/// bypass the notifier entirely (sync, imports, dive-computer downloads).
 final equipmentSetsProvider = FutureProvider<List<EquipmentSet>>((ref) async {
   final repository = ref.watch(equipmentSetRepositoryProvider);
   final validatedDiverId = await ref.watch(
     validatedCurrentDiverIdProvider.future,
   );
+  ref.invalidateSelfWhen(repository.watchSetChanges());
   return repository.getAllSets(diverId: validatedDiverId);
 });
 
-/// Single equipment set provider (with items populated)
+/// Single equipment set provider (with items and geofences populated).
+///
+/// Self-invalidates on the same change tick as [equipmentSetsProvider]; see
+/// that provider for why.
 final equipmentSetProvider = FutureProvider.family<EquipmentSet?, String>((
   ref,
   id,
 ) async {
   final repository = ref.watch(equipmentSetRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchSetChanges());
   return repository.getSetById(id, includeItems: true, includeGeofences: true);
 });
 
-/// Equipment set with items provider (alias for equipmentSetProvider)
+/// Equipment set with items populated.
+///
+/// Delegates to [equipmentSetProvider] rather than issuing its own query: as a
+/// separate provider it had a separate cache that nothing ever invalidated, so
+/// consumers such as the dive-log "use set" picker could render membership that
+/// was stale by an arbitrary amount. Geofences ride along unused, which costs
+/// one extra small query on a cache miss and buys a single source of truth.
 final equipmentSetWithItemsProvider =
     FutureProvider.family<EquipmentSet?, String>((ref, id) async {
-      final repository = ref.watch(equipmentSetRepositoryProvider);
-      return repository.getSetById(id, includeItems: true);
+      return ref.watch(equipmentSetProvider(id).future);
     });
 
 /// The active diver's default equipment set, or null.
@@ -93,9 +111,24 @@ class EquipmentSetListNotifier
   final Ref _ref;
   String? _validatedDiverId;
 
+  /// True once the validated diver id has been read at least once; guards
+  /// the reactive reload against the "null means unfiltered" startup window.
+  bool _diverResolved = false;
+
+  StreamSubscription<void>? _changeSub;
+
   EquipmentSetListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
     _initializeAndLoad();
+
+    // A StateNotifier cannot self-invalidate the way the FutureProviders above
+    // do, and the sets list renders itemCount straight off equipmentIds -- so
+    // without this a deleted gear item left the list showing a stale member
+    // count until a manual pull-to-refresh (issue #819). Reload in place rather
+    // than through _loadSets so the list does not flash a spinner on every tick.
+    _changeSub = _repository.watchSetChanges().listen((_) {
+      if (mounted) _reloadSetsPreservingState();
+    });
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -108,10 +141,33 @@ class EquipmentSetListNotifier
     });
   }
 
+  @override
+  void dispose() {
+    _changeSub?.cancel();
+    super.dispose();
+  }
+
+  /// Re-reads the sets without dropping to [AsyncValue.loading] first, so a
+  /// background change tick refreshes the rendered list instead of blanking it.
+  ///
+  /// Skipped until the diver id has resolved once: a null [_validatedDiverId]
+  /// means "no filter", so an early tick would briefly publish every diver's
+  /// sets. The pending [_initializeAndLoad] covers that window.
+  Future<void> _reloadSetsPreservingState() async {
+    if (!_diverResolved) return;
+    try {
+      final sets = await _repository.getAllSets(diverId: _validatedDiverId);
+      if (mounted) state = AsyncValue.data(sets);
+    } catch (e, st) {
+      if (mounted) state = AsyncValue.error(e, st);
+    }
+  }
+
   Future<void> _initializeAndLoad() async {
     state = const AsyncValue.loading();
     final validatedId = await _ref.read(validatedCurrentDiverIdProvider.future);
     _validatedDiverId = validatedId;
+    _diverResolved = true;
     await _loadSets();
   }
 
@@ -129,6 +185,7 @@ class EquipmentSetListNotifier
     // Get fresh validated diver ID before loading
     final validatedId = await _ref.read(validatedCurrentDiverIdProvider.future);
     _validatedDiverId = validatedId;
+    _diverResolved = true;
     await _loadSets();
     _ref.invalidate(equipmentSetsProvider);
   }

--- a/test/features/equipment/data/repositories/equipment_set_repository_items_test.dart
+++ b/test/features/equipment/data/repositories/equipment_set_repository_items_test.dart
@@ -1,0 +1,182 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart'
+    hide EquipmentSet, EquipmentSetGeofence;
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Membership writes on [EquipmentSetRepository].
+///
+/// Regression cover for issue #819: deleting a gear item that belongs to a set
+/// left a stale [EquipmentSet] in the provider cache, and saving that set
+/// re-inserted the dead id -- an FK violation (SqliteException 787) that
+/// aborted the save *after* the delete-all step had already emptied the set and
+/// tombstoned every member for sync.
+void main() {
+  late AppDatabase db;
+  late EquipmentSetRepository repo;
+  late EquipmentRepository equipmentRepo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = EquipmentSetRepository();
+    equipmentRepo = EquipmentRepository();
+    final t = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion.insert(
+            id: 'd1',
+            name: 'd1',
+            createdAt: t,
+            updatedAt: t,
+          ),
+        );
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  Future<void> seedEquipment(String id) async {
+    final t = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.equipment)
+        .insert(
+          EquipmentCompanion.insert(
+            id: id,
+            name: id,
+            type: 'bcd',
+            createdAt: t,
+            updatedAt: t,
+            diverId: const Value('d1'),
+          ),
+        );
+  }
+
+  EquipmentSet newSet(String id, List<String> equipmentIds) => EquipmentSet(
+    id: id,
+    diverId: 'd1',
+    name: id,
+    equipmentIds: equipmentIds,
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  );
+
+  Future<List<DeletionLogData>> itemTombstones() async {
+    final rows = await db.select(db.deletionLog).get();
+    return rows.where((r) => r.entityType == 'equipmentSetItems').toList();
+  }
+
+  group('updateSet', () {
+    test('drops members whose equipment was deleted (issue #819)', () async {
+      for (final id in ['e1', 'e2', 'e3']) {
+        await seedEquipment(id);
+      }
+      await repo.createSet(newSet('s1', ['e1', 'e2', 'e3']));
+
+      // SQLite cascades the junction row away, but a cached EquipmentSet held
+      // by equipmentSetProvider still carries all three ids -- and the edit
+      // page seeds its selection from that cache.
+      await equipmentRepo.deleteEquipment('e2');
+
+      final stale = newSet('s1', ['e1', 'e2', 'e3']);
+      await repo.updateSet(stale);
+
+      expect(
+        await repo.getEquipmentIdsInSet('s1'),
+        unorderedEquals(['e1', 'e3']),
+        reason: 'the dead id must be pruned, not inserted',
+      );
+    });
+
+    test('a save carrying a dead id still persists the real edits', () async {
+      for (final id in ['e1', 'e2']) {
+        await seedEquipment(id);
+      }
+      await repo.createSet(newSet('s1', ['e1', 'e2']));
+      await equipmentRepo.deleteEquipment('e2');
+
+      // The form still carries the deleted id in its selection, alongside a
+      // genuine rename the diver expects to keep.
+      await repo.updateSet(
+        EquipmentSet(
+          id: 's1',
+          diverId: 'd1',
+          name: 'Renamed',
+          equipmentIds: const ['e1', 'e2'],
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      final saved = await repo.getSetById('s1');
+      expect(saved!.name, 'Renamed');
+      expect(saved.equipmentIds, ['e1']);
+    });
+
+    test('unchanged membership writes no item tombstones', () async {
+      for (final id in ['e1', 'e2']) {
+        await seedEquipment(id);
+      }
+      await repo.createSet(newSet('s1', ['e1', 'e2']));
+
+      await repo.updateSet(newSet('s1', ['e1', 'e2']));
+
+      expect(
+        await itemTombstones(),
+        isEmpty,
+        reason:
+            'a diff-based write must not delete-and-reinsert unchanged rows; '
+            'spurious tombstones race live rows on the next sync',
+      );
+      expect(
+        await repo.getEquipmentIdsInSet('s1'),
+        unorderedEquals(['e1', 'e2']),
+      );
+    });
+
+    test('tombstones only the members actually removed', () async {
+      for (final id in ['e1', 'e2', 'e3']) {
+        await seedEquipment(id);
+      }
+      await repo.createSet(newSet('s1', ['e1', 'e2', 'e3']));
+
+      await repo.updateSet(newSet('s1', ['e1', 'e3']));
+
+      final tombs = await itemTombstones();
+      expect(tombs.map((t) => t.recordId), ['s1|e2']);
+      expect(
+        await repo.getEquipmentIdsInSet('s1'),
+        unorderedEquals(['e1', 'e3']),
+      );
+    });
+
+    test('a failed write rolls back and logs no sync bookkeeping', () async {
+      await seedEquipment('e1');
+
+      // No such set: the junction insert violates the set_id FK. The whole
+      // write must roll back, and because sync bookkeeping runs only after the
+      // transaction commits, nothing may be marked pending or tombstoned.
+      await expectLater(
+        repo.updateSet(newSet('ghost', ['e1'])),
+        throwsA(anything),
+      );
+
+      expect(await itemTombstones(), isEmpty);
+      final pending = await db.select(db.syncRecords).get();
+      expect(pending, isEmpty);
+    });
+  });
+
+  group('createSet', () {
+    test('ignores ids with no equipment row', () async {
+      await seedEquipment('e1');
+
+      await repo.createSet(newSet('s1', ['e1', 'gone']));
+
+      expect(await repo.getEquipmentIdsInSet('s1'), ['e1']);
+    });
+  });
+}

--- a/test/features/equipment/data/services/dive_equipment_defaulter_test.dart
+++ b/test/features/equipment/data/services/dive_equipment_defaulter_test.dart
@@ -18,10 +18,26 @@ void main() {
   setUp(() async {
     db = await setUpTestDatabase();
     // This test exercises junction writes (dive_equipment) without building
-    // full Dives/Equipment fixtures; relax FK enforcement for it.
+    // full Dives fixtures; relax FK enforcement for it.
     await db.customStatement('PRAGMA foreign_keys = OFF');
     sets = EquipmentSetRepository();
     defaulter = DiveEquipmentDefaulter();
+    // Set membership is pruned to ids that have a real equipment row, so these
+    // must exist even with FK enforcement off (issue #819).
+    final t = DateTime.now().millisecondsSinceEpoch;
+    for (final id in ['e1', 'e2', 'warm', 'drysuit']) {
+      await db
+          .into(db.equipment)
+          .insert(
+            EquipmentCompanion.insert(
+              id: id,
+              name: id,
+              type: 'bcd',
+              createdAt: t,
+              updatedAt: t,
+            ),
+          );
+    }
   });
   tearDown(tearDownTestDatabase);
 

--- a/test/features/equipment/presentation/pages/equipment_set_edit_page_test.dart
+++ b/test/features/equipment/presentation/pages/equipment_set_edit_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,7 @@ import 'package:submersion/features/dive_sites/presentation/providers/site_provi
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
 import 'package:submersion/features/equipment/presentation/pages/equipment_set_edit_page.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
@@ -35,11 +37,12 @@ void main() {
   });
   tearDown(tearDownTestDatabase);
 
-  Future<Widget> buildPage({String? setId}) async {
+  Future<Widget> buildPage({String? setId, bool realEquipment = false}) async {
     final overrides = await getBaseOverrides();
     overrides.addAll([
       validatedCurrentDiverIdProvider.overrideWith((ref) async => 'd1'),
-      activeEquipmentProvider.overrideWith((ref) async => <EquipmentItem>[]),
+      if (!realEquipment)
+        activeEquipmentProvider.overrideWith((ref) async => <EquipmentItem>[]),
       sitesProvider.overrideWith(
         (ref) async => const [
           DiveSite(
@@ -150,5 +153,80 @@ void main() {
     expect(sets, hasLength(1));
     expect(sets.first.isDefault, isTrue);
     expect(await repo.getGeofencesForSet(sets.first.id), hasLength(1));
+  });
+
+  testWidgets('saving a set survives a member being deleted while the form is '
+      'open (issue #819)', (tester) async {
+    final db = DatabaseService.instance.database;
+    final t = DateTime.now().millisecondsSinceEpoch;
+    for (final id in ['e1', 'e2', 'e3']) {
+      await db
+          .into(db.equipment)
+          .insert(
+            EquipmentCompanion.insert(
+              id: id,
+              name: id,
+              type: 'bcd',
+              createdAt: t,
+              updatedAt: t,
+              diverId: const Value('d1'),
+            ),
+          );
+    }
+    final repo = EquipmentSetRepository();
+    await repo.createSet(
+      EquipmentSet(
+        id: 's1',
+        diverId: 'd1',
+        name: 'My Equipment',
+        equipmentIds: const ['e1', 'e2', 'e3'],
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+
+    // Open the editor: the set provider caches all three members.
+    await tester.pumpWidget(await buildPage(setId: 's1', realEquipment: true));
+    await tester.pumpAndSettle();
+    expect(find.text('e2'), findsOneWidget);
+
+    // The diver deletes the BCD from the equipment tab -- through the same
+    // notifier that tab uses, so activeEquipmentProvider refreshes and the
+    // checkbox disappears. SQLite cascades the junction row away; before the
+    // fix the cached set kept the dead id and the save below died on
+    // SqliteException(787).
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(EquipmentSetEditPage)),
+    );
+    await container
+        .read(equipmentListNotifierProvider.notifier)
+        .deleteEquipment('e2');
+    await tester.pump(EquipmentSetRepository.changeTickDebounce * 2);
+    await tester.pumpAndSettle();
+    expect(find.text('e2'), findsNothing);
+
+    await tester.scrollUntilVisible(
+      find.widgetWithText(FilledButton, 'Save Changes'),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Save Changes'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Error saving equipment set'),
+      findsNothing,
+      reason: 'the stale member must not abort the save',
+    );
+    expect(
+      find.text('home'),
+      findsOneWidget,
+      reason: 'the form pops on success',
+    );
+    expect(
+      await repo.getEquipmentIdsInSet('s1'),
+      unorderedEquals(['e1', 'e3']),
+      reason: 'the surviving members must still be saved, not wiped',
+    );
   });
 }

--- a/test/features/equipment/presentation/providers/equipment_set_providers_reactivity_test.dart
+++ b/test/features/equipment/presentation/providers/equipment_set_providers_reactivity_test.dart
@@ -1,0 +1,252 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart'
+    hide EquipmentSet, EquipmentSetGeofence;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
+import 'package:submersion/features/equipment/presentation/providers/equipment_set_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// The equipment-set providers must refresh when the gear they point at
+/// changes, even when the write never touches [EquipmentSetListNotifier].
+///
+/// Issue #819: deleting a gear item cascades its `equipment_set_items` rows
+/// away, but the cached [EquipmentSet] kept serving the dead id. The edit form
+/// seeded its selection from that cache and the save died on the foreign key.
+/// Deleting equipment also happens during a sync or an import, which bypass the
+/// notifier entirely -- hence a table-change stream rather than hand-written
+/// invalidations on the mutation paths.
+void main() {
+  late AppDatabase db;
+  late EquipmentSetRepository setRepo;
+  late EquipmentRepository equipmentRepo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    setRepo = EquipmentSetRepository();
+    equipmentRepo = EquipmentRepository();
+    final t = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion.insert(
+            id: 'd1',
+            name: 'd1',
+            createdAt: t,
+            updatedAt: t,
+          ),
+        );
+    for (final id in ['e1', 'e2', 'e3']) {
+      await db
+          .into(db.equipment)
+          .insert(
+            EquipmentCompanion.insert(
+              id: id,
+              name: id,
+              type: 'bcd',
+              createdAt: t,
+              updatedAt: t,
+              diverId: const Value('d1'),
+            ),
+          );
+    }
+    await setRepo.createSet(
+      EquipmentSet(
+        id: 's1',
+        diverId: 'd1',
+        name: 'My Equipment',
+        equipmentIds: const ['e1', 'e2', 'e3'],
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  ProviderContainer makeContainer() {
+    final c = ProviderContainer(
+      overrides: [
+        validatedCurrentDiverIdProvider.overrideWith((ref) async => 'd1'),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  /// Polls [read] until [settled], budgeting off the repository's debounce
+  /// rather than a magic number.
+  Future<T> pollUntil<T>(
+    Future<T> Function() read,
+    bool Function(T) settled,
+  ) async {
+    final deadline = DateTime.now().add(
+      EquipmentSetRepository.changeTickDebounce * 20,
+    );
+    var value = await read();
+    while (!settled(value) && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      value = await read();
+    }
+    return value;
+  }
+
+  test('equipmentSetProvider drops a member deleted straight from the DB '
+      '(sync scenario)', () async {
+    final c = makeContainer();
+    // An active listener keeps the provider -- and its table-change
+    // subscription -- alive, mirroring a widget watching the set.
+    final sub = c.listen(equipmentSetProvider('s1'), (_, _) {});
+    addTearDown(sub.close);
+
+    expect((await c.read(equipmentSetProvider('s1').future))!.equipmentIds, [
+      'e1',
+      'e2',
+      'e3',
+    ]);
+
+    // No notifier involved: this is what a sync or an import does.
+    await equipmentRepo.deleteEquipment('e2');
+
+    final ids = await pollUntil(
+      () async =>
+          (await c.read(equipmentSetProvider('s1').future))!.equipmentIds,
+      (v) => v.length == 2,
+    );
+
+    expect(
+      ids,
+      unorderedEquals(['e1', 'e3']),
+      reason:
+          'drift propagates the equipment ON DELETE CASCADE to '
+          'equipment_set_items, so the set provider must re-read',
+    );
+  });
+
+  test('equipmentSetProvider drops the hydrated item too', () async {
+    final c = makeContainer();
+    final sub = c.listen(equipmentSetProvider('s1'), (_, _) {});
+    addTearDown(sub.close);
+
+    expect(
+      (await c.read(equipmentSetProvider('s1').future))!.items,
+      hasLength(3),
+    );
+
+    await equipmentRepo.deleteEquipment('e2');
+
+    final items = await pollUntil(
+      () async => (await c.read(equipmentSetProvider('s1').future))!.items!,
+      (v) => v.length == 2,
+    );
+    expect(items.map((e) => e.id), unorderedEquals(['e1', 'e3']));
+  });
+
+  test('equipmentSetProvider reflects a renamed member (rename does not '
+      'cascade, so the equipment table is watched directly)', () async {
+    final c = makeContainer();
+    final sub = c.listen(equipmentSetProvider('s1'), (_, _) {});
+    addTearDown(sub.close);
+
+    expect(
+      (await c.read(
+        equipmentSetProvider('s1').future,
+      ))!.items!.map((e) => e.name),
+      contains('e2'),
+    );
+
+    await (db.update(db.equipment)..where((t) => t.id.equals('e2'))).write(
+      const EquipmentCompanion(name: Value('Renamed BCD')),
+    );
+
+    final names = await pollUntil(
+      () async => (await c.read(
+        equipmentSetProvider('s1').future,
+      ))!.items!.map((e) => e.name).toList(),
+      (v) => v.contains('Renamed BCD'),
+    );
+    expect(names, contains('Renamed BCD'));
+  });
+
+  test('equipmentSetsProvider drops the member from the list view', () async {
+    final c = makeContainer();
+    final sub = c.listen(equipmentSetsProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    expect((await c.read(equipmentSetsProvider.future)).single.itemCount, 3);
+
+    await equipmentRepo.deleteEquipment('e2');
+
+    final count = await pollUntil(
+      () async => (await c.read(equipmentSetsProvider.future)).single.itemCount,
+      (v) => v == 2,
+    );
+    expect(
+      count,
+      2,
+      reason: 'the sets list renders itemCount off equipmentIds',
+    );
+  });
+
+  test('equipmentSetWithItemsProvider shares the refreshed cache', () async {
+    final c = makeContainer();
+    final sub = c.listen(equipmentSetWithItemsProvider('s1'), (_, _) {});
+    addTearDown(sub.close);
+
+    expect(
+      (await c.read(equipmentSetWithItemsProvider('s1').future))!.equipmentIds,
+      hasLength(3),
+    );
+
+    await equipmentRepo.deleteEquipment('e2');
+
+    final ids = await pollUntil(
+      () async => (await c.read(
+        equipmentSetWithItemsProvider('s1').future,
+      ))!.equipmentIds,
+      (v) => v.length == 2,
+    );
+    expect(
+      ids,
+      unorderedEquals(['e1', 'e3']),
+      reason:
+          'the picker sheet reads this provider; as an independent cache it '
+          'was never invalidated by anything',
+    );
+  });
+
+  test(
+    'equipmentSetListNotifier refreshes its list on a gear delete',
+    () async {
+      final c = makeContainer();
+      final sub = c.listen(equipmentSetListNotifierProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      final counts = await pollUntil(
+        () async => c
+            .read(equipmentSetListNotifierProvider)
+            .valueOrNull
+            ?.map((s) => s.itemCount)
+            .toList(),
+        (v) => v != null && v.isNotEmpty,
+      );
+      expect(counts, [3]);
+
+      await equipmentRepo.deleteEquipment('e2');
+
+      final after = await pollUntil(
+        () async => c
+            .read(equipmentSetListNotifierProvider)
+            .valueOrNull
+            ?.map((s) => s.itemCount)
+            .toList(),
+        (v) => v != null && v.isNotEmpty && v.first == 2,
+      );
+      expect(after, [2]);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #819. Deleting a gear item that belonged to an equipment set left the set unusable — editing it and saving died with `SqliteException(787): FOREIGN KEY constraint failed` on an `INSERT INTO "equipment_set_items"`.

**The database was behaving correctly.** `equipment_set_items` declares `onDelete: KeyAction.cascade` and foreign keys are ON, so SQLite removed the junction row. The stale membership lived in Riverpod: `EquipmentListNotifier.refresh()` invalidated six equipment providers and zero equipment-*set* providers, and none of the set providers carried an `invalidateSelfWhen`. The edit form then seeded its selection from the pre-delete snapshot (3 ids) while rendering checkboxes from the fresh equipment list (2 tiles) — the deleted id was selected, invisible, and impossible to un-check. That mismatch is exactly why the reporter saw the detail view show 3 members and the edit form show 2.

The same flow exposed a **second, more damaging defect**: `updateSet` was not transactional. It deleted every junction row, tombstoned each one for sync, and only then re-inserted — so the failing save left the set **empty with the deletions already logged**, propagating the emptiness to the diver's other devices. The error message understated what had happened.

## Changes

**Repository (`equipment_set_repository_impl.dart`)**
- `watchSetChanges()` — a debounced (300 ms) `tableUpdates` stream over `equipment_sets`, `equipment_set_items`, `equipment` and `equipment_set_geofences`. Watching `equipment_set_items` catches gear deletes through drift's generated `WritePropagation` for the cascade; that propagation carries `limitUpdateKind: UpdateKind.delete`, so `equipment` is watched directly to pick up renames.
- `updateSet` / `createSet` are now transactional and reconcile membership as a **diff**, mirroring `DivePlanRepository.updatePlan`, with sync bookkeeping after the commit. Unchanged members no longer emit a tombstone plus a live pending marker on every save — the churn `SyncService`'s contradicted-key handling exists to absorb.
- Membership is pruned to ids that still have an `equipment` row, logged at `warning`. Deliberately not `insertOrIgnore`: this is a foreign-key violation rather than a uniqueness conflict, and swallowing it silently would hide precisely the provider-staleness regression this fixes.

**Providers (`equipment_set_providers.dart`)**
- `invalidateSelfWhen` on `equipmentSetsProvider` and `equipmentSetProvider` only; the derived providers re-derive through them. A stream rather than hand-written invalidations because sync, imports and dive-computer downloads all delete equipment without touching the notifier.
- `equipmentSetWithItemsProvider` now delegates to `equipmentSetProvider`. Despite documenting itself as an alias it was a separate cache that **nothing ever invalidated**, so the dive-log "use set" picker could render arbitrarily stale membership.
- `EquipmentSetListNotifier` subscribes to the stream (a `StateNotifier` cannot self-invalidate), reloading without dropping to `AsyncValue.loading` so the list does not flash, and only once the diver id has resolved — a null id means "no filter", which would briefly publish every diver's sets.

**Edit page (`equipment_set_edit_page.dart`)**
- Reconciles the selection against equipment that still exists, deliberately keeping retired members and any the diver-scoped provider does not return.

**Test fixture**
- `dive_equipment_defaulter_test` ran with `PRAGMA foreign_keys = OFF` and built sets from equipment ids that had no `equipment` row at all — a state the database cannot hold in production. Seeded the rows.

## Test Plan

- [x] `flutter test` passes — 16076 passed, 15 skipped, 0 failed
- [x] `flutter analyze` passes — no issues
- [x] `dart format` clean
- [x] Manual testing on: not yet run

13 new tests, each **verified failing against the pre-fix code** — the repository tests reproduce the exact production `SqliteException(787)`:

- `equipment_set_repository_items_test.dart` (new) — the #819 repro, rollback leaves membership and the deletion log untouched, unchanged membership writes no tombstones, only genuinely removed members are tombstoned.
- `equipment_set_providers_reactivity_test.dart` (new) — the cascade tick reaches the cache with no notifier involved (the sync path), renames surface, and the list/picker/notifier surfaces all settle.
- `equipment_set_edit_page_test.dart` — end-to-end: open the editor, delete a member, save succeeds and the survivors persist.

One earlier full-suite run showed 2 failures in `saved_plans_sheet_test` and `shearwater_db_reader_test`. Both pass in isolation, neither references `EquipmentSet`, and the shearwater one is a pure gzip decompression test that touches neither the database nor Riverpod. A clean re-run confirmed them as load-sensitive flakes.

## Follow-up (not in this PR)

`deleteEquipment` does not tombstone the cascaded `equipment_set_items`, `dive_equipment`, `dive_plan_equipment` or `equipment_attributes` rows. `SyncService`'s `parentRefs` marks those parents non-nullable, so the parent-deletion guard already drops such inbound records — no reproduction, and bundling it would enlarge the diff into the riskiest file in the repo.
