### PR TITLE
fix(media): let the dive computer overlay be dragged out of the top-right corner

### DIFF
--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -242,51 +242,6 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
                     ),
                   ),
 
-                // Perdix dive computer overlay. Deliberately independent of
-                // the _showOverlay chrome (which auto-hides during video
-                // playback, exactly when this must stay up) and mounted
-                // BELOW it so the toolbar keeps hit-test priority when the
-                // chrome is visible (the default corner overlaps the top
-                // bar). The face absorbs pointer events over its own bounds
-                // (drags move it, taps do nothing); chrome-toggle and video
-                // play/pause taps work anywhere outside it.
-                if (perdixAvailable && settings.perdixOverlayEnabled)
-                  DraggablePerdixOverlay(
-                    // Re-key when the persisted seed first arrives so a late
-                    // settings load re-seeds the position (same trick as the
-                    // fullscreen readout card).
-                    key: ValueKey(
-                      'perdix-${currentItem.id}-'
-                      '${settings.perdixOverlayX}-${settings.perdixOverlayY}',
-                    ),
-                    resolver: perdixResolver,
-                    baseElapsedSeconds: enrichment.elapsedSeconds!,
-                    settings: settings,
-                    playback: currentItem.isVideo
-                        ? _videoControllers[currentItem.id]
-                        : null,
-                    positionGetter:
-                        currentItem.isVideo &&
-                            _videoControllers[currentItem.id] != null
-                        ? () =>
-                              _videoControllers[currentItem.id]
-                                  ?.value
-                                  .position ??
-                              Duration.zero
-                        : null,
-                    initialFraction:
-                        (settings.perdixOverlayX != null &&
-                            settings.perdixOverlayY != null)
-                        ? Offset(
-                            settings.perdixOverlayX!,
-                            settings.perdixOverlayY!,
-                          )
-                        : null,
-                    onDragEnd: (fraction) => ref
-                        .read(settingsProvider.notifier)
-                        .setPerdixOverlayPosition(fraction.dx, fraction.dy),
-                  ),
-
                 // Overlay controls (app bar and metadata)
                 if (_showOverlay) ...[
                   // Top app bar
@@ -336,6 +291,62 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
                     ),
                   ),
                 ],
+
+                // Perdix dive computer overlay. Deliberately independent of
+                // the _showOverlay chrome, which auto-hides during video
+                // playback exactly when this must stay up.
+                //
+                // Mounted ABOVE the chrome so it always wins the pointers
+                // that drag it: the bottom metadata's gradient Container and
+                // the mini profile chart both absorb hit tests across their
+                // full bounds, and either would strand the face where it
+                // could no longer be picked up. Neither is interactive, so
+                // nothing is lost by the face shadowing them. The top
+                // toolbar is the exception -- it does have buttons -- so
+                // rather than order, the face is kept out of its band
+                // entirely via topReserve.
+                //
+                // The face absorbs pointer events over its own bounds (drags
+                // move it, taps do nothing); chrome-toggle and video
+                // play/pause taps work anywhere outside it.
+                if (perdixAvailable && settings.perdixOverlayEnabled)
+                  DraggablePerdixOverlay(
+                    // Re-key when the persisted seed first arrives so a late
+                    // settings load re-seeds the position (same trick as the
+                    // fullscreen readout card).
+                    key: ValueKey(
+                      'perdix-${currentItem.id}-'
+                      '${settings.perdixOverlayX}-${settings.perdixOverlayY}',
+                    ),
+                    resolver: perdixResolver,
+                    baseElapsedSeconds: enrichment.elapsedSeconds!,
+                    settings: settings,
+                    topReserve:
+                        MediaQuery.paddingOf(context).top + _topChromeHeight,
+                    playback: currentItem.isVideo
+                        ? _videoControllers[currentItem.id]
+                        : null,
+                    positionGetter:
+                        currentItem.isVideo &&
+                            _videoControllers[currentItem.id] != null
+                        ? () =>
+                              _videoControllers[currentItem.id]
+                                  ?.value
+                                  .position ??
+                              Duration.zero
+                        : null,
+                    initialFraction:
+                        (settings.perdixOverlayX != null &&
+                            settings.perdixOverlayY != null)
+                        ? Offset(
+                            settings.perdixOverlayX!,
+                            settings.perdixOverlayY!,
+                          )
+                        : null,
+                    onDragEnd: (fraction) => ref
+                        .read(settingsProvider.notifier)
+                        .setPerdixOverlayPosition(fraction.dx, fraction.dy),
+                  ),
               ],
             ),
           );
@@ -1049,6 +1060,12 @@ class _VideoControlsOverlayState extends State<_VideoControlsOverlay> {
     );
   }
 }
+
+/// Height of [_TopOverlay]'s content below the status bar: its 8 px vertical
+/// padding either side of a default 48 px [IconButton]. The Perdix overlay
+/// reserves this band so the face can never sit on top of the toolbar's
+/// buttons -- keep the two in step if the toolbar's padding changes.
+const double _topChromeHeight = 64;
 
 /// Top overlay with close button, page indicator, share, and write metadata.
 class _TopOverlay extends StatelessWidget {

--- a/lib/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay.dart
+++ b/lib/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay.dart
@@ -107,28 +107,33 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
         : DraggablePerdixOverlay.defaultFraction.dy,
   );
 
-  /// Whether the current gesture actually moved the face. The recognizer
-  /// claims the pointer on contact, so a plain tap on the face also produces a
-  /// start/end pair; without this a tap would persist an unchanged position and
-  /// bounce the settings provider (and the page) for nothing.
-  bool _movedDuringDrag = false;
+  /// Position when the current gesture started, or null outside a gesture.
+  /// The recognizer claims the pointer on contact, so a plain tap produces a
+  /// start/end pair too, and dragging further into an edge the fraction is
+  /// already clamped against produces updates that change nothing. Comparing
+  /// against this covers both: only a net move reaches [onDragEnd], instead of
+  /// persisting an unchanged position and bouncing the settings provider (and
+  /// the page) for nothing.
+  Offset? _dragStartFraction;
 
   void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
     final faceSize = _faceKey.currentContext?.size;
     if (faceSize == null) return;
-    _movedDuringDrag = true;
     final movableW = constraints.maxWidth - faceSize.width;
     final movableH = constraints.maxHeight - faceSize.height;
-    setState(() {
-      _fraction = Offset(
-        movableW <= 0
-            ? 0
-            : (_fraction.dx + details.delta.dx / movableW).clamp(0.0, 1.0),
-        movableH <= 0
-            ? 0
-            : (_fraction.dy + details.delta.dy / movableH).clamp(0.0, 1.0),
-      );
-    });
+    final next = Offset(
+      movableW <= 0
+          ? 0
+          : (_fraction.dx + details.delta.dx / movableW).clamp(0.0, 1.0),
+      movableH <= 0
+          ? 0
+          : (_fraction.dy + details.delta.dy / movableH).clamp(0.0, 1.0),
+    );
+    // A drag pushing past an edge repeats the clamped value every frame; not
+    // rebuilding for those keeps the face's per-frame video rebuild the only
+    // work happening during playback.
+    if (next == _fraction) return;
+    setState(() => _fraction = next);
   }
 
   @override
@@ -160,15 +165,16 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
                         _EagerPanGestureRecognizer
                       >(_EagerPanGestureRecognizer.new, (recognizer) {
                         recognizer.onStart = (_) {
-                          _movedDuringDrag = false;
+                          _dragStartFraction = _fraction;
                         };
                         recognizer.onUpdate = (details) {
                           _onPanUpdate(details, constraints);
                         };
                         recognizer.onEnd = (_) {
-                          if (_movedDuringDrag) {
+                          if (_fraction != _dragStartFraction) {
                             widget.onDragEnd?.call(_fraction);
                           }
+                          _dragStartFraction = null;
                         };
                       }),
                 },
@@ -198,6 +204,7 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
         return PerdixFace(
           data: widget.resolver.resolve(t),
           settings: widget.settings,
+          showDragHandle: true,
         );
       },
     );

--- a/lib/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay.dart
+++ b/lib/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -23,6 +24,7 @@ class DraggablePerdixOverlay extends StatefulWidget {
     this.positionGetter,
     this.initialFraction,
     this.onDragEnd,
+    this.topReserve = 0,
   }) : assert(
          playback == null || positionGetter != null,
          'positionGetter is required in video mode',
@@ -52,11 +54,37 @@ class DraggablePerdixOverlay extends StatefulWidget {
   /// persists it in settings.
   final ValueChanged<Offset>? onDragEnd;
 
+  /// Height at the top of the stack the face is kept out of, on top of the
+  /// standard inset. The viewer passes its top toolbar's height: the toolbar
+  /// is the only chrome with buttons, and a face parked underneath them both
+  /// shadows the buttons and loses the pointers that would drag it back out.
+  final double topReserve;
+
   /// Default position: top-right corner.
   static const Offset defaultFraction = Offset(1, 0);
 
   @override
   State<DraggablePerdixOverlay> createState() => _DraggablePerdixOverlayState();
+}
+
+/// Pan recognizer that claims the pointer the moment it lands on the face,
+/// rather than waiting for the pan slop to be exceeded.
+///
+/// The photo viewer wraps its whole Stack in a swipe-down-to-close
+/// [VerticalDragGestureRecognizer], which is an ancestor of the face and so
+/// contends for every drag that starts on it -- being painted above the chrome
+/// does not help. That recognizer accepts at `kTouchSlop` while a plain
+/// [PanGestureRecognizer] holds out for the larger `kPanSlop`, so it won every
+/// downward drag: pulling the face out of its corner either did nothing or
+/// dismissed the viewer. Winning the arena on pointer-down keeps drags that
+/// begin on the face for the face. Taps on it already do nothing, and
+/// swipe-to-close still works everywhere outside it.
+class _EagerPanGestureRecognizer extends PanGestureRecognizer {
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    super.addAllowedPointer(event);
+    resolve(GestureDisposition.accepted);
+  }
 }
 
 class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
@@ -79,9 +107,16 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
         : DraggablePerdixOverlay.defaultFraction.dy,
   );
 
+  /// Whether the current gesture actually moved the face. The recognizer
+  /// claims the pointer on contact, so a plain tap on the face also produces a
+  /// start/end pair; without this a tap would persist an unchanged position and
+  /// bounce the settings provider (and the page) for nothing.
+  bool _movedDuringDrag = false;
+
   void _onPanUpdate(DragUpdateDetails details, BoxConstraints constraints) {
     final faceSize = _faceKey.currentContext?.size;
     if (faceSize == null) return;
+    _movedDuringDrag = true;
     final movableW = constraints.maxWidth - faceSize.width;
     final movableH = constraints.maxHeight - faceSize.height;
     setState(() {
@@ -100,17 +135,45 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
   Widget build(BuildContext context) {
     return Positioned.fill(
       child: Padding(
-        padding: const EdgeInsets.all(_inset),
+        padding: EdgeInsets.fromLTRB(
+          _inset,
+          _inset + widget.topReserve,
+          _inset,
+          _inset,
+        ),
         child: LayoutBuilder(
           builder: (context, constraints) => Align(
             alignment: FractionalOffset(_fraction.dx, _fraction.dy),
-            child: GestureDetector(
-              // Sized by its child: measuring this context yields the face
-              // size for the fraction math in _onPanUpdate.
-              key: _faceKey,
-              onPanUpdate: (details) => _onPanUpdate(details, constraints),
-              onPanEnd: (_) => widget.onDragEnd?.call(_fraction),
-              child: _buildFace(),
+            child: MouseRegion(
+              cursor: SystemMouseCursors.grab,
+              child: RawGestureDetector(
+                // Sized by its child: measuring this context yields the face
+                // size for the fraction math in _onPanUpdate.
+                key: _faceKey,
+                // Opaque rather than deferToChild so the grab surface is the
+                // panel's bounds, independent of which parts of the readout
+                // happen to hit-test.
+                behavior: HitTestBehavior.opaque,
+                gestures: {
+                  _EagerPanGestureRecognizer:
+                      GestureRecognizerFactoryWithHandlers<
+                        _EagerPanGestureRecognizer
+                      >(_EagerPanGestureRecognizer.new, (recognizer) {
+                        recognizer.onStart = (_) {
+                          _movedDuringDrag = false;
+                        };
+                        recognizer.onUpdate = (details) {
+                          _onPanUpdate(details, constraints);
+                        };
+                        recognizer.onEnd = (_) {
+                          if (_movedDuringDrag) {
+                            widget.onDragEnd?.call(_fraction);
+                          }
+                        };
+                      }),
+                },
+                child: _buildFace(),
+              ),
             ),
           ),
         ),
@@ -124,6 +187,7 @@ class _DraggablePerdixOverlayState extends State<DraggablePerdixOverlay> {
       return PerdixFace(
         data: widget.resolver.resolve(widget.baseElapsedSeconds),
         settings: widget.settings,
+        showDragHandle: true,
       );
     }
     return AnimatedBuilder(

--- a/lib/features/media/presentation/widgets/perdix_overlay/perdix_face.dart
+++ b/lib/features/media/presentation/widgets/perdix_overlay/perdix_face.dart
@@ -21,11 +21,20 @@ class PerdixFace extends StatelessWidget {
     required this.data,
     required this.settings,
     this.width = 300,
+    this.showDragHandle = false,
   });
 
   final PerdixFaceData data;
   final AppSettings settings;
   final double width;
+
+  /// Draws a grabber bar above the readout. Set by [DraggablePerdixOverlay];
+  /// nothing about the face is draggable on its own, so the affordance must
+  /// not appear where the face is rendered statically.
+  final bool showDragHandle;
+
+  /// Identifies the grabber bar for tests.
+  static const dragHandleKey = Key('perdix-face-drag-handle');
 
   static const perdixGreen = Color(0xFF35D43C);
   static const perdixYellow = Color(0xFFFFD83A);
@@ -52,6 +61,18 @@ class PerdixFace extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (showDragHandle) ...[
+            Container(
+              key: dragHandleKey,
+              width: 28,
+              height: 3,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.35),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
           for (var i = 0; i < rows.length; i++) ...[
             if (i > 0) const SizedBox(height: 8),
             Row(

--- a/test/features/media/presentation/pages/photo_viewer_perdix_overlay_test.dart
+++ b/test/features/media/presentation/pages/photo_viewer_perdix_overlay_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/perdix_overlay/perdix_face.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// The Perdix face defaults to the top-right corner, which is where the
+/// viewer's toolbar keeps its action buttons. Those buttons are mounted in the
+/// same Stack and absorb pointers, so a face drawn underneath them cannot be
+/// dragged out of the corner by its most natural grab points. The page keeps
+/// the face out of that band entirely.
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({'perdix_overlay_enabled': true});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final media = MediaItem(
+    id: 'm1',
+    diveId: 'd1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: 'g1',
+    takenAt: DateTime.utc(2026, 7, 1, 10),
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 1),
+    enrichment: MediaEnrichment(
+      id: 'e1',
+      mediaId: 'm1',
+      diveId: 'd1',
+      elapsedSeconds: 180,
+      depthMeters: 15.0,
+      matchConfidence: MatchConfidence.exact,
+      createdAt: DateTime.utc(2026, 7, 1),
+    ),
+  );
+
+  final dive = domain.Dive(
+    id: 'd1',
+    dateTime: DateTime.utc(2026, 7, 1, 9, 30),
+    profile: const [
+      domain.DiveProfilePoint(timestamp: 0, depth: 0.0),
+      domain.DiveProfilePoint(timestamp: 60, depth: 10.0),
+      domain.DiveProfilePoint(timestamp: 120, depth: 20.0),
+      domain.DiveProfilePoint(timestamp: 180, depth: 15.0),
+      domain.DiveProfilePoint(timestamp: 240, depth: 5.0),
+    ],
+  );
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            mediaForDiveProvider('d1').overrideWith((ref) async => [media]),
+            diveProvider('d1').overrideWith((ref) async => dive),
+          ],
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: PhotoViewerPage(diveId: 'd1', initialMediaId: 'm1'),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+    });
+  }
+
+  testWidgets('the face clears the toolbar buttons at its default corner', (
+    tester,
+  ) async {
+    await pump(tester);
+    expect(find.byType(PerdixFace), findsOneWidget);
+
+    final face = tester.getRect(find.byType(PerdixFace));
+    final buttons = tester
+        .widgetList<IconButton>(find.byType(IconButton))
+        .toList();
+    expect(buttons, isNotEmpty, reason: 'toolbar should be showing');
+
+    for (var i = 0; i < buttons.length; i++) {
+      final button = tester.getRect(find.byType(IconButton).at(i));
+      expect(
+        face.overlaps(button),
+        isFalse,
+        reason: 'face $face overlaps toolbar button $i at $button',
+      );
+    }
+  });
+
+  testWidgets('a downward drag on the face moves it instead of closing the '
+      'viewer', (tester) async {
+    await pump(tester);
+    final before = tester.getRect(find.byType(PerdixFace));
+
+    // Straight down is the natural way to pull the face out of the top-right
+    // corner, and it is also the viewer's swipe-to-close gesture. The page
+    // wraps the whole Stack in that recognizer, so it contends for this drag
+    // from an ancestor; the face has to win the arena or the gesture either
+    // does nothing or dismisses the page.
+    await tester.fling(find.byType(PerdixFace), const Offset(0, 260), 1200);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(PhotoViewerPage),
+      findsOneWidget,
+      reason: 'the viewer should not have been dismissed',
+    );
+    expect(
+      tester.getRect(find.byType(PerdixFace)).top,
+      greaterThan(before.top),
+    );
+  });
+
+  testWidgets('the face is grabbable where it would meet the bottom chrome', (
+    tester,
+  ) async {
+    await pump(tester);
+    final before = tester.getRect(find.byType(PerdixFace));
+
+    // Drag toward the bottom-right, where the metadata gradient and the mini
+    // profile chart sit. Both absorb pointers, so the face only keeps moving
+    // if it is mounted above them.
+    await tester.drag(find.byType(PerdixFace), const Offset(0, 4000));
+    await tester.pumpAndSettle();
+    final parked = tester.getRect(find.byType(PerdixFace));
+    expect(parked.top, greaterThan(before.top));
+
+    // Now drag it back out from where it landed.
+    await tester.drag(find.byType(PerdixFace), const Offset(0, -200));
+    await tester.pumpAndSettle();
+    expect(tester.getRect(find.byType(PerdixFace)).top, lessThan(parked.top));
+  });
+}

--- a/test/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay_test.dart
+++ b/test/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay_test.dart
@@ -93,6 +93,128 @@ void main() {
     expect(after.dy, greaterThan(before.dy));
   });
 
+  testWidgets('the whole panel is a grab target, not just its text', (
+    tester,
+  ) async {
+    Offset? reported;
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+          initialFraction: const Offset(0, 0),
+          onDragEnd: (f) => reported = f,
+        ),
+      ),
+    );
+    final before = tester.getTopLeft(find.byType(PerdixFace));
+    // The panel's own padding: inside the decorated background but outside
+    // every Text. RenderDecoratedBox.hitTestSelf defers to the decoration's
+    // shape, so the rounded rect absorbs this; a face rebuilt without a
+    // decoration (or with a transparent one) would silently lose most of its
+    // drag surface.
+    final padding = tester.getRect(find.byType(PerdixFace)).topLeft;
+    await tester.dragFrom(padding + const Offset(5, 5), const Offset(120, 80));
+    await tester.pumpAndSettle();
+
+    expect(reported, isNotNull);
+    final after = tester.getTopLeft(find.byType(PerdixFace));
+    expect(after.dx, greaterThan(before.dx));
+    expect(after.dy, greaterThan(before.dy));
+  });
+
+  testWidgets('a tap on the face does not persist a position', (tester) async {
+    var writes = 0;
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+          onDragEnd: (_) => writes++,
+        ),
+      ),
+    );
+    // The recognizer claims the pointer on contact, so a tap still produces a
+    // drag start/end pair; only real movement should reach settings.
+    await tester.tap(find.byType(PerdixFace));
+    await tester.pumpAndSettle();
+    expect(writes, 0);
+
+    await tester.drag(find.byType(PerdixFace), const Offset(-40, 40));
+    await tester.pumpAndSettle();
+    expect(writes, 1);
+  });
+
+  testWidgets('dragging up cannot push the face into the reserved band', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+          topReserve: 64,
+        ),
+      ),
+    );
+    await tester.drag(find.byType(PerdixFace), const Offset(0, -4000));
+    await tester.pumpAndSettle();
+
+    // The face is clamped out of the band the page reserves for the top
+    // toolbar, so it can never sit under the toolbar's IconButtons.
+    expect(
+      tester.getRect(find.byType(PerdixFace)).top,
+      greaterThanOrEqualTo(64),
+    );
+  });
+
+  testWidgets('the face carries a drag handle and a grab cursor', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+        ),
+      ),
+    );
+    expect(find.byKey(PerdixFace.dragHandleKey), findsOneWidget);
+
+    final region = tester.widget<MouseRegion>(
+      find
+          .ancestor(
+            of: find.byType(PerdixFace),
+            matching: find.byType(MouseRegion),
+          )
+          .first,
+    );
+    expect(region.cursor, SystemMouseCursors.grab);
+  });
+
+  testWidgets('topReserve keeps the default corner below the top chrome', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+          topReserve: 64,
+        ),
+      ),
+    );
+    final stackSize = tester.getSize(find.byType(Stack).first);
+    final faceRect = tester.getRect(find.byType(PerdixFace));
+    expect(faceRect.right, closeTo(stackSize.width - 12, 1.0));
+    expect(faceRect.top, closeTo(12 + 64, 1.0));
+  });
+
   testWidgets('non-finite initial fraction sanitizes to default corner', (
     tester,
   ) async {

--- a/test/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay_test.dart
+++ b/test/features/media/presentation/widgets/perdix_overlay/draggable_perdix_overlay_test.dart
@@ -147,6 +147,32 @@ void main() {
     expect(writes, 1);
   });
 
+  testWidgets('a drag that only pushes past an edge persists nothing', (
+    tester,
+  ) async {
+    var writes = 0;
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 0,
+          settings: settings,
+          initialFraction: const Offset(1, 0),
+          onDragEnd: (_) => writes++,
+        ),
+      ),
+    );
+    final before = tester.getRect(find.byType(PerdixFace));
+
+    // Already pinned to the top-right, so up-and-right is clamped away
+    // entirely: the gesture moves the pointer but not the face.
+    await tester.drag(find.byType(PerdixFace), const Offset(200, -200));
+    await tester.pumpAndSettle();
+
+    expect(tester.getRect(find.byType(PerdixFace)), before);
+    expect(writes, 0);
+  });
+
   testWidgets('dragging up cannot push the face into the reserved band', (
     tester,
   ) async {
@@ -194,6 +220,30 @@ void main() {
           .first,
     );
     expect(region.cursor, SystemMouseCursors.grab);
+  });
+
+  testWidgets('video mode carries the drag handle too', (tester) async {
+    final position = ValueNotifier<Duration>(Duration.zero);
+    addTearDown(position.dispose);
+    await tester.pumpWidget(
+      host(
+        DraggablePerdixOverlay(
+          resolver: resolver,
+          baseElapsedSeconds: 180,
+          settings: settings,
+          playback: position,
+          positionGetter: () => position.value,
+        ),
+      ),
+    );
+    // The face is equally draggable in video mode, and video is where this
+    // overlay is mostly used, so the affordance has to survive the separate
+    // AnimatedBuilder build path.
+    expect(find.byKey(PerdixFace.dragHandleKey), findsOneWidget);
+
+    position.value = const Duration(seconds: 60);
+    await tester.pump();
+    expect(find.byKey(PerdixFace.dragHandleKey), findsOneWidget);
   });
 
   testWidgets('topReserve keeps the default corner below the top chrome', (


### PR DESCRIPTION
## Problem

In the media viewer, the Perdix dive computer face was effectively pinned to the upper-right corner and could not be moved away.

The overlay has had drag-to-reposition with a persisted position since #168, so this was not a missing feature — three separate defects met at that one corner:

**1. The page-level swipe-to-close gesture stole the drag.** `PhotoViewerPage` wraps its whole `Stack` in `GestureDetector(onVerticalDragEnd:)` → `Navigator.pop`. That recognizer is an *ancestor* of the face, so it joins the gesture arena for drags starting on it — `Stack` ordering cannot prevent this, because arena membership follows the hit-test path upward. `VerticalDragGestureRecognizer` accepts at `kTouchSlop` (18px) while `PanGestureRecognizer` waits for the larger `kPanSlop` (36px), so it won every downward drag. Dragging the face straight down — the natural way out of the top-right corner — either did nothing or **dismissed the viewer entirely**.

**2. The default corner sat under the toolbar buttons.** `defaultFraction = Offset(1, 0)` put the 300×128 face directly beneath the toolbar's action `IconButton`s, which absorb pointers and are painted above it. Measured overlap: face `(488, 12, 788, 140)` vs button `(652, 8, …)`. The most natural grab points either did nothing or triggered share / write-metadata / the overlay toggle.

**3. Chrome above the face could strand it.** The overlay was mounted below the bottom metadata gradient and the mini profile chart. `RenderDecoratedBox.hitTestSelf` delegates to the decoration's shape, so both absorb hit tests across their full bounds — a face dragged downward could land somewhere it could no longer be picked up.

## Fix

- **`_EagerPanGestureRecognizer`** — a `PanGestureRecognizer` that calls `resolve(GestureDisposition.accepted)` in `addAllowedPointer`, claiming the pointer on contact so it beats the ancestor. Swipe-to-close is unchanged everywhere outside the face.
- **`topReserve`** on `DraggablePerdixOverlay`, passed by the page as `MediaQuery.paddingOf(context).top + _topChromeHeight`. This shrinks the draggable region so the face is *geometrically unable* to sit under the toolbar, rather than merely starting elsewhere. Users currently stuck at the top are nudged clear automatically.
- **Overlay moved above the chrome** in the `Stack`. Neither the metadata gradient nor the mini profile is interactive, so nothing is lost by the face shadowing them. The toolbar is the exception — it has buttons — and is handled by `topReserve` instead of by ordering.
- **Affordances the overlay never had**: a grabber bar on the face and `SystemMouseCursors.grab` on desktop.
- **`_movedDuringDrag`** — since the recognizer now accepts on contact, a bare tap produces a start/end pair; without this guard a tap would persist an unchanged position and bounce the settings provider and the page.

## Testing

New `photo_viewer_perdix_overlay_test.dart` covers all three defects at page level, plus widget-level tests for the reserved band, the tap guard, and the affordances.

Each new page test was confirmed to **fail against the previous code** — the three lib files were reverted to `HEAD` and the suite re-run:

- drag test: `Found 0 widgets with type "PhotoViewerPage"` (the viewer was dismissed by the drag)
- toolbar test: `face Rect.fromLTRB(488.0, 12.0, 788.0, 140.0) overlaps toolbar button 1`
- reposition test: face `top` stayed at `12.0`

`flutter analyze` clean; full suite green at 17,037 passing.

## Note

One adjacent gap is deliberately left out of scope: the face can still be parked over the video playback controls (`Positioned(bottom: 160)`), which unlike the other chrome *are* interactive. That predates this change — the overlay was already above the gallery — and closing it means a bottom reserve that shrinks the draggable region on every video, which is worth deciding separately.
