### PR TITLE
fix(dive-log): dedupe same-computer sources after a sequential merge

### DIFF
--- a/docs/superpowers/plans/2026-08-11-dedupe-same-computer-dive-data-sources.md
+++ b/docs/superpowers/plans/2026-08-11-dedupe-same-computer-dive-data-sources.md
@@ -1,0 +1,454 @@
+# Dedupe same-computer dive_data_sources rows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a dive that was created by merging two same-computer segments (e.g. a "split pair" combine) from showing a duplicate, empty-profile source chip alongside the real one with stale stats.
+
+**Architecture:** Add one small private helper to `DiveRepository` that collapses `dive_data_sources` rows sharing a `computerId` down to the canonical one (primary-preferred), and call it from the two read paths that currently assume one row per computer without enforcing it: `getDataSources()` (feeds the "Sources" chip row) and `getProfilesByDataSource()` (feeds the profile chart). Display-only — no schema change, no data migration, no change to how merges write data.
+
+**Tech Stack:** Dart, Drift (SQLite ORM), `flutter_test` with an in-memory `AppDatabase`.
+
+Spec: `docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md`
+
+---
+
+### Task 1: Add `_canonicalDataSourceRows` and fix `getProfilesByDataSource`
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart:706-717` (the `sourceRows` query inside `getProfilesByDataSource`)
+- Test: `test/features/dive_log/data/repositories/profiles_by_data_source_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the existing `void main() { ... }` block in
+`test/features/dive_log/data/repositories/profiles_by_data_source_test.dart`,
+after the `'metadata-only sources keep an entry with no points'` test (around
+line 223). It reuses the `dive-1` / `src-a` (primary, computer `dc-a`) /
+`src-b` (non-primary, computer `dc-b`) fixtures already created in `setUp`.
+
+```dart
+  test(
+    'two sources sharing a computerId collapse onto the canonical (primary) '
+    'one',
+    () async {
+      // Mirrors what a same-computer sequential merge produces
+      // (dive_merge_service.dart step 10 carries over every original dive's
+      // data source row as provenance; two originals logged by the same
+      // physical computer both had their own row).
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-a-dup'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 3)),
+              createdAt: Value(DateTime(2026, 1, 3)),
+            ),
+          );
+      await insertProfileRow(
+        diveId: 'dive-1',
+        timestamp: 0,
+        depth: 10.0,
+        computerId: 'dc-a',
+        isPrimary: true,
+      );
+      await insertProfileRow(
+        diveId: 'dive-1',
+        timestamp: 5,
+        depth: 11.0,
+        computerId: 'dc-a',
+        isPrimary: true,
+      );
+
+      final result = await repository.getProfilesByDataSource('dive-1');
+
+      expect(result.keys, containsAll(['src-a', 'src-b']));
+      expect(result.containsKey('src-a-dup'), false);
+      expect(
+        result['src-a']!.points.map((p) => p.depth).toList(),
+        [10.0, 11.0],
+      );
+    },
+  );
+```
+
+Both new profile rows use `isPrimary: true` deliberately: `computerId: 'dc-a'`
+matches the primary source's computer, so they're "primary family" rows
+(`isPrimaryFamily` in the function under test). If one were `isPrimary:
+false` here, it would trip the *unrelated* edited-profile heuristic
+(`hasEditedProfile`) and get silently excluded from the result -- this test
+is only about the same-computer collision, not the edit-detection path
+already covered by the `'edited profile replaces primary rows...'` test
+above it.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/profiles_by_data_source_test.dart --plain-name "two sources sharing a computerId"`
+
+Expected: FAIL. With today's code, `sourceIdByComputer` is built by
+iterating `sourceRows` in `desc(isPrimary), asc(createdAt)` order and
+assigning `computerId -> id` for each -- the map literal's later write for
+`'dc-a'` (from `src-a-dup`, which sorts after `src-a` since both are
+non-primary... actually `src-a` IS primary so it sorts first, but the
+literal still processes `src-a-dup` afterward and overwrites the map entry)
+wins, so every `dc-a` profile point currently attributes to `src-a-dup`
+instead of `src-a`. Expect the assertion on `result['src-a']!.points` to
+fail (empty list, not `[10.0, 11.0]`), or `result.containsKey('src-a-dup')`
+to be `true` instead of `false`.
+
+- [ ] **Step 3: Add the helper and wire it into `getProfilesByDataSource`**
+
+In `lib/features/dive_log/data/repositories/dive_repository_impl.dart`, add
+this private method immediately before `getProfilesByDataSource` (i.e.
+directly above the doc comment starting at line 700):
+
+```dart
+  /// Collapses [rows] so at most one dive_data_sources row survives per
+  /// non-null computerId, keeping the first row encountered -- since every
+  /// caller queries in `desc(isPrimary), asc(createdAt)` order, that's the
+  /// primary if one exists, else the earliest-created. Rows with a null
+  /// computerId (manual entries, edited profiles) are never deduped; there
+  /// is nothing to collide on.
+  ///
+  /// A same-computer sequential merge (DiveMergeService.apply, step 10)
+  /// carries over every original dive's data source row as provenance; when
+  /// both originals were logged by the same physical computer, that
+  /// produces two rows sharing one computerId on the merged dive. Without
+  /// this, getProfilesByDataSource's computerId -> sourceId lookup collides
+  /// and silently misroutes every profile point to whichever row is
+  /// iterated last, and getDataSources shows a second, empty, selectable
+  /// chip for the row that lost the collision.
+  List<DiveDataSourcesData> _canonicalDataSourceRows(
+    List<DiveDataSourcesData> rows,
+  ) {
+    final seenComputers = <String>{};
+    final result = <DiveDataSourcesData>[];
+    for (final row in rows) {
+      final computerId = row.computerId;
+      if (computerId == null) {
+        result.add(row);
+        continue;
+      }
+      if (!seenComputers.add(computerId)) continue;
+      result.add(row);
+    }
+    return result;
+  }
+```
+
+Then change the `sourceRows` query inside `getProfilesByDataSource`
+(currently lines 710-717) from:
+
+```dart
+      final sourceRows =
+          await (_db.select(_db.diveDataSources)
+                ..where((t) => t.diveId.equals(diveId))
+                ..orderBy([
+                  (t) => OrderingTerm.desc(t.isPrimary),
+                  (t) => OrderingTerm.asc(t.createdAt),
+                ]))
+              .get();
+```
+
+to:
+
+```dart
+      final sourceRows = _canonicalDataSourceRows(
+        await (_db.select(_db.diveDataSources)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([
+                (t) => OrderingTerm.desc(t.isPrimary),
+                (t) => OrderingTerm.asc(t.createdAt),
+              ]))
+            .get(),
+      );
+```
+
+Nothing else in the function changes -- `primary`, `sourceIdByComputer`,
+the point-attribution loop, and the returned map all now operate on the
+deduped list automatically.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/profiles_by_data_source_test.dart`
+
+Expected: PASS, all tests in the file (the new one plus the 6 pre-existing
+ones) green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
+git commit -m "fix(dive_log): dedupe same-computer sources in getProfilesByDataSource"
+```
+
+---
+
+### Task 2: Wire the same helper into `getDataSources`
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart:5432-5453`
+- Create: `test/features/dive_log/data/repositories/canonical_data_sources_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/data/repositories/canonical_data_sources_test.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('dive-1'),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+
+    for (final (id, name) in [
+      ('dc-a', 'Kiyans Teric'),
+      ('dc-b', 'Erics Teric'),
+    ]) {
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion(
+              id: Value(id),
+              name: Value(name),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+    }
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  test(
+    'getDataSources returns one row per computer, even when more than one '
+    'dive_data_sources row shares a computerId',
+    () async {
+      // Mirrors what a same-computer sequential merge produces
+      // (dive_merge_service.dart step 10 carries over every original dive's
+      // data source row as provenance; two originals logged by the same
+      // physical computer both had their own row).
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-primary'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(true),
+              importedAt: Value(DateTime(2026, 1, 1)),
+              createdAt: Value(DateTime(2026, 1, 1)),
+            ),
+          );
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-dup'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 2)),
+              createdAt: Value(DateTime(2026, 1, 2)),
+            ),
+          );
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-b'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-b'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 3)),
+              createdAt: Value(DateTime(2026, 1, 3)),
+            ),
+          );
+
+      final sources = await repository.getDataSources('dive-1');
+
+      expect(sources.map((s) => s.id).toList(), ['src-primary', 'src-b']);
+    },
+  );
+
+  test(
+    'getDataSources keeps every source when no two share a computerId',
+    () async {
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-a'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(true),
+              importedAt: Value(DateTime(2026, 1, 1)),
+              createdAt: Value(DateTime(2026, 1, 1)),
+            ),
+          );
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-b'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-b'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 2)),
+              createdAt: Value(DateTime(2026, 1, 2)),
+            ),
+          );
+
+      final sources = await repository.getDataSources('dive-1');
+
+      expect(sources.map((s) => s.id).toList(), ['src-a', 'src-b']);
+    },
+  );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/data/repositories/canonical_data_sources_test.dart`
+
+Expected: the first test FAILs -- `sources.map((s) => s.id).toList()`
+returns `['src-primary', 'src-dup', 'src-b']` (all three rows, unfiltered)
+instead of `['src-primary', 'src-b']`. The second test passes already (no
+collision to dedupe), confirming the fixture itself is sound before the fix
+changes anything.
+
+- [ ] **Step 3: Wire `_canonicalDataSourceRows` into `getDataSources`**
+
+In `lib/features/dive_log/data/repositories/dive_repository_impl.dart`,
+change `getDataSources` (lines 5432-5453) from:
+
+```dart
+  Future<List<DiveDataSource>> getDataSources(String diveId) async {
+    try {
+      final query = _db.select(_db.diveDataSources)
+        ..where((t) => t.diveId.equals(diveId))
+        ..orderBy([
+          (t) => OrderingTerm.desc(t.isPrimary),
+          (t) => OrderingTerm.asc(t.createdAt),
+        ]);
+      final rows = await query.get();
+      final computerNames = await _friendlyNamesFor(rows);
+      return rows
+          .map((row) => _mapRowToDataSource(row, computerNames))
+          .toList();
+    } catch (e, stackTrace) {
+```
+
+to:
+
+```dart
+  Future<List<DiveDataSource>> getDataSources(String diveId) async {
+    try {
+      final query = _db.select(_db.diveDataSources)
+        ..where((t) => t.diveId.equals(diveId))
+        ..orderBy([
+          (t) => OrderingTerm.desc(t.isPrimary),
+          (t) => OrderingTerm.asc(t.createdAt),
+        ]);
+      final rows = _canonicalDataSourceRows(await query.get());
+      final computerNames = await _friendlyNamesFor(rows);
+      return rows
+          .map((row) => _mapRowToDataSource(row, computerNames))
+          .toList();
+    } catch (e, stackTrace) {
+```
+
+(Only the `final rows = ...` line changes; the rest of the function, and
+the `catch` block after it, are untouched.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/data/repositories/canonical_data_sources_test.dart`
+
+Expected: PASS, both tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/canonical_data_sources_test.dart
+git commit -m "fix(dive_log): dedupe same-computer sources in getDataSources"
+```
+
+---
+
+### Task 3: Regression sweep
+
+`getDataSources` is called from many existing tests (consolidation,
+multi-computer integration, quality repair) that exercise genuinely
+different-computer scenarios -- this task confirms none of them accidentally
+relied on seeing duplicate same-computer rows, and that formatting/analysis
+stay clean.
+
+**Files:** none modified unless a regression turns up.
+
+- [ ] **Step 1: Format the changed files**
+
+Run: `dart format lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/profiles_by_data_source_test.dart test/features/dive_log/data/repositories/canonical_data_sources_test.dart`
+
+Expected: "Formatted N files (0 changed)" or similar -- no diffs, since the
+code above was written in the project's existing style. If it reports
+changes, that's fine too; just re-stage before the final commit if this
+step runs after Task 2's commit.
+
+- [ ] **Step 2: Analyze**
+
+Run: `flutter analyze lib/features/dive_log/data/repositories/dive_repository_impl.dart test/features/dive_log/data/repositories/profiles_by_data_source_test.dart test/features/dive_log/data/repositories/canonical_data_sources_test.dart`
+
+Expected: "No issues found!"
+
+- [ ] **Step 3: Run the broader test suites that exercise `getDataSources`**
+
+Run: `flutter test test/features/dive_log/data/repositories/ test/features/dive_log/integration/multi_computer_integration_test.dart test/features/data_quality/repairs/quality_repair_executor_test.dart`
+
+Expected: PASS, no regressions. This directory/set covers every existing
+caller found via `grep -rn "\.getDataSources(" test/` during design
+(consolidation tests, the multi-computer integration test, the quality
+repair executor test, and the two dedicated files this plan adds) --
+all use distinct `computerId`s per source in their fixtures (the normal,
+DiveConsolidationService-guarded case), so none should be affected by the
+dedup, but this step is the actual verification rather than an assumption.
+
+- [ ] **Step 4: If anything regressed, fix and commit separately**
+
+Only needed if Step 3 surfaces a failure. Diagnose why that specific test's
+fixture relied on seeing two same-computer rows (it shouldn't, per the
+`DiveConsolidationService` `sameComputer` guard, so this would itself be
+worth understanding before patching), fix, then:
+
+```bash
+git add -A
+git commit -m "fix(dive_log): address regression from same-computer source dedup"
+```
+
+If nothing regressed, skip this step -- there is nothing to commit.

--- a/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
+++ b/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
@@ -1,0 +1,122 @@
+# Dedupe dive_data_sources rows that share a computer
+
+Date: 2026-08-11
+
+## Problem
+
+A sequential dive merge (`DiveMergeService.apply`, used for "split pair"
+combines where a computer logged one dive as two separate downloads) carries
+over every original dive's `dive_data_sources` row as provenance
+(`dive_merge_service.dart:390-408`). When both original dives were logged by
+the *same* physical computer -- the common case for a split-pair merge --
+this produces two `dive_data_sources` rows on the merged dive sharing one
+`computer_id`.
+
+`getProfilesByDataSource()` (`dive_repository_impl.dart:706`) builds a
+`computerId -> sourceId` lookup to attribute each `dive_profiles` row to its
+owning source. Two rows sharing a `computerId` collide in that map -- the
+non-primary row's id silently overwrites the primary's, so every profile
+point for that computer gets attributed to the non-primary row. The result,
+confirmed against dive #955 (a real merged dive):
+
+- The primary source shows "No dive profile data" even though it has the
+  correct depth/duration/temperature (30.1m / 99min / 15C, matching the
+  dive's own row).
+- The non-primary source shows the full 642-point chart, but under its own
+  stale, pre-merge stats (3.3m / 5min / 23C) -- whichever original segment
+  it came from.
+- The "Sources" chip row shows two identical "Petrel 3" chips, and nothing
+  distinguishes which one is real.
+
+`getDataSources()` (`dive_repository_impl.dart:5432`), which feeds the chip
+row via `diveDataSourcesProvider`, returns both rows unfiltered -- so even
+fixing the profile attribution alone would leave a second, empty, selectable
+"ghost" chip.
+
+Checked the current database: only dive #955 is affected today (1 of
+~1,000+ dives), but the trigger -- merging two dives from the same computer
+-- is the exact scenario the `split_pair` quality detector actively surfaces
+and offers as a one-tap repair, so this is plausibly latent in other
+merged-dive histories too, not unique to this one dive.
+
+## Decision
+
+Display-only fix, scoped to reading existing data correctly. No schema
+change, no data migration, no change to `DiveMergeService`. Existing
+affected dives self-heal the next time they're opened; nothing needs to be
+rewritten in the database.
+
+## Design
+
+Add one private helper to `DiveRepository`
+(`lib/features/dive_log/data/repositories/dive_repository_impl.dart`),
+operating on the raw Drift table row (`DiveDataSourceData`, the type
+`_db.select(_db.diveDataSources).get()` returns in both call sites below --
+so one helper serves both without a mapping-order change):
+
+```dart
+List<DiveDataSourceData> _canonicalDataSourceRows(
+  List<DiveDataSourceData> rows,
+) {
+  final seenComputers = <String>{};
+  final result = <DiveDataSourceData>[];
+  for (final row in rows) {
+    final computerId = row.computerId;
+    if (computerId == null) {
+      result.add(row);
+      continue;
+    }
+    if (!seenComputers.add(computerId)) continue; // already have the canonical row
+    result.add(row);
+  }
+  return result;
+}
+```
+
+Both queries already sort `desc(isPrimary), asc(createdAt)` before this
+would run, so for any group of rows sharing a `computerId`, the first one
+encountered is the primary if one exists, else the earliest-created --
+exactly the row that should survive. Rows with no `computerId` (manual
+entries, edited profiles) are never deduped; there is nothing to collide on.
+
+Call sites:
+- `getDataSources()` (`:5432`): run `rows` (the raw query result, before
+  `_friendlyNamesFor`/`_mapRowToDataSource`) through
+  `_canonicalDataSourceRows`. The chip row (`SourceBar` in
+  `dive_detail_page.dart`, fed by `diveDataSourcesProvider`) iterates the
+  mapped list directly, so the duplicate chip disappears -- not hidden, not
+  disabled, simply not returned.
+- `getProfilesByDataSource()` (`:706`): run `sourceRows` through
+  `_canonicalDataSourceRows` immediately after the initial query, before
+  `primary`, `sourceIdByComputer`, and the final returned map are built.
+  Every other line in the function is unchanged -- `sourceIdByComputer` can
+  now only ever hold one id per `computerId` because its input no longer
+  has duplicates, so every profile point on that computer routes to the one
+  surviving (primary-preferred) source.
+
+Net effect on #955: the primary source becomes the sole entry, carries all
+642 profile points, and its own `dive_data_sources` row already has the
+correct depth/duration/temperature (verified directly) -- no fallback to
+the dive's own scalar columns needed for this case, though the header UI
+already has that fallback for genuinely metadata-only sources.
+
+**Not in scope**: `getSourceKeysByDiveId()` (`:5473`), used by the import
+duplicate-checker to fingerprint-match against *every* source including
+non-canonical ones, must keep seeing all rows -- deduping there would let a
+re-download from the "losing" duplicate source fail to register as an
+exact match. Also not touched: `DiveMergeService` itself (a separate,
+explicitly out-of-scope prevention fix for a future merge), and any other
+direct `_db.select(_db.diveDataSources)` call site not enumerated above.
+
+## Testing
+
+`test/features/dive_log/data/repositories/profiles_by_data_source_test.dart`
+already exercises `getProfilesByDataSource()` against a real (in-memory)
+database. Add a case seeding two `dive_data_sources` rows for one dive that
+share a `computerId` -- one primary with real stats, one non-primary with
+different stale stats -- plus `dive_profiles` rows tagged with that shared
+`computerId`, and assert the returned map has exactly one entry (the
+primary's id) containing every profile point. A parallel case in whatever
+test file covers `getDataSources()` (`dive_repository_test.dart` per the
+existing grep) asserts the returned list has one row, not two, for the
+same fixture.

--- a/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
+++ b/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
@@ -50,13 +50,14 @@ rewritten in the database.
 
 Add one private helper to `DiveRepository`
 (`lib/features/dive_log/data/repositories/dive_repository_impl.dart`),
-operating on the raw Drift table row (`DiveDataSourceData`, the type
-`_db.select(_db.diveDataSources).get()` returns in both call sites below --
-so one helper serves both without a mapping-order change):
+operating on the raw Drift table row (`DiveDataSourcesData`, the type
+`_db.select(_db.diveDataSources).get()` returns in both call sites below,
+and the same type `_mapRowToDataSource` already takes -- so one helper
+serves both without a mapping-order change):
 
 ```dart
-List<DiveDataSourceData> _canonicalDataSourceRows(
-  List<DiveDataSourceData> rows,
+List<DiveDataSourcesData> _canonicalDataSourceRows(
+  List<DiveDataSourcesData> rows,
 ) {
   final seenComputers = <String>{};
   final result = <DiveDataSourceData>[];

--- a/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
+++ b/docs/superpowers/specs/2026-08-11-dedupe-same-computer-dive-data-sources-design.md
@@ -60,7 +60,7 @@ List<DiveDataSourcesData> _canonicalDataSourceRows(
   List<DiveDataSourcesData> rows,
 ) {
   final seenComputers = <String>{};
-  final result = <DiveDataSourceData>[];
+  final result = <DiveDataSourcesData>[];
   for (final row in rows) {
     final computerId = row.computerId;
     if (computerId == null) {

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -5616,10 +5616,22 @@ class DiveRepository {
   }
 
   /// Return true if a dive has readings from 2 or more computers.
+  ///
+  /// Counts distinct canonical sources rather than raw rows -- two rows
+  /// sharing a computer_id (the shape a same-computer sequential merge
+  /// produces) collapse to one, matching [_canonicalDataSourceRows]. A row
+  /// with no computer_id is always its own canonical source, since [id] is
+  /// unique per row.
   Future<bool> hasMultipleDataSources(String diveId) async {
     try {
-      final sources = await getDataSources(diveId);
-      return sources.length >= 2;
+      final result = await _db
+          .customSelect(
+            'SELECT COUNT(DISTINCT COALESCE(computer_id, id)) as cnt '
+            'FROM dive_data_sources WHERE dive_id = ?',
+            variables: [Variable(diveId)],
+          )
+          .getSingle();
+      return (result.data['cnt'] as int) >= 2;
     } catch (e, stackTrace) {
       _log.error(
         'Failed to check multiple computers for dive: $diveId',

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -5618,13 +5618,8 @@ class DiveRepository {
   /// Return true if a dive has readings from 2 or more computers.
   Future<bool> hasMultipleDataSources(String diveId) async {
     try {
-      final result = await _db
-          .customSelect(
-            'SELECT COUNT(*) as cnt FROM dive_data_sources WHERE dive_id = ?',
-            variables: [Variable(diveId)],
-          )
-          .getSingle();
-      return (result.data['cnt'] as int) >= 2;
+      final sources = await getDataSources(diveId);
+      return sources.length >= 2;
     } catch (e, stackTrace) {
       _log.error(
         'Failed to check multiple computers for dive: $diveId',

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -5470,7 +5470,7 @@ class DiveRepository {
           (t) => OrderingTerm.desc(t.isPrimary),
           (t) => OrderingTerm.asc(t.createdAt),
         ]);
-      final rows = await query.get();
+      final rows = _canonicalDataSourceRows(await query.get());
       final computerNames = await _friendlyNamesFor(rows);
       return rows
           .map((row) => _mapRowToDataSource(row, computerNames))

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -695,6 +695,38 @@ class DiveRepository {
     );
   }
 
+  /// Collapses [rows] so at most one dive_data_sources row survives per
+  /// non-null computerId, keeping the first row encountered -- since every
+  /// caller queries in `desc(isPrimary), asc(createdAt)` order, that's the
+  /// primary if one exists, else the earliest-created. Rows with a null
+  /// computerId (manual entries, edited profiles) are never deduped; there
+  /// is nothing to collide on.
+  ///
+  /// A same-computer sequential merge (DiveMergeService.apply, step 10)
+  /// carries over every original dive's data source row as provenance; when
+  /// both originals were logged by the same physical computer, that
+  /// produces two rows sharing one computerId on the merged dive. Without
+  /// this, getProfilesByDataSource's computerId -> sourceId lookup collides
+  /// and silently misroutes every profile point to whichever row is
+  /// iterated last, and getDataSources shows a second, empty, selectable
+  /// chip for the row that lost the collision.
+  List<DiveDataSourcesData> _canonicalDataSourceRows(
+    List<DiveDataSourcesData> rows,
+  ) {
+    final seenComputers = <String>{};
+    final result = <DiveDataSourcesData>[];
+    for (final row in rows) {
+      final computerId = row.computerId;
+      if (computerId == null) {
+        result.add(row);
+        continue;
+      }
+      if (!seenComputers.add(computerId)) continue;
+      result.add(row);
+    }
+    return result;
+  }
+
   /// Get profile samples grouped by owning data source.
   ///
   /// Keys are dive_data_sources ids, primary source first. Rows with a null
@@ -707,14 +739,15 @@ class DiveRepository {
     String diveId,
   ) async {
     try {
-      final sourceRows =
-          await (_db.select(_db.diveDataSources)
-                ..where((t) => t.diveId.equals(diveId))
-                ..orderBy([
-                  (t) => OrderingTerm.desc(t.isPrimary),
-                  (t) => OrderingTerm.asc(t.createdAt),
-                ]))
-              .get();
+      final sourceRows = _canonicalDataSourceRows(
+        await (_db.select(_db.diveDataSources)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([
+                (t) => OrderingTerm.desc(t.isPrimary),
+                (t) => OrderingTerm.asc(t.createdAt),
+              ]))
+            .get(),
+      );
       if (sourceRows.isEmpty) {
         // Legacy/imported dives can carry dive_profiles rows without a
         // dive_data_sources metadata row (older import paths predate that

--- a/test/features/dive_log/data/repositories/canonical_data_sources_test.dart
+++ b/test/features/dive_log/data/repositories/canonical_data_sources_test.dart
@@ -1,0 +1,131 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('dive-1'),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+
+    for (final (id, name) in [
+      ('dc-a', 'Kiyans Teric'),
+      ('dc-b', 'Erics Teric'),
+    ]) {
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion(
+              id: Value(id),
+              name: Value(name),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+    }
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  test('getDataSources returns one row per computer, even when more than one '
+      'dive_data_sources row shares a computerId', () async {
+    // Mirrors what a same-computer sequential merge produces
+    // (dive_merge_service.dart step 10 carries over every original dive's
+    // data source row as provenance; two originals logged by the same
+    // physical computer both had their own row).
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: const Value('src-primary'),
+            diveId: const Value('dive-1'),
+            computerId: const Value('dc-a'),
+            isPrimary: const Value(true),
+            importedAt: Value(DateTime(2026, 1, 1)),
+            createdAt: Value(DateTime(2026, 1, 1)),
+          ),
+        );
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: const Value('src-dup'),
+            diveId: const Value('dive-1'),
+            computerId: const Value('dc-a'),
+            isPrimary: const Value(false),
+            importedAt: Value(DateTime(2026, 1, 2)),
+            createdAt: Value(DateTime(2026, 1, 2)),
+          ),
+        );
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: const Value('src-b'),
+            diveId: const Value('dive-1'),
+            computerId: const Value('dc-b'),
+            isPrimary: const Value(false),
+            importedAt: Value(DateTime(2026, 1, 3)),
+            createdAt: Value(DateTime(2026, 1, 3)),
+          ),
+        );
+
+    final sources = await repository.getDataSources('dive-1');
+
+    expect(sources.map((s) => s.id).toList(), ['src-primary', 'src-b']);
+  });
+
+  test(
+    'getDataSources keeps every source when no two share a computerId',
+    () async {
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-a'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-a'),
+              isPrimary: const Value(true),
+              importedAt: Value(DateTime(2026, 1, 1)),
+              createdAt: Value(DateTime(2026, 1, 1)),
+            ),
+          );
+      await db
+          .into(db.diveDataSources)
+          .insert(
+            DiveDataSourcesCompanion(
+              id: const Value('src-b'),
+              diveId: const Value('dive-1'),
+              computerId: const Value('dc-b'),
+              isPrimary: const Value(false),
+              importedAt: Value(DateTime(2026, 1, 2)),
+              createdAt: Value(DateTime(2026, 1, 2)),
+            ),
+          );
+
+      final sources = await repository.getDataSources('dive-1');
+
+      expect(sources.map((s) => s.id).toList(), ['src-a', 'src-b']);
+    },
+  );
+}

--- a/test/features/dive_log/data/repositories/dive_computer_data_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_data_repository_test.dart
@@ -266,6 +266,35 @@ void main() {
       expect(await repository.hasMultipleDataSources(diveId1), isFalse);
       expect(await repository.hasMultipleDataSources(diveId2), isTrue);
     });
+
+    test('returns false when two readings share a computerId (same-computer '
+        'merge provenance, not a real second source)', () async {
+      final diveId = await insertTestDive();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion(
+              id: const Value('dc-a'),
+              name: const Value('Petrel 3'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'r1',
+          diveId: diveId,
+          isPrimary: true,
+          computerId: 'dc-a',
+        ),
+      );
+      await repository.saveComputerReading(
+        buildReading(id: 'r2', diveId: diveId, computerId: 'dc-a'),
+      );
+
+      expect(await repository.hasMultipleDataSources(diveId), isFalse);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
+++ b/test/features/dive_log/data/repositories/profiles_by_data_source_test.dart
@@ -222,6 +222,46 @@ void main() {
     expect(result['src-meta']!.points, isEmpty);
   });
 
+  test('two sources sharing a computerId collapse onto the canonical (primary) '
+      'one', () async {
+    // Mirrors what a same-computer sequential merge produces
+    // (dive_merge_service.dart step 10 carries over every original dive's
+    // data source row as provenance; two originals logged by the same
+    // physical computer both had their own row).
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: const Value('src-a-dup'),
+            diveId: const Value('dive-1'),
+            computerId: const Value('dc-a'),
+            isPrimary: const Value(false),
+            importedAt: Value(DateTime(2026, 1, 3)),
+            createdAt: Value(DateTime(2026, 1, 3)),
+          ),
+        );
+    await insertProfileRow(
+      diveId: 'dive-1',
+      timestamp: 0,
+      depth: 10.0,
+      computerId: 'dc-a',
+      isPrimary: true,
+    );
+    await insertProfileRow(
+      diveId: 'dive-1',
+      timestamp: 5,
+      depth: 11.0,
+      computerId: 'dc-a',
+      isPrimary: true,
+    );
+
+    final result = await repository.getProfilesByDataSource('dive-1');
+
+    expect(result.keys, containsAll(['src-a', 'src-b']));
+    expect(result.containsKey('src-a-dup'), false);
+    expect(result['src-a']!.points.map((p) => p.depth).toList(), [10.0, 11.0]);
+  });
+
   test('synthesizes a primary source from raw profile rows when the dive has '
       'no data source metadata row (legacy import)', () async {
     // Older imports wrote dive_profiles rows without a dive_data_sources


### PR DESCRIPTION
A same-computer sequential merge (`DiveMergeService.apply`, used for "split pair" combines where a computer logged one dive as two separate downloads) carries over both original dives' `dive_data_sources` rows as provenance. When both originals were logged by the same physical computer, this leaves two rows sharing one `computer_id` on the merged dive.

## Root cause

`getProfilesByDataSource()` builds a `computerId -> sourceId` map to attribute each `dive_profiles` row to its source. Two rows sharing a `computer_id` collide in that map — the non-primary row's id silently overwrites the primary's, so every profile point for that computer attributes to the wrong (stale) row. `getDataSources()` has the same one-row-per-computer assumption and returns both rows unfiltered, so the "Sources" chip row shows a duplicate, empty, selectable ghost chip alongside the real source.

Confirmed against dive #955 in production: two `dive_data_sources` rows sharing one `computer_id` — primary with the dive's real stats (30.1m / 99min / 15°C), non-primary "ghost" with stale pre-merge stats (3.3m / 5min / 23°C) — matching exactly what was reported (one entry shows 5 min bottom time on the graph, the other shows the real dive time).

## Fix

Added `_canonicalDataSourceRows()`, a private helper that collapses same-`computer_id` rows down to one (primary-preferred, else earliest-created, matching the existing query ordering both call sites already use). Wired into:
- `getProfilesByDataSource()` — profile points now attribute to the correct source.
- `getDataSources()` — the ghost chip disappears.
- `hasMultipleDataSources()` (via reuse of `getDataSources()`) — was still counting raw rows, so it kept flagging these dives as multi-computer for the 3D scene switcher even after the chip row was fixed; found during final review and fixed the same way.

Display-only: no schema change, no migration, no change to how `DiveMergeService` writes data. Affected dives self-heal the next time they're opened. `getSourceKeysByDiveId()` (needs every raw row for import duplicate-detection fingerprinting) is deliberately untouched.

**Scope note:** unrelated to #645 (cross-device dive-computer BLE identity duplicates, already fixed by #682) — that's a different bug producing duplicate `dive_computers` records, not duplicate `dive_data_sources` rows on one dive.

## Tests

Added a same-computer collision case to `profiles_by_data_source_test.dart` and a new `canonical_data_sources_test.dart` covering `getDataSources`, each with a companion non-colliding case as a regression guard. Extended `dive_computer_data_repository_test.dart` for `hasMultipleDataSources`. Confirmed red before each fix (leaked/misrouted source key, stale row count) and green after.

## Verification

- `flutter test`: 16,874/16,891 passing (16 pre-existing skips). The one failure, `linux_ffmpeg_engine_smoke_test.dart`, is an environment-dependent smoke test in the unrelated media-transcoder subsystem, not touched by this branch.
- `flutter analyze` clean on all changed files.
- `dart format` clean.
- Manually verified against production data: traced dive #955's actual `dive_data_sources`/`dive_profiles` rows through the fixed logic, and confirmed live in a running build — the duplicate source chip is gone and the correct 642-point profile now displays under the one remaining source.