### PR TITLE
Show weather on trip surface days

### DIFF
--- a/docs/superpowers/plans/2026-08-12-trip-surface-day-weather.md
+++ b/docs/superpowers/plans/2026-08-12-trip-surface-day-weather.md
@@ -1,0 +1,759 @@
+# Trip Surface-Day Weather Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show fetched historical weather on true trip surface-day headers using the same icon and unit-aware temperature badge as dive days.
+
+**Architecture:** Keep trip-story composition synchronous and render headers immediately. The story view selects the nearest existing trip map point for each surface day and passes an immutable request to a cached Riverpod family provider; that provider asks the existing Open-Meteo service for local-noon weather and returns the compact `TripStoryDayWeather` already consumed by the header.
+
+**Tech Stack:** Flutter, Dart, Riverpod, `http`, Open-Meteo Historical Weather API, `flutter_test`
+
+## Global Constraints
+
+- Work only in `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/trip-surface-day-weather` on `codex/trip-surface-day-weather`.
+- No database migration, trip-day weather entity, sync changes, or offline persistence.
+- No copying or interpolating weather values from adjacent dives.
+- Fetch only for `TripStoryDay.isSurface`; a dive day with missing logged weather must not fetch.
+- Use the nearest existing trip map point, preserving route order for equidistant ties.
+- Request 12:00 on the surface date with Open-Meteo `timezone=auto`.
+- Loading, missing-location, unavailable-weather, and request failures render no placeholder or error and cannot block the trip story.
+- Reuse the existing badge's icon precedence, semantics, typography, and active-diver temperature conversion.
+- Keep the existing dive-edit weather request URL unchanged unless a caller explicitly opts into location-local time.
+- Write every production change only after its focused test has failed for the expected missing behavior.
+- Run `dart format` on every changed Dart file.
+
+## File Structure
+
+- Modify `lib/features/trips/domain/entities/trip_story_day.dart`: pure nearest-point selection.
+- Modify `lib/features/weather/data/services/weather_service.dart`: opt-in `timezone=auto`.
+- Create `lib/features/trips/presentation/providers/surface_day_weather_provider.dart`: request/cache key and weather mapping.
+- Modify `lib/features/trips/presentation/widgets/story/trip_story_day_header.dart`: select logged or fetched weather.
+- Modify `lib/features/trips/presentation/widgets/story/trip_story_view.dart`: pass the nearest-coordinate request to surface headers.
+- Modify the matching tests under `test/features/trips/` and `test/features/weather/`; create a focused provider test.
+
+---
+
+### Task 1: Select the nearest trip map point
+
+**Files:**
+- Modify: `lib/features/trips/domain/entities/trip_story_day.dart`
+- Test: `test/features/trips/domain/entities/trip_story_day_test.dart`
+
+**Interfaces:**
+- Consumes: `TripStoryMapGeometry.points` and an integer story-day index.
+- Produces: `TripStoryMapPoint? TripStoryMapGeometry.nearestPointForDay(int dayIndex)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these cases to the existing `TripStoryMapGeometry` group. They catch selecting the wrong day, replacing the stable tie with a later point, and returning a value for empty geometry.
+
+```dart
+test('nearestPointForDay returns a point on the requested day', () {
+  const geometry = TripStoryMapGeometry(
+    points: [
+      TripStoryMapPoint(latitude: 1, longitude: 2, dayIndex: 0, label: 'A'),
+      TripStoryMapPoint(latitude: 3, longitude: 4, dayIndex: 2, label: 'B'),
+    ],
+  );
+  expect(geometry.nearestPointForDay(2)?.label, 'B');
+});
+
+test('nearestPointForDay uses the closest point at trip boundaries', () {
+  const geometry = TripStoryMapGeometry(
+    points: [
+      TripStoryMapPoint(latitude: 1, longitude: 2, dayIndex: 2, label: 'First'),
+      TripStoryMapPoint(latitude: 3, longitude: 4, dayIndex: 4, label: 'Last'),
+    ],
+  );
+  expect(geometry.nearestPointForDay(0)?.label, 'First');
+  expect(geometry.nearestPointForDay(7)?.label, 'Last');
+});
+
+test('nearestPointForDay preserves route order for an equidistant tie', () {
+  const geometry = TripStoryMapGeometry(
+    points: [
+      TripStoryMapPoint(latitude: 1, longitude: 2, dayIndex: 0, label: 'Prior'),
+      TripStoryMapPoint(latitude: 3, longitude: 4, dayIndex: 2, label: 'Next'),
+    ],
+  );
+  expect(geometry.nearestPointForDay(1)?.label, 'Prior');
+});
+
+test('nearestPointForDay returns null for empty geometry', () {
+  const geometry = TripStoryMapGeometry(points: []);
+  expect(geometry.nearestPointForDay(1), isNull);
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+flutter test test/features/trips/domain/entities/trip_story_day_test.dart
+```
+
+Expected: compilation fails because `nearestPointForDay` does not exist.
+
+- [ ] **Step 3: Add the minimal stable scan**
+
+```dart
+TripStoryMapPoint? nearestPointForDay(int dayIndex) {
+  TripStoryMapPoint? nearest;
+  int? nearestDistance;
+  for (final point in points) {
+    final distance = (point.dayIndex - dayIndex).abs();
+    if (nearestDistance == null || distance < nearestDistance) {
+      nearest = point;
+      nearestDistance = distance;
+    }
+  }
+  return nearest;
+}
+```
+
+The strict `<` preserves the first route point on a tie.
+
+- [ ] **Step 4: Format and verify GREEN**
+
+```bash
+dart format lib/features/trips/domain/entities/trip_story_day.dart test/features/trips/domain/entities/trip_story_day_test.dart
+flutter test test/features/trips/domain/entities/trip_story_day_test.dart
+```
+
+Expected: every test in the file passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/trips/domain/entities/trip_story_day.dart test/features/trips/domain/entities/trip_story_day_test.dart
+git commit -m "feat(trips): resolve nearest story day location"
+```
+
+---
+
+### Task 2: Opt surface requests into location-local time
+
+**Files:**
+- Modify: `lib/features/weather/data/services/weather_service.dart`
+- Test: `test/features/weather/data/services/weather_service_test.dart`
+
+**Interfaces:**
+- Consumes: existing `WeatherService.fetchWeather` arguments plus `bool useLocationTimezone = false`.
+- Produces: the same `Future<WeatherData?>`; opted-in URLs contain `timezone=auto`.
+
+- [ ] **Step 1: Protect the default URL and add the failing opt-in test**
+
+Add `expect(request.url.queryParameters['timezone'], isNull);` to the existing success callback. Then add:
+
+```dart
+test('fetchWeather can request the coordinate local timezone', () async {
+  final mockClient = MockClient((request) async {
+    expect(request.url.queryParameters['timezone'], 'auto');
+    return http.Response(
+      jsonEncode({
+        'hourly': {
+          'time': ['2024-06-15T12:00'],
+          'temperature_2m': [28.0],
+          'relative_humidity_2m': [70.0],
+          'precipitation': [0.0],
+          'cloud_cover': [20.0],
+          'wind_speed_10m': [14.0],
+          'wind_direction_10m': [50.0],
+          'surface_pressure': [1014.0],
+          'weathercode': [0],
+        },
+      }),
+      200,
+    );
+  });
+  final service = WeatherService(client: mockClient);
+  final result = await service.fetchWeather(
+    latitude: 28.5,
+    longitude: -80.6,
+    date: DateTime(2024, 6, 15),
+    entryTime: DateTime(2024, 6, 15, 12),
+    useLocationTimezone: true,
+  );
+  expect(result?.airTemp, 28.0);
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+flutter test test/features/weather/data/services/weather_service_test.dart
+```
+
+Expected: compilation fails because `useLocationTimezone` is not a named parameter.
+
+- [ ] **Step 3: Add the optional flag and query entry**
+
+```dart
+Future<WeatherData?> fetchWeather({
+  required double latitude,
+  required double longitude,
+  required DateTime date,
+  required DateTime entryTime,
+  bool useLocationTimezone = false,
+}) async {
+```
+
+```dart
+final uri = Uri.https(_baseUrl, _path, {
+  'latitude': latitude.toString(),
+  'longitude': longitude.toString(),
+  'start_date': dateStr,
+  'end_date': dateStr,
+  'hourly': _hourlyParams,
+  if (useLocationTimezone) 'timezone': 'auto',
+});
+```
+
+Document that the flag requests coordinate-local hourly timestamps; default callers retain GMT behavior.
+
+- [ ] **Step 4: Format and verify GREEN**
+
+```bash
+dart format lib/features/weather/data/services/weather_service.dart test/features/weather/data/services/weather_service_test.dart
+flutter test test/features/weather/data/services/weather_service_test.dart
+```
+
+Expected: every service test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/weather/data/services/weather_service.dart test/features/weather/data/services/weather_service_test.dart
+git commit -m "feat(weather): support location local archive hours"
+```
+
+---
+
+### Task 3: Fetch and cache compact surface-day weather
+
+**Files:**
+- Create: `lib/features/trips/presentation/providers/surface_day_weather_provider.dart`
+- Create: `test/features/trips/presentation/providers/surface_day_weather_provider_test.dart`
+
+**Interfaces:**
+- Consumes: `SurfaceDayWeatherRequest(date, latitude, longitude)` and `weatherServiceProvider`.
+- Produces: `surfaceDayWeatherProvider`, a non-auto-dispose `FutureProvider.family<TripStoryDayWeather?, SurfaceDayWeatherRequest>`.
+
+- [ ] **Step 1: Create the failing provider test**
+
+Use a literal Open-Meteo response with 09:00 and 12:00 entries. The first test proves local noon is selected and mapped, the second proves equal family keys make one HTTP call, and the third proves service failure becomes null.
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
+import 'package:submersion/features/trips/presentation/providers/surface_day_weather_provider.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
+
+http.Response weatherResponse() => http.Response(
+  jsonEncode({
+    'hourly': {
+      'time': ['2024-06-15T09:00', '2024-06-15T12:00'],
+      'temperature_2m': [24.0, 29.0],
+      'relative_humidity_2m': [80.0, 70.0],
+      'precipitation': [0.0, 1.0],
+      'cloud_cover': [10.0, 95.0],
+      'wind_speed_10m': [8.0, 12.0],
+      'wind_direction_10m': [30.0, 45.0],
+      'surface_pressure': [1012.0, 1011.0],
+      'weathercode': [0, 61],
+    },
+  }),
+  200,
+);
+
+void main() {
+  final request = SurfaceDayWeatherRequest(
+    date: DateTime(2024, 6, 15),
+    latitude: 12.1,
+    longitude: -68.2,
+  );
+
+  test('fetches local noon and maps compact trip weather', () async {
+    final client = MockClient((http.Request httpRequest) async {
+      expect(httpRequest.url.queryParameters['timezone'], 'auto');
+      expect(httpRequest.url.queryParameters['start_date'], '2024-06-15');
+      return weatherResponse();
+    });
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+
+    final weather = await container.read(
+      surfaceDayWeatherProvider(request).future,
+    );
+    expect(
+      weather,
+      const TripStoryDayWeather(
+        airTemp: 29,
+        cloudCover: CloudCover.overcast,
+        precipitation: Precipitation.rain,
+      ),
+    );
+  });
+
+  test('caches one request for an equal family key', () async {
+    var calls = 0;
+    final client = MockClient((_) async {
+      calls++;
+      return weatherResponse();
+    });
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(surfaceDayWeatherProvider(request).future);
+    await container.read(
+      surfaceDayWeatherProvider(
+        SurfaceDayWeatherRequest(
+          date: DateTime(2024, 6, 15),
+          latitude: 12.1,
+          longitude: -68.2,
+        ),
+      ).future,
+    );
+    expect(calls, 1);
+  });
+
+  test('propagates unavailable weather as null', () async {
+    final client = MockClient((_) async => http.Response('', 500));
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+    expect(
+      await container.read(surfaceDayWeatherProvider(request).future),
+      isNull,
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run the provider test and verify RED**
+
+```bash
+flutter test test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
+```
+
+Expected: compilation fails because the provider file, request type, and family do not exist.
+
+- [ ] **Step 3: Implement the request and provider**
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
+
+class SurfaceDayWeatherRequest extends Equatable {
+  final DateTime date;
+  final double latitude;
+  final double longitude;
+
+  const SurfaceDayWeatherRequest({
+    required this.date,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  DateTime get localNoon => DateTime(date.year, date.month, date.day, 12);
+
+  @override
+  List<Object?> get props => [date, latitude, longitude];
+}
+
+final surfaceDayWeatherProvider =
+    FutureProvider.family<TripStoryDayWeather?, SurfaceDayWeatherRequest>((
+      ref,
+      request,
+    ) async {
+      final weather = await ref.watch(weatherServiceProvider).fetchWeather(
+        latitude: request.latitude,
+        longitude: request.longitude,
+        date: DateTime(request.date.year, request.date.month, request.date.day),
+        entryTime: request.localNoon,
+        useLocationTimezone: true,
+      );
+      if (weather == null) return null;
+      return TripStoryDayWeather(
+        airTemp: weather.airTemp,
+        cloudCover: weather.cloudCover,
+        precipitation: weather.precipitation,
+      );
+    });
+```
+
+Do not use `.autoDispose`; cached results must survive sliver unmount/remount.
+
+- [ ] **Step 4: Format and verify GREEN**
+
+```bash
+dart format lib/features/trips/presentation/providers/surface_day_weather_provider.dart test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
+flutter test test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
+```
+
+Expected: all three provider tests pass and the cache test observes one call.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/trips/presentation/providers/surface_day_weather_provider.dart test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
+git commit -m "feat(trips): fetch surface day weather"
+```
+
+---
+
+### Task 4: Render fetched weather through the existing badge
+
+**Files:**
+- Modify: `lib/features/trips/presentation/widgets/story/trip_story_day_header.dart`
+- Test: `test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart`
+
+**Interfaces:**
+- Consumes: optional `SurfaceDayWeatherRequest? surfaceWeatherRequest`.
+- Produces: unchanged header presentation, with fetched weather used only when `day.isSurface`.
+
+- [ ] **Step 1: Extend the harness and write failing widget tests**
+
+Add `dart:async`, Riverpod `Override`, and the new provider imports. Extend `pumpHeader` with `SurfaceDayWeatherRequest? surfaceWeatherRequest` and `List<Override> extra = const []`; append `extra` to the overrides and pass the request into `TripStoryDayHeader`.
+
+Use this request:
+
+```dart
+final request = SurfaceDayWeatherRequest(
+  date: DateTime(2026, 3, 8),
+  latitude: 12.1,
+  longitude: -68.2,
+);
+```
+
+Add:
+
+```dart
+testWidgets('surface day shows fetched weather in the existing badge', (
+  tester,
+) async {
+  await pumpHeader(
+    tester,
+    surfaceDay(),
+    surfaceWeatherRequest: request,
+    extra: [
+      surfaceDayWeatherProvider(request).overrideWith(
+        (ref) async => const TripStoryDayWeather(
+          airTemp: 22,
+          cloudCover: CloudCover.clear,
+        ),
+      ),
+    ],
+  );
+  await tester.pump();
+  expect(find.byIcon(Icons.wb_sunny_outlined), findsOneWidget);
+  expect(find.text('22°C'), findsOneWidget);
+});
+
+testWidgets('fetched surface temperature respects Fahrenheit', (
+  tester,
+) async {
+  final settings = MockSettingsNotifier();
+  await settings.setTemperatureUnit(TemperatureUnit.fahrenheit);
+  await pumpHeader(
+    tester,
+    surfaceDay(),
+    settingsNotifier: settings,
+    surfaceWeatherRequest: request,
+    extra: [
+      surfaceDayWeatherProvider(request).overrideWith(
+        (ref) async => const TripStoryDayWeather(airTemp: 22),
+      ),
+    ],
+  );
+  await tester.pump();
+  expect(find.text('71.6°F'), findsOneWidget);
+});
+
+testWidgets('loading and failed surface weather stay badge-free', (
+  tester,
+) async {
+  final pending = Completer<TripStoryDayWeather?>();
+  await pumpHeader(
+    tester,
+    surfaceDay(),
+    surfaceWeatherRequest: request,
+    extra: [
+      surfaceDayWeatherProvider(request).overrideWith((ref) => pending.future),
+    ],
+  );
+  expect(find.textContaining('°'), findsNothing);
+  expect(find.byType(CircularProgressIndicator), findsNothing);
+
+  pending.completeError(Exception('weather unavailable'));
+  await tester.pump();
+  expect(find.textContaining('°'), findsNothing);
+  expect(find.byType(CircularProgressIndicator), findsNothing);
+});
+
+testWidgets('surface day without a request stays badge-free', (tester) async {
+  await pumpHeader(tester, surfaceDay());
+  expect(find.textContaining('°'), findsNothing);
+  expect(find.byType(CircularProgressIndicator), findsNothing);
+});
+```
+
+- [ ] **Step 2: Run the header test and verify RED**
+
+```bash
+flutter test test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+```
+
+Expected: compilation fails because the header has no `surfaceWeatherRequest` parameter.
+
+- [ ] **Step 3: Watch surface weather and reuse one badge builder**
+
+Add the field and constructor parameter:
+
+```dart
+final SurfaceDayWeatherRequest? surfaceWeatherRequest;
+
+const TripStoryDayHeader({
+  super.key,
+  required this.day,
+  this.surfaceWeatherRequest,
+});
+```
+
+In `build`:
+
+```dart
+final request = day.isSurface ? surfaceWeatherRequest : null;
+final fetchedWeather = request == null
+    ? null
+    : ref.watch(surfaceDayWeatherProvider(request)).asData?.value;
+final weather = day.weather ?? fetchedWeather;
+final units = UnitFormatter(ref.watch(settingsProvider));
+final weatherBadge = _weatherBadge(context, theme, units, weather);
+```
+
+Change `_weatherBadge` to accept `TripStoryDayWeather? weather` and remove its internal `final weather = day.weather;`. Leave its current icon, semantic label, formatter, style, and null checks intact.
+
+- [ ] **Step 4: Format and verify GREEN**
+
+```bash
+dart format lib/features/trips/presentation/widgets/story/trip_story_day_header.dart test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+flutter test test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+```
+
+Expected: existing dive-weather tests and all new surface-weather tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/trips/presentation/widgets/story/trip_story_day_header.dart test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+git commit -m "feat(trips): show weather on surface day headers"
+```
+
+---
+
+### Task 5: Wire surface headers to nearest story coordinates
+
+**Files:**
+- Modify: `lib/features/trips/presentation/widgets/story/trip_story_view.dart`
+- Test: `test/features/trips/presentation/widgets/story/trip_story_view_test.dart`
+
+**Interfaces:**
+- Consumes: `TripStory.mapGeometry.nearestPointForDay(index)`.
+- Produces: a `SurfaceDayWeatherRequest` passed only to a surface day's `TripStoryDayHeader`.
+
+- [ ] **Step 1: Add the failing story-view integration test**
+
+Import `dart:convert`, `http`, and `MockClient`. Extend `pumpView` with `http.Client? weatherHttpClient` and pass it to `getBaseOverrides(weatherHttpClient: weatherHttpClient)`.
+
+Add this regression test. The one-call assertion catches accidental dive-day fetching; the coordinates catch choosing the later point in the middle-day tie.
+
+```dart
+testWidgets('only the surface day fetches from the nearest trip point', (
+  tester,
+) async {
+  final trip = _trip(
+    start: DateTime(2026, 3, 25),
+    end: DateTime(2026, 3, 27),
+  );
+  final story = _story(
+    trip,
+    dives: [
+      _diveAt('d1', DateTime(2026, 3, 25, 9), 12.10, -68.20),
+      _diveAt('d3', DateTime(2026, 3, 27, 9), 13.30, -69.40),
+    ],
+    today: DateTime(2026, 6, 1),
+  );
+  var calls = 0;
+  final client = MockClient((request) async {
+    calls++;
+    expect(request.url.queryParameters['latitude'], '12.1');
+    expect(request.url.queryParameters['longitude'], '-68.2');
+    expect(request.url.queryParameters['start_date'], '2026-03-26');
+    expect(request.url.queryParameters['timezone'], 'auto');
+    return http.Response(
+      jsonEncode({
+        'hourly': {
+          'time': ['2026-03-26T12:00'],
+          'temperature_2m': [26.0],
+          'relative_humidity_2m': [70.0],
+          'precipitation': [0.0],
+          'cloud_cover': [10.0],
+          'wind_speed_10m': [8.0],
+          'wind_direction_10m': [30.0],
+          'surface_pressure': [1012.0],
+          'weathercode': [0],
+        },
+      }),
+      200,
+    );
+  });
+
+  await pumpView(tester, story, weatherHttpClient: client);
+  await tester.pump();
+
+  expect(calls, 1);
+  expect(find.text('26°C'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Run the view test and verify RED**
+
+```bash
+flutter test test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+```
+
+Expected: the call count is zero and `26°C` is absent because the view passes no request.
+
+- [ ] **Step 3: Resolve and pass the request in `_daySliver`**
+
+Import the surface weather provider. After reading `day`, add:
+
+```dart
+final weatherPoint = day.isSurface
+    ? story.mapGeometry.nearestPointForDay(index)
+    : null;
+final surfaceWeatherRequest = weatherPoint == null
+    ? null
+    : SurfaceDayWeatherRequest(
+        date: day.date,
+        latitude: weatherPoint.latitude,
+        longitude: weatherPoint.longitude,
+      );
+```
+
+Pass it to the pinned header:
+
+```dart
+PinnedHeaderSliver(
+  child: TripStoryDayHeader(
+    day: day,
+    surfaceWeatherRequest: surfaceWeatherRequest,
+  ),
+),
+```
+
+- [ ] **Step 4: Format and run the focused suite**
+
+```bash
+dart format lib/features/trips/presentation/widgets/story/trip_story_view.dart test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+flutter test \
+  test/features/trips/domain/entities/trip_story_day_test.dart \
+  test/features/weather/data/services/weather_service_test.dart \
+  test/features/trips/presentation/providers/surface_day_weather_provider_test.dart \
+  test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart \
+  test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+```
+
+Expected: all focused tests pass. The pre-existing `flutter_map` OpenStreetMap policy message may appear; no new warning or exception may appear.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/trips/presentation/widgets/story/trip_story_view.dart test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+git commit -m "feat(trips): wire surface weather to trip location"
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:**
+- Verify all production and test files changed in Tasks 1-5.
+
+**Interfaces:**
+- Consumes: the complete branch.
+- Produces: formatted, analyzed, fully tested implementation with a clean worktree.
+
+- [ ] **Step 1: Verify formatting and patch hygiene**
+
+```bash
+dart format --set-exit-if-changed \
+  lib/features/trips/domain/entities/trip_story_day.dart \
+  lib/features/weather/data/services/weather_service.dart \
+  lib/features/trips/presentation/providers/surface_day_weather_provider.dart \
+  lib/features/trips/presentation/widgets/story/trip_story_day_header.dart \
+  lib/features/trips/presentation/widgets/story/trip_story_view.dart \
+  test/features/trips/domain/entities/trip_story_day_test.dart \
+  test/features/weather/data/services/weather_service_test.dart \
+  test/features/trips/presentation/providers/surface_day_weather_provider_test.dart \
+  test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart \
+  test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+git diff --check origin/main...HEAD
+```
+
+Expected: both commands exit 0 without formatting changes or whitespace errors.
+
+- [ ] **Step 2: Run static analysis**
+
+```bash
+flutter analyze
+```
+
+Expected: exit 0 with no issues introduced by the branch.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+flutter test
+```
+
+Expected: exit 0 with all tests passing.
+
+- [ ] **Step 4: Review the final diff against the spec**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- lib/features/trips lib/features/weather test/features/trips test/features/weather
+```
+
+Confirm all of the following from the diff and test output:
+
+- only surface days construct a weather request;
+- nearest-point ties preserve route order;
+- the request targets local noon with `timezone=auto`;
+- non-surface weather callers retain their previous URL;
+- loading, error, and missing location show no UI;
+- no database, sync, localization, or persistence file changed.
+
+- [ ] **Step 5: Confirm branch status**
+
+```bash
+git status --short --branch
+git log --oneline --decorate origin/main..HEAD
+```
+
+Expected: the worktree is clean on `codex/trip-surface-day-weather`, and the log contains the design plus focused implementation commits.

--- a/docs/superpowers/specs/2026-08-12-trip-surface-day-weather-design.md
+++ b/docs/superpowers/specs/2026-08-12-trip-surface-day-weather-design.md
@@ -1,0 +1,154 @@
+# Trip Surface-Day Weather
+
+**Date:** 2026-08-12
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Trip story headers already show a compact weather badge on dive days: a
+conditions icon plus air temperature in the active diver's temperature unit.
+The badge is derived from weather stored on that day's dive records. A true
+surface day has no dives or itinerary content, so it has no weather source and
+its otherwise-identical header renders without the badge.
+
+Surface days should fetch real historical weather and display the same badge
+without delaying the rest of the trip story or inventing weather by copying a
+neighboring dive day.
+
+## Design summary
+
+Fetch surface-day weather lazily and best-effort when its trip story header is
+mounted. Resolve the geographically nearest point already present in the trip
+story map (itinerary port, dive site, or liveaboard endpoint), request
+Open-Meteo's historical hourly weather for local noon on the surface-day date,
+and feed the result through the existing weather badge presentation.
+
+The result is cached by Riverpod for the current application provider
+container. It is not persisted to the database or sync payloads. A missing
+coordinate, loading request, or failed request leaves the header unchanged.
+
+## Components
+
+### 1. Nearest trip location
+
+`TripStoryMapGeometry` gains a pure nearest-point lookup for a day index.
+
+- Compare points by the absolute difference between `point.dayIndex` and the
+  requested day index.
+- Preserve map-point order when distances tie. Because the route is built in
+  trip order, this deterministically prefers the earlier point in an
+  equidistant tie.
+- A surface day before the first mapped day uses the first future point; one
+  after the last mapped day uses the last prior point.
+- Empty geometry returns no point and therefore causes no network request.
+
+The story view resolves this point only for a surface day and passes its
+coordinates to the day header. Dive-day headers keep deriving weather solely
+from their logged dives and never start this fetch.
+
+### 2. Surface weather request and provider
+
+Add an immutable request value containing the surface date, latitude, and
+longitude. A non-auto-dispose Riverpod family provider uses this value as its
+cache key so the same surface day and coordinate are fetched once per app
+provider container, including when its sliver scrolls offscreen and remounts.
+
+The provider:
+
+1. Builds a target timestamp at 12:00 on the surface date.
+2. Calls the existing `WeatherService` for the selected coordinate and date.
+3. Requests `timezone=auto` so Open-Meteo returns hourly timestamps in the
+   coordinate's local timezone and the mapper selects local noon rather than
+   noon GMT.
+4. Converts the returned `WeatherData` to the existing compact
+   `TripStoryDayWeather` fields: air temperature, cloud cover, and
+   precipitation.
+5. Returns null for unavailable or failed weather, matching the existing
+   service's best-effort contract.
+
+`WeatherService.fetchWeather` gains an optional location-timezone flag. It is
+off by default so existing dive-edit weather requests retain their current API
+contract; the surface-day provider enables it explicitly.
+
+### 3. Header presentation
+
+`TripStoryDayHeader` accepts an optional surface-weather request.
+
+- Logged dive weather remains the first and only source for non-surface days.
+- For a surface day with no logged weather, the header watches the surface
+  weather provider when a request is available.
+- While loading or on error, it renders no placeholder, spinner, error text,
+  or layout reservation.
+- Once data arrives, it sends the fetched summary through the same badge
+  builder used by dive days. Icon precedence, semantic labels, typography,
+  colors, and unit conversion therefore stay identical.
+
+No new localization strings or visual components are required.
+
+## Data flow
+
+```text
+TripStory map geometry
+        |
+        v
+nearest map point for surface-day index
+        |
+        v
+SurfaceDayWeatherRequest(date, latitude, longitude)
+        |
+        v
+surfaceDayWeatherProvider --cached--> WeatherService
+        |                                  |
+        |                         Open-Meteo archive API
+        v
+TripStoryDayWeather? --> existing header weather badge
+```
+
+The trip story and header render before the network request completes. Weather
+failure cannot fail or hold the trip story provider.
+
+## Error handling and edge cases
+
+- **No map points:** do not request weather and show no badge.
+- **HTTP, network, malformed-data, or unavailable-date failure:** the existing
+  service returns null; show no badge and keep the trip usable.
+- **Surface day between different locations:** use the nearest day by calendar
+  distance; ties follow route order deterministically.
+- **Surface day at either trip boundary:** use the closest mapped point on the
+  available side.
+- **Multiple points on the chosen day:** use the first point in established map
+  route order.
+- **Header remount while scrolling:** the family provider's request key reuses
+  the in-memory result instead of repeating the HTTP request.
+- **Dive day with missing logged weather:** do not fetch. This feature is
+  explicitly limited to true surface days so it does not silently replace the
+  dive-log weather workflow.
+- **Today or a date unavailable from the archive endpoint:** degrade to no
+  badge. Forecast routing and retry UI are outside this feature.
+
+## Testing
+
+- Extend `trip_story_day_test.dart` with nearest-point selection for exact-day,
+  prior/future boundary, equidistant tie, and empty-geometry cases.
+- Extend `weather_service_test.dart` to prove the opt-in request includes
+  `timezone=auto` while the default request contract remains unchanged.
+- Add provider tests proving local-noon request construction, conversion to
+  `TripStoryDayWeather`, one cached request per key, and null propagation.
+- Extend `trip_story_day_header_test.dart` to prove fetched surface weather uses
+  the existing icon and Celsius/Fahrenheit formatting, and that loading,
+  failure, and missing-location states remain badge-free.
+- Extend `trip_story_view_test.dart` to prove a surface header receives the
+  nearest story coordinate and a dive day does not opt into surface fetching.
+- Run the focused trip-story/weather suite, `flutter analyze`, and the full
+  Flutter test suite before completion.
+
+## Non-goals
+
+- No database migration, trip-day weather entity, sync changes, or offline
+  persistence.
+- No copying or interpolating weather values from adjacent dives.
+- No forecast API, recent-weather endpoint switching, retry button, loading
+  indicator, or error message.
+- No change to dive-day weather sourcing, editing, or persistence.
+- No additional weather details beyond the existing compact icon and air
+  temperature badge.

--- a/lib/features/trips/domain/entities/trip_story_day.dart
+++ b/lib/features/trips/domain/entities/trip_story_day.dart
@@ -162,6 +162,21 @@ class TripStoryMapGeometry extends Equatable {
   List<TripStoryMapPoint> pointsForDay(int dayIndex) =>
       points.where((p) => p.dayIndex == dayIndex).toList();
 
+  /// The map point closest to [dayIndex], preserving route order when two
+  /// points are equally distant.
+  TripStoryMapPoint? nearestPointForDay(int dayIndex) {
+    TripStoryMapPoint? nearest;
+    int? nearestDistance;
+    for (final point in points) {
+      final distance = (point.dayIndex - dayIndex).abs();
+      if (nearestDistance == null || distance < nearestDistance) {
+        nearest = point;
+        nearestDistance = distance;
+      }
+    }
+    return nearest;
+  }
+
   @override
   List<Object?> get props => [points];
 }

--- a/lib/features/trips/presentation/providers/surface_day_weather_provider.dart
+++ b/lib/features/trips/presentation/providers/surface_day_weather_provider.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
+
+/// One historical-weather lookup for a contentless trip day.
+///
+/// Value equality makes this a stable Riverpod family key, so scrolling a day
+/// header out of the sliver tree and back in reuses the same in-memory result.
+class SurfaceDayWeatherRequest extends Equatable {
+  final DateTime date;
+  final double latitude;
+  final double longitude;
+
+  const SurfaceDayWeatherRequest({
+    required this.date,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  DateTime get localNoon => DateTime(date.year, date.month, date.day, 12);
+
+  @override
+  List<Object?> get props => [date, latitude, longitude];
+}
+
+/// Best-effort historical weather for a trip surface day.
+///
+/// Intentionally not auto-disposed: a trip story can repeatedly mount and
+/// unmount day slivers while scrolling, and each request should be fetched at
+/// most once during the provider container's lifetime.
+final surfaceDayWeatherProvider =
+    FutureProvider.family<TripStoryDayWeather?, SurfaceDayWeatherRequest>((
+      ref,
+      request,
+    ) async {
+      final weather = await ref
+          .watch(weatherServiceProvider)
+          .fetchWeather(
+            latitude: request.latitude,
+            longitude: request.longitude,
+            date: DateTime(
+              request.date.year,
+              request.date.month,
+              request.date.day,
+            ),
+            entryTime: request.localNoon,
+            useLocationTimezone: true,
+          );
+      if (weather == null) return null;
+
+      return TripStoryDayWeather(
+        airTemp: weather.airTemp,
+        cloudCover: weather.cloudCover,
+        precipitation: weather.precipitation,
+      );
+    });

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
 import 'package:submersion/features/trips/presentation/helpers/day_type_l10n.dart';
 import 'package:submersion/features/trips/presentation/helpers/weather_icon.dart';
+import 'package:submersion/features/trips/presentation/providers/surface_day_weather_provider.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -32,8 +33,13 @@ class TripStoryDayHeader extends ConsumerWidget {
   static const double minHeight = 52;
 
   final TripStoryDay day;
+  final SurfaceDayWeatherRequest? surfaceWeatherRequest;
 
-  const TripStoryDayHeader({super.key, required this.day});
+  const TripStoryDayHeader({
+    super.key,
+    required this.day,
+    this.surfaceWeatherRequest,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -53,8 +59,13 @@ class TripStoryDayHeader extends ConsumerWidget {
       ...day.siteNames,
     ].map((part) => part.trim()).where((part) => part.isNotEmpty).toList();
 
+    final request = day.isSurface ? surfaceWeatherRequest : null;
+    final fetchedWeather = request == null
+        ? null
+        : ref.watch(surfaceDayWeatherProvider(request)).asData?.value;
+    final weather = day.weather ?? fetchedWeather;
     final units = UnitFormatter(ref.watch(settingsProvider));
-    final weatherBadge = _weatherBadge(context, theme, units);
+    final weatherBadge = _weatherBadge(context, theme, units, weather);
 
     return Material(
       color: theme.colorScheme.surface,
@@ -113,8 +124,8 @@ class TripStoryDayHeader extends ConsumerWidget {
     BuildContext context,
     ThemeData theme,
     UnitFormatter units,
+    TripStoryDayWeather? weather,
   ) {
-    final weather = day.weather;
     if (weather == null) return null;
 
     final icon = weatherIconFor(

--- a/lib/features/trips/presentation/widgets/story/trip_story_view.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_view.dart
@@ -7,6 +7,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:submersion/features/checklists/presentation/widgets/trip_checklist_section.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story.dart';
+import 'package:submersion/features/trips/presentation/providers/surface_day_weather_provider.dart';
 import 'package:submersion/features/trips/presentation/widgets/story/trip_flight_countdown_card.dart';
 import 'package:submersion/features/trips/presentation/widgets/story/trip_story_day_card.dart';
 import 'package:submersion/features/trips/presentation/widgets/story/trip_story_day_header.dart';
@@ -230,6 +231,16 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
   /// header, surface days included - theirs simply has no body under it.
   Widget _daySliver(TripStory story, int index, int? todayIndex) {
     final day = story.days[index];
+    final weatherPoint = day.isSurface
+        ? story.mapGeometry.nearestPointForDay(index)
+        : null;
+    final surfaceWeatherRequest = weatherPoint == null
+        ? null
+        : SurfaceDayWeatherRequest(
+            date: day.date,
+            latitude: weatherPoint.latitude,
+            longitude: weatherPoint.longitude,
+          );
     final showTodayDivider = todayIndex != null && index == todayIndex;
     const divider = SliverPadding(
       padding: EdgeInsets.symmetric(horizontal: 16),
@@ -260,7 +271,12 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
         // PinnedHeaderSliver (not SliverPersistentHeader) so the header sizes
         // itself: scaled accessibility text grows the band instead of being
         // clipped by a fixed extent we would have to predict.
-        PinnedHeaderSliver(child: TripStoryDayHeader(day: day)),
+        PinnedHeaderSliver(
+          child: TripStoryDayHeader(
+            day: day,
+            surfaceWeatherRequest: surfaceWeatherRequest,
+          ),
+        ),
         body,
       ],
     );

--- a/lib/features/weather/data/services/weather_service.dart
+++ b/lib/features/weather/data/services/weather_service.dart
@@ -25,12 +25,15 @@ class WeatherService {
   /// Fetch historical weather for a given location and date.
   ///
   /// [entryTime] is used to select the closest hourly data point.
+  /// [useLocationTimezone] requests timestamps in the coordinate's local
+  /// timezone instead of Open-Meteo's default GMT.
   /// Returns null if the request fails or data is unavailable.
   Future<WeatherData?> fetchWeather({
     required double latitude,
     required double longitude,
     required DateTime date,
     required DateTime entryTime,
+    bool useLocationTimezone = false,
   }) async {
     try {
       final dateStr =
@@ -42,6 +45,10 @@ class WeatherService {
         'start_date': dateStr,
         'end_date': dateStr,
         'hourly': _hourlyParams,
+        // Open-Meteo defaults to GMT. Surface-day summaries opt into the
+        // coordinate's local wall clock so their noon sample is really noon
+        // at the trip location; existing dive callers keep their current URL.
+        if (useLocationTimezone) 'timezone': 'auto',
       });
 
       final response = await _client.get(uri);

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -3,13 +3,12 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
-import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 
+import '../../../helpers/changeset_test_helpers.dart';
 import '../../../helpers/fake_cloud_storage_provider.dart';
-import '../../../helpers/sync_test_helpers.dart';
 import '../../../helpers/mock_providers.dart';
 import '../../../helpers/test_database.dart';
 
@@ -33,8 +32,8 @@ void main() {
       cloud = FakeCloudStorageProvider();
     });
 
-    tearDown(() {
-      DatabaseService.instance.resetForTesting();
+    tearDown(() async {
+      await tearDownTestDatabase();
     });
 
     SyncService buildService() => SyncService(
@@ -92,9 +91,7 @@ void main() {
         'createdAt': 1000,
       });
 
-      await buildService().performSync();
-      await serializer.deleteRecord('diveCustomFields', 'cf-1');
-      await impersonateFreshDevice();
+      await seedPeerLog(cloud, 'device-a');
       expect(await serializer.fetchRecord('diveCustomFields', 'cf-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -119,9 +116,7 @@ void main() {
         'createdAt': 1000,
       });
 
-      await buildService().performSync();
-      await serializer.deleteRecord('siteSpecies', 'ss-1');
-      await impersonateFreshDevice();
+      await seedPeerLog(cloud, 'device-a');
       expect(await serializer.fetchRecord('siteSpecies', 'ss-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -143,9 +138,7 @@ void main() {
         'updatedAt': 1000,
       });
 
-      await buildService().performSync();
-      await serializer.deleteRecord('csvPresets', 'csv-1');
-      await impersonateFreshDevice();
+      await seedPeerLog(cloud, 'device-a');
       expect(await serializer.fetchRecord('csvPresets', 'csv-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -169,9 +162,7 @@ void main() {
         'updatedAt': 1000,
       });
 
-      await buildService().performSync();
-      await serializer.deleteRecord('viewConfigs', 'vc-1');
-      await impersonateFreshDevice();
+      await seedPeerLog(cloud, 'device-a');
       expect(await serializer.fetchRecord('viewConfigs', 'vc-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -196,9 +187,7 @@ void main() {
         'createdAt': 1000,
       });
 
-      await buildService().performSync();
-      await serializer.deleteRecord('fieldPresets', 'fp-1');
-      await impersonateFreshDevice();
+      await seedPeerLog(cloud, 'device-a');
       expect(await serializer.fetchRecord('fieldPresets', 'fp-1'), isNull);
 
       final pull = await buildService().performSync();
@@ -229,9 +218,7 @@ void main() {
           'rawFingerprint': fingerprint,
         });
 
-        await buildService().performSync();
-        await serializer.deleteRecord('diveDataSources', 'ds-1');
-        await impersonateFreshDevice();
+        await seedPeerLog(cloud, 'device-a');
         expect(await serializer.fetchRecord('diveDataSources', 'ds-1'), isNull);
 
         final pull = await buildService().performSync();

--- a/test/features/setup_wizard/data/setup_apply_service_test.dart
+++ b/test/features/setup_wizard/data/setup_apply_service_test.dart
@@ -152,6 +152,8 @@ void main() {
       );
       addTearDown(container.dispose);
 
+      await container.read(settingsProvider.notifier).initialLoad;
+
       // The re-entry draft must mirror the live schedule, not defaults.
       final draft = container.read(
         setupWizardProvider(SetupWizardMode.settings),

--- a/test/features/trips/domain/entities/trip_story_day_test.dart
+++ b/test/features/trips/domain/entities/trip_story_day_test.dart
@@ -200,6 +200,66 @@ void main() {
       expect(geometry.pointsForDay(9), isEmpty);
     });
 
+    test('nearestPointForDay returns a point on the requested day', () {
+      const geometry = TripStoryMapGeometry(
+        points: [
+          TripStoryMapPoint(latitude: 1, longitude: 2, dayIndex: 0, label: 'A'),
+          TripStoryMapPoint(latitude: 3, longitude: 4, dayIndex: 2, label: 'B'),
+        ],
+      );
+
+      expect(geometry.nearestPointForDay(2)?.label, 'B');
+    });
+
+    test('nearestPointForDay uses the closest point at trip boundaries', () {
+      const geometry = TripStoryMapGeometry(
+        points: [
+          TripStoryMapPoint(
+            latitude: 1,
+            longitude: 2,
+            dayIndex: 2,
+            label: 'First',
+          ),
+          TripStoryMapPoint(
+            latitude: 3,
+            longitude: 4,
+            dayIndex: 4,
+            label: 'Last',
+          ),
+        ],
+      );
+
+      expect(geometry.nearestPointForDay(0)?.label, 'First');
+      expect(geometry.nearestPointForDay(7)?.label, 'Last');
+    });
+
+    test('nearestPointForDay preserves route order for an equidistant tie', () {
+      const geometry = TripStoryMapGeometry(
+        points: [
+          TripStoryMapPoint(
+            latitude: 1,
+            longitude: 2,
+            dayIndex: 0,
+            label: 'Prior',
+          ),
+          TripStoryMapPoint(
+            latitude: 3,
+            longitude: 4,
+            dayIndex: 2,
+            label: 'Next',
+          ),
+        ],
+      );
+
+      expect(geometry.nearestPointForDay(1)?.label, 'Prior');
+    });
+
+    test('nearestPointForDay returns null for empty geometry', () {
+      const geometry = TripStoryMapGeometry(points: []);
+
+      expect(geometry.nearestPointForDay(1), isNull);
+    });
+
     test('empty geometry has no points', () {
       const geometry = TripStoryMapGeometry(points: []);
       expect(geometry.hasPoints, isFalse);

--- a/test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
+++ b/test/features/trips/presentation/providers/surface_day_weather_provider_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
+import 'package:submersion/features/trips/presentation/providers/surface_day_weather_provider.dart';
+import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
+
+http.Response weatherResponse() => http.Response(
+  jsonEncode({
+    'hourly': {
+      'time': ['2024-06-15T09:00', '2024-06-15T12:00'],
+      'temperature_2m': [24.0, 29.0],
+      'relative_humidity_2m': [80.0, 70.0],
+      'precipitation': [0.0, 1.0],
+      'cloud_cover': [10.0, 95.0],
+      'wind_speed_10m': [8.0, 12.0],
+      'wind_direction_10m': [30.0, 45.0],
+      'surface_pressure': [1012.0, 1011.0],
+      'weathercode': [0, 61],
+    },
+  }),
+  200,
+);
+
+void main() {
+  final request = SurfaceDayWeatherRequest(
+    date: DateTime(2024, 6, 15),
+    latitude: 12.1,
+    longitude: -68.2,
+  );
+
+  test('fetches local noon and maps compact trip weather', () async {
+    final client = MockClient((http.Request httpRequest) async {
+      expect(httpRequest.url.queryParameters['timezone'], 'auto');
+      expect(httpRequest.url.queryParameters['start_date'], '2024-06-15');
+      return weatherResponse();
+    });
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+
+    final weather = await container.read(
+      surfaceDayWeatherProvider(request).future,
+    );
+
+    expect(
+      weather,
+      const TripStoryDayWeather(
+        airTemp: 29,
+        cloudCover: CloudCover.overcast,
+        precipitation: Precipitation.lightRain,
+      ),
+    );
+  });
+
+  test('caches one request for an equal family key', () async {
+    var calls = 0;
+    final client = MockClient((_) async {
+      calls++;
+      return weatherResponse();
+    });
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(surfaceDayWeatherProvider(request).future);
+    await container.read(
+      surfaceDayWeatherProvider(
+        SurfaceDayWeatherRequest(
+          date: DateTime(2024, 6, 15),
+          latitude: 12.1,
+          longitude: -68.2,
+        ),
+      ).future,
+    );
+
+    expect(calls, 1);
+  });
+
+  test('propagates unavailable weather as null', () async {
+    final client = MockClient((_) async => http.Response('', 500));
+    final container = ProviderContainer(
+      overrides: [weatherHttpClientProvider.overrideWithValue(client)],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      await container.read(surfaceDayWeatherProvider(request).future),
+      isNull,
+    );
+  });
+}

--- a/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
@@ -8,6 +10,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/itinerary_day.dart';
 import 'package:submersion/features/trips/domain/entities/trip_story_day.dart';
+import 'package:submersion/features/trips/presentation/providers/surface_day_weather_provider.dart';
 import 'package:submersion/features/trips/presentation/widgets/story/trip_story_day_header.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -30,6 +33,8 @@ Future<void> pumpHeader(
   TripStoryDay day, {
   double textScale = 1.0,
   MockSettingsNotifier? settingsNotifier,
+  SurfaceDayWeatherRequest? surfaceWeatherRequest,
+  List<Override> extra = const [],
 }) async {
   // The header dates itself with DateFormat.MMMEd(), which resolves against
   // Intl.defaultLocale - a process global that app.dart sets from the app
@@ -43,7 +48,7 @@ Future<void> pumpHeader(
   final overrides = await getBaseOverrides(settingsNotifier: settingsNotifier);
   await tester.pumpWidget(
     ProviderScope(
-      overrides: overrides,
+      overrides: [...overrides, ...extra],
       child: MaterialApp(
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -58,7 +63,10 @@ Future<void> pumpHeader(
                 data: MediaQuery.of(
                   context,
                 ).copyWith(textScaler: TextScaler.linear(textScale)),
-                child: TripStoryDayHeader(day: day),
+                child: TripStoryDayHeader(
+                  day: day,
+                  surfaceWeatherRequest: surfaceWeatherRequest,
+                ),
               ),
             ),
           ),
@@ -149,6 +157,11 @@ void main() {
       dayNumber: 2,
       kind: TripStoryDayKind.past,
     );
+    final request = SurfaceDayWeatherRequest(
+      date: DateTime(2026, 3, 8),
+      latitude: 12.1,
+      longitude: -68.2,
+    );
 
     testWidgets('gets the same title line as any other day', (tester) async {
       await pumpHeader(tester, surfaceDay());
@@ -198,6 +211,75 @@ void main() {
       await pumpHeader(tester, surfaceDay());
 
       expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('shows fetched weather in the existing badge', (tester) async {
+      await pumpHeader(
+        tester,
+        surfaceDay(),
+        surfaceWeatherRequest: request,
+        extra: [
+          surfaceDayWeatherProvider(request).overrideWith(
+            (ref) async => const TripStoryDayWeather(
+              airTemp: 22,
+              cloudCover: CloudCover.clear,
+            ),
+          ),
+        ],
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.wb_sunny_outlined), findsOneWidget);
+      expect(find.text('22°C'), findsOneWidget);
+    });
+
+    testWidgets('fetched temperature respects Fahrenheit', (tester) async {
+      final settings = MockSettingsNotifier();
+      await settings.setTemperatureUnit(TemperatureUnit.fahrenheit);
+      await pumpHeader(
+        tester,
+        surfaceDay(),
+        settingsNotifier: settings,
+        surfaceWeatherRequest: request,
+        extra: [
+          surfaceDayWeatherProvider(
+            request,
+          ).overrideWith((ref) async => const TripStoryDayWeather(airTemp: 22)),
+        ],
+      );
+      await tester.pump();
+
+      expect(find.text('71.6°F'), findsOneWidget);
+    });
+
+    testWidgets('loading and failed weather stay badge-free', (tester) async {
+      final pending = Completer<TripStoryDayWeather?>();
+      await pumpHeader(
+        tester,
+        surfaceDay(),
+        surfaceWeatherRequest: request,
+        extra: [
+          surfaceDayWeatherProvider(
+            request,
+          ).overrideWith((ref) => pending.future),
+        ],
+      );
+
+      expect(find.textContaining('°'), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      pending.completeError(Exception('weather unavailable'));
+      await tester.pump();
+
+      expect(find.textContaining('°'), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('without a request stays badge-free', (tester) async {
+      await pumpHeader(tester, surfaceDay());
+
+      expect(find.textContaining('°'), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
     });
   });
 

--- a/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
@@ -1,6 +1,10 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -72,11 +76,14 @@ Future<void> pumpView(
   TripStory story, {
   List<Override> extra = const [],
   Size viewSize = const Size(800, 2600),
+  http.Client? weatherHttpClient,
 }) async {
   tester.view.physicalSize = viewSize;
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
-  final overrides = await getBaseOverrides();
+  final overrides = await getBaseOverrides(
+    weatherHttpClient: weatherHttpClient,
+  );
   final stats = TripWithStats(trip: story.trip, diveCount: 2);
   final router = GoRouter(
     routes: [
@@ -345,5 +352,52 @@ void main() {
     expect(find.byType(TripStoryDayHeader), findsNWidgets(3));
     expect(find.textContaining('Day 2 -'), findsOneWidget);
     expect(find.text('Surface day'), findsOneWidget);
+  });
+
+  testWidgets('only the surface day fetches from the nearest trip point', (
+    tester,
+  ) async {
+    final trip = _trip(
+      start: DateTime(2026, 3, 25),
+      end: DateTime(2026, 3, 27),
+    );
+    final story = _story(
+      trip,
+      dives: [
+        _diveAt('d1', DateTime(2026, 3, 25, 9), 12.10, -68.20),
+        _diveAt('d3', DateTime(2026, 3, 27, 9), 13.30, -69.40),
+      ],
+      today: DateTime(2026, 6, 1),
+    );
+    var calls = 0;
+    final client = MockClient((request) async {
+      calls++;
+      expect(request.url.queryParameters['latitude'], '12.1');
+      expect(request.url.queryParameters['longitude'], '-68.2');
+      expect(request.url.queryParameters['start_date'], '2026-03-26');
+      expect(request.url.queryParameters['timezone'], 'auto');
+      return http.Response(
+        jsonEncode({
+          'hourly': {
+            'time': ['2026-03-26T12:00'],
+            'temperature_2m': [26.0],
+            'relative_humidity_2m': [70.0],
+            'precipitation': [0.0],
+            'cloud_cover': [10.0],
+            'wind_speed_10m': [8.0],
+            'wind_direction_10m': [30.0],
+            'surface_pressure': [1012.0],
+            'weathercode': [0],
+          },
+        }),
+        200,
+      );
+    });
+
+    await pumpView(tester, story, weatherHttpClient: client);
+    await tester.pump();
+
+    expect(calls, 1);
+    expect(find.text('26°C'), findsOneWidget);
   });
 }

--- a/test/features/weather/data/services/weather_service_test.dart
+++ b/test/features/weather/data/services/weather_service_test.dart
@@ -15,6 +15,7 @@ void main() {
         expect(request.url.queryParameters['longitude'], '-80.6');
         expect(request.url.queryParameters['start_date'], '2024-06-15');
         expect(request.url.queryParameters['end_date'], '2024-06-15');
+        expect(request.url.queryParameters['timezone'], isNull);
 
         return http.Response(
           jsonEncode({
@@ -46,6 +47,39 @@ void main() {
       expect(result!.airTemp, 27.0);
       expect(result.cloudCover, CloudCover.partlyCloudy);
       expect(result.precipitation, Precipitation.none);
+    });
+
+    test('fetchWeather can request the coordinate local timezone', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.queryParameters['timezone'], 'auto');
+        return http.Response(
+          jsonEncode({
+            'hourly': {
+              'time': ['2024-06-15T12:00'],
+              'temperature_2m': [28.0],
+              'relative_humidity_2m': [70.0],
+              'precipitation': [0.0],
+              'cloud_cover': [20.0],
+              'wind_speed_10m': [14.0],
+              'wind_direction_10m': [50.0],
+              'surface_pressure': [1014.0],
+              'weathercode': [0],
+            },
+          }),
+          200,
+        );
+      });
+
+      final service = WeatherService(client: mockClient);
+      final result = await service.fetchWeather(
+        latitude: 28.5,
+        longitude: -80.6,
+        date: DateTime(2024, 6, 15),
+        entryTime: DateTime(2024, 6, 15, 12),
+        useLocationTimezone: true,
+      );
+
+      expect(result?.airTemp, 28.0);
     });
 
     test('fetchWeather returns null on HTTP error', () async {

--- a/test/helpers/changeset_test_helpers.dart
+++ b/test/helpers/changeset_test_helpers.dart
@@ -76,7 +76,7 @@ Future<void> seedPeerLog(
     epochId: epochId,
     uploadNonce: uploadNonce,
   );
-  DatabaseService.instance.resetForTesting();
+  await tearDownTestDatabase();
   await setUpTestDatabase();
 }
 


### PR DESCRIPTION
## Summary

Show weather on trip surface days using the same compact header treatment already used for dive days. Surface-day weather is resolved from the nearest trip map point and fetched for the location local noon so historical archive data maps to the intended calendar day.

The full-suite failures found on this branch were test lifecycle issues: the sync round-trip test retained local database state while pretending to be a second device, and the setup test closed Drift before settings initialization completed.

## Changes

- Resolve the nearest trip location for each story day
- Fetch and cache surface-day weather using coordinate-local archive hours
- Render surface-day weather in the existing trip day header badge
- Exercise entity, provider, service, and widget behavior
- Use a real publish-then-fresh-database sync test harness and close the replaced database
- Await settings provider initialization before setup test teardown

## Test Plan

- [x] `flutter test` — 17,300 passed, 17 skipped
- [x] `flutter analyze`
- [x] Affected pre-push test suite — 38 files
- [x] Manual testing on a device