### PR TITLE
fix(ble): recognise stale Apple pairing and save zero-dive computers (#865)

### DIFF
--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -666,6 +666,15 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
     if (state.errorCode == 'no_serial_ports') {
       return l10n.diveComputer_download_noSerialPortsFound;
     }
+    // Apple platforms expose no API for deleting a pairing record, so a stale
+    // one can only be cleared by the diver in Bluetooth settings. Say so
+    // instead of showing the generic connect failure (issue #865).
+    if (state.errorCode == 'stale_pairing') {
+      return l10n.diveComputer_download_stalePairing;
+    }
+    if (state.errorCode == 'discovery_stalled') {
+      return l10n.diveComputer_download_discoveryStalled;
+    }
     if (state.errorCode == 'connect_failed' && state.errorMessage != null) {
       return l10n.diveComputer_download_serialConnectFailedWithDetails(
         state.errorMessage!,

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -432,10 +432,14 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
     widget.adapter.setDownloadedDives(state.downloadedDives);
 
     // No dives — show an informational message instead of advancing to an
-    // empty Review step.
-    if (state.downloadedDives.isEmpty) {
-      if (mounted) setState(() => _noDives = true);
-      return;
+    // empty Review step. The computer itself is still saved below: reaching
+    // this point means it paired, connected and completed a download, which is
+    // exactly what makes it worth remembering for next time. Returning early
+    // here used to strand a working computer as unknown whenever the diver's
+    // first download had nothing new on it (issue #865).
+    final hasDives = state.downloadedDives.isNotEmpty;
+    if (!hasDives && mounted) {
+      setState(() => _noDives = true);
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -444,6 +448,8 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
       final discoveryState = ref.read(discoveryNotifierProvider);
       final device = discoveryState.selectedDevice;
       if (device != null) {
+        // Serial and firmware ride on the completion event, not on the dives,
+        // so the hardware-identity rebind still works with an empty download.
         await widget.adapter.ensureComputer(
           device: device,
           serialNumber: state.serialNumber,
@@ -451,7 +457,9 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
         );
       }
 
-      if (mounted) {
+      // Only a download that actually produced dives has a Review step to
+      // advance to; the empty case stays on DcNoNewDivesView.
+      if (hasDives && mounted) {
         ref.read(dcAdapterDownloadCanAdvanceProvider.notifier).state = true;
       }
     });

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1341,6 +1341,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "حدث خطأ",
   "diveComputer_download_noSerialPortsFound": "لم يتم العثور على منافذ USB تسلسلية. هل حاسوب الغوص متصل وقيد التشغيل؟",
+  "diveComputer_download_stalePairing": "إقران البلوتوث لكمبيوتر الغوص هذا لم يعد صالحًا. انسَ كمبيوتر الغوص من إعدادات البلوتوث في جهازك، ثم أعد إقرانه من قائمة البلوتوث في كمبيوتر الغوص.",
+  "diveComputer_download_discoveryStalled": "تم الاتصال بكمبيوتر الغوص، لكنه توقف عن الاستجابة قبل بدء التنزيل. يعني هذا عادةً أن إقران البلوتوث لم يعد صالحًا: انسَ كمبيوتر الغوص من إعدادات البلوتوث في جهازك ثم حاول مرة أخرى.",
   "diveComputer_download_serialConnectFailedWithDetails": "تعذر الاتصال بحاسوب الغوص.\n\nتفاصيل التشخيص (شاركها مع المطورين):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Ein Fehler ist aufgetreten",
   "diveComputer_download_noSerialPortsFound": "Keine USB-Seriellports gefunden. Ist der Tauchcomputer angeschlossen und eingeschaltet?",
+  "diveComputer_download_stalePairing": "Die Bluetooth-Kopplung dieses Tauchcomputers ist veraltet. Entfernen Sie den Tauchcomputer in den Bluetooth-Einstellungen Ihres Geräts und koppeln Sie ihn anschließend über das Bluetooth-Menü des Tauchcomputers erneut.",
+  "diveComputer_download_discoveryStalled": "Der Tauchcomputer wurde verbunden, hat aber vor dem Start des Downloads nicht mehr geantwortet. Meist ist die Bluetooth-Kopplung veraltet: Entfernen Sie den Tauchcomputer in den Bluetooth-Einstellungen Ihres Geräts und versuchen Sie es erneut.",
   "diveComputer_download_serialConnectFailedWithDetails": "Verbindung zum Tauchcomputer konnte nicht hergestellt werden.\n\nDiagnosedetails (mit Entwicklern teilen):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12088,6 +12088,8 @@
   },
   "diveComputer_download_errorOccurred": "An error occurred",
   "diveComputer_download_noSerialPortsFound": "No USB serial ports found. Is the dive computer connected and powered on?",
+  "diveComputer_download_stalePairing": "This dive computer's Bluetooth pairing is out of date. Forget the dive computer in your device's Bluetooth settings, then pair it again from the dive computer's Bluetooth menu.",
+  "diveComputer_download_discoveryStalled": "Connected to the dive computer, but it stopped responding before the download could start. This usually means the Bluetooth pairing is out of date: forget the dive computer in your device's Bluetooth settings, then try again.",
   "diveComputer_download_serialConnectFailedWithDetails": "Could not connect to dive computer.\n\nDiagnostic details (share with developers):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Se produjo un error",
   "diveComputer_download_noSerialPortsFound": "No se encontraron puertos serie USB. ¿Está el ordenador de buceo conectado y encendido?",
+  "diveComputer_download_stalePairing": "El emparejamiento Bluetooth de este ordenador de buceo está obsoleto. Olvida el ordenador de buceo en los ajustes de Bluetooth de tu dispositivo y vuelve a emparejarlo desde el menú Bluetooth del ordenador de buceo.",
+  "diveComputer_download_discoveryStalled": "Se conectó al ordenador de buceo, pero dejó de responder antes de que comenzara la descarga. Normalmente esto significa que el emparejamiento Bluetooth está obsoleto: olvida el ordenador de buceo en los ajustes de Bluetooth de tu dispositivo y vuelve a intentarlo.",
   "diveComputer_download_serialConnectFailedWithDetails": "No se pudo conectar al ordenador de buceo.\n\nDetalles de diagnóstico (compartir con los desarrolladores):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Une erreur est survenue",
   "diveComputer_download_noSerialPortsFound": "Aucun port série USB trouvé. L'ordinateur de plongée est-il connecté et allumé ?",
+  "diveComputer_download_stalePairing": "L'appairage Bluetooth de cet ordinateur de plongée n'est plus valide. Oubliez l'ordinateur de plongée dans les réglages Bluetooth de votre appareil, puis appairez-le à nouveau depuis le menu Bluetooth de l'ordinateur de plongée.",
+  "diveComputer_download_discoveryStalled": "Connexion établie avec l'ordinateur de plongée, mais il a cessé de répondre avant le début du téléchargement. Cela signifie généralement que l'appairage Bluetooth n'est plus valide : oubliez l'ordinateur de plongée dans les réglages Bluetooth de votre appareil, puis réessayez.",
   "diveComputer_download_serialConnectFailedWithDetails": "Impossible de se connecter à l'ordinateur de plongée.\n\nDétails de diagnostic (à partager avec les développeurs) :\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "אירעה שגיאה",
   "diveComputer_download_noSerialPortsFound": "לא נמצאו חיבורי USB טוריים. האם מחשב הצלילה מחובר ופועל?",
+  "diveComputer_download_stalePairing": "התאמת ה-Bluetooth של מחשב הצלילה הזה אינה עדכנית. שכח את מחשב הצלילה בהגדרות ה-Bluetooth של המכשיר שלך, ולאחר מכן התאם אותו מחדש מתפריט ה-Bluetooth של מחשב הצלילה.",
+  "diveComputer_download_discoveryStalled": "ההתחברות למחשב הצלילה הצליחה, אך הוא הפסיק להגיב לפני תחילת ההורדה. בדרך כלל המשמעות היא שהתאמת ה-Bluetooth אינה עדכנית: שכח את מחשב הצלילה בהגדרות ה-Bluetooth של המכשיר שלך ונסה שוב.",
   "diveComputer_download_serialConnectFailedWithDetails": "לא ניתן להתחבר למחשב הצלילה.\n\nפרטי אבחון (שתפו עם המפתחים):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Hiba tortent",
   "diveComputer_download_noSerialPortsFound": "Nem található USB soros port. A búvárszámítógép csatlakoztatva van és be van kapcsolva?",
+  "diveComputer_download_stalePairing": "Ennek a merülőkomputernek a Bluetooth-párosítása elavult. Felejtesd el a merülőkomputert az eszközöd Bluetooth-beállításaiban, majd párosítsd újra a merülőkomputer Bluetooth menüjéből.",
+  "diveComputer_download_discoveryStalled": "A merülőkomputer csatlakozott, de a letöltés megkezdése előtt nem válaszolt tovább. Ez általában azt jelenti, hogy a Bluetooth-párosítás elavult: felejtesd el a merülőkomputert az eszközöd Bluetooth-beállításaiban, majd próbáld újra.",
   "diveComputer_download_serialConnectFailedWithDetails": "Nem sikerült csatlakozni a búvárszámítógéphez.\n\nDiagnosztikai részletek (ossza meg a fejlesztőkkel):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Si è verificato un errore",
   "diveComputer_download_noSerialPortsFound": "Nessuna porta seriale USB trovata. Il computer subacqueo è collegato e acceso?",
+  "diveComputer_download_stalePairing": "L'associazione Bluetooth di questo computer subacqueo non è più valida. Dimentica il computer subacqueo nelle impostazioni Bluetooth del tuo dispositivo, quindi associalo di nuovo dal menu Bluetooth del computer subacqueo.",
+  "diveComputer_download_discoveryStalled": "Connessione al computer subacqueo riuscita, ma ha smesso di rispondere prima dell'avvio del download. Di solito significa che l'associazione Bluetooth non è più valida: dimentica il computer subacqueo nelle impostazioni Bluetooth del tuo dispositivo e riprova.",
   "diveComputer_download_serialConnectFailedWithDetails": "Impossibile connettersi al computer subacqueo.\n\nDettagli diagnostici (da condividere con gli sviluppatori):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -32104,6 +32104,18 @@ abstract class AppLocalizations {
   /// **'No USB serial ports found. Is the dive computer connected and powered on?'**
   String get diveComputer_download_noSerialPortsFound;
 
+  /// No description provided for @diveComputer_download_stalePairing.
+  ///
+  /// In en, this message translates to:
+  /// **'This dive computer\'s Bluetooth pairing is out of date. Forget the dive computer in your device\'s Bluetooth settings, then pair it again from the dive computer\'s Bluetooth menu.'**
+  String get diveComputer_download_stalePairing;
+
+  /// No description provided for @diveComputer_download_discoveryStalled.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected to the dive computer, but it stopped responding before the download could start. This usually means the Bluetooth pairing is out of date: forget the dive computer in your device\'s Bluetooth settings, then try again.'**
+  String get diveComputer_download_discoveryStalled;
+
   /// No description provided for @diveComputer_download_serialConnectFailedWithDetails.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -18898,6 +18898,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'لم يتم العثور على منافذ USB تسلسلية. هل حاسوب الغوص متصل وقيد التشغيل؟';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'إقران البلوتوث لكمبيوتر الغوص هذا لم يعد صالحًا. انسَ كمبيوتر الغوص من إعدادات البلوتوث في جهازك، ثم أعد إقرانه من قائمة البلوتوث في كمبيوتر الغوص.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'تم الاتصال بكمبيوتر الغوص، لكنه توقف عن الاستجابة قبل بدء التنزيل. يعني هذا عادةً أن إقران البلوتوث لم يعد صالحًا: انسَ كمبيوتر الغوص من إعدادات البلوتوث في جهازك ثم حاول مرة أخرى.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'تعذر الاتصال بحاسوب الغوص.\n\nتفاصيل التشخيص (شاركها مع المطورين):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -19215,6 +19215,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Keine USB-Seriellports gefunden. Ist der Tauchcomputer angeschlossen und eingeschaltet?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'Die Bluetooth-Kopplung dieses Tauchcomputers ist veraltet. Entfernen Sie den Tauchcomputer in den Bluetooth-Einstellungen Ihres Geräts und koppeln Sie ihn anschließend über das Bluetooth-Menü des Tauchcomputers erneut.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Der Tauchcomputer wurde verbunden, hat aber vor dem Start des Downloads nicht mehr geantwortet. Meist ist die Bluetooth-Kopplung veraltet: Entfernen Sie den Tauchcomputer in den Bluetooth-Einstellungen Ihres Geräts und versuchen Sie es erneut.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Verbindung zum Tauchcomputer konnte nicht hergestellt werden.\n\nDiagnosedetails (mit Entwicklern teilen):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -18915,6 +18915,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'No USB serial ports found. Is the dive computer connected and powered on?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'This dive computer\'s Bluetooth pairing is out of date. Forget the dive computer in your device\'s Bluetooth settings, then pair it again from the dive computer\'s Bluetooth menu.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Connected to the dive computer, but it stopped responding before the download could start. This usually means the Bluetooth pairing is out of date: forget the dive computer in your device\'s Bluetooth settings, then try again.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Could not connect to dive computer.\n\nDiagnostic details (share with developers):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -19261,6 +19261,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se encontraron puertos serie USB. ¿Está el ordenador de buceo conectado y encendido?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'El emparejamiento Bluetooth de este ordenador de buceo está obsoleto. Olvida el ordenador de buceo en los ajustes de Bluetooth de tu dispositivo y vuelve a emparejarlo desde el menú Bluetooth del ordenador de buceo.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Se conectó al ordenador de buceo, pero dejó de responder antes de que comenzara la descarga. Normalmente esto significa que el emparejamiento Bluetooth está obsoleto: olvida el ordenador de buceo en los ajustes de Bluetooth de tu dispositivo y vuelve a intentarlo.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'No se pudo conectar al ordenador de buceo.\n\nDetalles de diagnóstico (compartir con los desarrolladores):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -19317,6 +19317,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun port série USB trouvé. L\'ordinateur de plongée est-il connecté et allumé ?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'L\'appairage Bluetooth de cet ordinateur de plongée n\'est plus valide. Oubliez l\'ordinateur de plongée dans les réglages Bluetooth de votre appareil, puis appairez-le à nouveau depuis le menu Bluetooth de l\'ordinateur de plongée.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Connexion établie avec l\'ordinateur de plongée, mais il a cessé de répondre avant le début du téléchargement. Cela signifie généralement que l\'appairage Bluetooth n\'est plus valide : oubliez l\'ordinateur de plongée dans les réglages Bluetooth de votre appareil, puis réessayez.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Impossible de se connecter à l\'ordinateur de plongée.\n\nDétails de diagnostic (à partager avec les développeurs) :\n$details';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -18757,6 +18757,14 @@ class AppLocalizationsHe extends AppLocalizations {
       'לא נמצאו חיבורי USB טוריים. האם מחשב הצלילה מחובר ופועל?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'התאמת ה-Bluetooth של מחשב הצלילה הזה אינה עדכנית. שכח את מחשב הצלילה בהגדרות ה-Bluetooth של המכשיר שלך, ולאחר מכן התאם אותו מחדש מתפריט ה-Bluetooth של מחשב הצלילה.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'ההתחברות למחשב הצלילה הצליחה, אך הוא הפסיק להגיב לפני תחילת ההורדה. בדרך כלל המשמעות היא שהתאמת ה-Bluetooth אינה עדכנית: שכח את מחשב הצלילה בהגדרות ה-Bluetooth של המכשיר שלך ונסה שוב.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'לא ניתן להתחבר למחשב הצלילה.\n\nפרטי אבחון (שתפו עם המפתחים):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -19186,6 +19186,14 @@ class AppLocalizationsHu extends AppLocalizations {
       'Nem található USB soros port. A búvárszámítógép csatlakoztatva van és be van kapcsolva?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'Ennek a merülőkomputernek a Bluetooth-párosítása elavult. Felejtesd el a merülőkomputert az eszközöd Bluetooth-beállításaiban, majd párosítsd újra a merülőkomputer Bluetooth menüjéből.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'A merülőkomputer csatlakozott, de a letöltés megkezdése előtt nem válaszolt tovább. Ez általában azt jelenti, hogy a Bluetooth-párosítás elavult: felejtesd el a merülőkomputert az eszközöd Bluetooth-beállításaiban, majd próbáld újra.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Nem sikerült csatlakozni a búvárszámítógéphez.\n\nDiagnosztikai részletek (ossza meg a fejlesztőkkel):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -19244,6 +19244,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessuna porta seriale USB trovata. Il computer subacqueo è collegato e acceso?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'L\'associazione Bluetooth di questo computer subacqueo non è più valida. Dimentica il computer subacqueo nelle impostazioni Bluetooth del tuo dispositivo, quindi associalo di nuovo dal menu Bluetooth del computer subacqueo.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Connessione al computer subacqueo riuscita, ma ha smesso di rispondere prima dell\'avvio del download. Di solito significa che l\'associazione Bluetooth non è più valida: dimentica il computer subacqueo nelle impostazioni Bluetooth del tuo dispositivo e riprova.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Impossibile connettersi al computer subacqueo.\n\nDettagli diagnostici (da condividere con gli sviluppatori):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -19092,6 +19092,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Geen USB-seriële poorten gevonden. Is de duikcomputer aangesloten en ingeschakeld?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'De Bluetooth-koppeling van deze duikcomputer is verouderd. Vergeet de duikcomputer in de Bluetooth-instellingen van je apparaat en koppel hem daarna opnieuw via het Bluetooth-menu van de duikcomputer.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Verbonden met de duikcomputer, maar hij reageerde niet meer voordat de download kon beginnen. Meestal betekent dit dat de Bluetooth-koppeling verouderd is: vergeet de duikcomputer in de Bluetooth-instellingen van je apparaat en probeer het opnieuw.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Kan geen verbinding maken met de duikcomputer.\n\nDiagnostische gegevens (deel met ontwikkelaars):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -19247,6 +19247,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nenhuma porta serial USB encontrada. O computador de mergulho está conectado e ligado?';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      'O emparelhamento Bluetooth deste computador de mergulho está desatualizado. Esqueça o computador de mergulho nas definições de Bluetooth do seu dispositivo e emparelhe-o novamente a partir do menu Bluetooth do computador de mergulho.';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      'Ligou-se ao computador de mergulho, mas ele deixou de responder antes de a transferência começar. Normalmente isto significa que o emparelhamento Bluetooth está desatualizado: esqueça o computador de mergulho nas definições de Bluetooth do seu dispositivo e tente novamente.';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return 'Não foi possível conectar ao computador de mergulho.\n\nDetalhes de diagnóstico (compartilhe com os desenvolvedores):\n$details';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -18261,6 +18261,14 @@ class AppLocalizationsZh extends AppLocalizations {
       '未找到 USB 串行端口。潜水电脑是否已连接并开机？';
 
   @override
+  String get diveComputer_download_stalePairing =>
+      '此潜水电脑的蓝牙配对已失效。请在设备的蓝牙设置中忽略该潜水电脑，然后从潜水电脑的蓝牙菜单重新配对。';
+
+  @override
+  String get diveComputer_download_discoveryStalled =>
+      '已连接到潜水电脑，但在下载开始前它停止响应。这通常表示蓝牙配对已失效：请在设备的蓝牙设置中忽略该潜水电脑，然后重试。';
+
+  @override
   String diveComputer_download_serialConnectFailedWithDetails(Object details) {
     return '无法连接到潜水电脑。\n\n诊断详情（请分享给开发人员）：\n$details';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Er is een fout opgetreden",
   "diveComputer_download_noSerialPortsFound": "Geen USB-seriële poorten gevonden. Is de duikcomputer aangesloten en ingeschakeld?",
+  "diveComputer_download_stalePairing": "De Bluetooth-koppeling van deze duikcomputer is verouderd. Vergeet de duikcomputer in de Bluetooth-instellingen van je apparaat en koppel hem daarna opnieuw via het Bluetooth-menu van de duikcomputer.",
+  "diveComputer_download_discoveryStalled": "Verbonden met de duikcomputer, maar hij reageerde niet meer voordat de download kon beginnen. Meestal betekent dit dat de Bluetooth-koppeling verouderd is: vergeet de duikcomputer in de Bluetooth-instellingen van je apparaat en probeer het opnieuw.",
   "diveComputer_download_serialConnectFailedWithDetails": "Kan geen verbinding maken met de duikcomputer.\n\nDiagnostische gegevens (deel met ontwikkelaars):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1269,6 +1269,8 @@
   "diveComputer_download_durationMin": "{duration} min",
   "diveComputer_download_errorOccurred": "Ocorreu um erro",
   "diveComputer_download_noSerialPortsFound": "Nenhuma porta serial USB encontrada. O computador de mergulho está conectado e ligado?",
+  "diveComputer_download_stalePairing": "O emparelhamento Bluetooth deste computador de mergulho está desatualizado. Esqueça o computador de mergulho nas definições de Bluetooth do seu dispositivo e emparelhe-o novamente a partir do menu Bluetooth do computador de mergulho.",
+  "diveComputer_download_discoveryStalled": "Ligou-se ao computador de mergulho, mas ele deixou de responder antes de a transferência começar. Normalmente isto significa que o emparelhamento Bluetooth está desatualizado: esqueça o computador de mergulho nas definições de Bluetooth do seu dispositivo e tente novamente.",
   "diveComputer_download_serialConnectFailedWithDetails": "Não foi possível conectar ao computador de mergulho.\n\nDetalhes de diagnóstico (compartilhe com os desenvolvedores):\n{details}",
   "@diveComputer_download_serialConnectFailedWithDetails": {
     "placeholders": {

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1373,6 +1373,8 @@
   "diveComputer_download_newDivesOnlySubtitle": "仅下载自上次同步以来新增的潜水",
   "diveComputer_download_newDivesOnlyTitle": "仅下载新潜水",
   "diveComputer_download_noSerialPortsFound": "未找到 USB 串行端口。潜水电脑是否已连接并开机？",
+  "diveComputer_download_stalePairing": "此潜水电脑的蓝牙配对已失效。请在设备的蓝牙设置中忽略该潜水电脑，然后从潜水电脑的蓝牙菜单重新配对。",
+  "diveComputer_download_discoveryStalled": "已连接到潜水电脑，但在下载开始前它停止响应。这通常表示蓝牙配对已失效：请在设备的蓝牙设置中忽略该潜水电脑，然后重试。",
   "diveComputer_download_preparing": "准备中...",
   "diveComputer_download_progressPercent": "{percent}%",
   "diveComputer_download_retry": "重试",

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleConnectFailure.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleConnectFailure.swift
@@ -1,0 +1,67 @@
+import CoreBluetooth
+import Foundation
+
+/// Why a BLE connect/discovery attempt was abandoned, and whether another
+/// attempt could plausibly do better.
+///
+/// Apple platforms expose no API for deleting a pairing record, so when the OS
+/// and the dive computer disagree about their shared keys the app cannot repair
+/// it the way the Android backend does (GATT status 5 -> removeBond -> retry,
+/// see BleIoStream.kt). All it can do is recognise the condition and tell the
+/// user which switch to throw, which is how the reporter in issue #865 fixed it
+/// -- by forgetting the computer in the iPad's Bluetooth settings.
+enum BleConnectFailure: Equatable {
+    /// The OS holds pairing information the dive computer no longer honours,
+    /// typically after the computer was factory reset or paired with another
+    /// phone. CoreBluetooth refuses the connection outright.
+    case stalePairing
+
+    /// The link came up but the peer never answered service discovery. On a
+    /// healthy connection the first callback lands in milliseconds; a silent
+    /// stall is the shape a stale bond takes on macOS, where CoreBluetooth
+    /// waits forever for an encryption upgrade the peer will not complete
+    /// rather than reporting `peerRemovedPairingInformation` the way iOS does.
+    case discoveryStalled
+
+    /// Anything else: out of range, powered off, or dropped out of its BLE menu.
+    case other
+
+    /// Codes that mean the local pairing record and the peer's disagree.
+    private static let stalePairingCodes: Set<Int> = [
+        CBError.Code.peerRemovedPairingInformation.rawValue,
+        CBError.Code.encryptionTimedOut.rawValue,
+    ]
+
+    /// Whether retrying inside the app is pointless.
+    ///
+    /// Only the user can clear a pairing record on Apple platforms, so a second
+    /// attempt fails exactly as the first did -- the iPad log in #865 shows the
+    /// retry returning the same error 500 ms later. Stopping early replaces
+    /// that dead time with the instruction that actually resolves it.
+    var isTerminal: Bool { self == .stalePairing }
+
+    /// The error code handed to the Dart layer, which switches on it in
+    /// `DownloadStepWidget._localizedError` to choose the advice to show.
+    var errorCode: String {
+        switch self {
+        case .stalePairing:
+            return "stale_pairing"
+        case .discoveryStalled:
+            return "discovery_stalled"
+        case .other:
+            return "connect_failed"
+        }
+    }
+
+    /// Classify the error CoreBluetooth reported to `didFailToConnect`.
+    ///
+    /// The domain check matters: the pairing codes are small integers that
+    /// collide with common POSIX errnos, and sending a user to Bluetooth
+    /// settings over an unrelated EFAULT would be a pure red herring.
+    static func fromConnectError(_ error: Error?) -> BleConnectFailure {
+        guard let error else { return .other }
+        let nsError = error as NSError
+        guard nsError.domain == CBErrorDomain else { return .other }
+        return stalePairingCodes.contains(nsError.code) ? .stalePairing : .other
+    }
+}

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/BleIoStream.swift
@@ -125,8 +125,9 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
     // MARK: - Connection
 
     /// Connect to the peripheral and discover services/characteristics.
-    /// Blocks until ready or timeout. Returns true on success.
-    func connectAndDiscover() -> Bool {
+    /// Blocks until ready or timeout. Returns nil once the stream is usable,
+    /// or the reason the attempt was abandoned.
+    func connectAndDiscover() -> BleConnectFailure? {
         NativeLogger.d(
             "BleIoStream", category: "BLE",
             "connectAndDiscover start for \(self.peripheral.identifier.uuidString)"
@@ -139,7 +140,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
                 "BleIoStream", category: "BLE",
                 "Central not powered on (state=\(self.centralManager.state.rawValue))"
             )
-            return false
+            return .other
         }
 
         connectError = nil
@@ -172,13 +173,13 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
                 NativeLogger.w("BleIoStream", category: "BLE",
                     "Timed out waiting for in-flight connect callback")
                 centralManager.cancelPeripheralConnection(peripheral)
-                return false
+                return .other
             }
             if let error = connectError {
                 NativeLogger.e("BleIoStream", category: "BLE",
                     "In-flight connect failed: \(error.localizedDescription)")
                 centralManager.cancelPeripheralConnection(peripheral)
-                return false
+                return BleConnectFailure.fromConnectError(error)
             }
         default:
             centralManager.connect(peripheral, options: nil)
@@ -187,13 +188,13 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
                 NativeLogger.w("BleIoStream", category: "BLE",
                     "Timed out waiting for connect callback")
                 centralManager.cancelPeripheralConnection(peripheral)
-                return false
+                return .other
             }
             if let error = connectError {
                 NativeLogger.e("BleIoStream", category: "BLE",
                     "Connect failed: \(error.localizedDescription)")
                 centralManager.cancelPeripheralConnection(peripheral)
-                return false
+                return BleConnectFailure.fromConnectError(error)
             }
         }
 
@@ -207,23 +208,27 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         peripheral.discoverServices(nil)
         let discoverResult = discoverSemaphore.wait(timeout: .now() + .seconds(10))
         if discoverResult == .timedOut {
+            // The link is up but the peer never answered, so this is not the
+            // "no usable characteristics" case below: nothing was enumerated at
+            // all. On macOS that is what a stale bond looks like -- iOS names
+            // the condition, macOS just waits (issue #865).
             NativeLogger.w("BleIoStream", category: "BLE",
                 "Timed out waiting for service/characteristic discovery")
             centralManager.cancelPeripheralConnection(peripheral)
-            return false
+            return .discoveryStalled
         }
         if !isReady {
             NativeLogger.w("BleIoStream", category: "BLE",
                 "Discovery completed without usable write/notify characteristics")
             centralManager.cancelPeripheralConnection(peripheral)
-            return false
+            return .other
         }
         // A Telit Terminal I/O module keeps its UART bridge closed until the
         // client grants initial credits, so the first command write would fail
         // outright without this (issue #923).
         if !grantInitialCredits() {
             centralManager.cancelPeripheralConnection(peripheral)
-            return false
+            return .other
         }
         Thread.sleep(forTimeInterval: Self.notifySettleDelaySeconds)
         NativeLogger.d("BleIoStream", category: "BLE",
@@ -231,7 +236,7 @@ class BleIoStream: NSObject, CBPeripheralDelegate {
         NativeLogger.d("BleIoStream", category: "BLE",
             "Discovery ready (write=\(self.writeCharacteristic?.uuid.uuidString ?? "nil")"
                 + " notify=\(self.notifyCharacteristic?.uuid.uuidString ?? "nil"))")
-        return true
+        return nil
     }
 
     // MARK: - Terminal I/O credits

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -524,6 +524,9 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             ("scan-only", false, 20),
         ]
         var connectedStream: BleIoStream?
+        // Remembered across attempts so the error the user sees describes the
+        // reason the attempts failed, not just that they did.
+        var lastFailure: BleConnectFailure = .other
 
         for (index, plan) in resolvePlans.enumerated() {
             NativeLogger.d("DiveComputerHost", category: "BLE",
@@ -551,24 +554,57 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
                 self?.flutterApi.onPinCodeRequired(deviceAddress: address) { _ in }
             }
             self.activeBleStream = stream
-            if stream.connectAndDiscover() {
+            guard let failure = stream.connectAndDiscover() else {
                 connectedStream = stream
                 break
             }
+            lastFailure = failure
 
             NativeLogger.w("DiveComputerHost", category: "BLE",
                 "connectAndDiscover failed on attempt \(index + 1) for \(peripheral.identifier.uuidString)")
             if peripheral.state != .disconnected {
                 centralMgr.cancelPeripheralConnection(peripheral)
             }
+
+            // A pairing record the peer has disowned cannot be repaired from
+            // here -- CoreBluetooth offers no unpair API -- so a second attempt
+            // only delays the instruction that does fix it (issue #865).
+            if failure.isTerminal {
+                NativeLogger.w("DiveComputerHost", category: "BLE",
+                    "Not retrying: \(failure.errorCode) needs the user to clear the pairing")
+                break
+            }
         }
 
         guard let bleStream = connectedStream else {
-            reportError(code: "connect_failed", message: "Failed to connect to device")
+            reportError(
+                code: lastFailure.errorCode,
+                message: Self.connectFailureMessage(for: lastFailure))
             self.activeBleStream = nil
             return nil
         }
         return bleStream.makeCallbacks()
+    }
+
+    /// Fallback text for a failed BLE connect.
+    ///
+    /// The Dart layer localises the known codes and only falls back to this
+    /// string for `connect_failed`, but the native message is what lands in the
+    /// debug logs users attach to bug reports, so it spells the diagnosis out.
+    private static func connectFailureMessage(for failure: BleConnectFailure) -> String {
+        switch failure {
+        case .stalePairing:
+            return "The Bluetooth pairing for this dive computer is out of date."
+                + " Forget the dive computer in your device's Bluetooth settings,"
+                + " then try again."
+        case .discoveryStalled:
+            return "Connected to the dive computer, but it stopped responding"
+                + " before the download could start. This is usually an out-of-date"
+                + " Bluetooth pairing: forget the dive computer in your device's"
+                + " Bluetooth settings, then try again."
+        case .other:
+            return "Failed to connect to device"
+        }
     }
 
     // MARK: - Dive Conversion

--- a/packages/libdivecomputer_plugin/darwin/Tests/BleConnectFailureTests/main.swift
+++ b/packages/libdivecomputer_plugin/darwin/Tests/BleConnectFailureTests/main.swift
@@ -1,0 +1,98 @@
+import CoreBluetooth
+import Foundation
+
+// Standalone test runner for BleConnectFailure (no XCTest: the LibDCDarwin
+// package cannot build under SwiftPM because it depends on Flutter modules
+// only present in the CocoaPods build). Run via run_native_tests.sh.
+
+var failures = 0
+
+func expect(_ condition: Bool, _ message: String, line: Int = #line) {
+    if condition {
+        print("PASS: \(message)")
+    } else {
+        print("FAIL: \(message) (main.swift:\(line))")
+        failures += 1
+    }
+}
+
+/// A CoreBluetooth error as CoreBluetooth itself reports it.
+func cbError(_ code: CBError.Code) -> NSError {
+    return NSError(domain: CBErrorDomain, code: code.rawValue, userInfo: nil)
+}
+
+// 1. The error the reporter's iPad logged against a Perdix 3 whose pairing
+// record had gone stale (issue #865): CoreBluetooth refuses the connection
+// outright with "Peer removed pairing information".
+do {
+    expect(
+        BleConnectFailure.fromConnectError(cbError(.peerRemovedPairingInformation))
+            == .stalePairing,
+        "peerRemovedPairingInformation classifies as stale pairing")
+}
+
+// 2. The other side of the same coin: the peer still accepts the connection but
+// the link cannot be encrypted with the stored key, so encryption times out.
+do {
+    expect(
+        BleConnectFailure.fromConnectError(cbError(.encryptionTimedOut)) == .stalePairing,
+        "encryptionTimedOut classifies as stale pairing")
+}
+
+// 3. An ordinary connection timeout is not a pairing problem -- the computer
+// was simply out of range or had left its BLE menu.
+do {
+    expect(
+        BleConnectFailure.fromConnectError(cbError(.connectionTimeout)) == .other,
+        "connectionTimeout is not a pairing failure")
+}
+
+// 4. didFailToConnect is allowed to report no error at all.
+do {
+    expect(BleConnectFailure.fromConnectError(nil) == .other,
+           "a missing error classifies as other")
+}
+
+// 5. The classifier must key off the CoreBluetooth domain, not the bare code.
+// POSIX errno 14 is EFAULT and errno 15 is ENOTBLK; neither says anything
+// about pairing, and misreading one as a stale bond would send the user off to
+// Bluetooth settings for nothing.
+do {
+    let posix = NSError(
+        domain: NSPOSIXErrorDomain,
+        code: CBError.Code.peerRemovedPairingInformation.rawValue,
+        userInfo: nil)
+    expect(BleConnectFailure.fromConnectError(posix) == .other,
+           "a matching code in another error domain is not a pairing failure")
+}
+
+// 6. Only a stale bond is terminal. Apple exposes no API to delete a pairing
+// record, so no amount of retrying inside the app can clear one -- the download
+// path must stop and hand the user the fix instead of burning a second attempt
+// (the iPad log shows attempt 2 failing identically 500 ms later).
+do {
+    expect(BleConnectFailure.stalePairing.isTerminal,
+           "stale pairing is terminal: only the user can clear the bond")
+    expect(!BleConnectFailure.discoveryStalled.isTerminal,
+           "a discovery stall is worth one more attempt")
+    expect(!BleConnectFailure.other.isTerminal,
+           "an unclassified failure is worth one more attempt")
+}
+
+// 7. Every failure has to name an error code for the Dart layer, and the codes
+// have to stay distinct: DownloadStepWidget switches on them to pick which
+// piece of advice to show.
+do {
+    expect(BleConnectFailure.stalePairing.errorCode == "stale_pairing",
+           "stale pairing reports the stale_pairing code")
+    expect(BleConnectFailure.discoveryStalled.errorCode == "discovery_stalled",
+           "a discovery stall reports the discovery_stalled code")
+    expect(BleConnectFailure.other.errorCode == "connect_failed",
+           "an unclassified failure keeps the existing connect_failed code")
+}
+
+if failures > 0 {
+    print("\(failures) test(s) failed")
+    exit(1)
+}
+print("All BleConnectFailure tests passed")

--- a/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
+++ b/packages/libdivecomputer_plugin/darwin/run_native_tests.sh
@@ -22,6 +22,16 @@ swiftc -o "$BUILD_DIR/ble_characteristic_selector_tests" \
 
 "$BUILD_DIR/ble_characteristic_selector_tests"
 
+# BLE connect-failure classification (issue #865): a dive computer whose
+# pairing record has gone stale cannot be repaired from inside the app on Apple
+# platforms, so the failure has to be recognised and handed to the user rather
+# than retried.
+swiftc -o "$BUILD_DIR/ble_connect_failure_tests" \
+    Sources/LibDCDarwin/BleConnectFailure.swift \
+    Tests/BleConnectFailureTests/main.swift
+
+"$BUILD_DIR/ble_connect_failure_tests"
+
 # Telit Terminal I/O credit accounting (issue #923). The OSTC4's BlueMod+SR
 # module keeps its UART bridge closed until the client grants credits, and
 # spends one per notification, so the balance has to be topped up mid-transfer.

--- a/packages/libdivecomputer_plugin/ios/Classes/BleConnectFailure.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/BleConnectFailure.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/BleConnectFailure.swift

--- a/packages/libdivecomputer_plugin/macos/Classes/BleConnectFailure.swift
+++ b/packages/libdivecomputer_plugin/macos/Classes/BleConnectFailure.swift
@@ -1,0 +1,1 @@
+../../darwin/Sources/LibDCDarwin/BleConnectFailure.swift

--- a/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
+++ b/test/features/dive_computer/presentation/widgets/download_step_widget_test.dart
@@ -748,6 +748,42 @@ void main() {
       expect(find.textContaining('USB serial ports'), findsOneWidget);
     });
 
+    // Issue #865: an out-of-date pairing record cannot be cleared from inside
+    // the app on Apple platforms, so the error has to name the one thing that
+    // does fix it instead of showing the generic connect failure. The native
+    // message is deliberately ignored in favour of the localized advice.
+    testWidgets('shows stale_pairing localized error', (tester) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: const DownloadState(
+            phase: DownloadPhase.error,
+            errorCode: 'stale_pairing',
+            errorMessage: 'Failed to connect to device',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Bluetooth settings'), findsOneWidget);
+      expect(find.text('Failed to connect to device'), findsNothing);
+    });
+
+    testWidgets('shows discovery_stalled localized error', (tester) async {
+      await tester.pumpWidget(
+        _buildWidget(
+          initialState: const DownloadState(
+            phase: DownloadPhase.error,
+            errorCode: 'discovery_stalled',
+            errorMessage: 'Failed to connect to device',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('stopped responding'), findsOneWidget);
+      expect(find.text('Failed to connect to device'), findsNothing);
+    });
+
     testWidgets('calls onError when error phase is entered', (tester) async {
       String? errorMessage;
 

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_steps_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_steps_test.dart
@@ -90,6 +90,35 @@ class _FakeDiveComputerRepository extends DiveComputerRepository {
   }) async => null;
 }
 
+/// Repository that records the computers created through it, so a test can
+/// assert that a download persisted the dive computer it talked to.
+class _RecordingDiveComputerRepository extends DiveComputerRepository {
+  final List<DiveComputer> created = [];
+
+  @override
+  Future<DiveComputer> createComputer(DiveComputer computer) async {
+    created.add(computer);
+    return computer;
+  }
+
+  @override
+  Future<void> updateComputer(dynamic computer) async {}
+
+  @override
+  Future<DiveComputer?> findByBluetoothAddress(
+    String address, {
+    String? diverId,
+  }) async => null;
+
+  @override
+  Future<DiveComputer?> findByHardwareIdentity({
+    required String manufacturer,
+    required String model,
+    required String serialNumber,
+    String? diverId,
+  }) async => null;
+}
+
 /// Repository that never resolves findByBluetoothAddress, simulating
 /// an async delay during computer resolution.
 class _NeverResolveDiveComputerRepository extends DiveComputerRepository {
@@ -602,6 +631,46 @@ void main() {
       expect(find.byType(DcNoNewDivesView), findsOneWidget);
       expect(container.read(dcAdapterDownloadCanAdvanceProvider), isFalse);
     });
+
+    // Issue #865: a first-time pairing whose download happened to find nothing
+    // new used to return before ensureComputer(), so a dive computer that had
+    // just proved it pairs, connects and downloads was never saved -- the diver
+    // had to rediscover it every time.
+    testWidgets(
+      'a completed download with no dives still saves the dive computer',
+      (tester) async {
+        final repository = _RecordingDiveComputerRepository();
+        final adapter = _makeAdapter(computerRepository: repository);
+
+        await tester.pumpWidget(
+          _buildDownloadStep(
+            adapter: adapter,
+            discoveryState: DiscoveryState(selectedDevice: _testDevice),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(DcAdapterDownloadStep)),
+        );
+        container
+            .read(downloadNotifierProvider.notifier)
+            .state = const DownloadState(
+          phase: DownloadPhase.complete,
+          downloadedDives: [],
+          firmwareVersion: '92',
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DcNoNewDivesView), findsOneWidget);
+        expect(repository.created, hasLength(1));
+        expect(repository.created.single.bluetoothAddress, _testDevice.address);
+        expect(repository.created.single.firmwareVersion, '92');
+        // Still no Review step to advance to -- only the saving changed.
+        expect(container.read(dcAdapterDownloadCanAdvanceProvider), isFalse);
+      },
+    );
 
     testWidgets(
       'importing a partial download captures dives and advances the wizard',


### PR DESCRIPTION
Fixes the remaining problems in #865 (Perdix 3 sync on iPad and MacBook).

## Root cause

Both debug logs the reporter attached are the same fault in two different
presentations: the OS-level Bluetooth pairing record for the Perdix 3 had gone
stale, and CoreBluetooth reports that differently per platform.

**iPad** — the connection is refused outright:

```
didFailToConnect 6613B027-...: Peer removed pairing information
Download failed (connect_failed): Failed to connect to device
```

That is `CBError.peerRemovedPairingInformation` (code 14).

**MacBook** — the connection succeeds and then service discovery never answers:

```
didConnect AE29DF2A-...
Connected; discovering services
(10 s of nothing)
Timed out waiting for service/characteristic discovery
```

No `didDiscoverServices` callback arrives at all — macOS sits waiting for an
encryption upgrade the peer will not complete, rather than naming the condition
the way iOS does. This is not a lost callback: `BleIoStream.init` sets both
`centralManager.delegate` and `peripheral.delegate` to itself, and `didConnect`
(a central-manager callback) did fire, so the delegate queue was alive.

**Apple platforms expose no API for deleting a pairing record.** The Android
backend self-heals this (GATT status 5 -> `removeBond` -> retry); CoreBluetooth
has no equivalent, so only the diver can clear it in Bluetooth settings — which
is exactly how the reporter fixed their iPad. The app's job is therefore to
recognise the condition and say so. Previously both presentations collapsed into
a generic "Failed to connect to device", and the retry loop spent a further
20-35 s re-attempting something that could never succeed.

## Changes

**Recognise the failure** — new pure `BleConnectFailure` type in the darwin
plugin classifies a connect/discovery failure as `.stalePairing` (CoreBluetooth
`peerRemovedPairingInformation` / `encryptionTimedOut`, matched inside
`CBErrorDomain` so a colliding POSIX errno cannot be mistaken for one),
`.discoveryStalled` (connected, zero discovery callbacks) or `.other`.
`connectAndDiscover()` now returns `BleConnectFailure?` instead of `Bool`.

**Stop retrying what cannot be retried** — `connectBle` breaks out of the
resolve/connect loop when the failure is terminal. The iPad log shows attempt 2
returning the identical error 500 ms later, so the retry only delays the
instruction that actually resolves it.

**Tell the diver what to do** — the native layer reports `stale_pairing` /
`discovery_stalled`, which `DownloadStepWidget._localizedError` maps to
actionable advice ("forget the dive computer in your device's Bluetooth
settings, then try again"), translated across all 11 locales. The native message
still spells the diagnosis out, since that is what lands in attached debug logs.

**Save a computer that downloaded nothing** — the reporter also noted
"Submersion does not save the Perdix as a known computer… but that could be
because I have no new dives to download", and they were right. In
`_captureAndAdvance`, a completed download with zero dives returned before the
post-frame callback that calls `ensureComputer()`, so a computer that had just
proved it pairs, connects and downloads was never persisted. It is now saved on
both paths; only the advance-to-Review step remains gated on having dives.
(`ensureComputer()` reads only device/serial/firmware, never the dives, and
self-guards with `if (computer != null) return`; serial and firmware ride on
`DownloadCompleteEvent`, which fires with zero dives, so the hardware-identity
rebind still works.)

## Testing

- New standalone Swift suite `BleConnectFailureTests` (11 assertions) wired into
  `darwin/run_native_tests.sh`, covering both stale-pairing codes, the
  wrong-domain guard, terminality and the error-code mapping. Full native run:
  366 assertions, 0 failures.
- New widget regression test asserting a zero-dive download still persists the
  computer — verified to fail against the previous behaviour before the fix.
- New widget tests for the `stale_pairing` and `discovery_stalled` messages,
  including that the generic native message is not shown for them.
- `flutter analyze` clean, `dart format` clean, full `flutter test` suite green.
- `flutter build macos` and `flutter build ios --no-codesign` both succeed
  (the new shared source needed the usual symlink into `ios/Classes` and
  `macos/Classes` plus a `pod install`).

## Note on hardware validation

The classification and the messaging are exercised by unit tests, but the
end-to-end behaviour against a Perdix 3 whose bond has actually gone stale can
only be confirmed on real hardware. The zero-dive save fix is fully covered by
the widget test.
