### PR TITLE
fix(courses): course page stops showing a dive after it's merged away

### DIFF
--- a/lib/features/courses/presentation/providers/course_providers.dart
+++ b/lib/features/courses/presentation/providers/course_providers.dart
@@ -135,21 +135,40 @@ final courseForCertificationProvider = FutureProvider.family<Course?, String>((
   return repository.getCourseForCertification(certificationId);
 });
 
-/// Dives for a specific course
+/// Dives for a specific course.
+///
+/// Self-invalidates on any `dives` table write (a merge/consolidate, a direct
+/// edit, a sync apply, ...). The only manual invalidation paths are
+/// [CourseListNotifier.linkDiveToCourse]/[CourseListNotifier.unlinkDiveFromCourse]
+/// and the dive edit form's course reassignment; a merge or consolidate deletes
+/// the losing dive straight through `DiveRepository.bulkDeleteDives`, bypassing
+/// all of them. Without this the course detail page keeps listing a dive that
+/// was merged away -- while `courseProgressProvider`, which already watches this
+/// tick, drops it from the requirements section on the same page.
 final courseDivesProvider = FutureProvider.family<List<Dive>, String>((
   ref,
   courseId,
 ) async {
   final diveRepository = ref.watch(diveRepositoryProvider);
+
+  ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+
   return diveRepository.getDivesForCourse(courseId);
 });
 
-/// Dive count for a course
+/// Dive count for a course.
+///
+/// See [courseDivesProvider] for why this self-invalidates on dives-table
+/// writes; `getDiveCountForCourse` counts the same rows.
 final courseDiveCountProvider = FutureProvider.family<int, String>((
   ref,
   courseId,
 ) async {
   final repository = ref.watch(courseRepositoryProvider);
+  final diveRepository = ref.watch(diveRepositoryProvider);
+
+  ref.invalidateSelfWhen(diveRepository.watchDivesChanges());
+
   return repository.getDiveCountForCourse(courseId);
 });
 

--- a/test/features/courses/presentation/providers/course_providers_test.dart
+++ b/test/features/courses/presentation/providers/course_providers_test.dart
@@ -6,6 +6,8 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/courses/data/repositories/course_repository.dart';
 import 'package:submersion/features/courses/domain/entities/course.dart';
 import 'package:submersion/features/courses/presentation/providers/course_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -57,6 +59,7 @@ void main() {
   late SharedPreferences prefs;
   late CourseRepository courseRepo;
   late DiverRepository diverRepo;
+  late DiveRepository diveRepo;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -64,6 +67,7 @@ void main() {
     await setUpTestDatabase();
     courseRepo = CourseRepository();
     diverRepo = DiverRepository();
+    diveRepo = DiveRepository();
   });
 
   tearDown(() async {
@@ -82,6 +86,67 @@ void main() {
     final diver = await diverRepo.createDiver(_makeDiver());
     await prefs.setString(currentDiverIdKey, diver.id);
     return diver;
+  }
+
+  /// Polls [read] until [settled] holds, giving the dives-table tick ->
+  /// invalidateSelfWhen -> rebuild round trip a chance to run.
+  ///
+  /// The budget is derived from [DiveRepository.changeTickDebounce] rather than
+  /// hard-coded: `watchDivesChanges()` is debounced, so a budget copied from a
+  /// test that watches an undebounced stream would be largely consumed before
+  /// the tick even fires. Never settling fails here, naming the round trip that
+  /// stalled and the stale contents still held, instead of surfacing as a bare
+  /// value mismatch that reads like a wrong query.
+  Future<T> pollUntil<T>(
+    Future<T> Function() read,
+    bool Function(T value) settled, {
+    required String awaiting,
+    required String provider,
+    required String Function(T value) describe,
+  }) async {
+    const interval = Duration(milliseconds: 20);
+    final budget = DiveRepository.changeTickDebounce * 20;
+    final deadline = DateTime.now().add(budget);
+
+    var value = await read();
+    while (!settled(value) && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(interval);
+      value = await read();
+    }
+
+    if (!settled(value)) {
+      fail(
+        'Timed out after ${budget.inMilliseconds}ms waiting for $awaiting. '
+        'The dives-table tick -> invalidateSelfWhen -> rebuild round trip '
+        'never settled; $provider still holds ${describe(value)}.',
+      );
+    }
+    return value;
+  }
+
+  /// Seeds a course owned by [diver] plus two dives linked to it, mirroring the
+  /// state the course detail page renders before a merge folds one dive away.
+  Future<(Course, Dive, Dive)> seedCourseWithTwoDives(Diver diver) async {
+    final course = await courseRepo.createCourse(
+      _makeCourse(name: 'Rescue Diver', diverId: diver.id),
+    );
+    final survivor = await diveRepo.createDive(
+      Dive(
+        id: '',
+        diverId: diver.id,
+        dateTime: DateTime(2024, 6, 1),
+        courseId: course.id,
+      ),
+    );
+    final loser = await diveRepo.createDive(
+      Dive(
+        id: '',
+        diverId: diver.id,
+        dateTime: DateTime(2024, 6, 2),
+        courseId: course.id,
+      ),
+    );
+    return (course, survivor, loser);
   }
 
   group('allCoursesProvider', () {
@@ -214,6 +279,82 @@ void main() {
       }
 
       expect(container.read(courseListNotifierProvider).hasError, isTrue);
+    });
+  });
+
+  group('courseDivesProvider', () {
+    test('auto-refreshes after a course dive is deleted directly from the DB '
+        '(dive merge/consolidate scenario)', () async {
+      final diver = await seedCurrentDiver();
+      final (course, survivor, loser) = await seedCourseWithTwoDives(diver);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // Active listener keeps the provider (and its dives-table subscription)
+      // alive, mirroring the course detail page watching the dive list.
+      final sub = container.listen(courseDivesProvider(course.id), (_, _) {});
+      addTearDown(sub.close);
+
+      final initial = await container.read(
+        courseDivesProvider(course.id).future,
+      );
+      expect(initial.map((d) => d.id), containsAll([survivor.id, loser.id]));
+
+      // A merge or consolidate deletes the losing dive through bulkDeleteDives
+      // (dive_merge_service.dart, dive_consolidation_service.dart), bypassing
+      // CourseListNotifier entirely -- the same primitive a sync pull uses when
+      // applying a remote deletion. The provider has to notice on its own.
+      await diveRepo.bulkDeleteDives([loser.id]);
+
+      final dives = await pollUntil(
+        () => container.read(courseDivesProvider(course.id).future),
+        (d) => !d.any((dive) => dive.id == loser.id),
+        awaiting: 'the merged-away dive to leave the course dive list',
+        provider: 'courseDivesProvider',
+        describe: (d) => d.map((dive) => dive.id).toList().toString(),
+      );
+
+      expect(
+        dives.map((d) => d.id).toList(),
+        equals([survivor.id]),
+        reason:
+            'courseDivesProvider should auto-refresh after a dive delete, the '
+            'same way courseProgressProvider already does for the requirements '
+            'section on the same page',
+      );
+    });
+  });
+
+  group('courseDiveCountProvider', () {
+    test('auto-refreshes after a course dive is deleted directly from the DB '
+        '(dive merge/consolidate scenario)', () async {
+      final diver = await seedCurrentDiver();
+      final (course, _, loser) = await seedCourseWithTwoDives(diver);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(
+        courseDiveCountProvider(course.id),
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(courseDiveCountProvider(course.id).future),
+        2,
+      );
+
+      await diveRepo.bulkDeleteDives([loser.id]);
+
+      final count = await pollUntil(
+        () => container.read(courseDiveCountProvider(course.id).future),
+        (c) => c == 1,
+        awaiting: 'the course dive count to drop the merged-away dive',
+        provider: 'courseDiveCountProvider',
+        describe: (c) => '$c',
+      );
+
+      expect(count, 1);
     });
   });
 }


### PR DESCRIPTION
## Summary

The course detail page kept showing a dive after a merge or consolidate folded it away, and kept counting it. This is the trips fix from #958 applied to courses.

`courseDivesProvider` and `courseDiveCountProvider` both read the `dives` table but never subscribed to its change tick. The only invalidation paths were `CourseListNotifier.linkDiveToCourse` / `unlinkDiveFromCourse` and the dive edit form's course reassignment. A merge or consolidate deletes the losing dive straight through `DiveRepository.bulkDeleteDives` (`dive_merge_service.dart:443`, `dive_consolidation_service.dart:588`), and a sync pull applying a remote deletion uses the same primitive, so none of those paths fired.

That left the page contradicting itself. `courseProgressProvider` already self-invalidates on `watchDivesChanges()`, so the requirements section dropped the merged-away dive immediately while the dive list above it kept showing it until an app restart or an unrelated invalidation.

The stale cache also reached a second, quieter consumer: the PDF training-log export (`course_detail_page.dart:725`) reads `courseDivesProvider`, so an exported log could list a dive that no longer exists.

Closes #970.

## Changes

- `courseDivesProvider` — added `ref.invalidateSelfWhen(diveRepository.watchDivesChanges())`, the same pattern `courseProgressProvider`, `suggestedDivesProvider`, and `activeCoursesProgressProvider` already use on this page.
- `courseDiveCountProvider` — same tick, plus `ref.watch(diveRepositoryProvider)` since it otherwise only held the course repository. This provider currently has no UI consumer; it is kept rather than deleted so it stays correct if something wires it up, and dead-code removal stays a separate concern.
- Doc comments on both providers naming the bypass (`bulkDeleteDives`) that makes the subscription necessary, so the next reader does not have to rediscover it.
- Two tests in `course_providers_test.dart`, one per provider, deleting a course-linked dive via `diveRepo.bulkDeleteDives([...])` and asserting the provider drops it, with an active listener keeping the subscription alive.

`watchDivesChanges()` is already `.debounce(changeTickDebounce)` at 300 ms and constructs a fresh stream per call, so this does not reintroduce the invalidation storm from #427.

### Test budget

The poll budget is derived from `DiveRepository.changeTickDebounce` (`* 20`) rather than hard-coded, and fails explicitly on timeout naming the stalled round trip and the stale contents still held — following f0c0118c1a5. This matters here: `watchDivesChanges()` is debounced, so the 500 ms budget used by tests that watch an undebounced stream would be mostly consumed before the tick ever fires.

Both tests were run against the unfixed providers first and observed to fail on that timeout diagnostic (`courseDivesProvider still holds [<survivor>, <loser>]` / `courseDiveCountProvider still holds 2`), so they are verified non-vacuous.

## Test Plan

- [x] `flutter test` passes — full suite, 16222 passed / 15 skipped
- [x] `flutter analyze` passes — No issues found
- [x] `dart format lib/ test/` clean
- [x] Manual testing: not performed. The reproduction (log two dives into a course, merge them, watch the course detail page) is covered by the new provider-level tests.

## Screenshots

Not applicable — no visual changes; this is a cache-invalidation fix.

## Follow-up, not addressed here

Nothing mechanically enforces this convention, and a survey found several more live instances of the same gap — the statistics block (~35 providers riding a version counter that merge/consolidate never bumps), three providers on the buddy detail page, `orderedDiveIdsProvider` (stale prev/next navigation), `diveRecordsProvider`, and `weeklyOtuProvider`. Filed as #974 with the full inventory and citations.
