### PR TITLE
fix(ui): stop stacked text fields overlapping the field above

### DIFF
--- a/lib/features/backup/presentation/widgets/backup_change_password_dialog.dart
+++ b/lib/features/backup/presentation/widgets/backup_change_password_dialog.dart
@@ -90,6 +90,7 @@ class _BackupChangePasswordDialogState
                   errorText: _currentError,
                 ),
               ),
+              const SizedBox(height: 16),
               TextField(
                 controller: _next,
                 obscureText: true,
@@ -98,6 +99,7 @@ class _BackupChangePasswordDialogState
                   errorText: _nextError,
                 ),
               ),
+              const SizedBox(height: 16),
               TextField(
                 controller: _confirm,
                 obscureText: true,

--- a/lib/features/backup/presentation/widgets/backup_enable_encryption_dialog.dart
+++ b/lib/features/backup/presentation/widgets/backup_enable_encryption_dialog.dart
@@ -125,6 +125,7 @@ class _BackupEnableEncryptionDialogState
                     errorText: _passwordError,
                   ),
                 ),
+                const SizedBox(height: 16),
                 TextField(
                   controller: _confirm,
                   obscureText: true,

--- a/lib/features/media/presentation/widgets/manifest_subscription_card.dart
+++ b/lib/features/media/presentation/widgets/manifest_subscription_card.dart
@@ -283,6 +283,7 @@ class _SubscriptionTile extends ConsumerWidget {
                 labelText: 'Manifest URL',
               ),
             ),
+            const SizedBox(height: 16),
             TextField(
               controller: nameController,
               decoration: const InputDecoration(

--- a/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_session_runner_page.dart
@@ -340,6 +340,7 @@ class _ValueEntryDialogState extends State<_ValueEntryDialog> {
               suffixText: widget.item.valueUnit,
             ),
           ),
+          const SizedBox(height: 16),
           TextField(
             controller: _noteController,
             decoration: InputDecoration(labelText: l10n.preDive_runner_addNote),

--- a/lib/features/settings/presentation/pages/security_settings_page.dart
+++ b/lib/features/settings/presentation/pages/security_settings_page.dart
@@ -523,6 +523,7 @@ class _ChangePasswordDialogState extends State<_ChangePasswordDialog> {
                 errorText: _currentError,
               ),
             ),
+            const SizedBox(height: 16),
             TextField(
               controller: _next,
               obscureText: true,
@@ -532,6 +533,7 @@ class _ChangePasswordDialogState extends State<_ChangePasswordDialog> {
                 errorText: _nextError,
               ),
             ),
+            const SizedBox(height: 16),
             TextField(
               controller: _confirm,
               obscureText: true,

--- a/lib/features/settings/presentation/widgets/enable_encryption_dialog.dart
+++ b/lib/features/settings/presentation/widgets/enable_encryption_dialog.dart
@@ -97,6 +97,7 @@ class _EnableEncryptionDialogState extends State<EnableEncryptionDialog> {
                     errorText: _passphraseError,
                   ),
                 ),
+                const SizedBox(height: 16),
                 TextField(
                   controller: _confirm,
                   obscureText: true,

--- a/lib/features/settings/presentation/widgets/encryption_passphrase_dialog.dart
+++ b/lib/features/settings/presentation/widgets/encryption_passphrase_dialog.dart
@@ -215,6 +215,7 @@ class _ChangePassphraseDialogState extends State<_ChangePassphraseDialog> {
               errorText: _currentError,
             ),
           ),
+          const SizedBox(height: 16),
           TextField(
             controller: _next,
             obscureText: true,
@@ -224,6 +225,7 @@ class _ChangePassphraseDialogState extends State<_ChangePassphraseDialog> {
               errorText: _nextError,
             ),
           ),
+          const SizedBox(height: 16),
           TextField(
             controller: _confirm,
             obscureText: true,

--- a/lib/features/settings/presentation/widgets/security_setup_dialog.dart
+++ b/lib/features/settings/presentation/widgets/security_setup_dialog.dart
@@ -95,6 +95,10 @@ class _SecuritySetupDialogState extends State<SecuritySetupDialog> {
                     errorText: _passwordError,
                   ),
                 ),
+                // Outlined fields float their label over the top border and
+                // reserve no room above the box for it, so stacking them flush
+                // paints this label onto the field above.
+                const SizedBox(height: 16),
                 TextField(
                   controller: _confirm,
                   obscureText: true,

--- a/test/features/backup/presentation/widgets/backup_enable_encryption_dialog_test.dart
+++ b/test/features/backup/presentation/widgets/backup_enable_encryption_dialog_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/theme/full_themes/submersion_theme.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/features/backup/presentation/widgets/backup_enable_encryption_dialog.dart';
 
-Widget _host(Widget child) => MaterialApp(
+Widget _host(Widget child, {ThemeData? theme}) => MaterialApp(
+  theme: theme,
   // Pinned: the assertions match English strings.
   locale: const Locale('en'),
   localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -13,6 +15,51 @@ Widget _host(Widget child) => MaterialApp(
 );
 
 void main() {
+  testWidgets('keeps the confirm field clear of the password field above it', (
+    tester,
+  ) async {
+    // The app theme uses filled fields with an OutlineInputBorder. Flutter
+    // floats such a label so it straddles the top border and reserves no space
+    // above the box for it, so two fields stacked flush let the confirm label
+    // paint over the password field. Pump the real theme, not a bare
+    // MaterialApp, or the overlap cannot reproduce.
+    await tester.pumpWidget(
+      _host(
+        theme: submersionLight,
+        Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (_) => BackupEnableEncryptionDialog(
+                onEnable: (p) async => 'alpha-bravo-charlie',
+                onFinished: () async {},
+              ),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Both labels must be floating: that is the state the overlap appears in.
+    await tester.enterText(find.byType(TextField).at(0), 'backuppass1');
+    await tester.enterText(find.byType(TextField).at(1), 'backuppass1');
+    await tester.pumpAndSettle();
+
+    final passwordField = tester.getRect(find.byType(TextField).at(0));
+    final confirmLabel = tester.getRect(find.text('Confirm password'));
+
+    expect(
+      confirmLabel.top,
+      greaterThanOrEqualTo(passwordField.bottom),
+      reason:
+          'the floating confirm label paints '
+          '${passwordField.bottom - confirmLabel.top}px inside the field above',
+    );
+  });
+
   testWidgets('enable flow: form -> recovery gate -> finish', (tester) async {
     var enabled = false;
     var finished = false;

--- a/test/features/settings/presentation/widgets/security_setup_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/security_setup_dialog_test.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/theme/full_themes/submersion_theme.dart';
 import 'package:submersion/features/settings/presentation/widgets/security_setup_dialog.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 Future<List<Object?>> _pumpSetup(
   WidgetTester tester, {
   required Future<String> Function(String password) onSetPassword,
+  ThemeData? theme,
 }) async {
   final results = <Object?>[];
   await tester.pumpWidget(
     MaterialApp(
+      theme: theme,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       locale: const Locale('en'),
@@ -37,6 +40,37 @@ Future<List<Object?>> _pumpSetup(
 }
 
 void main() {
+  testWidgets('keeps the confirm field clear of the password field above it', (
+    tester,
+  ) async {
+    // The app theme uses filled fields with an OutlineInputBorder. Flutter
+    // floats such a label so it straddles the top border and reserves no
+    // space above the box for it, so two fields stacked flush let the confirm
+    // label paint over the password field. Pump the real theme, not a bare
+    // MaterialApp, or the overlap cannot reproduce.
+    await _pumpSetup(
+      tester,
+      theme: submersionLight,
+      onSetPassword: (_) async => 'a-b-c-d',
+    );
+
+    // Both labels must be floating: that is the state the overlap appears in.
+    await tester.enterText(find.byType(TextField).at(0), 'hunter2!');
+    await tester.enterText(find.byType(TextField).at(1), 'hunter2!');
+    await tester.pumpAndSettle();
+
+    final passwordField = tester.getRect(find.byType(TextField).at(0));
+    final confirmLabel = tester.getRect(find.text('Confirm password'));
+
+    expect(
+      confirmLabel.top,
+      greaterThanOrEqualTo(passwordField.bottom),
+      reason:
+          'the floating "Confirm password" label paints ${passwordField.bottom - confirmLabel.top}px '
+          'inside the password field above it',
+    );
+  });
+
   testWidgets('rejects a short password and a mismatch before minting a key', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

On the set-app-password dialog, the **Confirm password** field visually overlaps the password field above it.

This is not a spacing oversight — it is a real paint overlap. Measured geometry with the app theme applied:

```
FIELD0 (Password)  rect: 232.0 -> 288.0
FIELD1 (Confirm)   rect: 288.0 -> 344.0     gap = 0.0px
LABEL "Confirm password" paints at y = 283.0
  -> 5px ABOVE its own field, inside the password field's box
```

## Root cause

Every app theme in `lib/core/theme/full_themes/` sets:

```dart
inputDecorationTheme: InputDecorationTheme(
  filled: true,
  border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
),
```

Flutter floats an outlined field's label so it *straddles the top border* — that is how the border-notch effect is produced — and reserves **no vertical space above the container** for it. The label legitimately paints outside its own render box.

That is normally harmless because padding or a spacer sits above. But where two `TextField`s were stacked flush in a `Column` at gap 0, the overhang landed on the neighbour's filled container. `filled: true` makes the collision solid and obvious.

The overlap only appears once the label floats (field focused or non-empty), which is exactly when the user is looking at it.

## Fix

Insert `const SizedBox(height: 16)` between every adjacent `TextField` pair. The reported dialog was one instance of a systemic pattern — **11 pairs across 8 files**:

| File | Pairs |
| --- | --- |
| `security_setup_dialog.dart` (reported) | 1 |
| `security_settings_page.dart` (`_ChangePasswordDialog`) | 2 |
| `encryption_passphrase_dialog.dart` | 2 |
| `backup_change_password_dialog.dart` | 2 |
| `enable_encryption_dialog.dart` | 1 |
| `backup_enable_encryption_dialog.dart` | 1 |
| `pre_dive_session_runner_page.dart` | 1 |
| `manifest_subscription_card.dart` | 1 |

A source scan confirms no abutting `TextField` pairs remain in `lib/`.

## Why no existing test caught this

Every one of these dialogs already had passing widget tests — but all of them built a bare `MaterialApp` with **no `theme:`**, so they rendered Flutter's default *underline* input border. Underline borders have no label overhang, so those tests exercised a different rendering path than production and were structurally incapable of seeing the bug.

The two regression tests added here pump the real `submersionLight` theme and assert on rects rather than widget presence:

```dart
expect(confirmLabel.top, greaterThanOrEqualTo(passwordField.bottom));
```

`findsOneWidget` would have passed either way. Geometry bugs need geometry assertions.

Coverage went on `SecuritySetupDialog` (the reported case) and the public `BackupEnableEncryptionDialog`. `_ChangePasswordDialog` is private and only reachable through the settings page's full provider graph, which is disproportionate scaffolding for one assertion.

## Verification

- Regression test confirmed **red before / green after**, so it demonstrably detects the defect rather than being written to fit the fix.
- Full suite: **16611 passed, 15 skipped**.
- `dart format lib/ test/`: clean, 0 changed.
- `flutter analyze lib/ test/`: no issues.

Two `ocr_scan_page_test.dart` cases failed in the full run and pass **7/7 in isolation** — a pre-existing under-load flake, unrelated to these files.
