### PR TITLE
fix(sites): sort the site picker by distance after a dive computer import

### DIFF
--- a/docs/superpowers/specs/2026-08-11-site-picker-device-location-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-11-site-picker-device-location-fallback-design.md
@@ -1,0 +1,152 @@
+# Site picker: device-location fallback (issue #965)
+
+Date: 2026-08-11
+Issue: https://github.com/submersion-app/submersion/issues/965
+
+## Problem
+
+Reported against v1.7.3.5623: assigning a dive site to a manually recorded dive
+lists the nearest sites first, but doing the same to a dive brought in by a
+Bluetooth dive computer import lists sites alphabetically.
+
+## Root cause
+
+There is no separate site picker for imports. Both paths open the same
+`SitePickerSheet`
+(`lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart`),
+which sorts by distance only when it can resolve an anchor point:
+
+```dart
+GeoPoint? get _anchor {
+  if (widget.diveLocation != null) return widget.diveLocation;
+  final cl = widget.currentLocation;
+  return cl == null ? null : GeoPoint(cl.latitude, cl.longitude);
+}
+```
+
+With no anchor the sheet takes the `else` branch and preserves the order it
+received from `sitesProvider`, which is `SiteRepositoryImpl.getAllSites` ->
+`OrderingTerm.asc(t.name)`. Alphabetical order is therefore not a separate code
+path; it is the absence of a location.
+
+Both anchors are null after a dive computer import:
+
+- `diveLocation` is null because dive computers do not record surface GPS.
+  `parsed_dive_mapper.dart` never sets `entryLocation`/`exitLocation`; GPS is
+  only stamped opportunistically from a recorded surface track in
+  `dive_import_service.dart`.
+- `currentLocation` is null because `DiveEditPage` calls
+  `_captureLocationForNearby()` only on the new-dive branch
+  (`dive_edit_page.dart`), never when `isEditing` and never when `isBulk`.
+
+An imported dive is edited, not created, so it never gets a device fix. The same
+gap silently affects `BulkDiveEditPage`, which is how a user would assign one
+site to a batch of freshly imported dives.
+
+## Design
+
+Make `SitePickerSheet` self-sufficient about its anchor rather than fixing the
+one caller. Showing nearby sites is the sheet's job, so resolving the location
+belongs there, and every present and future caller benefits.
+
+### Anchor resolution
+
+`_anchor` gains a third rung: `diveLocation ?? currentLocation ?? _deviceLocation`.
+
+`_deviceLocation` is resolved once from `initState`, and only when the caller
+supplied neither anchor:
+
+```dart
+if (widget.diveLocation == null && widget.currentLocation == null) {
+  unawaited(_resolveDeviceLocation());
+}
+```
+
+The resolver reads `locationServiceProvider` and requests coordinates only
+(`includeGeocoding: false`) with a 10 second timeout, mirroring
+`DiveEditPage._captureLocationForNearby`.
+
+Resolution lives in `initState`, not `build`: `build` re-runs on every keystroke
+in the search field, so a build-triggered lookup would fire repeated GPS
+requests.
+
+The `diveLocation == null && currentLocation == null` guard keeps this cheap. A
+dive that already has GPS never pays for a fix, and the new-dive path still uses
+the `_currentLocation` the edit page pre-warmed.
+
+### Data flow
+
+Unchanged downstream. The anchor feeds `_distanceToSite` (Haversine,
+`core/utils/geo_math.dart`), which feeds the existing nearest-first sort with
+GPS-less sites last. The search filter still runs after sorting, so filtered
+results stay distance-ordered. When the fix arrives, `setState` re-runs `build`
+and the list re-sorts in place.
+
+`SiteRepositoryImpl.getAllSites` keeps its name ordering. That order is correct
+for the sites list page, and the picker has always been the layer that re-ranks.
+
+### Header states
+
+Three, up from two:
+
+| Condition | Icon | String |
+| --- | --- | --- |
+| dive GPS anchor | `Icons.place` | `diveLog_sitePicker_sortedByDiveDistance` |
+| device GPS anchor | `Icons.my_location` | `diveLog_sitePicker_sortedByDistance` |
+| resolving, no anchor yet | `Icons.my_location`, muted | `diveLog_edit_gettingLocation` |
+
+All three keys already exist, so no ARB changes across the 11 locales.
+
+The resolving state uses a static icon rather than a `CircularProgressIndicator`,
+which the first draft of this change used. An indeterminate indicator schedules
+frames forever, so `pumpAndSettle` never returns while one is on screen. Because
+this is a shared widget, the breakage landed in an unrelated consumer test
+(`dive_edit_geofence_suggestion_test.dart`, which taps "Add site" and settles),
+and it would recur in every future test that opens the sheet. Reusing the
+resolved-state icon also avoids an icon swap when the fix arrives; only the text
+changes.
+
+### Error handling
+
+`LocationService.getCurrentLocation` already returns null for disabled location
+services, denied permission, and permanently denied permission, and swallows
+platform errors internally. A `try`/`catch` in the resolver is belt and braces.
+A null result leaves the anchor null and the list alphabetical, which is exactly
+today's behavior. Nothing is surfaced to the user: proximity sort is a
+convenience, not a requirement.
+
+## Testing
+
+`locationServiceProvider` is the existing injection seam. The `_pump` helper in
+`site_picker_sheet_test.dart` gains a default fake returning null so none of the
+8 existing tests reach a platform channel.
+
+New tests:
+
+1. No `diveLocation`, no `currentLocation`, fake device GPS at the reef ->
+   distance order and the "Sorted by distance" caption. This is the #965
+   regression test.
+2. Device GPS returns null -> alphabetical order, no caption. Guards the
+   graceful fallback.
+3. `diveLocation` supplied -> the fake is never called. Guards against spending
+   a GPS fix when the dive already has coordinates.
+4. A fix still in flight -> the "Getting location..." caption shows, and
+   completing the fix replaces it with distance order.
+
+Test 3 passes against the unfixed code, so it was verified by mutation: removing
+the `initState` guard makes it, and only it, fail.
+
+## Out of scope
+
+- Pre-warming GPS in `DiveEditPage.initState` on the edit path.
+- Changing repository ordering.
+- The `!widget.isEditing` gate on the form-row caption in `dive_edit_page.dart`,
+  which is the form's own hint and independent of the sheet.
+
+## Known limitation
+
+Importing dives by Bluetooth long after the trip and away from the site ranks
+sites near the device now, not near where the dive happened. This is inherent to
+the parity the issue asks for; the manual path behaves identically. It is
+mitigated by the per-tile distance readout, by the "nearby" highlight firing
+only under 50 km, and by search. No date or location heuristics are added.

--- a/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import 'package:submersion/core/providers/location_service_provider.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/core/text/fuzzy_match.dart';
@@ -39,17 +42,58 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
 
+  /// Device fix resolved by the sheet itself, used only when the caller
+  /// supplied neither a dive nor a device location.
+  LocationResult? _deviceLocation;
+  bool _isLocating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Callers that already know where the dive is (or where the device is)
+    // cost nothing here. The rest — editing an imported dive, bulk edit —
+    // would otherwise fall back to the repository's alphabetical order (#965).
+    if (widget.diveLocation == null && widget.currentLocation == null) {
+      unawaited(_resolveDeviceLocation());
+    }
+  }
+
   @override
   void dispose() {
     _searchController.dispose();
     super.dispose();
   }
 
-  /// The point distances are measured from: the dive's GPS if present,
-  /// otherwise the device location (today's behavior).
+  /// Resolve a device fix in the background. Runs once, from [initState]:
+  /// `build` re-runs on every keystroke in the search field, so resolving
+  /// there would fire a GPS request per character.
+  Future<void> _resolveDeviceLocation() async {
+    setState(() => _isLocating = true);
+    try {
+      final location = await ref
+          .read(locationServiceProvider)
+          .getCurrentLocation(
+            // Coordinates are all the distance sort needs; skip geocoding.
+            includeGeocoding: false,
+            timeout: const Duration(seconds: 10),
+          );
+      if (mounted && location != null) {
+        setState(() => _deviceLocation = location);
+      }
+    } catch (_) {
+      // Proximity sorting is a convenience; the list stays usable without it.
+    } finally {
+      if (mounted) {
+        setState(() => _isLocating = false);
+      }
+    }
+  }
+
+  /// The point distances are measured from: the dive's GPS if present, then a
+  /// device location supplied by the caller, then one this sheet resolved.
   GeoPoint? get _anchor {
     if (widget.diveLocation != null) return widget.diveLocation;
-    final cl = widget.currentLocation;
+    final cl = widget.currentLocation ?? _deviceLocation;
     return cl == null ? null : GeoPoint(cl.latitude, cl.longitude);
   }
 
@@ -111,6 +155,31 @@ class _SitePickerSheetState extends ConsumerState<SitePickerSheet> {
                                         .diveLog_sitePicker_sortedByDistance,
                               style: Theme.of(context).textTheme.bodySmall
                                   ?.copyWith(color: colorScheme.primary),
+                            ),
+                          ),
+                        ],
+                      )
+                    else if (_isLocating)
+                      Row(
+                        children: [
+                          // Deliberately a static icon, not a spinner: an
+                          // indeterminate indicator schedules frames forever,
+                          // so it hangs pumpAndSettle in every consumer test
+                          // that opens this sheet. Reusing the resolved-state
+                          // icon also avoids a swap when the fix lands.
+                          Icon(
+                            Icons.my_location,
+                            size: 14,
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(width: 4),
+                          Flexible(
+                            child: Text(
+                              context.l10n.diveLog_edit_gettingLocation,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
                             ),
                           ),
                         ],

--- a/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/providers/location_service_provider.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/pickers/site_picker_sheet.dart';
@@ -35,6 +38,33 @@ class _TestSettingsNotifier extends StateNotifier<AppSettings>
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// Fake device GPS. [LocationService] has a private constructor, so the fake
+/// implements the interface rather than extending it.
+class _FakeLocationService implements LocationService {
+  _FakeLocationService({this.result, this.pending});
+
+  /// Resolved fix, or null for "no fix available".
+  final LocationResult? result;
+
+  /// When set, [getCurrentLocation] hangs on this instead of resolving, so a
+  /// test can observe the in-progress state.
+  final Completer<LocationResult?>? pending;
+
+  int calls = 0;
+
+  @override
+  Future<LocationResult?> getCurrentLocation({
+    bool includeGeocoding = true,
+    Duration timeout = const Duration(seconds: 15),
+  }) {
+    calls++;
+    return pending?.future ?? Future.value(result);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 Future<void> _pump(
   WidgetTester tester, {
   required List<DiveSite> sites,
@@ -44,6 +74,7 @@ Future<void> _pump(
   String? selectedSiteId,
   void Function(DiveSite)? onSiteSelected,
   VoidCallback? onCreateNewSite,
+  LocationService? locationService,
 }) async {
   tester.view.physicalSize = const Size(900, 2000);
   tester.view.devicePixelRatio = 1.0;
@@ -53,6 +84,10 @@ Future<void> _pump(
       overrides: [
         sitesProvider.overrideWith((ref) async => sites),
         settingsProvider.overrideWith((ref) => _TestSettingsNotifier(settings)),
+        // Default to "no fix" so no test reaches the real platform channel.
+        locationServiceProvider.overrideWithValue(
+          locationService ?? _FakeLocationService(),
+        ),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -163,6 +198,68 @@ void main() {
     expect(_tileTitles(tester), ['House Reef', 'Channel', 'Blue Hole']);
     expect(find.text('Sorted by distance'), findsOneWidget);
     expect(find.text('Sorted by distance from this dive'), findsNothing);
+  });
+
+  // #965: a dive computer import produces a dive with no GPS, and the edit
+  // page captures device GPS only for new dives, so the sheet used to receive
+  // no anchor at all and fell back to the repository's alphabetical order.
+  testWidgets('falls back to device location when the caller gives none', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _noGpsSite, _nearSite, _midSite],
+      locationService: _FakeLocationService(result: _here),
+    );
+    expect(_tileTitles(tester), [
+      'House Reef',
+      'Channel',
+      'Blue Hole',
+      'Mystery Lake',
+    ]);
+    expect(find.text('Sorted by distance'), findsOneWidget);
+  });
+
+  testWidgets('keeps the provided order when no device fix is available', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite, _midSite],
+      locationService: _FakeLocationService(),
+    );
+    expect(_tileTitles(tester), ['Blue Hole', 'House Reef', 'Channel']);
+    expect(find.text('Sorted by distance'), findsNothing);
+  });
+
+  testWidgets('does not request device location when the dive has GPS', (
+    tester,
+  ) async {
+    final service = _FakeLocationService(result: _here);
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite],
+      diveLocation: const GeoPoint(10.0, 10.0),
+      locationService: service,
+    );
+    expect(service.calls, 0);
+  });
+
+  testWidgets('shows a progress caption while the device fix resolves', (
+    tester,
+  ) async {
+    final pending = Completer<LocationResult?>();
+    await _pump(
+      tester,
+      sites: const [_farSite, _nearSite],
+      locationService: _FakeLocationService(pending: pending),
+    );
+    expect(find.text('Getting location...'), findsOneWidget);
+
+    pending.complete(_here);
+    await tester.pumpAndSettle();
+    expect(find.text('Getting location...'), findsNothing);
+    expect(_tileTitles(tester), ['House Reef', 'Blue Hole']);
   });
 
   testWidgets('distance readout respects imperial units', (tester) async {

--- a/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/site_picker_sheet_test.dart
@@ -92,6 +92,10 @@ Future<void> _pump(
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        // Every assertion below is an English literal. flutter_test forwards
+        // the host machine's locale list, so without this the UI resolves to
+        // the developer's own language and 6 of these tests miss.
+        locale: const Locale('en'),
         home: Scaffold(
           body: SitePickerSheet(
             scrollController: ScrollController(),


### PR DESCRIPTION
Fixes #965.

## The report

Assigning a dive site to a manually recorded dive lists the nearest sites first. Doing the same to a dive brought in over Bluetooth lists them alphabetically. Reported against v1.7.3.5623.

## Root cause

There is no separate site picker for imports. Both paths open the same `SitePickerSheet`, which ranks by distance only when it can resolve an anchor point:

```dart
GeoPoint? get _anchor {
  if (widget.diveLocation != null) return widget.diveLocation;
  final cl = widget.currentLocation;
  return cl == null ? null : GeoPoint(cl.latitude, cl.longitude);
}
```

After a dive computer import both anchors are null:

- `diveLocation` is null because dive computers do not record surface GPS. `parsed_dive_mapper.dart` never sets `entryLocation`/`exitLocation`; GPS is only stamped opportunistically from a recorded surface track.
- `currentLocation` is null because `DiveEditPage` calls `_captureLocationForNearby()` only on its new-dive branch, never when `isEditing` and never when `isBulk`.

An imported dive is edited, not created, so it never gets a device fix. With no anchor the sheet falls through to its `else` branch and preserves the order it received from `sitesProvider`, which is `SiteRepositoryImpl.getAllSites` -> `OrderingTerm.asc(t.name)`.

So the alphabetical list was never a second sort path. It was the absence of a location, which is why nothing looked broken from the code's point of view.

## The fix

`SitePickerSheet` resolves a device fix itself when the caller supplies neither anchor, so `_anchor` now reads `diveLocation ?? currentLocation ?? _deviceLocation`.

Putting the fallback in the sheet rather than in `DiveEditPage` fixes the reported path and `BulkDiveEditPage` in one change, which is the screen you would use to assign one site to a batch of freshly imported dives. It also means future callers get proximity sorting without having to remember to pass a location.

Resolution runs once from `initState`, guarded on both anchors being absent:

- `build` re-runs on every keystroke in the search field, so resolving there would fire a GPS request per character.
- A dive that already has GPS never pays for a fix, and the new-dive path still uses the `_currentLocation` the edit page pre-warms.

`SiteRepositoryImpl.getAllSites` keeps its name ordering. That order is correct for the sites list page, and the picker has always been the layer that re-ranks.

## No spinner, deliberately

The resolving state shows a static icon, not a `CircularProgressIndicator`. An indeterminate indicator schedules frames forever, so `pumpAndSettle` never returns while one is on screen. Because this is a shared widget, the first draft broke `dive_edit_geofence_suggestion_test.dart` -- a test about equipment sets that merely taps "Add site" -- and it would have recurred in every future test that opens the sheet. Reusing the resolved-state icon also avoids an icon swap when the fix lands; only the text changes.

## Header states

| Condition | Icon | String |
| --- | --- | --- |
| dive GPS anchor | `Icons.place` | `diveLog_sitePicker_sortedByDiveDistance` |
| device GPS anchor | `Icons.my_location` | `diveLog_sitePicker_sortedByDistance` |
| resolving, no anchor yet | `Icons.my_location`, muted | `diveLog_edit_gettingLocation` |

All three keys already existed, so there are no ARB changes across the 11 locales.

## Error handling

`LocationService.getCurrentLocation` already returns null for disabled location services and for denied or permanently denied permission, and swallows platform errors internally. A null result leaves the anchor null and the list alphabetical, which is exactly today's behavior. Nothing is surfaced to the user: proximity sorting is a convenience, not a requirement.

## Tests

Four new widget tests in `site_picker_sheet_test.dart`, using the existing `locationServiceProvider` injection seam. The `_pump` helper now defaults to a fake returning null so no test reaches a real platform channel.

1. No `diveLocation`, no `currentLocation`, fake device GPS -> distance order and the "Sorted by distance" caption. This is the #965 regression test.
2. No fix available -> the provided order is preserved. Guards the graceful fallback.
3. `diveLocation` supplied -> the fake is never called. Guards against spending a GPS fix when the dive already has coordinates.
4. Fix in flight -> the "Getting location..." caption shows, and completing the fix switches to distance order.

Test 3 passes against the unfixed code, so it was verified by mutation: removing the `initState` guard makes it, and only it, fail.

Verified locally: `dart format` reports 0 changed, `flutter analyze` finds no issues project-wide, and the full suite is 16,223 passed / 15 skipped. One unrelated failure in `setup_apply_service_test.dart` is the known full-suite concurrency flake; it passes in isolation and the combined `setup_wizard` + `backup` run is 387 green.

## Known limitation

Importing dives by Bluetooth long after the trip and away from the site ranks sites near the device now, not near where the dive happened. This is inherent to the parity the issue asks for, and the manual path has always behaved this way. It is mitigated by the per-tile distance readout, by the "nearby" highlight firing only under 50 km, and by search. Anchoring on a neighbouring dive or the trip when the dive itself has no GPS would be a separate product change.

## Not verified here

The real permission prompt. `getCurrentLocation` calls `requestPermission()`, so a user who has never granted location access will now see the system dialog when opening the site picker on an imported dive. This is the same prompt the manual-entry path already raises, but widget tests cannot exercise it.