### PR TITLE
fix: decouple App Lock from database encryption

### DIFF
--- a/docs/superpowers/plans/2026-08-11-decouple-app-lock-database-encryption.md
+++ b/docs/superpowers/plans/2026-08-11-decouple-app-lock-database-encryption.md
@@ -1,0 +1,188 @@
+# Decouple App Lock from Database Encryption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow database encryption to be enabled and remain enabled without automatically enabling App Lock.
+
+**Architecture:** Keep the existing shared master key, password keyslot, recovery keyslot, and secure-storage cache. Separate credential creation from the `app_lock_enabled` preference, expose an explicit App Lock state transition, and make the settings UI handle all four App Lock/encryption combinations. When the last tier is disabled, remove the now-unused sidecar and cached key.
+
+**Tech Stack:** Flutter, Dart, SharedPreferences, SQLCipher orchestration, Flutter widget tests
+
+## Global Constraints
+
+- Database Encryption remains at-rest encryption of `submersion.db`; App Lock remains a UI gate.
+- Both tiers continue sharing one password, recovery code, master key, and keyslot sidecar.
+- Encryption-only startup reads the cached master key silently and prompts only when that key is unavailable.
+- Existing unrelated worktree changes must remain untouched.
+
+---
+
+### Task 1: Separate credential creation from App Lock state
+
+**Files:**
+- Modify: `lib/core/services/security/database_security_service.dart`
+- Test: `test/core/services/security/database_security_service_test.dart`
+
+**Interfaces:**
+- Produces: `enableSecurity(...)` creates and caches credentials without changing `app_lock_enabled`.
+- Produces: `setAppLockEnabled(bool enabled)` changes only the App Lock preference and requires an unlocked credential when enabling.
+- Consumes: Existing `SecurityPreferences.setAppLockEnabled(bool)`.
+
+- [x] **Step 1: Write failing service tests**
+
+Change the existing setup test to assert that `enableSecurity(...)` writes the sidecar and caches the key while leaving App Lock off. Add a test that `setAppLockEnabled(true)` turns on App Lock after credential setup and that `setAppLockEnabled(false)` turns it off without deleting the sidecar or clearing the cached key.
+
+```dart
+test('enableSecurity creates credentials without enabling app lock', () async {
+  await svc.enableSecurity(password: 'hunter2', dbPath: dbPath, kdf: testKdf);
+  expect(svc.appLockEnabled, false);
+  expect(svc.isUnlocked, true);
+  expect(File('${tmp.path}/submersion.keys').existsSync(), true);
+});
+
+test('setAppLockEnabled changes only the UI gate', () async {
+  await svc.enableSecurity(password: 'pw', dbPath: dbPath, kdf: testKdf);
+  await svc.setAppLockEnabled(true);
+  expect(svc.appLockEnabled, true);
+  await svc.setAppLockEnabled(false);
+  expect(svc.appLockEnabled, false);
+  expect(svc.isUnlocked, true);
+  expect(File('${tmp.path}/submersion.keys').existsSync(), true);
+});
+```
+
+- [x] **Step 2: Run the service tests and verify RED**
+
+Run: `flutter test test/core/services/security/database_security_service_test.dart`
+
+Expected: the credential test reports App Lock is unexpectedly true and `setAppLockEnabled` is undefined.
+
+- [x] **Step 3: Implement the explicit state transition**
+
+Remove the App Lock preference write from `enableSecurity(...)` and add:
+
+```dart
+Future<void> setAppLockEnabled(bool enabled) async {
+  if (enabled && _mlk == null) {
+    throw StateError('Cannot enable App Lock without an unlocked credential');
+  }
+  await _p.setAppLockEnabled(enabled);
+}
+```
+
+Update tests and non-UI setup call sites that specifically require App Lock to call `setAppLockEnabled(true)` explicitly.
+
+- [x] **Step 4: Run the service and startup tests and verify GREEN**
+
+Run: `flutter test test/core/services/security/database_security_service_test.dart test/core/presentation/pages/startup_lock_gate_test.dart`
+
+Expected: PASS.
+
+---
+
+### Task 2: Support all four settings combinations
+
+**Files:**
+- Modify: `lib/features/settings/presentation/pages/security_settings_page.dart`
+- Test: `test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+**Interfaces:**
+- Consumes: `DatabaseSecurityService.setAppLockEnabled(bool)` from Task 1.
+- Produces: encryption setup creates credentials without changing App Lock.
+- Produces: disabling App Lock while encryption is active retains encryption credentials.
+- Produces: disabling the final enabled tier removes unused security credentials.
+
+- [x] **Step 1: Write failing widget tests**
+
+Add tests proving:
+
+```dart
+testWidgets('encryption setup leaves app lock off', (tester) async {
+  // Complete the password/recovery flow from the Encrypt database switch.
+  // Assert appLockEnabled is false before confirming the migration.
+});
+
+testWidgets('encryption-only state renders the encryption switch on', (tester) async {
+  await configure({'db_encryption_enabled': true});
+  await pumpPage(tester);
+  final encryptionSwitch = tester.widget<SwitchListTile>(
+    find.widgetWithText(SwitchListTile, 'Encrypt database'),
+  );
+  expect(encryptionSwitch.value, true);
+});
+
+testWidgets('app lock can be turned off while encryption remains on', (tester) async {
+  // Configure a real shared credential with both flags on, complete password
+  // confirmation, then assert App Lock is false, encryption is true, and the
+  // sidecar still exists.
+});
+```
+
+- [x] **Step 2: Run the widget tests and verify RED**
+
+Run: `flutter test test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+Expected: encryption setup enables App Lock, the encryption-only switch renders off, and disabling App Lock is blocked.
+
+- [x] **Step 3: Implement independent settings transitions**
+
+Refactor the page so:
+
+- App Lock setup creates credentials if neither tier exists, then explicitly enables App Lock.
+- Enabling App Lock while encryption is already active only calls `setAppLockEnabled(true)`.
+- Encryption setup creates credentials but never calls `setAppLockEnabled(true)`.
+- Password/recovery management is visible when either tier is active.
+- Biometrics and auto-lock remain visible only while App Lock is active.
+- The encryption switch always reflects `encryptionEnabled`.
+- Disabling App Lock while encryption is active calls `setAppLockEnabled(false)` after password confirmation and retains the sidecar.
+- Disabling encryption while App Lock is inactive decrypts first, then calls `disableSecurity(...)` to remove the unused credential.
+
+- [x] **Step 4: Run the widget tests and verify GREEN**
+
+Run: `flutter test test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+Expected: PASS.
+
+---
+
+### Task 3: Preserve reset cleanup and verify regressions
+
+**Files:**
+- Modify: `lib/core/services/security/database_security_service.dart`
+- Test: existing security, startup, App Lock provider, lock barrier, and settings coverage
+
+**Interfaces:**
+- Consumes: `disableEncryption(...)` and `disableSecurity(...)`.
+- Produces: database reset clears shared security credentials even when encryption was the only enabled tier.
+
+- [x] **Step 1: Clean up credentials when encryption was the final tier**
+
+After decryption succeeds and the encryption preference is cleared, remove the shared credential only when App Lock is already off. This keeps reset behavior safe without duplicating cleanup in the storage page:
+
+```dart
+await _p.setEncryptionEnabled(false);
+await refreshKeyStatus(dbPath: dbPath);
+if (!appLockEnabled) {
+  await disableSecurity(dbPath: dbPath);
+}
+```
+
+- [x] **Step 2: Format and run focused regression tests**
+
+Run: `dart format lib/core/services/security/database_security_service.dart lib/features/settings/presentation/pages/security_settings_page.dart test/core/services/security/database_security_service_test.dart test/core/presentation/pages/startup_lock_gate_test.dart test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+Run: `flutter test test/core/services/security test/core/presentation/pages/startup_lock_gate_test.dart test/core/presentation/providers/app_lock_provider_test.dart test/core/presentation/widgets/lock_barrier_test.dart test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+Expected: PASS.
+
+- [x] **Step 3: Run static analysis for changed Dart files**
+
+Run: `flutter analyze lib/core/services/security/database_security_service.dart lib/features/settings/presentation/pages/security_settings_page.dart test/core/services/security/database_security_service_test.dart test/core/presentation/pages/startup_lock_gate_test.dart test/features/settings/presentation/pages/security_settings_page_test.dart`
+
+Expected: no issues.
+
+- [x] **Step 4: Review the final diff**
+
+Run: `git diff --check` and `git diff -- lib/core/services/security/database_security_service.dart lib/features/settings/presentation/pages/security_settings_page.dart test/core/services/security/database_security_service_test.dart test/core/presentation/pages/startup_lock_gate_test.dart test/features/settings/presentation/pages/security_settings_page_test.dart docs/superpowers/plans/2026-08-11-decouple-app-lock-database-encryption.md`
+
+Expected: no whitespace errors; only the planned behavior and tests are present.

--- a/lib/core/services/security/database_security_service.dart
+++ b/lib/core/services/security/database_security_service.dart
@@ -100,8 +100,9 @@ class DatabaseSecurityService {
   }
 
   /// Mints the Master Key and sidecar (password + recovery slots), caches
-  /// the key, flips App Lock on, and returns the recovery code — shown to
-  /// the user exactly once.
+  /// the key, and returns the recovery code — shown to the user exactly once.
+  /// App Lock is an independent tier and must be enabled explicitly with
+  /// [setAppLockEnabled].
   Future<String> enableSecurity({
     required String password,
     required String dbPath,
@@ -134,8 +135,16 @@ class DatabaseSecurityService {
     );
     await DatabaseSecuritySidecar.write(dbPath, file);
     await _adoptMlk(mlk, libraryKeyId, persist: true);
-    await _p.setAppLockEnabled(true);
     return recoveryCode;
+  }
+
+  /// Enables or disables the App Lock UI gate without changing database
+  /// encryption, keyslots, or the cached Master Key.
+  Future<void> setAppLockEnabled(bool enabled) async {
+    if (enabled && _mlk == null) {
+      throw StateError('Cannot enable App Lock without an unlocked credential');
+    }
+    await _p.setAppLockEnabled(enabled);
   }
 
   /// Rewraps the passphrase slot only — the master key and recovery slot
@@ -243,8 +252,10 @@ class DatabaseSecurityService {
     }
   }
 
-  /// Decrypts in place; mirror image of [enableEncryption]. App Lock stays
-  /// on — only the at-rest tier is removed.
+  /// Decrypts in place; mirror image of [enableEncryption]. When App Lock is
+  /// still enabled, the shared credential remains for that tier. Otherwise
+  /// this was the last enabled tier, so the unused sidecar and cached key are
+  /// removed as well.
   Future<void> disableEncryption({
     DatabaseEncryptionMigrator? migrator,
     void Function(String phase)? onPhase,
@@ -270,6 +281,9 @@ class DatabaseSecurityService {
 
     await _p.setDbEncryptionEnabled(false);
     await refreshDerivedKey();
+    if (!appLockEnabled) {
+      await disableSecurity(dbPath: dbPath);
+    }
 
     if (!skipReopenForTesting) {
       onPhase?.call('reopen');

--- a/lib/core/services/security/database_security_service.dart
+++ b/lib/core/services/security/database_security_service.dart
@@ -60,6 +60,10 @@ class DatabaseSecurityService {
   bool get encryptionEnabled => _p.dbEncryptionEnabled;
   bool get isUnlocked => _mlk != null;
 
+  /// Whether durable security credentials already exist for [dbPath].
+  bool hasCredential({required String dbPath}) =>
+      DatabaseSecuritySidecar.existsFor(dbPath);
+
   /// The key id minted at enableSecurity, once unlocked. Stable across
   /// password changes (rewrap only); used to label rebuilt sidecars.
   String? get libraryKeyId => _libraryKeyId;

--- a/lib/features/settings/presentation/pages/security_settings_page.dart
+++ b/lib/features/settings/presentation/pages/security_settings_page.dart
@@ -111,12 +111,20 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
               await _disableEncryption();
               return;
             }
-            final createdCredential = !hasCredential;
-            if (createdCredential) {
+            final dbPath = await _dbPath();
+            if (!mounted) return;
+            final credentialExists =
+                hasCredential || _security.hasCredential(dbPath: dbPath);
+            if (!credentialExists) {
               final ok = await _setupCredential(enableAppLock: false);
               if (!ok || !mounted) return;
+            } else if (!_security.isUnlocked) {
+              final secret = await _promptPassword(
+                l10n.settings_security_unlock_title,
+              );
+              if (secret == null || !mounted) return;
             }
-            await _enableEncryption(clearCredentialOnCancel: createdCredential);
+            await _enableEncryption(clearCredentialOnCancel: !hasCredential);
           },
         ),
       ],
@@ -132,6 +140,12 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
 
   Future<bool> _enableAppLock() async {
     if (_security.encryptionEnabled) {
+      if (!_security.isUnlocked) {
+        final secret = await _promptPassword(
+          context.l10n.settings_security_unlock_title,
+        );
+        if (secret == null || !mounted) return false;
+      }
       await _security.setAppLockEnabled(true);
       if (mounted) setState(() {});
       return true;

--- a/lib/features/settings/presentation/pages/security_settings_page.dart
+++ b/lib/features/settings/presentation/pages/security_settings_page.dart
@@ -51,6 +51,7 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
     final theme = Theme.of(context);
     final appLockOn = _security.appLockEnabled;
     final encryptionOn = _security.encryptionEnabled;
+    final hasCredential = appLockOn || encryptionOn;
 
     return ListView(
       children: [
@@ -83,6 +84,8 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
             ),
             onTap: _pickTimeout,
           ),
+        ],
+        if (hasCredential) ...[
           ListTile(
             leading: const Icon(Icons.password),
             title: Text(l10n.settings_security_changePassword),
@@ -94,31 +97,28 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
             onTap: _regenerateRecovery,
           ),
           const Divider(),
-          SwitchListTile(
-            secondary: Icon(
-              encryptionOn ? Icons.enhanced_encryption : Icons.no_encryption,
-              color: encryptionOn ? theme.colorScheme.primary : null,
-            ),
-            title: Text(l10n.settings_security_encryption),
-            subtitle: Text(l10n.settings_security_encryption_subtitle),
-            value: encryptionOn,
-            onChanged: (v) => v ? _enableEncryption() : _disableEncryption(),
-          ),
-        ] else ...[
-          // Encryption without App Lock first runs the password setup (spec:
-          // "prompts you to set the app password first").
-          SwitchListTile(
-            secondary: const Icon(Icons.no_encryption),
-            title: Text(l10n.settings_security_encryption),
-            subtitle: Text(l10n.settings_security_encryption_subtitle),
-            value: false,
-            onChanged: (v) async {
-              if (!v) return;
-              final ok = await _enableAppLock();
-              if (ok && mounted) await _enableEncryption();
-            },
-          ),
         ],
+        SwitchListTile(
+          secondary: Icon(
+            encryptionOn ? Icons.enhanced_encryption : Icons.no_encryption,
+            color: encryptionOn ? theme.colorScheme.primary : null,
+          ),
+          title: Text(l10n.settings_security_encryption),
+          subtitle: Text(l10n.settings_security_encryption_subtitle),
+          value: encryptionOn,
+          onChanged: (v) async {
+            if (!v) {
+              await _disableEncryption();
+              return;
+            }
+            final createdCredential = !hasCredential;
+            if (createdCredential) {
+              final ok = await _setupCredential(enableAppLock: false);
+              if (!ok || !mounted) return;
+            }
+            await _enableEncryption(clearCredentialOnCancel: createdCredential);
+          },
+        ),
       ],
     );
   }
@@ -131,17 +131,32 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
   }
 
   Future<bool> _enableAppLock() async {
+    if (_security.encryptionEnabled) {
+      await _security.setAppLockEnabled(true);
+      if (mounted) setState(() {});
+      return true;
+    }
+    return _setupCredential(enableAppLock: true);
+  }
+
+  Future<bool> _setupCredential({required bool enableAppLock}) async {
     final dbPath = await _dbPath();
     if (!mounted) return false;
     final ok = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
       builder: (_) => SecuritySetupDialog(
-        onSetPassword: (password) => _security.enableSecurity(
-          password: password,
-          dbPath: dbPath,
-          kdf: widget.kdf,
-        ),
+        onSetPassword: (password) async {
+          final recoveryCode = await _security.enableSecurity(
+            password: password,
+            dbPath: dbPath,
+            kdf: widget.kdf,
+          );
+          if (enableAppLock) {
+            await _security.setAppLockEnabled(true);
+          }
+          return recoveryCode;
+        },
       ),
     );
     if (mounted) setState(() {});
@@ -150,22 +165,6 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
 
   Future<void> _disableAppLock() async {
     final l10n = context.l10n;
-    if (_security.encryptionEnabled) {
-      await showDialog<void>(
-        context: context,
-        builder: (dialogContext) => AlertDialog(
-          title: Text(l10n.settings_security_disableBlockedByEncryption_title),
-          content: Text(l10n.settings_security_disableBlockedByEncryption_body),
-          actions: [
-            FilledButton(
-              onPressed: () => Navigator.of(dialogContext).pop(),
-              child: Text(l10n.settings_security_done),
-            ),
-          ],
-        ),
-      );
-      return;
-    }
     final secret = await _promptPassword(l10n.settings_security_unlock_title);
     if (secret == null || !mounted) return;
     final confirmed = await showDialog<bool>(
@@ -186,11 +185,15 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
       ),
     );
     if (confirmed != true || !mounted) return;
-    await _security.disableSecurity(dbPath: await _dbPath());
+    if (_security.encryptionEnabled) {
+      await _security.setAppLockEnabled(false);
+    } else {
+      await _security.disableSecurity(dbPath: await _dbPath());
+    }
     if (mounted) setState(() {});
   }
 
-  Future<void> _enableEncryption() async {
+  Future<void> _enableEncryption({bool clearCredentialOnCancel = false}) async {
     final l10n = context.l10n;
     final confirmed = await showDialog<bool>(
       context: context,
@@ -209,7 +212,16 @@ class _SecuritySettingsPageState extends State<SecuritySettingsPage> {
         ],
       ),
     );
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true) {
+      if (clearCredentialOnCancel &&
+          !_security.appLockEnabled &&
+          !_security.encryptionEnabled) {
+        await _security.disableSecurity(dbPath: await _dbPath());
+        if (mounted) setState(() {});
+      }
+      return;
+    }
+    if (!mounted) return;
     await _runWithProgress(
       (onPhase) => _security.enableEncryption(onPhase: onPhase),
     );

--- a/test/core/presentation/pages/startup_lock_gate_test.dart
+++ b/test/core/presentation/pages/startup_lock_gate_test.dart
@@ -111,6 +111,7 @@ void main() {
           dbPath: dbPath,
           kdf: testKdf,
         );
+        await DatabaseSecurityService.instance.setAppLockEnabled(true);
         DatabaseSecurityService.instance.resetForTesting();
         await DatabaseSecurityService.instance.configure(
           prefs: prefs,

--- a/test/core/services/security/database_security_service_test.dart
+++ b/test/core/services/security/database_security_service_test.dart
@@ -52,7 +52,7 @@ void main() {
   });
 
   test(
-    'enableSecurity writes sidecar, caches key, flips app lock on',
+    'enableSecurity creates credentials without enabling app lock',
     () async {
       final recovery = await svc.enableSecurity(
         password: 'hunter2',
@@ -60,11 +60,23 @@ void main() {
         kdf: testKdf,
       );
       expect(recovery.split('-'), hasLength(8));
-      expect(svc.appLockEnabled, true);
+      expect(svc.appLockEnabled, false);
       expect(svc.isUnlocked, true);
       expect(File('${tmp.path}/submersion.keys').existsSync(), true);
     },
   );
+
+  test('setAppLockEnabled changes only the UI gate', () async {
+    await svc.enableSecurity(password: 'pw', dbPath: dbPath, kdf: testKdf);
+
+    await svc.setAppLockEnabled(true);
+    expect(svc.appLockEnabled, true);
+
+    await svc.setAppLockEnabled(false);
+    expect(svc.appLockEnabled, false);
+    expect(svc.isUnlocked, true);
+    expect(File('${tmp.path}/submersion.keys').existsSync(), true);
+  });
 
   test('enableSecurity throws when a sidecar already exists', () async {
     await svc.enableSecurity(password: 'pw', dbPath: dbPath, kdf: testKdf);
@@ -206,6 +218,7 @@ void main() {
 
     test('disableEncryption reverses and clears the derived key', () async {
       await svc.enableSecurity(password: 'pw', dbPath: dbPath, kdf: testKdf);
+      await svc.setAppLockEnabled(true);
       File(dbPath).writeAsStringSync('PLAIN');
       final calls = <String>[];
       await svc.enableEncryption(
@@ -222,6 +235,30 @@ void main() {
       expect(calls, ['export:false']);
       expect(svc.encryptionEnabled, false);
       expect(svc.databaseKeyHex, isNull);
+      expect(svc.isUnlocked, true);
+      expect(File('${tmp.path}/submersion.keys').existsSync(), true);
+    });
+
+    test('disableEncryption clears credentials when no tier remains', () async {
+      await svc.enableSecurity(password: 'pw', dbPath: dbPath, kdf: testKdf);
+      File(dbPath).writeAsStringSync('PLAIN');
+      final calls = <String>[];
+      await svc.enableEncryption(
+        migrator: fakeMigrator(calls),
+        dbPathOverride: dbPath,
+        skipReopenForTesting: true,
+      );
+
+      await svc.disableEncryption(
+        migrator: fakeMigrator(calls),
+        dbPathOverride: dbPath,
+        skipReopenForTesting: true,
+      );
+
+      expect(svc.encryptionEnabled, false);
+      expect(svc.appLockEnabled, false);
+      expect(svc.isUnlocked, false);
+      expect(File('${tmp.path}/submersion.keys').existsSync(), false);
     });
 
     test('enableEncryption throws when locked', () async {

--- a/test/features/settings/presentation/pages/security_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/security_settings_page_test.dart
@@ -52,16 +52,20 @@ void main() {
   /// so calling it directly in a test body hangs until the 10-minute timeout.
   Future<void> configureWithPassword(
     WidgetTester tester,
-    String password,
-  ) async {
+    String password, {
+    bool appLockEnabled = true,
+  }) async {
     await configure({});
-    await tester.runAsync(
-      () => DatabaseSecurityService.instance.enableSecurity(
+    await tester.runAsync(() async {
+      await DatabaseSecurityService.instance.enableSecurity(
         password: password,
         dbPath: dbPath,
         kdf: testKdf,
-      ),
-    );
+      );
+      if (appLockEnabled) {
+        await DatabaseSecurityService.instance.setAppLockEnabled(true);
+      }
+    });
   }
 
   /// Alternates real-async windows with pumps. Argon2id yields internally,
@@ -131,14 +135,65 @@ void main() {
     expect(find.byType(SecuritySetupDialog), findsOneWidget);
   });
 
-  testWidgets('disable app lock is blocked while encryption is on', (
+  testWidgets(
+    'cancelling encryption after setup leaves app lock off and clears credentials',
+    (tester) async {
+      await configure({});
+      await pumpPage(tester);
+      await tester.tap(find.text('Encrypt database'));
+      await tester.pump();
+
+      final fields = find.byType(TextField);
+      await tester.enterText(fields.at(0), 'encrypt-only');
+      await tester.enterText(fields.at(1), 'encrypt-only');
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await settle(tester);
+      await tester.tap(find.text('I saved my recovery code'));
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Done'));
+      await settle(tester);
+
+      expect(DatabaseSecurityService.instance.appLockEnabled, false);
+      expect(find.text('Encrypt database?'), findsOneWidget);
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await settle(tester);
+
+      expect(DatabaseSecurityService.instance.appLockEnabled, false);
+      expect(DatabaseSecurityService.instance.encryptionEnabled, false);
+      expect(DatabaseSecurityService.instance.isUnlocked, false);
+      expect(File(p.join(tmp.path, 'submersion.keys')).existsSync(), false);
+    },
+  );
+
+  testWidgets('encryption-only state renders encryption on and management', (
     tester,
   ) async {
-    await configure({'app_lock_enabled': true, 'db_encryption_enabled': true});
+    await configure({'db_encryption_enabled': true});
     await pumpPage(tester);
+
+    final encryptionSwitch = tester.widget<SwitchListTile>(
+      find.widgetWithText(SwitchListTile, 'Encrypt database'),
+    );
+    expect(encryptionSwitch.value, true);
+    expect(find.text('Change password'), findsOneWidget);
+    expect(find.text('New recovery code'), findsOneWidget);
+    expect(find.text('Auto-lock'), findsNothing);
+  });
+
+  testWidgets('encryption-only state can enable app lock without setup', (
+    tester,
+  ) async {
+    await configureWithPassword(tester, 'pw', appLockEnabled: false);
+    await DatabaseSecurityService.instance.preferences.setDbEncryptionEnabled(
+      true,
+    );
+    await pumpPage(tester);
+
     await tester.tap(find.text('App Lock'));
     await tester.pump();
-    expect(find.text('Encryption is on'), findsOneWidget);
+
+    expect(find.byType(SecuritySetupDialog), findsNothing);
+    expect(DatabaseSecurityService.instance.appLockEnabled, true);
   });
 
   group('auto-lock timeout', () {
@@ -295,6 +350,30 @@ void main() {
   });
 
   group('disable app lock', () {
+    testWidgets('while encrypted preserves encryption and credentials', (
+      tester,
+    ) async {
+      await configureWithPassword(tester, 'keep-encryption');
+      await DatabaseSecurityService.instance.preferences.setDbEncryptionEnabled(
+        true,
+      );
+      await pumpPage(tester);
+
+      await tester.tap(find.text('App Lock'));
+      await settle(tester);
+      await tester.enterText(find.byType(TextField), 'keep-encryption');
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await settle(tester);
+
+      expect(find.text('Turn off App Lock?'), findsOneWidget);
+      await tester.tap(find.widgetWithText(FilledButton, 'Turn off'));
+      await settle(tester);
+
+      expect(DatabaseSecurityService.instance.appLockEnabled, false);
+      expect(DatabaseSecurityService.instance.encryptionEnabled, true);
+      expect(File(p.join(tmp.path, 'submersion.keys')).existsSync(), true);
+    });
+
     testWidgets('requires the password and a confirmation, then clears '
         'security', (tester) async {
       await configureWithPassword(tester, 'to-be-removed');

--- a/test/features/settings/presentation/pages/security_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/security_settings_page_test.dart
@@ -20,6 +20,8 @@ void main() {
 
   late Directory tmp;
   late String dbPath;
+  late SharedPreferences prefs;
+  late InMemoryKeychain keychain;
 
   setUp(() async {
     tmp = await Directory.systemTemp.createTemp('security_page_test');
@@ -37,10 +39,19 @@ void main() {
 
   Future<void> configure(Map<String, Object> prefsValues) async {
     SharedPreferences.setMockInitialValues(prefsValues);
-    final prefs = await SharedPreferences.getInstance();
+    prefs = await SharedPreferences.getInstance();
+    keychain = InMemoryKeychain();
     await DatabaseSecurityService.instance.configure(
       prefs: prefs,
-      keyStore: DatabaseSecurityKeyStore(storage: InMemoryKeychain()),
+      keyStore: DatabaseSecurityKeyStore(storage: keychain),
+    );
+  }
+
+  Future<void> resetInMemorySecurity() async {
+    DatabaseSecurityService.instance.resetForTesting();
+    await DatabaseSecurityService.instance.configure(
+      prefs: prefs,
+      keyStore: DatabaseSecurityKeyStore(storage: keychain),
     );
   }
 
@@ -165,6 +176,33 @@ void main() {
     },
   );
 
+  testWidgets(
+    'orphaned sidecar unlocks existing credential before encryption confirmation',
+    (tester) async {
+      await configureWithPassword(
+        tester,
+        'existing-encryption-pw',
+        appLockEnabled: false,
+      );
+      await resetInMemorySecurity();
+      await pumpPage(tester);
+
+      await tester.tap(find.text('Encrypt database'));
+      await settle(tester);
+
+      expect(find.byType(SecuritySetupDialog), findsNothing);
+      expect(find.byType(TextField), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'existing-encryption-pw');
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await settle(tester);
+
+      expect(find.text('Encrypt database?'), findsOneWidget);
+      expect(DatabaseSecurityService.instance.appLockEnabled, false);
+      expect(DatabaseSecurityService.instance.encryptionEnabled, false);
+    },
+  );
+
   testWidgets('encryption-only state renders encryption on and management', (
     tester,
   ) async {
@@ -195,6 +233,31 @@ void main() {
     expect(find.byType(SecuritySetupDialog), findsNothing);
     expect(DatabaseSecurityService.instance.appLockEnabled, true);
   });
+
+  testWidgets(
+    'locked encryption credential is required before enabling app lock',
+    (tester) async {
+      await configureWithPassword(tester, 'existing-pw', appLockEnabled: false);
+      await DatabaseSecurityService.instance.preferences.setDbEncryptionEnabled(
+        true,
+      );
+      await resetInMemorySecurity();
+      await pumpPage(tester);
+
+      await tester.tap(find.text('App Lock'));
+      await settle(tester);
+
+      expect(find.byType(SecuritySetupDialog), findsNothing);
+      expect(find.byType(TextField), findsOneWidget);
+      expect(DatabaseSecurityService.instance.appLockEnabled, false);
+
+      await tester.enterText(find.byType(TextField), 'existing-pw');
+      await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
+      await settle(tester);
+
+      expect(DatabaseSecurityService.instance.appLockEnabled, true);
+    },
+  );
 
   group('auto-lock timeout', () {
     testWidgets('shows the current value and persists a new selection', (


### PR DESCRIPTION
## Summary

Database encryption and App Lock are separate security tiers, but credential setup previously enabled App Lock as a side effect. This change separates those state transitions so users can encrypt the database without enabling the UI lock.

## Changes

- Create and cache the shared security credential without changing the App Lock preference.
- Add an explicit App Lock state transition that preserves database encryption and shared keyslots.
- Support encryption-only, App-Lock-only, both-enabled, and both-disabled states in Security settings.
- Retain shared credentials while either tier remains enabled and remove them after the final tier is disabled.
- Clean up unused credentials when encryption setup is cancelled.
- Add service, startup, and widget regression coverage for the independent states.

## Test Plan

- [x] `dart format --output=none --set-exit-if-changed .` — 3,506 files checked, 0 changed
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 16,616 passed, 15 skipped
- [x] Pre-push affected tests — 50 passed
- [x] Manual platform testing

Manual platform testing was not performed; the PR is intentionally opened as a draft.
