### PR TITLE
fix(home): maintenance-due taps open the equipment item, not the list

### DIFF
--- a/lib/features/dashboard/presentation/providers/gauge_providers.dart
+++ b/lib/features/dashboard/presentation/providers/gauge_providers.dart
@@ -41,11 +41,16 @@ enum HomeChipType {
 /// The worst service clock for one equipment type, shown as one chip.
 class GearGauge {
   final EquipmentType type;
+
+  /// Id of the item the chip names, so the tap can open that item rather
+  /// than the equipment list (issue #816).
+  final String itemId;
   final String itemName;
   final ServiceClockStatus status;
 
   const GearGauge({
     required this.type,
+    required this.itemId,
     required this.itemName,
     required this.status,
   });
@@ -123,6 +128,7 @@ List<GearGauge> worstGaugePerType(List<EquipmentClocks> clocks) {
     for (final status in entry.statuses) {
       final candidate = GearGauge(
         type: entry.item.type,
+        itemId: entry.item.id,
         itemName: entry.item.name,
         status: status,
       );

--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -98,7 +98,9 @@ class GaugeStrip extends ConsumerWidget {
               icon: Icons.build_outlined,
               label: label,
               tone: tone,
-              onTap: () => context.push('/equipment'),
+              // The chip names one item, so open that item rather than the
+              // list the diver would then have to search.
+              onTap: () => context.push('/equipment/${gauge.itemId}'),
             ),
           );
         }

--- a/lib/features/dashboard/presentation/widgets/urgent_banner.dart
+++ b/lib/features/dashboard/presentation/widgets/urgent_banner.dart
@@ -6,8 +6,12 @@ import 'package:submersion/features/dashboard/presentation/providers/dashboard_p
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// One line of the urgent banner and the place that fixes it.
+typedef _UrgentLine = ({String label, String destination});
+
 /// Compact banner listing only genuinely urgent items: overdue service
-/// and expired insurance. Hidden otherwise.
+/// and expired insurance. Hidden otherwise. Each line is its own tap
+/// target so it can open the specific item it names.
 class UrgentBanner extends ConsumerWidget {
   const UrgentBanner({super.key});
 
@@ -26,56 +30,84 @@ class UrgentBanner extends ConsumerWidget {
     final scheme = Theme.of(context).colorScheme;
     // Cap the overdue-gear lines so a diver with many lapsed clocks doesn't
     // get a banner that dominates the dashboard; the overflow collapses to
-    // a localized "+N more" line and the tap still opens the gear list.
+    // a localized "+N more" line that opens the full gear list.
     const maxGearLines = 3;
     final shownOverdue = overdue.take(maxGearLines).toList();
     final hiddenCount = overdue.length - shownOverdue.length;
-    final lines = <String>[
+    // Each line carries its own destination: a line that names one item
+    // opens that item, so the diver lands on the thing that needs attention
+    // instead of an equipment list they then have to search. Only the
+    // "+N more" overflow, which names nothing, falls back to the list.
+    final lines = <_UrgentLine>[
       for (final clock in shownOverdue)
-        context.l10n.dashboard_gauges_gearOverdue(clock.item.name),
-      if (hiddenCount > 0) context.l10n.dashboard_serviceDue_more(hiddenCount),
+        (
+          label: context.l10n.dashboard_gauges_gearOverdue(clock.item.name),
+          destination: '/equipment/${clock.item.id}',
+        ),
+      if (hiddenCount > 0)
+        (
+          label: context.l10n.dashboard_serviceDue_more(hiddenCount),
+          destination: '/equipment',
+        ),
       if (alerts.insuranceExpired)
-        context.l10n.dashboard_gauges_insuranceExpired,
+        (
+          label: context.l10n.dashboard_gauges_insuranceExpired,
+          destination: '/settings/diver-profile/insurance',
+        ),
     ];
-    // Send the tap where the listed problem is fixed: gear service when
-    // any clock is overdue, otherwise the insurance record.
-    final destination = overdue.isNotEmpty
-        ? '/equipment'
-        : '/settings/diver-profile/insurance';
     return Card(
       margin: EdgeInsets.zero,
       color: scheme.errorContainer,
-      child: InkWell(
-        onTap: () => context.go(destination),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Row(
-            children: [
-              Icon(Icons.warning_amber_rounded, color: scheme.onErrorContainer),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      context.l10n.dashboard_urgent_title,
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        color: scheme.onErrorContainer,
-                        fontWeight: FontWeight.w600,
-                      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.warning_amber_rounded, color: scheme.onErrorContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.l10n.dashboard_urgent_title,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: scheme.onErrorContainer,
+                      fontWeight: FontWeight.w600,
                     ),
-                    for (final line in lines)
-                      Text(
-                        line,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: scheme.onErrorContainer,
-                        ),
-                      ),
-                  ],
-                ),
+                  ),
+                  for (final line in lines)
+                    _lineTile(context, line, scheme.onErrorContainer),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// One tappable banner line. Pushes rather than goes so Back returns to
+  /// the dashboard the diver started from.
+  Widget _lineTile(BuildContext context, _UrgentLine line, Color foreground) {
+    return InkWell(
+      onTap: () => context.push(line.destination),
+      child: ConstrainedBox(
+        // Keep the row at the minimum comfortable tap target; the label
+        // alone is only a bodySmall line high.
+        constraints: const BoxConstraints(minHeight: 48),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                line.label,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: foreground),
+              ),
+            ),
+            Icon(Icons.chevron_right, size: 16, color: foreground),
+          ],
         ),
       ),
     );

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -692,6 +692,8 @@ void main() {
     const destinations = <String>[
       '/equipment',
       '/equipment/new',
+      // Gear chips and urgent-banner lines deep-link to one item (issue #816).
+      '/equipment/e1',
       '/settings/diver-profile/insurance',
       '/planning/no-fly',
       '/dives',

--- a/test/features/dashboard/presentation/providers/gauge_providers_test.dart
+++ b/test/features/dashboard/presentation/providers/gauge_providers_test.dart
@@ -91,6 +91,28 @@ void main() {
       expect(worstGaugePerType([]), isEmpty);
     });
 
+    test('carries the winning item id so the chip can deep-link', () {
+      // Id and name deliberately differ: the chip labels with the name but
+      // must route with the id.
+      final result = worstGaugePerType([
+        _clocks(
+          const EquipmentItem(
+            id: 'reg-b-id',
+            name: 'Reg B',
+            type: EquipmentType.regulator,
+          ),
+          [
+            _status(
+              ServiceClockSeverity.overdue,
+              dueDate: DateTime(2026, 6, 1),
+            ),
+          ],
+        ),
+      ]);
+      expect(result.single.itemId, 'reg-b-id');
+      expect(result.single.itemName, 'Reg B');
+    });
+
     test('a dated clock beats an undated one when tied on severity', () {
       // The first-seen item is undated; the dated candidate must replace it,
       // exercising the null-dueDate tie-break branch.

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -63,6 +63,11 @@ Future<NavSpy> pumpStrip(
         builder: (_, _) => stub('/equipment'),
         routes: [
           GoRoute(path: 'new', builder: (_, _) => stub('/equipment/new')),
+          GoRoute(
+            path: ':equipmentId',
+            builder: (_, state) =>
+                stub('/equipment/${state.pathParameters['equipmentId']}'),
+          ),
         ],
       ),
       GoRoute(
@@ -140,8 +145,10 @@ GearGauge _gearGauge(
   EquipmentType type,
   ServiceClockSeverity severity, {
   DateTime? dueDate,
+  String? id,
 }) => GearGauge(
   type: type,
+  itemId: id ?? name,
   itemName: name,
   status: ServiceClockStatus(
     schedule: ServiceSchedule(
@@ -238,6 +245,7 @@ void main() {
               EquipmentType.regulator,
               ServiceClockSeverity.overdue,
               dueDate: DateTime(2026, 6, 1),
+              id: 'reg-1',
             ),
             _gearGauge(
               'BCD',
@@ -263,8 +271,10 @@ void main() {
       expect(find.text('Teric OK'), findsOneWidget);
       expect(find.text('Add gear'), findsNothing);
 
+      // The chip names one item, so it must open that item rather than the
+      // list the diver would then have to search (issue #816).
       await tapChip(tester, 'Regulator overdue');
-      expect(spy.location, '/equipment');
+      expect(spy.location, '/equipment/reg-1');
     });
 
     testWidgets('due-soon clock without a due date falls back to 0 days', (

--- a/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
+++ b/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
@@ -256,7 +256,16 @@ void main() {
       ),
     );
 
-    final inkWells = tester.widgetList<InkWell>(find.byType(InkWell)).toList();
+    // Scoped to the banner so the count asserts the banner's own contract
+    // rather than the surrounding harness's widget structure.
+    final inkWells = tester
+        .widgetList<InkWell>(
+          find.descendant(
+            of: find.byType(UrgentBanner),
+            matching: find.byType(InkWell),
+          ),
+        )
+        .toList();
     // Three capped gear lines, the "+2 more" overflow, and insurance.
     expect(inkWells, hasLength(5));
     for (final ink in inkWells) {

--- a/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
+++ b/test/features/dashboard/presentation/widgets/urgent_banner_test.dart
@@ -16,28 +16,33 @@ import '../../../../helpers/mock_providers.dart';
 
 final _t0 = DateTime(2026, 1, 1);
 
-DueClock _dueClock(String name, ServiceClockSeverity severity) => (
-  item: EquipmentItem(id: name, name: name, type: EquipmentType.regulator),
-  status: ServiceClockStatus(
-    schedule: ServiceSchedule(
-      id: 'schedule',
-      equipmentId: 'equipment',
-      serviceKindId: 'kind',
-      createdAt: _t0,
-      updatedAt: _t0,
-    ),
-    kind: ServiceKind(
-      id: 'kind',
-      name: 'Annual service',
-      createdAt: _t0,
-      updatedAt: _t0,
-    ),
-    anchor: _t0,
-    dueDate: DateTime(2026, 6, 1),
-    severity: severity,
-    now: DateTime(2026, 7, 24),
-  ),
-);
+DueClock _dueClock(String name, ServiceClockSeverity severity, {String? id}) =>
+    (
+      item: EquipmentItem(
+        id: id ?? name,
+        name: name,
+        type: EquipmentType.regulator,
+      ),
+      status: ServiceClockStatus(
+        schedule: ServiceSchedule(
+          id: 'schedule',
+          equipmentId: 'equipment',
+          serviceKindId: 'kind',
+          createdAt: _t0,
+          updatedAt: _t0,
+        ),
+        kind: ServiceKind(
+          id: 'kind',
+          name: 'Annual service',
+          createdAt: _t0,
+          updatedAt: _t0,
+        ),
+        anchor: _t0,
+        dueDate: DateTime(2026, 6, 1),
+        severity: severity,
+        now: DateTime(2026, 7, 24),
+      ),
+    );
 
 /// Records the location the banner navigated to, if any.
 class NavSpy {
@@ -59,7 +64,17 @@ Future<NavSpy> pumpBanner(WidgetTester tester, DashboardAlerts alerts) async {
         path: '/',
         builder: (_, _) => const Scaffold(body: UrgentBanner()),
       ),
-      GoRoute(path: '/equipment', builder: (_, _) => stub('/equipment')),
+      GoRoute(
+        path: '/equipment',
+        builder: (_, _) => stub('/equipment'),
+        routes: [
+          GoRoute(
+            path: ':equipmentId',
+            builder: (_, state) =>
+                stub('/equipment/${state.pathParameters['equipmentId']}'),
+          ),
+        ],
+      ),
       GoRoute(
         path: '/settings/diver-profile/insurance',
         builder: (_, _) => stub('/settings/diver-profile/insurance'),
@@ -82,6 +97,14 @@ Future<NavSpy> pumpBanner(WidgetTester tester, DashboardAlerts alerts) async {
   );
   await tester.pumpAndSettle();
   return spy;
+}
+
+/// Taps the banner line whose text is [label] and settles.
+Future<void> tapLine(WidgetTester tester, String label) async {
+  await tester.tap(
+    find.ancestor(of: find.text(label), matching: find.byType(InkWell)),
+  );
+  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -110,13 +133,13 @@ void main() {
     expect(find.byIcon(Icons.warning_amber_rounded), findsNothing);
   });
 
-  testWidgets('lists overdue gear and navigates to gear', (tester) async {
+  testWidgets('lists overdue gear and opens the tapped item', (tester) async {
     final spy = await pumpBanner(
       tester,
       DashboardAlerts(
         serviceClocksDue: [
-          _dueClock('Regulator', ServiceClockSeverity.overdue),
-          _dueClock('BCD', ServiceClockSeverity.dueSoon),
+          _dueClock('Regulator', ServiceClockSeverity.overdue, id: 'reg-1'),
+          _dueClock('BCD', ServiceClockSeverity.dueSoon, id: 'bcd-1'),
         ],
         insuranceExpiringSoon: false,
         insuranceExpired: false,
@@ -128,9 +151,27 @@ void main() {
     // Due-soon clocks stay in the strip, not the urgent banner.
     expect(find.text('BCD overdue'), findsNothing);
 
-    await tester.tap(find.byType(InkWell));
-    await tester.pumpAndSettle();
-    expect(spy.location, '/equipment');
+    // Issue #816: the line names one item, so open that item's detail page
+    // rather than dropping the diver on the equipment list.
+    await tapLine(tester, 'Regulator overdue');
+    expect(spy.location, '/equipment/reg-1');
+  });
+
+  testWidgets('each overdue line opens its own item', (tester) async {
+    final spy = await pumpBanner(
+      tester,
+      DashboardAlerts(
+        serviceClocksDue: [
+          _dueClock('Regulator', ServiceClockSeverity.overdue, id: 'reg-1'),
+          _dueClock('BCD', ServiceClockSeverity.overdue, id: 'bcd-1'),
+        ],
+        insuranceExpiringSoon: false,
+        insuranceExpired: false,
+      ),
+    );
+
+    await tapLine(tester, 'BCD overdue');
+    expect(spy.location, '/equipment/bcd-1');
   });
 
   testWidgets('caps overdue lines and shows a "+N more" overflow', (
@@ -154,9 +195,8 @@ void main() {
     expect(find.text('Gear 3 overdue'), findsNothing);
     expect(find.text('+3 more'), findsOneWidget);
 
-    // Tap still opens the gear list.
-    await tester.tap(find.byType(InkWell));
-    await tester.pumpAndSettle();
+    // The overflow line names no single item, so it keeps opening the list.
+    await tapLine(tester, '+3 more');
     expect(spy.location, '/equipment');
   });
 
@@ -173,19 +213,20 @@ void main() {
 
     expect(find.text('Insurance expired'), findsOneWidget);
 
-    await tester.tap(find.byType(InkWell));
-    await tester.pumpAndSettle();
+    await tapLine(tester, 'Insurance expired');
     expect(spy.location, '/settings/diver-profile/insurance');
   });
 
-  testWidgets('overdue gear wins the destination over expired insurance', (
+  testWidgets('insurance line keeps its own destination alongside gear', (
     tester,
   ) async {
+    // Previously one card-wide tap meant overdue gear hijacked the insurance
+    // line's destination; each line now routes independently.
     final spy = await pumpBanner(
       tester,
       DashboardAlerts(
         serviceClocksDue: [
-          _dueClock('Regulator', ServiceClockSeverity.overdue),
+          _dueClock('Regulator', ServiceClockSeverity.overdue, id: 'reg-1'),
         ],
         insuranceExpiringSoon: false,
         insuranceExpired: true,
@@ -195,8 +236,31 @@ void main() {
     expect(find.text('Regulator overdue'), findsOneWidget);
     expect(find.text('Insurance expired'), findsOneWidget);
 
-    await tester.tap(find.byType(InkWell));
-    await tester.pumpAndSettle();
-    expect(spy.location, '/equipment');
+    await tapLine(tester, 'Insurance expired');
+    expect(spy.location, '/settings/diver-profile/insurance');
+  });
+
+  testWidgets('every banner line is tappable', (tester) async {
+    // Guard mirroring the gauge-strip contract: an InkWell with onTap: null
+    // renders identically to a live row, so a dead line is invisible to both
+    // the user and the compiler.
+    await pumpBanner(
+      tester,
+      DashboardAlerts(
+        serviceClocksDue: [
+          for (var i = 0; i < 5; i++)
+            _dueClock('Gear $i', ServiceClockSeverity.overdue, id: 'gear-$i'),
+        ],
+        insuranceExpiringSoon: false,
+        insuranceExpired: true,
+      ),
+    );
+
+    final inkWells = tester.widgetList<InkWell>(find.byType(InkWell)).toList();
+    // Three capped gear lines, the "+2 more" overflow, and insurance.
+    expect(inkWells, hasLength(5));
+    for (final ink in inkWells) {
+      expect(ink.onTap, isNotNull);
+    }
   });
 }


### PR DESCRIPTION
## Problem

The home page names a specific piece of gear that needs service, then tapping it drops the diver on the equipment list they have to search. Reported on Android v1.7.1.118.

Two home surfaces are affected, and both discarded the item's identity — for different reasons:

| Surface | Cause |
| --- | --- |
| Gauge-strip gear chip (`gauge_strip.dart`) | The chip labels itself with `gauge.itemName`, but `GearGauge` never carried the id, so the widget *could not* deep-link — even though `worstGaugePerType` holds the item at construction time. |
| Urgent "Needs attention" banner (`urgent_banner.dart`) | The id **was** available on `DueClock`, but every line rendered as plain `Text` inside one card-wide `InkWell` pointing at the literal `'/equipment'`. |

The `/equipment/:equipmentId` route already existed and is already used for notification taps (`app_router.dart`). Nothing was missing from the router — only these two callers were wrong.

## Changes

**Gauge-strip chip**
- Added `itemId` to `GearGauge`, populated from `entry.item.id`.
- The chip now pushes `/equipment/<id>`, matching the convention the course chip in the same file already documents: *"The chip names one course, so open that course rather than the list the user would then have to search."*

**Urgent banner**
- Each line is now its own tap target with its own destination, so `lines` changed from `List<String>` to `List<({String label, String destination})>`:
  - a gear line opens that item (`/equipment/<id>`)
  - the `+N more` overflow, which names no single item, keeps opening the list
  - the insurance line opens the insurance record
- Rows get a 48dp minimum tap target and a chevron affordance.
- Lines `push` rather than `go`, so Android Back returns to the dashboard instead of unwinding out of the app. This matches the gauge strip's existing convention.

### Second bug fixed along the way

With gear overdue **and** insurance expired, the old single-destination card sent a tap on the "Insurance expired" line to the equipment list. Pairing each label with its destination at construction makes that structurally impossible rather than merely currently-correct. Covered by a regression test.

## Testing

Tests were written first and watched fail — the two gauge tests failed at *load* (no `itemId`), which is the correct red.

- `gauge_providers_test.dart` — the gauge carries the winning item's id, with id and name deliberately different so the test can tell them apart.
- `gauge_strip_test.dart` — the chip deep-links to `/equipment/reg-1`.
- `urgent_banner_test.dart` — per-line destinations, each overdue line opening its own item, the `+N more` fallback, insurance keeping its own destination alongside overdue gear, and an "every banner line is tappable" guard mirroring the gauge-strip contract that once let four dead chips ship.
- `app_router_test.dart` — added `/equipment/e1` to the real-path resolution list, since the gauge-strip widget test navigates a stub router and cannot catch a bad path on its own.

`dart format` and `flutter analyze` clean; all 166 dashboard tests pass, including `dashboard_page_test`, which mounts the banner in situ.

Closes #816
