### PR TITLE
Drop unused ChartAxis members and cover the empty-series guard

### DIFF
--- a/lib/features/statistics/presentation/widgets/chart_axis.dart
+++ b/lib/features/statistics/presentation/widgets/chart_axis.dart
@@ -128,9 +128,23 @@ class ChartAxis {
         magnitude;
   }
 
+  /// The largest power of ten not exceeding [value], so that
+  /// `value / _magnitudeOf(value)` always lands inside `[1, 10)`.
+  ///
+  /// The floor of `log(value) / ln10` is not enough on its own: for some exact
+  /// powers of ten the division comes back a few ULPs short of the whole
+  /// number (`log(1000) / ln10` is 2.9999999999999996, likewise at 1e6 and
+  /// 1e9), which floors one exponent too low and pushes the normalized value
+  /// to exactly 10. The correction restores the range the callers rely on.
   static double _magnitudeOf(double value) {
     if (!value.isFinite || value <= 0) return 1;
-    return math.pow(10, (math.log(value) / math.ln10).floor()).toDouble();
+
+    final magnitude = math
+        .pow(10, (math.log(value) / math.ln10).floor())
+        .toDouble();
+    if (value / magnitude >= 10) return magnitude * 10;
+    if (value / magnitude < 1) return magnitude / 10;
+    return magnitude;
   }
 
   /// Relative slack so a value already sitting on a tick is not pushed a whole

--- a/lib/features/statistics/presentation/widgets/chart_axis.dart
+++ b/lib/features/statistics/presentation/widgets/chart_axis.dart
@@ -121,10 +121,11 @@ class ChartAxis {
     final magnitude = _magnitudeOf(interval);
     final normalized = interval / magnitude;
     final steps = wholeSteps ? _wholeSteps : _fractionalSteps;
-    for (final step in steps) {
-      if (step > normalized * (1 + _epsilon)) return step * magnitude;
-    }
-    return 10 * magnitude;
+    // _magnitudeOf floors the exponent, so normalized is in [1, 10) and the
+    // trailing 10 in both ladders always matches. A throw here would mean that
+    // invariant broke, which is worth hearing about rather than papering over.
+    return steps.firstWhere((step) => step > normalized * (1 + _epsilon)) *
+        magnitude;
   }
 
   static double _magnitudeOf(double value) {
@@ -141,17 +142,4 @@ class ChartAxis {
 
   static double _ceilTo(double value, double interval) =>
       (value / interval - _epsilon).ceilToDouble() * interval;
-
-  @override
-  bool operator ==(Object other) =>
-      other is ChartAxis &&
-      other.min == min &&
-      other.max == max &&
-      other.interval == interval;
-
-  @override
-  int get hashCode => Object.hash(min, max, interval);
-
-  @override
-  String toString() => 'ChartAxis(min: $min, max: $max, interval: $interval)';
 }

--- a/test/features/statistics/presentation/widgets/chart_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/chart_axis_test.dart
@@ -91,6 +91,50 @@ void main() {
     });
   });
 
+  group('ChartAxis step ladder', () {
+    // math.log(1000) / math.ln10 is 2.9999999999999996, so flooring it alone
+    // put the normalized step at exactly 10 for intervals of 1e3, 1e6 and 1e9.
+    // The ladder ends at 10, so the search for a wider rung found nothing and
+    // threw "Bad state: No element" while snapping the axis.
+    test('survives a step that lands on an exact power of ten', () {
+      expect(
+        () => ChartAxis.forTrend(const [1407.7040137891763, 5630.816055156705]),
+        returnsNormally,
+      );
+      expect(
+        () => ChartAxis.forTrend(const [789.8540953036263, 5528.978667125384]),
+        returnsNormally,
+      );
+    });
+
+    test('produces a valid axis across a wide span of ranges', () {
+      for (var span = 1.0; span <= 200000; span *= 1.01) {
+        for (final lowest in [0.0, 1.0, span / 3]) {
+          final axis = ChartAxis.forTrend([lowest, lowest + span]);
+
+          expect(
+            axis.max,
+            greaterThan(axis.min),
+            reason: 'empty axis for [$lowest, ${lowest + span}]',
+          );
+          expect(
+            _isOnTick(axis.min, axis.interval),
+            isTrue,
+            reason: 'min ${axis.min} off tick for span $span',
+          );
+          expect(
+            _isOnTick(axis.max, axis.interval),
+            isTrue,
+            reason: 'max ${axis.max} off tick for span $span',
+          );
+          expect(axis.max, greaterThanOrEqualTo(lowest + span));
+        }
+
+        expect(() => ChartAxis.forCounts(span), returnsNormally);
+      }
+    });
+  });
+
   group('ChartAxis.forCounts', () {
     test('anchors at zero and steps in whole dives', () {
       final axis = ChartAxis.forCounts(10);

--- a/test/features/statistics/presentation/widgets/chart_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/chart_axis_test.dart
@@ -72,6 +72,15 @@ void main() {
       expect(axis.interval, greaterThan(0));
     });
 
+    test('stays drawable when handed no values at all', () {
+      final axis = ChartAxis.forTrend(const []);
+
+      expect(axis.max, greaterThan(axis.min));
+      expect(axis.interval, greaterThan(0));
+      expect(_isOnTick(axis.min, axis.interval), isTrue);
+      expect(_isOnTick(axis.max, axis.interval), isTrue);
+    });
+
     test('handles sub-unit SAC pressure values without collapsing', () {
       // bar/min SAC lives well under 1; the interval must scale down with it.
       final axis = ChartAxis.forTrend(const [0.52, 0.61, 0.58, 0.74]);


### PR DESCRIPTION
## Summary

Follow-up to #948, which merged before this landed on the branch. Addresses the
Codecov report on that PR: patch coverage 84.06%, with 11 lines uncovered in the
new `chart_axis.dart`.

Reading the gap rather than just filling it, only one of the three causes was
actually untested behaviour:

- **8 lines were dead API.** `operator ==`, `hashCode` and `toString` were added
  speculatively. `ChartAxis` is built fresh inside `build()` and is never
  compared, hashed or printed anywhere in the codebase. Removed.
- **1 line looked structurally unreachable, and was not.** The trailing
  `return 10 * magnitude` in `_nextStepUp` was removed on the grounds that
  `normalized` is always in `[1, 10)`. Review on this PR caught that the claim
  is false, and the removal turned a graceful degradation into a crash. See the
  correction below.

- **The genuine gap** was `ChartAxis.forTrend` handed an empty series, which
  still has to produce a drawable axis. That one gets a test.

Writing tests for the dead API would have been coverage theatre. `chart_axis.dart`
is now at 52/52 lines.

## Correction: a crash introduced and fixed within this PR

The second bullet above was wrong, and Copilot's review caught it.
`math.log(1000) / math.ln10` is `2.9999999999999996`, so flooring it yields 2,
`_magnitudeOf` returns 100 instead of 1000, and `normalized` lands on exactly
`10`. The same holds at 1e6, 1e9 and 1e12. Both step ladders end at 10, so the
search for a wider rung matched nothing and threw `Bad state: No element` while
snapping the axis. A sweep over the public API found 22 reproducing inputs, for
instance `ChartAxis.forTrend([1407.7040137891763, 5630.816055156705])`.

The deleted fallback had been quietly absorbing this: it returned `10 *
magnitude`, which equalled the current interval, so the caller's
`if (wider <= interval) break` ended the loop cleanly.

Fixed at the source rather than by restoring the fallback: `_magnitudeOf` now
corrects the exponent in either direction, so `value / magnitude` genuinely sits
in `[1, 10)` and the `firstWhere` is safe. Restoring the fallback would have kept
a broken contract alive behind a plausible-looking default.

## Changes

- Remove unused `operator ==`, `hashCode` and `toString` from `ChartAxis`.
- Simplify `_nextStepUp` to a single `firstWhere` expression.
- Correct `_magnitudeOf` so `value / magnitude` really is in `[1, 10)`, fixing
  the `Bad state: No element` crash that the `firstWhere` exposed.
- Add a `ChartAxis.forTrend(const [])` test asserting the empty-series axis is
  still drawable and tick-aligned.
- Add regression tests for the power-of-ten step: the two reproducing inputs
  plus a sweep over spans from 1 to 200000 asserting every axis is non-empty and
  tick-aligned. Both fail against the previous commit with that StateError.

## Test Plan

- [x] `flutter analyze` passes
- [x] `dart format .` clean
- [x] Chart axis and stat chart tests pass (28)
- [x] `chart_axis.dart` line coverage 52/52
- [x] `flutter test` full suite passes
- [ ] Manual testing: not applicable, no behaviour change

The removed members had no callers. The one behaviour change is the
`_magnitudeOf` correction, which fixes a crash.
