### PR TITLE
Fix species sighting count provider refresh

### DIFF
--- a/docs/superpowers/plans/2026-08-11-species-sighting-count-refresh.md
+++ b/docs/superpowers/plans/2026-08-11-species-sighting-count-refresh.md
@@ -1,0 +1,197 @@
+# Species Sighting Count Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the cached species sighting-count map refresh after every committed write to the `sightings` table.
+
+**Architecture:** Add a focused Drift table-update stream to `SpeciesRepository` and subscribe `speciesSightingCountsProvider` with Riverpod's `invalidateSelfWhen`. Prove the behavior with a provider integration test that writes a real sighting into the in-memory database and observes the cached provider refresh without manual invalidation.
+
+**Tech Stack:** Dart, Flutter Test, Drift, Riverpod
+
+## Global Constraints
+
+- The tick must watch only the `sightings` table.
+- The provider must refresh after direct database-backed writes without page-level invalidation.
+- Do not change count calculation, selection behavior, or deletion behavior.
+- Write and verify the behavioral regression test before production code.
+- All Dart changes must pass `dart format` with no changes remaining.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `test/features/marine_life/presentation/providers/species_providers_test.dart` | Proves the provider refreshes after the table it reads changes. |
+| `lib/features/marine_life/data/repositories/species_repository.dart` | Exposes the focused `sightings` table change stream. |
+| `lib/features/marine_life/presentation/providers/species_providers.dart` | Subscribes the count provider to the new stream. |
+
+### Task 1: Refresh sighting counts from the sightings-table tick
+
+**Files:**
+- Modify: `test/features/marine_life/presentation/providers/species_providers_test.dart`
+- Modify: `lib/features/marine_life/data/repositories/species_repository.dart`
+- Modify: `lib/features/marine_life/presentation/providers/species_providers.dart`
+
+**Interfaces:**
+- Consumes: `AppDatabase`, `DivesCompanion`, `SpeciesRepository.addSighting`, `SpeciesRepository.sightingCountsBySpecies`, and `Ref.invalidateSelfWhen`.
+- Produces: `SpeciesRepository.watchSightingChanges() -> Stream<void>` and an automatically refreshing `speciesSightingCountsProvider`.
+
+- [ ] **Step 1: Add a minimal real-database test fixture**
+
+Add the Drift, database, and database-service imports to
+`species_providers_test.dart`:
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+```
+
+Then add this helper before `main()`:
+
+```dart
+Future<void> _insertTestDive({required String id}) async {
+  final db = DatabaseService.instance.database;
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
+```
+
+- [ ] **Step 2: Write the failing provider behavior test**
+
+Add this group between `allSpeciesProvider` and
+`speciesListNotifierProvider`:
+
+```dart
+group('speciesSightingCountsProvider', () {
+  test('auto-refreshes after a sighting is written directly to the DB '
+      '(sync scenario)', () async {
+    final species = await speciesRepo.createSpecies(
+      commonName: 'Counted Grouper',
+      category: SpeciesCategory.fish,
+    );
+    await _insertTestDive(id: 'counted-dive');
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+    final sub = container.listen(speciesSightingCountsProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    expect(await container.read(speciesSightingCountsProvider.future), isEmpty);
+
+    await speciesRepo.addSighting(
+      diveId: 'counted-dive',
+      speciesId: species.id,
+    );
+
+    var counts = <String, int>{};
+    for (var i = 0; i < 50; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      counts = await container.read(speciesSightingCountsProvider.future);
+      if (counts[species.id] == 1) break;
+    }
+
+    expect(
+      counts,
+      {species.id: 1},
+      reason:
+          'speciesSightingCountsProvider should refresh after a sightings '
+          'table write without manual invalidation',
+    );
+  });
+});
+```
+
+The production mutation this test catches is removal or omission of the
+`watchSightingChanges()` subscription. Its expected map is hand-derived from
+the single inserted sighting.
+
+- [ ] **Step 3: Run the provider test and verify the new test fails**
+
+Run:
+
+```bash
+flutter test test/features/marine_life/presentation/providers/species_providers_test.dart
+```
+
+Expected: the new `speciesSightingCountsProvider` test fails because `counts`
+remains empty. Existing tests in the file continue to pass.
+
+- [ ] **Step 4: Add the focused repository tick**
+
+Immediately after `watchSpeciesChanges()` in `species_repository.dart`, add:
+
+```dart
+/// Emits whenever the `sightings` table changes so aggregate providers can
+/// refresh after a sync or any other write.
+Stream<void> watchSightingChanges() =>
+    _db.tableUpdates(TableUpdateQuery.onTable(_db.sightings));
+```
+
+- [ ] **Step 5: Subscribe the provider to the focused tick**
+
+Replace the body of `speciesSightingCountsProvider` with:
+
+```dart
+final repository = ref.watch(speciesRepositoryProvider);
+ref.invalidateSelfWhen(repository.watchSightingChanges());
+return repository.sightingCountsBySpecies();
+```
+
+- [ ] **Step 6: Run targeted tests and verify green**
+
+Run:
+
+```bash
+flutter test \
+  test/features/marine_life/presentation/providers/species_providers_test.dart \
+  test/architecture/provider_change_tick_test.dart
+```
+
+Expected: both files pass with zero failures. This proves both the runtime
+behavior and the architecture rule.
+
+- [ ] **Step 7: Format and run static analysis**
+
+Run:
+
+```bash
+dart format lib/ test/
+git diff --exit-code --check
+flutter analyze
+```
+
+Expected: formatting leaves no pending formatting changes after the first run,
+the diff check exits zero, and analysis reports no issues.
+
+- [ ] **Step 8: Run the full Flutter test suite**
+
+Run:
+
+```bash
+flutter test
+```
+
+Expected: the full suite passes with zero failures.
+
+- [ ] **Step 9: Commit the implementation**
+
+Stage only the three implementation files and commit:
+
+```bash
+git add \
+  lib/features/marine_life/data/repositories/species_repository.dart \
+  lib/features/marine_life/presentation/providers/species_providers.dart \
+  test/features/marine_life/presentation/providers/species_providers_test.dart
+git commit -m "fix: refresh species sighting counts"
+```

--- a/docs/superpowers/specs/2026-08-11-species-sighting-count-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-11-species-sighting-count-refresh-design.md
@@ -1,0 +1,101 @@
+# Species Sighting Count Refresh Design
+
+## Problem
+
+`speciesSightingCountsProvider` caches the result of
+`SpeciesRepository.sightingCountsBySpecies()`, but the provider does not
+subscribe to any database change tick. The query reads the `sightings` table,
+so a sync pull, merge, bulk edit, or other direct database write can leave the
+species-management page using stale sighting counts. The architecture test now
+detects this missing subscription on `main`, which also blocks PRs #1003 and
+#1004 even though neither PR changes marine-life code.
+
+## Goal
+
+Refresh `speciesSightingCountsProvider` whenever the `sightings` table changes,
+and protect that behavior with both a provider-level regression test and the
+existing architecture test.
+
+## Non-goals
+
+- Do not change how sighting counts are calculated.
+- Do not change species selection or deletion behavior.
+- Do not broaden `watchSpeciesChanges()` to include unrelated tables.
+- Do not use the broad, debounced dive-detail tick for this focused aggregate.
+- Do not modify either PR's feature-specific files.
+
+## Considered Approaches
+
+### 1. Dedicated sightings-table tick (selected)
+
+Add `SpeciesRepository.watchSightingChanges()`, backed only by Drift updates to
+the `sightings` table, and subscribe the count provider with
+`ref.invalidateSelfWhen`.
+
+This follows the repository's existing table-tick pattern, matches the table the
+query actually reads, reacts to direct sync writes, and avoids invalidating on
+unrelated dive-detail changes.
+
+### 2. Reuse `DiveRepository.watchDiveDetailChanges()`
+
+This stream includes `sightings`, so it would make the provider correct, but it
+also watches many other detail tables and is debounced. The count provider would
+refresh for unrelated tanks, profiles, equipment, media, and safety-review
+writes. That coupling and extra work are unnecessary.
+
+### 3. Manually invalidate after known writes
+
+Manual invalidation already happens after one page-level bulk-delete path, but
+it cannot cover sync pulls, consolidation, merges, repository-level bulk edits,
+or future writers. It would preserve the stale-cache defect at the database
+boundary.
+
+## Design
+
+`SpeciesRepository` will expose:
+
+```dart
+Stream<void> watchSightingChanges() =>
+    _db.tableUpdates(TableUpdateQuery.onTable(_db.sightings));
+```
+
+`speciesSightingCountsProvider` will keep a local repository reference,
+subscribe with `ref.invalidateSelfWhen(repository.watchSightingChanges())`, and
+then call `repository.sightingCountsBySpecies()`.
+
+No additional debounce is needed. The provider is watched only by the species
+management surface, and invalidation should track the settled table state after
+each committed write. Riverpod handles subscription disposal with the provider.
+
+## Data Flow
+
+1. A local action or sync operation commits a write to `sightings`.
+2. Drift emits a table-update event through `watchSightingChanges()`.
+3. `invalidateSelfWhen` invalidates `speciesSightingCountsProvider`.
+4. An active watcher causes the provider to rerun
+   `sightingCountsBySpecies()`.
+5. The species-management page receives the new count map and recalculates
+   which species are selectable for deletion.
+
+## Testing
+
+Add a provider regression test that:
+
+1. Creates a species and a dive in the test database.
+2. Keeps `speciesSightingCountsProvider` alive with an active listener.
+3. Confirms the initial count map is empty.
+4. Writes a sighting through `SpeciesRepository` without manually invalidating
+   the provider.
+5. Polls the provider until the species count becomes one and asserts that
+   result.
+
+The test must fail before the production change because the cached provider
+continues returning the empty map. After implementation, run the provider test,
+the architecture test, formatting, analysis, and the full Flutter test suite.
+
+## Delivery
+
+Publish the fix as a small shared PR based on `main`. Once the commit is on the
+two affected branches, rerun PR #1003 and PR #1004 checks. Keeping the fix in a
+single commit makes it easy for `main` and both feature branches to converge on
+the same history.

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -32,6 +32,11 @@ class SpeciesRepository {
   Stream<void> watchSpeciesChanges() =>
       _db.tableUpdates(TableUpdateQuery.onTable(_db.species));
 
+  /// Emits whenever the `sightings` table changes so aggregate providers can
+  /// refresh after a sync or any other write.
+  Stream<void> watchSightingChanges() =>
+      _db.tableUpdates(TableUpdateQuery.onTable(_db.sightings));
+
   /// Get species by category
   Future<List<domain.Species>> getSpeciesByCategory(
     SpeciesCategory category,

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -23,7 +23,9 @@ final allSpeciesProvider = FutureProvider<List<Species>>((ref) async {
 final speciesSightingCountsProvider = FutureProvider<Map<String, int>>((
   ref,
 ) async {
-  return ref.watch(speciesRepositoryProvider).sightingCountsBySpecies();
+  final repository = ref.watch(speciesRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchSightingChanges());
+  return repository.sightingCountsBySpecies();
 });
 
 final speciesByCategoryProvider =

--- a/test/features/marine_life/presentation/providers/species_providers_test.dart
+++ b/test/features/marine_life/presentation/providers/species_providers_test.dart
@@ -1,13 +1,30 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/providers/provider.dart';
-
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/test_database.dart';
+
+Future<void> _insertTestDive({required String id}) async {
+  final db = DatabaseService.instance.database;
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await db
+      .into(db.dives)
+      .insert(
+        DivesCompanion(
+          id: Value(id),
+          diveDateTime: Value(now),
+          createdAt: Value(now),
+          updatedAt: Value(now),
+        ),
+      );
+}
 
 void main() {
   late SharedPreferences prefs;
@@ -66,6 +83,47 @@ void main() {
         reason:
             'allSpeciesProvider should auto-refresh after a direct table '
             'write without any manual invalidation',
+      );
+    });
+  });
+
+  group('speciesSightingCountsProvider', () {
+    test('auto-refreshes after a sighting is written directly to the DB '
+        '(sync scenario)', () async {
+      final species = await speciesRepo.createSpecies(
+        commonName: 'Counted Grouper',
+        category: SpeciesCategory.fish,
+      );
+      await _insertTestDive(id: 'counted-dive');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      final sub = container.listen(speciesSightingCountsProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(speciesSightingCountsProvider.future),
+        isEmpty,
+      );
+
+      await speciesRepo.addSighting(
+        diveId: 'counted-dive',
+        speciesId: species.id,
+      );
+
+      var counts = <String, int>{};
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        counts = await container.read(speciesSightingCountsProvider.future);
+        if (counts[species.id] == 1) break;
+      }
+
+      expect(
+        counts,
+        {species.id: 1},
+        reason:
+            'speciesSightingCountsProvider should refresh after a sightings '
+            'table write without manual invalidation',
       );
     });
   });


### PR DESCRIPTION
## Summary

- expose a Drift table-update stream for sightings
- invalidate `speciesSightingCountsProvider` when sightings change, including sync writes
- add a regression test that writes a sighting directly to the database

## Verification

- `flutter analyze`
- `flutter test test/features/marine_life/presentation/providers/species_providers_test.dart test/architecture/provider_change_tick_test.dart`
- pre-push affected-test suite: 341 passed
- full local suite: 17,286 passed, 17 skipped, 1 unrelated suite-order failure; the failing planner test passed immediately in isolation