### PR TITLE
fix(stats): count prior dives in every lifetime total

### DIFF
--- a/lib/features/dashboard/presentation/providers/milestone_providers.dart
+++ b/lib/features/dashboard/presentation/providers/milestone_providers.dart
@@ -77,8 +77,10 @@ class DashboardMilestones {
 /// diver carrying a pre-app logbook is not sent back to the "10 dives"
 /// milestone they passed decades ago (issue #808).
 final milestonesProvider = FutureProvider<DashboardMilestones>((ref) async {
-  final career = await ref.watch(careerTotalsProvider.future);
+  // Watched before the await so the dependency is registered synchronously
+  // rather than across an async gap.
   final certsAsync = ref.watch(certificationListNotifierProvider);
+  final career = await ref.watch(careerTotalsProvider.future);
   final certs = certsAsync.valueOrNull ?? const <Certification>[];
 
   final total = career.combinedDives;

--- a/lib/features/dashboard/presentation/providers/milestone_providers.dart
+++ b/lib/features/dashboard/presentation/providers/milestone_providers.dart
@@ -2,7 +2,7 @@ import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/features/certifications/domain/entities/certification.dart';
 import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/statistics/presentation/providers/career_totals_provider.dart';
 
 const _milestoneLadder = [10, 25, 50, 100, 250, 500, 1000];
 
@@ -72,15 +72,20 @@ class DashboardMilestones {
 }
 
 /// Next dive-count milestone and upcoming certification anniversaries.
+///
+/// Counts from the diver's combined career total (logged + prior dives), so a
+/// diver carrying a pre-app logbook is not sent back to the "10 dives"
+/// milestone they passed decades ago (issue #808).
 final milestonesProvider = FutureProvider<DashboardMilestones>((ref) async {
-  final stats = await ref.watch(diveStatisticsProvider.future);
+  final career = await ref.watch(careerTotalsProvider.future);
   final certsAsync = ref.watch(certificationListNotifierProvider);
   final certs = certsAsync.valueOrNull ?? const <Certification>[];
 
-  final next = nextDiveMilestone(stats.totalDives);
+  final total = career.combinedDives;
+  final next = nextDiveMilestone(total);
   return DashboardMilestones(
     nextMilestone: next,
-    divesRemaining: next == null ? null : next - stats.totalDives,
+    divesRemaining: next == null ? null : next - total,
     anniversaries: upcomingAnniversaries(certs, DateTime.now()),
   );
 });

--- a/lib/features/dashboard/presentation/widgets/hero_header.dart
+++ b/lib/features/dashboard/presentation/widgets/hero_header.dart
@@ -3,9 +3,10 @@ import 'package:intl/intl.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/presentation/widgets/ocean_background.dart';
 
-import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dashboard/presentation/providers/dashboard_providers.dart';
+import 'package:submersion/features/statistics/domain/career_totals.dart';
+import 'package:submersion/features/statistics/presentation/providers/career_totals_provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
 
@@ -15,13 +16,16 @@ import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.d
 /// At desktop widths (>=800) the app logo anchors left and subdued
 /// lifetime stats fill the center; on phones the header keeps the
 /// compact greeting + headline stats layout.
+///
+/// Dive and time totals come from [careerTotalsProvider], so they include the
+/// diver's pre-app logbook and agree with the Statistics overview (issue #808).
 class HeroHeader extends ConsumerWidget {
   const HeroHeader({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final diverAsync = ref.watch(dashboardDiverProvider);
-    final statsAsync = ref.watch(diveStatisticsProvider);
+    final careerAsync = ref.watch(careerTotalsProvider);
     final theme = Theme.of(context);
     final isDesktop = ResponsiveBreakpoints.isDesktop(context);
 
@@ -90,14 +94,14 @@ class HeroHeader extends ConsumerWidget {
                       )
                     else
                       // Headline stats (phone)
-                      statsAsync.when(
-                        data: (stats) {
+                      careerAsync.when(
+                        data: (career) {
                           final screenWidth = MediaQuery.sizeOf(context).width;
                           final isNarrow = screenWidth < 600;
                           return Text(
                             _buildHeadlineStats(
                               context,
-                              stats,
+                              career,
                               isNarrow: isNarrow,
                             ),
                             style: theme.textTheme.bodyLarge?.copyWith(
@@ -149,26 +153,28 @@ class HeroHeader extends ConsumerWidget {
 
   String _buildHeadlineStats(
     BuildContext context,
-    DiveStatistics stats, {
+    CareerTotals career, {
     bool isNarrow = false,
   }) {
-    if (stats.totalDives == 0) return context.l10n.dashboard_hero_noDives;
+    final dives = career.combinedDives;
+    if (dives == 0) return context.l10n.dashboard_hero_noDives;
 
     final parts = <String>[];
 
-    final diveText = stats.totalDives == 1
+    final diveText = dives == 1
         ? context.l10n.dashboard_hero_divesLoggedOne
-        : context.l10n.dashboard_hero_divesLoggedOther(stats.totalDives);
+        : context.l10n.dashboard_hero_divesLoggedOther(dives);
     parts.add(diveText);
 
-    final hours = stats.totalTimeSeconds / 3600;
+    final totalTimeSeconds = career.combinedTimeSeconds;
+    final hours = totalTimeSeconds / 3600;
     if (hours >= 1) {
       final hoursStr = hours < 10
           ? hours.toStringAsFixed(1)
           : hours.round().toString();
       parts.add(context.l10n.dashboard_hero_hoursUnderwater(hoursStr));
-    } else if (stats.totalTimeSeconds > 0) {
-      final minutes = stats.totalTimeSeconds ~/ 60;
+    } else if (totalTimeSeconds > 0) {
+      final minutes = totalTimeSeconds ~/ 60;
       parts.add(context.l10n.dashboard_hero_minutesUnderwater(minutes));
     }
 
@@ -184,19 +190,26 @@ class _QuietStats extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final statsAsync = ref.watch(diveStatisticsProvider);
+    final careerAsync = ref.watch(careerTotalsProvider);
     final quickAsync = ref.watch(dashboardQuickStatsProvider);
-    final stats = statsAsync.valueOrNull;
-    if (stats == null || stats.totalDives == 0) {
+    final career = careerAsync.valueOrNull;
+    if (career == null || career.combinedDives == 0) {
       return const SizedBox.shrink();
     }
+    // Sites stay logged-only: the prior-experience offset records dives and
+    // time, not the distinct sites behind them.
+    final totalSites = ref
+        .watch(diveStatisticsProvider)
+        .valueOrNull
+        ?.totalSites;
     final countries = quickAsync.valueOrNull?.countriesVisited ?? 0;
-    final hours = (stats.totalTimeSeconds / 3600).round();
+    final hours = (career.combinedTimeSeconds / 3600).round();
 
     final items = <(String, String)>[
-      ('${stats.totalDives}', context.l10n.dashboard_hero_statDives),
+      ('${career.combinedDives}', context.l10n.dashboard_hero_statDives),
       ('$hours', context.l10n.dashboard_hero_statHours),
-      ('${stats.totalSites}', context.l10n.dashboard_hero_statSites),
+      if (totalSites != null)
+        ('$totalSites', context.l10n.dashboard_hero_statSites),
       if (countries > 0)
         ('$countries', context.l10n.dashboard_hero_statCountries),
     ];

--- a/lib/features/dashboard/presentation/widgets/hero_header.dart
+++ b/lib/features/dashboard/presentation/widgets/hero_header.dart
@@ -161,9 +161,20 @@ class HeroHeader extends ConsumerWidget {
 
     final parts = <String>[];
 
-    final diveText = dives == 1
-        ? context.l10n.dashboard_hero_divesLoggedOne
-        : context.l10n.dashboard_hero_divesLoggedOther(dives);
+    // "N dives logged" would misdescribe a total that includes the diver's
+    // prior offset -- those dives are precisely the ones NOT logged in-app, and
+    // the Statistics breakdown reserves "logged" for the in-app count. Divers
+    // without prior experience keep the original copy.
+    final String diveText;
+    if (career.hasPriorDives) {
+      diveText = dives == 1
+          ? context.l10n.dashboard_hero_divesTotalOne
+          : context.l10n.dashboard_hero_divesTotalOther(dives);
+    } else {
+      diveText = dives == 1
+          ? context.l10n.dashboard_hero_divesLoggedOne
+          : context.l10n.dashboard_hero_divesLoggedOther(dives);
+    }
     parts.add(diveText);
 
     final totalTimeSeconds = career.combinedTimeSeconds;

--- a/lib/features/dive_log/presentation/widgets/dive_summary_widget.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_summary_widget.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/statistics/domain/career_totals.dart';
+import 'package:submersion/features/statistics/presentation/providers/career_totals_provider.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Summary widget shown in the detail pane when no dive is selected.
 ///
 /// Displays aggregate statistics about the user's dive history,
 /// including total dives, hours logged, records, and recent activity.
+///
+/// Dive count and dive time are career totals (logged + prior dives), matching
+/// the Statistics overview and the home hero header (issue #808).
 class DiveSummaryWidget extends ConsumerWidget {
   const DiveSummaryWidget({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final statsAsync = ref.watch(diveStatisticsProvider);
+    final careerAsync = ref.watch(careerTotalsProvider);
     final recordsAsync = ref.watch(diveRecordsProvider);
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
@@ -30,8 +36,17 @@ class DiveSummaryWidget extends ConsumerWidget {
           children: [
             _buildHeader(context),
             const SizedBox(height: 24),
-            statsAsync.when(
-              data: (stats) => _buildStatsSummary(context, stats, units),
+            careerAsync.when(
+              // careerTotalsProvider awaits diveStatisticsProvider, so stats
+              // are resolved by the time career totals are; the null branch is
+              // only reachable while a refresh is in flight.
+              data: (career) {
+                final stats = statsAsync.valueOrNull;
+                if (stats == null) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                return _buildStatsSummary(context, stats, career, units);
+              },
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, _) => Center(child: Text('Error: $e')),
             ),
@@ -86,10 +101,12 @@ class DiveSummaryWidget extends ConsumerWidget {
   Widget _buildStatsSummary(
     BuildContext context,
     DiveStatistics stats,
+    CareerTotals career,
     UnitFormatter units,
   ) {
-    final hours = stats.totalTimeSeconds ~/ 3600;
-    final minutes = (stats.totalTimeSeconds % 3600) ~/ 60;
+    final totalTimeSeconds = career.combinedTimeSeconds;
+    final hours = totalTimeSeconds ~/ 3600;
+    final minutes = (totalTimeSeconds % 3600) ~/ 60;
     final timeString = hours > 0 ? '${hours}h ${minutes}m' : '${minutes}m';
 
     return Column(
@@ -109,8 +126,14 @@ class DiveSummaryWidget extends ConsumerWidget {
             _buildStatCard(
               context,
               icon: Icons.tag,
-              value: '${stats.totalDives}',
+              value: '${career.combinedDives}',
               label: context.l10n.diveLog_summary_stat_totalDives,
+              subtitle: career.hasPriorDives
+                  ? context.l10n.statistics_priorBreakdown(
+                      '${career.loggedDives}',
+                      '${career.priorDives}',
+                    )
+                  : null,
               color: Colors.blue,
             ),
             _buildStatCard(
@@ -118,6 +141,12 @@ class DiveSummaryWidget extends ConsumerWidget {
               icon: Icons.timer,
               value: timeString,
               label: context.l10n.diveLog_summary_stat_diveTime,
+              subtitle: career.hasPriorTime
+                  ? context.l10n.statistics_priorBreakdown(
+                      career.loggedTimeFormatted,
+                      career.priorTimeFormatted,
+                    )
+                  : null,
               color: Colors.teal,
             ),
             _buildStatCard(
@@ -166,6 +195,7 @@ class DiveSummaryWidget extends ConsumerWidget {
     required String value,
     required String label,
     required Color color,
+    String? subtitle,
   }) {
     return SizedBox(
       width: 140,
@@ -199,6 +229,16 @@ class DiveSummaryWidget extends ConsumerWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/features/statistics/presentation/pages/statistics_overview_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_overview_page.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
 import 'package:submersion/features/statistics/domain/career_totals.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -47,13 +48,21 @@ class _OverviewBody extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final diverAsync = ref.watch(currentDiverProvider);
+    // The prior-dive offset is a single lifetime scalar -- no date, site or
+    // buddy behind it -- so it cannot be narrowed to a filtered subset. While a
+    // filter is active the totals stay logged-only, rather than adding an
+    // entire pre-app career on top of (say) one year's dives.
+    final filtered = ref.watch(
+      statisticsFilterProvider.select((f) => f.hasActiveFilters),
+    );
     // With no logged dives, whether to show the empty state depends on prior
     // experience -- so wait for the diver to resolve rather than briefly
     // flashing the empty state (currentDiverProvider is a FutureProvider).
-    if (stats.totalDives == 0 && diverAsync.isLoading) {
+    // Irrelevant under a filter, where prior experience is excluded anyway.
+    if (stats.totalDives == 0 && !filtered && diverAsync.isLoading) {
       return const Center(child: CircularProgressIndicator());
     }
-    final diver = diverAsync.valueOrNull;
+    final diver = filtered ? null : diverAsync.valueOrNull;
     final career = CareerTotals.from(
       loggedDives: stats.totalDives,
       loggedTimeSeconds: stats.totalTimeSeconds,

--- a/lib/features/statistics/presentation/providers/career_totals_provider.dart
+++ b/lib/features/statistics/presentation/providers/career_totals_provider.dart
@@ -1,0 +1,30 @@
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/statistics/domain/career_totals.dart';
+
+/// Lifetime career totals for every surface that shows an unfiltered "total
+/// dives": app-logged dives combined with the active diver's manually entered
+/// prior-experience offset (issue #331).
+///
+/// Reads [diveStatisticsProvider], the UNFILTERED totals -- not
+/// `filteredDiveStatisticsProvider` -- so a filter set on the Statistics tab
+/// never leaks into the home dashboard.
+///
+/// Before this existed, only the Statistics overview combined the two, so the
+/// home hero header and the milestones card reported a smaller total than the
+/// Statistics page for any diver with a pre-app logbook (issue #808).
+final careerTotalsProvider = FutureProvider<CareerTotals>((ref) async {
+  final stats = await ref.watch(diveStatisticsProvider.future);
+  final diver = await ref.watch(currentDiverProvider.future);
+
+  return CareerTotals.from(
+    loggedDives: stats.totalDives,
+    loggedTimeSeconds: stats.totalTimeSeconds,
+    firstLoggedDive: stats.firstDiveDate,
+    priorDives: diver?.priorDiveCount,
+    priorTimeSeconds: diver?.priorDiveTimeSeconds,
+    divingSince: diver?.divingSince,
+  );
+});

--- a/lib/features/statistics/presentation/providers/career_totals_provider.dart
+++ b/lib/features/statistics/presentation/providers/career_totals_provider.dart
@@ -16,8 +16,14 @@ import 'package:submersion/features/statistics/domain/career_totals.dart';
 /// home hero header and the milestones card reported a smaller total than the
 /// Statistics page for any diver with a pre-app logbook (issue #808).
 final careerTotalsProvider = FutureProvider<CareerTotals>((ref) async {
-  final stats = await ref.watch(diveStatisticsProvider.future);
-  final diver = await ref.watch(currentDiverProvider.future);
+  // Both watches happen synchronously, before either await: the two reads are
+  // independent, so this lets them resolve in parallel and registers both
+  // dependencies without crossing an async gap.
+  final statsFuture = ref.watch(diveStatisticsProvider.future);
+  final diverFuture = ref.watch(currentDiverProvider.future);
+
+  final stats = await statsFuture;
+  final diver = await diverFuture;
 
   return CareerTotals.from(
     loggedDives: stats.totalDives,

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "غوصة واحدة مسجلة",
   "dashboard_hero_divesLoggedOther": "{count} غوصات مسجلة",
+  "dashboard_hero_divesTotalOne": "غوصة واحدة",
+  "dashboard_hero_divesTotalOther": "{count} غوصات",
   "dashboard_hero_error": "هل أنت مستعد لاستكشاف الأعماق؟",
   "dashboard_hero_hoursUnderwater": "{hours} ساعات تحت الماء",
   "dashboard_hero_loading": "جارٍ تحميل إحصائيات الغوص...",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 Tauchgang protokolliert",
   "dashboard_hero_divesLoggedOther": "{count} Tauchgänge protokolliert",
+  "dashboard_hero_divesTotalOne": "1 Tauchgang",
+  "dashboard_hero_divesTotalOther": "{count} Tauchgänge",
   "dashboard_hero_error": "Bereit, die Tiefen zu erkunden?",
   "dashboard_hero_hoursUnderwater": "{hours} Stunden unter Wasser",
   "dashboard_hero_loading": "Ihre Tauchstatistiken werden geladen...",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1837,6 +1837,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 dive logged",
   "dashboard_hero_divesLoggedOther": "{count} dives logged",
+  "dashboard_hero_divesTotalOne": "1 dive",
+  "dashboard_hero_divesTotalOther": "{count} dives",
   "dashboard_hero_error": "Ready to explore the depths?",
   "dashboard_hero_hoursUnderwater": "{hours} hours underwater",
   "dashboard_hero_loading": "Loading your dive stats...",
@@ -2222,6 +2224,13 @@
     }
   },
   "@dashboard_hero_divesLoggedOther": {
+    "placeholders": {
+      "count": {
+        "type": "Object"
+      }
+    }
+  },
+  "@dashboard_hero_divesTotalOther": {
     "placeholders": {
       "count": {
         "type": "Object"

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "¡{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 inmersión registrada",
   "dashboard_hero_divesLoggedOther": "{count} inmersiones registradas",
+  "dashboard_hero_divesTotalOne": "1 inmersión",
+  "dashboard_hero_divesTotalOther": "{count} inmersiones",
   "dashboard_hero_error": "¿Listo para explorar las profundidades?",
   "dashboard_hero_hoursUnderwater": "{hours} horas bajo el agua",
   "dashboard_hero_loading": "Cargando tus estadísticas de buceo...",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting} !",
   "dashboard_hero_divesLoggedOne": "1 plongee enregistree",
   "dashboard_hero_divesLoggedOther": "{count} plongees enregistrees",
+  "dashboard_hero_divesTotalOne": "1 plongee",
+  "dashboard_hero_divesTotalOther": "{count} plongees",
   "dashboard_hero_error": "Pret a explorer les profondeurs ?",
   "dashboard_hero_hoursUnderwater": "{hours} heures sous l'eau",
   "dashboard_hero_loading": "Chargement de tes statistiques de plongee...",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "צלילה אחת רשומה",
   "dashboard_hero_divesLoggedOther": "{count} צלילות רשומות",
+  "dashboard_hero_divesTotalOne": "צלילה אחת",
+  "dashboard_hero_divesTotalOther": "{count} צלילות",
   "dashboard_hero_error": "מוכן לחקור את המעמקים?",
   "dashboard_hero_hoursUnderwater": "{hours} שעות מתחת למים",
   "dashboard_hero_loading": "טוען את נתוני הצלילה שלך...",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 merules rogzitve",
   "dashboard_hero_divesLoggedOther": "{count} merules rogzitve",
+  "dashboard_hero_divesTotalOne": "1 merules",
+  "dashboard_hero_divesTotalOther": "{count} merules",
   "dashboard_hero_error": "Kesz felfedezni a melyseget?",
   "dashboard_hero_hoursUnderwater": "{hours} ora viz alatt",
   "dashboard_hero_loading": "Merulesi statisztikak betoltese...",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 immersione registrata",
   "dashboard_hero_divesLoggedOther": "{count} immersioni registrate",
+  "dashboard_hero_divesTotalOne": "1 immersione",
+  "dashboard_hero_divesTotalOther": "{count} immersioni",
   "dashboard_hero_error": "Pronti a esplorare le profondita?",
   "dashboard_hero_hoursUnderwater": "{hours} ore sott'acqua",
   "dashboard_hero_loading": "Caricamento statistiche immersioni...",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -5045,6 +5045,18 @@ abstract class AppLocalizations {
   /// **'{count} dives logged'**
   String dashboard_hero_divesLoggedOther(Object count);
 
+  /// No description provided for @dashboard_hero_divesTotalOne.
+  ///
+  /// In en, this message translates to:
+  /// **'1 dive'**
+  String get dashboard_hero_divesTotalOne;
+
+  /// No description provided for @dashboard_hero_divesTotalOther.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} dives'**
+  String dashboard_hero_divesTotalOther(Object count);
+
   /// No description provided for @dashboard_hero_error.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2906,6 +2906,14 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => 'غوصة واحدة';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count غوصات';
+  }
+
+  @override
   String get dashboard_hero_error => 'هل أنت مستعد لاستكشاف الأعماق؟';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2976,6 +2976,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 Tauchgang';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count Tauchgänge';
+  }
+
+  @override
   String get dashboard_hero_error => 'Bereit, die Tiefen zu erkunden?';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2913,6 +2913,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 dive';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count dives';
+  }
+
+  @override
   String get dashboard_hero_error => 'Ready to explore the depths?';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2970,6 +2970,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 inmersión';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count inmersiones';
+  }
+
+  @override
   String get dashboard_hero_error => '¿Listo para explorar las profundidades?';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2976,6 +2976,14 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 plongee';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count plongees';
+  }
+
+  @override
   String get dashboard_hero_error => 'Pret a explorer les profondeurs ?';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2884,6 +2884,14 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => 'צלילה אחת';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count צלילות';
+  }
+
+  @override
   String get dashboard_hero_error => 'מוכן לחקור את המעמקים?';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2953,6 +2953,14 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 merules';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count merules';
+  }
+
+  @override
   String get dashboard_hero_error => 'Kesz felfedezni a melyseget?';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2966,6 +2966,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 immersione';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count immersioni';
+  }
+
+  @override
   String get dashboard_hero_error => 'Pronti a esplorare le profondita?';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2947,6 +2947,14 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 duik';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count duiken';
+  }
+
+  @override
   String get dashboard_hero_error => 'Klaar om de diepte te verkennen?';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2967,6 +2967,14 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 mergulho';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count mergulhos';
+  }
+
+  @override
   String get dashboard_hero_error => 'Pronto para explorar as profundezas?';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2810,6 +2810,14 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get dashboard_hero_divesTotalOne => '1 次潜水';
+
+  @override
+  String dashboard_hero_divesTotalOther(Object count) {
+    return '$count 次潜水';
+  }
+
+  @override
   String get dashboard_hero_error => '准备好探索深海了吗？';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 duik gelogd",
   "dashboard_hero_divesLoggedOther": "{count} duiken gelogd",
+  "dashboard_hero_divesTotalOne": "1 duik",
+  "dashboard_hero_divesTotalOther": "{count} duiken",
   "dashboard_hero_error": "Klaar om de diepte te verkennen?",
   "dashboard_hero_hoursUnderwater": "{hours} uur onder water",
   "dashboard_hero_loading": "Uw duikstatistieken laden...",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1004,6 +1004,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "1 mergulho registrado",
   "dashboard_hero_divesLoggedOther": "{count} mergulhos registrados",
+  "dashboard_hero_divesTotalOne": "1 mergulho",
+  "dashboard_hero_divesTotalOther": "{count} mergulhos",
   "dashboard_hero_error": "Pronto para explorar as profundezas?",
   "dashboard_hero_hoursUnderwater": "{hours} horas submerso",
   "dashboard_hero_loading": "Carregando suas estatisticas de mergulho...",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1098,6 +1098,8 @@
   "dashboard_greeting_withoutName": "{greeting}!",
   "dashboard_hero_divesLoggedOne": "已记录 1 次潜水",
   "dashboard_hero_divesLoggedOther": "已记录 {count} 次潜水",
+  "dashboard_hero_divesTotalOne": "1 次潜水",
+  "dashboard_hero_divesTotalOther": "{count} 次潜水",
   "dashboard_hero_error": "准备好探索深海了吗？",
   "dashboard_hero_hoursUnderwater": "水下 {hours} 小时",
   "dashboard_hero_loading": "正在加载您的潜水统计...",

--- a/test/features/dashboard/presentation/providers/milestone_providers_test.dart
+++ b/test/features/dashboard/presentation/providers/milestone_providers_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dashboard/presentation/providers/milestone_p
 import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -90,9 +91,11 @@ void main() {
   group('milestonesProvider', () {
     late ProviderContainer container;
     var totalDives = 0;
+    int? priorDives;
     var certs = <Certification>[];
 
     setUp(() {
+      priorDives = null;
       container = ProviderContainer(
         overrides: [
           currentDiverIdProvider.overrideWith(
@@ -110,6 +113,15 @@ void main() {
               totalSites: 0,
             ),
           ),
+          currentDiverProvider.overrideWith(
+            (ref) async => Diver(
+              id: '1',
+              name: 'Eric Griffin',
+              priorDiveCount: priorDives,
+              createdAt: DateTime(2026, 1, 1),
+              updatedAt: DateTime(2026, 1, 1),
+            ),
+          ),
         ],
       );
       addTearDown(container.dispose);
@@ -121,6 +133,28 @@ void main() {
 
       expect(milestones.nextMilestone, 250);
       expect(milestones.divesRemaining, 3);
+      expect(milestones.isEmpty, isFalse);
+    });
+
+    test('counts prior dives toward the next milestone (#808)', () async {
+      totalDives = 30;
+      priorDives = 480;
+
+      final milestones = await container.read(milestonesProvider.future);
+
+      // 510 combined, not the 30 logged in-app.
+      expect(milestones.nextMilestone, 1000);
+      expect(milestones.divesRemaining, 490);
+    });
+
+    test('prior dives alone produce a milestone with nothing logged', () async {
+      totalDives = 0;
+      priorDives = 240;
+
+      final milestones = await container.read(milestonesProvider.future);
+
+      expect(milestones.nextMilestone, 250);
+      expect(milestones.divesRemaining, 10);
       expect(milestones.isEmpty, isFalse);
     });
 

--- a/test/features/dashboard/presentation/widgets/hero_header_test.dart
+++ b/test/features/dashboard/presentation/widgets/hero_header_test.dart
@@ -242,7 +242,10 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
       }
 
-      expect(find.textContaining('372 dives logged'), findsOneWidget);
+      // Neutral copy, not "dives logged": 125 of these were never logged
+      // in-app.
+      expect(find.textContaining('372 dives'), findsOneWidget);
+      expect(find.textContaining('logged'), findsNothing);
       expect(find.textContaining('286 hours'), findsOneWidget);
     });
 
@@ -344,7 +347,8 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
       }
 
-      expect(find.textContaining('480 dives logged'), findsOneWidget);
+      expect(find.textContaining('480 dives'), findsOneWidget);
+      expect(find.textContaining('logged'), findsNothing);
     });
 
     testWidgets('displays time-of-day greeting', (tester) async {

--- a/test/features/dashboard/presentation/widgets/hero_header_test.dart
+++ b/test/features/dashboard/presentation/widgets/hero_header_test.dart
@@ -197,6 +197,156 @@ void main() {
       expect(find.textContaining('247 dives logged'), findsOneWidget);
     });
 
+    testWidgets('headline totals include prior dives and time (#808)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(500, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            divesProvider.overrideWith((ref) async => <Dive>[]),
+            diveStatisticsProvider.overrideWith(
+              (ref) async => DiveStatistics(
+                totalDives: 247,
+                totalTimeSeconds: 669600, // 186h
+                maxDepth: 52.0,
+                avgMaxDepth: 27.5,
+                totalSites: 83,
+              ),
+            ),
+            currentDiverProvider.overrideWith(
+              (ref) async => Diver(
+                id: '1',
+                name: 'Eric Griffin',
+                priorDiveCount: 125,
+                priorDiveTimeSeconds: 360000, // 100h
+                createdAt: DateTime(2026, 1, 1),
+                updatedAt: DateTime(2026, 1, 1),
+              ),
+            ),
+          ].cast(),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SingleChildScrollView(child: HeroHeader())),
+          ),
+        ),
+      );
+      for (int i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(find.textContaining('372 dives logged'), findsOneWidget);
+      expect(find.textContaining('286 hours'), findsOneWidget);
+    });
+
+    testWidgets('quiet desktop stats include prior dives (#808)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1300, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            divesProvider.overrideWith((ref) async => <Dive>[]),
+            diveStatisticsProvider.overrideWith(
+              (ref) async => DiveStatistics(
+                totalDives: 247,
+                totalTimeSeconds: 669600,
+                maxDepth: 52.0,
+                avgMaxDepth: 27.5,
+                totalSites: 83,
+              ),
+            ),
+            dashboardQuickStatsProvider.overrideWith(
+              (ref) async => const DashboardQuickStats(countriesVisited: 14),
+            ),
+            currentDiverProvider.overrideWith(
+              (ref) async => Diver(
+                id: '1',
+                name: 'Eric Griffin',
+                priorDiveCount: 125,
+                priorDiveTimeSeconds: 360000,
+                createdAt: DateTime(2026, 1, 1),
+                updatedAt: DateTime(2026, 1, 1),
+              ),
+            ),
+          ].cast(),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SingleChildScrollView(child: HeroHeader())),
+          ),
+        ),
+      );
+      for (int i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(find.text('372'), findsOneWidget);
+      expect(find.text('286'), findsOneWidget);
+      // Sites stay logged-only: the prior offset carries no site information.
+      expect(find.text('83'), findsOneWidget);
+    });
+
+    testWidgets('shows prior-only career stats with nothing logged (#808)', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(500, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            divesProvider.overrideWith((ref) async => <Dive>[]),
+            diveStatisticsProvider.overrideWith(
+              (ref) async => DiveStatistics(
+                totalDives: 0,
+                totalTimeSeconds: 0,
+                maxDepth: 0,
+                avgMaxDepth: 0,
+                totalSites: 0,
+              ),
+            ),
+            currentDiverProvider.overrideWith(
+              (ref) async => Diver(
+                id: '1',
+                name: 'Eric Griffin',
+                priorDiveCount: 480,
+                createdAt: DateTime(2026, 1, 1),
+                updatedAt: DateTime(2026, 1, 1),
+              ),
+            ),
+          ].cast(),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SingleChildScrollView(child: HeroHeader())),
+          ),
+        ),
+      );
+      for (int i = 0; i < 10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(find.textContaining('480 dives logged'), findsOneWidget);
+    });
+
     testWidgets('displays time-of-day greeting', (tester) async {
       final overrides = await getBaseOverrides();
 

--- a/test/features/dive_log/presentation/widgets/dive_summary_widget_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_summary_widget_test.dart
@@ -4,6 +4,8 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_summary_widget.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -120,6 +122,73 @@ void main() {
 
       // Should render without crashing
       expect(find.byType(DiveSummaryWidget), findsOneWidget);
+    });
+  });
+
+  group('DiveSummaryWidget career totals (#808)', () {
+    Future<void> pumpWithDiver(WidgetTester tester, Diver? diver) async {
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            ...overrides,
+            diveStatisticsProvider.overrideWith(
+              (ref) async => DiveStatistics(
+                totalDives: 247,
+                totalTimeSeconds: 669600, // 186h 0m
+                maxDepth: 52.0,
+                avgMaxDepth: 27.5,
+                totalSites: 83,
+              ),
+            ),
+            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            currentDiverProvider.overrideWith((ref) async => diver),
+          ].cast(),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: DiveSummaryWidget()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('adds prior dives and time, with a breakdown', (tester) async {
+      await pumpWithDiver(
+        tester,
+        Diver(
+          id: '1',
+          name: 'Eric Griffin',
+          priorDiveCount: 125,
+          priorDiveTimeSeconds: 360000, // 100h 0m
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      );
+
+      expect(find.text('372'), findsOneWidget);
+      expect(find.text('286h 0m'), findsOneWidget);
+      expect(find.text('247 logged + 125 prior'), findsOneWidget);
+      expect(find.text('186h 0m logged + 100h 0m prior'), findsOneWidget);
+    });
+
+    testWidgets('shows logged totals alone without priors', (tester) async {
+      await pumpWithDiver(
+        tester,
+        Diver(
+          id: '1',
+          name: 'Eric Griffin',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      );
+
+      expect(find.text('247'), findsOneWidget);
+      expect(find.text('186h 0m'), findsOneWidget);
+      expect(find.textContaining('prior'), findsNothing);
     });
   });
 }

--- a/test/features/statistics/presentation/pages/statistics_overview_prior_experience_test.dart
+++ b/test/features/statistics/presentation/pages/statistics_overview_prior_experience_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/statistics/presentation/pages/statistics_overview_page.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -34,6 +35,7 @@ Future<void> _pump(
   WidgetTester tester,
   Diver diver, {
   DiveStatistics? stats,
+  DiveFilterState? filter,
 }) async {
   tester.view.physicalSize = const Size(800, 2000);
   tester.view.devicePixelRatio = 1.0;
@@ -48,6 +50,8 @@ Future<void> _pump(
         filteredDiveStatisticsProvider.overrideWith(
           (ref) async => stats ?? _stats(),
         ),
+        if (filter != null)
+          statisticsFilterProvider.overrideWith((ref) => filter),
         currentDiverProvider.overrideWith((ref) async => diver),
       ],
       child: const MaterialApp(
@@ -92,6 +96,35 @@ void main() {
     );
     // Not the empty state: the combined career total (0 logged + 1200) shows.
     expect(find.text('1200'), findsOneWidget);
+    expect(find.textContaining('1990'), findsOneWidget);
+  });
+
+  testWidgets('an active filter drops the prior offset from the total', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      _diver(count: 1200, seconds: 1150 * 3600, since: DateTime(1990)),
+      filter: DiveFilterState(startDate: DateTime(2024)),
+    );
+
+    // The 312 dives matching the filter, not 312 + a whole pre-app career.
+    expect(find.text('312'), findsOneWidget);
+    expect(find.textContaining('1512'), findsNothing);
+    expect(find.textContaining('prior'), findsNothing);
+    expect(find.textContaining('Diving since'), findsNothing);
+  });
+
+  testWidgets('clearing the filter restores the combined career total', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      _diver(count: 1200, seconds: 1150 * 3600, since: DateTime(1990)),
+      filter: const DiveFilterState(),
+    );
+
+    expect(find.textContaining('1512'), findsWidgets);
     expect(find.textContaining('1990'), findsOneWidget);
   });
 

--- a/test/features/statistics/presentation/providers/career_totals_provider_test.dart
+++ b/test/features/statistics/presentation/providers/career_totals_provider_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/statistics/presentation/providers/career_totals_provider.dart';
+
+DiveStatistics _stats({
+  int totalDives = 0,
+  int totalTimeSeconds = 0,
+  DateTime? firstDiveDate,
+}) => DiveStatistics(
+  totalDives: totalDives,
+  totalTimeSeconds: totalTimeSeconds,
+  maxDepth: 0,
+  avgMaxDepth: 0,
+  totalSites: 0,
+  firstDiveDate: firstDiveDate,
+);
+
+Diver _diver({
+  int? priorDiveCount,
+  int? priorDiveTimeSeconds,
+  DateTime? divingSince,
+}) => Diver(
+  id: '1',
+  name: 'Eric Griffin',
+  priorDiveCount: priorDiveCount,
+  priorDiveTimeSeconds: priorDiveTimeSeconds,
+  divingSince: divingSince,
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+);
+
+ProviderContainer _container({
+  required DiveStatistics stats,
+  required Diver? diver,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      diveStatisticsProvider.overrideWith((ref) async => stats),
+      currentDiverProvider.overrideWith((ref) async => diver),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('careerTotalsProvider', () {
+    test('combines logged dives with the diver prior-dive offset', () async {
+      final container = _container(
+        stats: _stats(totalDives: 247, totalTimeSeconds: 669600),
+        diver: _diver(priorDiveCount: 125, priorDiveTimeSeconds: 360000),
+      );
+
+      final career = await container.read(careerTotalsProvider.future);
+
+      expect(career.loggedDives, 247);
+      expect(career.priorDives, 125);
+      expect(career.combinedDives, 372);
+      expect(career.combinedTimeSeconds, 1029600);
+      expect(career.hasPriorDives, isTrue);
+    });
+
+    test('falls back to logged totals when the diver has no priors', () async {
+      final container = _container(
+        stats: _stats(totalDives: 12, totalTimeSeconds: 3600),
+        diver: _diver(),
+      );
+
+      final career = await container.read(careerTotalsProvider.future);
+
+      expect(career.combinedDives, 12);
+      expect(career.combinedTimeSeconds, 3600);
+      expect(career.hasPriorDives, isFalse);
+    });
+
+    test('treats a null diver as no prior experience', () async {
+      final container = _container(
+        stats: _stats(totalDives: 5, totalTimeSeconds: 1800),
+        diver: null,
+      );
+
+      final career = await container.read(careerTotalsProvider.future);
+
+      expect(career.combinedDives, 5);
+      expect(career.hasPriorExperience, isFalse);
+    });
+
+    test('surfaces prior experience with nothing logged in-app', () async {
+      final container = _container(
+        stats: _stats(),
+        diver: _diver(priorDiveCount: 480, divingSince: DateTime(1998, 6, 1)),
+      );
+
+      final career = await container.read(careerTotalsProvider.future);
+
+      expect(career.combinedDives, 480);
+      expect(career.divingSinceResolved, DateTime(1998, 6, 1));
+    });
+
+    test('clamps divingSince to the first logged dive', () async {
+      final container = _container(
+        stats: _stats(totalDives: 3, firstDiveDate: DateTime(1995, 4, 2)),
+        diver: _diver(priorDiveCount: 10, divingSince: DateTime(1998, 6, 1)),
+      );
+
+      final career = await container.read(careerTotalsProvider.future);
+
+      expect(career.divingSinceResolved, DateTime(1995, 4, 2));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #808.

## The problem

"Total dives" was computed two different ways.

`CareerTotals` — the value object that combines app-logged dives with the diver's manually entered prior-dive offset (#331) — was constructed **inline inside `StatisticsOverviewPage`**. So the Statistics tab was the only surface that knew prior experience existed. Everywhere else read `DiveStatistics.totalDives` straight from the repository, which counts rows in the `dives` table and nothing more.

A diver with a pre-app paper logbook saw a different career total depending on which screen they were looking at. The milestones card was the sharpest symptom: 480 prior + 30 logged dives was reported as *20 dives away from the "50 dives" milestone* they passed years ago.

## The fix

Lift the combine step out of the page and into a provider, then point the other surfaces at it.

| Surface | Before | After |
| --- | --- | --- |
| Statistics overview | logged + prior | unchanged |
| Home hero header (phone headline + desktop quiet stats) | logged only | logged + prior |
| Milestones card | logged only | logged + prior |
| Dive-log summary pane | logged only | logged + prior, with a `247 logged + 125 prior` breakdown |

New `careerTotalsProvider` = **unfiltered** `diveStatisticsProvider` × `currentDiverProvider` → `CareerTotals`. Reading the unfiltered stats provider is deliberate: `filteredDiveStatisticsProvider` is scoped by the Statistics tab's filter, and the home dashboard must never inherit that.

**Total sites stays logged-only.** The prior-experience feature models a paper logbook as a scalar dives + time offset; there is no site list behind it, so inflating a distinct-site count would be inventing data.

No new ARB keys — the breakdown line reuses the existing `statistics_priorBreakdown`, already translated in all 13 locales.

## Adjacent fix: prior dives vs. the Statistics filter

While in here: the Statistics overview built its `CareerTotals` from the **filtered** stats but still added the **whole** prior offset. Filtering to "2024 only" showed that year's logged dives plus an entire pre-app career, which is meaningless — a prior-dive offset is a single lifetime scalar with no date, site or buddy to filter on.

The overview now stays logged-only while a filter is active (the breakdown subtitle and the "Diving since" line drop out with it), and restores the combined career total when the filter is cleared.

This creates a deliberate asymmetry that is worth stating: the **Statistics tab** respects its filter, while the **dashboard** always shows the lifetime combined total. That is correct — the dashboard has no filter concept.

One knock-on: a diver with prior experience whose active filter matches zero dives now sees the standard empty state rather than their career total. That matches what a diver *without* prior experience already sees in the same situation.

## Tests

- **New** `career_totals_provider_test.dart` — 5 cases: combining, no priors, null diver, prior-only career with nothing logged, `divingSince` clamped to the first logged dive.
- `milestone_providers_test.dart` — prior dives shift the milestone ladder (30 logged + 480 prior → next milestone 1000, not 50); prior dives alone produce a milestone with nothing logged.
- `hero_header_test.dart` — combined totals in the phone headline and the desktop quiet stats; sites stay logged-only; prior-only career renders.
- `dive_summary_widget_test.dart` — combined totals plus the logged/prior breakdown; breakdown absent without priors.
- `statistics_overview_prior_experience_test.dart` — an active filter drops the prior offset; clearing it restores the combined total.

`dart format`, `flutter analyze` and the full `flutter test` suite are green.
