### PR TITLE
fix(backup): scheduled backups honour the cloud switch (#969)

### DIFF
--- a/lib/core/services/background_service.dart
+++ b/lib/core/services/background_service.dart
@@ -71,7 +71,11 @@ void callbackDispatcher() {
       if (task == kNotificationRefreshTask) {
         await _refreshNotifications(log);
       } else if (task == kBackupTask) {
-        await _performScheduledBackup(log);
+        await runScheduledBackup(
+          prefs: prefs,
+          dbAdapter: DefaultBackupDatabaseAdapter(DatabaseService.instance),
+          log: log,
+        );
       }
 
       log.info('Background task completed: $task');
@@ -150,12 +154,32 @@ Future<BackupService> buildScheduledBackupService({
   );
 }
 
-Future<void> _performScheduledBackup(LoggerService log) async {
+/// How the scheduled backup reports its outcome. A seam over
+/// [NotificationService.showBackupNotification] so the flow's decisions --
+/// above all whether the cloud copy is missing -- are assertable without a
+/// platform channel.
+typedef BackupNotifier =
+    Future<void> Function({
+      required bool success,
+      String? error,
+      bool cloudCopyMissing,
+    });
+
+/// Run the scheduled backup if one is due, then report the outcome.
+///
+/// [notify] and [instanceFor] are seams for tests; production passes neither.
+Future<void> runScheduledBackup({
+  required SharedPreferences prefs,
+  required BackupDatabaseAdapter dbAdapter,
+  required LoggerService log,
+  BackupNotifier? notify,
+  CloudStorageProvider Function(CloudProviderType type)? instanceFor,
+}) async {
   log.info('Checking if scheduled backup is due');
 
-  final prefs = await SharedPreferences.getInstance();
-  final preferences = BackupPreferences(prefs);
-  final settings = preferences.getSettings();
+  final notifier =
+      notify ?? NotificationService.instance.showBackupNotification;
+  final settings = BackupPreferences(prefs).getSettings();
 
   if (!settings.enabled) {
     log.info('Automatic backups disabled, skipping');
@@ -171,7 +195,8 @@ Future<void> _performScheduledBackup(LoggerService log) async {
 
   final service = await buildScheduledBackupService(
     prefs: prefs,
-    dbAdapter: DefaultBackupDatabaseAdapter(DatabaseService.instance),
+    dbAdapter: dbAdapter,
+    instanceFor: instanceFor,
   );
 
   try {
@@ -185,16 +210,10 @@ Future<void> _performScheduledBackup(LoggerService log) async {
       'Automatic backup completed: ${record.filename} '
       '(location: ${record.location.name})',
     );
-    await NotificationService.instance.showBackupNotification(
-      success: true,
-      cloudCopyMissing: cloudCopyMissing,
-    );
+    await notifier(success: true, cloudCopyMissing: cloudCopyMissing);
   } catch (e, stack) {
     log.error('Automatic backup failed', error: e, stackTrace: stack);
-    await NotificationService.instance.showBackupNotification(
-      success: false,
-      error: e.toString(),
-    );
+    await notifier(success: false, error: e.toString());
   }
 }
 

--- a/lib/core/services/background_service.dart
+++ b/lib/core/services/background_service.dart
@@ -1,16 +1,24 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart'
+    show CloudProviderType;
 import 'package:submersion/core/database/sqlcipher_setup.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/headless_cloud_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/security/database_security_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
+import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
+import 'package:submersion/core/services/sync/sync_preferences.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_encryption_key_store.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/notifications/data/repositories/scheduled_notification_repository.dart';
 import 'package:submersion/features/notifications/data/services/notification_scheduler.dart';
@@ -104,6 +112,42 @@ Future<void> _refreshNotifications(LoggerService log) async {
   await scheduler.scheduleAll(settings: settings);
 }
 
+/// The [BackupService] the scheduled backup runs on.
+///
+/// Every store this reaches for is isolate-safe: SharedPreferences and secure
+/// storage (credentials, both encryption keys). That is what lets a scheduled
+/// backup honour the user's "Cloud Backup" switch -- for a long time this
+/// isolate built a cloud-less service, so automatic backups silently stayed on
+/// the device while the UI advertised cloud uploads (issue #969).
+///
+/// The two key stores are separately load-bearing:
+///   * backup encryption -- when the flag is on, the artifact MUST be written
+///     as an encrypted `.sbe`, otherwise `_activeBackupKey` fails closed and
+///     the whole scheduled backup throws.
+///   * sync encryption -- the cloud copy of an otherwise-plaintext backup is
+///     framed before upload, exactly as the foreground path frames it, so
+///     restore sees one artifact format regardless of who wrote it.
+///
+/// [instanceFor] is a test seam for the cloud-provider singletons.
+@visibleForTesting
+Future<BackupService> buildScheduledBackupService({
+  required SharedPreferences prefs,
+  required BackupDatabaseAdapter dbAdapter,
+  CloudStorageProvider Function(CloudProviderType type)? instanceFor,
+}) async {
+  return BackupService(
+    dbAdapter: dbAdapter,
+    preferences: BackupPreferences(prefs),
+    cloudProvider: await resolveHeadlessCloudProvider(
+      prefs: prefs,
+      instanceFor: instanceFor,
+    ),
+    encryptionKeyStore: EncryptionKeyStore(),
+    syncPreferences: SyncPreferences(prefs),
+    backupEncryptionKeyStore: BackupEncryptionKeyStore(),
+  );
+}
+
 Future<void> _performScheduledBackup(LoggerService log) async {
   log.info('Checking if scheduled backup is due');
 
@@ -123,22 +167,26 @@ Future<void> _performScheduledBackup(LoggerService log) async {
 
   log.info('Backup is due, starting automatic backup');
 
-  // Background isolate cannot access cloud auth, so backup is local-only.
-  // The backup-encryption key store IS injected: when the user has enabled
-  // backup encryption, the scheduled backup must still be written as an
-  // encrypted .sbe (otherwise _activeBackupKey fails closed and the whole
-  // scheduled backup fails). Secure storage is reachable from this isolate.
-  final dbAdapter = DefaultBackupDatabaseAdapter(DatabaseService.instance);
-  final service = BackupService(
-    dbAdapter: dbAdapter,
-    preferences: preferences,
-    backupEncryptionKeyStore: BackupEncryptionKeyStore(),
+  final service = await buildScheduledBackupService(
+    prefs: prefs,
+    dbAdapter: DefaultBackupDatabaseAdapter(DatabaseService.instance),
   );
 
   try {
     final record = await service.performBackup(isAutomatic: true);
-    log.info('Automatic backup completed: ${record.filename}');
-    await NotificationService.instance.showBackupNotification(success: true);
+    // The record's location is the only honest signal: the upload swallows
+    // its own failures to protect the local artifact, so a cloud copy the
+    // user asked for can be missing from an otherwise successful backup.
+    final cloudCopyMissing =
+        settings.cloudBackupEnabled && record.location == BackupLocation.local;
+    log.info(
+      'Automatic backup completed: ${record.filename} '
+      '(location: ${record.location.name})',
+    );
+    await NotificationService.instance.showBackupNotification(
+      success: true,
+      cloudCopyMissing: cloudCopyMissing,
+    );
   } catch (e, stack) {
     log.error('Automatic backup failed', error: e, stackTrace: stack);
     await NotificationService.instance.showBackupNotification(

--- a/lib/core/services/background_service.dart
+++ b/lib/core/services/background_service.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
@@ -129,20 +128,23 @@ Future<void> _refreshNotifications(LoggerService log) async {
 ///     restore sees one artifact format regardless of who wrote it.
 ///
 /// [instanceFor] is a test seam for the cloud-provider singletons.
-@visibleForTesting
 Future<BackupService> buildScheduledBackupService({
   required SharedPreferences prefs,
   required BackupDatabaseAdapter dbAdapter,
   CloudStorageProvider Function(CloudProviderType type)? instanceFor,
 }) async {
+  // One store for both the provider wrap and the upload's framing, mirroring
+  // the foreground's single encryptionKeyStoreProvider.
+  final encryptionKeyStore = EncryptionKeyStore();
   return BackupService(
     dbAdapter: dbAdapter,
     preferences: BackupPreferences(prefs),
     cloudProvider: await resolveHeadlessCloudProvider(
       prefs: prefs,
+      encryptionKeyStore: encryptionKeyStore,
       instanceFor: instanceFor,
     ),
-    encryptionKeyStore: EncryptionKeyStore(),
+    encryptionKeyStore: encryptionKeyStore,
     syncPreferences: SyncPreferences(prefs),
     backupEncryptionKeyStore: BackupEncryptionKeyStore(),
   );

--- a/lib/core/services/cloud_storage/headless_cloud_provider.dart
+++ b/lib/core/services/cloud_storage/headless_cloud_provider.dart
@@ -1,0 +1,75 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_provider_instances.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/encrypting_cloud_storage_provider.dart';
+import 'package:submersion/core/services/database_location_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
+import 'package:submersion/core/services/sync/crypto/keyslots.dart';
+import 'package:submersion/core/services/sync/sync_initializer.dart'
+    show lastCloudProviderFromPrefs;
+import 'package:submersion/core/services/sync/sync_preferences.dart';
+
+const _log = LoggerService('HeadlessCloudProvider');
+
+/// The configured cloud provider, resolved without a `ProviderScope`.
+///
+/// The foreground app resolves the same thing through
+/// `cloudStorageProviderProvider`; a headless isolate (the Workmanager
+/// scheduled backup) has no Riverpod container, so it rebuilds the answer
+/// from the two stores that ARE reachable there: SharedPreferences (which
+/// provider was selected, which storage mode is active) and secure storage
+/// (credentials, and the master library key).
+///
+/// Differences from the foreground resolution, both deliberate:
+///   * account-first resolution is skipped -- picking a connected account
+///     needs the database-backed registry. The legacy per-type singleton it
+///     falls back to is always valid, because the connect UIs keep writing
+///     the legacy credential keys.
+///   * a provider whose auth cannot be re-established headlessly (Google
+///     Drive needs an interactive session) still resolves here; the upload
+///     then fails and the caller keeps its local-only artifact.
+///
+/// Returns null when nothing should be uploaded: no provider selected, an
+/// unreadable selection, or custom-folder storage mode (where an external
+/// sync client owns the folder and app-managed sync is off).
+Future<CloudStorageProvider?> resolveHeadlessCloudProvider({
+  required SharedPreferences prefs,
+  EncryptionKeyStore? encryptionKeyStore,
+  CloudStorageProvider Function(CloudProviderType type)? instanceFor,
+}) async {
+  try {
+    final storage = await DatabaseLocationService(prefs).getStorageConfig();
+    if (storage.isCustomLocation) return null;
+
+    final type = lastCloudProviderFromPrefs(prefs);
+    if (type == null) return null;
+
+    final raw = (instanceFor ?? cloudProviderInstanceFor)(type);
+
+    // End-to-end encryption: mirror the foreground wrap so nothing this
+    // provider stores can be plaintext by accident. Backup artifacts frame
+    // themselves and are exempt from the decorator, so for a scheduled
+    // backup this is a safety net rather than the active codec.
+    if (!SyncPreferences(prefs).syncEncryptionEnabled) return raw;
+    final key = await (encryptionKeyStore ?? EncryptionKeyStore()).loadKey();
+    if (key == null) return raw;
+    return EncryptingCloudStorageProvider(
+      raw,
+      dataKey: await Keyslots.deriveDataKey(key.mlk),
+      libraryKeyId: key.libraryKeyId,
+    );
+  } catch (e, stack) {
+    // A locked keychain or an unreadable preference must not take the whole
+    // scheduled task down: resolving to no provider degrades to a local
+    // backup, which is what this isolate did before it could reach the cloud.
+    _log.warning(
+      'Headless cloud provider resolution failed; staying local-only',
+      error: e,
+      stackTrace: stack,
+    );
+    return null;
+  }
+}

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -276,6 +276,40 @@ class NotificationService {
     return notificationId;
   }
 
+  /// Title for [showBackupNotification]. Pure, so the wording is testable
+  /// without the platform channel (as with [serviceReminderBody]).
+  static String backupNotificationTitle({
+    required bool success,
+    required bool cloudCopyMissing,
+  }) {
+    if (!success) return 'Backup Failed';
+    return cloudCopyMissing
+        ? 'Backup Complete (device only)'
+        : 'Backup Complete';
+  }
+
+  /// Body for [showBackupNotification].
+  ///
+  /// [cloudCopyMissing] means the user has cloud backup switched on but this
+  /// run produced no cloud copy -- an unreachable provider, expired auth, or
+  /// no network. The local backup is intact, so this is not a failure, but
+  /// saying "backed up successfully" would tell the user their off-device
+  /// copy is safe when it is not.
+  static String backupNotificationBody({
+    required bool success,
+    required bool cloudCopyMissing,
+    String? error,
+  }) {
+    if (!success) {
+      return 'Automatic backup failed'
+          '${error != null ? ': $error' : '. Please try a manual backup.'}';
+    }
+    return cloudCopyMissing
+        ? 'Your dive data was backed up on this device. The cloud copy could '
+              'not be uploaded -- it will be retried at the next backup.'
+        : 'Your dive data has been backed up successfully.';
+  }
+
   /// Show an immediate notification for backup results.
   ///
   /// Used by both foreground operations and background tasks.
@@ -283,6 +317,7 @@ class NotificationService {
   Future<void> showBackupNotification({
     required bool success,
     String? error,
+    bool cloudCopyMissing = false,
   }) async {
     if (!_isMobilePlatform) return;
 
@@ -306,10 +341,15 @@ class NotificationService {
       iOS: iosDetails,
     );
 
-    final title = success ? 'Backup Complete' : 'Backup Failed';
-    final body = success
-        ? 'Your dive data has been backed up successfully.'
-        : 'Automatic backup failed${error != null ? ': $error' : '. Please try a manual backup.'}';
+    final title = backupNotificationTitle(
+      success: success,
+      cloudCopyMissing: cloudCopyMissing,
+    );
+    final body = backupNotificationBody(
+      success: success,
+      cloudCopyMissing: cloudCopyMissing,
+      error: error,
+    );
 
     // Use a fixed ID so repeated backup notifications replace each other
     const backupNotificationId = 99000;
@@ -321,7 +361,10 @@ class NotificationService {
       notificationDetails: details,
     );
 
-    _log.info('Showed backup notification (success: $success)');
+    _log.info(
+      'Showed backup notification (success: $success, '
+      'cloudCopyMissing: $cloudCopyMissing)',
+    );
   }
 
   /// Cancel a specific notification

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -341,30 +341,24 @@ class NotificationService {
       iOS: iosDetails,
     );
 
-    final title = backupNotificationTitle(
-      success: success,
-      cloudCopyMissing: cloudCopyMissing,
-    );
-    final body = backupNotificationBody(
-      success: success,
-      cloudCopyMissing: cloudCopyMissing,
-      error: error,
-    );
-
     // Use a fixed ID so repeated backup notifications replace each other
     const backupNotificationId = 99000;
 
     await _plugin.show(
       id: backupNotificationId,
-      title: title,
-      body: body,
+      title: backupNotificationTitle(
+        success: success,
+        cloudCopyMissing: cloudCopyMissing,
+      ),
+      body: backupNotificationBody(
+        success: success,
+        cloudCopyMissing: cloudCopyMissing,
+        error: error,
+      ),
       notificationDetails: details,
     );
 
-    _log.info(
-      'Showed backup notification (success: $success, '
-      'cloudCopyMissing: $cloudCopyMissing)',
-    );
+    _log.info('Showed backup notification (success: $success)');
   }
 
   /// Cancel a specific notification

--- a/lib/core/services/sync/sync_initializer.dart
+++ b/lib/core/services/sync/sync_initializer.dart
@@ -10,6 +10,20 @@ import 'package:submersion/core/services/sync/sync_clock.dart';
 import 'package:submersion/core/services/sync/sync_preferences.dart'
     show syncLastProviderPrefsKey;
 
+/// The cloud provider the foreground app last selected, as recorded in
+/// [prefs]. Free-standing (not a [SyncInitializer] method) so the headless
+/// background isolate -- which has no `SyncRepository` to build an
+/// initializer with -- reads the selection through the same parser.
+CloudProviderType? lastCloudProviderFromPrefs(SharedPreferences prefs) {
+  final providerString = prefs.getString(syncLastProviderPrefsKey);
+  if (providerString == null) return null;
+
+  for (final type in CloudProviderType.values) {
+    if (type.name == providerString) return type;
+  }
+  return null;
+}
+
 /// Handles sync initialization and checks on app launch
 class SyncInitializer {
   static final _log = LoggerService.forClass(SyncInitializer);
@@ -54,18 +68,7 @@ class SyncInitializer {
        _prefs = prefs;
 
   /// Get the last used cloud provider type
-  CloudProviderType? getLastProvider() {
-    final providerString = _prefs.getString(_lastProviderKey);
-    if (providerString == null) return null;
-
-    try {
-      return CloudProviderType.values.firstWhere(
-        (p) => p.name == providerString,
-      );
-    } catch (e) {
-      return null;
-    }
-  }
+  CloudProviderType? getLastProvider() => lastCloudProviderFromPrefs(_prefs);
 
   /// Save the selected cloud provider
   Future<void> saveProvider(CloudProviderType? provider) async {

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -232,8 +232,16 @@ class BackupService {
     if (settings.cloudBackupEnabled && _cloudProvider != null) {
       try {
         cloudFileId = await _uploadToCloud(ref, storedName);
-        location = BackupLocation.both;
-        _log.info('Backup uploaded to cloud: $cloudFileId');
+        // Only a real file id means a cloud copy exists: the upload also
+        // gives up (returning null) when the backup folder is unreachable,
+        // and history that claims `both` with no id sends restore looking
+        // for a file that was never written.
+        if (cloudFileId != null) {
+          location = BackupLocation.both;
+          _log.info('Backup uploaded to cloud: $cloudFileId');
+        } else {
+          _log.warning('Cloud upload skipped, backup is local-only');
+        }
       } catch (e, stack) {
         _log.error(
           'Cloud upload failed, backup is local-only',

--- a/test/core/services/background_service_backup_test.dart
+++ b/test/core/services/background_service_backup_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/background_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -37,6 +38,30 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
       throw UnimplementedError('Fake database does not support queries');
 }
 
+/// An adapter whose backup always fails, modelling a full disk or an
+/// unreadable database.
+class _FailingBackupDatabaseAdapter extends _FakeBackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async =>
+      throw const FileSystemException('no space left on device');
+}
+
+/// A connected provider whose uploads fail: offline, expired token, or a
+/// revoked scope. The local artifact still lands, so the backup "succeeds".
+class _UploadFailingCloud extends FakeCloudStorageProvider {
+  _UploadFailingCloud() : super(providerId: 'dropbox');
+
+  @override
+  Future<UploadResult> uploadFileFromPath(
+    String sourcePath,
+    String filename, {
+    String? folderId,
+  }) async => throw const CloudStorageException('network unreachable');
+}
+
+/// One recorded call to the notification seam.
+typedef _Notification = ({bool success, String? error, bool cloudCopyMissing});
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -54,21 +79,45 @@ void main() {
         );
   });
 
+  const log = LoggerService('BackgroundServiceTest');
   late FakeCloudStorageProvider cloud;
+  late List<_Notification> notifications;
 
   setUp(() {
     cloud = FakeCloudStorageProvider(providerId: 'dropbox');
+    notifications = [];
   });
 
+  Future<void> record({
+    required bool success,
+    String? error,
+    bool cloudCopyMissing = false,
+  }) async {
+    notifications.add((
+      success: success,
+      error: error,
+      cloudCopyMissing: cloudCopyMissing,
+    ));
+  }
+
+  /// Seeds an enabled, due backup configuration. `lastBackupTime` is left
+  /// unset, which BackupSettings.isBackupDue treats as due.
   Future<SharedPreferences> seedPrefs({
-    required bool cloudBackupEnabled,
+    bool enabled = true,
+    bool cloudBackupEnabled = true,
     String? lastProvider = 'dropbox',
+    DateTime? lastBackupTime,
   }) async {
     SharedPreferences.setMockInitialValues(
       lastProvider == null ? {} : {'sync_last_provider': lastProvider},
     );
     final prefs = await SharedPreferences.getInstance();
-    await BackupPreferences(prefs).setCloudBackupEnabled(cloudBackupEnabled);
+    final preferences = BackupPreferences(prefs);
+    await preferences.setEnabled(enabled);
+    await preferences.setCloudBackupEnabled(cloudBackupEnabled);
+    if (lastBackupTime != null) {
+      await preferences.setLastBackupTime(lastBackupTime);
+    }
     return prefs;
   }
 
@@ -78,48 +127,170 @@ void main() {
     namePattern: 'submersion_backup_',
   );
 
-  Future<BackupRecord> runScheduledBackup(SharedPreferences prefs) async {
-    final service = await buildScheduledBackupService(
+  Future<void> run(
+    SharedPreferences prefs, {
+    BackupDatabaseAdapter? dbAdapter,
+  }) => runScheduledBackup(
+    prefs: prefs,
+    dbAdapter: dbAdapter ?? _FakeBackupDatabaseAdapter(),
+    log: log,
+    notify: record,
+    instanceFor: (CloudProviderType type) => cloud,
+  );
+
+  group('when a backup runs', () {
+    test(
+      'it uploads to the cloud when the user turned cloud backup on',
+      () async {
+        final prefs = await seedPrefs();
+
+        await run(prefs);
+
+        expect(
+          await uploadedBackups(),
+          hasLength(1),
+          reason:
+              'issue #969: the background isolate built a BackupService with no '
+              'cloud provider, so automatic backups never left the device',
+        );
+        final history = BackupPreferences(prefs).getHistory();
+        expect(history.single.location, BackupLocation.both);
+        expect(history.single.isAutomatic, isTrue);
+        expect(notifications.single.success, isTrue);
+        expect(notifications.single.cloudCopyMissing, isFalse);
+      },
+    );
+
+    test('it stays local when the user has not enabled cloud backup', () async {
+      final prefs = await seedPrefs(cloudBackupEnabled: false);
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), isEmpty);
+      expect(
+        BackupPreferences(prefs).getHistory().single.location,
+        BackupLocation.local,
+      );
+      expect(
+        notifications.single.cloudCopyMissing,
+        isFalse,
+        reason: 'no cloud copy was ever asked for, so none is missing',
+      );
+    });
+
+    test('it stays local when no cloud provider is connected', () async {
+      final prefs = await seedPrefs(lastProvider: null);
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), isEmpty);
+      expect(
+        BackupPreferences(prefs).getHistory().single.location,
+        BackupLocation.local,
+      );
+    });
+  });
+
+  group('what the user is told', () {
+    test('a cloud copy the user asked for but did not get is reported, not '
+        'hidden behind a plain success', () async {
+      cloud = _UploadFailingCloud();
+      final prefs = await seedPrefs();
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), isEmpty);
+      expect(notifications.single.success, isTrue);
+      expect(
+        notifications.single.cloudCopyMissing,
+        isTrue,
+        reason:
+            'the local backup succeeded, but claiming plain success would tell '
+            'the user their off-device copy is safe when it is not',
+      );
+    });
+
+    test('a failed backup reports the reason', () async {
+      final prefs = await seedPrefs();
+
+      await run(prefs, dbAdapter: _FailingBackupDatabaseAdapter());
+
+      expect(notifications.single.success, isFalse);
+      expect(notifications.single.error, contains('no space left on device'));
+      expect(BackupPreferences(prefs).getHistory(), isEmpty);
+    });
+  });
+
+  group('when no backup should run', () {
+    test('automatic backups switched off: nothing happens at all', () async {
+      final prefs = await seedPrefs(enabled: false);
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), isEmpty);
+      expect(BackupPreferences(prefs).getHistory(), isEmpty);
+      expect(
+        notifications,
+        isEmpty,
+        reason: 'a skipped run must not notify -- there is nothing to report',
+      );
+    });
+
+    test('not yet due: the previous backup still stands', () async {
+      final prefs = await seedPrefs(
+        lastBackupTime: DateTime.now().subtract(const Duration(hours: 2)),
+      );
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), isEmpty);
+      expect(BackupPreferences(prefs).getHistory(), isEmpty);
+      expect(notifications, isEmpty);
+    });
+
+    test('due again once the frequency window has passed', () async {
+      final prefs = await seedPrefs(
+        lastBackupTime: DateTime.now().subtract(const Duration(days: 8)),
+      );
+
+      await run(prefs);
+
+      expect(await uploadedBackups(), hasLength(1));
+    });
+  });
+
+  test('with no notifier injected it falls back to the real notification '
+      'service, which production relies on', () async {
+    final prefs = await seedPrefs();
+
+    // No `notify:` -- the default tear-off runs. On a desktop test host
+    // showBackupNotification returns before touching the platform channel,
+    // so this exercises the production wiring without mocking the plugin.
+    await runScheduledBackup(
       prefs: prefs,
       dbAdapter: _FakeBackupDatabaseAdapter(),
+      log: log,
       instanceFor: (CloudProviderType type) => cloud,
     );
-    return service.performBackup(isAutomatic: true);
-  }
 
-  test('the scheduled (headless) backup uploads to the cloud when the user '
-      'turned cloud backup on', () async {
-    final prefs = await seedPrefs(cloudBackupEnabled: true);
-
-    final record = await runScheduledBackup(prefs);
-
-    expect(
-      await uploadedBackups(),
-      hasLength(1),
-      reason:
-          'issue #969: the background isolate built a BackupService with no '
-          'cloud provider, so automatic backups never left the device',
-    );
-    expect(record.location, BackupLocation.both);
-    expect(record.cloudFileId, isNotNull);
-    expect(record.isAutomatic, isTrue);
+    expect(await uploadedBackups(), hasLength(1));
+    expect(notifications, isEmpty, reason: 'the fake was not wired in');
   });
 
-  test('stays local when the user has not enabled cloud backup', () async {
-    final prefs = await seedPrefs(cloudBackupEnabled: false);
+  group('buildScheduledBackupService', () {
+    test('injects the resolved cloud provider so the shared upload gate can '
+        'see it', () async {
+      final prefs = await seedPrefs();
 
-    final record = await runScheduledBackup(prefs);
+      final service = await buildScheduledBackupService(
+        prefs: prefs,
+        dbAdapter: _FakeBackupDatabaseAdapter(),
+        instanceFor: (CloudProviderType type) => cloud,
+      );
+      final backup = await service.performBackup(isAutomatic: true);
 
-    expect(await uploadedBackups(), isEmpty);
-    expect(record.location, BackupLocation.local);
-  });
-
-  test('stays local when no cloud provider is connected', () async {
-    final prefs = await seedPrefs(cloudBackupEnabled: true, lastProvider: null);
-
-    final record = await runScheduledBackup(prefs);
-
-    expect(await uploadedBackups(), isEmpty);
-    expect(record.location, BackupLocation.local);
+      expect(backup.location, BackupLocation.both);
+      expect(backup.cloudFileId, isNotNull);
+    });
   });
 }

--- a/test/core/services/background_service_backup_test.dart
+++ b/test/core/services/background_service_backup_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/background_service.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+
+import '../../support/fake_cloud_storage_provider.dart';
+
+/// Writes a stand-in backup file so the service has real bytes to upload.
+class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async {
+    final file = File(destinationPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsString('fake backup data');
+  }
+
+  @override
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
+
+  @override
+  Future<String> get databasePath async => '/fake/db/path';
+
+  @override
+  AppDatabase get database =>
+      throw UnimplementedError('Fake database does not support queries');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'getTemporaryDirectory' ||
+                methodCall.method == 'getApplicationDocumentsDirectory') {
+              return Directory.systemTemp.path;
+            }
+            return null;
+          },
+        );
+  });
+
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() {
+    cloud = FakeCloudStorageProvider(providerId: 'dropbox');
+  });
+
+  Future<SharedPreferences> seedPrefs({
+    required bool cloudBackupEnabled,
+    String? lastProvider = 'dropbox',
+  }) async {
+    SharedPreferences.setMockInitialValues(
+      lastProvider == null ? {} : {'sync_last_provider': lastProvider},
+    );
+    final prefs = await SharedPreferences.getInstance();
+    await BackupPreferences(prefs).setCloudBackupEnabled(cloudBackupEnabled);
+    return prefs;
+  }
+
+  // The support fake's createFolder returns the folder name as its id.
+  Future<List<CloudFileInfo>> uploadedBackups() => cloud.listFiles(
+    folderId: 'Submersion Backups',
+    namePattern: 'submersion_backup_',
+  );
+
+  Future<BackupRecord> runScheduledBackup(SharedPreferences prefs) async {
+    final service = await buildScheduledBackupService(
+      prefs: prefs,
+      dbAdapter: _FakeBackupDatabaseAdapter(),
+      instanceFor: (CloudProviderType type) => cloud,
+    );
+    return service.performBackup(isAutomatic: true);
+  }
+
+  test('the scheduled (headless) backup uploads to the cloud when the user '
+      'turned cloud backup on', () async {
+    final prefs = await seedPrefs(cloudBackupEnabled: true);
+
+    final record = await runScheduledBackup(prefs);
+
+    expect(
+      await uploadedBackups(),
+      hasLength(1),
+      reason:
+          'issue #969: the background isolate built a BackupService with no '
+          'cloud provider, so automatic backups never left the device',
+    );
+    expect(record.location, BackupLocation.both);
+    expect(record.cloudFileId, isNotNull);
+    expect(record.isAutomatic, isTrue);
+  });
+
+  test('stays local when the user has not enabled cloud backup', () async {
+    final prefs = await seedPrefs(cloudBackupEnabled: false);
+
+    final record = await runScheduledBackup(prefs);
+
+    expect(await uploadedBackups(), isEmpty);
+    expect(record.location, BackupLocation.local);
+  });
+
+  test('stays local when no cloud provider is connected', () async {
+    final prefs = await seedPrefs(cloudBackupEnabled: true, lastProvider: null);
+
+    final record = await runScheduledBackup(prefs);
+
+    expect(await uploadedBackups(), isEmpty);
+    expect(record.location, BackupLocation.local);
+  });
+}

--- a/test/core/services/backup_notification_text_test.dart
+++ b/test/core/services/backup_notification_text_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/notification_service.dart';
+
+void main() {
+  group('title', () {
+    test('a backup that reached the cloud, or was never meant to, reads as a '
+        'plain completion', () {
+      expect(
+        NotificationService.backupNotificationTitle(
+          success: true,
+          cloudCopyMissing: false,
+        ),
+        'Backup Complete',
+      );
+    });
+
+    test(
+      'a local-only fallback is still a completed backup, not a failure',
+      () {
+        expect(
+          NotificationService.backupNotificationTitle(
+            success: true,
+            cloudCopyMissing: true,
+          ),
+          'Backup Complete (device only)',
+        );
+      },
+    );
+
+    test('a failed backup reads as a failure', () {
+      expect(
+        NotificationService.backupNotificationTitle(
+          success: false,
+          cloudCopyMissing: false,
+        ),
+        'Backup Failed',
+      );
+    });
+  });
+
+  group('body', () {
+    test('a cloud backup that landed says so plainly', () {
+      expect(
+        NotificationService.backupNotificationBody(
+          success: true,
+          cloudCopyMissing: false,
+        ),
+        'Your dive data has been backed up successfully.',
+      );
+    });
+
+    test('a local-only fallback names the missing cloud copy: silence here is '
+        'what let issue #969 go unreported', () {
+      final body = NotificationService.backupNotificationBody(
+        success: true,
+        cloudCopyMissing: true,
+      );
+      expect(body, contains('on this device'));
+      expect(body, contains('cloud'));
+      expect(
+        body,
+        isNot(contains('successfully')),
+        reason: 'an unqualified success reads as "the cloud copy is safe"',
+      );
+    });
+
+    test('a failure carries the reason when there is one', () {
+      expect(
+        NotificationService.backupNotificationBody(
+          success: false,
+          cloudCopyMissing: false,
+          error: 'disk full',
+        ),
+        'Automatic backup failed: disk full',
+      );
+    });
+
+    test('a failure without a reason suggests the manual path', () {
+      expect(
+        NotificationService.backupNotificationBody(
+          success: false,
+          cloudCopyMissing: false,
+        ),
+        'Automatic backup failed. Please try a manual backup.',
+      );
+    });
+
+    test('a failure ignores cloudCopyMissing: nothing was written at all', () {
+      expect(
+        NotificationService.backupNotificationBody(
+          success: false,
+          cloudCopyMissing: true,
+        ),
+        'Automatic backup failed. Please try a manual backup.',
+      );
+    });
+  });
+}

--- a/test/core/services/cloud_storage/headless_cloud_provider_test.dart
+++ b/test/core/services/cloud_storage/headless_cloud_provider_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/encrypting_cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/headless_cloud_provider.dart';
+import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
+import 'package:submersion/core/services/sync/sync_preferences.dart';
+
+import '../../../support/fake_cloud_storage_provider.dart';
+import '../../../support/fake_keychain_storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late EncryptionKeyStore keyStore;
+  final built = <CloudProviderType>[];
+
+  CloudStorageProvider instanceFor(CloudProviderType type) {
+    built.add(type);
+    return FakeCloudStorageProvider(providerId: type.name);
+  }
+
+  setUp(() {
+    keyStore = EncryptionKeyStore(storage: InMemoryKeychain());
+    built.clear();
+  });
+
+  Future<SharedPreferences> prefsWith(Map<String, Object> values) async {
+    SharedPreferences.setMockInitialValues(values);
+    return SharedPreferences.getInstance();
+  }
+
+  Future<CloudStorageProvider?> resolve(SharedPreferences prefs) =>
+      resolveHeadlessCloudProvider(
+        prefs: prefs,
+        encryptionKeyStore: keyStore,
+        instanceFor: instanceFor,
+      );
+
+  test('resolves the provider recorded by the foreground app', () async {
+    final prefs = await prefsWith({'sync_last_provider': 'dropbox'});
+
+    final provider = await resolve(prefs);
+
+    expect(provider, isA<FakeCloudStorageProvider>());
+    expect(provider!.providerId, 'dropbox');
+    expect(built, [CloudProviderType.dropbox]);
+  });
+
+  test('null when no provider has been selected', () async {
+    final prefs = await prefsWith({});
+
+    expect(await resolve(prefs), isNull);
+    expect(built, isEmpty);
+  });
+
+  test('null for an unrecognized stored provider name', () async {
+    final prefs = await prefsWith({'sync_last_provider': 'mystery-drive'});
+
+    expect(await resolve(prefs), isNull);
+    expect(built, isEmpty);
+  });
+
+  test('null in custom-folder storage mode, where an external service '
+      'owns the sync', () async {
+    final prefs = await prefsWith({
+      'sync_last_provider': 'dropbox',
+      'db_storage_mode': 'customFolder',
+    });
+
+    expect(await resolve(prefs), isNull);
+    expect(built, isEmpty);
+  });
+
+  test('wraps in the encrypting decorator when sync encryption is on and '
+      'the key is on this device', () async {
+    final prefs = await prefsWith({'sync_last_provider': 's3'});
+    await SyncPreferences(prefs).setSyncEncryptionEnabled(true);
+    await keyStore.saveKey(
+      libraryKeyId: 'lib-1',
+      mlkBytes: List<int>.generate(32, (i) => i),
+    );
+
+    final provider = await resolve(prefs);
+
+    expect(provider, isA<EncryptingCloudStorageProvider>());
+    expect((provider as EncryptingCloudStorageProvider).inner.providerId, 's3');
+  });
+
+  test(
+    'stays raw when sync encryption is on but no key is cached here',
+    () async {
+      final prefs = await prefsWith({'sync_last_provider': 's3'});
+      await SyncPreferences(prefs).setSyncEncryptionEnabled(true);
+
+      final provider = await resolve(prefs);
+
+      expect(provider, isA<FakeCloudStorageProvider>());
+    },
+  );
+
+  test('stays raw when a key exists but sync encryption is off', () async {
+    final prefs = await prefsWith({'sync_last_provider': 's3'});
+    await keyStore.saveKey(
+      libraryKeyId: 'lib-1',
+      mlkBytes: List<int>.generate(32, (i) => i),
+    );
+
+    final provider = await resolve(prefs);
+
+    expect(provider, isA<FakeCloudStorageProvider>());
+  });
+
+  test('a decorator failure resolves to no provider rather than throwing '
+      'the whole scheduled backup away', () async {
+    final prefs = await prefsWith({'sync_last_provider': 's3'});
+    await SyncPreferences(prefs).setSyncEncryptionEnabled(true);
+    await keyStore.saveKey(
+      libraryKeyId: 'lib-1',
+      mlkBytes: List<int>.generate(32, (i) => i),
+    );
+
+    final provider = await resolveHeadlessCloudProvider(
+      prefs: prefs,
+      encryptionKeyStore: _ThrowingKeyStore(),
+      instanceFor: instanceFor,
+    );
+
+    expect(provider, isNull);
+  });
+}
+
+/// Models a keychain read that fails (locked device, revoked entitlement).
+class _ThrowingKeyStore implements EncryptionKeyStore {
+  @override
+  Future<UnlockedKey?> loadKey() async => throw StateError('keychain locked');
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -114,6 +114,11 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
   bool shouldFailUpload = false;
   bool shouldFailDelete = false;
   bool shouldFailDownload = false;
+
+  /// Models a provider that is reachable for auth but cannot serve the backup
+  /// folder (offline, revoked scope, quota) -- the path where the upload is
+  /// abandoned before any bytes are sent.
+  bool shouldFailCreateFolder = false;
   String? createdFolder;
   int uploadCallCount = 0;
 
@@ -202,6 +207,9 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
     String folderName, {
     String? parentFolderId,
   }) async {
+    if (shouldFailCreateFolder) {
+      throw const CloudStorageException('Folder unavailable');
+    }
     createdFolder = folderName;
     return 'folder-$folderName';
   }
@@ -995,6 +1003,45 @@ void main() {
         expect(fakeDb.lastBackupPath, contains('Submersion'));
         expect(fakeDb.lastBackupPath, contains('Backups'));
       });
+    });
+
+    group('performBackup cloud upload', () {
+      test('records both locations when the upload lands', () async {
+        await preferences.setCloudBackupEnabled(true);
+
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          cloudProvider: fakeCloud,
+        );
+
+        final record = await service.performBackup(isAutomatic: true);
+
+        expect(fakeCloud.uploadedFiles, hasLength(1));
+        expect(record.location, BackupLocation.both);
+        expect(record.cloudFileId, isNotNull);
+      });
+
+      test(
+        'records local-only when the cloud folder cannot be reached: '
+        'history must never claim a cloud copy that does not exist',
+        () async {
+          await preferences.setCloudBackupEnabled(true);
+          fakeCloud.shouldFailCreateFolder = true;
+
+          final service = BackupService(
+            dbAdapter: fakeDb,
+            preferences: preferences,
+            cloudProvider: fakeCloud,
+          );
+
+          final record = await service.performBackup();
+
+          expect(fakeCloud.uploadedFiles, isEmpty);
+          expect(record.cloudFileId, isNull);
+          expect(record.location, BackupLocation.local);
+        },
+      );
     });
 
     group('resolveBackupsDirectory', () {


### PR DESCRIPTION
Fixes #969.

## The bug

With "Cloud Backup" switched on, automatic backups were written to the device
and never uploaded. Backup history recorded them with the phone icon while the
settings page advertised cloud uploads. Manual "Back Up Now" was unaffected, and
so was desktop, which is why this survived so long.

## Root cause

Both paths run the same code — `BackupService._performBackupInto` gates the
upload on `settings.cloudBackupEnabled && _cloudProvider != null`. But the
mobile scheduled backup runs in a Workmanager headless isolate that built its
own `BackupService` **without** `cloudProvider:`, so the second conjunct was
permanently false and the user's switch was unreachable. Desktop's timer runs
inside the app's Riverpod scope, so it always had the cloud-capable service.

The code justified this with "Background isolate cannot access cloud auth". That
is not true, and the same function already disproved it by injecting
`BackupEncryptionKeyStore` from secure storage. Everything the foreground
resolution needs is isolate-reachable:

| Input | Where it lives |
| --- | --- |
| Selected provider | SharedPreferences `sync_last_provider` |
| Custom-folder mode | SharedPreferences `db_storage_mode` |
| Provider credentials | flutter_secure_storage |
| Master library key | `EncryptionKeyStore` (secure storage) |

## Changes

**`resolveHeadlessCloudProvider`** (new, `core/services/cloud_storage/headless_cloud_provider.dart`)
rebuilds what `cloudStorageProviderProvider` produces, without a `ProviderScope`:
rejects custom-folder mode, reads the persisted provider type, builds the
per-type singleton, and wraps it in `EncryptingCloudStorageProvider` when sync
encryption is on and the key is on this device. Two deliberate differences from
the foreground path, both documented at the call site:

- account-first resolution is skipped (it needs the DB-backed account registry).
  The legacy per-type singleton it falls back to is always valid, because the
  connect UIs keep writing the legacy credential keys.
- a provider whose auth cannot be re-established headlessly (Google Drive needs
  an interactive session) still resolves; the upload then fails and the local
  artifact stands, exactly as before.

Any failure resolving — locked keychain, unreadable preference — degrades to no
provider rather than taking the scheduled task down.

**`buildScheduledBackupService`** (`background_service.dart`) injects that
provider plus `EncryptionKeyStore` and `SyncPreferences`, so a scheduled backup
frames its cloud copy exactly the way the foreground path does and restore sees
one artifact format regardless of who wrote it.

**`lastCloudProviderFromPrefs`** (`sync_initializer.dart`) — extracted so the
foreground and headless paths parse the stored selection through one function.

## Two honesty fixes on the same path

Both are about the app claiming a cloud copy exists when it does not — the same
class of problem as the reported bug, found while tracing it.

**`BackupLocation.both` was set unconditionally** after `_uploadToCloud`, even
when it returned `null` because the backup folder could not be reached. History
then claimed a cloud copy with no `cloudFileId`, pointing restore at a file that
was never written. It is now promoted only on a real file id.

**The success notification did not distinguish a local-only fallback.** Upload
failures are swallowed by design, to protect the local artifact — so an offline
run or an expired token produced "Your dive data has been backed up
successfully" while nothing left the device. A run that was supposed to reach
the cloud and did not now reads "Backup Complete (device only)" and says the
cloud copy will be retried. The title/body builders were extracted as pure
statics (following `serviceReminderBody`) so the wording is unit-tested.

Note these notification strings are hardcoded English, consistent with the rest
of `NotificationService` — localizing that surface is separate work.

## Behaviour change worth knowing

Scheduled backups on mobile now do real network work. On a large library an
upload can exceed Android's background window and be killed; the next 12-hour
check retries. This is what the cloud switch was always meant to do, and matches
desktop, but it is new on mobile.

## Tests

- `headless_cloud_provider_test.dart` — provider resolution, custom-folder mode,
  unrecognized selection, encryption wrap on/off, keychain failure.
- `background_service_backup_test.dart` — the scheduled path uploads when the
  switch is on, stays local when it is off or nothing is connected. This is the
  regression guard for the exact wiring that broke.
- `backup_notification_text_test.dart` — the local-only wording, including that
  it never reads as an unqualified success.
- `backup_service_test.dart` — `both` only when the upload returned a file id.

Each new test was confirmed to fail against the old code rather than pass
vacuously.

## Not covered by tests

That Dropbox's token refresh and chunked upload actually run inside Android's
Workmanager isolate is unverified — the tests prove the wiring, not the
platform. Worth a device smoke test before release: force the job with
`adb shell cmd jobscheduler run -f app.submersion <job_id>` and look for
`Backup uploaded to cloud:` in logcat plus a `cloud_done` icon on the new
history row.
