### PR TITLE
Fix the iPhone crash when exiting a photo opened from the home photo ribbon

### DIFF
--- a/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
+++ b/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
@@ -6,6 +6,10 @@ import 'package:submersion/features/media/presentation/pages/photo_viewer_page.d
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Ribbon tile size in logical pixels.
+const double _tileWidth = 128;
+const double _tileHeight = 96;
+
 /// Horizontal ribbon of the newest dive photos.
 class PhotoRibbonCard extends ConsumerWidget {
   const PhotoRibbonCard({super.key});
@@ -30,6 +34,16 @@ class PhotoRibbonCard extends ConsumerWidget {
     final photos = photosAsync.valueOrNull ?? const [];
     if (photos.isEmpty) return const SizedBox.shrink();
 
+    // ThumbnailSize reaches PHImageManager (and its Android counterpart) in
+    // DEVICE pixels, so a tile-sized request has to be scaled or it lands
+    // soft on a 2x/3x screen. Square, like every other tile request in the
+    // app, so BoxFit.cover does the cropping here rather than in
+    // photo_manager. Even at 3x this is ~0.15 MP against the ~12 MP original
+    // the unsized request used to decode.
+    final thumbnailTarget = Size.square(
+      _tileWidth * MediaQuery.devicePixelRatioOf(context),
+    );
+
     return Card(
       margin: EdgeInsets.zero,
       child: Padding(
@@ -45,7 +59,7 @@ class PhotoRibbonCard extends ConsumerWidget {
             ),
             const SizedBox(height: 8),
             SizedBox(
-              height: 96,
+              height: _tileHeight,
               child: ListView.separated(
                 scrollDirection: Axis.horizontal,
                 itemCount: photos.length,
@@ -60,15 +74,11 @@ class PhotoRibbonCard extends ConsumerWidget {
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(8),
                       child: SizedBox(
-                        width: 128,
+                        width: _tileWidth,
                         child: MediaItemView(
                           item: item,
                           thumbnail: true,
-                          // Sized to the tile, not the photo: the ribbon
-                          // draws a screenful of these at once, and the
-                          // originals behind them are full-resolution
-                          // camera files.
-                          targetSize: const Size(200, 200),
+                          targetSize: thumbnailTarget,
                         ),
                       ),
                     ),

--- a/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
+++ b/lib/features/dashboard/presentation/widgets/photo_ribbon_card.dart
@@ -61,7 +61,15 @@ class PhotoRibbonCard extends ConsumerWidget {
                       borderRadius: BorderRadius.circular(8),
                       child: SizedBox(
                         width: 128,
-                        child: MediaItemView(item: item, thumbnail: true),
+                        child: MediaItemView(
+                          item: item,
+                          thumbnail: true,
+                          // Sized to the tile, not the photo: the ribbon
+                          // draws a screenful of these at once, and the
+                          // originals behind them are full-resolution
+                          // camera files.
+                          targetSize: const Size(200, 200),
+                        ),
                       ),
                     ),
                   );

--- a/lib/features/media/presentation/pages/photo_viewer_page.dart
+++ b/lib/features/media/presentation/pages/photo_viewer_page.dart
@@ -56,7 +56,12 @@ class PhotoViewerPage extends ConsumerStatefulWidget {
 }
 
 class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
-  late PageController _pageController;
+  /// Built once, on the first frame that has a gallery to show, because
+  /// [PageController.initialPage] is the only way to open on a page other
+  /// than the first and the initial page is not known until the dive's media
+  /// resolves. Null until then; the loading branch renders no gallery.
+  PageController? _pageController;
+
   int _currentIndex = 0;
   bool _showOverlay = true;
 
@@ -87,7 +92,6 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
   @override
   void initState() {
     super.initState();
-    _pageController = PageController();
 
     // Set immersive mode for full-screen experience
     SystemChrome.setEnabledSystemUIMode(
@@ -98,7 +102,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
 
   @override
   void dispose() {
-    _pageController.dispose();
+    _pageController?.dispose();
     // Restore system UI
     SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.edgeToEdge,
@@ -130,16 +134,27 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
             );
           }
 
-          // Find initial index
-          final initialIndex = mediaList.indexWhere(
-            (m) => m.id == widget.initialMediaId,
-          );
-          if (initialIndex != -1 && _pageController.hasClients == false) {
-            _currentIndex = initialIndex;
-            _pageController = PageController(initialPage: initialIndex);
+          // Seed the pager on the photo that was tapped, once. Keyed on the
+          // controller being absent rather than on hasClients: the gallery
+          // detaches whenever it is unmounted (an emptied list, a rebuild
+          // between frames), which reads identically to "not attached yet"
+          // and had every such rebuild mint a replacement and leak the live
+          // controller.
+          if (_pageController == null) {
+            final initialIndex = mediaList.indexWhere(
+              (m) => m.id == widget.initialMediaId,
+            );
+            _currentIndex = initialIndex == -1 ? 0 : initialIndex;
+            _pageController = PageController(initialPage: _currentIndex);
           }
+          final pageController = _pageController!;
 
-          final currentItem = mediaList[_currentIndex];
+          // The gallery is live: a delete elsewhere, a dive-deletion cascade
+          // or a sync pull can drop it below the open page. The pager
+          // corrects itself on the next settle, so clamp for this frame
+          // rather than writing the state back during build.
+          final currentIndex = _currentIndex.clamp(0, mediaList.length - 1);
+          final currentItem = mediaList[currentIndex];
           final enrichment = currentItem.enrichment;
 
           // Get dive profile for the mini chart overlay
@@ -215,7 +230,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
                 // Photo/video gallery
                 _PhotoGallery(
                   mediaList: mediaList,
-                  pageController: _pageController,
+                  pageController: pageController,
                   onPageChanged: (index) {
                     setState(() => _currentIndex = index);
                   },
@@ -224,7 +239,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
                       setState(() => _showOverlay = !_showOverlay),
                   onSetOverlay: (value) => setState(() => _showOverlay = value),
                   onVideoControllerChanged: _onVideoControllerChanged,
-                  currentIndex: _currentIndex,
+                  currentIndex: currentIndex,
                 ),
 
                 // Transparent tap target to toggle overlays (photos only)
@@ -247,7 +262,7 @@ class _PhotoViewerPageState extends ConsumerState<PhotoViewerPage> {
                   // Top app bar
                   _TopOverlay(
                     item: currentItem,
-                    currentIndex: _currentIndex,
+                    currentIndex: currentIndex,
                     totalCount: mediaList.length,
                     onClose: () => Navigator.of(context).pop(),
                     onShare: () => _shareCurrentPhoto(currentItem),

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -9,6 +9,12 @@ import 'package:submersion/features/media/presentation/providers/media_resolver_
 import 'package:submersion/features/media/presentation/widgets/unavailable_media_placeholder.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
+/// Decode target used when a caller asks for a [MediaItemView.thumbnail]
+/// without naming a size. Matches the largest tile in the app (the media
+/// grid), so it is safe for any of them and still two orders of magnitude
+/// cheaper than the original.
+const Size kDefaultThumbnailTarget = Size(200, 200);
+
 /// Universal display widget for any [MediaItem] regardless of its source
 /// type.
 ///
@@ -31,7 +37,13 @@ import 'package:submersion/features/media_store/presentation/providers/media_sto
 class MediaItemView extends ConsumerStatefulWidget {
   final MediaItem item;
   final BoxFit fit;
+
+  /// Decode target for [thumbnail] requests. Defaults to
+  /// [kDefaultThumbnailTarget]; ignored when [thumbnail] is false.
   final Size? targetSize;
+
+  /// Whether this view only ever draws a tile. Thumbnail requests never touch
+  /// the full-resolution original, with or without a [targetSize].
   final bool thumbnail;
 
   const MediaItemView({
@@ -100,10 +112,16 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
   Future<_Resolution> _resolve() async {
     final registry = ref.read(mediaSourceResolverRegistryProvider);
     final resolver = registry.resolverFor(widget.item.sourceType);
-    final native = widget.thumbnail && widget.targetSize != null
+    // [thumbnail] alone decides the path. Requiring a [targetSize] too made
+    // the flag a silent no-op wherever one was omitted, and the fallback is
+    // the full-resolution original: for a gallery item, AssetEntity
+    // .originBytes, decoded at native resolution because the Image widgets
+    // below carry no cacheWidth. A screenful of 12 MP originals behind
+    // 128 px tiles is enough for iOS to kill the app.
+    final native = widget.thumbnail
         ? await resolver.resolveThumbnail(
             widget.item,
-            target: widget.targetSize!,
+            target: widget.targetSize ?? kDefaultThumbnailTarget,
           )
         : await resolver.resolve(widget.item);
     if (native is! UnavailableData) {

--- a/test/features/dashboard/presentation/widgets/photo_ribbon_exit_test.dart
+++ b/test/features/dashboard/presentation/widgets/photo_ribbon_exit_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dashboard/presentation/providers/photo_providers.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/photo_ribbon_card.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+final _t0 = DateTime.utc(2026, 1, 1);
+
+MediaItem _photo(String id, String diveId) => MediaItem(
+  id: id,
+  diveId: diveId,
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.platformGallery,
+  filePath: '/tmp/$id.jpg',
+  takenAt: _t0,
+  createdAt: _t0,
+  updatedAt: _t0,
+);
+
+void main() {
+  testWidgets('closing the viewer opened from the ribbon returns to the '
+      'dashboard without error', (tester) async {
+    final base = await getBaseOverrides();
+    final gallery = [
+      _photo('p1', 'd1'),
+      _photo('p2', 'd1'),
+      _photo('p3', 'd1'),
+    ];
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const Scaffold(
+            body: SingleChildScrollView(child: PhotoRibbonCard()),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          // The ribbon shows the newest photo first; tapping it opens the
+          // viewer positioned at that photo inside its dive's gallery.
+          recentPhotosProvider.overrideWith((ref) async => [gallery.last]),
+          mediaForDiveProvider('d1').overrideWith((ref) async => gallery),
+          diveProvider('d1').overrideWith(
+            (ref) async =>
+                domain.Dive(id: 'd1', dateTime: DateTime.utc(2026, 1, 1, 9)),
+          ),
+        ].cast(),
+        child: MaterialApp.router(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(ClipRRect).first);
+    await tester.pumpAndSettle();
+    expect(find.byType(PhotoViewerPage), findsOneWidget);
+
+    // Exit via the toolbar close button.
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PhotoViewerPage), findsNothing);
+    expect(find.byType(PhotoRibbonCard), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/features/dashboard/presentation/widgets/photo_ribbon_memory_test.dart
+++ b/test/features/dashboard/presentation/widgets/photo_ribbon_memory_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dashboard/presentation/providers/photo_providers.dart';
+import 'package:submersion/features/dashboard/presentation/widgets/photo_ribbon_card.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+import '../../../media/presentation/support/media_widget_harness.dart';
+
+final _t0 = DateTime.utc(2026, 1, 1);
+
+MediaItem _photo(String id) => MediaItem(
+  id: id,
+  diveId: 'd1',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.platformGallery,
+  platformAssetId: 'asset-$id',
+  takenAt: _t0,
+  createdAt: _t0,
+  updatedAt: _t0,
+);
+
+/// The ribbon draws 128x96 tiles. Resolving the full-resolution original for
+/// one is already wasteful; doing it for a screenful of them, on top of the
+/// full-resolution images the photo viewer legitimately holds, is what pushed
+/// the iPhone over its memory limit and had iOS kill the app on the way back
+/// out of the viewer.
+void main() {
+  testWidgets('the ribbon resolves thumbnails, never full-resolution '
+      'originals', (tester) async {
+    final base = await getBaseOverrides();
+    final resolver = FakeLocalFileResolver(BytesData(bytes: onePixelPng()));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          mediaSourceResolverRegistryProvider.overrideWithValue(
+            MediaSourceResolverRegistry({
+              MediaSourceType.platformGallery: resolver,
+            }),
+          ),
+          recentPhotosProvider.overrideWith(
+            (ref) async => [for (var i = 0; i < 12; i++) _photo('p$i')],
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: SingleChildScrollView(child: PhotoRibbonCard())),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      resolver.resolvedFullSize,
+      isEmpty,
+      reason:
+          'a 128x96 tile must not pull AssetEntity.originBytes; that is a '
+          'full-size decode per visible photo',
+    );
+    expect(resolver.resolvedThumbnailTargets, isNotEmpty);
+    for (final target in resolver.resolvedThumbnailTargets) {
+      expect(target.width, lessThanOrEqualTo(400));
+      expect(target.height, lessThanOrEqualTo(400));
+    }
+  });
+}

--- a/test/features/dashboard/presentation/widgets/photo_ribbon_memory_test.dart
+++ b/test/features/dashboard/presentation/widgets/photo_ribbon_memory_test.dart
@@ -38,6 +38,12 @@ void main() {
     final base = await getBaseOverrides();
     final resolver = FakeLocalFileResolver(BytesData(bytes: onePixelPng()));
 
+    // Pinned so the expected target is exact rather than whatever the host
+    // view happens to report. ThumbnailSize is in device pixels, so a 128 pt
+    // tile on a 3x screen wants 384 of them.
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
@@ -70,8 +76,11 @@ void main() {
     );
     expect(resolver.resolvedThumbnailTargets, isNotEmpty);
     for (final target in resolver.resolvedThumbnailTargets) {
-      expect(target.width, lessThanOrEqualTo(400));
-      expect(target.height, lessThanOrEqualTo(400));
+      expect(
+        target,
+        const Size.square(128 * 3.0),
+        reason: 'the target is the tile in device pixels, not a magic number',
+      );
     }
   });
 }

--- a/test/features/media/presentation/pages/photo_viewer_gallery_change_test.dart
+++ b/test/features/media/presentation/pages/photo_viewer_gallery_change_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photo_view/photo_view_gallery.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/pages/photo_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// The viewer is opened at one photo but pages across the whole dive gallery,
+/// and that gallery is live: a delete from the files tab, a dive-deletion
+/// cascade or a sync pull rewrites it underneath the open viewer.
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  MediaItem photo(String id) => MediaItem(
+    id: id,
+    diveId: 'd1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: 'g-$id',
+    takenAt: DateTime.utc(2026, 7, 1, 10),
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 1),
+  );
+
+  final all = [photo('p1'), photo('p2'), photo('p3')];
+
+  /// Mutable backing for the overridden gallery provider, so a test can
+  /// rewrite the list and invalidate to replay a real-world change.
+  late List<MediaItem> gallery;
+
+  Future<void> settle(WidgetTester tester) async {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    await tester.pump();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    await tester.pump();
+  }
+
+  /// Opens the viewer on the LAST photo, the way the home ribbon does: it
+  /// shows the newest photos, which sit at the end of their dive's gallery.
+  Future<ProviderContainer> pump(WidgetTester tester) async {
+    gallery = List.of(all);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          mediaForDiveProvider('d1').overrideWith((ref) async => gallery),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PhotoViewerPage(diveId: 'd1', initialMediaId: 'p3'),
+        ),
+      ),
+    );
+    await settle(tester);
+    return ProviderScope.containerOf(
+      tester.element(find.byType(PhotoViewerPage)),
+    );
+  }
+
+  Future<void> replaceGallery(
+    WidgetTester tester,
+    ProviderContainer container,
+    List<MediaItem> next,
+  ) async {
+    gallery = next;
+    container.invalidate(mediaForDiveProvider('d1'));
+    await settle(tester);
+  }
+
+  testWidgets('a gallery that shrinks past the open page does not throw', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final container = await pump(tester);
+      expect(find.text('3 / 3'), findsOneWidget);
+
+      // Two of the three photos are gone; the viewer was sitting on index 2.
+      await replaceGallery(tester, container, [photo('p1')]);
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'indexing the shrunken list must not go out of range',
+      );
+      expect(find.byType(PhotoViewerPage), findsOneWidget);
+      expect(find.text('1 / 1'), findsOneWidget);
+    });
+  });
+
+  testWidgets('the page controller is created once and survives the gallery '
+      'emptying and repopulating', (tester) async {
+    await tester.runAsync(() async {
+      final container = await pump(tester);
+      final first = tester
+          .widget<PhotoViewGallery>(find.byType(PhotoViewGallery))
+          .pageController;
+      expect(first, isNotNull);
+
+      // Emptying unmounts the gallery, which detaches the controller. That
+      // is the state the old hasClients check could not tell apart from
+      // "not attached yet", so it minted a replacement and dropped the
+      // original on the floor -- a leak on every such rebuild.
+      await replaceGallery(tester, container, []);
+      expect(find.byType(PhotoViewGallery), findsNothing);
+
+      await replaceGallery(tester, container, List.of(all));
+      final second = tester
+          .widget<PhotoViewGallery>(find.byType(PhotoViewGallery))
+          .pageController;
+
+      expect(
+        identical(first, second),
+        isTrue,
+        reason: 'the viewer must reuse its controller, not leak and replace',
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/media/presentation/widgets/media_item_view_thumbnail_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_thumbnail_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+import '../support/media_widget_harness.dart';
+
+/// `thumbnail: true` is the caller's statement that a few hundred pixels are
+/// all this tile will ever draw. Honouring it only when a [Size] happens to
+/// be supplied made the flag a silent no-op at any call site that forgot one,
+/// and the fallback is not a cheap one: for a gallery item it is
+/// `AssetEntity.originBytes`, the untouched original, decoded at full native
+/// resolution because the Image widgets carry no cacheWidth. A dozen 12 MP
+/// originals is roughly 600 MB of RGBA, which is how an iPhone gets jetsammed.
+void main() {
+  late FakeLocalFileResolver resolver;
+
+  Future<void> pumpView(
+    WidgetTester tester, {
+    required bool thumbnail,
+    Size? targetSize,
+  }) async {
+    final base = await getBaseOverrides();
+    resolver = FakeLocalFileResolver(BytesData(bytes: onePixelPng()));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          mediaSourceResolverRegistryProvider.overrideWithValue(
+            MediaSourceResolverRegistry({
+              MediaSourceType.localFile: resolver,
+              MediaSourceType.platformGallery: resolver,
+            }),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 128,
+              height: 96,
+              child: MediaItemView(
+                item: testMediaItem(),
+                thumbnail: thumbnail,
+                targetSize: targetSize,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a sized thumbnail request resolves a thumbnail', (tester) async {
+    await pumpView(tester, thumbnail: true, targetSize: const Size(200, 200));
+
+    expect(resolver.resolvedThumbnailTargets, [const Size(200, 200)]);
+    expect(resolver.resolvedFullSize, isEmpty);
+  });
+
+  testWidgets('an unsized thumbnail request still resolves a thumbnail, not '
+      'the full-resolution original', (tester) async {
+    await pumpView(tester, thumbnail: true);
+
+    expect(
+      resolver.resolvedFullSize,
+      isEmpty,
+      reason: 'thumbnail: true must never fall through to the original',
+    );
+    expect(resolver.resolvedThumbnailTargets, hasLength(1));
+  });
+
+  testWidgets('a non-thumbnail request resolves the full-resolution original', (
+    tester,
+  ) async {
+    await pumpView(tester, thumbnail: false);
+
+    expect(resolver.resolvedFullSize, ['m1']);
+    expect(resolver.resolvedThumbnailTargets, isEmpty);
+  });
+}

--- a/test/features/media_store/support/fake_local_file_resolver.dart
+++ b/test/features/media_store/support/fake_local_file_resolver.dart
@@ -19,6 +19,14 @@ class FakeLocalFileResolver implements MediaSourceResolver {
   /// gallery resolver's pre-compressed poster bytes for videos).
   MediaSourceData? thumbnailData;
 
+  /// Ids passed to [resolve], the full-resolution original path. Tiles that
+  /// only ever draw a few hundred pixels must not appear here: on the real
+  /// gallery resolver this is `AssetEntity.originBytes`.
+  final List<String> resolvedFullSize = [];
+
+  /// Thumbnail targets requested, in call order.
+  final List<Size> resolvedThumbnailTargets = [];
+
   @override
   MediaSourceType get sourceType => MediaSourceType.localFile;
 
@@ -26,13 +34,19 @@ class FakeLocalFileResolver implements MediaSourceResolver {
   bool canResolveOnThisDevice(MediaItem item) => true;
 
   @override
-  Future<MediaSourceData> resolve(MediaItem item) async => data;
+  Future<MediaSourceData> resolve(MediaItem item) async {
+    resolvedFullSize.add(item.id);
+    return data;
+  }
 
   @override
   Future<MediaSourceData> resolveThumbnail(
     MediaItem item, {
     required Size target,
-  }) async => thumbnailData ?? data;
+  }) async {
+    resolvedThumbnailTargets.add(target);
+    return thumbnailData ?? data;
+  }
 
   @override
   Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async => null;


### PR DESCRIPTION
## The crash

Reported: on iPhone, the app **quits to the home screen** when exiting a photo that was opened from the home page's "Recent photos" ribbon. TestFlight/release build. The same viewer opened from a dive gallery is fine.

A release build strips asserts and survives uncaught Dart exceptions, so a clean quit points at a native kill (jetsam) rather than a Flutter error. It is memory.

## Root cause

`MediaItemView._resolve` gated its cheap path on **two** conditions:

```dart
final native = widget.thumbnail && widget.targetSize != null
    ? await resolver.resolveThumbnail(...)
    : await resolver.resolve(widget.item);   // full-resolution original
```

So `thumbnail: true` was a silent no-op at any call site that omitted `targetSize`. The fallback is not cheap: for a `platformGallery` item it is `AssetEntity.originBytes`, the untouched camera original, rendered by `Image.memory` with no `cacheWidth`/`cacheHeight` — so it decodes at full native resolution however small the box. A 12 MP photo is ~48 MB of RGBA.

Every thumbnail call site in the app passes a size — `media_grid.dart` (200x200), `trip_photo_section.dart` (160x160), `trip_story_day_card.dart` (128x128), `photo_marker_overlay.dart` (200x200) — **except** `photo_ribbon_card.dart`, added three days ago in d098b24c084. It draws 128x96 tiles. The regression test in this PR measures it pulling **8 full-resolution originals for one screenful**.

The peak lands on the way *out*: during the fullscreen-dialog pop the viewer's own full-resolution images are still mounted while the dashboard re-decodes the ribbon behind it.

## Changes

**1. `thumbnail` alone decides the path** (`media_item_view.dart`), defaulting to `kDefaultThumbnailTarget` (200x200) when no size is named. Fixed in the widget rather than only at the call site, so the trap is closed for future callers.

The ribbon computes its own target from the tile: `Size.square(_tileWidth * devicePixelRatio)`. `ThumbnailSize` reaches `PHImageManager` in **device** pixels, so a fixed 200 would have been *under* the 384 a 128 pt tile needs at 3x and rendered soft. Square, matching every other tile request in the app, so `BoxFit.cover` crops in Flutter rather than in photo_manager. At 3x that is ~0.15 MP per tile against the ~12 MP original the unsized request used to decode.

**2. Two latent defects in `photo_viewer_page.dart`**, both on this path, neither able to quit a release build:

- The `PageController` was built in `initState` then **replaced** during `build` whenever `hasClients == false`, dropping the live one. That predicate conflates two states — `hasClients` reads false both before the gallery attaches and after it detaches, and an emptied list unmounts `PhotoViewGallery`. Now nullable and seeded once on `_pageController == null`.
- `mediaList[_currentIndex]` had no bounds guard, throwing `RangeError` when the gallery shrank under the open viewer (a delete from the files tab, a dive-deletion cascade, a sync pull). Clamped into a build-local `currentIndex` rather than written back during build — `PageView` corrects `_currentIndex` itself on the next settle.

## Tests

Four new files, each written failing first and observed failing with the expected symptom:

| Test | Caught |
|---|---|
| `media_item_view_thumbnail_test.dart` | unsized thumbnail request reaching for the original |
| `photo_ribbon_memory_test.dart` | 8 full-resolution originals for one screenful of tiles |
| `photo_viewer_gallery_change_test.dart` | `RangeError (length): Only valid value is 0: 2`; replaced controller |
| `photo_ribbon_exit_test.dart` | ribbon -> viewer -> close, end to end |

`FakeLocalFileResolver` gained `resolvedFullSize` / `resolvedThumbnailTargets` call logs so any tile can assert it never reaches for an original.

Verified locally: `dart format` clean, `flutter analyze` clean project-wide, full `flutter test` green.

## Note on history

This branch originally carried a third commit fixing `speciesSightingCountsProvider`, which was failing `provider_change_tick_test` on `main`. #1006 landed the same fix first, and with a tighter tick — a dedicated `watchSightingChanges()` on the `sightings` table rather than the broad `watchDiveDetailChanges()`. That commit has been dropped and the branch rebased onto current `main`, which is also what unblocked CI (the conflict was suppressing it).

## Caveat

The defect and the full mechanism are proven, but the jetsam kill itself was not reproduced — that needs a build on the device. The ribbon's footprint drops from roughly 400 MB to under 1 MB, which is the only memory-relevant difference between the ribbon path and the dive-gallery path that does not crash. If it still quits after this, the next suspect is the viewer's own uncapped full-resolution decode, which is shared with the paths reported as working.
