### PR TITLE
fix(tanks): keep fractional cylinder sizes intact in tank displays

### DIFF
--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -153,14 +153,22 @@ class UnitFormatter {
     return '${converted.toStringAsFixed(decimals)} ${settings.volumeUnit.symbol}';
   }
 
-  /// Format tank volume - handles gas capacity conversion for imperial units.
+  /// Format a cylinder's size - handles gas capacity conversion for imperial.
   /// Pass [ratedCapacityCuft] (from a preset) for accurate display;
   /// otherwise falls back to ideal-gas calculation from volume and pressure.
+  ///
+  /// Metric shows the cylinder's physical volume in liters with up to one
+  /// decimal and no trailing zero, so a 1.5 L stage stays distinct from the
+  /// 2 L bottle beside it while a 12 L twin still reads as "12 L".
+  ///
+  /// Imperial shows rated gas capacity, rounded to [cuftDecimals]. A tenth of
+  /// a cubic foot is below the accuracy of the ideal-gas fallback, so whole
+  /// numbers are the default there. [cuftDecimals] does not affect metric.
   String formatTankVolume(
     double? volumeLiters,
     double? workingPressureBar, {
     double? ratedCapacityCuft,
-    int decimals = 0,
+    int cuftDecimals = 0,
   }) {
     if (volumeLiters == null) return '--';
 
@@ -178,21 +186,22 @@ class UnitFormatter {
         cuft = match?.ratedCapacityCuft;
       }
       if (cuft != null) {
-        return '${cuft.toStringAsFixed(decimals)} ${settings.volumeUnit.symbol}';
+        return '${cuft.toStringAsFixed(cuftDecimals)} ${settings.volumeUnit.symbol}';
       }
       if (workingPressureBar != null && workingPressureBar > 0) {
         // Ideal gas approximation for non-standard tanks
         final calcCuft = (volumeLiters * workingPressureBar) / 28.3168;
-        return '${calcCuft.toStringAsFixed(decimals)} ${settings.volumeUnit.symbol}';
+        return '${calcCuft.toStringAsFixed(cuftDecimals)} ${settings.volumeUnit.symbol}';
       } else {
         // No working pressure - approximate assuming 200 bar
         final calcCuft = (volumeLiters * 200) / 28.3168;
-        return '~${calcCuft.toStringAsFixed(decimals)} ${settings.volumeUnit.symbol}';
+        return '~${calcCuft.toStringAsFixed(cuftDecimals)} ${settings.volumeUnit.symbol}';
       }
     }
 
-    // For liters, just show physical volume
-    return '${volumeLiters.toStringAsFixed(decimals)} ${settings.volumeUnit.symbol}';
+    // For liters, show the physical volume the cylinder is named by
+    final liters = _trimTrailingZeros(volumeLiters.toStringAsFixed(1));
+    return '$liters ${settings.volumeUnit.symbol}';
   }
 
   /// Get volume unit symbol

--- a/lib/features/cylinder_configs/presentation/widgets/cylinder_config_item_editor.dart
+++ b/lib/features/cylinder_configs/presentation/widgets/cylinder_config_item_editor.dart
@@ -71,6 +71,14 @@ class _CylinderConfigItemEditorState
     }
   }
 
+  /// A preset's cylinder size in the diver's units - gas capacity in imperial,
+  /// physical volume in metric.
+  String _presetSize(TankPresetEntity preset) => widget.units.formatTankVolume(
+    preset.volumeLiters,
+    preset.workingPressureBar,
+    ratedCapacityCuft: preset.ratedCapacityCuft,
+  );
+
   Future<void> _pickPreset() async {
     final presets = await ref.read(tankPresetsProvider.future);
     if (!mounted || presets.isEmpty) return;
@@ -85,7 +93,7 @@ class _CylinderConfigItemEditorState
               ListTile(
                 title: Text(preset.displayName),
                 subtitle: Text(
-                  '${widget.units.formatVolume(preset.volumeLiters)} - '
+                  '${_presetSize(preset)} - '
                   '${widget.units.formatPressure(preset.workingPressureBar)}',
                 ),
                 onTap: () => Navigator.of(sheetContext).pop(preset),
@@ -212,7 +220,10 @@ class _CylinderConfigItemEditorState
               child: Text(
                 [
                   if (item.volumeL != null)
-                    widget.units.formatVolume(item.volumeL!),
+                    widget.units.formatTankVolume(
+                      item.volumeL,
+                      item.workingPressureBar,
+                    ),
                   if (item.workingPressureBar != null)
                     widget.units.formatPressure(item.workingPressureBar!),
                 ].join(' - '),

--- a/lib/features/dive_log/presentation/widgets/cylinders_card.dart
+++ b/lib/features/dive_log/presentation/widgets/cylinders_card.dart
@@ -114,7 +114,7 @@ class CylindersCard extends ConsumerWidget {
             ? units.formatTankVolume(
                 tank.volume,
                 tank.workingPressure,
-                decimals: 1,
+                cuftDecimals: 1,
               )
             : null);
     final tankTitle = tank.name != null && tank.name!.isNotEmpty

--- a/lib/features/dive_planner/presentation/widgets/plan_tank_list.dart
+++ b/lib/features/dive_planner/presentation/widgets/plan_tank_list.dart
@@ -134,10 +134,11 @@ class _TankChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final tankSize = units.formatTankVolume(tank.volume, tank.workingPressure);
     final tankLabel =
         '${tank.name ?? tank.gasMix.name}, '
         '${units.formatPressure(tank.startPressure)}, '
-        '${units.formatVolume(tank.volume)}';
+        '$tankSize';
 
     return Semantics(
       label: tankLabel,
@@ -160,7 +161,7 @@ class _TankChip extends StatelessWidget {
           children: [
             Text(tank.name ?? tank.gasMix.name),
             Text(
-              '${units.formatPressure(tank.startPressure)} • ${units.formatVolume(tank.volume)}',
+              '${units.formatPressure(tank.startPressure)} • $tankSize',
               style: theme.textTheme.bodySmall,
             ),
           ],

--- a/lib/features/tank_presets/presentation/pages/tank_presets_page.dart
+++ b/lib/features/tank_presets/presentation/pages/tank_presets_page.dart
@@ -135,7 +135,6 @@ class TankPresetsPage extends ConsumerWidget {
       preset.volumeLiters,
       preset.workingPressureBar,
       ratedCapacityCuft: preset.ratedCapacityCuft,
-      decimals: 0,
     );
     final pressureStr = units.formatPressure(
       preset.workingPressureBar,

--- a/test/core/utils/unit_formatter_volume_test.dart
+++ b/test/core/utils/unit_formatter_volume_test.dart
@@ -20,14 +20,23 @@ void main() {
     });
 
     test('metric shows physical volume in liters', () {
-      expect(metricFormatter.formatTankVolume(11.1, 207.0), '11 L');
+      expect(metricFormatter.formatTankVolume(11.1, 207.0), '11.1 L');
     });
 
-    test('metric shows volume with decimals', () {
-      expect(
-        metricFormatter.formatTankVolume(11.1, 207.0, decimals: 1),
-        '11.1 L',
-      );
+    test('metric keeps fractional sizes distinct from whole ones', () {
+      // A 1.5 L stage must never render as the 2 L bottle beside it.
+      expect(metricFormatter.formatTankVolume(1.5, 200.0), '1.5 L');
+      expect(metricFormatter.formatTankVolume(2.0, 200.0), '2 L');
+    });
+
+    test('metric trims a trailing zero from whole sizes', () {
+      expect(metricFormatter.formatTankVolume(12.0, 232.0), '12 L');
+      expect(metricFormatter.formatTankVolume(15.0, 232.0), '15 L');
+    });
+
+    test('metric rounds to a single decimal', () {
+      expect(metricFormatter.formatTankVolume(11.14, 207.0), '11.1 L');
+      expect(metricFormatter.formatTankVolume(11.16, 207.0), '11.2 L');
     });
 
     test('imperial uses ratedCapacityCuft when provided', () {
@@ -47,7 +56,7 @@ void main() {
           11.1,
           206.843,
           ratedCapacityCuft: 77.4,
-          decimals: 1,
+          cuftDecimals: 1,
         ),
         '77.4 cuft',
       );
@@ -71,6 +80,31 @@ void main() {
 
     test('imperial shows approximate when working pressure is zero', () {
       expect(imperialFormatter.formatTankVolume(11.1, 0.0), '~78 cuft');
+    });
+
+    test('metric ignores cuftDecimals, which only governs the cuft branch', () {
+      expect(
+        metricFormatter.formatTankVolume(1.5, 200.0, cuftDecimals: 0),
+        '1.5 L',
+      );
+    });
+  });
+
+  group('UnitFormatter formatVolume', () {
+    test('gas quantities stay whole - a fractional liter is noise', () {
+      const metricFormatter = UnitFormatter(AppSettings());
+      expect(metricFormatter.formatVolume(1800.0), '1800 L');
+      expect(metricFormatter.formatVolume(1823.6), '1824 L');
+    });
+
+    test('honours an explicit decimals argument', () {
+      const metricFormatter = UnitFormatter(AppSettings());
+      expect(metricFormatter.formatVolume(1823.6, decimals: 1), '1823.6 L');
+    });
+
+    test('returns -- for null', () {
+      const metricFormatter = UnitFormatter(AppSettings());
+      expect(metricFormatter.formatVolume(null), '--');
     });
   });
 }

--- a/test/features/cylinder_configs/presentation/cylinder_config_item_editor_test.dart
+++ b/test/features/cylinder_configs/presentation/cylinder_config_item_editor_test.dart
@@ -187,7 +187,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('11 L - 207 bar'), findsOneWidget);
+    expect(find.text('11.1 L - 207 bar'), findsOneWidget);
   });
 
   testWidgets('the spec summary respects the diver imperial units', (
@@ -198,8 +198,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // 11.1 L -> 0.39 cuft (0 decimals), 207 bar -> 3002 psi.
-    expect(find.text('0 cuft - 3002 psi'), findsOneWidget);
+    // Imperial divers name a cylinder by its gas capacity, not its physical
+    // volume: 11.1 L @ 207 bar is the AL80's 77 cuft, not 0.39 cuft of
+    // aluminum. 207 bar -> 3002 psi.
+    expect(find.text('77 cuft - 3002 psi'), findsOneWidget);
   });
 
   testWidgets('a cylinder with only a volume shows just that', (tester) async {
@@ -249,7 +251,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The sheet describes each preset in the diver's units.
-    expect(find.text('11 L - 207 bar'), findsWidgets);
+    expect(find.text('11.1 L - 207 bar'), findsWidgets);
 
     await tester.tap(find.text('AL80').first);
     await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/edit_sections/tank_row_test.dart
+++ b/test/features/dive_log/presentation/widgets/edit_sections/tank_row_test.dart
@@ -20,7 +20,7 @@ const _testTank = DiveTank(
   gasMix: GasMix(o2: 32),
 );
 
-Future<void> _pump(WidgetTester tester) async {
+Future<void> _pump(WidgetTester tester, {DiveTank tank = _testTank}) async {
   final overrides = await getBaseOverrides();
   await tester.pumpWidget(
     ProviderScope(
@@ -35,7 +35,7 @@ Future<void> _pump(WidgetTester tester) async {
           body: SingleChildScrollView(
             child: Material(
               child: TankRow(
-                tank: _testTank,
+                tank: tank,
                 tankNumber: 1,
                 units: const UnitFormatter(AppSettings()),
                 onChanged: (_) {},
@@ -65,6 +65,30 @@ void main() {
     // The old hero cells are gone.
     expect(find.text('PRESSURE'), findsNothing);
     expect(find.text('Edit'), findsNothing);
+  });
+
+  testWidgets('collapsed: subtitle keeps a fractional tank size intact', (
+    tester,
+  ) async {
+    // Regression for #955: a 1.5 L stage rendered as "2 L", which is
+    // indistinguishable from the 2 L bottle many divers carry alongside it.
+    await _pump(
+      tester,
+      tank: _testTank.copyWith(volume: 1.5, workingPressure: 200),
+    );
+    expect(find.textContaining('1.5 L'), findsOneWidget);
+    expect(find.textContaining('2 L'), findsNothing);
+  });
+
+  testWidgets('collapsed: subtitle drops the trailing zero on whole sizes', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      tank: _testTank.copyWith(volume: 12, workingPressure: 232),
+    );
+    expect(find.textContaining('12 L'), findsOneWidget);
+    expect(find.textContaining('12.0 L'), findsNothing);
   });
 
   testWidgets('tap expands inline editor; Done collapses', (tester) async {

--- a/test/features/dive_log/presentation/widgets/edit_sections/tank_row_test.dart
+++ b/test/features/dive_log/presentation/widgets/edit_sections/tank_row_test.dart
@@ -29,6 +29,10 @@ Future<void> _pump(WidgetTester tester, {DiveTank tank = _testTank}) async {
         customTankPresetsProvider.overrideWith((ref) async => []),
       ],
       child: MaterialApp(
+        // Pinned: flutter_test forwards the host machine's locale list, so an
+        // unpinned MaterialApp translates "Tank 1" and "Done" out from under
+        // the finders on a non-English dev machine.
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(


### PR DESCRIPTION
Fixes #955.

## The reported bug

A 1.5 L tank rendered as **"2 L"** in the collapsed tank row of the dive edit form, which is indistinguishable from the 2 L bottle many divers carry alongside it.

`UnitFormatter.formatTankVolume` defaulted to `decimals = 0`, and `tank_row.dart` passed no override — so `1.5.toStringAsFixed(0)` became `"2"`. The read-only dive-details card already passed `decimals: 1`, which is why the same tank read correctly there and wrong in the edit form.

## The fix

The metric branch of `formatTankVolume` now shows the cylinder's physical volume with **up to one decimal and no trailing zero**:

| volume | before | after |
| --- | --- | --- |
| 1.5 L | `2 L` | `1.5 L` |
| 11.1 L | `11 L` | `11.1 L` |
| 12.0 L | `12 L` | `12 L` |

It reuses `_trimTrailingZeros`, the helper `formatTemperature` already uses for the same purpose (`26.0°C` -> `26°C`), so volume follows the convention already settled elsewhere in the file.

`tank_row.dart` itself needed no change — the corrected default now does the right thing, which is the sign the fix landed at the root rather than at the symptom.

### `decimals:` renamed to `cuftDecimals:`

The parameter only ever governed the imperial gas-capacity paths. A tenth of a cubic foot sits below the accuracy of the ideal-gas fallback, so whole numbers remain the imperial default; naming it plainly stops it reading as a knob for metric precision, and makes the compiler point at every call site. Imperial output is unchanged.

## A second bug found along the way

`plan_tank_list.dart` and `cylinder_config_item_editor.dart` used `formatVolume`, which converts liters to cubic feet as a **physical** volume. An imperial diver therefore saw an 11.1 L AL80 described as **"0 cuft"** — and that nonsense was frozen into a passing test (`cylinder_config_item_editor_test.dart` asserted `'0 cuft - 3002 psi'`).

Both now use `formatTankVolume`, which routes through the preset/ideal-gas gas-capacity path, and read **"77 cuft"**. The three affected assertions were updated; this is a correction rather than a regression, but it is the part of this PR most worth a reviewer's eye since it was not in the issue.

Gas *quantities* (`litersUsed`, `litersRequired`, `gasConsumed`) deliberately keep `formatVolume` and stay whole — a fractional liter of consumed gas is noise. A test now guards that boundary.

## Out of scope

The expanded tank editor's volume **text field** still shows `12.0` for a 12 L tank (`tank_editor.dart:88-90`). It is an editable input rather than a display, and changing it touches the preset-apply and parse paths, so it was left alone.

## Testing

- New coverage in `unit_formatter_volume_test.dart`: fractional vs. whole sizes, trailing-zero trim, single-decimal rounding, imperial unchanged, `cuftDecimals` inert on metric, and gas quantities staying whole.
- Two new `tank_row_test.dart` widget tests reproducing the issue's exact 1.5 L -> 2 L path and the 12 L trailing-zero case.
- `flutter analyze` clean, `dart format` reports no changes, and 5,060 tests pass across every volume-adjacent area (core, gas calculators, tank presets, planner, dive planner, cylinder configs, dive log widgets, setup wizard, statistics).