### PR TITLE
fix(media): open PDF attachments and render their first page as the tile

### DIFF
--- a/lib/features/media/data/resolvers/media_store_resolver.dart
+++ b/lib/features/media/data/resolvers/media_store_resolver.dart
@@ -61,10 +61,14 @@ class MediaStoreResolver {
 
   Future<MediaSourceData?> _fetchThumb(MediaItem item, String hash) async {
     // The pipeline always uploads thumbs as JPEG, whatever the source's own
-    // format. For a video that JPEG is a poster frame, so the result is
-    // decodable as an image even though the row is a video -- something only
-    // this side knows, and the flag is how MediaItemView is told.
-    final isPoster = item.mediaType == MediaType.video;
+    // format. For a video that JPEG is a poster frame and for a document it
+    // is a page-1 render, so the result is decodable as an image even though
+    // the row is not -- something only this side knows, and the flag is how
+    // MediaItemView is told. A photo's thumb is the photo itself, resized,
+    // so it is not a stand-in and stays unflagged.
+    final isPoster =
+        item.mediaType == MediaType.video ||
+        item.mediaType == MediaType.document;
     File? staging;
     try {
       final cached = await _cache.get(hash, MediaCacheKind.thumb);

--- a/lib/features/media/data/services/pdf_page_renderer.dart
+++ b/lib/features/media/data/services/pdf_page_renderer.dart
@@ -6,6 +6,20 @@ import 'package:pdfrx/pdfrx.dart';
 
 import 'package:submersion/core/services/logger_service.dart';
 
+/// Signature of the PDF page-1 render seam, injectable so tests do not need
+/// a pdfium binary. Matches [PdfPageRenderer.renderFirstPageJpeg].
+///
+/// Declared here rather than beside either consumer: both the upload
+/// pipeline's `ThumbnailGenerator` and the grid's `PdfThumbnailService` take
+/// the seam, and neither feature should have to import the other to name it.
+typedef PdfThumbRenderer =
+    Future<Uint8List?> Function({
+      File? file,
+      Uint8List? bytes,
+      int maxDimension,
+      int quality,
+    });
+
 /// Renders the first page of a PDF to JPEG bytes for thumbnails.
 ///
 /// Every failure path returns null: thumbnail absence must never block an

--- a/lib/features/media/data/services/pdf_thumbnail_service.dart
+++ b/lib/features/media/data/services/pdf_thumbnail_service.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/features/media/data/services/pdf_page_renderer.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// Produces and caches page-1 renders of PDF attachments so the media grid
+/// shows the document instead of a generic icon.
+///
+/// The store-side [ThumbnailGenerator] already renders page 1 for upload, but
+/// only a device that cannot resolve the PDF locally ever sees that JPEG: a
+/// row whose own source resolves hands back the raw PDF, which no Image
+/// widget can decode, and the tile falls through to the icon placeholder
+/// (issue #1019). This is the local counterpart, so the tile looks the same
+/// on the device that attached the file as on every other one.
+///
+/// Same failure contract as [VideoThumbnailService]: null on every failure
+/// path, leaving the caller with its placeholder.
+class PdfThumbnailService {
+  PdfThumbnailService({
+    required Future<Directory> Function() cacheDir,
+    PdfThumbRenderer? renderer,
+    Duration renderBudget = const Duration(seconds: 15),
+  }) : _cacheDir = cacheDir,
+       _renderer = renderer ?? PdfPageRenderer.renderFirstPageJpeg,
+       _renderBudget = renderBudget;
+
+  final Future<Directory> Function() _cacheDir;
+  final PdfThumbRenderer _renderer;
+
+  /// Ceiling on one page render.
+  ///
+  /// Not a performance budget -- a 512 px page takes milliseconds. It bounds
+  /// the one pdfrx failure that is neither a throw nor a null: when the
+  /// engine cannot initialise, the crash happens inside its worker isolate
+  /// and the calling future simply never completes. Without this the tile
+  /// would shimmer forever instead of falling back to the icon.
+  final Duration _renderBudget;
+  Directory? _resolvedDir;
+
+  /// Matches [ThumbnailGenerator.maxDimension] so a locally rendered tile and
+  /// one served from the store are the same picture.
+  ///
+  /// Deliberately NOT the caller's tile size, which is what the video poster
+  /// path keys on: a pdfium render is far more expensive than a poster
+  /// fetch, and sizing per tile would re-render the same document once per
+  /// grid geometry. 512 px covers every tile in the app; the decode down to
+  /// the tile is Flutter's job.
+  static const int maxDimension = 512;
+
+  /// Page-1 JPEG for [item], or null when one cannot be produced.
+  ///
+  /// [source] is called only on a cache miss. It is a callback rather than a
+  /// resolved value because resolving is the expensive half on the platforms
+  /// that matter here: an Android SAF read or a bookmark read pulls the
+  /// whole PDF across a platform channel, and a warm cache must not pay for
+  /// it on every tile that scrolls into view.
+  Future<Uint8List?> thumbFor(
+    MediaItem item, {
+    required Future<MediaSourceData> Function() source,
+  }) async {
+    if (!item.isPdf) return null;
+
+    final dir = await _resolveCacheDir();
+    final cacheFile = dir == null
+        ? null
+        : File(p.join(dir.path, '${cacheKeyFor(item)}.jpg'));
+    if (cacheFile != null && await cacheFile.exists()) {
+      try {
+        return await cacheFile.readAsBytes();
+      }
+      // coverage:ignore-start
+      // Reading back a file this class just wrote fails only on a permission
+      // or I/O error, which flutter_test's tmpdir fixtures cannot produce.
+      // Dropping the entry keeps the failure self-healing instead of
+      // re-throwing on every render; regeneration runs either way.
+      on FileSystemException {
+        try {
+          await cacheFile.delete();
+        } on FileSystemException {
+          // Leave it; the regenerate below still runs.
+        }
+      }
+      // coverage:ignore-end
+    }
+
+    final Uint8List? jpeg;
+    try {
+      jpeg = await switch (await source()) {
+        FileData(file: final f) => _render(file: f),
+        BytesData(bytes: final b) => _render(bytes: b),
+        NetworkData() || UnavailableData() => Future.value(null),
+      };
+    } on Object {
+      // A resolver that throws, or a render that ran out of time, is the
+      // caller's placeholder -- not an error escaping into a grid tile
+      // mid-scroll.
+      return null;
+    }
+    if (jpeg == null) return null;
+
+    if (dir != null && cacheFile != null) {
+      try {
+        await dir.create(recursive: true);
+        await cacheFile.writeAsBytes(jpeg, flush: true);
+      } on FileSystemException {
+        // Caching is best-effort; the freshly rendered bytes still return.
+      }
+    }
+    return jpeg;
+  }
+
+  static const int _jpegQuality = 80;
+
+  Future<Uint8List?> _render({File? file, Uint8List? bytes}) => _renderer(
+    file: file,
+    bytes: bytes,
+    maxDimension: maxDimension,
+    quality: _jpegQuality,
+  ).timeout(_renderBudget);
+
+  /// Cache key for [item]'s page-1 render.
+  ///
+  /// Keys on content when the row knows it ([MediaItem.contentHash], stamped
+  /// by the upload pipeline) and on row identity plus its update stamp
+  /// otherwise. The fallback is weaker than the video path's path+mtime+size
+  /// because a document has no path to stat on the platform this matters
+  /// most on: Android stores a SAF content URI. Replacing the bytes behind a
+  /// URI without touching the row therefore keeps a stale tile until the row
+  /// is next written -- a thumbnail being one revision behind, which is the
+  /// cheaper wrong answer than a channel read per tile.
+  @visibleForTesting
+  static String cacheKeyFor(MediaItem item) {
+    final signature =
+        item.contentHash ??
+        '${item.id}|${item.updatedAt.millisecondsSinceEpoch}';
+    return sha1.convert(utf8.encode('$signature|$maxDimension')).toString();
+  }
+
+  /// Resolves (and memoises) the cache directory, or null when it cannot be
+  /// determined. A host without a usable support directory renders without a
+  /// cache rather than losing the thumbnail entirely.
+  Future<Directory?> _resolveCacheDir() async {
+    final cached = _resolvedDir;
+    if (cached != null) return cached;
+    try {
+      return _resolvedDir = await _cacheDir();
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/lib/features/media/domain/value_objects/media_source_data.dart
+++ b/lib/features/media/domain/value_objects/media_source_data.dart
@@ -41,12 +41,15 @@ class FileData extends MediaSourceData {
   final File file;
 
   /// Whether [file] holds a still image standing in for the item rather than
-  /// the item's own bytes — a poster frame derived from a video.
+  /// the item's own bytes — a poster frame derived from a video, or a page-1
+  /// render of a document.
   ///
-  /// A video row's [FileData] is normally raw video that `Image.file` cannot
-  /// decode, so the view substitutes a placeholder. A poster is the one case
-  /// where a video's file IS decodable, and only the producer knows which it
-  /// handed back: `MediaItemView` sees the same `FileData` either way.
+  /// A video or document row's [FileData] is normally raw bytes that
+  /// `Image.file` cannot decode, so the view substitutes a placeholder. A
+  /// stand-in is the one case where such a row's file IS decodable, and only
+  /// the producer knows which it handed back: `MediaItemView` sees the same
+  /// `FileData` either way. A photo's thumbnail is NOT a stand-in — it is the
+  /// photo itself, resized.
   final bool isPoster;
 
   const FileData({required this.file, this.isPoster = false});

--- a/lib/features/media/presentation/helpers/document_open_helper.dart
+++ b/lib/features/media/presentation/helpers/document_open_helper.dart
@@ -9,8 +9,8 @@ import 'package:submersion/features/media/data/services/document_import_service.
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/pages/document_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
-import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media/presentation/providers/site_media_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -48,9 +48,7 @@ class DocumentOpenHelper {
     MediaItem item,
   ) async {
     final l10n = context.l10n;
-    final resolved = await ref.read(
-      resolvedFullResolutionProvider(item).future,
-    );
+    final resolved = await ref.read(mediaBytesProvider(item).future);
     if (resolved.isUnavailable || resolved.bytes == null) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/media/presentation/pages/document_viewer_page.dart
+++ b/lib/features/media/presentation/pages/document_viewer_page.dart
@@ -5,15 +5,15 @@ import 'package:share_plus/share_plus.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
-import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Full-screen in-app viewer for PDF document attachments.
 ///
-/// Bytes come through [resolvedFullResolutionProvider], which already
-/// handles every source type plus the media-store fallback, so a PDF views
-/// identically whether it lives behind a local bookmark, a SAF URI, a
-/// plain path, or only in the cloud store.
+/// Bytes come through [mediaBytesProvider], which resolves the row against
+/// the source it points at and falls back to the media store, so a PDF views
+/// identically whether it lives behind a local bookmark, a SAF URI, a plain
+/// path, or only in the cloud store.
 class DocumentViewerPage extends ConsumerStatefulWidget {
   final MediaItem item;
 
@@ -30,9 +30,7 @@ class _DocumentViewerPageState extends ConsumerState<DocumentViewerPage> {
 
   @override
   Widget build(BuildContext context) {
-    final resolvedAsync = ref.watch(
-      resolvedFullResolutionProvider(widget.item),
-    );
+    final resolvedAsync = ref.watch(mediaBytesProvider(widget.item));
 
     return Scaffold(
       appBar: AppBar(
@@ -85,9 +83,7 @@ class _DocumentViewerPageState extends ConsumerState<DocumentViewerPage> {
   Future<void> _share(BuildContext context) async {
     final l10n = context.l10n;
     try {
-      final resolved = await ref.read(
-        resolvedFullResolutionProvider(widget.item).future,
-      );
+      final resolved = await ref.read(mediaBytesProvider(widget.item).future);
       if (resolved.isUnavailable || resolved.bytes == null) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/media/presentation/providers/media_bytes_providers.dart
+++ b/lib/features/media/presentation/providers/media_bytes_providers.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+const _log = LoggerService('mediaBytesProvider');
+
+/// Full-resolution bytes for any [MediaItem], read from the source the row
+/// actually points at and falling back to the media store.
+///
+/// This is the byte-level companion to `MediaItemView`: same registry, same
+/// store fallback, so a document, a local-file photo and a gallery photo all
+/// resolve here. [resolvedFullResolutionProvider] answers a narrower
+/// question — "where did this row's `platformAssetId` end up in the photo
+/// library on THIS device" — and returns unavailable for every row that has
+/// no asset id at all. Document attachments never have one: they are
+/// reference-linked by path, bookmark or SAF URI. Routing the PDF viewer
+/// through the gallery provider therefore made every attachment read as
+/// "not available on this device" (issue #1019).
+///
+/// Callers get [ResolvedAssetResult] rather than [MediaSourceData] because
+/// they all want the same thing — bytes to render or to write into a share
+/// temp file — and a resolution they cannot use (a bare URL) is, for that
+/// purpose, indistinguishable from an absent one.
+final mediaBytesProvider =
+    FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      final native = await _resolveNative(ref, item);
+      final bytes = await _bytesOf(native, item);
+      if (bytes != null) {
+        return ResolvedAssetResult(
+          bytes: bytes,
+          status: ResolutionStatus.resolved,
+        );
+      }
+
+      // The store is the cross-device path for reference-linked media: the
+      // originating device holds the file, everyone else holds the row. Its
+      // resolver self-gates on the upload stamps, so an item that was never
+      // uploaded costs one null return rather than a fetch.
+      final remote = await _resolveRemote(ref, item);
+      final remoteBytes = await _bytesOf(remote, item);
+      if (remoteBytes != null) {
+        return ResolvedAssetResult(
+          bytes: remoteBytes,
+          status: ResolutionStatus.resolved,
+        );
+      }
+
+      return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
+    });
+
+/// Resolves [item] through its registered source resolver.
+///
+/// An unregistered source type makes the registry throw [UnsupportedError] —
+/// a programmer error, but one whose blast radius here is a single
+/// attachment. Swallowed to the unavailable placeholder so a mis-registered
+/// row cannot turn the viewer into an error screen.
+Future<MediaSourceData> _resolveNative(Ref ref, MediaItem item) async {
+  try {
+    final registry = ref.read(mediaSourceResolverRegistryProvider);
+    return await registry.resolverFor(item.sourceType).resolve(item);
+  } on Object catch (e, st) {
+    _log.warning(
+      'Source resolution failed for media ${item.id}',
+      error: e,
+      stackTrace: st,
+    );
+    return const UnavailableData(kind: UnavailableKind.notFound);
+  }
+}
+
+Future<MediaSourceData?> _resolveRemote(Ref ref, MediaItem item) async {
+  try {
+    final runtime = await ref.read(mediaStoreRuntimeProvider.future);
+    return await runtime?.resolver.tryResolveRemote(item, thumbnail: false);
+  } on Object catch (e, st) {
+    _log.warning(
+      'Media store fallback failed for media ${item.id}',
+      error: e,
+      stackTrace: st,
+    );
+    return null;
+  }
+}
+
+/// Bytes for the resolutions that carry any, null for the ones that do not.
+///
+/// [NetworkData] is deliberately not fetched: it is `cached_network_image`'s
+/// contract, and the rows that produce it (URL imports, manifest entries)
+/// have their own display path.
+Future<Uint8List?> _bytesOf(MediaSourceData? data, MediaItem item) async {
+  switch (data) {
+    case BytesData(bytes: final b):
+      return b;
+    case FileData(file: final f):
+      try {
+        return await f.readAsBytes();
+      } on FileSystemException catch (e) {
+        _log.warning('Resolved file unreadable for media ${item.id}: $e');
+        return null;
+      }
+    case NetworkData():
+    case UnavailableData():
+    case null:
+      return null;
+  }
+}

--- a/lib/features/media/presentation/providers/media_resolver_providers.dart
+++ b/lib/features/media/presentation/providers/media_resolver_providers.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/media/data/services/local_media_platform.dar
 import 'package:submersion/features/media/data/services/manifest_fetch_service.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
 import 'package:submersion/features/media/data/services/network_credentials_service.dart';
+import 'package:submersion/features/media/data/services/pdf_thumbnail_service.dart';
 import 'package:submersion/features/media/data/services/subscription_poller.dart';
 import 'package:submersion/features/media/data/services/subscription_poller_scheduler.dart';
 import 'package:submersion/features/media/data/services/video_thumbnail_service.dart';
@@ -61,6 +62,17 @@ final videoThumbnailServiceProvider = Provider<VideoThumbnailService>(
     cacheDir: () async {
       final support = await getApplicationSupportDirectory();
       return Directory(p.join(support.path, 'Submersion', 'video_thumbnails'));
+    },
+  ),
+);
+
+/// Renders and caches page-1 images of PDF attachments so a document tile
+/// shows the document rather than a generic icon.
+final pdfThumbnailServiceProvider = Provider<PdfThumbnailService>(
+  (ref) => PdfThumbnailService(
+    cacheDir: () async {
+      final support = await getApplicationSupportDirectory();
+      return Directory(p.join(support.path, 'Submersion', 'pdf_thumbnails'));
     },
   ),
 );

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -67,14 +67,16 @@ class MediaItemView extends ConsumerStatefulWidget {
 /// do. Carried alongside the data rather than folded into it so the resolver
 /// contract stays a plain "bytes or a reason".
 ///
-/// [isStoreData] marks bytes served by the media-store fallback. Documents
-/// need it: a PDF's STORE THUMB is a renderable JPEG, while every other
-/// document resolution (local original, store original) is raw document
-/// bytes that Image widgets cannot decode.
+/// [documentRenderable] marks a document resolution whose bytes are an
+/// IMAGE rather than the document itself — a page-1 render, produced either
+/// locally by [PdfThumbnailService] or by the upload pipeline and served
+/// back as the store's THUMB. Every other document resolution (local
+/// original, store original) is raw document bytes that Image widgets
+/// cannot decode, and draws the placeholder instead.
 typedef _Resolution = ({
   MediaSourceData data,
   bool videoPosterMissing,
-  bool isStoreData,
+  bool documentRenderable,
 });
 
 class _MediaItemViewState extends ConsumerState<MediaItemView> {
@@ -112,6 +114,27 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
   Future<_Resolution> _resolve() async {
     final registry = ref.read(mediaSourceResolverRegistryProvider);
     final resolver = registry.resolverFor(widget.item.sourceType);
+    // A PDF tile draws page 1. Rendering is the only way raw document bytes
+    // become an image, and doing it here rather than in the resolver keeps
+    // resolveThumbnail's contract intact -- ThumbnailGenerator calls it
+    // expecting the PDF itself to feed to the same renderer. Cache-first
+    // inside the service, so the source read (on Android, the whole file
+    // back across a platform channel) happens once per document instead of
+    // once per tile that scrolls into view.
+    if (widget.thumbnail && widget.item.isPdf) {
+      final page1 = await ref
+          .read(pdfThumbnailServiceProvider)
+          .thumbFor(widget.item, source: () => resolver.resolve(widget.item));
+      if (page1 != null) {
+        return (
+          data: BytesData(bytes: page1),
+          videoPosterMissing: false,
+          documentRenderable: true,
+        );
+      }
+      // No local render (bytes unavailable here, or an unreadable PDF):
+      // fall through, which reaches the store's own page-1 thumb below.
+    }
     // [thumbnail] alone decides the path. Requiring a [targetSize] too made
     // the flag a silent no-op wherever one was omitted, and the fallback is
     // the full-resolution original: for a gallery item, AssetEntity
@@ -125,7 +148,11 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
           )
         : await resolver.resolve(widget.item);
     if (native is! UnavailableData) {
-      return (data: native, videoPosterMissing: false, isStoreData: false);
+      return (
+        data: native,
+        videoPosterMissing: false,
+        documentRenderable: false,
+      );
     }
     // Media store fallback (design spec section 10): only engages when the
     // native source cannot produce bytes on this device and the row is
@@ -146,7 +173,11 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
             widget.item.remoteCompressedUploadedAt != null ||
             (widget.thumbnail && widget.item.remoteThumbUploadedAt != null));
     if (!storeConfirmed) {
-      return (data: native, videoPosterMissing: false, isStoreData: false);
+      return (
+        data: native,
+        videoPosterMissing: false,
+        documentRenderable: false,
+      );
     }
     try {
       final runtime = await ref.read(mediaStoreRuntimeProvider.future);
@@ -154,14 +185,22 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
       // somewhere, but nothing here can reach them, so the native
       // placeholder is the honest answer.
       if (runtime == null) {
-        return (data: native, videoPosterMissing: false, isStoreData: false);
+        return (
+          data: native,
+          videoPosterMissing: false,
+          documentRenderable: false,
+        );
       }
       final remote = await runtime.resolver.tryResolveRemote(
         widget.item,
         thumbnail: widget.thumbnail,
       );
       if (remote != null) {
-        return (data: remote, videoPosterMissing: false, isStoreData: true);
+        return (
+          data: remote,
+          videoPosterMissing: false,
+          documentRenderable: widget.thumbnail,
+        );
       }
       // The movie tile claims something specific -- this video has no poster
       // frame -- so it is shown only when that is what happened: the store
@@ -176,10 +215,14 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
             widget.thumbnail &&
             widget.item.isVideo &&
             widget.item.remoteThumbUploadedAt == null,
-        isStoreData: false,
+        documentRenderable: false,
       );
     } catch (_) {
-      return (data: native, videoPosterMissing: false, isStoreData: false);
+      return (
+        data: native,
+        videoPosterMissing: false,
+        documentRenderable: false,
+      );
     }
   }
 
@@ -202,10 +245,10 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         }
         final data = resolution.data;
         // A document resolves to raw document bytes (PDF, docx, ...), which
-        // the Image widgets cannot decode. The one renderable exception is
-        // a PDF's media-store THUMB: a JPEG served by the store fallback
-        // for a thumbnail request.
-        final documentRenderable = resolution.isStoreData && widget.thumbnail;
+        // the Image widgets cannot decode. The renderable exception is a
+        // PDF's page-1 image: rendered here for a tile, or served as the
+        // store's THUMB when this device cannot read the PDF itself.
+        final documentRenderable = resolution.documentRenderable;
         return switch (data) {
           FileData() when widget.item.isDocument && !documentRenderable =>
             _DocumentThumbnailPlaceholder(item: widget.item),

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -199,7 +199,13 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         return (
           data: remote,
           videoPosterMissing: false,
-          documentRenderable: widget.thumbnail,
+          // Not "the request was a thumbnail": a thumbnail request whose
+          // thumb object is missing or unfetchable degrades to the ORIGINAL
+          // (see MediaStoreResolver.tryResolveRemote), and for a document
+          // that original is the PDF. Only the store knows which of the two
+          // it handed back, and isPoster is how it says so.
+          documentRenderable:
+              widget.thumbnail && remote is FileData && remote.isPoster,
         );
       }
       // The movie tile claims something specific -- this video has no poster

--- a/lib/features/media_store/data/thumbnail_generator.dart
+++ b/lib/features/media_store/data/thumbnail_generator.dart
@@ -12,16 +12,6 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
 
-/// Signature of the PDF page-1 render seam, injectable so tests do not need
-/// a pdfium binary. Matches [PdfPageRenderer.renderFirstPageJpeg].
-typedef PdfThumbRenderer =
-    Future<Uint8List?> Function({
-      File? file,
-      Uint8List? bytes,
-      int maxDimension,
-      int quality,
-    });
-
 /// Best-effort thumbnail production for the upload pipeline (design spec
 /// section 9 step 4). Only the gallery source hands back genuinely
 /// pre-compressed thumbnail bytes; everything else (including bookmark

--- a/test/features/media/data/media_store_resolver_video_test.dart
+++ b/test/features/media/data/media_store_resolver_video_test.dart
@@ -172,6 +172,63 @@ void main() {
     expect((data! as FileData).isPoster, isFalse);
   });
 
+  // A document's thumb is a page-1 render: an image standing in for bytes no
+  // Image widget can decode, exactly like a video's poster. Without the flag
+  // MediaItemView cannot tell it apart from the PDF the same call returns
+  // when no thumb was stamped, and draws a broken tile for one of the two.
+  test('a document thumb from the store is flagged as a stand-in', () async {
+    final render = 'jpeg-page-1-bytes'.codeUnits;
+    final hash = 'd7${'3' * 62}';
+    store.objects[StoreKeys.thumbKey(hash)] = render;
+
+    final data = await resolver.tryResolveRemote(
+      MediaItem(
+        id: 'd1',
+        siteId: 'site-1',
+        mediaType: MediaType.document,
+        sourceType: MediaSourceType.localFile,
+        originalFilename: 'reef-map.pdf',
+        takenAt: DateTime(2026),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        contentHash: hash,
+        remoteThumbUploadedAt: DateTime(2026),
+      ),
+      thumbnail: true,
+    );
+
+    expect(data, isA<FileData>());
+    expect((data! as FileData).isPoster, isTrue);
+  });
+
+  // The other half of the pair: no thumb stamp, so the same call degrades to
+  // the document itself, which must NOT be flagged.
+  test('a document served as its original is not flagged', () async {
+    final pdf = '%PDF-1.7 not an image'.codeUnits;
+    final seed = File('${root.path}/reef-map.pdf')..writeAsBytesSync(pdf);
+    final digest = await sha256OfFile(seed);
+    store.objects[StoreKeys.objectKey(digest.hash, extension: 'pdf')] = pdf;
+
+    final data = await resolver.tryResolveRemote(
+      MediaItem(
+        id: 'd2',
+        siteId: 'site-1',
+        mediaType: MediaType.document,
+        sourceType: MediaSourceType.localFile,
+        originalFilename: 'reef-map.pdf',
+        takenAt: DateTime(2026),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        contentHash: digest.hash,
+        remoteUploadedAt: DateTime(2026),
+      ),
+      thumbnail: true,
+    );
+
+    expect(data, isA<FileData>());
+    expect((data! as FileData).isPoster, isFalse);
+  });
+
   // Rows created by the Files tab before it recorded a filename have
   // originalFilename == null, so StoreKeys.extensionFor yields 'bin' and the
   // object was UPLOADED under `<hash>.bin`. That key must not change -- it is

--- a/test/features/media/data/services/pdf_thumbnail_service_test.dart
+++ b/test/features/media/data/services/pdf_thumbnail_service_test.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/media/data/services/pdf_thumbnail_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// The renderer is always injected: pdfrx cannot initialise under
+/// flutter_test, and a failed init hangs the calling future rather than
+/// throwing.
+void main() {
+  late Directory root;
+  late int renderCalls;
+  late int sourceCalls;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('pdf_thumbs');
+    renderCalls = 0;
+    sourceCalls = 0;
+  });
+
+  tearDown(() => root.delete(recursive: true));
+
+  final jpeg = Uint8List.fromList([255, 216, 255, 224, 7, 7]);
+
+  MediaItem pdf({
+    String id = 'doc-1',
+    String? contentHash,
+    String filename = 'reef-map.pdf',
+    DateTime? updatedAt,
+  }) => MediaItem(
+    id: id,
+    siteId: 'site-1',
+    mediaType: MediaType.document,
+    sourceType: MediaSourceType.localFile,
+    originalFilename: filename,
+    contentHash: contentHash,
+    takenAt: DateTime(2026, 8, 12),
+    createdAt: DateTime(2026, 8, 12),
+    updatedAt: updatedAt ?? DateTime(2026, 8, 12),
+  );
+
+  PdfThumbnailService service({
+    bool declines = false,
+    Future<Directory> Function()? cacheDir,
+  }) => PdfThumbnailService(
+    cacheDir: cacheDir ?? () async => Directory('${root.path}/cache'),
+    renderer:
+        ({
+          File? file,
+          Uint8List? bytes,
+          int maxDimension = 512,
+          int quality = 80,
+        }) async {
+          renderCalls++;
+          return declines ? null : jpeg;
+        },
+  );
+
+  Future<MediaSourceData> Function() serving(MediaSourceData data) => () async {
+    sourceCalls++;
+    return data;
+  };
+
+  test('renders page 1 from resolved bytes', () async {
+    final result = await service().thumbFor(
+      pdf(),
+      source: serving(BytesData(bytes: Uint8List.fromList([37, 80]))),
+    );
+
+    expect(result, equals(jpeg));
+    expect(renderCalls, 1);
+  });
+
+  test('renders page 1 from a resolved file', () async {
+    final file = File('${root.path}/reef-map.pdf')..writeAsBytesSync([37, 80]);
+
+    final result = await service().thumbFor(
+      pdf(),
+      source: serving(FileData(file: file)),
+    );
+
+    expect(result, equals(jpeg));
+  });
+
+  // The cache is the whole point on Android, where resolving the source
+  // reads the entire PDF back across a platform channel.
+  test('a second request is served from disk without resolving or '
+      're-rendering', () async {
+    final svc = service();
+    final source = serving(BytesData(bytes: Uint8List.fromList([37, 80])));
+
+    await svc.thumbFor(pdf(), source: source);
+    final second = await svc.thumbFor(pdf(), source: source);
+
+    expect(second, equals(jpeg));
+    expect(renderCalls, 1);
+    expect(sourceCalls, 1);
+  });
+
+  test(
+    'a row whose content hash changed does not reuse the old tile',
+    () async {
+      final svc = service();
+      final source = serving(BytesData(bytes: Uint8List.fromList([37, 80])));
+
+      await svc.thumbFor(pdf(contentHash: 'a' * 64), source: source);
+      await svc.thumbFor(pdf(contentHash: 'b' * 64), source: source);
+
+      expect(renderCalls, 2);
+    },
+  );
+
+  test('without a content hash the update stamp busts the entry', () async {
+    expect(
+      PdfThumbnailService.cacheKeyFor(pdf(updatedAt: DateTime(2026, 8, 12))),
+      isNot(
+        PdfThumbnailService.cacheKeyFor(pdf(updatedAt: DateTime(2026, 8, 13))),
+      ),
+    );
+  });
+
+  test('an unresolvable source never reaches the renderer', () async {
+    final result = await service().thumbFor(
+      pdf(),
+      source: serving(const UnavailableData(kind: UnavailableKind.notFound)),
+    );
+
+    expect(result, isNull);
+    expect(renderCalls, 0);
+  });
+
+  test('a source that throws yields null rather than escaping into the '
+      'grid', () async {
+    final result = await service().thumbFor(
+      pdf(),
+      source: () async => throw const FileSystemException('denied'),
+    );
+
+    expect(result, isNull);
+  });
+
+  test('a declined render is not cached', () async {
+    final svc = service(declines: true);
+    final source = serving(BytesData(bytes: Uint8List.fromList([37, 80])));
+
+    expect(await svc.thumbFor(pdf(), source: source), isNull);
+    expect(await svc.thumbFor(pdf(), source: source), isNull);
+    expect(renderCalls, 2);
+  });
+
+  test('a non-PDF document is never rendered', () async {
+    final result = await service().thumbFor(
+      pdf(filename: 'briefing.txt'),
+      source: serving(BytesData(bytes: Uint8List.fromList([1]))),
+    );
+
+    expect(result, isNull);
+    expect(sourceCalls, 0);
+  });
+
+  // pdfrx's worst failure is silence: a failed engine init crashes its
+  // background worker isolate, so the render future never completes and
+  // nothing throws. The budget is what turns that into a placeholder rather
+  // than a tile that shimmers for the life of the screen.
+  test('a render that never completes yields null', () async {
+    final svc = PdfThumbnailService(
+      cacheDir: () async => Directory('${root.path}/cache'),
+      renderBudget: const Duration(milliseconds: 20),
+      renderer:
+          ({
+            File? file,
+            Uint8List? bytes,
+            int maxDimension = 512,
+            int quality = 80,
+          }) => Completer<Uint8List?>().future,
+    );
+
+    expect(
+      await svc.thumbFor(
+        pdf(),
+        source: serving(BytesData(bytes: Uint8List.fromList([37, 80]))),
+      ),
+      isNull,
+    );
+  });
+
+  // A host that cannot hand out a support directory still gets thumbnails,
+  // just without the cache -- losing the picture entirely would be a worse
+  // trade than re-rendering.
+  test('an unusable cache directory degrades to uncached rendering', () async {
+    final svc = service(
+      cacheDir: () async => throw const FileSystemException('no dir'),
+    );
+    final source = serving(BytesData(bytes: Uint8List.fromList([37, 80])));
+
+    expect(await svc.thumbFor(pdf(), source: source), equals(jpeg));
+    expect(await svc.thumbFor(pdf(), source: source), equals(jpeg));
+    expect(renderCalls, 2);
+  });
+}

--- a/test/features/media/presentation/helpers/document_open_helper_test.dart
+++ b/test/features/media/presentation/helpers/document_open_helper_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/media/data/services/asset_resolution_service
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/helpers/document_open_helper.dart';
 import 'package:submersion/features/media/presentation/pages/document_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 
 import '../support/media_widget_harness.dart';
@@ -22,7 +23,7 @@ void main() {
     await tester.pumpWidget(
       await mediaTestApp(
         overrides: [
-          resolvedFullResolutionProvider(item).overrideWith(
+          mediaBytesProvider(item).overrideWith(
             (ref) async =>
                 const ResolvedAssetResult(status: ResolutionStatus.unavailable),
           ),

--- a/test/features/media/presentation/media_item_view_store_fallback_test.dart
+++ b/test/features/media/presentation/media_item_view_store_fallback_test.dart
@@ -516,6 +516,88 @@ void main() {
     expect(find.byIcon(Icons.movie_outlined), findsNothing);
   });
 
+  // A document's store fallback can hand back the PDF ITSELF: the thumb
+  // object exists only once the uploading device has stamped
+  // remoteThumbUploadedAt, and until then tryResolveRemote degrades a
+  // thumbnail request to the original. Marking every store result renderable
+  // because the REQUEST was a thumbnail therefore fed a PDF to Image.file and
+  // drew the broken-image tile instead of the document placeholder.
+  testWidgets('a document served as its original, not a thumb, keeps the '
+      'document placeholder', (tester) async {
+    await tester.runAsync(() async {
+      // Genuinely undecodable bytes: _fetchOriginal hash-verifies what it
+      // downloads, so the fixture has to be a real object in the store.
+      final bytes = utf8.encode('%PDF-1.7 not an image');
+      final seed = File('${root.path}/reef-map.pdf');
+      await seed.writeAsBytes(bytes, flush: true);
+      final digest = await sha256OfFile(seed);
+      store.objects[StoreKeys.objectKey(digest.hash, extension: 'pdf')] = bytes;
+
+      final runtime = MediaStoreRuntime(
+        storeId: 'store-1',
+        store: store,
+        cache: cache,
+        resolver: MediaStoreResolver(store: store, cache: cache),
+      );
+
+      // Original uploaded, thumb never stamped -- the window in which the
+      // store can only offer the document itself.
+      final noThumbRow = MediaItem(
+        id: 'm-doc',
+        siteId: 'site-1',
+        mediaType: MediaType.document,
+        sourceType: MediaSourceType.platformGallery,
+        platformAssetId: 'asset-from-other-device',
+        originalFilename: 'reef-map.pdf',
+        takenAt: DateTime(2026),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+        contentHash: digest.hash,
+        remoteUploadedAt: DateTime(2026, 7, 1),
+      );
+      expect(noThumbRow.remoteThumbUploadedAt, isNull);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mediaSourceResolverRegistryProvider.overrideWithValue(
+              MediaSourceResolverRegistry({
+                MediaSourceType.platformGallery:
+                    const _UnavailableGalleryResolver(),
+              }),
+            ),
+            mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                height: 100,
+                child: MediaItemView(
+                  item: noThumbRow,
+                  thumbnail: true,
+                  targetSize: const Size(100, 100),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        if (find.byIcon(Icons.picture_as_pdf_outlined).evaluate().isNotEmpty) {
+          break;
+        }
+      }
+    });
+
+    expect(find.byIcon(Icons.picture_as_pdf_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+
   testWidgets('keeps the native placeholder when no store runtime '
       'exists', (tester) async {
     await tester.runAsync(() async {

--- a/test/features/media/presentation/pages/document_viewer_page_test.dart
+++ b/test/features/media/presentation/pages/document_viewer_page_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/pages/document_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -24,12 +25,20 @@ MediaItem _doc({String? originDeviceId, String? originalFilename}) => MediaItem(
 /// pdfium binary that flutter_test cannot load, and a failed init hangs
 /// the calling future. Every override below therefore resolves to
 /// unavailable, an error, or nothing at all.
+///
+/// Overriding [mediaBytesProvider] is also what pins the page to the right
+/// resolution stack. It used to read [resolvedFullResolutionProvider], which
+/// only ever looks a `platformAssetId` up in the photo library — an id no
+/// document attachment carries — so every PDF opened to the unavailable
+/// state (issue #1019). If the page regressed to that provider, the
+/// pending-completer test below would show the unavailable state instead of
+/// its spinner.
 Widget _host(
   MediaItem item, {
   FutureOr<ResolvedAssetResult> Function(Ref ref)? resolve,
 }) => ProviderScope(
   overrides: [
-    resolvedFullResolutionProvider(item).overrideWith(
+    mediaBytesProvider(item).overrideWith(
       resolve ??
           (ref) async =>
               const ResolvedAssetResult(status: ResolutionStatus.unavailable),

--- a/test/features/media/presentation/providers/media_bytes_providers_test.dart
+++ b/test/features/media/presentation/providers/media_bytes_providers_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+import '../../../../helpers/in_memory_media_object_store.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+
+/// A document attachment is the case that broke: it carries no
+/// `platformAssetId`, so the gallery-asset provider the document viewer used
+/// to call could never resolve it and every PDF opened to "not available on
+/// this device" (issue #1019). These tests pin the replacement to the source
+/// the row actually points at.
+void main() {
+  late FakeLocalFileResolver resolver;
+
+  setUp(() => resolver = FakeLocalFileResolver());
+
+  MediaItem pdf({
+    String? contentHash,
+    DateTime? remoteUploadedAt,
+    MediaSourceType sourceType = MediaSourceType.localFile,
+  }) => MediaItem(
+    id: 'doc-1',
+    siteId: 'site-1',
+    mediaType: MediaType.document,
+    sourceType: sourceType,
+    originalFilename: 'reef-map.pdf',
+    takenAt: DateTime(2026, 8, 12),
+    createdAt: DateTime(2026, 8, 12),
+    updatedAt: DateTime(2026, 8, 12),
+    contentHash: contentHash,
+    remoteUploadedAt: remoteUploadedAt,
+  );
+
+  ProviderContainer container({MediaStoreRuntime? runtime}) {
+    final c = ProviderContainer(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWithValue(
+          MediaSourceResolverRegistry({MediaSourceType.localFile: resolver}),
+        ),
+        mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('serves the bytes a localFile document resolves to', () async {
+    final bytes = Uint8List.fromList([37, 80, 68, 70]);
+    resolver.data = BytesData(bytes: bytes);
+
+    final result = await container().read(mediaBytesProvider(pdf()).future);
+
+    expect(result.isAvailable, isTrue);
+    expect(result.bytes, equals(bytes));
+  });
+
+  test('reads a resolved file off disk', () async {
+    final dir = await Directory.systemTemp.createTemp('media_bytes');
+    addTearDown(() => dir.delete(recursive: true));
+    final file = File('${dir.path}/reef-map.pdf')
+      ..writeAsBytesSync([1, 2, 3, 4]);
+    resolver.data = FileData(file: file);
+
+    final result = await container().read(mediaBytesProvider(pdf()).future);
+
+    expect(result.bytes, equals(Uint8List.fromList([1, 2, 3, 4])));
+  });
+
+  test('reports unavailable when the source cannot resolve and no store '
+      'is attached', () async {
+    resolver.data = const UnavailableData(kind: UnavailableKind.notFound);
+
+    final result = await container().read(mediaBytesProvider(pdf()).future);
+
+    expect(result.isUnavailable, isTrue);
+    expect(result.bytes, isNull);
+  });
+
+  test('a NetworkData source is not bytes and reads unavailable', () async {
+    resolver.data = NetworkData(url: Uri.parse('https://example.com/a.pdf'));
+
+    final result = await container().read(mediaBytesProvider(pdf()).future);
+
+    expect(result.isUnavailable, isTrue);
+  });
+
+  // A row whose source type has no registered resolver is a programmer
+  // error the registry signals by throwing. It must not escape into the
+  // viewer as a red error screen: the honest answer for one unopenable
+  // attachment is the unavailable placeholder.
+  test('an unregistered source type reads unavailable rather than '
+      'throwing', () async {
+    final result = await container().read(
+      mediaBytesProvider(pdf(sourceType: MediaSourceType.signature)).future,
+    );
+
+    expect(result.isUnavailable, isTrue);
+  });
+
+  test('falls back to the media store when the device holds no local '
+      'copy', () async {
+    final db = LocalCacheDatabase(NativeDatabase.memory());
+    final root = await Directory.systemTemp.createTemp('media_bytes_store');
+    addTearDown(() async {
+      await db.close();
+      await root.delete(recursive: true);
+    });
+    final store = InMemoryMediaObjectStore();
+    final cache = MediaCacheStore(database: db, root: root);
+
+    final bytes = List<int>.generate(2048, (i) => (i * 7) % 251);
+    final seed = File('${root.path}/seed.pdf')..writeAsBytesSync(bytes);
+    final digest = await sha256OfFile(seed);
+    store.objects[StoreKeys.objectKey(digest.hash, extension: 'pdf')] = bytes;
+
+    resolver.data = const UnavailableData(kind: UnavailableKind.notFound);
+
+    final runtime = MediaStoreRuntime(
+      storeId: 's1',
+      store: store,
+      cache: cache,
+      resolver: MediaStoreResolver(store: store, cache: cache),
+    );
+
+    final result = await container(runtime: runtime).read(
+      mediaBytesProvider(
+        pdf(contentHash: digest.hash, remoteUploadedAt: DateTime(2026, 8, 12)),
+      ).future,
+    );
+
+    expect(result.isAvailable, isTrue);
+    expect(result.bytes, equals(Uint8List.fromList(bytes)));
+  });
+}

--- a/test/features/media/presentation/providers/media_bytes_providers_test.dart
+++ b/test/features/media/presentation/providers/media_bytes_providers_test.dart
@@ -113,6 +113,43 @@ void main() {
     expect(result.isUnavailable, isTrue);
   });
 
+  // The resolver checks the file exists before handing it back, so a read
+  // that still fails means it went away in between (an ejected volume, a
+  // cache sweep). That is a placeholder, not an exception thrown out of a
+  // provider the viewer is watching.
+  test('a resolved file that has since vanished reads unavailable', () async {
+    final dir = await Directory.systemTemp.createTemp('media_bytes_gone');
+    addTearDown(() => dir.delete(recursive: true));
+    resolver.data = FileData(file: File('${dir.path}/never-written.pdf'));
+
+    final result = await container().read(mediaBytesProvider(pdf()).future);
+
+    expect(result.isUnavailable, isTrue);
+  });
+
+  // Building the store runtime reads credentials out of the keychain, which
+  // can fail for reasons that have nothing to do with this document.
+  test('a store runtime that fails to build leaves the item '
+      'unavailable', () async {
+    resolver.data = const UnavailableData(kind: UnavailableKind.notFound);
+
+    final c = ProviderContainer(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWithValue(
+          MediaSourceResolverRegistry({MediaSourceType.localFile: resolver}),
+        ),
+        mediaStoreRuntimeProvider.overrideWith(
+          (ref) async => throw StateError('keychain unavailable'),
+        ),
+      ],
+    );
+    addTearDown(c.dispose);
+
+    final result = await c.read(mediaBytesProvider(pdf()).future);
+
+    expect(result.isUnavailable, isTrue);
+  });
+
   test('falls back to the media store when the device holds no local '
       'copy', () async {
     final db = LocalCacheDatabase(NativeDatabase.memory());

--- a/test/features/media/presentation/widgets/media_item_view_document_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_document_test.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/pdf_thumbnail_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 
 import '../support/media_widget_harness.dart';
@@ -145,5 +148,90 @@ void main() {
     expect(find.byType(Image), findsOneWidget);
     expect(find.byIcon(Icons.picture_as_pdf_outlined), findsNothing);
     expect(find.byIcon(Icons.description_outlined), findsNothing);
+  });
+
+  /// A tile is the one place a PDF becomes an image: the page-1 render is
+  /// what the user reported missing in issue #1019, where every attachment
+  /// showed the icon above whether or not a media store held a thumb.
+  ///
+  /// The renderer is injected throughout — pdfrx cannot initialise under
+  /// flutter_test, and a failed init hangs rather than throws.
+  group('thumbnail requests', () {
+    Future<void> pumpTile(
+      WidgetTester tester, {
+      required MediaItem item,
+      required Uint8List? renders,
+    }) async {
+      await tester.pumpWidget(
+        await mediaTestApp(
+          resolverData: BytesData(bytes: onePixelPng()),
+          overrides: [
+            pdfThumbnailServiceProvider.overrideWithValue(
+              PdfThumbnailService(
+                // No cache directory on purpose. The service reaches real
+                // dart:io from inside the widget tree, and a real I/O
+                // completion never lands in the zone pumpAndSettle drives --
+                // the test hangs rather than fails. Declining the directory
+                // takes the documented uncached path, which is pure
+                // microtasks. Caching itself is covered by
+                // pdf_thumbnail_service_test.dart, which runs unfaked.
+                cacheDir: () async =>
+                    throw const FileSystemException('no cache under test'),
+                renderer:
+                    ({
+                      File? file,
+                      Uint8List? bytes,
+                      int maxDimension = 512,
+                      int quality = 80,
+                    }) async => renders,
+              ),
+            ),
+          ],
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 120,
+                height: 120,
+                child: MediaItemView(item: item, thumbnail: true),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a PDF tile draws its rendered first page', (tester) async {
+      await pumpTile(
+        tester,
+        item: document('reef-map.pdf'),
+        renders: onePixelPng(),
+      );
+
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byIcon(Icons.picture_as_pdf_outlined), findsNothing);
+    });
+
+    testWidgets('a PDF that cannot be rendered keeps the icon placeholder', (
+      tester,
+    ) async {
+      await pumpTile(tester, item: document('reef-map.pdf'), renders: null);
+
+      expect(find.byIcon(Icons.picture_as_pdf_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+    });
+
+    testWidgets('a non-PDF document tile is never rendered', (tester) async {
+      // The service declines before the renderer, so a .txt attachment
+      // cannot accidentally be decoded as a PDF.
+      await pumpTile(
+        tester,
+        item: document('dive-notes.txt'),
+        renders: onePixelPng(),
+      );
+
+      expect(find.byIcon(Icons.description_outlined), findsOneWidget);
+      expect(find.byType(Image), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #1019. A PDF attached to a dive site could not be opened, and its grid
tile showed a generic icon instead of the document.

### Bug 1 — PDFs could never be opened, on any platform

`DocumentViewerPage` and `DocumentOpenHelper.openExternally` read bytes from
`resolvedFullResolutionProvider`, whose doc comment claimed it "handles every
source type plus the media-store fallback". It does not. It delegates to
`AssetResolutionService.resolveAssetId`, the **photo-gallery** resolver — the
one that re-finds a row's `platformAssetId` in the device photo library after
a cross-device sync:

```dart
// asset_resolution_service.dart:71
if (item.platformAssetId == null) {
  return const ResolutionResult(status: ResolutionStatus.unavailable);
}
```

A document attachment never carries a `platformAssetId` — it is
reference-linked by path, macOS/iOS security-scoped bookmark, or Android SAF
URI. So every PDF resolved to `unavailable` and the viewer drew "This document
is not available on this device". The desktop branch reaches the same result a
different way: `supportsGalleryBrowsing == false` returns `resolved` carrying a
null asset id, which the provider then rejects.

**Fix:** new `mediaBytesProvider` resolves through `MediaSourceResolverRegistry`
plus the media-store fallback — the same stack `MediaItemView` already uses —
and both document entry points read it.

### Bug 2 — no thumbnail

`MediaItemView` treated a document's bytes as renderable **only** when they
arrived as the media store's THUMB object. A PDF the device can read resolves
natively, so `_resolve` returned early and the tile fell through to
`_DocumentThumbnailPlaceholder`. The page-1 render (`PdfPageRenderer`) already
existed but was wired only into the upload pipeline, so the rendered tile was
visible on every device *except* the one that attached the file.

**Fix:** new `PdfThumbnailService` renders page 1 locally and caches it on
disk, so the tile looks the same everywhere.

## Changes

- **`media_bytes_providers.dart`** (new) — `mediaBytesProvider`: registry
  resolution, then `MediaStoreResolver.tryResolveRemote`, returning the same
  `ResolvedAssetResult` the call sites already consumed. An unregistered source
  type degrades to unavailable rather than throwing an `UnsupportedError` into
  the viewer.
- **`pdf_thumbnail_service.dart`** (new) — page-1 JPEG, disk-cached, injectable
  renderer seam.
  - Keys the cache on `contentHash` (falling back to `id|updatedAt`) rather
    than the video path's `path+mtime+size`: an Android document is a SAF
    content URI with no path to stat, and the key has to be cheap enough not to
    pull the whole file back across a platform channel per tile.
  - 512 px to match `ThumbnailGenerator.maxDimension`, deliberately *not* the
    caller's tile size — a pdfium render is expensive enough that sizing per
    tile would re-render the same document once per grid geometry.
  - 15 s render budget. A failed pdfium init crashes pdfrx's worker isolate and
    the future never completes, which would leave the tile shimmering forever;
    the budget turns that into the icon placeholder.
- **`media_item_view.dart`** — PDF thumbnail branch; `isStoreData` renamed to
  `documentRenderable` and set explicitly at each return instead of derived at
  the switch. Rendering lives here rather than in `resolveThumbnail` because
  `ThumbnailGenerator` calls that expecting the *raw PDF* to feed to the same
  renderer — moving it would double-render.
- **`pdf_page_renderer.dart`** — `PdfThumbRenderer` typedef moved here from
  `thumbnail_generator.dart` so both consumers can name the seam without the
  `media` feature importing `media_store`.

### Why it went unnoticed

Every case in `document_viewer_page_test.dart` overrode
`resolvedFullResolutionProvider` to unavailable, an error, or a pending future
— because pdfrx cannot render under `flutter_test` (a failed init hangs rather
than throws). The mock hid the seam: the suite only exercised the branches that
did not need bytes, which is exactly what production did too, so nothing ever
disagreed. Those tests now override `mediaBytesProvider`, which is what makes
the pending-completer case discriminate the right stack.

New tests: 6 for `mediaBytesProvider` (local bytes, file-on-disk, `NetworkData`,
unregistered source type, no-store unavailable, and the Dropbox-style store
fallback with a real hash-verified object); 11 for `PdfThumbnailService`
(render from bytes and from file, cache hit avoids both resolve and re-render,
hash and update-stamp key busting, unresolvable source, throwing source,
declined render, non-PDF, never-completing render, unusable cache dir); 3
widget tests for the tile.

## Test Plan

- [x] `flutter test` — 17,374 passed, 17 skipped, 0 failed
- [x] `flutter analyze lib test` — no issues
- [x] `dart format` — clean
- [x] Manual testing on: **not verified on-device.** The diagnosis is read off
      the resolution code rather than a repro, and the PDF render itself cannot
      run in the test suite (injected seam throughout). Worth attaching a PDF to
      a site on Android and on macOS before release: the tile should show page 1
      and tapping it should open the viewer.

### Adjacent issue, deliberately not fixed here

The share actions in `photo_viewer_page`, `site_media_viewer_page` and
`trip_photo_viewer_page` still use `resolvedFullResolutionProvider`. That is
correct for gallery photos but fails the same way for a locally-imported
(Files-tab) photo. Out of scope for #1019; happy to do it in a follow-up.
