### PR TITLE
feat(selection): move bulk delete behind the overflow menu

### DIFF
--- a/lib/features/media/presentation/widgets/media_grid.dart
+++ b/lib/features/media/presentation/widgets/media_grid.dart
@@ -13,57 +13,6 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 /// break consumer widget tests that pump without localization delegates,
 /// and the dive/site sections want differently-worded labels anyway.
 
-/// Header shown during multi-select mode with count, select all, and unlink.
-class MediaSelectionHeader extends StatelessWidget {
-  final int selectedCount;
-  final int totalCount;
-  final VoidCallback onSelectAll;
-  final VoidCallback onCancel;
-  final VoidCallback onUnlinkSelected;
-  final String selectedCountLabel;
-  final String selectAllLabel;
-  final String cancelTooltip;
-  final String unlinkTooltip;
-
-  const MediaSelectionHeader({
-    super.key,
-    required this.selectedCount,
-    required this.totalCount,
-    required this.onSelectAll,
-    required this.onCancel,
-    required this.onUnlinkSelected,
-    required this.selectedCountLabel,
-    required this.selectAllLabel,
-    required this.cancelTooltip,
-    required this.unlinkTooltip,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-
-    return Row(
-      children: [
-        IconButton(
-          icon: const Icon(Icons.close),
-          tooltip: cancelTooltip,
-          onPressed: onCancel,
-        ),
-        Text(selectedCountLabel, style: textTheme.titleMedium),
-        const Spacer(),
-        if (selectedCount < totalCount)
-          TextButton(onPressed: onSelectAll, child: Text(selectAllLabel)),
-        IconButton(
-          icon: Icon(Icons.delete_outline, color: colorScheme.error),
-          tooltip: unlinkTooltip,
-          onPressed: selectedCount > 0 ? onUnlinkSelected : null,
-        ),
-      ],
-    );
-  }
-}
-
 /// Empty state shown when a section has no media.
 class MediaEmptyState extends StatelessWidget {
   final IconData icon;

--- a/lib/shared/selection/selection_app_bar.dart
+++ b/lib/shared/selection/selection_app_bar.dart
@@ -125,6 +125,16 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
     int count,
     Set<String> checkedIds,
   ) {
+    // A surface that picked the sentinel as an action id would have its menu
+    // entry silently invoke onDelete instead of its own handler -- the wrong
+    // handler, and a destructive one. BulkAction.id is free-form, so make the
+    // collision fail loudly in debug rather than shipping that.
+    assert(
+      actions.every((action) => action.id != _deleteMenuValue),
+      'BulkAction.id "$_deleteMenuValue" is reserved for the baseline delete '
+      'entry; rename the action.',
+    );
+
     final allChecked =
         count >= selectableIds.length && selectableIds.isNotEmpty;
     final inline = actions.take(maxInlineActions).toList();

--- a/lib/shared/selection/selection_app_bar.dart
+++ b/lib/shared/selection/selection_app_bar.dart
@@ -20,11 +20,24 @@ enum SelectionBarShell {
 /// deselect all, delete -- are injected here rather than declared per surface,
 /// so no list can ship without them. Surfaces contribute only their extras.
 ///
+/// Delete is deliberately the one baseline control that never renders inline.
+/// It sits at the bottom of the overflow menu, below a divider, so destroying a
+/// whole selection takes a deliberate open-then-choose rather than a single tap
+/// next to the controls a user reaches for constantly. That is a safety
+/// property of the shared bar, not a per-surface choice: every surface inherits
+/// it.
+///
 /// The action set and its ordering are computed once in [_buildControls] and
 /// are identical in both shells; only the split between inline icons and the
 /// overflow menu depends on [maxInlineActions]. That is what stops the pane
 /// variant from quietly offering fewer actions than the full-width one.
 class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
+  /// Menu value for the baseline delete entry.
+  ///
+  /// Fenced so it cannot collide with a surface-supplied [BulkAction.id],
+  /// which lets [_buildControls] keep a single dispatch point for the menu.
+  static const String _deleteMenuValue = '__selection_delete__';
+
   final SelectionController controller;
 
   /// Ids the surface will accept actions on, already filtered to exclude
@@ -36,16 +49,19 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   final SelectionBarShell shell;
 
-  /// Invoked by the baseline delete control.
+  /// Invoked by the baseline delete entry in the overflow menu.
   ///
   /// Null only for surfaces that have no true delete -- the dive media section
-  /// unlinks media from a dive without destroying files, so a trash control
-  /// there would misdescribe what it does. When null the delete control is
-  /// omitted entirely rather than rendered disabled, so the bar never shows a
-  /// dead button. Every surface that can delete must pass this.
+  /// unlinks media from a dive without destroying files, so a trash entry
+  /// there would misdescribe what it does. When null the delete entry is
+  /// omitted entirely rather than rendered disabled, so the menu never shows a
+  /// dead row. Every surface that can delete must pass this.
   final VoidCallback? onDelete;
 
   /// How many extras render as inline icons before the rest overflow.
+  ///
+  /// Counts extras only. Delete is never inline, so it never consumes a slot
+  /// and lowering this can never push delete back into the bar.
   final int maxInlineActions;
 
   const SelectionAppBar({
@@ -141,20 +157,13 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
               ? action.onInvoke
               : null,
         ),
-      if (_hasDelete)
-        IconButton(
-          key: const ValueKey('selection_delete'),
-          icon: const Icon(Icons.delete_outline),
-          tooltip: MaterialLocalizations.of(context).deleteButtonTooltip,
-          color: Theme.of(context).colorScheme.error,
-          onPressed: count == 0 ? null : onDelete,
-        ),
-      if (overflow.isNotEmpty)
+      if (overflow.isNotEmpty || _hasDelete)
         PopupMenuButton<String>(
           key: const ValueKey('selection_overflow'),
           itemBuilder: (context) => [
             for (final action in overflow)
               PopupMenuItem<String>(
+                key: ValueKey('selection_menu_${action.id}'),
                 value: action.id,
                 enabled: action.isEnabledForSelection(count, checkedIds),
                 child: ListTile(
@@ -163,8 +172,18 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
+            if (_hasDelete) ...[
+              // Delete sorts last, behind a divider, so it is never adjacent
+              // to a benign entry the user is aiming for.
+              if (overflow.isNotEmpty) const PopupMenuDivider(),
+              _buildDeleteItem(context, count),
+            ],
           ],
           onSelected: (id) {
+            if (id == _deleteMenuValue) {
+              onDelete?.call();
+              return;
+            }
             for (final action in overflow) {
               if (action.id == id) {
                 action.onInvoke();
@@ -174,5 +193,31 @@ class SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
           },
         ),
     ];
+  }
+
+  /// The baseline delete entry.
+  ///
+  /// The colour is resolved here rather than left to the menu because the
+  /// [ListTile] child resolves its own icon colour: an unconditional error
+  /// colour would keep the row looking live while [PopupMenuItem.enabled] had
+  /// already made it inert.
+  PopupMenuItem<String> _buildDeleteItem(BuildContext context, int count) {
+    final theme = Theme.of(context);
+    final enabled = count > 0;
+    final color = enabled ? theme.colorScheme.error : theme.disabledColor;
+
+    return PopupMenuItem<String>(
+      key: const ValueKey('selection_delete'),
+      value: _deleteMenuValue,
+      enabled: enabled,
+      child: ListTile(
+        leading: Icon(Icons.delete_outline, color: color),
+        title: Text(
+          MaterialLocalizations.of(context).deleteButtonTooltip,
+          style: TextStyle(color: color),
+        ),
+        contentPadding: EdgeInsets.zero,
+      ),
+    );
   }
 }

--- a/test/features/media/presentation/widgets/dive_media_section_test.dart
+++ b/test/features/media/presentation/widgets/dive_media_section_test.dart
@@ -149,9 +149,8 @@ void main() {
       await tester.longPress(find.byType(MediaThumbnailTile).first);
       await tester.pumpAndSettle();
 
-      // Both media sections now render the shared SelectionAppBar.
-      // MediaSelectionHeader in media_grid.dart has no remaining consumers;
-      // removing it belongs to the phase 6 cleanup.
+      // Both media sections render the shared SelectionAppBar; the old
+      // MediaSelectionHeader has been removed.
       expect(find.byKey(const ValueKey('selection_exit')), findsOneWidget);
       expect(find.text('1 selected'), findsOneWidget);
       // The normal header and its add affordance yield to selection.

--- a/test/features/media/presentation/widgets/media_grid_test.dart
+++ b/test/features/media/presentation/widgets/media_grid_test.dart
@@ -23,53 +23,6 @@ void main() {
     expect(find.byIcon(Icons.map_outlined), findsOneWidget);
   });
 
-  Widget header({required int selectedCount, VoidCallback? onUnlink}) {
-    return MaterialApp(
-      home: Scaffold(
-        body: MediaSelectionHeader(
-          selectedCount: selectedCount,
-          totalCount: 3,
-          onSelectAll: () {},
-          onCancel: () {},
-          onUnlinkSelected: onUnlink ?? () {},
-          selectedCountLabel: '$selectedCount selected',
-          selectAllLabel: 'Select all',
-          cancelTooltip: 'Cancel',
-          unlinkTooltip: 'Unlink',
-        ),
-      ),
-    );
-  }
-
-  testWidgets('MediaSelectionHeader disables unlink at zero selection', (
-    tester,
-  ) async {
-    await tester.pumpWidget(header(selectedCount: 0));
-    final button = tester.widget<IconButton>(
-      find.widgetWithIcon(IconButton, Icons.delete_outline),
-    );
-    expect(button.onPressed, isNull);
-  });
-
-  testWidgets('MediaSelectionHeader enables unlink with a selection', (
-    tester,
-  ) async {
-    var fired = 0;
-    await tester.pumpWidget(header(selectedCount: 1, onUnlink: () => fired++));
-    await tester.tap(find.widgetWithIcon(IconButton, Icons.delete_outline));
-    expect(fired, 1);
-    // Select-all appears while not everything is selected.
-    expect(find.text('Select all'), findsOneWidget);
-    expect(find.text('1 selected'), findsOneWidget);
-  });
-
-  testWidgets('MediaSelectionHeader hides select-all once all are selected', (
-    tester,
-  ) async {
-    await tester.pumpWidget(header(selectedCount: 3));
-    expect(find.text('Select all'), findsNothing);
-  });
-
   group('MediaThumbnailTile', () {
     Future<void> pumpTile(
       WidgetTester tester, {

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -165,9 +165,15 @@ void main() {
     await tester.pump();
     await tester.tap(find.byKey(const ValueKey('selection_select_all')));
     await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+    await tester.pump();
+    // The page animates its in-flight progress, so pumpAndSettle would never
+    // return; run the menu route out by its own duration instead.
+    await tester.pump(const Duration(milliseconds: 300));
     await tester.tap(find.byKey(const ValueKey('selection_delete')));
     await tester.pump();
-    await tester.tap(find.text('Delete'));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Delete').hitTestable().last);
     await tester.pump();
 
     await tester.runAsync(() async {

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -12,6 +12,26 @@ import 'package:submersion/features/media_store/presentation/pages/transfers_pag
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
+/// Runs out a route transition without pumpAndSettle.
+///
+/// This page animates the progress of in-flight transfers, so pumpAndSettle
+/// never returns here. Widget tests run on a fake clock, so this advances
+/// simulated time deterministically -- machine speed cannot affect it. The
+/// duration deliberately overshoots any plausible menu or dialog transition
+/// rather than matching Flutter's internal constants, which this test has no
+/// business encoding.
+///
+/// Three frames, not one: the first starts the transition, the second runs it
+/// out, and the third renders whatever the completed route caused. Selecting a
+/// popup menu entry needs all three -- PopupMenuButton.onSelected fires only
+/// once the pop animation finishes, so the dialog it opens appears a frame
+/// after the menu is gone.
+Future<void> pumpRoute(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+  await tester.pump();
+}
+
 /// The page renders from SNAPSHOT streams here: live drift watch() streams
 /// held open by the widget tree deadlock against db.close() in the
 /// fake-async test zone. Stream behavior is covered by the repository
@@ -166,13 +186,10 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('selection_select_all')));
     await tester.pump();
     await tester.tap(find.byKey(const ValueKey('selection_overflow')));
-    await tester.pump();
-    // The page animates its in-flight progress, so pumpAndSettle would never
-    // return; run the menu route out by its own duration instead.
-    await tester.pump(const Duration(milliseconds: 300));
+    await pumpRoute(tester);
     await tester.tap(find.byKey(const ValueKey('selection_delete')));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await pumpRoute(tester);
+    expect(find.byType(AlertDialog), findsOneWidget);
     await tester.tap(find.text('Delete').hitTestable().last);
     await tester.pump();
 

--- a/test/features/tags/presentation/pages/tag_manage_page_test.dart
+++ b/test/features/tags/presentation/pages/tag_manage_page_test.dart
@@ -229,7 +229,9 @@ void main() {
       await tester.longPress(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
-      // Tap the delete icon in the app bar
+      // Delete lives behind the selection bar's overflow menu.
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('selection_delete')));
       await tester.pumpAndSettle();
 

--- a/test/helpers/bulk_delete_contract.dart
+++ b/test/helpers/bulk_delete_contract.dart
@@ -4,10 +4,14 @@ import 'package:flutter_test/flutter_test.dart';
 /// Drives a surface's bulk-delete flow end to end and reports what it deleted.
 ///
 /// Every selectable surface got the same baseline delete: enter selection,
-/// check rows, tap the keyed delete control, confirm, and see a snackbar. The
-/// handlers are near-identical per surface and were the least-covered part of
-/// the selection work, so this exercises the real path rather than asserting
-/// the button exists.
+/// check rows, open the overflow, choose the keyed delete entry, confirm, and
+/// see a snackbar. The handlers are near-identical per surface and were the
+/// least-covered part of the selection work, so this exercises the real path
+/// rather than asserting the entry exists.
+///
+/// Delete lives behind the overflow menu on every surface, so the two extra
+/// taps here are load-bearing: if a surface ever regressed to a one-tap inline
+/// delete, opening the overflow would fail rather than silently pass.
 ///
 /// [build] returns a fully wired widget for the surface.
 /// [selectButton] finds the surface's Select affordance.
@@ -40,19 +44,28 @@ Future<void> verifyBulkDelete(
   await tester.tap(find.byKey(const ValueKey('selection_select_all')));
   await advance();
 
-  final deleteButton = find.byKey(const ValueKey('selection_delete'));
   expect(
-    deleteButton,
+    find.byKey(const ValueKey('selection_delete')),
+    findsNothing,
+    reason: 'delete must stay behind the overflow, never inline',
+  );
+
+  await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+  await advance();
+
+  final deleteEntry = find.byKey(const ValueKey('selection_delete'));
+  expect(
+    deleteEntry,
     findsOneWidget,
     reason: 'delete is a guaranteed baseline control',
   );
   expect(
-    tester.widget<IconButton>(deleteButton).onPressed,
-    isNotNull,
+    tester.widget<PopupMenuItem<String>>(deleteEntry).enabled,
+    isTrue,
     reason: 'delete must be enabled with rows checked',
   );
 
-  await tester.tap(deleteButton);
+  await tester.tap(deleteEntry);
   await advance();
 
   // The confirmation is not optional: bulk delete must never act on a single
@@ -92,6 +105,8 @@ Future<void> verifyBulkDeleteCancels(
   await tester.tap(selectButton);
   await advance();
   await tester.tap(find.byKey(const ValueKey('selection_select_all')));
+  await advance();
+  await tester.tap(find.byKey(const ValueKey('selection_overflow')));
   await advance();
   await tester.tap(find.byKey(const ValueKey('selection_delete')));
   await advance();

--- a/test/shared/selection/selection_app_bar_test.dart
+++ b/test/shared/selection/selection_app_bar_test.dart
@@ -96,63 +96,120 @@ void main() {
       expect(button.onPressed, isNull);
     });
 
+    testWidgets('delete is never an inline control', (tester) async {
+      controller.enterImplicit('a');
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+
+      // Delete sits behind the overflow so it cannot be hit by accident while
+      // reaching for a neighbouring control.
+      expect(find.byKey(const ValueKey('selection_delete')), findsNothing);
+      expect(find.byIcon(Icons.delete_outline), findsNothing);
+    });
+
+    testWidgets('a delete-only surface still gets an overflow menu', (
+      tester,
+    ) async {
+      controller.enterImplicit('a');
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('selection_overflow')), findsOneWidget);
+    });
+
     testWidgets('delete is disabled at zero checked', (tester) async {
       controller.enterExplicit();
       await tester.pumpWidget(host());
       await tester.pumpAndSettle();
-      final button = tester.widget<IconButton>(
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
+
+      final item = tester.widget<PopupMenuItem<String>>(
         find.byKey(const ValueKey('selection_delete')),
       );
-      expect(button.onPressed, isNull);
+      expect(item.enabled, isFalse);
     });
 
-    testWidgets('delete invokes onDelete when something is checked', (
+    testWidgets('delete invokes onDelete when chosen from the overflow', (
       tester,
     ) async {
       var deleted = false;
       controller.enterImplicit('a');
       await tester.pumpWidget(host(onDelete: () => deleted = true));
       await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('selection_delete')));
       await tester.pumpAndSettle();
       expect(deleted, isTrue);
     });
 
-    testWidgets('omits the delete control entirely when onDelete is null', (
-      tester,
-    ) async {
+    testWidgets('delete sorts last, below the surface extras', (tester) async {
       controller.enterImplicit('a');
       await tester.pumpWidget(
-        testApp(
-          locale: const Locale('en'),
-          child: Scaffold(
-            appBar: SelectionAppBar(
-              controller: controller,
-              selectableIds: const ['a', 'b', 'c'],
-              actions: const [],
-              shell: SelectionBarShell.appBar,
-              onDelete: null,
+        host(
+          maxInlineActions: 0,
+          actions: [
+            BulkAction(
+              id: 'merge',
+              icon: Icons.merge_type,
+              label: 'Merge',
+              onInvoke: () {},
             ),
-            body: const SizedBox(),
-          ),
+          ],
         ),
       );
       await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
 
-      // Omitted, not disabled: a surface with no true delete must not show a
-      // dead trash button.
-      expect(find.byKey(const ValueKey('selection_delete')), findsNothing);
-      // The rest of the baseline still renders.
-      expect(
-        find.byKey(const ValueKey('selection_select_all')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const ValueKey('selection_deselect_all')),
-        findsOneWidget,
-      );
-      expect(find.byKey(const ValueKey('selection_exit')), findsOneWidget);
+      // A divider keeps the destructive entry visually apart from the extras.
+      expect(find.byType(PopupMenuDivider), findsOneWidget);
+      final mergeY = tester
+          .getCenter(find.byKey(const ValueKey('selection_menu_merge')))
+          .dy;
+      final deleteY = tester
+          .getCenter(find.byKey(const ValueKey('selection_delete')))
+          .dy;
+      expect(deleteY, greaterThan(mergeY));
     });
+
+    testWidgets(
+      'omits the overflow entirely when there is nothing to put in it',
+      (tester) async {
+        controller.enterImplicit('a');
+        await tester.pumpWidget(
+          testApp(
+            locale: const Locale('en'),
+            child: Scaffold(
+              appBar: SelectionAppBar(
+                controller: controller,
+                selectableIds: const ['a', 'b', 'c'],
+                actions: const [],
+                shell: SelectionBarShell.appBar,
+                onDelete: null,
+              ),
+              body: const SizedBox(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Omitted, not disabled: a surface with no true delete and no extras has
+        // nothing to overflow, so the menu button itself must not render.
+        expect(find.byKey(const ValueKey('selection_delete')), findsNothing);
+        expect(find.byKey(const ValueKey('selection_overflow')), findsNothing);
+        // The rest of the baseline still renders.
+        expect(
+          find.byKey(const ValueKey('selection_select_all')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('selection_deselect_all')),
+          findsOneWidget,
+        );
+        expect(find.byKey(const ValueKey('selection_exit')), findsOneWidget);
+      },
+    );
 
     testWidgets('an extra below its minCount renders disabled', (tester) async {
       controller.enterImplicit('a');
@@ -305,6 +362,12 @@ void main() {
         findsOneWidget,
       );
       expect(find.byKey(const ValueKey('selection_exit')), findsOneWidget);
+
+      // The pane shell hides delete behind the overflow too, so neither shell
+      // offers a one-tap destructive control.
+      expect(find.byKey(const ValueKey('selection_delete')), findsNothing);
+      await tester.tap(find.byKey(const ValueKey('selection_overflow')));
+      await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey('selection_delete')), findsOneWidget);
     });
   });

--- a/test/shared/selection/selection_app_bar_test.dart
+++ b/test/shared/selection/selection_app_bar_test.dart
@@ -143,6 +143,28 @@ void main() {
       expect(deleted, isTrue);
     });
 
+    testWidgets('an action id colliding with the delete sentinel asserts', (
+      tester,
+    ) async {
+      controller.enterImplicit('a');
+      await tester.pumpWidget(
+        host(
+          actions: [
+            BulkAction(
+              id: '__selection_delete__',
+              icon: Icons.merge_type,
+              label: 'Collides',
+              onInvoke: () {},
+            ),
+          ],
+        ),
+      );
+
+      // Silently routing this action's menu entry to onDelete would fire the
+      // wrong handler, and a destructive one. It must fail loudly instead.
+      expect(tester.takeException(), isAssertionError);
+    });
+
     testWidgets('delete sorts last, below the surface extras', (tester) async {
       controller.enterImplicit('a');
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Bulk **Delete** was an inline icon button in the selection bar, sitting immediately next to select-all and deselect-all — the two controls a user reaches for constantly while multi-selecting. A mis-aimed tap put the entire selection one confirmation away from destruction.

Delete now lives at the **bottom of the overflow menu**, below a divider separating it from the surface's benign extras, so acting on it takes a deliberate open-then-choose rather than a single tap.

All 17 selection surfaces inherit this from one production file, because `SelectionAppBar` injects the baseline controls (select-all, deselect-all, delete) itself rather than letting each surface declare them.

## Changes

- Delete moved from an inline `IconButton` to the last `PopupMenuItem` in the existing overflow menu, preceded by a `PopupMenuDivider` when the surface has extras.
- **The overflow menu now renders whenever there is a delete**, not only when a surface declares more extras than `maxInlineActions`. Without this, the seven delete-only surfaces (cylinder configs, dive computers, species, trips, certifications, dive centers, service kinds) would have lost delete entirely.
- `maxInlineActions` consequently counts *extras only*. Delete can never be pushed back inline by per-surface tuning, making the safety property structural rather than configuration-dependent.
- Delete keeps its `selection_delete` key, its disabled-at-zero-checked gate, and its error coloring — but the color is now resolved conditionally. A `ListTile` inside a `PopupMenuItem` resolves its own icon color, so an unconditional `colorScheme.error` would have kept the row looking live while `enabled: false` had already made it inert.
- Overflow entries gained `selection_menu_<id>` keys, which they previously lacked.
- No new l10n string: the menu label reuses `MaterialLocalizations.deleteButtonTooltip`, already translated in every locale Flutter ships.
- Second commit removes `MediaSelectionHeader` from `media_grid.dart` — dead since both media sections moved to the shared `SelectionAppBar`, with only its own tests referencing it and a comment in `dive_media_section_test.dart` deferring removal to "the phase 6 cleanup". It also carried the last unreviewed trash button in a selection context: a `delete_outline` icon wired to `onUnlinkSelected`, which misdescribed what it did.

**Surfaces affected:** dives (full-width and master pane), dive sites, buddies, equipment, courses, tags, trips, certifications, dive centers, cylinder configs, dive computers, marine life species, equipment service kinds, media-store transfers. The two surfaces that unlink rather than destroy (dive media section, site media section) pass `onDelete: null` and are unchanged — they now correctly render no overflow button at all when they also have no extras.

## Test Plan

Written test-first; every new assertion was watched failing against the unchanged widget before implementing.

- [x] `flutter test` passes — **17,289 passed**. The single failure was `global_drop_target_test.dart`, a known load-dependent flake unrelated to selection; it passes 13/13 in isolation.
- [x] `flutter analyze` passes — no issues. `dart format` clean.
- [x] Manual testing on: **none yet.** This is a pure UI-affordance change and has not been exercised in a running app.

Test changes:

- `test/shared/selection/selection_app_bar_test.dart` — rewrote the delete assertions and added cases for menu-only placement, delete-sorts-last with a divider, delete-only surfaces still getting a menu, and the overflow being omitted when there is genuinely nothing to put in it. 18/18.
- `test/helpers/bulk_delete_contract.dart` — the shared contract driving nine surface suites now asserts delete is **absent** before opening the overflow, so a regression to a one-tap inline delete fails loudly across all of them at once.
- `transfers_page_test.dart` needed an explicit `pump(300ms)` for the menu route: that page animates in-flight transfer progress, so `pumpAndSettle` never returns.

## Screenshots

Not captured — worth a look before merge, since tests confirm the menus are *correct*, not that they *read* well. Two spots specifically:

- The dives master pane (`maxInlineActions: 1`) now has a six-entry menu: 4 extras, divider, delete.
- Delete-only surfaces now show a `⋮` button whose menu holds exactly one item — functional, but new chrome where there was none.
