### PR TITLE
test(zoom): probe hit testing across window sizes (#953)

### DIFF
--- a/test/core/theme/display_zoom_hit_test.dart
+++ b/test/core/theme/display_zoom_hit_test.dart
@@ -2,6 +2,33 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/theme/display_zoom.dart';
 
+/// Window sizes to re-run the geometry checks at.
+///
+/// A dead band produced by hit-testing a `sizedByParent` box through the
+/// enclosing transform is a FRACTION of the window, not a fixed inset, so it is
+/// invisible at the default 800x600 test surface and obvious on a maximised
+/// desktop window. Issue #953 was reported at roughly 1120x850 logical: the
+/// same button was live in a narrow window and dead in a wide one.
+const _windows = <Size>[
+  Size(400, 300),
+  Size(800, 600),
+  Size(1120, 850),
+  Size(1600, 1000),
+];
+
+/// Resizes the test view, which drives the layout constraints and the implicit
+/// MediaQuery together.
+///
+/// `setSurfaceSize` is deliberately not used: it moves the render surface but
+/// leaves the view metrics alone, so `DisplayZoomScope` would read a stale
+/// `MediaQuery.size` and compute its logical size against a window that is not
+/// the one being laid out.
+void _resizeWindow(WidgetTester tester, Size size) {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+}
+
 void main() {
   for (final zoom in const [0.7, 0.8, 1.0, 1.3, 1.4]) {
     testWidgets('forwards taps through the transform at zoom $zoom', (
@@ -79,45 +106,109 @@ void main() {
     });
   }
 
-  for (final zoom in const [0.7, 0.8, 1.0, 1.3, 1.4]) {
-    testWidgets('hit-tests every corner of the window at zoom $zoom', (
-      tester,
-    ) async {
-      final hits = <Offset>[];
+  for (final zoom in const [0.7, 0.8, 0.95, 1.0, 1.05, 1.3, 1.4]) {
+    for (final window in _windows) {
+      testWidgets('hit-tests every corner of a ${window.width.toInt()}x'
+          '${window.height.toInt()} window at zoom $zoom', (tester) async {
+        _resizeWindow(tester, window);
+        final hits = <Offset>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: DisplayZoomScope(
+              zoom: zoom,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTapDown: (details) => hits.add(details.globalPosition),
+                child: const SizedBox.expand(),
+              ),
+            ),
+          ),
+        );
+
+        final corners = <Offset>[
+          const Offset(1, 1),
+          Offset(window.width - 1, 1),
+          Offset(1, window.height - 1),
+          Offset(window.width - 1, window.height - 1),
+        ];
+
+        for (final corner in corners) {
+          await tester.tapAt(corner);
+          await tester.pump();
+        }
+
+        expect(
+          hits,
+          corners,
+          reason:
+              'the whole painted window must stay hit-testable at zoom $zoom '
+              'in a ${window.width}x${window.height} window; missing corners '
+              'mean the scaled subtree is laid out larger than the box that '
+              'guards the hit test',
+        );
+      });
+    }
+  }
+
+  // Issue #953: the same controls were live in a narrow/short window and dead
+  // in a wide/tall one at the same zoom. Growing the window must not move the
+  // hit box off the control, so the identical probes run at every size.
+  for (final window in _windows) {
+    testWidgets('keeps edge controls live in a ${window.width.toInt()}x'
+        '${window.height.toInt()} window at 95% zoom', (tester) async {
+      _resizeWindow(tester, window);
+      var menuTaps = 0;
+      var rowTaps = 0;
 
       await tester.pumpWidget(
         MaterialApp(
           home: DisplayZoomScope(
-            zoom: zoom,
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTapDown: (details) => hits.add(details.globalPosition),
-              child: const SizedBox.expand(),
+            zoom: 0.95,
+            child: Scaffold(
+              appBar: AppBar(
+                title: const Text('Shearwater Petrel 3'),
+                actions: [
+                  IconButton(
+                    tooltip: 'Show menu',
+                    icon: const Icon(Icons.more_horiz),
+                    onPressed: () => menuTaps++,
+                  ),
+                ],
+              ),
+              // Fills the body so the last row sits against the bottom edge,
+              // matching the tag list in the report.
+              body: Column(
+                children: [
+                  const Spacer(),
+                  ListTile(
+                    title: const Text('backmount'),
+                    onTap: () => rowTaps++,
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       );
 
-      final window = tester.view.physicalSize / tester.view.devicePixelRatio;
-      final corners = <Offset>[
-        const Offset(1, 1),
-        Offset(window.width - 1, 1),
-        Offset(1, window.height - 1),
-        Offset(window.width - 1, window.height - 1),
-      ];
-
-      for (final corner in corners) {
-        await tester.tapAt(corner);
-        await tester.pump();
-      }
+      await tester.tap(find.byIcon(Icons.more_horiz));
+      await tester.tap(find.text('backmount'));
+      await tester.pump();
 
       expect(
-        hits,
-        corners,
+        menuTaps,
+        1,
         reason:
-            'the whole painted window must stay hit-testable at zoom $zoom; '
-            'missing corners mean the scaled subtree is laid out larger than '
-            'the box that guards the hit test',
+            'the top-right app bar action must stay tappable in a '
+            '${window.width}x${window.height} window',
+      );
+      expect(
+        rowTaps,
+        1,
+        reason:
+            'the bottom-most list row must stay tappable in a '
+            '${window.width}x${window.height} window',
       );
     });
   }


### PR DESCRIPTION
Closes #953 (already fixed on `main`; this adds the regression coverage that was missing).

## What #953 actually was

The reporter saw the same controls respond in a small macOS window and go dead in a large one — the ⋯ app bar action on the dive computer page, the bottom row of the tags list — with no tooltip and no hover highlight in the large window.

That is the display-zoom hit-test defect fixed in 9786492997c, seen from the user side. The dead band is `(1 - zoom) x windowSize`: a **fraction** of the window, not a fixed inset. A control at a constant offset from the window edge therefore falls inside it only once the window grows past a threshold, which presents as "resizing changes which buttons work" and hides the fact that zoom is involved at all.

Measuring the ⋯ button's inset from the window edge in the two reported width screenshots (identical in both, ~20 logical pt) and solving against the two window widths pins the reporter's zoom to **95%**. The same arithmetic reproduces the tags-list behaviour on the vertical axis.

### Why users are hitting it

The fix is not an ancestor of the release the reporter is on:

| Commit | Date | |
| --- | --- | --- |
| `5ba572483fc` bump to 1.7.2 | Aug 1 | reporter's build |
| `1bd41f1e5a2` bump to 1.7.3 | Aug 3 | |
| `9786492997c` zoom hit-test fix | Aug 7 | not in either |

Expect duplicate reports until the next release ships.

## Why the existing tests did not cover it

`display_zoom_hit_test.dart` already probed the four window corners, which is what caught the original defect at zoom 0.70. But it only ever ran at the default 800x600 surface, and it only tested zooms at 0.70/0.80/1.30/1.40. At a zoom near 1.0 the dead band on an 800x600 surface is roughly 40 px — thin enough that a corner probe at `size - 1` is the only thing that lands in it, and nothing realistic does.

## Changes

- Re-run the corner probes across 400x300, 800x600, 1120x850 (the reported window size) and 1600x1000.
- Add zoom 0.95 and 1.05 to the probed levels.
- Add a test that taps a top-right app bar action and a bottom-most list row at 95% zoom at every window size — the reporter's literal repro.
- Resize with `tester.view.physicalSize` rather than `setSurfaceSize`, which moves the render surface but leaves the view metrics that `DisplayZoomScope` reads `MediaQuery.size` from, silently desyncing the geometry under test.

Test only. No production code is touched.

## Verification

Reverted `DisplayZoomScope` to the pre-fix nesting (`OverflowBox` inside `Transform.scale`) and confirmed the new test reproduces the reported gradient at 95% zoom, then restored it:

| Window | pre-fix | on `main` |
| --- | --- | --- |
| 400x300 | passes | passes |
| 800x600 | fails | passes |
| 1120x850 | fails | passes |
| 1600x1000 | fails | passes |

`flutter analyze` clean, `dart format` clean, `flutter test test/core/theme/` green (85 tests).