### PR TITLE
Remove long-press entry into multi-select; keep delete behind the overflow

### DIFF
--- a/lib/features/buddies/presentation/widgets/buddy_list_content.dart
+++ b/lib/features/buddies/presentation/widgets/buddy_list_content.dart
@@ -154,23 +154,15 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
     }
   }
 
-  /// Enter selection mode implicitly, from a long-press or modifier-click.
-  void _enterSelectionMode(String? initialId) {
-    if (initialId == null) {
-      _selection.enterExplicit();
-    } else {
-      _selection.enterImplicit(initialId);
-    }
-  }
-
   void _exitSelectionMode() => _selection.exit();
 
   void _toggleSelection(String id) => _selection.toggle(id);
 
   /// One tap policy for every buddy row, in every view mode.
   ///
-  /// A held modifier turns a tap into an implicit entry, so desktop users
-  /// never have to discover long-press.
+  /// A held modifier turns a tap into an implicit entry -- the one path
+  /// that still evaporates at zero checked, since touch has no gesture
+  /// entry left.
   void _handleRowTap(String id, List<BuddyWithDiveCount> buddies) {
     final orderedIds = buddies.map((b) => b.buddy.id).toList();
     if (SelectableListScope.isShiftPressed()) {
@@ -454,8 +446,8 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
                         );
                       },
                     ),
-                    // Discoverability: buddies had no Select affordance at all --
-                    // long-press was the only way into bulk actions.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -580,9 +572,6 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
             if (_isSelectionMode) return;
             context.push('/buddies/$id');
           },
-          onEntityLongPress: _isSelectionMode
-              ? null
-              : (id) => _enterSelectionMode(id),
           selectedIds: _selectedIds,
           isSelectionMode: _isSelectionMode,
           highlightedId: ref.watch(highlightedBuddyIdProvider),
@@ -631,8 +620,8 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
               showSearch(context: context, delegate: BuddySearchDelegate(ref));
             },
           ),
-          // Discoverability: buddies had no Select affordance at all --
-          // long-press was the only way into bulk actions.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),
@@ -763,31 +752,21 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
           final isChecked = _selectedIds.contains(buddy.id);
           final viewMode = ref.watch(buddyListViewModeProvider);
           return switch (viewMode) {
-            ListViewMode.detailed || ListViewMode.compact => GestureDetector(
-              onLongPress: _isSelectionMode
-                  ? null
-                  : () => _enterSelectionMode(buddy.id),
-              child: BuddyListTile(
-                buddy: buddy,
-                diveCount: buddyWithCount.diveCount,
-                isSelected: isSelected,
-                isChecked: isChecked,
-                isSelectionMode: _isSelectionMode,
-                onTap: () => _handleRowTap(buddy.id, buddies),
-              ),
+            ListViewMode.detailed || ListViewMode.compact => BuddyListTile(
+              buddy: buddy,
+              diveCount: buddyWithCount.diveCount,
+              isSelected: isSelected,
+              isChecked: isChecked,
+              isSelectionMode: _isSelectionMode,
+              onTap: () => _handleRowTap(buddy.id, buddies),
             ),
-            ListViewMode.dense || ListViewMode.table => GestureDetector(
-              onLongPress: _isSelectionMode
-                  ? null
-                  : () => _enterSelectionMode(buddy.id),
-              child: DenseBuddyListTile(
-                buddy: buddy,
-                diveCount: buddyWithCount.diveCount,
-                isChecked: isChecked,
-                isHighlighted: !_isSelectionMode && isHighlighted,
-                isSelectionMode: _isSelectionMode,
-                onTap: () => _handleRowTap(buddy.id, buddies),
-              ),
+            ListViewMode.dense || ListViewMode.table => DenseBuddyListTile(
+              buddy: buddy,
+              diveCount: buddyWithCount.diveCount,
+              isChecked: isChecked,
+              isHighlighted: !_isSelectionMode && isHighlighted,
+              isSelectionMode: _isSelectionMode,
+              onTap: () => _handleRowTap(buddy.id, buddies),
             ),
           };
         },

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -217,8 +217,8 @@ class _CertificationListContentState
                         );
                       },
                     ),
-                    // Discoverability: bulk actions must not be reachable only by a
-                    // long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -381,9 +381,6 @@ class _CertificationListContentState
           onEntityTap: (id) {
             if (_isSelectionMode) _selection.toggle(id);
           },
-          onEntityLongPress: _isSelectionMode
-              ? null
-              : (id) => _selection.enterImplicit(id),
           onEntityDoubleTap: (id) {
             context.push('/certifications/$id');
           },
@@ -441,8 +438,8 @@ class _CertificationListContentState
               );
             },
           ),
-          // Discoverability: bulk actions must not be reachable only by a
-          // long-press that nothing on screen advertises.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),

--- a/lib/features/courses/presentation/widgets/course_list_content.dart
+++ b/lib/features/courses/presentation/widgets/course_list_content.dart
@@ -147,8 +147,8 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
                       tooltip: context.l10n.courses_action_sort,
                       onPressed: () => _showSortSheet(context),
                     ),
-                    // Discoverability: bulk actions must not be reachable only by a
-                    // long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -360,9 +360,6 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
           onEntityTap: (id) {
             if (_isSelectionMode) _selection.toggle(id);
           },
-          onEntityLongPress: _isSelectionMode
-              ? null
-              : (id) => _selection.enterImplicit(id),
           onEntityDoubleTap: (id) {
             context.push('/courses/$id');
           },
@@ -408,8 +405,8 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
               tooltip: context.l10n.courses_action_sort,
               onPressed: () => _showSortSheet(context),
             ),
-          // Discoverability: bulk actions must not be reachable only by a
-          // long-press that nothing on screen advertises.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),

--- a/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
@@ -250,8 +250,8 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
                       tooltip: context.l10n.diveCenters_tooltip_sort,
                       onPressed: () => _showSortSheet(context),
                     ),
-                    // Discoverability: bulk actions must not be reachable only by a
-                    // long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -446,9 +446,6 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
           onEntityTap: (id) {
             if (_isSelectionMode) _selection.toggle(id);
           },
-          onEntityLongPress: _isSelectionMode
-              ? null
-              : (id) => _selection.enterImplicit(id),
           selectedIds: _selectedIds,
           isSelectionMode: _isSelectionMode,
           onEntityDoubleTap: (id) {
@@ -517,8 +514,8 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
             tooltip: context.l10n.diveCenters_tooltip_sort,
             onPressed: () => _showSortSheet(context),
           ),
-          // Discoverability: bulk actions must not be reachable only by a
-          // long-press that nothing on screen advertises.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -659,7 +659,6 @@ class DiveListTile extends ConsumerWidget {
   final bool isFavorite;
   final List<Tag> tags;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final VoidCallback? onDoubleTap;
 
   /// Currently open in the detail pane. Renders as a leading edge stripe.
@@ -725,7 +724,6 @@ class DiveListTile extends ConsumerWidget {
     this.isFavorite = false,
     this.tags = const [],
     this.onTap,
-    this.onLongPress,
     this.onDoubleTap,
     this.isHighlighted = false,
     this.isSelectionMode = false,
@@ -1138,7 +1136,6 @@ class DiveListTile extends ConsumerWidget {
           child: InkWell(
             onTap: onTap,
             onDoubleTap: onDoubleTap,
-            onLongPress: onLongPress,
             child: Stack(
               children: [
                 // Static map tile background (cached)
@@ -1197,7 +1194,6 @@ class DiveListTile extends ConsumerWidget {
           child: InkWell(
             onTap: onTap,
             onDoubleTap: onDoubleTap,
-            onLongPress: onLongPress,
             borderRadius: BorderRadius.circular(12),
             child: buildContent(),
           ),

--- a/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
@@ -22,7 +22,6 @@ class CompactDiveListTile extends ConsumerWidget {
   final double? maxDepth;
   final Duration? duration;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
 
   /// In the current bulk selection. Renders as a fill tint plus the leading
@@ -66,7 +65,6 @@ class CompactDiveListTile extends ConsumerWidget {
     this.maxDepth,
     this.duration,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isChecked = false,
     this.isHighlighted = false,
@@ -258,7 +256,6 @@ class CompactDiveListTile extends ConsumerWidget {
           child: InkWell(
             onTap: onTap,
             onDoubleTap: onDoubleTap,
-            onLongPress: onLongPress,
             borderRadius: BorderRadius.circular(12),
             child: Padding(
               padding: const EdgeInsets.all(10),

--- a/lib/features/dive_log/presentation/widgets/dense_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/dense_dive_list_tile.dart
@@ -20,7 +20,6 @@ class DenseDiveListTile extends ConsumerWidget {
   final double? maxDepth;
   final Duration? duration;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final bool isHighlighted;
@@ -59,7 +58,6 @@ class DenseDiveListTile extends ConsumerWidget {
     this.maxDepth,
     this.duration,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.isHighlighted = false,
@@ -278,7 +276,6 @@ class DenseDiveListTile extends ConsumerWidget {
         child: InkWell(
           onTap: onTap,
           onDoubleTap: onDoubleTap,
-          onLongPress: onLongPress,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
             child: Row(

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -222,7 +222,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     });
   }
 
-  /// Enter selection mode implicitly, from a long-press or modifier-click.
+  /// Enter selection mode implicitly, from a modifier-click.
   ///
   /// Clearing the highlight keeps the detail pane from arguing with the bulk
   /// selection about what the row means.
@@ -653,7 +653,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// One tap policy for every dive row, in every view mode.
   ///
   /// Outside selection mode a held modifier turns a tap into an implicit
-  /// entry, so desktop users never have to discover long-press. Shift extends
+  /// entry -- the one path that still evaporates at zero checked. Shift extends
   /// from the anchor, falling back to the highlighted row.
   void _handleRowTap(String id, List<DiveSummary> dives) {
     if (SelectableListScope.isShiftPressed()) {
@@ -852,8 +852,8 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
           tooltip: context.l10n.diveLog_listPage_tooltip_sort,
           onPressed: () => _showSortSheet(context),
         ),
-        // Discoverability: bulk actions must not be reachable only by a
-        // long-press that nothing on screen advertises.
+        // The only way into bulk actions: entry by long-press was removed,
+        // so nothing but this control opens selection mode on touch.
         IconButton(
           key: const ValueKey('enter_selection'),
           icon: const Icon(Icons.checklist),
@@ -1263,9 +1263,6 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                   if (_isSelectionMode) return;
                   context.push('/dives/$id');
                 },
-                onDiveLongPress: _isSelectionMode
-                    ? null
-                    : (id) => _enterSelectionMode(id),
                 selectedIds: _selectedIds,
                 isSelectionMode: _isSelectionMode,
                 highlightedId: ref.watch(highlightedDiveIdProvider),
@@ -1369,9 +1366,6 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                   isChecked: isSelected,
                   isHighlighted: isMasterSelected || isHighlighted,
                   onTap: () => _handleRowTap(dive.id, dives),
-                  onLongPress: _isSelectionMode
-                      ? null
-                      : () => _enterSelectionMode(dive.id),
                 );
               },
             ),

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -222,17 +222,17 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
     });
   }
 
-  /// Enter selection mode implicitly, from a modifier-click.
+  /// Enter selection mode implicitly, from a modifier-click, checking [id].
   ///
   /// Clearing the highlight keeps the detail pane from arguing with the bulk
   /// selection about what the row means.
-  void _enterSelectionMode(String? initialId) {
+  ///
+  /// The Select control routes to [SelectionController.enterExplicit] directly
+  /// -- it has no row to check and must not clear the highlight -- so this
+  /// helper only ever serves the implicit path.
+  void _enterImplicitSelection(String id) {
     ref.read(highlightedDiveIdProvider.notifier).state = null;
-    if (initialId == null) {
-      _selection.enterExplicit();
-    } else {
-      _selection.enterImplicit(initialId);
-    }
+    _selection.enterImplicit(id);
   }
 
   void _exitSelectionMode() => _selection.exit();
@@ -661,7 +661,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
       return;
     }
     if (SelectableListScope.isModifierPressed()) {
-      _enterSelectionMode(id);
+      _enterImplicitSelection(id);
       return;
     }
     // No-op when the id is gone. A stale tap callback firing after the list
@@ -1254,7 +1254,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                   if (SelectableListScope.isShiftPressed()) {
                     _selectRangeTo(id, summaries);
                   } else if (SelectableListScope.isModifierPressed()) {
-                    _enterSelectionMode(id);
+                    _enterImplicitSelection(id);
                   } else if (_isSelectionMode) {
                     _toggleSelection(id);
                   }

--- a/lib/features/dive_log/presentation/widgets/dive_list_item.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_item.dart
@@ -40,7 +40,6 @@ class DiveListItem extends ConsumerWidget {
   final EdgeInsetsGeometry? margin;
 
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
 
   /// Selection / highlight state (defaults suit read-only lists like Recent).
   ///
@@ -73,7 +72,6 @@ class DiveListItem extends ConsumerWidget {
     this.gradientEndColor,
     this.margin,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isChecked = false,
     this.isHighlighted = false,
@@ -121,7 +119,6 @@ class DiveListItem extends ConsumerWidget {
           stat2Field: _slotField(slots, 'stat2', DiveField.bottomTime),
           diveTypeLabelResolver: diveTypeLabelResolver,
           onTap: onTap,
-          onLongPress: onLongPress,
         );
       case ListViewMode.detailed:
       case ListViewMode.dense:
@@ -150,7 +147,6 @@ class DiveListItem extends ConsumerWidget {
           siteLongitude: summary.siteLongitude,
           margin: margin,
           onTap: onTap,
-          onLongPress: onLongPress,
           summary: summary,
           fullDive: fullDive,
           diveTypeLabelResolver: diveTypeLabelResolver,

--- a/lib/features/dive_log/presentation/widgets/dive_table_view.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_table_view.dart
@@ -27,7 +27,6 @@ class DiveTableView extends ConsumerStatefulWidget {
   final List<Dive> dives;
   final void Function(String diveId) onDiveTap;
   final void Function(String diveId)? onDiveTapDown;
-  final void Function(String diveId)? onDiveLongPress;
   final void Function(String diveId)? onDiveDoubleTap;
   final Set<String> selectedIds;
   final bool isSelectionMode;
@@ -38,7 +37,6 @@ class DiveTableView extends ConsumerStatefulWidget {
     required this.dives,
     required this.onDiveTap,
     this.onDiveTapDown,
-    this.onDiveLongPress,
     this.onDiveDoubleTap,
     this.selectedIds = const {},
     this.isSelectionMode = false,
@@ -413,9 +411,6 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
                           onDoubleTap: widget.onDiveDoubleTap != null
                               ? () => widget.onDiveDoubleTap!(dive.id)
                               : null,
-                          onLongPress: widget.onDiveLongPress != null
-                              ? () => widget.onDiveLongPress!(dive.id)
-                              : null,
                           child: ColoredBox(
                             color: _rowBackground(
                               index: index,
@@ -501,9 +496,6 @@ class _DiveTableViewState extends ConsumerState<DiveTableView> {
                               onTap: () => widget.onDiveTap(dive.id),
                               onDoubleTap: widget.onDiveDoubleTap != null
                                   ? () => widget.onDiveDoubleTap!(dive.id)
-                                  : null,
-                              onLongPress: widget.onDiveLongPress != null
-                                  ? () => widget.onDiveLongPress!(dive.id)
                                   : null,
                               child: ColoredBox(
                                 color: _rowBackground(

--- a/lib/features/dive_sites/presentation/widgets/compact_site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/compact_site_list_tile.dart
@@ -11,7 +11,6 @@ class CompactSiteListTile extends StatelessWidget {
   final String? location;
   final int diveCount;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final bool isHighlighted;
@@ -23,7 +22,6 @@ class CompactSiteListTile extends StatelessWidget {
     this.location,
     required this.diveCount,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.isHighlighted = false,
@@ -46,7 +44,6 @@ class CompactSiteListTile extends StatelessWidget {
         label: name,
         child: InkWell(
           onTap: onTap,
-          onLongPress: onLongPress,
           borderRadius: BorderRadius.circular(12),
           child: Padding(
             padding: const EdgeInsets.only(

--- a/lib/features/dive_sites/presentation/widgets/dense_site_list_tile.dart
+++ b/lib/features/dive_sites/presentation/widgets/dense_site_list_tile.dart
@@ -10,7 +10,6 @@ class DenseSiteListTile extends StatelessWidget {
   final String? location;
   final int diveCount;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final bool isHighlighted;
@@ -22,7 +21,6 @@ class DenseSiteListTile extends StatelessWidget {
     this.location,
     required this.diveCount,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.isHighlighted = false,
@@ -52,7 +50,6 @@ class DenseSiteListTile extends StatelessWidget {
         ),
         child: InkWell(
           onTap: onTap,
-          onLongPress: onLongPress,
           child: Padding(
             padding: const EdgeInsets.only(
               left: 8,

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -176,15 +176,6 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
     }
   }
 
-  /// Enter selection mode implicitly, from a modifier-click.
-  void _enterSelectionMode(String? initialId) {
-    if (initialId == null) {
-      _selection.enterExplicit();
-    } else {
-      _selection.enterImplicit(initialId);
-    }
-  }
-
   void _exitSelectionMode() => _selection.exit();
 
   void _toggleSelection(String id) => _selection.toggle(id);
@@ -480,7 +471,7 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                       icon: const Icon(Icons.more_vert),
                       onSelected: (value) {
                         if (value == 'select') {
-                          _enterSelectionMode(null);
+                          _selection.enterExplicit();
                         } else if (value == 'import') {
                           context.push('/sites/import');
                         } else if (value.startsWith('view_')) {
@@ -702,7 +693,7 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
             icon: const Icon(Icons.more_vert, size: 20),
             onSelected: (value) {
               if (value == 'select') {
-                _enterSelectionMode(null);
+                _selection.enterExplicit();
               } else if (value == 'import') {
                 context.push('/sites/import');
               } else if (value.startsWith('view_')) {

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -176,7 +176,7 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
     }
   }
 
-  /// Enter selection mode implicitly, from a long-press or modifier-click.
+  /// Enter selection mode implicitly, from a modifier-click.
   void _enterSelectionMode(String? initialId) {
     if (initialId == null) {
       _selection.enterExplicit();
@@ -191,8 +191,9 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
 
   /// One tap policy for every site row, in every view mode.
   ///
-  /// A held modifier turns a tap into an implicit entry, so desktop users
-  /// never have to discover long-press.
+  /// A held modifier turns a tap into an implicit entry -- the one path
+  /// that still evaporates at zero checked, since touch has no gesture
+  /// entry left.
   void _handleRowTap(String id, List<SiteWithDiveCount> sites) {
     final orderedIds = sites.map((s) => s.site.id).toList();
     if (SelectableListScope.isShiftPressed()) {
@@ -467,8 +468,8 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                       tooltip: context.l10n.diveSites_list_tooltip_sort,
                       onPressed: () => _showSortSheet(context),
                     ),
-                    // Discoverability: bulk actions must not be reachable only
-                    // by a long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -611,9 +612,6 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                   if (_isSelectionMode) return;
                   context.push('/sites/$id');
                 },
-                onEntityLongPress: _isSelectionMode
-                    ? null
-                    : (id) => _enterSelectionMode(id),
                 selectedIds: _selectedIds,
                 isSelectionMode: _isSelectionMode,
                 highlightedId: ref.watch(highlightedSiteIdProvider),
@@ -830,9 +828,6 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
               longitude: site.location?.longitude,
               showSharedBadge: showSharedBadge,
               onTap: () => _handleRowTap(site.id, sites),
-              onLongPress: _isSelectionMode
-                  ? null
-                  : () => _enterSelectionMode(site.id),
             ),
             ListViewMode.compact => CompactSiteListTile(
               name: site.name,
@@ -843,9 +838,6 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
               isHighlighted: !_isSelectionMode && isSelected,
               showSharedBadge: showSharedBadge,
               onTap: () => _handleRowTap(site.id, sites),
-              onLongPress: _isSelectionMode
-                  ? null
-                  : () => _enterSelectionMode(site.id),
             ),
             ListViewMode.dense || ListViewMode.table => DenseSiteListTile(
               name: site.name,
@@ -856,9 +848,6 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
               isHighlighted: !_isSelectionMode && isSelected,
               showSharedBadge: showSharedBadge,
               onTap: () => _handleRowTap(site.id, sites),
-              onLongPress: _isSelectionMode
-                  ? null
-                  : () => _enterSelectionMode(site.id),
             ),
           };
         },
@@ -1213,7 +1202,6 @@ class SiteListTile extends ConsumerStatefulWidget {
   final int diveCount;
   final double? rating;
   final VoidCallback? onTap;
-  final VoidCallback? onLongPress;
   final bool isSelectionMode;
   final bool isSelected;
   final bool isChecked;
@@ -1231,7 +1219,6 @@ class SiteListTile extends ConsumerStatefulWidget {
     this.diveCount = 0,
     this.rating,
     this.onTap,
-    this.onLongPress,
     this.isSelectionMode = false,
     this.isSelected = false,
     this.isChecked = false,
@@ -1267,7 +1254,6 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
     final diveCount = widget.diveCount;
     final rating = widget.rating;
     final onTap = widget.onTap;
-    final onLongPress = widget.onLongPress;
     final isSelectionMode = widget.isSelectionMode;
     final isSelected = widget.isSelected;
     final isChecked = widget.isChecked;
@@ -1402,7 +1388,6 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
           label: context.l10n.diveSites_list_tile_semantics(name),
           child: InkWell(
             onTap: onTap,
-            onLongPress: onLongPress,
             child: Stack(
               children: [
                 Positioned.fill(
@@ -1468,7 +1453,6 @@ class _SiteListTileState extends ConsumerState<SiteListTile> {
         label: context.l10n.diveSites_list_tile_semantics(name),
         child: InkWell(
           onTap: onTap,
-          onLongPress: onLongPress,
           borderRadius: BorderRadius.circular(12),
           child: buildContent(),
         ),

--- a/lib/features/equipment/presentation/pages/service_kind_list_page.dart
+++ b/lib/features/equipment/presentation/pages/service_kind_list_page.dart
@@ -150,11 +150,18 @@ class _ServiceKindListPageState extends ConsumerState<ServiceKindListPage> {
                         }
                         _showEditDialog(context, ref, kind: kind);
                       },
-                      trailing: IconButton(
-                        tooltip: l10n.equipment_serviceKinds_delete,
-                        icon: const Icon(Icons.delete_outline),
-                        onPressed: () => _confirmDelete(context, ref, kind),
-                      ),
+                      // The per-row trash yields to selection mode: the bulk
+                      // delete deliberately sits behind the selection bar's
+                      // overflow, and a one-tap delete next to the checkbox
+                      // would contradict that.
+                      trailing: _isSelectionMode
+                          ? null
+                          : IconButton(
+                              tooltip: l10n.equipment_serviceKinds_delete,
+                              icon: const Icon(Icons.delete_outline),
+                              onPressed: () =>
+                                  _confirmDelete(context, ref, kind),
+                            ),
                     ),
                   const SizedBox(height: 80),
                 ],

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -255,8 +255,8 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
                         );
                       },
                     ),
-                    // Discoverability: bulk actions must not be reachable only by a
-                    // long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -491,9 +491,6 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
           onEntityTap: (id) {
             if (_isSelectionMode) _selection.toggle(id);
           },
-          onEntityLongPress: _isSelectionMode
-              ? null
-              : (id) => _selection.enterImplicit(id),
           selectedIds: _selectedIds,
           isSelectionMode: _isSelectionMode,
           onEntityDoubleTap: (id) {
@@ -543,8 +540,8 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
               showSearch(context: context, delegate: EquipmentSearchDelegate());
             },
           ),
-          // Discoverability: bulk actions must not be reachable only by a
-          // long-press that nothing on screen advertises.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),

--- a/lib/features/marine_life/presentation/pages/species_manage_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_manage_page.dart
@@ -290,13 +290,14 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
               children: [
                 IconButton(
                   icon: const Icon(Icons.edit_outlined),
-                  tooltip: 'Edit species',
+                  tooltip: context.l10n.marineLife_speciesManage_editTooltip,
                   onPressed: () => context.push('/species/${species.id}/edit'),
                 ),
                 if (isCustom)
                   IconButton(
                     icon: const Icon(Icons.delete_outline),
-                    tooltip: 'Delete species',
+                    tooltip:
+                        context.l10n.marineLife_speciesManage_deleteTooltip,
                     onPressed: () => _confirmDelete(species),
                   ),
               ],

--- a/lib/features/marine_life/presentation/pages/species_manage_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_manage_page.dart
@@ -279,22 +279,28 @@ class _SpeciesManagePageState extends ConsumerState<SpeciesManagePage> {
               style: const TextStyle(fontStyle: FontStyle.italic),
             )
           : Text(species.category.displayName),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.edit_outlined),
-            tooltip: 'Edit species',
-            onPressed: () => context.push('/species/${species.id}/edit'),
-          ),
-          if (isCustom)
-            IconButton(
-              icon: const Icon(Icons.delete_outline),
-              tooltip: 'Delete species',
-              onPressed: () => _confirmDelete(species),
+      // Per-row actions yield to selection mode. Leaving the trash here would
+      // put a one-tap delete beside the checkbox while the bulk delete sits
+      // deliberately behind the selection bar's overflow -- two contradictory
+      // answers to how destructive an action delete is on this screen.
+      trailing: _isSelectionMode
+          ? null
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit_outlined),
+                  tooltip: 'Edit species',
+                  onPressed: () => context.push('/species/${species.id}/edit'),
+                ),
+                if (isCustom)
+                  IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    tooltip: 'Delete species',
+                    onPressed: () => _confirmDelete(species),
+                  ),
+              ],
             ),
-        ],
-      ),
       onTap: () {
         if (_isSelectionMode) {
           if (_isSelectable(species)) _selection.toggle(species.id);

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -47,7 +47,8 @@ String showInOsFileManagerLabel() {
 
 /// Section widget displaying media (photos/videos) for a dive.
 ///
-/// Supports multi-select mode via long-press and drag, with bulk unlink.
+/// Supports multi-select mode via the Select control, with drag-to-range
+/// inside it and bulk unlink.
 class DiveMediaSection extends ConsumerStatefulWidget {
   final String diveId;
   final VoidCallback? onAddPressed;
@@ -408,8 +409,8 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
                       style: textTheme.titleMedium,
                     ),
                   ),
-                  // Discoverability: selecting media required a long-press
-                  // on a thumbnail, which nothing on screen advertised.
+                  // The only way into selection: entry by long-press was
+                  // removed, so nothing but this control opens the mode.
                   mediaAsync.whenOrNull(
                         data: (media) => media.isEmpty
                             ? const SizedBox.shrink()
@@ -508,17 +509,17 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
                   initialSelection: _indicesFor(media),
                   // The controller owns the mode, because only it knows how the
                   // mode was entered: a Select-button entry must survive at
-                  // zero checked, a long-press must evaporate. Letting the grid
-                  // also decide had the two fight -- its exit callback cleared
-                  // the controller and the selection callback immediately
-                  // reactivated it, so a long-press selection emptied by hand
-                  // left the bar stranded at "0 selected".
+                  // zero checked, an incidental one must evaporate. Letting the
+                  // grid also decide had the two fight -- its exit callback
+                  // cleared the controller and the selection callback
+                  // immediately reactivated it, leaving the bar stranded at
+                  // "0 selected".
                   exitOnEmptySelection: false,
                   onSelectionChanged: (indices) {
                     // The grid reports its complete selection, not a delta, so
                     // this replaces rather than toggles. Not selectAll: that
-                    // declares the mode explicit, which would launder the
-                    // grid's own long-press into a deliberate entry.
+                    // declares the mode explicit, which would launder a
+                    // grid gesture into a deliberate entry.
                     _selection.replaceChecked(_idsFor(media, indices));
                   },
                   // Entry and exit both travel through onSelectionChanged

--- a/lib/features/media/presentation/widgets/site_media_section.dart
+++ b/lib/features/media/presentation/widgets/site_media_section.dart
@@ -225,8 +225,8 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
                       style: textTheme.titleMedium,
                     ),
                   ),
-                  // Discoverability: selecting media required a long-press
-                  // on a thumbnail, which nothing on screen advertised.
+                  // The only way into selection: entry by long-press was
+                  // removed, so nothing but this control opens the mode.
                   mediaAsync.whenOrNull(
                         data: (media) => media.isEmpty
                             ? const SizedBox.shrink()
@@ -297,14 +297,14 @@ class _SiteMediaSectionState extends ConsumerState<SiteMediaSection> {
                   // The controller owns the mode. Letting the grid also
                   // decide had the two fight -- its exit callback cleared the
                   // controller and the selection callback immediately
-                  // reactivated it, so a long-press selection emptied by hand
-                  // left the bar stranded at "0 selected".
+                  // reactivated it, leaving a selection emptied by hand
+                  // stranded at "0 selected".
                   exitOnEmptySelection: false,
                   onSelectionChanged: (indices) {
                     // The grid reports its complete selection, not a delta, so
                     // this replaces rather than toggles. Not selectAll: that
-                    // declares the mode explicit, which would launder the
-                    // grid's own long-press into a deliberate entry.
+                    // declares the mode explicit, which would launder a
+                    // grid gesture into a deliberate entry.
                     _selection.replaceChecked(_idsFor(media, indices));
                   },
                   // Entry and exit both travel through onSelectionChanged

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -46,10 +46,10 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
     // Render stale data during a reload rather than flashing a spinner.
     final plans = summaries.valueOrNull;
 
-    // The compare-mode toggle only renders with >=2 plans. If an in-mode delete
-    // drops the count below that, actually leave compare mode (not merely hide
-    // it) so the sheet can't silently re-enter it when the count later climbs
-    // back to >=2 (e.g. via Import while the sheet is still open).
+    // The compare-mode toggle only renders with >=2 plans. If the count drops
+    // below that while the sheet is open, actually leave compare mode (not
+    // merely hide it) so the sheet can't silently re-enter it when the count
+    // later climbs back to >=2 (e.g. via Import while the sheet is open).
     ref.listen(divePlanSummariesProvider, (_, next) {
       if (_selecting && (next.valueOrNull?.length ?? 0) < 2) {
         setState(() {
@@ -133,17 +133,10 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
                               _selected.remove(plans[i].id);
                             }
                           }),
-                          secondary: IconButton(
-                            icon: const Icon(Icons.delete_outline),
-                            color: theme.colorScheme.error,
-                            tooltip: context.l10n.common_action_delete,
-                            onPressed: () => _confirmAndDeletePlan(
-                              context,
-                              ref,
-                              plans[i].id,
-                              plans[i].name,
-                            ),
-                          ),
+                          // No per-row trash while selecting: a destructive
+                          // one-tap action does not belong beside a checkbox
+                          // whose whole purpose is to gather rows for a
+                          // different action. Delete stays on the normal row.
                         )
                       : _PlanTile(summary: plans[i], units: units),
                 ),

--- a/lib/features/tags/presentation/pages/tag_manage_page.dart
+++ b/lib/features/tags/presentation/pages/tag_manage_page.dart
@@ -190,7 +190,6 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
       onTap: _isSelectionMode
           ? () => _toggleSelection(tag.id)
           : () => _showEditDialog(tag),
-      onLongPress: _isSelectionMode ? null : () => _enterSelectionMode(tag.id),
     );
   }
 
@@ -428,15 +427,6 @@ class _TagManagePageState extends ConsumerState<TagManagePage> {
 
     if (merged == true) {
       _exitSelectionMode();
-    }
-  }
-
-  /// Enter selection mode implicitly, from a long-press.
-  void _enterSelectionMode(String? initialId) {
-    if (initialId == null) {
-      _selection.enterExplicit();
-    } else {
-      _selection.enterImplicit(initialId);
     }
   }
 

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -228,8 +228,8 @@ class _TripListContentState extends ConsumerState<TripListContent> {
                       tooltip: context.l10n.trips_list_tooltip_sort,
                       onPressed: () => _showSortSheet(context),
                     ),
-                    // Discoverability: bulk actions must not be reachable only by a
-                    // long-press that nothing on screen advertises.
+                    // The only way into bulk actions: entry by long-press was removed,
+                    // so nothing but this control opens selection mode on touch.
                     IconButton(
                       key: const ValueKey('enter_selection'),
                       icon: const Icon(Icons.checklist),
@@ -339,8 +339,9 @@ class _TripListContentState extends ConsumerState<TripListContent> {
 
   /// One tap policy for every trip row.
   ///
-  /// A held modifier turns a tap into an implicit entry, so desktop users
-  /// never have to discover long-press.
+  /// A held modifier turns a tap into an implicit entry -- the one path
+  /// that still evaporates at zero checked, since touch has no gesture
+  /// entry left.
   void _handleRowTap(Trip trip) {
     if (SelectableListScope.isModifierPressed()) {
       _selection.enterImplicit(trip.id);
@@ -419,9 +420,6 @@ class _TripListContentState extends ConsumerState<TripListContent> {
                 onEntityTap: (id) {
                   if (_isSelectionMode) _selection.toggle(id);
                 },
-                onEntityLongPress: _isSelectionMode
-                    ? null
-                    : (id) => _selection.enterImplicit(id),
                 selectedIds: _selectedIds,
                 isSelectionMode: _isSelectionMode,
                 onEntityDoubleTap: (id) {
@@ -476,8 +474,8 @@ class _TripListContentState extends ConsumerState<TripListContent> {
             tooltip: context.l10n.trips_list_tooltip_sort,
             onPressed: () => _showSortSheet(context),
           ),
-          // Discoverability: bulk actions must not be reachable only by a
-          // long-press that nothing on screen advertises.
+          // The only way into bulk actions: entry by long-press was removed,
+          // so nothing but this control opens selection mode on touch.
           IconButton(
             key: const ValueKey('enter_selection'),
             icon: const Icon(Icons.checklist, size: 20),

--- a/lib/shared/selection/selection_controller.dart
+++ b/lib/shared/selection/selection_controller.dart
@@ -43,8 +43,11 @@ class SelectionController extends ValueNotifier<SelectionState> {
     );
   }
 
-  /// Enter selection mode as a side effect of long-press or modifier-click,
-  /// checking [id]. Behaves as [toggle] when the mode is already active.
+  /// Enter selection mode as a side effect of a modifier-click, checking
+  /// [id]. Behaves as [toggle] when the mode is already active.
+  ///
+  /// Touch has no equivalent: long-press no longer enters selection mode on
+  /// any surface, so on a phone every entry is explicit.
   void enterImplicit(String id) {
     if (value.isActive) {
       toggle(id);
@@ -122,13 +125,17 @@ class SelectionController extends ValueNotifier<SelectionState> {
   /// For surfaces whose child widget owns the gesture layer and reports its
   /// complete selection rather than a delta -- the media grid. [selectAll] is
   /// the wrong call there despite also taking a whole set, because it declares
-  /// the mode explicit, which would launder a long-press into a deliberate
-  /// entry and stop it evaporating at zero checked.
+  /// the mode explicit, which would launder an incidental gesture into a
+  /// deliberate entry and stop it evaporating at zero checked.
   ///
   /// Only a gesture can activate the mode through this path, so an activating
   /// call counts as implicit entry; the Select button routes through
   /// [enterExplicit] instead. An empty [ids] on an inactive controller is a
   /// no-op rather than an activation.
+  ///
+  /// No grid gesture activates the mode today -- the media grids are driven
+  /// into selection by their Select control -- but the branch is kept so a
+  /// future grid gesture cannot silently declare itself deliberate.
   void replaceChecked(List<String> ids) {
     final next = ids.toSet();
 

--- a/lib/shared/selection/selection_state.dart
+++ b/lib/shared/selection/selection_state.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// [enteredExplicitly] records how selection mode began, because that decides
 /// how it ends: a mode the user asked for with the Select button survives at
-/// zero checked items, while one entered by long-press or modifier-click
+/// zero checked items, while one entered incidentally by modifier-click
 /// evaporates when the last item is unchecked.
 @immutable
 class SelectionState {

--- a/lib/shared/widgets/drag_select_grid_view.dart
+++ b/lib/shared/widgets/drag_select_grid_view.dart
@@ -14,9 +14,11 @@ typedef DragSelectItemBuilder<T> =
 
 /// A grid view that supports drag-to-range-select inside selection mode.
 ///
-/// In normal mode, taps fire [onItemTap] and long-press does nothing:
-/// selection mode is entered only through the surface's own Select control,
-/// never by a gesture on an item.
+/// In normal mode, selection mode is entered only through the surface's own
+/// Select control, never by a gesture on an item. No long-press recognizer is
+/// registered at all, so a hold falls through to the tap recognizer -- which
+/// has no upper duration bound -- and fires [onItemTap] on release, exactly as
+/// a quick tap would.
 ///
 /// In selection mode, taps toggle individual items, and long-pressing an item
 /// anchors a drag; dragging from the anchor adds every item between anchor and

--- a/lib/shared/widgets/drag_select_grid_view.dart
+++ b/lib/shared/widgets/drag_select_grid_view.dart
@@ -12,14 +12,16 @@ import 'package:flutter/services.dart';
 typedef DragSelectItemBuilder<T> =
     Widget Function(BuildContext context, T item, bool isSelected);
 
-/// A grid view that supports long-press-to-start drag-to-range-select.
+/// A grid view that supports drag-to-range-select inside selection mode.
 ///
-/// In normal mode, taps fire [onItemTap]. Long-pressing an item enters
-/// selection mode and makes that item the drag anchor. Dragging from the
-/// anchor selects all items between anchor and finger position.
+/// In normal mode, taps fire [onItemTap] and long-press does nothing:
+/// selection mode is entered only through the surface's own Select control,
+/// never by a gesture on an item.
 ///
-/// In selection mode, taps toggle individual items. When selection becomes
-/// empty, selection mode exits automatically.
+/// In selection mode, taps toggle individual items, and long-pressing an item
+/// anchors a drag; dragging from the anchor adds every item between anchor and
+/// finger position to the existing selection. When selection becomes empty,
+/// selection mode exits automatically.
 ///
 /// This widget is a pure Flutter widget with no Riverpod dependency.
 /// It communicates entirely via callbacks.
@@ -64,7 +66,7 @@ class DragSelectGridView<T> extends StatefulWidget {
   ///
   /// Set false when an outer selection controller owns the mode: it alone
   /// knows whether the mode was entered deliberately (Select button, which
-  /// must survive at zero checked) or by long-press (which must evaporate),
+  /// must survive at zero checked) or incidentally (which must evaporate),
   /// and the grid cannot tell those apart. The owner then drives the grid back
   /// out through [startInSelectionMode].
   final bool exitOnEmptySelection;
@@ -132,15 +134,20 @@ class _DragSelectGridViewState<T> extends State<DragSelectGridView<T>> {
     super.dispose();
   }
 
-  void _enterSelectionMode(int anchorIndex) {
+  /// Anchor a range drag on [anchorIndex], keeping what is already checked.
+  ///
+  /// Only reachable in selection mode, so the drag extends a selection the
+  /// user already opened rather than starting one. [_preDragSelection] is the
+  /// set as it stood before the anchor was added, because [_onDragUpdate]
+  /// re-unions it with the whole anchor-to-finger span on every move.
+  void _beginRangeDrag(int anchorIndex) {
     if (widget.disabledIndices.contains(anchorIndex)) return;
+    final priorSelection = Set<int>.from(_selectedIndices);
     setState(() {
-      _isSelectionMode = true;
       _dragAnchorIndex = anchorIndex;
-      _selectedIndices = {anchorIndex};
-      _preDragSelection = {};
+      _preDragSelection = priorSelection;
+      _selectedIndices = Set<int>.from(priorSelection)..add(anchorIndex);
     });
-    widget.onSelectionModeChanged(true);
     widget.onSelectionChanged(_selectedIndices);
     HapticFeedback.mediumImpact();
   }
@@ -280,17 +287,16 @@ class _DragSelectGridViewState<T> extends State<DragSelectGridView<T>> {
               widget.onItemTap?.call(index);
             }
           },
+          // All three are null outside selection mode so no long-press
+          // recognizer is registered at all, leaving the gesture free for
+          // whatever the item itself wants to do with it.
           onLongPressStart: _isSelectionMode
-              ? null
-              : (details) {
-                  _enterSelectionMode(index);
-                },
-          onLongPressMoveUpdate: (details) {
-            _onDragUpdate(details.globalPosition);
-          },
-          onLongPressEnd: (_) {
-            _onDragEnd();
-          },
+              ? (_) => _beginRangeDrag(index)
+              : null,
+          onLongPressMoveUpdate: _isSelectionMode
+              ? (details) => _onDragUpdate(details.globalPosition)
+              : null,
+          onLongPressEnd: _isSelectionMode ? (_) => _onDragEnd() : null,
           child: widget.itemBuilder(context, widget.items[index], isSelected),
         );
       },

--- a/lib/shared/widgets/entity_table/entity_table_view.dart
+++ b/lib/shared/widgets/entity_table/entity_table_view.dart
@@ -47,9 +47,6 @@ class EntityTableView<T, F extends EntityField> extends StatefulWidget {
   /// Called when user double-taps a row.
   final void Function(String entityId)? onEntityDoubleTap;
 
-  /// Called when user long-presses a row.
-  final void Function(String entityId)? onEntityLongPress;
-
   /// IDs of selected entities (for bulk selection mode).
   final Set<String> selectedIds;
 
@@ -71,7 +68,6 @@ class EntityTableView<T, F extends EntityField> extends StatefulWidget {
     required this.onEntityTap,
     this.onEntityTapDown,
     this.onEntityDoubleTap,
-    this.onEntityLongPress,
     this.selectedIds = const {},
     this.isSelectionMode = false,
     this.highlightedId,
@@ -377,9 +373,6 @@ class _EntityTableViewState<T, F extends EntityField>
                           onDoubleTap: widget.onEntityDoubleTap != null
                               ? () => widget.onEntityDoubleTap!(entityId)
                               : null,
-                          onLongPress: widget.onEntityLongPress != null
-                              ? () => widget.onEntityLongPress!(entityId)
-                              : null,
                           child: ColoredBox(
                             color: _rowBackground(
                               index: index,
@@ -464,9 +457,6 @@ class _EntityTableViewState<T, F extends EntityField>
                               onTap: () => widget.onEntityTap(entityId),
                               onDoubleTap: widget.onEntityDoubleTap != null
                                   ? () => widget.onEntityDoubleTap!(entityId)
-                                  : null,
-                              onLongPress: widget.onEntityLongPress != null
-                                  ? () => widget.onEntityLongPress!(entityId)
                                   : null,
                               child: ColoredBox(
                                 color: _rowBackground(

--- a/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
@@ -352,30 +352,6 @@ void main() {
       expect(find.text('Deep Wall'), findsOneWidget);
     });
 
-    testWidgets('fires onLongPress callback', (tester) async {
-      bool longPressed = false;
-      await tester.pumpWidget(
-        testApp(
-          overrides: [
-            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
-          ],
-          child: CompactDiveListTile(
-            diveId: 'lp-id',
-            diveNumber: 8,
-            dateTime: DateTime(2026, 3, 15),
-            siteName: 'Reef Point',
-            onTap: () {},
-            onLongPress: () => longPressed = true,
-          ),
-        ),
-      );
-
-      await tester.longPress(find.text('Reef Point'));
-      await tester.pumpAndSettle();
-
-      expect(longPressed, isTrue);
-    });
-
     testWidgets('renders stat slot with icon when field has icon', (
       tester,
     ) async {

--- a/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/dense_dive_list_tile_test.dart
@@ -247,30 +247,6 @@ void main() {
       expect(find.text('Deep Wall'), findsOneWidget);
     });
 
-    testWidgets('fires onLongPress callback', (tester) async {
-      bool longPressed = false;
-      await tester.pumpWidget(
-        testApp(
-          overrides: [
-            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
-          ],
-          child: DenseDiveListTile(
-            diveId: 'lp-id',
-            diveNumber: 8,
-            dateTime: DateTime(2026, 3, 15),
-            siteName: 'Reef Point',
-            onTap: () {},
-            onLongPress: () => longPressed = true,
-          ),
-        ),
-      );
-
-      await tester.longPress(find.text('Reef Point'));
-      await tester.pumpAndSettle();
-
-      expect(longPressed, isTrue);
-    });
-
     testWidgets('renders with configurable slot fields from summary', (
       tester,
     ) async {

--- a/test/features/dive_log/presentation/widgets/dive_list_bulk_export_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_bulk_export_test.dart
@@ -174,7 +174,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.longPress(_tile('d1'));
+    await tester.tap(find.byKey(const ValueKey('enter_selection')));
+    await tester.pumpAndSettle();
+    await tester.tap(_tile('d1'));
     await tester.pumpAndSettle();
     await tester.tap(_tile('d2'));
     await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
@@ -84,7 +84,6 @@ Widget _buildTableModeLayout({
   Set<String> selectedIds = const {},
   void Function(String)? onDiveTap,
   void Function(String)? onDiveDoubleTap,
-  void Function(String)? onDiveLongPress,
 }) {
   final tableConfig =
       config ??
@@ -118,7 +117,6 @@ Widget _buildTableModeLayout({
             dives: dives,
             onDiveTap: onDiveTap ?? (_) {},
             onDiveDoubleTap: onDiveDoubleTap,
-            onDiveLongPress: onDiveLongPress,
             selectedIds: selectedIds,
             isSelectionMode: isSelectionMode,
             highlightedId: highlightedId,
@@ -335,25 +333,20 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // Long-press fires onDiveLongPress (enters selection mode)
+    // Long-press is not a selection gesture in table mode
     // -----------------------------------------------------------------------
 
-    testWidgets('long-press fires onDiveLongPress callback', (tester) async {
-      String? longPressedId;
+    testWidgets('long-press on a table row does not check it', (tester) async {
       final dives = [_makeDive(id: 'lp-1', diveNumber: 7, maxDepth: 20.0)];
 
-      await tester.pumpWidget(
-        _buildTableModeLayout(
-          dives: dives,
-          onDiveLongPress: (id) => longPressedId = id,
-        ),
-      );
+      await tester.pumpWidget(_buildTableModeLayout(dives: dives));
       await tester.pumpAndSettle();
 
       await tester.longPress(find.text('#7'));
       await tester.pumpAndSettle();
 
-      expect(longPressedId, 'lp-1');
+      // No checkbox column means the table never entered selection mode.
+      expect(find.byType(Checkbox), findsNothing);
     });
 
     // -----------------------------------------------------------------------
@@ -1049,7 +1042,7 @@ void main() {
     ];
 
     testWidgets(
-      'long-press enters selection; shift-tap selects a range; tap toggles',
+      'Select enters selection; shift-tap selects a range; tap toggles',
       (tester) async {
         final overrides = await _buildPhoneOverrides(
           dives: fourDives(),
@@ -1070,8 +1063,10 @@ void main() {
         Finder tileFinder(String id) =>
             find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == id);
 
-        // Long-press d1 -> enter selection mode with d1 as the anchor.
-        await tester.longPress(tileFinder('d1'));
+        // Select, then check d1 -> selection mode with d1 as the anchor.
+        await tester.tap(find.byKey(const ValueKey('enter_selection')));
+        await tester.pumpAndSettle();
+        await tester.tap(tileFinder('d1'));
         await tester.pumpAndSettle();
         expect(tile('d1').isSelectionMode, isTrue);
         expect(tile('d1').isChecked, isTrue);
@@ -1093,7 +1088,7 @@ void main() {
       },
     );
 
-    testWidgets('compact view: long-press enters selection and tap toggles', (
+    testWidgets('compact view: Select enters selection and tap toggles', (
       tester,
     ) async {
       final overrides = await _buildPhoneOverrides(
@@ -1116,7 +1111,7 @@ void main() {
         (w) => w is CompactDiveListTile && w.diveId == id,
       );
 
-      await tester.longPress(tileFinder('d1'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
       await tester.pumpAndSettle();
       expect(tile('d1').isSelectionMode, isTrue);
 
@@ -1188,9 +1183,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Long-press d1 to enter selection mode with d1 as the only selection.
-      // With 1 of 4 selected, both Select All and Deselect All are visible.
-      await tester.longPress(tileFinder('d1'));
+      // Enter selection mode and check d1 as the only selection. With 1 of 4
+      // selected, both Select All and Deselect All are visible.
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(tileFinder('d1'));
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.select_all), findsOneWidget);
@@ -1251,7 +1248,9 @@ void main() {
       // One dive checked -> Compare is visible but disabled. Actions below
       // their minCount render disabled rather than hidden, so the action set
       // stays stable and users can see what an action needs.
-      await tester.longPress(tileFinder('d1'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(tileFinder('d1'));
       await tester.pumpAndSettle();
       expect(compare, findsOneWidget);
       expect(tester.widget<IconButton>(compare).onPressed, isNull);

--- a/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_selection_test.dart
@@ -129,6 +129,47 @@ void main() {
     expect(inDateRange(summary('c', DateTime(2026, 5, 31)), r), isFalse);
   });
 
+  testWidgets('long-press on a dive row does not enter selection mode', (
+    tester,
+  ) async {
+    final summaries = [
+      _makeDive(
+        id: 'd1',
+        site: const DiveSite(id: 's1', name: 'Aaa'),
+      ),
+    ].map(DiveSummary.fromDive).toList();
+    final base = await getBaseOverrides();
+    final opened = <String?>[];
+
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveListViewModeProvider.overrideWith((ref) => ListViewMode.detailed),
+          paginatedDiveListProvider.overrideWith(
+            (ref) => _MockPaginatedNotifier(summaries),
+          ),
+        ],
+        // Routed through the callback rather than context.push so the row's
+        // tap has somewhere to land: with no long-press handler the hold now
+        // resolves as an ordinary tap on release, which is the point.
+        child: DiveListContent(showAppBar: false, onItemSelected: opened.add),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.longPress(
+      find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == 'd1'),
+    );
+    await tester.pumpAndSettle();
+
+    // The contextual bar is the tell: it only exists in selection mode, and
+    // the Select control is still offered because we never left normal mode.
+    expect(find.byKey(const ValueKey('selection_exit')), findsNothing);
+    expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
+    expect(opened, ['d1']);
+  });
+
   testWidgets('Combine action appears only with 2+ selected', (tester) async {
     final dives = [
       _makeDive(
@@ -161,11 +202,13 @@ void main() {
     Finder tileFinder(String id) =>
         find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == id);
 
-    // Long-press d1 -> selection mode with only d1 checked. Combine is a
-    // baseline-adjacent extra rendered as an inline icon; below its minCount
+    // Select, then check d1 -> selection mode with only d1 checked. Combine is
+    // a baseline-adjacent extra rendered as an inline icon; below its minCount
     // of 2 it is disabled rather than hidden, so the user can see the action
     // exists and learn what it needs.
-    await tester.longPress(tileFinder('d1'));
+    await tester.tap(find.byKey(const ValueKey('enter_selection')));
+    await tester.pumpAndSettle();
+    await tester.tap(tileFinder('d1'));
     await tester.pumpAndSettle();
     expect(combineButton, findsOneWidget);
     expect(
@@ -224,7 +267,9 @@ void main() {
     Finder tileFinder(String id) =>
         find.byWidgetPredicate((w) => w is DiveListTile && w.diveId == id);
 
-    await tester.longPress(tileFinder('d1'));
+    await tester.tap(find.byKey(const ValueKey('enter_selection')));
+    await tester.pumpAndSettle();
+    await tester.tap(tileFinder('d1'));
     await tester.pumpAndSettle();
     await tester.tap(tileFinder('d2'));
     await tester.pumpAndSettle();
@@ -289,7 +334,9 @@ void main() {
     // Merged dive not present / off-screen before the combine.
     expect(tileFinder('merged-1'), findsNothing);
 
-    await tester.longPress(tileFinder('d0'));
+    await tester.tap(find.byKey(const ValueKey('enter_selection')));
+    await tester.pumpAndSettle();
+    await tester.tap(tileFinder('d0'));
     await tester.pumpAndSettle();
     await tester.tap(tileFinder('d1'));
     await tester.pumpAndSettle();

--- a/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
@@ -96,7 +96,6 @@ final _sacConfig = TableViewConfig(
 Widget _buildTable({
   required List<Dive> dives,
   void Function(String)? onDiveTap,
-  void Function(String)? onDiveLongPress,
   void Function(String)? onDiveDoubleTap,
   Set<String>? selectedIds,
   bool isSelectionMode = false,
@@ -113,7 +112,6 @@ Widget _buildTable({
     child: DiveTableView(
       dives: dives,
       onDiveTap: onDiveTap ?? (_) {},
-      onDiveLongPress: onDiveLongPress,
       onDiveDoubleTap: onDiveDoubleTap,
       selectedIds: selectedIds ?? const {},
       isSelectionMode: isSelectionMode,
@@ -194,21 +192,28 @@ void main() {
       expect(doubleTappedId, 'a');
     });
 
-    testWidgets('fires onDiveLongPress on long press', (tester) async {
-      String? longPressedId;
+    testWidgets('rows register no long-press recognizer', (tester) async {
       await tester.pumpWidget(
         _buildTable(
           dives: [_makeDive(id: 'lp-1', diveNumber: 7)],
           onDiveTap: (_) {},
-          onDiveLongPress: (id) => longPressedId = id,
         ),
       );
       await tester.pumpAndSettle();
 
-      await tester.longPress(find.text('#7'));
-      await tester.pumpAndSettle();
-
-      expect(longPressedId, 'lp-1');
+      // Long-press no longer enters selection mode anywhere, so no row may
+      // carry a handler for it.
+      final detectors = tester.widgetList<GestureDetector>(
+        find.descendant(
+          of: find.byType(DiveTableView),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      expect(detectors, isNotEmpty);
+      for (final detector in detectors) {
+        expect(detector.onLongPress, isNull);
+        expect(detector.onLongPressStart, isNull);
+      }
     });
 
     testWidgets('selection mode shows checkboxes', (tester) async {
@@ -567,18 +572,14 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // GestureDetector exists for tap/double-tap/long-press
+    // GestureDetector exists for tap/double-tap
     // -----------------------------------------------------------------------
 
     testWidgets('rows have GestureDetector for interaction', (tester) async {
       final dives = [_makeDive(id: 'gd1', diveNumber: 1, maxDepth: 10.0)];
 
       await tester.pumpWidget(
-        _buildTable(
-          dives: dives,
-          onDiveLongPress: (_) {},
-          onDiveDoubleTap: (_) {},
-        ),
+        _buildTable(dives: dives, onDiveDoubleTap: (_) {}),
       );
       await tester.pumpAndSettle();
 
@@ -797,9 +798,7 @@ void main() {
     testWidgets('table renders without optional callbacks', (tester) async {
       final dives = [_makeDive(id: 'nc1', diveNumber: 1, maxDepth: 10.0)];
 
-      await tester.pumpWidget(
-        _buildTable(dives: dives, onDiveLongPress: null, onDiveDoubleTap: null),
-      );
+      await tester.pumpWidget(_buildTable(dives: dives, onDiveDoubleTap: null));
       await tester.pumpAndSettle();
 
       expect(find.text('#1'), findsOneWidget);

--- a/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_table_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
@@ -203,16 +204,24 @@ void main() {
 
       // Long-press no longer enters selection mode anywhere, so no row may
       // carry a handler for it.
-      final detectors = tester.widgetList<GestureDetector>(
+      //
+      // The assertion is on the recognizer, not on individual callbacks:
+      // GestureDetector registers one LongPressGestureRecognizer keyed by its
+      // own Type if ANY of seven long-press callbacks is non-null, so checking
+      // the map key covers onLongPressMoveUpdate, onLongPressEnd, onLongPressUp
+      // and the rest without having to enumerate them.
+      final detectors = tester.widgetList<RawGestureDetector>(
         find.descendant(
           of: find.byType(DiveTableView),
-          matching: find.byType(GestureDetector),
+          matching: find.byType(RawGestureDetector),
         ),
       );
       expect(detectors, isNotEmpty);
       for (final detector in detectors) {
-        expect(detector.onLongPress, isNull);
-        expect(detector.onLongPressStart, isNull);
+        expect(
+          detector.gestures.containsKey(LongPressGestureRecognizer),
+          isFalse,
+        );
       }
     });
 

--- a/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
@@ -153,7 +153,9 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      await tester.longPress(find.text('Alpha Site'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Alpha Site'));
       await tester.pumpAndSettle();
       expect(find.text('1 selected'), findsOneWidget);
 
@@ -703,7 +705,9 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        await tester.longPress(find.text('First Site'));
+        await tester.tap(find.byKey(const ValueKey('enter_selection')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('First Site'));
         await tester.pumpAndSettle();
         expect(find.text('1 selected'), findsOneWidget);
 
@@ -724,7 +728,46 @@ void main() {
       },
     );
 
-    testWidgets('tapping last selected site exits selection mode', (
+    testWidgets('long-press on a site does not enter selection mode', (
+      tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      await siteRepository.createSite(
+        const DiveSite(id: 's1', name: 'Held Site'),
+      );
+      final opened = <String?>[];
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            siteRepositoryProvider.overrideWithValue(siteRepository),
+            validatedCurrentDiverIdProvider.overrideWith((ref) async => null),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            // Routed through the callback rather than context.push: with no
+            // long-press handler the hold resolves as an ordinary tap on
+            // release, which would otherwise try to navigate.
+            home: Scaffold(
+              body: SiteListContent(
+                showAppBar: false,
+                onItemSelected: opened.add,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.longPress(find.text('Held Site'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
+      expect(opened, ['s1']);
+    });
+
+    testWidgets('unchecking the last site keeps the deliberate mode open', (
       tester,
     ) async {
       _setMobileTestSurfaceSize(tester);
@@ -746,13 +789,17 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.longPress(find.text('Toggle Site'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Toggle Site'));
       await tester.pumpAndSettle();
       expect(find.text('1 selected'), findsOneWidget);
       await tester.tap(find.text('Toggle Site'));
       await tester.pumpAndSettle();
-      // Selection mode exits when last item is deselected.
-      expect(find.text('1 selected'), findsNothing);
+      // The Select button is a deliberate entry, so emptying the selection
+      // leaves the bar standing at zero rather than dropping the user out.
+      // Only an implicit entry (modifier-click) evaporates.
+      expect(find.text('0 selected'), findsOneWidget);
     });
   });
 

--- a/test/features/equipment/presentation/pages/service_kind_list_page_test.dart
+++ b/test/features/equipment/presentation/pages/service_kind_list_page_test.dart
@@ -88,6 +88,24 @@ void main() {
       );
     });
 
+    testWidgets('selection mode hides the per-row delete action', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildPage([custom('c1', 'Custom kind')]));
+      await tester.pumpAndSettle();
+
+      // Normal mode offers the row's own trash.
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+
+      // In selection mode the only delete is the bulk one, which the shared
+      // bar keeps behind its overflow menu.
+      expect(find.byIcon(Icons.delete_outline), findsNothing);
+      expect(find.byKey(const ValueKey('selection_overflow')), findsOneWidget);
+    });
+
     testWidgets('built-in kinds render no checkbox and are excluded from '
         'select-all', (tester) async {
       await tester.pumpWidget(

--- a/test/features/marine_life/presentation/pages/species_manage_page_test.dart
+++ b/test/features/marine_life/presentation/pages/species_manage_page_test.dart
@@ -154,6 +154,31 @@ void main() {
       );
     });
 
+    testWidgets('selection mode hides the per-row edit and delete actions', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          species: [_species(id: 'c1', name: 'Custom fish')],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Normal mode offers both row actions.
+      expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+
+      // In selection mode the only delete is the bulk one, which the shared
+      // bar keeps behind its overflow menu. A live per-row trash beside the
+      // checkbox would undo that.
+      expect(find.byIcon(Icons.delete_outline), findsNothing);
+      expect(find.byIcon(Icons.edit_outlined), findsNothing);
+      expect(find.byKey(const ValueKey('selection_overflow')), findsOneWidget);
+    });
+
     testWidgets('a species with sightings renders no checkbox and is '
         'excluded from select-all', (tester) async {
       await tester.pumpWidget(

--- a/test/features/media/presentation/widgets/dive_media_section_selection_test.dart
+++ b/test/features/media/presentation/widgets/dive_media_section_selection_test.dart
@@ -231,7 +231,7 @@ void main() {
       expect(find.text('0 selected'), findsOneWidget);
     });
 
-    testWidgets('a long-press entry evaporates when unchecked by hand', (
+    testWidgets('a long-press on a thumbnail does not enter selection mode', (
       tester,
     ) async {
       await tester.pumpWidget(host([_item('a'), _item('b')]));
@@ -246,52 +246,12 @@ void main() {
 
       await tester.longPress(thumb, warnIfMissed: false);
       await tester.pumpAndSettle();
-      expect(find.text('1 selected'), findsOneWidget);
 
-      await tester.tap(thumb, warnIfMissed: false);
-      await tester.pumpAndSettle();
-
-      expect(
-        find.byKey(const ValueKey('selection_exit')),
-        findsNothing,
-        reason: 'unchecking the last item must end a long-press selection',
-      );
-    });
-
-    testWidgets('a long-press entry stays implicit and evaporates on prune', (
-      tester,
-    ) async {
-      final a = _item('a');
-      final b = _item('b');
-      await tester.pumpWidget(host([a, b]));
-      await tester.pumpAndSettle();
-
-      // Long-press is the grid's own gesture, so it must register as implicit
-      // entry rather than being laundered into an explicit one.
-      await tester.longPress(
-        find
-            .descendant(
-              of: find.byType(DragSelectGridView<MediaItem>),
-              matching: find.byType(GestureDetector),
-            )
-            .first,
-        warnIfMissed: false,
-      );
-      await tester.pumpAndSettle();
-      expect(find.text('1 selected'), findsOneWidget);
-
-      // Detaching the only checked item empties the selection by pruning.
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(DiveMediaSection)),
-      );
-      container.read(_mediaProvider.notifier).state = [b];
-      await tester.pumpAndSettle();
-
-      expect(
-        find.byKey(const ValueKey('selection_exit')),
-        findsNothing,
-        reason: 'an implicitly entered mode must evaporate at zero checked',
-      );
+      // The grid's long-press now only anchors a range drag inside an already
+      // active selection, so from the normal header it cannot open the mode.
+      // The hold falls through to the tile's tap, which opens the viewer.
+      expect(find.byKey(const ValueKey('selection_exit')), findsNothing);
+      expect(find.text('1 selected'), findsNothing);
     });
 
     testWidgets('removing an item prunes it from the selection', (

--- a/test/features/media/presentation/widgets/dive_media_section_test.dart
+++ b/test/features/media/presentation/widgets/dive_media_section_test.dart
@@ -146,7 +146,9 @@ void main() {
       await pumpWithTwo(tester);
       expect(find.text('Photos & Video'), findsOneWidget);
 
-      await tester.longPress(find.byType(MediaThumbnailTile).first);
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(MediaThumbnailTile).first);
       await tester.pumpAndSettle();
 
       // Both media sections render the shared SelectionAppBar; the old
@@ -161,7 +163,9 @@ void main() {
     testWidgets('select all covers every tile, then cancel restores the '
         'normal header', (tester) async {
       await pumpWithTwo(tester);
-      await tester.longPress(find.byType(MediaThumbnailTile).first);
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(MediaThumbnailTile).first);
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('selection_select_all')));

--- a/test/features/media/presentation/widgets/site_media_section_test.dart
+++ b/test/features/media/presentation/widgets/site_media_section_test.dart
@@ -272,29 +272,23 @@ void main() {
       expect(find.text('0 selected'), findsOneWidget);
     });
 
-    testWidgets('a long-press selection emptied by hand exits the mode', (
+    testWidgets('a long-press on a tile does not enter selection mode', (
       tester,
     ) async {
       await tester.pumpWidget(await host(attachments: [photoA]));
       await tester.pumpAndSettle();
 
-      // Long-press is an implicit entry, so unchecking the last item must
-      // evaporate the mode. Bridging the grid with selectAll would have
-      // declared the entry explicit and stranded the bar at "0 selected";
-      // letting the grid own exitOnEmptySelection would have had the two
-      // fight instead.
       await tester.longPress(find.byType(MediaThumbnailTile).first);
-      await tester.pumpAndSettle();
-      expect(find.text('1 selected'), findsOneWidget);
-
-      await tester.tap(find.byType(MediaThumbnailTile).first);
       await tester.pumpAndSettle();
 
       expect(
         find.byKey(const ValueKey('selection_exit')),
         findsNothing,
-        reason: 'an implicit entry must not survive at zero checked',
+        reason: 'selection mode is reachable only through the Select control',
       );
+      // With no long-press handler left, the hold resolves as an ordinary tap
+      // on release and opens the viewer, exactly as a tap would.
+      expect(find.byType(SiteMediaViewerPage), findsOneWidget);
     });
 
     testWidgets('Escape leaves selection mode', (tester) async {
@@ -311,18 +305,18 @@ void main() {
   });
 
   group('selection mode', () {
-    /// Long-presses the first attachment tile to enter selection mode.
+    /// Enters selection mode and checks the first attachment tile.
     Future<void> enterSelection(WidgetTester tester) async {
-      await tester.longPress(find.byType(MediaThumbnailTile).first);
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(MediaThumbnailTile).first);
       await tester.pumpAndSettle();
     }
 
-    testWidgets('long-pressing a tile shows the selection header', (
-      tester,
-    ) async {
+    testWidgets('selecting a tile shows the selection header', (tester) async {
       await tester.pumpWidget(await host(attachments: [photoA, photoB]));
       await tester.pumpAndSettle();
-      // Normal header before the long press.
+      // Normal header before entering selection.
       expect(find.text('Site Media'), findsOneWidget);
 
       await enterSelection(tester);
@@ -400,7 +394,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.longPress(find.byType(MediaThumbnailTile).first);
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const ValueKey('selection_select_all')));
       await tester.pumpAndSettle();

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/planner/data/repositories/dive_plan_repository.dart';
 import 'package:submersion/features/planner/data/services/plan_file_codec.dart';
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
+import 'package:submersion/features/planner/presentation/providers/plan_repository_providers.dart';
 import 'package:submersion/features/planner/presentation/widgets/saved_plans_sheet.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
@@ -180,31 +181,30 @@ void main() {
     expect(find.text('compare-page'), findsOneWidget);
   });
 
-  testWidgets('delete is reachable from compare mode', (tester) async {
+  testWidgets('delete is not offered per-row inside compare mode', (
+    tester,
+  ) async {
     await repository.savePlan(_plan('a', 'Reef dive'));
     await repository.savePlan(_plan('b', 'Wreck dive'));
 
     await tester.pumpWidget(harness());
     await tester.pumpAndSettle();
 
-    // Enter compare mode -> each checkbox row carries its own trash button.
-    await tester.tap(find.text('Compare'));
-    await tester.pumpAndSettle();
+    // Normal mode: each row carries its own trash button.
     expect(find.byIcon(Icons.delete_outline), findsNWidgets(2));
 
-    await tester.tap(find.byIcon(Icons.delete_outline).first);
+    await tester.tap(find.text('Compare'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Delete plan?'), findsOneWidget);
-    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    // Compare mode: the rows are checkboxes gathering plans for a comparison,
+    // so a one-tap destructive action has no business sitting beside them.
+    expect(find.byType(CheckboxListTile), findsNWidgets(2));
+    expect(find.byIcon(Icons.delete_outline), findsNothing);
+
+    // Cancelling restores the per-row delete.
+    await tester.tap(find.text('Cancel'));
     await tester.pumpAndSettle();
-
-    expect(await repository.getAllPlanSummaries(), hasLength(1));
-
-    // Dropping to a single plan must actually leave compare mode (not merely
-    // hide the checkboxes): the surviving row renders as a normal tile.
-    expect(find.byType(CheckboxListTile), findsNothing);
-    expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsNWidgets(2));
   });
 
   testWidgets('compare mode is not silently re-entered after the count '
@@ -215,18 +215,27 @@ void main() {
     await tester.pumpWidget(harness());
     await tester.pumpAndSettle();
 
-    // Enter compare mode, then delete down to one plan so the mode resets.
+    // Enter compare mode, then drop to one plan behind the sheet's back. The
+    // count can fall while the sheet is open without the sheet doing it --
+    // deleting from the canvas, or a sync -- so the listener must still reset
+    // the mode rather than relying on the sheet's own controls.
     await tester.tap(find.text('Compare'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.delete_outline).first);
-    await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    expect(find.byType(CheckboxListTile), findsNWidgets(2));
+
+    await repository.deletePlan('b');
+    ProviderScope.containerOf(
+      tester.element(find.byType(SavedPlansSheet)),
+    ).invalidate(divePlanSummariesProvider);
     await tester.pumpAndSettle();
     expect(find.byType(CheckboxListTile), findsNothing);
 
     // Adding a plan back climbs the count to >=2 again. The sheet must stay in
     // normal mode; a stale `_selecting` flag would resurrect the checkboxes.
     await repository.savePlan(_plan('c', 'Drift dive'));
+    ProviderScope.containerOf(
+      tester.element(find.byType(SavedPlansSheet)),
+    ).invalidate(divePlanSummariesProvider);
     await tester.pumpAndSettle();
 
     expect(find.byType(CheckboxListTile), findsNothing);

--- a/test/features/tags/presentation/pages/tag_manage_page_test.dart
+++ b/test/features/tags/presentation/pages/tag_manage_page_test.dart
@@ -202,12 +202,13 @@ void main() {
       expect(find.text('Color'), findsOneWidget);
     });
 
-    testWidgets('long-press enters selection mode', (tester) async {
+    testWidgets('Select button enters selection mode', (tester) async {
       await tester.pumpWidget(_buildTestWidget(stats: _testStats));
       await tester.pumpAndSettle();
 
-      // Long press the first tag to enter selection mode
-      await tester.longPress(find.text('Night Dive'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
       // Selection mode indicators: close button, "1 selected" text, checkboxes
@@ -219,14 +220,30 @@ void main() {
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
+    testWidgets('long-press on a tag does not enter selection mode', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildTestWidget(stats: _testStats));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('Night Dive'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
+    });
+
     testWidgets('delete button shows confirmation with dive count', (
       tester,
     ) async {
       await tester.pumpWidget(_buildTestWidget(stats: _testStats));
       await tester.pumpAndSettle();
 
-      // Enter selection mode by long-pressing "Night Dive" (12 dives)
-      await tester.longPress(find.text('Night Dive'));
+      // Enter selection mode and check "Night Dive" (12 dives)
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
       // Delete lives behind the selection bar's overflow menu.
@@ -248,7 +265,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Enter selection mode with one tag
-      await tester.longPress(find.text('Night Dive'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
       // Keyed by SelectionAppBar, so this no longer depends on which glyph
@@ -263,7 +282,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Enter selection mode with first tag
-      await tester.longPress(find.text('Night Dive'));
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Night Dive'));
       await tester.pumpAndSettle();
 
       // Select second tag by tapping

--- a/test/shared/widgets/drag_select_grid_view_test.dart
+++ b/test/shared/widgets/drag_select_grid_view_test.dart
@@ -64,28 +64,41 @@ void main() {
       expect(item1.color, Colors.grey);
     });
 
-    testWidgets('long press enters selection mode', (tester) async {
-      bool selectionModeActive = false;
+    testWidgets('long press does not enter selection mode', (tester) async {
+      bool? selectionModeChangedTo;
+      Set<int> selection = {};
       await tester.pumpWidget(
         buildTestGrid(
-          onSelectionModeChanged: (active) => selectionModeActive = active,
+          onSelectionModeChanged: (active) => selectionModeChangedTo = active,
+          onSelectionChanged: (s) => selection = s,
         ),
       );
 
       await tester.longPress(find.text('0'));
       await tester.pumpAndSettle();
-      expect(selectionModeActive, isTrue);
+
+      expect(selectionModeChangedTo, isNull);
+      expect(selection, isEmpty);
     });
 
-    testWidgets('long press selects the pressed item', (tester) async {
+    testWidgets('long press inside selection mode checks the anchor', (
+      tester,
+    ) async {
       Set<int> selection = {};
       await tester.pumpWidget(
-        buildTestGrid(onSelectionChanged: (s) => selection = s),
+        buildTestGrid(
+          initialSelection: {1},
+          startInSelectionMode: true,
+          onSelectionChanged: (s) => selection = s,
+        ),
       );
 
       await tester.longPress(find.text('3'));
       await tester.pumpAndSettle();
-      expect(selection, contains(3));
+
+      // The drag anchor joins the selection rather than replacing it, so an
+      // accidental hold cannot wipe out what the user already checked.
+      expect(selection, containsAll(<int>[1, 3]));
     });
 
     testWidgets('tap toggles selection when in selection mode', (tester) async {

--- a/test/shared/widgets/entity_table/entity_table_view_test.dart
+++ b/test/shared/widgets/entity_table/entity_table_view_test.dart
@@ -117,7 +117,6 @@ Widget _buildTable({
   EntityTableViewConfig<_TestField>? config,
   void Function(String)? onEntityTap,
   void Function(String)? onEntityDoubleTap,
-  void Function(String)? onEntityLongPress,
   void Function(_TestField)? onSortFieldChanged,
   void Function(_TestField, double)? onResizeColumn,
   Set<String>? selectedIds,
@@ -135,7 +134,6 @@ Widget _buildTable({
       onResizeColumn: onResizeColumn ?? (_, _) {},
       onEntityTap: onEntityTap ?? (_) {},
       onEntityDoubleTap: onEntityDoubleTap,
-      onEntityLongPress: onEntityLongPress,
       selectedIds: selectedIds ?? const {},
       isSelectionMode: isSelectionMode,
       highlightedId: highlightedId,
@@ -227,22 +225,31 @@ void main() {
       expect(doubleTappedId, equals('dt-1'));
     });
 
-    testWidgets('calls onEntityLongPress on long-press', (tester) async {
-      String? longPressedId;
-
+    testWidgets('rows register no long-press recognizer', (tester) async {
       await tester.pumpWidget(
         _buildTable(
           entities: [const _TestEntity('lp-1', 'Echo', 7)],
           onEntityTap: (_) {},
-          onEntityLongPress: (id) => longPressedId = id,
         ),
       );
       await tester.pumpAndSettle();
 
-      await tester.longPress(find.text('Echo'));
-      await tester.pumpAndSettle();
-
-      expect(longPressedId, equals('lp-1'));
+      // Long-press is no longer a selection gesture on any surface, so no row
+      // may carry a handler for it. Asserting on the detectors rather than on
+      // a callback is deliberate: with the parameter gone there is nothing
+      // left to observe from the outside, and a reintroduced handler would
+      // otherwise slip in unnoticed.
+      final detectors = tester.widgetList<GestureDetector>(
+        find.descendant(
+          of: find.byType(EntityTableView<_TestEntity, _TestField>),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      expect(detectors, isNotEmpty);
+      for (final detector in detectors) {
+        expect(detector.onLongPress, isNull);
+        expect(detector.onLongPressStart, isNull);
+      }
     });
 
     testWidgets('highlights the row matching highlightedId', (tester) async {
@@ -779,14 +786,13 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // No long-press or double-tap handlers
+    // No double-tap handler
     // -----------------------------------------------------------------------
 
     testWidgets('table renders without optional handlers', (tester) async {
       await tester.pumpWidget(
         _buildTable(
           entities: [const _TestEntity('np-1', 'NoPress', 5)],
-          onEntityLongPress: null,
           onEntityDoubleTap: null,
         ),
       );

--- a/test/shared/widgets/entity_table/entity_table_view_test.dart
+++ b/test/shared/widgets/entity_table/entity_table_view_test.dart
@@ -235,20 +235,28 @@ void main() {
       await tester.pumpAndSettle();
 
       // Long-press is no longer a selection gesture on any surface, so no row
-      // may carry a handler for it. Asserting on the detectors rather than on
-      // a callback is deliberate: with the parameter gone there is nothing
+      // may carry a handler for it. Asserting on the widget tree rather than
+      // on a callback is deliberate: with the parameter gone there is nothing
       // left to observe from the outside, and a reintroduced handler would
       // otherwise slip in unnoticed.
-      final detectors = tester.widgetList<GestureDetector>(
+      //
+      // The assertion is on the recognizer, not on individual callbacks:
+      // GestureDetector registers one LongPressGestureRecognizer keyed by its
+      // own Type if ANY of seven long-press callbacks is non-null, so checking
+      // the map key covers onLongPressMoveUpdate, onLongPressEnd, onLongPressUp
+      // and the rest without having to enumerate them.
+      final detectors = tester.widgetList<RawGestureDetector>(
         find.descendant(
           of: find.byType(EntityTableView<_TestEntity, _TestField>),
-          matching: find.byType(GestureDetector),
+          matching: find.byType(RawGestureDetector),
         ),
       );
       expect(detectors, isNotEmpty);
       for (final detector in detectors) {
-        expect(detector.onLongPress, isNull);
-        expect(detector.onLongPressStart, isNull);
+        expect(
+          detector.gestures.containsKey(LongPressGestureRecognizer),
+          isFalse,
+        );
       }
     });
 


### PR DESCRIPTION
Removes long-press as a way into multi-select mode everywhere, and closes three
surfaces that still offered a delete control while a selection was active.

## Long-press no longer enters selection mode

Selection mode is now reachable only through the `enter_selection` control,
which every converted surface already carried, so nothing lost an entry point.

The optional callbacks are deleted rather than merely left unwired, so the
gesture cannot quietly come back:

- `EntityTableView.onEntityLongPress` (fed courses, sites, certifications,
  trips, dive centers, equipment and buddies)
- `DiveTableView.onDiveLongPress`
- `onLongPress` on the six list tiles: `CompactSiteListTile`,
  `DenseSiteListTile`, `DiveListItem`, `CompactDiveListTile`,
  `DenseDiveListTile`, plus the tiles defined inline in `dive_list_page.dart`
  and `site_list_content.dart`

Two consequences worth knowing:

**`DragSelectGridView` needed care.** `_dragAnchorIndex` was set only inside
`_enterSelectionMode`, so drag-to-range-select existed purely as a continuation
of the entering long-press -- deleting the gesture outright would have silently
deleted drag-select with it. Long-press is demoted instead: it anchors a range
drag only when selection is already active, and the anchor joins the existing
selection rather than replacing it. Outside selection mode all three long-press
callbacks are null, so no recognizer is registered at all.

**A hold now resolves as an ordinary tap on release.** Flutter's
`TapGestureRecognizer` has no upper duration bound, so holding a dive row and
letting go opens the dive, and holding a media thumbnail opens the viewer. This
is inherent to removing the handler; the tests assert it explicitly.

Modifier-click is untouched and remains the one implicit entry path, so
`SelectionController.enterImplicit` and the evaporate-at-zero-checked rule still
apply on desktop.

Minor regression: in the photo picker, drag-select starting from a completely
empty selection now needs one item tapped first. Tap-to-select and
drag-select-from-one both still work.

## Delete behind the overflow in multi-select

`SelectionAppBar` was already structurally correct -- `maxInlineActions` slices
only the surface-supplied extras, and `_buildDeleteItem` is emitted solely
inside the `PopupMenuButton`. All three leaks were surfaces rendering their own
delete alongside the shared bar:

| Surface | Fix |
| --- | --- |
| `species_manage_page.dart` | the row's `trailing:` (edit + trash) yields to selection mode |
| `service_kind_list_page.dart` | the row's `trailing:` trash yields to selection mode |
| `saved_plans_sheet.dart` | trash removed from the compare-mode `CheckboxListTile`; still present on the normal row |

The first two were half-migrations: `SelectionLeading` and `SelectionAppBar`
were wired up, but the row's own `trailing:` was never revisited, leaving a
checkbox and a live one-tap trash on the same row -- which is exactly what a
phone-width row makes obvious.

## Tests

Tests that used long-press as *setup* now tap the Select button; tests whose
*subject* was long-press entry are inverted into regression tests asserting the
gesture does nothing.

One test premise needed correcting: `site_list_content_test`'s "tapping last
selected site exits selection mode" relied on long-press being an implicit
entry. Via the Select button the entry is explicit, so the bar correctly stays
at "0 selected"; the test now asserts that.

## Added after review: a Select control for table mode

Merging main surfaced a regression this PR would otherwise have shipped.
**Table mode has no app bar of its own** -- `TableModeLayout` owns the window
chrome and cannot reach the content's `SelectionController`, and the content
renders only the table. Long-press was therefore the only touch route into
multi-select there, and removing it left none. Modifier-click still covers
desktop.

The original claim in this PR that "every surface already had a Select control"
was checked against the `*ListContent` files and missed the table-mode host.

New `SelectionEntryBar` renders the Select control in the same slot and at the
same `kToolbarHeight` as `SelectionAppBar`'s pane shell, so opening the mode
swaps one bar for the other rather than shifting the table down a row.

Wiring it up also turned up that five of the eight table surfaces -- courses,
certifications, trips, dive centers, equipment -- rendered **no contextual bar
in table mode either**, so a modifier-click there produced checkboxes with
nothing to act on and no way out but Escape. Adding only an entry control would
have made that state easier to reach, so those five now get the pane bar too.

`site_list_content_table_test`'s selection helper entered via long-press; it now
uses the Select control, and there is an explicit test that the Select
affordance and the contextual bar occupy the slot one at a time.

## Merge note

Main gained `ed5e30e` (anchor shift and modifier clicks on the highlighted row)
while this branch was open. It is complementary -- it hardens the modifier-click
path, which this branch leaves as the only implicit entry -- and its `seedId`
plumbing is kept throughout.

One deliberate divergence: site's two overflow "Select" entries now call
`enterExplicit` directly rather than going through the helper, so unlike main
that path no longer clears the highlight. That makes the two explicit entries in
that file agree with each other, and brings sites in line with dives and
buddies.
