### PR TITLE
Fix safety review sweep ordering

### DIFF
--- a/lib/features/backup/presentation/providers/post_restore_safety_review.dart
+++ b/lib/features/backup/presentation/providers/post_restore_safety_review.dart
@@ -46,7 +46,9 @@ class PostRestoreSafetyReview {
     bool Function()? isCancelled,
   }) async {
     final diveRepo = _ref.read(diveRepositoryProvider);
-    final allIds = await diveRepo.getOrderedDiveIds();
+    final allIds = await diveRepo.getOrderedDiveIds(
+      sort: SafetyReviewSweep.oldestFirstSort,
+    );
     final total = allIds.length;
     onProgress?.call(0, total);
     if (total == 0) return SafetyReviewSweepResult.empty;
@@ -102,7 +104,10 @@ class PostRestoreSafetyReview {
     final passes = <_SweepPass>[];
     final owned = <String>{};
     for (final diver in divers) {
-      final ids = await diveRepo.getOrderedDiveIds(diverId: diver.id);
+      final ids = await diveRepo.getOrderedDiveIds(
+        diverId: diver.id,
+        sort: SafetyReviewSweep.oldestFirstSort,
+      );
       if (ids.isEmpty) continue;
       owned.addAll(ids);
       passes.add((diverId: diver.id, diveIds: ids));

--- a/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_sweep.dart
@@ -1,3 +1,5 @@
+import 'package:submersion/core/constants/sort_options.dart';
+import 'package:submersion/core/models/sort_state.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
@@ -37,6 +39,15 @@ class SafetyReviewSweep {
 
   const SafetyReviewSweep(this._ref);
 
+  /// Profile analysis carries residual tissue, CNS, and OTU state forward
+  /// from earlier dives. Sweeping in that same order primes the provider cache
+  /// one dive at a time instead of making the first newest dive recursively
+  /// analyze much of the logbook before progress can advance.
+  static const oldestFirstSort = SortState<DiveSortField>(
+    field: DiveSortField.date,
+    direction: SortDirection.ascending,
+  );
+
   /// Analyzes every dive matching [diverId] (null means every diver), or
   /// exactly [diveIds] when supplied.
   ///
@@ -65,7 +76,7 @@ class SafetyReviewSweep {
         diveIds ??
         await _ref
             .read(diveRepositoryProvider)
-            .getOrderedDiveIds(diverId: diverId);
+            .getOrderedDiveIds(diverId: diverId, sort: oldestFirstSort);
 
     final total = ids.length;
     onProgress?.call(0, total);

--- a/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
+++ b/test/features/dive_log/presentation/providers/safety_review_sweep_test.dart
@@ -88,6 +88,9 @@ void main() {
         safetyReviewEnabledProvider.overrideWithValue(true),
         profileAnalysisProvider('d1').overrideWith((ref) async => analysis),
         profileAnalysisProvider('d2').overrideWith((ref) async => analysis),
+        profileAnalysisProvider(
+          'd-newer',
+        ).overrideWith((ref) async => analysis),
       ],
     );
     addTearDown(container.dispose);
@@ -114,6 +117,34 @@ void main() {
 
     expect(repo.saved, <String>['d1']);
     expect(result.swept, 1);
+  });
+
+  test('sweeps oldest first so residual analysis is already cached', () async {
+    final newer = now.add(const Duration(days: 1)).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d-newer'),
+            diverId: const Value('diver-a'),
+            diveDateTime: Value(newer),
+            createdAt: Value(newer),
+            updatedAt: Value(newer),
+          ),
+        );
+    final repo = _RecordingRepo();
+
+    await makeContainer(
+      repo,
+    ).read(safetyReviewSweepProvider).run(diverId: 'diver-a');
+
+    expect(
+      repo.saved,
+      <String>['d1', 'd-newer'],
+      reason:
+          'newer profile analysis recursively awaits older dives, so the '
+          'sweep must warm that cache in chronological order',
+    );
   });
 
   test('reports progress ending at the total', () async {


### PR DESCRIPTION
## Summary

- process safety-review sweeps from oldest to newest
- reuse the same ordering for post-restore sweeps
- add a regression test covering persisted review order

## Root cause

The sweep queried dives newest-first. Analyzing the newest dive recursively loads older dives to reconstruct residual tissue loading and cumulative CNS/OTU exposure, so the first visible progress step could perform most of the logbook analysis and appear to hang.

Processing oldest-first lets each review build on already-cached prior results and advances progress steadily.

## Validation

- `flutter test --no-pub --reporter expanded --fail-fast` — 16,612 passed, 15 skipped
- focused safety-review tests — 18 passed
- `flutter analyze --no-pub` on the changed files — no issues
- `git diff --check` — clean
