### PR TITLE
fix(beta): split TestFlight upload from distribution so failures recover

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -33,6 +33,9 @@ jobs:
       proceed: ${{ steps.gate.outputs.proceed }}
       tag: ${{ steps.version.outputs.tag }}
       build-number: ${{ steps.version.outputs.build-number }}
+      # Marketing version alone (no build suffix). The TestFlight lanes address
+      # an already-uploaded build by version + build number.
+      semver: ${{ steps.version.outputs.semver }}
       sha: ${{ steps.version.outputs.sha }}
       # The previous beta's source commit. Every downstream job derives its
       # release notes from prev-sha..sha, so testers see what changed in this
@@ -70,6 +73,7 @@ jobs:
           fi
           echo "tag=v${SEMVER}.${BUILD}" >> "$GITHUB_OUTPUT"
           echo "build-number=${BUILD}" >> "$GITHUB_OUTPUT"
+          echo "semver=${SEMVER}" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Skip if nothing shippable changed since the last beta
@@ -313,29 +317,57 @@ jobs:
       # commit-derived content into GITHUB_ENV makes a commit subject that
       # matches the heredoc delimiter an environment-variable injection vector,
       # and this job holds the App Store Connect signing key.
-      - name: Upload to TestFlight (Public Beta)
+      # Uploading the binary and distributing it are separate steps because a
+      # build number can only ever be uploaded once. The upload runs exactly
+      # once and treats an already-uploaded build as success; only the
+      # distribution, which is idempotent, is retried.
+      - name: Upload binary to TestFlight
         working-directory: ios
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
-          BETA_CHANGELOG_FILE: ${{ github.workspace }}/beta-notes-store.txt
         run: |
           IPA_PATH=$(ls $GITHUB_WORKSPACE/Submersion-*-iOS.ipa 2>/dev/null | head -1)
           if [ -z "$IPA_PATH" ]; then
             echo "Error: No IPA artifact found"
             exit 1
           fi
-          for attempt in 1 2; do
-            if bundle exec fastlane upload_testflight_beta ipa:"$IPA_PATH"; then
-              break
+          bundle exec fastlane upload_testflight_beta_binary ipa:"$IPA_PATH"
+
+      - name: Distribute to Public Beta group
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BETA_CHANGELOG_FILE: ${{ github.workspace }}/beta-notes-store.txt
+          APP_VERSION: ${{ needs.precheck.outputs.semver }}
+          BUILD_NUMBER: ${{ needs.precheck.outputs.build-number }}
+        run: |
+          set -o pipefail
+          LOG="$RUNNER_TEMP/distribute.log"
+          RECOVER="cd ios && bundle exec fastlane distribute_testflight_beta app_version:$APP_VERSION build_number:$BUILD_NUMBER"
+          for attempt in 1 2 3; do
+            if bundle exec fastlane distribute_testflight_beta \
+                 app_version:"$APP_VERSION" build_number:"$BUILD_NUMBER" 2>&1 | tee "$LOG"; then
+              exit 0
             fi
-            if [ "$attempt" -eq 2 ]; then
-              echo "Fastlane upload failed after 2 attempts"
+            # Apple meters beta review submissions per day, so this one does not
+            # clear in a minute; retrying only delays the same failure.
+            if grep -q "Submission limit has been reached" "$LOG"; then
+              echo "::error::Apple refused the beta review submission (submission limit reached)." \
+                "Build $APP_VERSION ($BUILD_NUMBER) is uploaded and processed but was not" \
+                "distributed to Public Beta. Re-run this job once the limit clears, or run: $RECOVER"
               exit 1
             fi
-            echo "Fastlane attempt $attempt failed, retrying in 30s..."
-            sleep 30
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Distribution failed after 3 attempts. The binary is uploaded;" \
+                "re-run this job, or run: $RECOVER"
+              exit 1
+            fi
+            echo "Distribution attempt $attempt failed, retrying in 60s..."
+            sleep 60
           done
 
       - name: Cleanup sensitive files
@@ -379,13 +411,16 @@ jobs:
           name: beta-notes
 
       # Handed as a path, not as text - see the iOS job for why.
-      - name: Upload to TestFlight (Public Beta)
+      # Uploading the binary and distributing it are separate steps because a
+      # build number can only ever be uploaded once. The upload runs exactly
+      # once and treats an already-uploaded build as success; only the
+      # distribution, which is idempotent, is retried.
+      - name: Upload binary to TestFlight
         working-directory: macos
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
-          BETA_CHANGELOG_FILE: ${{ github.workspace }}/beta-notes-store.txt
         run: |
           # The Mac App Store package keeps its fixed name (no tag prefix).
           PKG_PATH="$GITHUB_WORKSPACE/Submersion.pkg"
@@ -393,16 +428,41 @@ jobs:
             echo "Error: No pkg artifact found at $PKG_PATH"
             exit 1
           fi
-          for attempt in 1 2; do
-            if bundle exec fastlane upload_testflight_beta pkg:"$PKG_PATH"; then
-              break
+          bundle exec fastlane upload_testflight_beta_binary pkg:"$PKG_PATH"
+
+      - name: Distribute to Public Beta group
+        working-directory: macos
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
+          BETA_CHANGELOG_FILE: ${{ github.workspace }}/beta-notes-store.txt
+          APP_VERSION: ${{ needs.precheck.outputs.semver }}
+          BUILD_NUMBER: ${{ needs.precheck.outputs.build-number }}
+        run: |
+          set -o pipefail
+          LOG="$RUNNER_TEMP/distribute.log"
+          RECOVER="cd macos && bundle exec fastlane distribute_testflight_beta app_version:$APP_VERSION build_number:$BUILD_NUMBER"
+          for attempt in 1 2 3; do
+            if bundle exec fastlane distribute_testflight_beta \
+                 app_version:"$APP_VERSION" build_number:"$BUILD_NUMBER" 2>&1 | tee "$LOG"; then
+              exit 0
             fi
-            if [ "$attempt" -eq 2 ]; then
-              echo "Fastlane upload failed after 2 attempts"
+            # Apple meters beta review submissions per day, so this one does not
+            # clear in a minute; retrying only delays the same failure.
+            if grep -q "Submission limit has been reached" "$LOG"; then
+              echo "::error::Apple refused the beta review submission (submission limit reached)." \
+                "Build $APP_VERSION ($BUILD_NUMBER) is uploaded and processed but was not" \
+                "distributed to Public Beta. Re-run this job once the limit clears, or run: $RECOVER"
               exit 1
             fi
-            echo "Fastlane attempt $attempt failed, retrying in 30s..."
-            sleep 30
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Distribution failed after 3 attempts. The binary is uploaded;" \
+                "re-run this job, or run: $RECOVER"
+              exit 1
+            fi
+            echo "Distribution attempt $attempt failed, retrying in 60s..."
+            sleep 60
           done
 
       - name: Cleanup sensitive files

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,12 +13,24 @@
 #   bundle exec fastlane upload_only           # Upload pre-built IPA to App Store
 #   bundle exec fastlane upload_testflight_only # Upload pre-built IPA to TestFlight
 #
+#   Beta pipeline (upload and distribution are separate so each can be rerun):
+#   bundle exec fastlane upload_testflight_beta_binary ipa:PATH
+#   bundle exec fastlane distribute_testflight_beta app_version:1.7.3 build_number:5829
+#
 #   Signing is handled automatically via Xcode + App Store Connect API key.
 
 default_platform(:ios)
 
 # Apple rejects an upload whose whatsNew exceeds 4000 characters.
 TESTFLIGHT_CHANGELOG_LIMIT = 4000
+
+# Markers App Store Connect returns when the build number has already been
+# accepted for this app. Re-running the beta pipeline after a distribution
+# failure hits this, because the binary landed on the first pass.
+DUPLICATE_BUILD_MARKERS = [
+  "ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE",
+  "bundle version must be higher than the previously uploaded version",
+].freeze
 
 platform :ios do
   # ============================================================================
@@ -110,6 +122,18 @@ platform :ios do
     end
 
     notes[0, TESTFLIGHT_CHANGELOG_LIMIT]
+  end
+
+  # True when an upload failed only because this exact build is already on App
+  # Store Connect.
+  #
+  # A build number can be uploaded once, so any retry or workflow re-run after
+  # the binary was accepted reports the duplicate rather than the failure that
+  # actually stopped the pipeline. Treating it as "already uploaded" lets the
+  # run continue to distribution, which is the step that still needs to happen.
+  def duplicate_build_error?(message)
+    text = message.to_s
+    DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
   end
 
   # Loads API key from environment variables or falls back to api_key.json
@@ -312,17 +336,59 @@ platform :ios do
     UI.success("iOS build uploaded to TestFlight!")
   end
 
-  desc "Upload pre-built IPA to TestFlight and distribute to the Public Beta group"
-  lane :upload_testflight_beta do |options|
+  # Uploading and distributing are separate lanes on purpose.
+  #
+  # They used to be one upload_to_testflight call, which uploads the binary,
+  # waits for processing, then submits it for beta review. Only the upload is
+  # one-shot: a build number can never be uploaded twice. So when the beta
+  # review submission failed (Apple's submission limit), every retry and
+  # re-run re-uploaded the same IPA and died on a duplicate-version error that
+  # masked the real cause, leaving the build stranded in TestFlight with no way
+  # to distribute it short of the App Store Connect UI.
+  desc "Upload pre-built IPA to TestFlight without distributing it"
+  lane :upload_testflight_beta_binary do |options|
     api_key = load_api_key
     ipa_path = options[:ipa] || "./build/Submersion.ipa"
 
-    UI.message("Uploading IPA to TestFlight (Public Beta): #{ipa_path}")
-    # distribute_external requires waiting for processing so the build can be
-    # assigned to the group; expect several minutes per upload.
+    UI.message("Uploading IPA to TestFlight: #{ipa_path}")
+    begin
+      # No changelog and no distribution here, so pilot returns as soon as the
+      # binary is accepted instead of waiting out processing.
+      upload_to_testflight(
+        api_key: api_key,
+        ipa: ipa_path,
+        skip_waiting_for_build_processing: true,
+      )
+    rescue StandardError => e
+      raise unless duplicate_build_error?(e.message)
+
+      UI.important(
+        "This build is already on App Store Connect; skipping the upload and " \
+        "continuing to distribution."
+      )
+    end
+    UI.success("iOS beta binary is on App Store Connect!")
+  end
+
+  desc "Distribute an already-uploaded TestFlight build to the Public Beta group"
+  lane :distribute_testflight_beta do |options|
+    api_key = load_api_key
+    app_version = options[:app_version] || UI.user_error!("app_version is required")
+    build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    UI.message("Distributing #{app_version} (#{build_number}) to the Public Beta group...")
+    # distribute_only touches no binary, so this lane is safe to retry and safe
+    # to run by hand against a build whose distribution failed earlier.
+    #
+    # app_platform is required rather than optional here: pilot normally infers
+    # the platform from the IPA, and with distribute_only there is no IPA to
+    # infer from, so it would fall back to an interactive prompt in CI.
     upload_to_testflight(
       api_key: api_key,
-      ipa: ipa_path,
+      distribute_only: true,
+      app_platform: "ios",
+      app_version: app_version,
+      build_number: build_number.to_s,
       distribute_external: true,
       groups: ["Public Beta"],
       changelog: beta_changelog,

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -363,8 +363,9 @@ platform :ios do
       raise unless duplicate_build_error?(e.message)
 
       UI.important(
-        "This build is already on App Store Connect; skipping the upload and " \
-        "continuing to distribution."
+        "This build is already on App Store Connect; skipping the upload. " \
+        "This lane does not distribute: run distribute_testflight_beta to " \
+        "assign the build to the Public Beta group."
       )
     end
     UI.success("iOS beta binary is on App Store Connect!")

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -445,8 +445,9 @@ platform :mac do
       raise unless duplicate_build_error?(e.message)
 
       UI.important(
-        "This build is already on App Store Connect; skipping the upload and " \
-        "continuing to distribution."
+        "This build is already on App Store Connect; skipping the upload. " \
+        "This lane does not distribute: run distribute_testflight_beta to " \
+        "assign the build to the Public Beta group."
       )
     end
     UI.success("macOS beta binary is on App Store Connect!")

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -13,12 +13,24 @@
 #   bundle exec fastlane upload_only           # Upload pre-built pkg to App Store
 #   bundle exec fastlane upload_testflight_only # Upload pre-built pkg to TestFlight
 #
+#   Beta pipeline (upload and distribution are separate so each can be rerun):
+#   bundle exec fastlane upload_testflight_beta_binary pkg:PATH
+#   bundle exec fastlane distribute_testflight_beta app_version:1.7.3 build_number:5829
+#
 #   Signing is handled automatically via Xcode + App Store Connect API key.
 
 default_platform(:mac)
 
 # Apple rejects an upload whose whatsNew exceeds 4000 characters.
 TESTFLIGHT_CHANGELOG_LIMIT = 4000
+
+# Markers App Store Connect returns when the build number has already been
+# accepted for this app. Re-running the beta pipeline after a distribution
+# failure hits this, because the binary landed on the first pass.
+DUPLICATE_BUILD_MARKERS = [
+  "ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE",
+  "bundle version must be higher than the previously uploaded version",
+].freeze
 
 platform :mac do
   # ============================================================================
@@ -65,6 +77,18 @@ platform :mac do
     end
 
     notes[0, TESTFLIGHT_CHANGELOG_LIMIT]
+  end
+
+  # True when an upload failed only because this exact build is already on App
+  # Store Connect.
+  #
+  # A build number can be uploaded once, so any retry or workflow re-run after
+  # the binary was accepted reports the duplicate rather than the failure that
+  # actually stopped the pipeline. Treating it as "already uploaded" lets the
+  # run continue to distribution, which is the step that still needs to happen.
+  def duplicate_build_error?(message)
+    text = message.to_s
+    DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
   end
 
   def load_api_key
@@ -394,17 +418,59 @@ platform :mac do
     UI.success("macOS build uploaded to TestFlight!")
   end
 
-  desc "Upload pre-built pkg to TestFlight and distribute to the Public Beta group"
-  lane :upload_testflight_beta do |options|
+  # Uploading and distributing are separate lanes on purpose.
+  #
+  # They used to be one upload_to_testflight call, which uploads the binary,
+  # waits for processing, then submits it for beta review. Only the upload is
+  # one-shot: a build number can never be uploaded twice. So when the beta
+  # review submission failed (Apple's submission limit), every retry and
+  # re-run re-uploaded the same pkg and died on a duplicate-version error that
+  # masked the real cause, leaving the build stranded in TestFlight with no way
+  # to distribute it short of the App Store Connect UI.
+  desc "Upload pre-built pkg to TestFlight without distributing it"
+  lane :upload_testflight_beta_binary do |options|
     api_key = load_api_key
     pkg_path = options[:pkg] || "./build/Submersion.pkg"
 
-    UI.message("Uploading pkg to TestFlight (Public Beta): #{pkg_path}")
-    # distribute_external requires waiting for processing so the build can be
-    # assigned to the group; expect several minutes per upload.
+    UI.message("Uploading pkg to TestFlight: #{pkg_path}")
+    begin
+      # No changelog and no distribution here, so pilot returns as soon as the
+      # binary is accepted instead of waiting out processing.
+      upload_to_testflight(
+        api_key: api_key,
+        pkg: pkg_path,
+        skip_waiting_for_build_processing: true,
+      )
+    rescue StandardError => e
+      raise unless duplicate_build_error?(e.message)
+
+      UI.important(
+        "This build is already on App Store Connect; skipping the upload and " \
+        "continuing to distribution."
+      )
+    end
+    UI.success("macOS beta binary is on App Store Connect!")
+  end
+
+  desc "Distribute an already-uploaded TestFlight build to the Public Beta group"
+  lane :distribute_testflight_beta do |options|
+    api_key = load_api_key
+    app_version = options[:app_version] || UI.user_error!("app_version is required")
+    build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    UI.message("Distributing #{app_version} (#{build_number}) to the Public Beta group...")
+    # distribute_only touches no binary, so this lane is safe to retry and safe
+    # to run by hand against a build whose distribution failed earlier.
+    #
+    # app_platform is required rather than optional here: pilot normally infers
+    # the platform from the pkg, and with distribute_only there is no pkg to
+    # infer from, so it would fall back to an interactive prompt in CI.
     upload_to_testflight(
       api_key: api_key,
-      pkg: pkg_path,
+      distribute_only: true,
+      app_platform: "osx",
+      app_version: app_version,
+      build_number: build_number.to_s,
       distribute_external: true,
       groups: ["Public Beta"],
       changelog: beta_changelog,
@@ -491,6 +557,8 @@ platform :mac do
     UI.message("    full_release       - Screenshots + build + upload")
     UI.message("    upload_only           - Upload pre-built pkg to App Store (CI)")
     UI.message("    upload_testflight_only - Upload pre-built pkg to TestFlight (CI)")
+    UI.message("    upload_testflight_beta_binary - Upload a beta pkg, no distribution (CI)")
+    UI.message("    distribute_testflight_beta    - Distribute an uploaded build to Public Beta")
     UI.message("")
     UI.message("  Utilities:")
     UI.message("    clean              - Clean all build artifacts")

--- a/scripts/release/fastlane_beta_changelog_test.rb
+++ b/scripts/release/fastlane_beta_changelog_test.rb
@@ -127,6 +127,61 @@ Dir.mktmpdir do |tmp|
   end
 end
 
+# --- Already-uploaded build detection (iOS/macOS Fastfiles) -----------------
+# The beta lanes upload the binary and distribute it as two steps, because a
+# build number can only ever be uploaded once. When distribution fails, the
+# re-run has to recognise "this build is already up there" and carry on to
+# distribution instead of failing on the duplicate.
+#
+# The message below is copied verbatim from the run where this broke
+# (actions/runs/31522488646): the distribution failed on Apple's beta review
+# submission limit, then every retry re-uploaded the same pkg and reported the
+# duplicate instead, which stranded the build with no recovery path.
+
+altool_duplicate_error = <<~ERROR
+  Error uploading pkg file:#{' '}
+   [Application Loader Error Output]: [altool.60000369C1C0] [ContentDelivery.Uploader.60000369C1C0] The provided entity includes an attribute with a value that has already been used (-19232) The bundle version must be higher than the previously uploaded version: 5829. (ID: 1d3ed621-6c27-4215-b1d0-0b96fbd95ea7)
+  [Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
+ERROR
+
+check(duplicate_build_error?(altool_duplicate_error),
+      'the duplicate-build message from App Store Connect was not recognised, so a ' \
+      're-run would fail on the duplicate instead of distributing the uploaded build')
+
+# The other shape of the same rejection, straight from the API error body.
+check(duplicate_build_error?('ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE'),
+      'the App Store Connect duplicate error code was not recognised')
+
+# Anything else has to keep failing. Swallowing a genuine upload failure would
+# send the run on to distribute a build that was never uploaded.
+[
+  'The call to the altool completed with a non-zero exit status: 1.',
+  'Could not find the certificate in the keychain',
+  'Submission limit has been reached. - Submission limit has been reached.',
+  '',
+  nil,
+].each do |unrelated|
+  check(!duplicate_build_error?(unrelated),
+        "#{unrelated.inspect} was treated as an already-uploaded build, which would " \
+        'let a real upload failure through')
+end
+
+# The macOS Fastfile carries its own copy of these helpers, the way it already
+# does for the changelog ones, and only the iOS file is loaded here (loading
+# both would redefine the same top-level methods). Compare the source text
+# instead, so the platform that actually hit this cannot quietly lose the
+# protection while the iOS tests keep passing.
+macos_fastfile = File.read(File.join(ROOT, 'macos', 'fastlane', 'Fastfile'))
+
+check(macos_fastfile.include?('def duplicate_build_error?'),
+      'the macOS Fastfile no longer defines duplicate_build_error?, so a macOS beta ' \
+      're-run would fail on the duplicate instead of distributing the uploaded build')
+
+DUPLICATE_BUILD_MARKERS.each do |marker|
+  check(macos_fastfile.include?(marker),
+        "the macOS Fastfile is missing the #{marker.inspect} marker that the iOS one has")
+end
+
 # --- Play changelog (Android Fastfile) --------------------------------------
 
 load File.join(ROOT, 'android', 'fastlane', 'Fastfile')


### PR DESCRIPTION
## What broke

The macOS TestFlight upload in [beta run 31522488646](https://github.com/submersion-app/submersion/actions/runs/31522488646/job/93893149175) failed with a duplicate `cfBundleVersion` error (`-19232`). That was not the cause.

Attempt 1 of that run got almost all the way through:

```
18:53:32  Successfully uploaded the new binary to App Store Connect
18:57:39  Successfully finished processing the build 1.7.3 - 5829 for MAC_OS
18:57:39  Successfully set the changelog for build
18:57:40  Distributing new build to testers: 1.7.3 - 5829
18:57:40  [!] Submission limit has been reached.
          spaceship/connect_api/testflight.rb:119:in `post_beta_app_review_submissions'
```

Apple refused the **beta app review submission** for external distribution. The binary was already accepted, so everything after that compounded the problem: the step's retry loop re-ran the whole lane and re-uploaded the same pkg, which Apple correctly rejected as a duplicate build number, and the workflow re-run did the same. Four attempts, all guaranteed to fail with an error that hid the real one.

Build 5829 was left uploaded and processed but never assigned to Public Beta, with no recovery path short of the App Store Connect UI.

## Root cause

`upload_to_testflight` with `distribute_external: true` is three operations in one action: upload the binary, wait for processing, then submit for beta review and assign to the group. Only the upload is one-shot — a build number can never be uploaded twice. Wrapping the whole thing in a retry loop turns any failure in the last two phases into a permanent, unrecoverable duplicate-version error.

## The change

**Fastfiles (iOS and macOS)** — `upload_testflight_beta` split into two lanes:

- `upload_testflight_beta_binary` uploads and returns (`skip_waiting_for_build_processing`, no changelog, no distribution). It recognises the "already uploaded" rejection and continues instead of failing, so a re-run proceeds to distribution.
- `distribute_testflight_beta app_version:X build_number:Y` distributes an already-uploaded build via `distribute_only`. It touches no binary, so it is idempotent and can be run by hand to rescue a stranded build.

`app_platform` is passed explicitly in the distribute lane: pilot normally infers the platform from the ipa/pkg, and with `distribute_only` there is none to infer from, so it would fall back to an interactive prompt that has no TTY in CI.

**`beta.yml`** — both TestFlight jobs now have separate "Upload binary" and "Distribute to Public Beta group" steps. The upload runs exactly once; only the distribution retries. A `Submission limit has been reached` response skips the retries entirely, since Apple's daily quota does not clear in 60 seconds, and prints the command that finishes the job once it does. Adds a `semver` precheck output, since distribution addresses a build by version plus build number.

**`fastlane_beta_changelog_test.rb`** — covers the duplicate detection against the verbatim altool error from the failing run, asserts unrelated failures are not swallowed (a genuine upload failure must still fail), and guards the macOS Fastfile against drifting from the iOS one.

## Verification

- `ruby -c` clean on both Fastfiles; `fastlane lanes` lists both new lanes on both platforms.
- Every option introduced (`distribute_only`, `app_platform`, `app_version`, `build_number`) confirmed present on `upload_to_testflight` via `fastlane action upload_to_testflight`.
- Ruby test suite passes, and is mutation-checked: corrupting the marker string makes it fail, so it is not vacuous.
- The distribute step's shell logic simulated across four modes — success exits 0; submission-limit fails immediately with no sleep; a transient failure retries and succeeds; a permanent failure exhausts three attempts and reports the recovery command.

## Notes

This makes distribution failures cheap and recoverable; it does not prevent them. Apple meters Public Beta assignment (beta app review) per day, and at the current beta cadence that ceiling is reachable. Whether to change the distribution policy — for example uploading every build but distributing the newest on a schedule — is deliberately left open pending a few days of data on how often the cap actually binds.
