### PR TITLE
fix(sync): stop the stale-restore cold-start from re-firing every sync

### DIFF
--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -554,8 +554,30 @@ class SyncRepository {
   }
 
   /// Public accessor for [_maxRowHlc] -- the highest hlc across conflict-capable
-  /// tables. Used by stale-restore detection.
+  /// tables.
   Future<String?> maxRowHlc() => _maxRowHlc();
+
+  /// The highest hlc this device still ACCOUNTS FOR: live rows or tombstones.
+  ///
+  /// [maxRowHlc] alone answers "what do I still have", which is the wrong
+  /// question for stale-restore detection. Deleting the newest record drops the
+  /// live-row maximum below the published watermark even though nothing was
+  /// rewound -- the tombstone stamped at deletion time (always ABOVE anything
+  /// previously published, since it comes from `SyncClock.issue()`) is the
+  /// device's record of that decision. Counting it distinguishes "the user
+  /// removed data" from "a restore rewound this device", which loses the
+  /// tombstones along with the rows.
+  Future<String?> maxAccountedHlc() async {
+    final rowHigh = await _maxRowHlc();
+    final maxDeletionHlc = _db.deletionLog.hlc.max();
+    final row = await (_db.selectOnly(
+      _db.deletionLog,
+    )..addColumns([maxDeletionHlc])).getSingleOrNull();
+    final tombstoneHigh = row?.read(maxDeletionHlc);
+    if (rowHigh == null) return tombstoneHigh;
+    if (tombstoneHigh == null) return rowHigh;
+    return rowHigh.compareTo(tombstoneHigh) >= 0 ? rowHigh : tombstoneHigh;
+  }
 
   /// Pick the greater of [a]/[b] by (physicalTime, counter) and rebuild it with
   /// [nodeId] so the clock always issues under THIS device's identity.

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -55,6 +55,14 @@ class ChangesetWriter {
     /// Null when the hostname identifies nothing; readers fall back to the id.
     String? deviceName,
     Map<String, String> appliedPeerHlc = const {},
+
+    /// Rewrite this device's log as a fresh base even when the cloud manifest
+    /// already has one. Set after a stale-restore cold-start: the published log
+    /// describes rows this device no longer holds, and `publishedHlcHigh` only
+    /// ever moves UP, so a changeset can never bring it back down to the truth.
+    /// Leaving it over-claiming makes the stale-restore detector fire again on
+    /// every subsequent sync, wiping all peer cursors each time (#997).
+    bool forceBase = false,
   }) async {
     final providerId = provider.providerId;
     final ownManifest = await _readOwnManifest(provider, folderId, deviceId);
@@ -68,7 +76,7 @@ class ChangesetWriter {
     // there is nothing to append to, so cold-start a fresh base. `state` still
     // recovers the seq counter (knownHeadSeq) so the new base never reuses a
     // number.
-    final hasBase = ownManifest?.baseSeq != null;
+    final hasBase = !forceBase && ownManifest?.baseSeq != null;
     final watermark = ownManifest?.publishedHlcHigh ?? state?.publishedHlcHigh;
     // The post-adopt marker (a publish-state row with a null baseSeq): this
     // device's library IS the adopted epoch the peers already published, so
@@ -86,7 +94,11 @@ class ChangesetWriter {
     // adopt for an empty library (the base below no-ops) or one whose rows
     // all predate HLC stamping (one streamed base publish, safely bounded).
     final adoptedNoBase =
-        !hasBase && state != null && state.baseSeq == null && watermark != null;
+        !forceBase &&
+        !hasBase &&
+        state != null &&
+        state.baseSeq == null &&
+        watermark != null;
 
     final newSeq = knownHeadSeq + 1;
     final now = DateTime.now().millisecondsSinceEpoch;
@@ -103,7 +115,12 @@ class ChangesetWriter {
         seq: newSeq,
       );
       try {
-        if (base.rowCount == 0 && deletions.isEmpty) {
+        // Nothing to say -- except under [forceBase], where the point of the
+        // publish is the manifest, not its contents: an empty base still
+        // replaces an over-claiming `publishedHlcHigh` with the truth (null),
+        // which is what stops the stale-restore loop for a device rewound to an
+        // empty library. Peers apply an empty base as a no-op (upsert + LWW).
+        if (base.rowCount == 0 && deletions.isEmpty && !forceBase) {
           return const ChangesetWriteResult(ChangesetWriteKind.noop);
         }
         final upload = await BasePartFileSource(base.path).uploadAll(
@@ -143,6 +160,14 @@ class ChangesetWriter {
             updatedAt: Value(now),
           ),
         );
+        // A forced base SUPERSEDES an existing log rather than starting one, so
+        // the old base parts and changesets are now dead weight -- potentially
+        // a whole library's worth. Prune them exactly as compaction does (see
+        // _pruneSupersededBelow: best-effort, readers self-heal from the new
+        // base). An ordinary cold-start has nothing below it to prune.
+        if (forceBase) {
+          await _pruneSupersededBelow(provider, folderId, deviceId, newSeq);
+        }
         return ChangesetWriteResult(ChangesetWriteKind.base, newSeq);
       } finally {
         try {

--- a/lib/core/services/sync/changeset_log/stale_restore_detector.dart
+++ b/lib/core/services/sync/changeset_log/stale_restore_detector.dart
@@ -25,7 +25,10 @@ class StaleRestoreDetector {
     final manifest = await _readOwnManifest(provider, folderId, deviceId);
     final published = manifest?.publishedHlcHigh;
     if (published == null) return false; // never published anything
-    final localHigh = await _repo.maxRowHlc();
+    // Tombstones count: a device that deliberately deleted its newest records
+    // has not been rewound, and treating that as a restore triggers a full
+    // cold-start re-pull of every peer on every sync (#997).
+    final localHigh = await _repo.maxAccountedHlc();
     if (localHigh == null) return true; // cloud has data, local has none
     return localHigh.compareTo(published) < 0;
   }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -476,11 +476,13 @@ class SyncService {
       if (fence.terminal != null) return fence.terminal!;
 
       // ---- Stale-restore: cold-start to re-pull the authoritative library ----
+      var staleRestoreDetected = false;
       if (await _staleRestoreDetector.isStaleRestore(
         provider: provider,
         deviceId: deviceId,
         folderId: folderId,
       )) {
+        staleRestoreDetected = true;
         _log.warning('Stale restore detected; resetting changeset cursors');
         final db = DatabaseService.instance.database;
         await PeerCursorStore(db).resetForProvider(provider.providerId);
@@ -584,6 +586,12 @@ class SyncService {
             uploadNonce: uploadNonce,
             deviceName: await _deviceNameForManifest(),
             appliedPeerHlc: appliedPeerHlc,
+            // Republish our log from what we actually hold now. Without this
+            // the cold-start above never converges: our manifest keeps
+            // claiming an HLC we no longer have, so the next sync detects the
+            // same "stale restore" and wipes every peer cursor again -- a full
+            // re-download of the whole fleet's data, every sync (#997).
+            forceBase: staleRestoreDetected,
           );
           // A publish that did not stamp this nonce into the manifest -- a
           // noop (nothing to say) or a heartbeat (which deliberately keeps

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -28,6 +28,7 @@ import 'package:submersion/core/services/cloud_storage/icloud_native_service.dar
 import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_credentials_store.dart';
 import 'package:submersion/core/services/cloud_storage/s3_storage_provider.dart';
+import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
 import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
 import 'package:submersion/core/services/sync/crypto/keyslots.dart';
 import 'package:submersion/core/services/sync/crypto/sync_encryption_service.dart';
@@ -811,6 +812,15 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// [firstSyncMergeInfo] pre-check pattern for the Sync Now button.
   Future<LibraryEpochMarker?> libraryReplaceInfo() async {
     try {
+      // Load any stored encryption key BEFORE resolving the provider, for the
+      // same reason performSync does: the provider wrap watches the SESSION, so
+      // reading it first hands back the raw provider and every byte of an
+      // encrypted library reads as an opaque SBE1 envelope. This runs from an
+      // unawaited launch hook (_detectReplacedLibraryForSurfacing), which is
+      // precisely when the session has not been loaded yet -- so without this
+      // an encrypted library could never surface a replace at all.
+      await _ref.read(encryptionKeyNotifierProvider.notifier).ensureLoaded();
+      if (!mounted) return null;
       final provider = _ref.read(cloudStorageProviderProvider);
       if (provider == null) return null;
       final store = _ref.read(libraryEpochStoreProvider);
@@ -824,6 +834,13 @@ class SyncNotifier extends StateNotifier<SyncState> {
           store.lastAcceptedEpochId;
       if (marker.epochId == accepted) return null;
       return marker;
+    } on SyncEncryptionRequired {
+      // Encrypted with no key on this device yet: an expected state, not a
+      // fault. performSync halts with awaitingPassphrase and the UI prompts,
+      // so this pre-check simply has nothing to report -- logging it as a
+      // warning on every launch would be noise.
+      _log.debug('Library replace pre-check skipped: library is locked');
+      return null;
     } catch (e) {
       // Never block the button on this pre-check; performSync gates anyway.
       _log.warning('Library replace pre-check failed: $e');

--- a/test/core/services/sync/changeset_log/changeset_writer_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_writer_test.dart
@@ -571,4 +571,101 @@ void main() {
       expect(result.kind, ChangesetWriteKind.noop);
     });
   });
+
+  group('forceBase (stale-restore republish, #997)', () {
+    Future<ChangesetWriteResult> publishForced() async {
+      final deviceId = await SyncRepository().getDeviceId();
+      return writer.publish(
+        provider: provider,
+        deviceId: deviceId,
+        folderId: folder,
+        deletions: await SyncRepository().getAllDeletions(),
+        forceBase: true,
+      );
+    }
+
+    Future<SyncManifest> ownManifest() async {
+      final deviceId = await SyncRepository().getDeviceId();
+      return SyncManifest.fromBytes(
+        await provider.downloadFile(
+          '$folder/${ChangesetLogLayout.manifestName(deviceId)}',
+        ),
+      );
+    }
+
+    test(
+      'lowers a published watermark the device can no longer back',
+      () async {
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'f1', diveNumber: 1),
+        );
+        await publish();
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'f2', diveNumber: 2),
+        );
+        await publish();
+        final claimed = (await ownManifest()).publishedHlcHigh;
+
+        // The rewind a restore leaves behind: f2 is gone with no tombstone.
+        await DatabaseService.instance.database.customStatement(
+          "DELETE FROM dives WHERE id = 'f2'",
+        );
+
+        final result = await publishForced();
+
+        expect(result.kind, ChangesetWriteKind.base);
+        final after = await ownManifest();
+        expect(
+          after.publishedHlcHigh,
+          await SyncRepository().maxRowHlc(),
+          reason: 'the manifest must describe what the device actually holds',
+        );
+        expect(after.publishedHlcHigh!.compareTo(claimed!), lessThan(0));
+      },
+    );
+
+    test('prunes the base it supersedes', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'p1', diveNumber: 1),
+      );
+      final first = await publish();
+      expect(first.kind, ChangesetWriteKind.base);
+
+      final forced = await publishForced();
+
+      final ns = await names();
+      expect(
+        ns.where((n) => ChangesetLogLayout.basePartOf(n)?.baseSeq == first.seq),
+        isEmpty,
+        reason: 'the superseded base parts must not be left orphaned',
+      );
+      expect(
+        ns.where(
+          (n) => ChangesetLogLayout.basePartOf(n)?.baseSeq == forced.seq,
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('publishes an honest empty base when the library is gone', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'e1', diveNumber: 1),
+      );
+      await publish();
+      await DatabaseService.instance.database.customStatement(
+        'DELETE FROM dives',
+      );
+
+      final result = await publishForced();
+
+      expect(
+        result.kind,
+        ChangesetWriteKind.base,
+        reason:
+            'a noop here would leave the manifest over-claiming forever, so '
+            'every later sync re-fires the stale-restore cold-start',
+      );
+      expect((await ownManifest()).publishedHlcHigh, isNull);
+    });
+  });
 }

--- a/test/core/services/sync/changeset_log/stale_restore_detector_test.dart
+++ b/test/core/services/sync/changeset_log/stale_restore_detector_test.dart
@@ -80,11 +80,41 @@ void main() {
       await publish(); // published watermark now == d2's hlc
 
       // Simulate a restore to an earlier state: drop the newest row so the local
-      // HLC high-water falls below the published watermark.
+      // HLC high-water falls below the published watermark. Raw SQL, so no
+      // tombstone is written -- a restore rewinds the deletion log too.
       await DatabaseService.instance.database.customStatement(
         "DELETE FROM dives WHERE id = 'd2'",
       );
       expect(await isStale(), isTrue);
     },
   );
+
+  test('not stale after the user deletes the newest record', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publish();
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+    );
+    await publish(); // published watermark now == d2's hlc
+
+    // A legitimate delete drops the highest live-row hlc below the published
+    // watermark, but leaves a tombstone stamped ABOVE it. Nothing was rewound,
+    // so the cold-start re-pull must not fire.
+    await DiveRepository().deleteDive('d2');
+    expect(await isStale(), isFalse);
+  });
+
+  test('not stale after the user deletes every record', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await publish();
+
+    await DiveRepository().deleteDive('d1');
+    // maxRowHlc() is now null (no live hlc-bearing row at all), which reads as
+    // "cloud has data, local has none" unless tombstones count.
+    expect(await isStale(), isFalse);
+  });
 }

--- a/test/core/services/sync/stale_restore_convergence_test.dart
+++ b/test/core/services/sync/stale_restore_convergence_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/stale_restore_detector.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../helpers/test_database.dart';
+import '../../../helpers/mock_providers.dart';
+import '../../../support/fake_cloud_storage_provider.dart';
+
+/// Issue #997: a device whose own cloud manifest claims a higher HLC than it
+/// still holds re-ran the stale-restore cold-start on EVERY sync, wiping all
+/// peer cursors each time and re-downloading every peer's full base. The
+/// recovery has to make the over-claiming manifest honest so it converges after
+/// one sync instead of looping forever.
+void main() {
+  late FakeCloudStorageProvider cloud;
+  late SyncService svc;
+  late StaleRestoreDetector detector;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    cloud = FakeCloudStorageProvider();
+    svc = SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+    detector = StaleRestoreDetector(SyncRepository());
+  });
+  tearDown(() => tearDownTestDatabase());
+
+  Future<bool> isStale() async => detector.isStaleRestore(
+    provider: cloud,
+    deviceId: await SyncRepository().getDeviceId(),
+    folderId: await cloud.getOrCreateSyncFolder(),
+  );
+
+  test('one sync clears the stale-restore condition', () async {
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+    );
+    await DiveRepository().createDive(
+      createTestDiveWithBottomTime(id: 'd2', diveNumber: 2),
+    );
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+
+    // Rewind past the published watermark, the way a database restore would:
+    // raw delete, so no tombstone is left behind.
+    await DatabaseService.instance.database.customStatement(
+      "DELETE FROM dives WHERE id = 'd2'",
+    );
+    expect(
+      await isStale(),
+      isTrue,
+      reason: 'precondition: the rewind must be detected',
+    );
+
+    expect((await svc.performSync()).status, SyncResultStatus.success);
+
+    expect(
+      await isStale(),
+      isFalse,
+      reason:
+          'the recovery sync must republish an honest watermark; otherwise '
+          'every later sync re-fires the cold-start and re-pulls every peer',
+    );
+  });
+
+  test(
+    'the recovery sync does not re-pull the peer it already holds',
+    () async {
+      // --- Device A: publish a base, then a changeset on top of it ---
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'a1', diveNumber: 1),
+      );
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'a2', diveNumber: 2),
+      );
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+      await tearDownTestDatabase();
+
+      // --- Device B: cold-start from A, then publish something of its own ---
+      await setUpTestDatabase();
+      svc = SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+      );
+      detector = StaleRestoreDetector(SyncRepository());
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'b1', diveNumber: 3),
+      );
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'b2', diveNumber: 4),
+      );
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+
+      // B is rewound below its own published watermark.
+      await DatabaseService.instance.database.customStatement(
+        "DELETE FROM dives WHERE id = 'b2'",
+      );
+      expect(await isStale(), isTrue);
+
+      // First sync after the rewind: the cold-start legitimately re-pulls A.
+      cloud.resetDownloadLog();
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+
+      // Second sync: nothing changed anywhere, so A's base must not move again.
+      cloud.resetDownloadLog();
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+      expect(
+        cloud.downloadedNames.where((n) => n.contains('.base.')),
+        isEmpty,
+        reason:
+            'a settled sync must not re-download any peer base -- that is the '
+            '#997 "sync takes forever and never finishes" symptom',
+      );
+    },
+  );
+}

--- a/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
+++ b/test/features/settings/presentation/providers/sync_providers_epoch_test.dart
@@ -6,7 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show SyncRepository;
+import 'package:submersion/core/services/cloud_storage/encrypting_cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
+import 'package:submersion/core/services/sync/crypto/sync_envelope.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
@@ -18,6 +21,7 @@ import '../../../../helpers/changeset_test_helpers.dart';
 import '../../../../helpers/fake_cloud_storage_provider.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_database.dart';
+import '../../../../support/fake_keychain_storage.dart';
 
 /// Coverage for the REAL SyncNotifier's library-epoch paths (the cloud sync
 /// page widget tests exercise a fake notifier, not this code): replace-info
@@ -135,6 +139,85 @@ void main() {
           .read(syncStateProvider.notifier)
           .libraryReplaceInfo();
       expect(info, isNull);
+    });
+
+    group('encrypted library', () {
+      const keyId = '8f14e45f-ceea-467f-ab37-a10a8d5f4c11';
+      final mlkBytes = List<int>.generate(32, (i) => i);
+      late EncryptionKeyStore keyStore;
+
+      /// A container wired the way the REAL cloudStorageProviderProvider is:
+      /// the encrypting wrap follows the unlocked SESSION, which only exists
+      /// after the notifier has loaded the key out of secure storage. Mirroring
+      /// that composition here is what makes the ordering observable -- reading
+      /// the provider before `ensureLoaded()` yields the RAW provider and the
+      /// encrypted marker is unreadable.
+      Future<ProviderContainer> makeEncryptedContainer() async {
+        keyStore = EncryptionKeyStore(storage: InMemoryKeychain());
+        await keyStore.saveKey(libraryKeyId: keyId, mlkBytes: mlkBytes);
+        SharedPreferences.setMockInitialValues({
+          'sync_encryption_enabled': true,
+        });
+        prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            encryptionKeyStoreProvider.overrideWithValue(keyStore),
+            cloudStorageProviderProvider.overrideWith((ref) {
+              final session = ref.watch(encryptionKeyNotifierProvider);
+              if (session == null) return cloud;
+              return EncryptingCloudStorageProvider(
+                cloud,
+                dataKey: session.dataKey,
+                libraryKeyId: session.key.libraryKeyId,
+              );
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+        container.read(syncStateProvider);
+        await container.read(syncStateProvider.notifier).refreshState();
+        return container;
+      }
+
+      Future<void> seedSealedMarker(
+        ProviderContainer container,
+        LibraryEpochMarker m,
+      ) async {
+        final session = await container
+            .read(encryptionKeyNotifierProvider.notifier)
+            .ensureLoaded();
+        cloud.seedFile(
+          libraryEpochFileName,
+          await SyncEnvelope.seal(
+            plaintext: Uint8List.fromList(utf8.encode(jsonEncode(m.toJson()))),
+            dataKey: session!.dataKey,
+            libraryKeyId: keyId,
+            filename: libraryEpochFileName,
+          ),
+        );
+        // Put the container back in its launch state: the key is in secure
+        // storage but no session has been loaded yet, exactly as it is when
+        // the launch-time surfacing hook runs.
+        await container.read(encryptionKeyNotifierProvider.notifier).clear();
+      }
+
+      test('returns the marker without waiting for a manual unlock', () async {
+        final container = await makeEncryptedContainer();
+        await seedSealedMarker(container, marker);
+
+        final info = await container
+            .read(syncStateProvider.notifier)
+            .libraryReplaceInfo();
+
+        expect(
+          info?.epochId,
+          'e1',
+          reason:
+              'the pre-check must load the stored key first, like performSync '
+              'does; otherwise an encrypted library never surfaces a replace',
+        );
+      });
     });
   });
 

--- a/test/support/fake_cloud_storage_provider.dart
+++ b/test/support/fake_cloud_storage_provider.dart
@@ -22,6 +22,7 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
   final Map<String, Uint8List> _files = {};
   final Map<String, int> _modified = {};
   final Map<String, int> _visibleAfterCall = {};
+  final List<String> _downloaded = [];
   int _clock = 0;
   int _listCalls = 0;
 
@@ -77,8 +78,16 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
     if (data == null) {
       throw CloudStorageException('Fake: not found: $fileId');
     }
+    _downloaded.add(fileId.substring(fileId.lastIndexOf('/') + 1));
     return Uint8List.fromList(data);
   }
+
+  /// Names (final path segment) downloaded since the last [resetDownloadLog],
+  /// so a test can assert what a sync actually pulled over the wire -- the
+  /// difference between an incremental sync and a full re-download.
+  List<String> get downloadedNames => List.unmodifiable(_downloaded);
+
+  void resetDownloadLog() => _downloaded.clear();
 
   @override
   Future<UploadResult> uploadFileFromPath(


### PR DESCRIPTION
Fixes #997.

## Symptom

Syncs ran 7-11 minutes back to back and often never appeared to finish; every
user-triggered sync bounced off `Already syncing, returning early`. From the
attached log:

```
22:26:18  Stale restore detected; resetting changeset cursors
22:33:53  Result: SyncResultStatus.success          (7m35s)
22:56:26  Stale restore detected; resetting changeset cursors   <- again
23:00:42  performSync() called / Already syncing, returning early
```

Sync was not slow. It was re-downloading every peer's entire base on *every*
sync, permanently.

## Root cause

`StaleRestoreDetector.isStaleRestore` compares our own cloud manifest's
`publishedHlcHigh` against local `maxRowHlc()`. The recovery it triggers --
wipe peer cursors and local publish state -- changes neither side:

* `publishedHlcHigh` lives in the CLOUD manifest, which the reset never touches.
* `maxRowHlc()` cannot recover, because `ChangesetReader.pull` skips our own
  device log: rows we published and then lost never come back.
* The publish that follows exports rows with `hlc > watermark`. There are none,
  so it degrades to a heartbeat that copies `publishedHlcHigh` forward verbatim.

`publishedHlcHigh` is monotonically increasing by construction, so once it
exceeded what the device held, the predicate became a fixed point: fire -> wipe
every peer cursor -> full re-pull of the whole fleet -> publish nothing -> fire
again next sync, forever. Wiping cursors makes `ChangesetReader.pull` see
`lastApplied (0) < manifest.baseSeq` for every peer, which is the full-base
re-download the incremental design exists to avoid.

The reporter entered that state by deleting records -- the log shows 11
`diveSafetyReviews` deleted at 22:31 -- which `maxRowHlc()` cannot distinguish
from a restore.

## Fix 1: tombstones count toward the local high-water

`maxRowHlc()` unions live tables only, but tombstones carry their own hlc
stamped at deletion time by `SyncClock.issue()`, so deleting your newest records
looked identical to being rewound. That is exactly the false positive the
comment in `performSync` already described but never fixed.

New `SyncRepository.maxAccountedHlc()` takes the max over live rows AND the
deletion log. Genuine restore detection is unaffected: a restore rewinds the
deletion log along with the rows, and the existing "stale when local data is
rewound" test (raw SQL delete, no tombstone) still passes.

## Fix 2: the recovery republishes an honest base

A fresh base is the only write path that can LOWER `publishedHlcHigh`, so
`ChangesetWriter.publish` takes `forceBase`, which `performSync` sets for the
sync in which the stale-restore branch fired. The condition then clears after
one sync instead of never.

The forced base supersedes an existing log rather than starting one, so it
prunes the old base parts and changesets exactly as compaction does; otherwise a
whole library's worth of dead files is orphaned in cloud storage. It also
publishes when the library is empty, since an empty base still replaces an
over-claiming watermark with the truth.

**Cost:** one full base upload on an affected device, re-downloaded once by its
peers. That replaces a permanent per-sync full download of the entire fleet.

## Fix 3: load the encryption key before the library-replace pre-check

Also visible in the log, on every launch:

```
Library replace pre-check failed:
  SyncEncryptionRequired(921c53be-...): The library epoch marker is encrypted
```

`libraryReplaceInfo()` resolved `cloudStorageProviderProvider` without first
awaiting `ensureLoaded()`. The encrypting wrap watches the unlocked SESSION, and
the session only exists once the notifier has read the key out of secure
storage, so the pre-check got the RAW provider and the marker read as an opaque
SBE1 envelope.

`performSync` already awaits `ensureLoaded()` first, with a comment naming this
exact hazard ("the provider wrap watches the session, so a launch-triggered sync
must not race the async key load"). The pre-check never got that line.

The warning was the visible part, but the real cost is that its caller --
`_detectReplacedLibraryForSurfacing`, an unawaited launch hook whose whole
purpose is to surface a Replace-everywhere adoption even when auto-sync is off
-- returned null every time on an encrypted library. That feature was silently
dead.

The genuinely-locked case (encryption on, no key on this device yet) now logs at
debug rather than warning: `performSync` halts with `awaitingPassphrase` and the
UI prompts, so the pre-check simply has nothing to report.

## Tests

8 new, each confirmed failing first for the right reason:

* `stale_restore_detector_test`: not stale after deleting the newest record; not
  stale after deleting every record. The existing genuine-rewind test still
  passes.
* `stale_restore_convergence_test` (new file): one sync clears the condition;
  and the end-to-end reproduction of the reported symptom -- a settled sync with
  nothing changed anywhere was still pulling
  `ssv1.<peer>.base.000000000003.p0000`.
* `changeset_writer_test`: forceBase lowers a watermark the device can no longer
  back, prunes the base it supersedes, and publishes an honest empty base.
* `sync_providers_epoch_test`: an encrypted library surfaces a replace without a
  manual unlock. Mirrors the real provider composition (wrap follows the
  session) so the ordering is observable.

`FakeCloudStorageProvider` gains a download log so a test can assert what a sync
actually pulled over the wire -- the difference between an incremental sync and
a full re-download.

Full suite green: 17,295 passed, 0 failed. `flutter analyze` clean, `dart
format` clean.

## Noted, not fixed here

`sync_providers_recovery_test.dart` initializes the test binding but does not
mock `path_provider`, so `resolveSyncTempDir()` falls back to
`Directory.systemTemp` -- shared across concurrently-running test isolates --
and its `repairSync()` test then sweeps every `ssv1_*` file out of it. Under
heavy machine load this can delete another test's in-flight streamed base. It is
pre-existing and unrelated to this change, so it is left for its own fix.
