### PR TITLE
chore(pods): lock pdfium_flutter for ios and macos

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -113,6 +113,9 @@ PODS:
     - ObjectBox (= 4.4.1)
   - package_info_plus (0.4.5):
     - Flutter
+  - pdfium_flutter (0.1.5):
+    - Flutter
+    - FlutterMacOS
   - permission_handler_apple (9.4.8):
     - Flutter
   - photo_manager (3.9.0):
@@ -179,6 +182,7 @@ DEPENDENCIES:
   - native_exif (from `.symlinks/plugins/native_exif/ios`)
   - objectbox_flutter_libs (from `.symlinks/plugins/objectbox_flutter_libs/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - pdfium_flutter (from `.symlinks/plugins/pdfium_flutter/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - photo_manager (from `.symlinks/plugins/photo_manager/darwin`)
   - printing (from `.symlinks/plugins/printing/ios`)
@@ -252,6 +256,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/objectbox_flutter_libs/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  pdfium_flutter:
+    :path: ".symlinks/plugins/pdfium_flutter/darwin"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   photo_manager:
@@ -310,6 +316,7 @@ SPEC CHECKSUMS:
   ObjectBox: 7da4aceb5013d041bfafdbc6d744a26918b09757
   objectbox_flutter_libs: 09b1dec1b4cd27bf1a5f9bae7ccaa7e43588bf31
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  pdfium_flutter: e5a6e881af0b182d5b0465ebad23a8a20caa28d4
   permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
   photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
   printing: 54ff03f28fe9ba3aa93358afb80a8595a071dd07

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -32,6 +32,11 @@ class SpeciesRepository {
   Stream<void> watchSpeciesChanges() =>
       _db.tableUpdates(TableUpdateQuery.onTable(_db.species));
 
+  /// Emits whenever the `sightings` table changes so aggregate providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchSightingChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.sightings));
+
   /// Get species by category
   Future<List<domain.Species>> getSpeciesByCategory(
     SpeciesCategory category,

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -23,7 +23,9 @@ final allSpeciesProvider = FutureProvider<List<Species>>((ref) async {
 final speciesSightingCountsProvider = FutureProvider<Map<String, int>>((
   ref,
 ) async {
-  return ref.watch(speciesRepositoryProvider).sightingCountsBySpecies();
+  final repository = ref.watch(speciesRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchSightingChanges());
+  return repository.sightingCountsBySpecies();
 });
 
 final speciesByCategoryProvider =

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -80,6 +80,9 @@ PODS:
     - ObjectBox (= 4.4.1)
   - package_info_plus (0.0.1):
     - FlutterMacOS
+  - pdfium_flutter (0.1.5):
+    - Flutter
+    - FlutterMacOS
   - photo_manager (3.9.0):
     - Flutter
     - FlutterMacOS
@@ -138,6 +141,7 @@ DEPENDENCIES:
   - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
   - objectbox_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/objectbox_flutter_libs/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - pdfium_flutter (from `Flutter/ephemeral/.symlinks/plugins/pdfium_flutter/darwin`)
   - photo_manager (from `Flutter/ephemeral/.symlinks/plugins/photo_manager/darwin`)
   - printing (from `Flutter/ephemeral/.symlinks/plugins/printing/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
@@ -204,6 +208,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/objectbox_flutter_libs/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  pdfium_flutter:
+    :path: Flutter/ephemeral/.symlinks/plugins/pdfium_flutter/darwin
   photo_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/photo_manager/darwin
   printing:
@@ -255,6 +261,7 @@ SPEC CHECKSUMS:
   ObjectBox: 7da4aceb5013d041bfafdbc6d744a26918b09757
   objectbox_flutter_libs: f51d18f6a4b5965c218843373b7dc5ed5e3a2008
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  pdfium_flutter: e5a6e881af0b182d5b0465ebad23a8a20caa28d4
   photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
   printing: c4cf83c78fd684f9bc318e6aadc18972aa48f617
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/test/features/marine_life/presentation/providers/species_providers_test.dart
+++ b/test/features/marine_life/presentation/providers/species_providers_test.dart
@@ -1,13 +1,30 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
-
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/test_database.dart';
+
+Future<void> _insertTestDive({required String id}) async {
+  final db = DatabaseService.instance.database;
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
 
 void main() {
   late SharedPreferences prefs;
@@ -66,6 +83,47 @@ void main() {
         reason:
             'allSpeciesProvider should auto-refresh after a direct table '
             'write without any manual invalidation',
+      );
+    });
+  });
+
+  group('speciesSightingCountsProvider', () {
+    test('auto-refreshes after a sighting is written directly to the DB '
+        '(sync scenario)', () async {
+      final species = await speciesRepo.createSpecies(
+        commonName: 'Counted Grouper',
+        category: SpeciesCategory.fish,
+      );
+      await _insertTestDive(id: 'counted-dive');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(speciesSightingCountsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(speciesSightingCountsProvider.future),
+        isEmpty,
+      );
+
+      await speciesRepo.addSighting(
+        diveId: 'counted-dive',
+        speciesId: species.id,
+      );
+
+      var counts = <String, int>{};
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        counts = await container.read(speciesSightingCountsProvider.future);
+        if (counts[species.id] == 1) break;
+      }
+
+      expect(
+        counts,
+        {species.id: 1},
+        reason:
+            'speciesSightingCountsProvider should refresh after a sightings '
+            'table write without manual invalidation',
       );
     });
   });


### PR DESCRIPTION
Both Darwin lockfiles were missing the `pdfium_flutter` pod that `pdfrx` pulls in transitively.

## What happened

`pdfrx: ^2.4.5` was added to `pubspec.yaml` in 167175c677f ("Add pdfrx and first-page PDF thumbnail renderer"), but neither `ios/Podfile.lock` nor `macos/Podfile.lock` was regenerated in that commit. The result is that any local macOS or iOS build runs `pod install`, adds the missing pod, and leaves a dirty working tree on `main`.

## Why it is worth fixing

Beyond the recurring dirty-tree annoyance, `.github/workflows/ci.yaml` keys three caches on these files:

- `pods-ios-*` on `hashFiles('ios/Podfile.lock')`
- `pods-macos-*` on `hashFiles('macos/Podfile.lock')`
- `deriveddata-*` on `hashFiles('macos/Podfile.lock')`

While the committed lockfiles do not reflect the real pod set, those keys do not change when the dependency graph does, so CI restores caches that predate `pdfium_flutter`. `pod install` repairs it at build time, so nothing breaks, but the cache keys are keyed on a stale pod set.

## Changes

Purely additive, `pdfium_flutter (0.1.5)` only, in the four sections CocoaPods writes (`PODS`, `DEPENDENCIES`, `EXTERNAL SOURCES`, `SPEC CHECKSUMS`). No other pod versions or checksums move, and the CocoaPods version stamp is unchanged.

The podspec version `0.1.5` is correct despite the pub package resolving to `0.2.3`: `pdfium_flutter-0.2.3/darwin/pdfium_flutter.podspec` declares `s.version = '0.1.5'`. Both platforms agree on checksum `e5a6e881af0b182d5b0465ebad23a8a20caa28d4`.

## How it was generated

- macOS: regenerated by a normal local `flutter build macos`.
- iOS: `flutter build ios --config-only --no-codesign`, with `enable-swift-package-manager: false` to match the CI configuration.

No Dart sources change.