### PR TITLE
Make the Home sync chip reflect unsynced changes (#990)

### DIFF
--- a/lib/core/data/repositories/sync_repository.dart
+++ b/lib/core/data/repositories/sync_repository.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/core/services/sync/hlc.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/core/services/sync/sync_clock.dart';
@@ -723,11 +724,19 @@ class SyncRepository {
     }
   }
 
-  /// Get count of pending changes
+  /// Get count of pending changes.
+  ///
+  /// Counts in SQL rather than materializing every pending row: this runs on
+  /// every local write now that the sync chip reflects it live.
   Future<int> getPendingCount() async {
     try {
-      final records = await getPendingRecords();
-      return records.length;
+      final count = _db.syncRecords.id.count();
+      final row =
+          await (_db.selectOnly(_db.syncRecords)
+                ..addColumns([count])
+                ..where(_db.syncRecords.syncStatus.equals('pending')))
+              .getSingle();
+      return row.read(count) ?? 0;
     } catch (e, stackTrace) {
       _log.error(
         'Failed to get pending count',
@@ -736,6 +745,74 @@ class SyncRepository {
       );
       return 0;
     }
+  }
+
+  /// Deletions this device has made that have NOT yet been published.
+  ///
+  /// Deletions never touch `sync_records`, so [getPendingCount] alone reports
+  /// a delete-only change set as zero -- the UI then claims "Synced" while
+  /// tombstones sit unsent. The whole deletion log is the wrong number too:
+  /// tombstones survive publication (only [clearAcknowledgedDeletions] removes
+  /// them, once the fleet has acked), so counting all of them would pin the UI
+  /// to "unsynced" forever.
+  ///
+  /// [upToHlc] is the active provider's `publishedHlcHigh`; this mirrors the
+  /// filter the changeset writer applies, so the count matches what a sync
+  /// would actually send. A null [upToHlc] means nothing has been published
+  /// yet, so every tombstone counts. A null row hlc is always counted: it
+  /// cannot be compared, so it rides every base and is unpublished until one
+  /// goes out.
+  Future<int> getUnpublishedDeletionCount({required String? upToHlc}) async {
+    try {
+      final count = _db.deletionLog.id.count();
+      final query = _db.selectOnly(_db.deletionLog)..addColumns([count]);
+      if (upToHlc != null) {
+        query.where(
+          _db.deletionLog.hlc.isNull() |
+              _db.deletionLog.hlc.isBiggerThanValue(upToHlc),
+        );
+      }
+      final row = await query.getSingle();
+      return row.read(count) ?? 0;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get unpublished deletion count',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return 0;
+    }
+  }
+
+  /// Every local change a sync would send: pending record edits plus the
+  /// tombstones above [providerId]'s publish watermark. This is the number the
+  /// UI means by "unsynced"; [getPendingCount] alone misses deletions.
+  ///
+  /// A null [providerId] means no cloud provider is configured, so nothing has
+  /// ever been published and every tombstone counts.
+  Future<int> getUnsyncedChangeCount({required String? providerId}) async {
+    final pending = await getPendingCount();
+    if (providerId == null) {
+      return pending + await getUnpublishedDeletionCount(upToHlc: null);
+    }
+    final String? watermark;
+    try {
+      watermark = (await PublishStateStore(
+        _db,
+      ).get(providerId))?.publishedHlcHigh;
+    } catch (e, stackTrace) {
+      // This count is advisory and its callers treat it as non-failing (the
+      // notifier would otherwise turn a status query into a page-wide error).
+      // Without a watermark, report the pending records alone rather than
+      // counting the entire deletion log as unsent.
+      _log.error(
+        'Failed to read publish watermark for $providerId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return pending;
+    }
+    return pending + await getUnpublishedDeletionCount(upToHlc: watermark);
   }
 
   /// Clear all pending sync records

--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -379,8 +379,16 @@ class GaugeStrip extends ConsumerWidget {
           // Tap syncs; the sync itself is what the user wants when they look
           // at this chip. runSyncNow (not performSync) so the first-contact
           // and replaced-library gates still get their confirmation dialogs.
-          // Inert mid-sync so a second tap cannot queue a redundant run.
-          onTap: syncing ? () {} : () => runSyncNow(context, ref),
+          //
+          // Mid-sync the tap opens the Cloud Sync page instead of queuing a
+          // redundant run. A no-op callback would be the wrong way to say
+          // "inert": it still announces a tap action to assistive tech and
+          // still splashes. Sending the user to the progress bar is both a
+          // real action and the one they want at that moment -- and it keeps
+          // onTap non-null, which is load-bearing here (see [_chip]).
+          onTap: syncing
+              ? () => context.push('/settings/cloud-sync')
+              : () => runSyncNow(context, ref),
           // The settings page stays reachable from the chip that points at it.
           onLongPress: () => context.push('/settings/cloud-sync'),
         ),

--- a/lib/features/dashboard/presentation/widgets/gauge_strip.dart
+++ b/lib/features/dashboard/presentation/widgets/gauge_strip.dart
@@ -7,6 +7,8 @@ import 'package:submersion/features/dashboard/presentation/providers/gauge_provi
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/sync_now_action.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Dive-currency thresholds for the last-dive chip: quiet under 6 months,
@@ -34,7 +36,7 @@ class GaugeStrip extends ConsumerWidget {
     final gaugesAsync = ref.watch(dashboardGaugesProvider);
     final hidden = ref.watch(settingsProvider.select((s) => s.hiddenHomeChips));
     return gaugesAsync.when(
-      data: (g) => _buildStrip(context, g, hidden),
+      data: (g) => _buildStrip(context, ref, g, hidden),
       loading: () => const SizedBox(height: 40),
       // Always-on block: contained error with a retry affordance instead
       // of vanishing.
@@ -56,6 +58,7 @@ class GaugeStrip extends ConsumerWidget {
 
   Widget _buildStrip(
     BuildContext context,
+    WidgetRef ref,
     DashboardGauges g,
     Set<String> hidden,
   ) {
@@ -356,15 +359,30 @@ class GaugeStrip extends ConsumerWidget {
     }
 
     if (_shown(hidden, HomeChipType.sync) && g.syncEnabled) {
+      final syncing = ref.watch(isSyncingProvider);
       chips.add(
         _chip(
           context,
           icon: Icons.sync_outlined,
-          label: g.syncPending > 0
+          // Reuses the Cloud Sync page's string rather than minting a
+          // dashboard-scoped duplicate of the same word in 12 locales.
+          label: syncing
+              ? l10n.settings_cloudSync_status_syncing
+              : g.syncPending > 0
               ? l10n.dashboard_gauges_syncPending(g.syncPending)
               : l10n.dashboard_gauges_synced,
-          tone: g.syncPending > 0 ? _Tone.warn : _Tone.ok,
-          onTap: () => context.push('/settings/cloud-sync'),
+          tone: syncing
+              ? _Tone.neutral
+              : g.syncPending > 0
+              ? _Tone.warn
+              : _Tone.ok,
+          // Tap syncs; the sync itself is what the user wants when they look
+          // at this chip. runSyncNow (not performSync) so the first-contact
+          // and replaced-library gates still get their confirmation dialogs.
+          // Inert mid-sync so a second tap cannot queue a redundant run.
+          onTap: syncing ? () {} : () => runSyncNow(context, ref),
+          // The settings page stays reachable from the chip that points at it.
+          onLongPress: () => context.push('/settings/cloud-sync'),
         ),
       );
     }
@@ -397,6 +415,7 @@ class GaugeStrip extends ConsumerWidget {
     required String label,
     required _Tone tone,
     required VoidCallback onTap,
+    VoidCallback? onLongPress,
   }) {
     final scheme = Theme.of(context).colorScheme;
     final (bg, fg) = switch (tone) {
@@ -410,6 +429,7 @@ class GaugeStrip extends ConsumerWidget {
     };
     return InkWell(
       onTap: onTap,
+      onLongPress: onLongPress,
       borderRadius: BorderRadius.circular(999),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/features/settings/presentation/pages/cloud_sync_page.dart
+++ b/lib/features/settings/presentation/pages/cloud_sync_page.dart
@@ -16,9 +16,9 @@ import 'package:submersion/features/settings/presentation/providers/storage_prov
     show StoragePlatformCapabilities, storagePlatformCapabilitiesProvider;
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
-import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/replace_cloud_library_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/skipped_peer_banner.dart';
+import 'package:submersion/features/settings/presentation/widgets/sync_now_action.dart';
 import 'package:submersion/features/settings/presentation/widgets/conflict_resolution_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/dropbox_connect_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_settings_section.dart';
@@ -54,11 +54,28 @@ String connectionErrorMessage(
   return l10n.settings_cloudSync_provider_connectionFailed(providerName, error);
 }
 
-class CloudSyncPage extends ConsumerWidget {
+class CloudSyncPage extends ConsumerStatefulWidget {
   const CloudSyncPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CloudSyncPage> createState() => _CloudSyncPageState();
+}
+
+class _CloudSyncPageState extends ConsumerState<CloudSyncPage> {
+  @override
+  void initState() {
+    super.initState();
+    // Recompute on entry. SyncState's counts and cursor are otherwise only
+    // written by a sync, so without this the page could report the state as of
+    // whenever the notifier was built -- the stale reading behind issue #990.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(syncStateProvider.notifier).refreshState();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final syncState = ref.watch(syncStateProvider);
     // Google Drive is hidden until its integration is implemented, but a
     // persisted selection or SyncRepository's fallback can still surface
@@ -340,16 +357,18 @@ class CloudSyncPage extends ConsumerWidget {
     SyncState syncState,
   ) {
     final theme = Theme.of(context);
+    final l10n = context.l10n;
 
     return Semantics(
-      label:
-          _getStatusTitle(syncState.status) +
-          (syncState.lastSync != null
-              ? ', last synced ${_formatDateTime(syncState.lastSync!)}'
-              : '') +
-          (syncState.pendingChanges > 0
-              ? ', ${syncState.pendingChanges} pending changes'
-              : ''),
+      label: [
+        _getStatusTitle(l10n, syncState.status),
+        if (syncState.lastSync != null)
+          l10n.settings_cloudSync_lastSynced(
+            _formatDateTime(l10n, syncState.lastSync!),
+          ),
+        if (syncState.pendingChanges > 0)
+          l10n.settings_cloudSync_pendingChanges(syncState.pendingChanges),
+      ].join(', '),
       liveRegion: syncState.status == SyncStatus.syncing,
       child: Card(
         margin: const EdgeInsets.all(16),
@@ -377,7 +396,7 @@ class CloudSyncPage extends ConsumerWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            _getStatusTitle(syncState.status),
+                            _getStatusTitle(l10n, syncState.status),
                             style: theme.textTheme.titleMedium,
                           ),
                           if (syncState.message != null)
@@ -404,7 +423,9 @@ class CloudSyncPage extends ConsumerWidget {
                 if (syncState.lastSync != null) ...[
                   const SizedBox(height: 12),
                   Text(
-                    'Last synced: ${_formatDateTime(syncState.lastSync!)}',
+                    l10n.settings_cloudSync_lastSynced(
+                      _formatDateTime(l10n, syncState.lastSync!),
+                    ),
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
@@ -413,7 +434,9 @@ class CloudSyncPage extends ConsumerWidget {
                 if (syncState.pendingChanges > 0) ...[
                   const SizedBox(height: 4),
                   Text(
-                    '${syncState.pendingChanges} pending change${syncState.pendingChanges == 1 ? '' : 's'}',
+                    l10n.settings_cloudSync_pendingChanges(
+                      syncState.pendingChanges,
+                    ),
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.primary,
                     ),
@@ -446,18 +469,18 @@ class CloudSyncPage extends ConsumerWidget {
     }
   }
 
-  String _getStatusTitle(SyncStatus status) {
+  String _getStatusTitle(AppLocalizations l10n, SyncStatus status) {
     switch (status) {
       case SyncStatus.idle:
-        return 'Ready to sync';
+        return l10n.settings_cloudSync_status_readyToSync;
       case SyncStatus.syncing:
-        return 'Syncing...';
+        return l10n.settings_cloudSync_status_syncing;
       case SyncStatus.success:
-        return 'Sync complete';
+        return l10n.settings_cloudSync_status_syncComplete;
       case SyncStatus.error:
-        return 'Sync error';
+        return l10n.settings_cloudSync_status_syncError;
       case SyncStatus.hasConflicts:
-        return 'Conflicts detected';
+        return l10n.settings_cloudSync_status_conflictsDetected;
     }
   }
 
@@ -1383,63 +1406,9 @@ class CloudSyncPage extends ConsumerWidget {
     await showReplaceCloudLibraryDialog(context, ref, preflight);
   }
 
-  /// Run a sync, first handling the two gated cases: a replaced cloud
-  /// library awaiting adoption, and the device's first library-combining
-  /// contact with existing cloud data.
-  Future<void> _onSyncNowPressed(BuildContext context, WidgetRef ref) async {
-    final notifier = ref.read(syncStateProvider.notifier);
-    final replaceInfo = await notifier.libraryReplaceInfo();
-    if (replaceInfo != null) {
-      if (!context.mounted) return;
-      await showAdoptReplacedLibraryDialog(context, ref, replaceInfo);
-      return;
-    }
-    final info = await notifier.firstSyncMergeInfo();
-    if (info == null) {
-      await notifier.performSync();
-      return;
-    }
-    if (!context.mounted) return;
-    final l10n = context.l10n;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(l10n.settings_cloudSync_firstSync_dialogTitle),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                l10n.settings_cloudSync_firstSync_dialogContent(
-                  info.peerFileCount,
-                  info.localDiveCount,
-                ),
-              ),
-              const SizedBox(height: 12),
-              // Merge is the only action here on purpose; the alternative is
-              // a fleet-wide wipe and does not belong one tap away in a
-              // dialog that appears routinely. Name where it lives instead.
-              Text(l10n.settings_cloudSync_firstSync_replaceHint),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(l10n.settings_cloudSync_firstSync_dialogConfirm),
-          ),
-        ],
-      ),
-    );
-    if (confirmed == true) {
-      await notifier.performSync();
-    }
-  }
+  /// The gated sync flow lives in [runSyncNow]: the Home sync chip runs it too.
+  Future<void> _onSyncNowPressed(BuildContext context, WidgetRef ref) =>
+      runSyncNow(context, ref);
 
   Future<void> _confirmSignOut(BuildContext context, WidgetRef ref) async {
     // Cloud backup uploads ride on the sync provider; losing it changes
@@ -1479,18 +1448,17 @@ class CloudSyncPage extends ConsumerWidget {
     }
   }
 
-  String _formatDateTime(DateTime dateTime) {
-    final now = DateTime.now();
-    final difference = now.difference(dateTime);
+  String _formatDateTime(AppLocalizations l10n, DateTime dateTime) {
+    final difference = DateTime.now().difference(dateTime);
 
     if (difference.inMinutes < 1) {
-      return 'Just now';
+      return l10n.settings_cloudSync_time_justNow;
     } else if (difference.inHours < 1) {
-      return '${difference.inMinutes} minute${difference.inMinutes == 1 ? '' : 's'} ago';
+      return l10n.settings_cloudSync_time_minutesAgo(difference.inMinutes);
     } else if (difference.inDays < 1) {
-      return '${difference.inHours} hour${difference.inHours == 1 ? '' : 's'} ago';
+      return l10n.settings_cloudSync_time_hoursAgo(difference.inHours);
     } else if (difference.inDays < 7) {
-      return '${difference.inDays} day${difference.inDays == 1 ? '' : 's'} ago';
+      return l10n.settings_cloudSync_time_daysAgo(difference.inDays);
     } else {
       return DateFormat.yMMMd().format(dateTime);
     }

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -619,6 +619,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
   final _log = LoggerService.forClass(SyncNotifier);
   StreamSubscription<void>? _changeSubscription;
   Timer? _autoSyncTimer;
+  Timer? _pendingCountTimer;
   bool _syncInFlight = false;
 
   SyncNotifier(this._syncRepository, this._ref) : super(const SyncState()) {
@@ -705,8 +706,45 @@ class SyncNotifier extends StateNotifier<SyncState> {
 
   void _listenForChanges() {
     _changeSubscription = SyncEventBus.changes.listen((_) {
+      // Refresh the displayed count REGARDLESS of the auto-sync setting.
+      // _scheduleAutoSync returns immediately when auto-sync is off, which is
+      // how the "Synced" chip used to survive a whole session of edits (#990):
+      // nothing else recomputes pendingChanges between syncs.
+      _schedulePendingCountRefresh();
       _scheduleAutoSync();
     });
+  }
+
+  /// Debounced: one local action (a bulk edit, a multi-entity save) fires many
+  /// bus events, and each refresh is two queries.
+  void _schedulePendingCountRefresh() {
+    _pendingCountTimer?.cancel();
+    _pendingCountTimer = Timer(
+      const Duration(milliseconds: 400),
+      _refreshPendingCount,
+    );
+  }
+
+  /// Deliberately narrower than [refreshState]: this runs on every local write,
+  /// so it must not probe the network via isSyncAvailable() nor rewrite
+  /// status/message (which would stomp a sync or an error the user is reading).
+  Future<void> _refreshPendingCount() async {
+    if (!mounted) return;
+    // A sync clears pending records as it publishes; its own post-sync
+    // refreshState lands the settled number.
+    if (state.status == SyncStatus.syncing) return;
+    try {
+      final providerId = _ref.read(cloudStorageProviderProvider)?.providerId;
+      final count = await _syncRepository.getUnsyncedChangeCount(
+        providerId: providerId,
+      );
+      if (!mounted || state.pendingChanges == count) return;
+      state = state.copyWith(pendingChanges: count);
+    } catch (e) {
+      // A count is advisory: leave the last known value rather than pushing
+      // the whole page into an error state over a failed status query.
+      _log.error('Failed to refresh pending count', error: e);
+    }
   }
 
   void _scheduleAutoSync() {
@@ -742,7 +780,11 @@ class SyncNotifier extends StateNotifier<SyncState> {
       final lastSync = await _syncRepository.getLastSyncTime(
         forProvider: activeProvider?.providerId,
       );
-      final pendingCount = await _syncRepository.getPendingCount();
+      // Same composite count the live refresh uses (record edits + tombstones
+      // above the publish watermark), so the two paths cannot disagree.
+      final pendingCount = await _syncRepository.getUnsyncedChangeCount(
+        providerId: activeProvider?.providerId,
+      );
       final conflictCount = await _syncRepository.getConflictCount();
       final isAvailable = await _syncService.isSyncAvailable();
 
@@ -1436,6 +1478,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
   @override
   void dispose() {
     _autoSyncTimer?.cancel();
+    _pendingCountTimer?.cancel();
     _changeSubscription?.cancel();
     super.dispose();
   }

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -620,6 +620,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
   StreamSubscription<void>? _changeSubscription;
   Timer? _autoSyncTimer;
   Timer? _pendingCountTimer;
+  int _pendingCountGeneration = 0;
   bool _syncInFlight = false;
 
   SyncNotifier(this._syncRepository, this._ref) : super(const SyncState()) {
@@ -728,17 +729,25 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// Deliberately narrower than [refreshState]: this runs on every local write,
   /// so it must not probe the network via isSyncAvailable() nor rewrite
   /// status/message (which would stomp a sync or an error the user is reading).
+  ///
+  /// The debounce cancels pending TIMERS, not an in-flight refresh: once the
+  /// queries are running, a later write can start a second refresh alongside
+  /// the first. [_pendingCountGeneration] makes the newest caller the only one
+  /// allowed to publish, so a slow earlier query cannot land a stale count on
+  /// top of a fresher one.
   Future<void> _refreshPendingCount() async {
     if (!mounted) return;
     // A sync clears pending records as it publishes; its own post-sync
     // refreshState lands the settled number.
     if (state.status == SyncStatus.syncing) return;
+    final generation = ++_pendingCountGeneration;
     try {
       final providerId = _ref.read(cloudStorageProviderProvider)?.providerId;
       final count = await _syncRepository.getUnsyncedChangeCount(
         providerId: providerId,
       );
-      if (!mounted || state.pendingChanges == count) return;
+      if (!mounted || generation != _pendingCountGeneration) return;
+      if (state.pendingChanges == count) return;
       state = state.copyWith(pendingChanges: count);
     } catch (e) {
       // A count is advisory: leave the last known value rather than pushing

--- a/lib/features/settings/presentation/widgets/sync_now_action.dart
+++ b/lib/features/settings/presentation/widgets/sync_now_action.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Run a sync, first handling the two gated cases: a replaced cloud library
+/// awaiting adoption, and the device's first library-combining contact with
+/// existing cloud data.
+///
+/// Shared rather than private to the Cloud Sync page because the Home sync
+/// chip triggers a sync too. Calling `performSync()` directly from a second
+/// entry point would skip these gates -- and the first-contact gate guards an
+/// irreversible merge of two libraries, so it must not be bypassable by
+/// whichever surface the user happened to tap.
+Future<void> runSyncNow(BuildContext context, WidgetRef ref) async {
+  final notifier = ref.read(syncStateProvider.notifier);
+  final replaceInfo = await notifier.libraryReplaceInfo();
+  if (replaceInfo != null) {
+    if (!context.mounted) return;
+    await showAdoptReplacedLibraryDialog(context, ref, replaceInfo);
+    return;
+  }
+  final info = await notifier.firstSyncMergeInfo();
+  if (info == null) {
+    await notifier.performSync();
+    return;
+  }
+  if (!context.mounted) return;
+  final l10n = context.l10n;
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(l10n.settings_cloudSync_firstSync_dialogTitle),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.settings_cloudSync_firstSync_dialogContent(
+                info.peerFileCount,
+                info.localDiveCount,
+              ),
+            ),
+            const SizedBox(height: 12),
+            // Merge is the only action here on purpose; the alternative is
+            // a fleet-wide wipe and does not belong one tap away in a
+            // dialog that appears routinely. Name where it lives instead.
+            Text(l10n.settings_cloudSync_firstSync_replaceHint),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: Text(l10n.settings_cloudSync_firstSync_dialogConfirm),
+        ),
+      ],
+    ),
+  );
+  if (confirmed == true) {
+    await notifier.performSync();
+  }
+}

--- a/test/core/data/repositories/sync_repository_pending_count_test.dart
+++ b/test/core/data/repositories/sync_repository_pending_count_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+
+import '../../../helpers/test_database.dart';
+
+void main() {
+  setUp(() async => setUpTestDatabase());
+  tearDown(() => tearDownTestDatabase());
+
+  group('getPendingCount', () {
+    test('counts only rows whose sync_status is pending', () async {
+      final db = DatabaseService.instance.database;
+      Future<void> seed(String id, String status) => db.customStatement(
+        'INSERT INTO sync_records (id, entity_type, record_id, '
+        'local_updated_at, sync_status, created_at, updated_at) '
+        "VALUES ('$id', 'dives', '$id', 1000, '$status', 1000, 1000)",
+      );
+      await seed('a', 'pending');
+      await seed('b', 'pending');
+      await seed('c', 'synced');
+      await seed('d', 'conflict');
+
+      expect(await SyncRepository().getPendingCount(), 2);
+    });
+
+    test('is zero on an empty log', () async {
+      expect(await SyncRepository().getPendingCount(), 0);
+    });
+  });
+
+  group('getUnpublishedDeletionCount', () {
+    // A tombstone is not cleared when it is published -- it lives on until the
+    // fleet-acked GC removes it (clearAcknowledgedDeletions). Counting the
+    // whole deletion log as "pending" would therefore pin the UI to "unsynced"
+    // forever. The publish watermark is what separates the two.
+    Future<void> seed(String id, String? hlc) =>
+        DatabaseService.instance.database.customStatement(
+          'INSERT INTO deletion_log '
+          '(id, entity_type, record_id, deleted_at, hlc) '
+          "VALUES ('$id', 'dives', '$id', 1000, "
+          "${hlc == null ? 'NULL' : "'$hlc'"})",
+        );
+
+    test('counts every tombstone when nothing has been published', () async {
+      await seed('a', '00000000000010:000000:x');
+      await seed('b', '00000000000020:000000:x');
+
+      expect(
+        await SyncRepository().getUnpublishedDeletionCount(upToHlc: null),
+        2,
+      );
+    });
+
+    test('counts only tombstones above the publish watermark', () async {
+      await seed('published', '00000000000010:000000:x');
+      await seed('at-watermark', '00000000000020:000000:x');
+      await seed('unpublished', '00000000000030:000000:x');
+
+      expect(
+        await SyncRepository().getUnpublishedDeletionCount(
+          upToHlc: '00000000000020:000000:x',
+        ),
+        1,
+      );
+    });
+
+    test('counts null-hlc tombstones regardless of the watermark', () async {
+      // A null hlc cannot be compared, so the serializer includes it in every
+      // base; it is genuinely unpublished until a base goes out.
+      await seed('published', '00000000000010:000000:x');
+      await seed('legacy', null);
+
+      expect(
+        await SyncRepository().getUnpublishedDeletionCount(
+          upToHlc: '00000000000020:000000:x',
+        ),
+        1,
+      );
+    });
+
+    test('is zero when every tombstone is at or below the watermark', () async {
+      await seed('a', '00000000000010:000000:x');
+      await seed('b', '00000000000020:000000:x');
+
+      expect(
+        await SyncRepository().getUnpublishedDeletionCount(
+          upToHlc: '00000000000020:000000:x',
+        ),
+        0,
+      );
+    });
+  });
+
+  group('getUnsyncedChangeCount', () {
+    // Through the real API rather than raw SQL: this is the exact call every
+    // dive/site/gear write makes, so the count is proven against the shape
+    // production actually writes.
+    Future<void> seedPending(String id) => SyncRepository().markRecordPending(
+      entityType: 'dives',
+      recordId: id,
+      localUpdatedAt: 1000,
+    );
+    Future<void> seedTombstone(String id, String hlc) =>
+        DatabaseService.instance.database.customStatement(
+          'INSERT INTO deletion_log '
+          '(id, entity_type, record_id, deleted_at, hlc) '
+          "VALUES ('$id', 'dives', '$id', 1000, '$hlc')",
+        );
+    Future<void> seedWatermark(String provider, String hlc) =>
+        DatabaseService.instance.database.customStatement(
+          'INSERT INTO local_publish_states '
+          '(provider, head_seq, published_hlc_high, '
+          'changeset_bytes_since_base, updated_at) '
+          "VALUES ('$provider', 1, '$hlc', 0, 1000)",
+        );
+
+    test('sums pending records and unpublished deletions', () async {
+      await seedPending('p1');
+      await seedPending('p2');
+      await seedTombstone('published', '00000000000010:000000:x');
+      await seedTombstone('unpublished', '00000000000030:000000:x');
+      await seedWatermark('icloud', '00000000000020:000000:x');
+
+      expect(
+        await SyncRepository().getUnsyncedChangeCount(providerId: 'icloud'),
+        3,
+      );
+    });
+
+    test('a delete-only change set is not reported as zero', () async {
+      // The bug behind #990: deletions never touch sync_records, so a pure
+      // delete used to leave the UI claiming "Synced".
+      await seedTombstone('gone', '00000000000030:000000:x');
+      await seedWatermark('icloud', '00000000000020:000000:x');
+
+      expect(
+        await SyncRepository().getUnsyncedChangeCount(providerId: 'icloud'),
+        1,
+      );
+    });
+
+    test('reads the watermark of the named provider only', () async {
+      // Per-provider watermarks: a backend switch must not import the old
+      // backend's published position.
+      await seedTombstone('t', '00000000000030:000000:x');
+      await seedWatermark('icloud', '00000000000040:000000:x');
+      await seedWatermark('dropbox', '00000000000010:000000:x');
+
+      final repo = SyncRepository();
+      expect(await repo.getUnsyncedChangeCount(providerId: 'icloud'), 0);
+      expect(await repo.getUnsyncedChangeCount(providerId: 'dropbox'), 1);
+    });
+
+    test('is zero with a clean log', () async {
+      await seedWatermark('icloud', '00000000000020:000000:x');
+      expect(
+        await SyncRepository().getUnsyncedChangeCount(providerId: 'icloud'),
+        0,
+      );
+    });
+  });
+}

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -15,7 +15,9 @@ import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/equipment/domain/entities/service_clock_status.dart';
 import 'package:submersion/features/equipment/domain/entities/service_kind.dart';
 import 'package:submersion/features/equipment/domain/entities/service_schedule.dart';
+import 'package:submersion/core/services/sync/library_epoch.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/trips/domain/entities/trip.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -39,10 +41,43 @@ const _emptyGauges = DashboardGauges(
   daysSinceLastDive: null,
 );
 
+/// Sync enabled, nothing pending: the state the sync chip renders as "Synced".
+const _syncGauges = DashboardGauges(
+  gearGauges: [],
+  hasGear: true,
+  insurance: null,
+  noFlyStatus: null,
+  daysSinceLastDive: null,
+  syncEnabled: true,
+);
+
+/// Counts the syncs the chip asks for, without touching the database.
+/// Only the members [runSyncNow] reaches are implemented; anything else
+/// throws, which is the point -- the chip must not take another path.
+class _RecordingSyncNotifier extends StateNotifier<SyncState>
+    implements SyncNotifier {
+  _RecordingSyncNotifier(super.state);
+
+  int syncCount = 0;
+
+  @override
+  Future<void> performSync({bool auto = false}) async => syncCount++;
+
+  @override
+  Future<FirstSyncMergeInfo?> firstSyncMergeInfo() async => null;
+
+  @override
+  Future<LibraryEpochMarker?> libraryReplaceInfo() async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 Future<NavSpy> pumpStrip(
   WidgetTester tester,
   DashboardGauges gauges, {
   MockSettingsNotifier? settingsNotifier,
+  List<Override> extraOverrides = const [],
 }) async {
   final overrides = await getBaseOverrides(settingsNotifier: settingsNotifier);
   final spy = NavSpy();
@@ -119,6 +154,7 @@ Future<NavSpy> pumpStrip(
       overrides: [
         ...overrides,
         dashboardGaugesProvider.overrideWith((ref) async => gauges),
+        ...extraOverrides,
       ].cast(),
       child: MaterialApp.router(
         locale: const Locale('en'),
@@ -846,20 +882,68 @@ void main() {
       expect(find.text('5 unsynced'), findsOneWidget);
     });
 
-    testWidgets('opens cloud sync settings', (tester) async {
+    testWidgets('shows the syncing state while a sync runs', (tester) async {
+      await pumpStrip(
+        tester,
+        _syncGauges,
+        extraOverrides: [
+          syncStateProvider.overrideWith(
+            (ref) => _RecordingSyncNotifier(
+              const SyncState(status: SyncStatus.syncing),
+            ),
+          ),
+        ],
+      );
+      expect(find.text('Syncing...'), findsOneWidget);
+      expect(find.text('Synced'), findsNothing);
+    });
+
+    // Issue #990: the chip's job is the sync itself, so tapping runs one
+    // rather than sending the user to a page to press another button.
+    testWidgets('tapping runs a sync instead of navigating', (tester) async {
+      final notifier = _RecordingSyncNotifier(const SyncState());
       final spy = await pumpStrip(
         tester,
-        const DashboardGauges(
-          gearGauges: [],
-          hasGear: true,
-          insurance: null,
-          noFlyStatus: null,
-          daysSinceLastDive: null,
-          syncEnabled: true,
-        ),
+        _syncGauges,
+        extraOverrides: [syncStateProvider.overrideWith((ref) => notifier)],
       );
+
       await tapChip(tester, 'Synced');
+
+      expect(notifier.syncCount, 1);
+      expect(spy.location, isNull);
+    });
+
+    testWidgets('a tap mid-sync does not queue a second run', (tester) async {
+      final notifier = _RecordingSyncNotifier(
+        const SyncState(status: SyncStatus.syncing),
+      );
+      await pumpStrip(
+        tester,
+        _syncGauges,
+        extraOverrides: [syncStateProvider.overrideWith((ref) => notifier)],
+      );
+
+      await tapChip(tester, 'Syncing...');
+
+      expect(notifier.syncCount, 0);
+    });
+
+    testWidgets('long-press still opens cloud sync settings', (tester) async {
+      final notifier = _RecordingSyncNotifier(const SyncState());
+      final spy = await pumpStrip(
+        tester,
+        _syncGauges,
+        extraOverrides: [syncStateProvider.overrideWith((ref) => notifier)],
+      );
+
+      await tester.longPress(
+        find.ancestor(of: find.text('Synced'), matching: find.byType(InkWell)),
+      );
+      await tester.pumpAndSettle();
+
       expect(spy.location, '/settings/cloud-sync');
+      expect(notifier.syncCount, 0);
     });
   });
 

--- a/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
+++ b/test/features/dashboard/presentation/widgets/gauge_strip_test.dart
@@ -914,11 +914,16 @@ void main() {
       expect(spy.location, isNull);
     });
 
-    testWidgets('a tap mid-sync does not queue a second run', (tester) async {
+    // Mid-sync the chip must not queue a second run, but it also must not go
+    // inert via a no-op callback: that still announces a tap action to
+    // assistive tech. It opens the page showing sync progress instead.
+    testWidgets('a tap mid-sync opens progress, not a second run', (
+      tester,
+    ) async {
       final notifier = _RecordingSyncNotifier(
         const SyncState(status: SyncStatus.syncing),
       );
-      await pumpStrip(
+      final spy = await pumpStrip(
         tester,
         _syncGauges,
         extraOverrides: [syncStateProvider.overrideWith((ref) => notifier)],
@@ -927,6 +932,7 @@ void main() {
       await tapChip(tester, 'Syncing...');
 
       expect(notifier.syncCount, 0);
+      expect(spy.location, '/settings/cloud-sync');
     });
 
     testWidgets('long-press still opens cloud sync settings', (tester) async {

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -655,6 +655,13 @@ void main() {
       await pumpPage(tester);
       expect(find.text('Duplicate diver profiles'), findsNothing);
     });
+
+    // Issue #990: SyncState's counts and cursor are otherwise only recomputed
+    // by a sync, so opening the page could report state from app launch.
+    testWidgets('refreshes sync state when opened', (tester) async {
+      final handles = await pumpPage(tester);
+      expect(handles.sync.refreshStateCalls, greaterThan(0));
+    });
   });
 
   group('CloudSyncPage - custom folder banner', () {

--- a/test/features/settings/presentation/providers/sync_pending_count_reactive_test.dart
+++ b/test/features/settings/presentation/providers/sync_pending_count_reactive_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -12,6 +14,22 @@ import '../../../../helpers/test_database.dart';
 /// Issue #990: with auto-sync OFF, editing dives left the Home "Synced" chip
 /// and the Cloud Sync page showing a launch-time count of zero for the whole
 /// session -- SyncState.pendingChanges was only ever recomputed by a sync.
+/// Holds each [getUnsyncedChangeCount] call open once [armed], so a test can
+/// choose the order the overlapping refreshes answer in. Before arming, calls
+/// resolve immediately so notifier construction and refreshState are unaffected.
+class _GatedSyncRepository extends SyncRepository {
+  bool armed = false;
+  final List<Completer<int>> gates = [];
+
+  @override
+  Future<int> getUnsyncedChangeCount({required String? providerId}) {
+    if (!armed) return Future.value(0);
+    final gate = Completer<int>();
+    gates.add(gate);
+    return gate.future;
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -107,6 +125,42 @@ void main() {
     await settleDebounce();
 
     expect(container.read(syncStateProvider).pendingChanges, 0);
+  });
+
+  test('a slow earlier refresh cannot overwrite a newer count', () async {
+    // The debounce cancels pending TIMERS, not an in-flight refresh: a write
+    // arriving while the queries run starts a second refresh alongside the
+    // first. If the slower earlier one published last, the chip would show a
+    // stale count until something else recomputed it.
+    final repo = _GatedSyncRepository();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+        syncRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+
+    repo.armed = true;
+    // Refresh A starts and blocks on its gate.
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+    // Refresh B starts alongside it.
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+    expect(repo.gates, hasLength(2));
+
+    // B (the newer caller) answers first, then A answers late with a lower,
+    // now-stale count.
+    repo.gates[1].complete(5);
+    await Future<void>.delayed(Duration.zero);
+    repo.gates[0].complete(1);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(syncStateProvider).pendingChanges, 5);
   });
 
   test('a disposed notifier does not refresh after its debounce', () async {

--- a/test/features/settings/presentation/providers/sync_pending_count_reactive_test.dart
+++ b/test/features/settings/presentation/providers/sync_pending_count_reactive_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+import '../../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Issue #990: with auto-sync OFF, editing dives left the Home "Synced" chip
+/// and the Cloud Sync page showing a launch-time count of zero for the whole
+/// session -- SyncState.pendingChanges was only ever recomputed by a sync.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+  late FakeCloudStorageProvider cloud;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    cloud = FakeCloudStorageProvider();
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(cloud),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(syncStateProvider);
+    await container.read(syncStateProvider.notifier).refreshState();
+    return container;
+  }
+
+  /// Past the notifier's 400ms coalescing window.
+  Future<void> settleDebounce() =>
+      Future<void>.delayed(const Duration(milliseconds: 700));
+
+  test('a local edit updates the count while auto-sync is OFF', () async {
+    final container = await makeContainer();
+    // The reporter's exact configuration, and the default.
+    expect(container.read(syncBehaviorProvider).autoSyncEnabled, isFalse);
+    expect(container.read(syncStateProvider).pendingChanges, 0);
+
+    await SyncRepository().markRecordPending(
+      entityType: 'dives',
+      recordId: 'dive-1',
+      localUpdatedAt: 1000,
+    );
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+
+    expect(container.read(syncStateProvider).pendingChanges, 1);
+  });
+
+  test('a local deletion updates the count', () async {
+    final container = await makeContainer();
+
+    await SyncRepository().logDeletion(entityType: 'dives', recordId: 'gone');
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+
+    expect(container.read(syncStateProvider).pendingChanges, 1);
+  });
+
+  test('a burst of edits coalesces into the settled total', () async {
+    final container = await makeContainer();
+    final repo = SyncRepository();
+
+    for (var i = 0; i < 5; i++) {
+      await repo.markRecordPending(
+        entityType: 'dives',
+        recordId: 'dive-$i',
+        localUpdatedAt: 1000,
+      );
+      SyncEventBus.notifyLocalChange();
+    }
+    await settleDebounce();
+
+    expect(container.read(syncStateProvider).pendingChanges, 5);
+  });
+
+  test('the count returns to zero once pending records clear', () async {
+    final container = await makeContainer();
+    final repo = SyncRepository();
+
+    await repo.markRecordPending(
+      entityType: 'dives',
+      recordId: 'dive-1',
+      localUpdatedAt: 1000,
+    );
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+    expect(container.read(syncStateProvider).pendingChanges, 1);
+
+    // What a successful publish does.
+    await repo.clearPendingRecords();
+    SyncEventBus.notifyLocalChange();
+    await settleDebounce();
+
+    expect(container.read(syncStateProvider).pendingChanges, 0);
+  });
+
+  test('a disposed notifier does not refresh after its debounce', () async {
+    final container = await makeContainer();
+    await SyncRepository().markRecordPending(
+      entityType: 'dives',
+      recordId: 'dive-1',
+      localUpdatedAt: 1000,
+    );
+    SyncEventBus.notifyLocalChange();
+    container.dispose();
+
+    // The pending timer must be cancelled in dispose; firing it would touch a
+    // disposed StateNotifier and throw.
+    await settleDebounce();
+  });
+}


### PR DESCRIPTION
Fixes #990.

## The bug

The Home "Synced" chip and the Cloud Sync page were never actually two disagreeing sources — they read the same `SyncState`, which nothing recomputed between syncs.

`SyncState.pendingChanges` is written only by `SyncNotifier.refreshState()`, which runs at notifier construction and after a sync. A dive edit fires `SyncEventBus.notifyLocalChange()`, but the notifier's only bus listener called `_scheduleAutoSync()` — which returns immediately when `autoSyncEnabled == false`, the default and the reporter's configuration. So `sync_records` filled with pending rows while the UI kept rendering the launch-time count of zero, i.e. "Synced", for the whole session.

## Changes

**Reactive count.** The bus listener now also schedules a debounced count refresh regardless of the auto-sync setting. It is deliberately narrower than `refreshState()`: no `isSyncAvailable()` network probe and no `status`/`message` write, because it runs on every local write. Debounced 400ms (a bulk edit marks dozens of records in one burst) and skipped while a sync is in flight, so the sync's own post-sync refresh lands the settled number.

**Deletions count too.** Deletions never touch `sync_records`, so a delete-only change set reported zero pending. Counting the whole deletion log would be wrong in the other direction: tombstones survive publication and are only removed by the fleet-acked GC (`clearAcknowledgedDeletions`), so the chip would be pinned to "N unsynced" forever. The new count filters on the active provider's `publishedHlcHigh` — the same predicate the changeset writer uses — so the number on screen is what a sync would actually send. `getPendingCount()` also moved to a real `COUNT(*)` now that it is on a hot path.

**Cloud Sync page.** Refreshes state when opened (it was a `ConsumerWidget` with no refresh hook, so entering the page recomputed nothing). Its hardcoded English — "Last synced:", "N pending changes", the relative-time strings, and the status titles — now uses the localized keys that already existed in all 12 ARBs but had never been wired up. No new ARB keys were needed.

**Tap to sync.** The Home sync chip runs a sync on tap rather than navigating; long-press still opens `/settings/cloud-sync`. It calls a shared `runSyncNow()` extracted from `CloudSyncPage`, not `performSync()` directly, so the replaced-library and first-contact confirmation gates still apply — the first-contact gate guards an irreversible merge of two libraries and must not be bypassable by whichever surface the user tapped. The chip is inert mid-sync and shows "Syncing...".

## Testing

New: `sync_repository_pending_count_test.dart` (watermark filtering, null-hlc tombstones, per-provider scoping, delete-only change sets) and `sync_pending_count_reactive_test.dart` (count updates with auto-sync **off**, burst coalescing, return to zero, timer cancelled on dispose). Updated `gauge_strip_test.dart` for the new tap contract and added a refresh-on-open assertion to `cloud_sync_page_test.dart`.

Each new behavioral test was verified to fail with the production change reverted. 1894 tests pass across the dashboard, settings, repository, sync-service and router suites; `flutter analyze` and `dart format` are clean.

## Note

Not included: a ticker to keep "3 hours ago" counting up while the page sits open. It is real but cosmetic, and rebuilding the page every second to fix it is a bad trade.
