### PR TITLE
fix(dives): restore the fill highlight on the active dive row

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -778,18 +778,23 @@ class DiveListTile extends ConsumerWidget {
     // Check if map background is enabled
     final showMapBackground = ref.watch(showMapBackgroundOnDiveCardsProvider);
 
+    // The active row carries a fill tint: checked in the bulk selection, or --
+    // outside selection mode -- open in the detail pane. Inside selection mode
+    // the fill belongs to the checked channel alone, so a highlighted but
+    // unchecked row stays plain instead of reading as selected.
+    final showsSelectionFill = isChecked || (isHighlighted && !isSelectionMode);
+
     // Determine if we should show the map (setting enabled + location available)
-    final shouldShowMap = showMapBackground && _hasLocation && !isChecked;
+    final shouldShowMap =
+        showMapBackground && _hasLocation && !showsSelectionFill;
 
     // Determine card background: selection takes priority, then attribute coloring
     // When map is shown, we don't use attribute coloring on the card itself
     final attributeColor = (showCardColors && !shouldShowMap)
         ? _getAttributeBackgroundColor()
         : null;
-    final cardColor = isChecked
+    final cardColor = showsSelectionFill
         ? colorScheme.primaryContainer.withValues(alpha: 0.5)
-        : isHighlighted
-        ? colorScheme.primaryContainer.withValues(alpha: 0.15)
         : attributeColor;
 
     // Determine text colors based on background luminance
@@ -1178,18 +1183,11 @@ class DiveListTile extends ConsumerWidget {
       );
     }
 
-    // Standard card without map
+    // Standard card without map. The highlight is the fill above, not an edge
+    // stripe -- the key marks the row for tests without decorating it.
     return Container(
       key: isHighlighted ? const ValueKey('dive_row_highlight') : null,
       margin: margin ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      decoration: isHighlighted
-          ? BoxDecoration(
-              border: Border(
-                left: BorderSide(color: colorScheme.primary, width: 3),
-              ),
-              borderRadius: BorderRadius.circular(12),
-            )
-          : null,
       child: Card(
         margin: EdgeInsets.zero,
         color: cardColor,

--- a/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
@@ -197,10 +197,13 @@ class CompactDiveListTile extends ConsumerWidget {
     final attributeColor = showCardColors
         ? _getAttributeBackgroundColor()
         : null;
-    final cardColor = isChecked
+    // The active row carries a fill tint: checked in the bulk selection, or --
+    // outside selection mode -- open in the detail pane. Inside selection mode
+    // the fill belongs to the checked channel alone, so a highlighted but
+    // unchecked row stays plain instead of reading as selected.
+    final showsSelectionFill = isChecked || (isHighlighted && !isSelectionMode);
+    final cardColor = showsSelectionFill
         ? colorScheme.primaryContainer.withValues(alpha: 0.5)
-        : isHighlighted
-        ? colorScheme.primaryContainer.withValues(alpha: 0.15)
         : attributeColor;
 
     final effectiveBackground =
@@ -241,17 +244,11 @@ class CompactDiveListTile extends ConsumerWidget {
               ? duration != null
               : maxDepth != null);
 
+    // The highlight is the fill above, not an edge stripe -- the key marks the
+    // row for tests without decorating it.
     return Container(
       key: isHighlighted ? const ValueKey('dive_row_highlight') : null,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      decoration: isHighlighted
-          ? BoxDecoration(
-              border: Border(
-                left: BorderSide(color: colorScheme.primary, width: 3),
-              ),
-              borderRadius: BorderRadius.circular(12),
-            )
-          : null,
       child: Card(
         margin: EdgeInsets.zero,
         color: cardColor,

--- a/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
@@ -217,17 +217,24 @@ void main() {
         ),
       );
 
-      // The outer Container should have a highlight border decoration
-      final container = tester.widget<Container>(
-        find
-            .descendant(
-              of: find.byType(CompactDiveListTile),
-              matching: find.byType(Container),
-            )
-            .first,
+      // A highlighted row is filled, the same way a checked row is -- see
+      // dive_tile_highlight_fill_test.dart for the full channel matrix.
+      final context = tester.element(find.byType(CompactDiveListTile));
+      final card = tester.widget<Card>(
+        find.descendant(
+          of: find.byType(CompactDiveListTile),
+          matching: find.byType(Card),
+        ),
       );
-      final decoration = container.decoration;
-      expect(decoration, isNotNull);
+      expect(
+        card.color,
+        Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.5),
+      );
+      expect(
+        find.byKey(const ValueKey('dive_row_highlight')),
+        findsOneWidget,
+        reason: 'the highlighted row stays identifiable',
+      );
     });
 
     testWidgets('renders with null depth and duration shows fallback', (

--- a/test/features/dive_log/presentation/widgets/dive_tile_highlight_fill_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_tile_highlight_fill_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/list_view_mode.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_list_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/compact_dive_list_tile.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The dive open in the detail pane is filled, never striped.
+///
+/// Splitting `isSelected` into `isChecked` and `isHighlighted` made the
+/// highlight channel reach the tiles for the first time, and the tiles rendered
+/// it as a 3px leading edge stripe over a barely-there tint. That is not how
+/// the dive list has ever looked, nor how the Sites and Buddies lists look --
+/// they render a highlighted row with the same fill a checked row gets. These
+/// tests pin the fill, and the absence of the stripe, on both card tiles.
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// The detailed tile reads its slot config through a provider chain that
+/// reaches SharedPreferences, so the config is pinned to the default here.
+class _TestCardConfigNotifier extends CardViewConfigNotifier {
+  _TestCardConfigNotifier() : super.withMode(ListViewMode.detailed);
+}
+
+void main() {
+  Widget compact({
+    required bool isSelectionMode,
+    required bool isChecked,
+    required bool isHighlighted,
+  }) => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    child: CompactDiveListTile(
+      diveId: 'd1',
+      diveNumber: 40,
+      dateTime: DateTime(2026, 5, 7, 9),
+      siteName: 'Unknown Site',
+      maxDepth: 18.6,
+      duration: const Duration(minutes: 59),
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      isHighlighted: isHighlighted,
+      onTap: () {},
+    ),
+  );
+
+  Widget detailed({
+    required bool isSelectionMode,
+    required bool isChecked,
+    required bool isHighlighted,
+  }) => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+      detailedCardConfigProvider.overrideWith(
+        (ref) => _TestCardConfigNotifier(),
+      ),
+    ],
+    child: DiveListTile(
+      diveId: 'd1',
+      diveNumber: 40,
+      dateTime: DateTime(2026, 5, 7, 9),
+      siteName: 'Unknown Site',
+      maxDepth: 18.6,
+      duration: const Duration(minutes: 59),
+      isSelectionMode: isSelectionMode,
+      isChecked: isChecked,
+      isHighlighted: isHighlighted,
+      onTap: () {},
+    ),
+  );
+
+  /// The fill the dive list has always used for the active row.
+  Color selectionFill(WidgetTester tester, Type tileType) {
+    final context = tester.element(find.byType(tileType));
+    return Theme.of(
+      context,
+    ).colorScheme.primaryContainer.withValues(alpha: 0.5);
+  }
+
+  Color? cardColor(WidgetTester tester, Type tileType) => tester
+      .widget<Card>(
+        find.descendant(of: find.byType(tileType), matching: find.byType(Card)),
+      )
+      .color;
+
+  /// The highlight marker container must carry no leading edge stripe.
+  void expectNoStripe(WidgetTester tester) {
+    final marker = find.byKey(const ValueKey('dive_row_highlight'));
+    if (marker.evaluate().isEmpty) return;
+    final decoration = tester.widget<Container>(marker).decoration;
+    expect(
+      (decoration as BoxDecoration?)?.border,
+      isNull,
+      reason: 'a highlighted row is filled, not striped',
+    );
+  }
+
+  void highlightRenderingTests(
+    String name,
+    Type type,
+    Widget Function({
+      required bool isSelectionMode,
+      required bool isChecked,
+      required bool isHighlighted,
+    })
+    build,
+  ) {
+    group('$name highlight rendering', () {
+      testWidgets('highlighted row is filled like a selected row', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          build(isSelectionMode: false, isChecked: false, isHighlighted: true),
+        );
+        await tester.pumpAndSettle();
+
+        expect(cardColor(tester, type), selectionFill(tester, type));
+        expectNoStripe(tester);
+      });
+
+      testWidgets('checked row uses the same fill', (tester) async {
+        await tester.pumpWidget(
+          build(isSelectionMode: true, isChecked: true, isHighlighted: false),
+        );
+        await tester.pumpAndSettle();
+
+        expect(cardColor(tester, type), selectionFill(tester, type));
+      });
+
+      testWidgets('highlight does not fill a row in selection mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          build(isSelectionMode: true, isChecked: false, isHighlighted: true),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          cardColor(tester, type),
+          isNot(selectionFill(tester, type)),
+          reason:
+              'in selection mode the fill means checked; a highlighted but '
+              'unchecked row must not read as selected',
+        );
+        expectNoStripe(tester);
+      });
+    });
+  }
+
+  highlightRenderingTests('CompactDiveListTile', CompactDiveListTile, compact);
+  highlightRenderingTests('DiveListTile', DiveListTile, detailed);
+}

--- a/test/features/dive_log/presentation/widgets/dive_tile_highlight_fill_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_tile_highlight_fill_test.dart
@@ -98,10 +98,21 @@ void main() {
       )
       .color;
 
-  /// The highlight marker container must carry no leading edge stripe.
-  void expectNoStripe(WidgetTester tester) {
+  /// A highlighted row must be marked, and its marker must carry no leading
+  /// edge stripe.
+  ///
+  /// The marker is asserted rather than tolerated: every caller passes
+  /// `isHighlighted: true` with no coordinates, so the tile always takes the
+  /// standard-card path that emits the key. Returning early on a missing
+  /// marker would turn the stripe check into a vacuous pass if a regression
+  /// ever stopped marking highlighted rows.
+  void expectMarkedWithoutStripe(WidgetTester tester) {
     final marker = find.byKey(const ValueKey('dive_row_highlight'));
-    if (marker.evaluate().isEmpty) return;
+    expect(
+      marker,
+      findsOneWidget,
+      reason: 'the highlighted row carries its marker',
+    );
     final decoration = tester.widget<Container>(marker).decoration;
     expect(
       (decoration as BoxDecoration?)?.border,
@@ -130,7 +141,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(cardColor(tester, type), selectionFill(tester, type));
-        expectNoStripe(tester);
+        expectMarkedWithoutStripe(tester);
       });
 
       testWidgets('checked row uses the same fill', (tester) async {
@@ -157,7 +168,7 @@ void main() {
               'in selection mode the fill means checked; a highlighted but '
               'unchecked row must not read as selected',
         );
-        expectNoStripe(tester);
+        expectMarkedWithoutStripe(tester);
       });
     });
   }


### PR DESCRIPTION
## Problem

The dive selected in the dives list was rendering with a 3px leading edge stripe over a barely-there tint instead of the fill it has always had.

## Cause

`e9888c9` ("refactor(dives): split isSelected into isChecked and isHighlighted") did not add the stripe — it **unblocked** one that had never been reachable.

`DiveListItem` used to fold both flags into a single value:

```dart
final resolvedSelected = isSelectionMode ? isSelected : (isSelected || isHighlighted);
```

The row open in the detail pane therefore arrived at the tiles as *selected* and drew `primaryContainer @ 0.5`. Nothing ever set `isHighlighted`, so the tiles' stripe branch was dead code. Separating the channels sent `isHighlighted: true` through for the first time, and the row dropped to `alpha 0.15` plus a `colorScheme.primary` left border.

No other list in the app renders highlight that way — `compact_site_list_tile.dart`, `dense_site_list_tile.dart`, and `dense_buddy_list_tile.dart` all use the checked fill for a highlighted row.

## Fix

The two channels stay independent as data, which is what bulk selection needs. Only the painting changes, via one predicate in each card tile:

```dart
final showsSelectionFill = isChecked || (isHighlighted && !isSelectionMode);
```

The `!isSelectionMode` guard reproduces the old semantics exactly: inside selection mode the fill means "checked", so a highlighted-but-unchecked row must not borrow it.

`shouldShowMap` in the detailed tile was gated on `!isChecked` alone, so the map background had started bleeding through the active row; it now follows the same predicate.

`DenseDiveListTile` keeps its stripe code — it is unreferenced anywhere in `lib/`, since `DiveListItem` routes dense mode to `DiveListTile`.

## Tests

- New `dive_tile_highlight_fill_test.dart` pins the fill and the absence of the stripe on both `CompactDiveListTile` and `DiveListTile`, across all three channel combinations (highlighted alone, checked alone, highlighted inside selection mode).
- `compact_dive_list_tile_test.dart` had one test asserting the stripe decoration specifically; it now asserts the restored fill.
- `dive_list_item_channels_test.dart` is untouched and still green — the `isChecked`/`isHighlighted` separation is intact.
- Full local suite: 17,298 passed. The single failure (`setup_apply_service_test.dart`) passes in isolation and is the known full-suite concurrency flake, unreachable from this diff.
- `flutter analyze` clean; `dart format` clean.
