### PR TITLE
fix(selection): anchor shift and modifier clicks on the highlighted row

### DIFF
--- a/lib/features/buddies/presentation/widgets/buddy_list_content.dart
+++ b/lib/features/buddies/presentation/widgets/buddy_list_content.dart
@@ -155,11 +155,16 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
   }
 
   /// Enter selection mode implicitly, from a long-press or modifier-click.
-  void _enterSelectionMode(String? initialId) {
+  ///
+  /// Clearing the highlight keeps the detail pane from arguing with the bulk
+  /// selection about what the row means: a row left highlighted but unchecked
+  /// reads as selected while no bulk action would touch it.
+  void _enterSelectionMode(String? initialId, {String? seedId}) {
+    ref.read(highlightedBuddyIdProvider.notifier).state = null;
     if (initialId == null) {
       _selection.enterExplicit();
     } else {
-      _selection.enterImplicit(initialId);
+      _selection.enterImplicit(initialId, seedId: seedId);
     }
   }
 
@@ -167,18 +172,46 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
 
   void _toggleSelection(String id) => _selection.toggle(id);
 
+  /// Select the contiguous span from the anchor buddy to [targetId].
+  ///
+  /// With no anchor yet, the highlighted row is the origin, matching Finder.
+  void _selectRangeTo(String targetId, List<String> orderedIds) {
+    _selection.extendTo(
+      targetId,
+      orderedIds,
+      fallbackAnchorId: ref.read(highlightedBuddyIdProvider),
+    );
+  }
+
+  /// Cmd/Ctrl-click [id], carrying the highlighted buddy into the selection.
+  ///
+  /// Outside selection mode the highlighted row is what the user sees as
+  /// selected, so a modifier-click adds to it rather than replacing it. A
+  /// highlight that filtering has pushed out of [orderedIds] is ignored, so
+  /// the count can never include a buddy that is not on screen.
+  void _modifierTap(String id, List<String> orderedIds) {
+    final highlighted = ref.read(highlightedBuddyIdProvider);
+    _enterSelectionMode(
+      id,
+      seedId: highlighted != null && orderedIds.contains(highlighted)
+          ? highlighted
+          : null,
+    );
+  }
+
   /// One tap policy for every buddy row, in every view mode.
   ///
   /// A held modifier turns a tap into an implicit entry, so desktop users
-  /// never have to discover long-press.
+  /// never have to discover long-press. Shift extends from the anchor,
+  /// falling back to the highlighted row.
   void _handleRowTap(String id, List<BuddyWithDiveCount> buddies) {
     final orderedIds = buddies.map((b) => b.buddy.id).toList();
     if (SelectableListScope.isShiftPressed()) {
-      _selection.extendTo(id, orderedIds);
+      _selectRangeTo(id, orderedIds);
       return;
     }
     if (SelectableListScope.isModifierPressed()) {
-      _selection.enterImplicit(id);
+      _modifierTap(id, orderedIds);
       return;
     }
     if (_isSelectionMode) {
@@ -522,17 +555,39 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
     BuildContext context,
     AsyncValue<List<BuddyWithDiveCount>> buddiesAsync,
   ) {
-    final tableContent = _buildTableView(context, buddiesAsync);
+    final loadedBuddies =
+        buddiesAsync.valueOrNull ?? const <BuddyWithDiveCount>[];
+    final visibleIds = loadedBuddies.map((b) => b.buddy.id).toList();
 
-    if (_isSelectionMode) {
-      return Column(
-        children: [
-          _buildCompactSelectionAppBar(context, buddiesAsync.valueOrNull ?? []),
-          Expanded(child: tableContent),
-        ],
-      );
-    }
-    return tableContent;
+    // Same pruning the list path does: drop checked buddies that fell out of
+    // the visible list, so the count always matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) {
+          final tableContent = _buildTableView(context, buddiesAsync);
+
+          if (selection.isActive) {
+            return Column(
+              children: [
+                _buildCompactSelectionAppBar(context, loadedBuddies),
+                Expanded(child: tableContent),
+              ],
+            );
+          }
+          return tableContent;
+        },
+      ),
+    );
   }
 
   /// Build the [EntityTableView] for buddy table mode.
@@ -567,12 +622,27 @@ class _BuddyListContentState extends ConsumerState<BuddyListContent> {
           onSortFieldChanged: notifier.setSortField,
           onResizeColumn: notifier.resizeColumn,
           onEntityTapDown: (id) {
-            if (!_isSelectionMode) {
-              ref.read(highlightedBuddyIdProvider.notifier).state = id;
+            // Rows carry a double-tap, so onEntityTap only resolves after the
+            // double-tap timer -- long after this fires. A modified click is a
+            // selection gesture, not a navigation one: moving the highlight
+            // here would overwrite the very anchor the shift-click is about to
+            // extend from.
+            if (_isSelectionMode ||
+                SelectableListScope.isShiftPressed() ||
+                SelectableListScope.isModifierPressed()) {
+              return;
             }
+            ref.read(highlightedBuddyIdProvider.notifier).state = id;
           },
           onEntityTap: (id) {
-            if (_isSelectionMode) {
+            // Table mode honours modifier and shift clicks too, so selection
+            // works the same way as in the list view modes.
+            final orderedIds = buddyRecords.map((b) => b.buddy.id).toList();
+            if (SelectableListScope.isShiftPressed()) {
+              _selectRangeTo(id, orderedIds);
+            } else if (SelectableListScope.isModifierPressed()) {
+              _modifierTap(id, orderedIds);
+            } else if (_isSelectionMode) {
               _toggleSelection(id);
             }
           },

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -345,9 +345,28 @@ class _CertificationListContentState
     BuildContext context,
     AsyncValue<List<Certification>> certificationsAsync,
   ) {
-    final tableContent = _buildTableView(context, certificationsAsync);
+    final visibleIds = (certificationsAsync.value ?? const <Certification>[])
+        .map((c) => c.id)
+        .toList();
 
-    return tableContent;
+    // Same pruning the list path does: drop checked certifications that fell
+    // out of the visible list, so the count matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) =>
+            _buildTableView(context, certificationsAsync),
+      ),
+    );
   }
 
   /// Build the [EntityTableView] for certification table mode.

--- a/lib/features/courses/presentation/widgets/course_list_content.dart
+++ b/lib/features/courses/presentation/widgets/course_list_content.dart
@@ -324,9 +324,29 @@ class _CourseListContentState extends ConsumerState<CourseListContent> {
     BuildContext context,
     AsyncValue<List<Course>> coursesAsync,
   ) {
-    final tableContent = _buildTableView(context, coursesAsync);
+    // The table renders the raw list, not the status-filtered one the list
+    // modes render, so selectable ids come from the raw list here -- pruning
+    // must follow whichever path is on screen.
+    final visibleIds = (coursesAsync.value ?? const <Course>[])
+        .map((c) => c.id)
+        .toList();
 
-    return tableContent;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) =>
+            _buildTableView(context, coursesAsync),
+      ),
+    );
   }
 
   /// Build the [EntityTableView] for course table mode.

--- a/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_list_content.dart
@@ -398,9 +398,28 @@ class _DiveCenterListContentState extends ConsumerState<DiveCenterListContent> {
     BuildContext context,
     AsyncValue<List<DiveCenter>> centersAsync,
   ) {
-    final tableContent = _buildTableView(context, centersAsync);
+    final visibleIds = (centersAsync.value ?? const <DiveCenter>[])
+        .map((c) => c.id)
+        .toList();
 
-    return tableContent;
+    // Same pruning the list path does: drop checked centers that fell out of
+    // the visible list, so the count matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) =>
+            _buildTableView(context, centersAsync),
+      ),
+    );
   }
 
   /// Build the [EntityTableView] for dive center table mode.

--- a/lib/features/dive_log/presentation/widgets/dive_list_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_list_content.dart
@@ -226,13 +226,29 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   ///
   /// Clearing the highlight keeps the detail pane from arguing with the bulk
   /// selection about what the row means.
-  void _enterSelectionMode(String? initialId) {
+  void _enterSelectionMode(String? initialId, {String? seedId}) {
     ref.read(highlightedDiveIdProvider.notifier).state = null;
     if (initialId == null) {
       _selection.enterExplicit();
     } else {
-      _selection.enterImplicit(initialId);
+      _selection.enterImplicit(initialId, seedId: seedId);
     }
+  }
+
+  /// Cmd/Ctrl-click [id], carrying the highlighted dive into the selection.
+  ///
+  /// Outside selection mode the highlighted row is what the user sees as
+  /// selected, so a modifier-click adds to it rather than replacing it. A
+  /// highlight that filtering has pushed out of [orderedIds] is ignored, so
+  /// the count can never include a dive that is not on screen.
+  void _modifierTap(String id, List<String> orderedIds) {
+    final highlighted = ref.read(highlightedDiveIdProvider);
+    _enterSelectionMode(
+      id,
+      seedId: highlighted != null && orderedIds.contains(highlighted)
+          ? highlighted
+          : null,
+    );
   }
 
   void _exitSelectionMode() => _selection.exit();
@@ -661,7 +677,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
       return;
     }
     if (SelectableListScope.isModifierPressed()) {
-      _enterSelectionMode(id);
+      _modifierTap(id, dives.map((d) => d.id).toList());
       return;
     }
     // No-op when the id is gone. A stale tap callback firing after the list
@@ -1204,23 +1220,43 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
   /// The outer Scaffold, profile panel, map, and column settings are all
   /// managed by [TableModeLayout].
   Widget _buildTableModeScaffold(BuildContext context, DiveFilterState filter) {
-    final content = _buildTableView(context, filter);
+    // Pass the real dive list, not an empty one. Passing const [] made
+    // select-all vanish and select-by-date-range select nothing whenever the
+    // list was in table mode.
+    final tableDives = ref.watch(allDivesForTableProvider).value ?? const [];
+    final visibleIds = tableDives.map((d) => d.id).toList();
 
-    if (_isSelectionMode) {
-      // Pass the real dive list, not an empty one. Passing const [] made
-      // select-all vanish and select-by-date-range select nothing whenever
-      // the list was in table mode.
-      final tableDives = ref.read(allDivesForTableProvider).value ?? const [];
-      return Column(
-        children: [
-          _buildSelectionBar(
-            tableDives.map((d) => DiveSummary.fromDive(d)).toList(),
-          ),
-          Expanded(child: content),
-        ],
-      );
-    }
-    return content;
+    // Same pruning the list path does: drop checked dives that fell out of
+    // the visible list, so the count always matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) {
+          final content = _buildTableView(context, filter);
+
+          if (selection.isActive) {
+            return Column(
+              children: [
+                _buildSelectionBar(
+                  tableDives.map((d) => DiveSummary.fromDive(d)).toList(),
+                ),
+                Expanded(child: content),
+              ],
+            );
+          }
+          return content;
+        },
+      ),
+    );
   }
 
   /// Build the DiveTableView widget from the full-Dive provider.
@@ -1241,9 +1277,17 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
               child: DiveTableView(
                 dives: dives,
                 onDiveTapDown: (id) {
-                  if (!_isSelectionMode) {
-                    ref.read(highlightedDiveIdProvider.notifier).state = id;
+                  // Rows carry a double-tap, so onDiveTap only resolves after
+                  // the double-tap timer -- long after this fires. A modified
+                  // click is a selection gesture, not a navigation one:
+                  // moving the highlight here would overwrite the very anchor
+                  // the shift-click is about to extend from.
+                  if (_isSelectionMode ||
+                      SelectableListScope.isShiftPressed() ||
+                      SelectableListScope.isModifierPressed()) {
+                    return;
                   }
+                  ref.read(highlightedDiveIdProvider.notifier).state = id;
                 },
                 onDiveTap: (id) {
                   // Table mode now honours modifier and shift clicks too, so
@@ -1254,7 +1298,7 @@ class _DiveListContentState extends ConsumerState<DiveListContent> {
                   if (SelectableListScope.isShiftPressed()) {
                     _selectRangeTo(id, summaries);
                   } else if (SelectableListScope.isModifierPressed()) {
-                    _enterSelectionMode(id);
+                    _modifierTap(id, summaries.map((d) => d.id).toList());
                   } else if (_isSelectionMode) {
                     _toggleSelection(id);
                   }

--- a/lib/features/dive_sites/presentation/widgets/site_list_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_list_content.dart
@@ -177,11 +177,16 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
   }
 
   /// Enter selection mode implicitly, from a long-press or modifier-click.
-  void _enterSelectionMode(String? initialId) {
+  ///
+  /// Clearing the highlight keeps the detail pane from arguing with the bulk
+  /// selection about what the row means: a row left highlighted but unchecked
+  /// reads as selected while no bulk action would touch it.
+  void _enterSelectionMode(String? initialId, {String? seedId}) {
+    ref.read(highlightedSiteIdProvider.notifier).state = null;
     if (initialId == null) {
       _selection.enterExplicit();
     } else {
-      _selection.enterImplicit(initialId);
+      _selection.enterImplicit(initialId, seedId: seedId);
     }
   }
 
@@ -189,18 +194,46 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
 
   void _toggleSelection(String id) => _selection.toggle(id);
 
+  /// Select the contiguous span from the anchor site to [targetId].
+  ///
+  /// With no anchor yet, the highlighted row is the origin, matching Finder.
+  void _selectRangeTo(String targetId, List<String> orderedIds) {
+    _selection.extendTo(
+      targetId,
+      orderedIds,
+      fallbackAnchorId: ref.read(highlightedSiteIdProvider),
+    );
+  }
+
+  /// Cmd/Ctrl-click [id], carrying the highlighted site into the selection.
+  ///
+  /// Outside selection mode the highlighted row is what the user sees as
+  /// selected, so a modifier-click adds to it rather than replacing it. A
+  /// highlight that filtering has pushed out of [orderedIds] is ignored, so
+  /// the count can never include a site that is not on screen.
+  void _modifierTap(String id, List<String> orderedIds) {
+    final highlighted = ref.read(highlightedSiteIdProvider);
+    _enterSelectionMode(
+      id,
+      seedId: highlighted != null && orderedIds.contains(highlighted)
+          ? highlighted
+          : null,
+    );
+  }
+
   /// One tap policy for every site row, in every view mode.
   ///
   /// A held modifier turns a tap into an implicit entry, so desktop users
-  /// never have to discover long-press.
+  /// never have to discover long-press. Shift extends from the anchor,
+  /// falling back to the highlighted row.
   void _handleRowTap(String id, List<SiteWithDiveCount> sites) {
     final orderedIds = sites.map((s) => s.site.id).toList();
     if (SelectableListScope.isShiftPressed()) {
-      _selection.extendTo(id, orderedIds);
+      _selectRangeTo(id, orderedIds);
       return;
     }
     if (SelectableListScope.isModifierPressed()) {
-      _selection.enterImplicit(id);
+      _modifierTap(id, orderedIds);
       return;
     }
     if (_isSelectionMode) {
@@ -547,17 +580,38 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
     AsyncValue<List<SiteWithDiveCount>> sitesAsync,
     SiteFilterState filter,
   ) {
-    final tableContent = _buildTableView(context, sitesAsync, filter);
+    final loadedSites = sitesAsync.valueOrNull ?? const <SiteWithDiveCount>[];
+    final visibleIds = loadedSites.map((s) => s.site.id).toList();
 
-    if (_isSelectionMode) {
-      return Column(
-        children: [
-          _buildCompactSelectionAppBar(context, sitesAsync.valueOrNull ?? []),
-          Expanded(child: tableContent),
-        ],
-      );
-    }
-    return tableContent;
+    // Same pruning the list path does: drop checked sites that fell out of
+    // the visible list, so the count always matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) {
+          final tableContent = _buildTableView(context, sitesAsync, filter);
+
+          if (selection.isActive) {
+            return Column(
+              children: [
+                _buildCompactSelectionAppBar(context, loadedSites),
+                Expanded(child: tableContent),
+              ],
+            );
+          }
+          return tableContent;
+        },
+      ),
+    );
   }
 
   /// Build the [EntityTableView] for site table mode.
@@ -598,12 +652,27 @@ class _SiteListContentState extends ConsumerState<SiteListContent> {
                 onSortFieldChanged: notifier.setSortField,
                 onResizeColumn: notifier.resizeColumn,
                 onEntityTapDown: (id) {
-                  if (!_isSelectionMode) {
-                    ref.read(highlightedSiteIdProvider.notifier).state = id;
+                  // Rows carry a double-tap, so onEntityTap only resolves
+                  // after the double-tap timer -- long after this fires. A
+                  // modified click is a selection gesture, not a navigation
+                  // one: moving the highlight here would overwrite the very
+                  // anchor the shift-click is about to extend from.
+                  if (_isSelectionMode ||
+                      SelectableListScope.isShiftPressed() ||
+                      SelectableListScope.isModifierPressed()) {
+                    return;
                   }
+                  ref.read(highlightedSiteIdProvider.notifier).state = id;
                 },
                 onEntityTap: (id) {
-                  if (_isSelectionMode) {
+                  // Table mode honours modifier and shift clicks too, so
+                  // selection works the same way as in the list view modes.
+                  final orderedIds = siteRecords.map((s) => s.site.id).toList();
+                  if (SelectableListScope.isShiftPressed()) {
+                    _selectRangeTo(id, orderedIds);
+                  } else if (SelectableListScope.isModifierPressed()) {
+                    _modifierTap(id, orderedIds);
+                  } else if (_isSelectionMode) {
                     _toggleSelection(id);
                   }
                 },

--- a/lib/features/equipment/presentation/widgets/equipment_list_content.dart
+++ b/lib/features/equipment/presentation/widgets/equipment_list_content.dart
@@ -447,14 +447,32 @@ class _EquipmentListContentState extends ConsumerState<EquipmentListContent> {
     BuildContext context,
     AsyncValue<List<EquipmentItem>> equipmentAsync,
   ) {
-    final tableContent = _buildTableView(context, equipmentAsync);
+    final visibleIds = (equipmentAsync.value ?? const <EquipmentItem>[])
+        .map((e) => e.id)
+        .toList();
 
-    return Column(
-      children: [
-        if (widget.headerExtension != null) widget.headerExtension!,
-        _buildFilterChips(context),
-        Expanded(child: tableContent),
-      ],
+    // Same pruning the list path does: drop checked items that fell out of
+    // the visible list, so the count always matches what is on screen.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _selection.pruneTo(visibleIds);
+    });
+
+    // The scope carries Escape, Ctrl/Cmd-A and the Android back handling, and
+    // the builder is what repaints the table as checks change -- the table is
+    // built inside it for that reason.
+    return SelectableListScope(
+      controller: _selection,
+      selectableIds: visibleIds,
+      child: ValueListenableBuilder<SelectionState>(
+        valueListenable: _selection,
+        builder: (context, selection, _) => Column(
+          children: [
+            if (widget.headerExtension != null) widget.headerExtension!,
+            _buildFilterChips(context),
+            Expanded(child: _buildTableView(context, equipmentAsync)),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -358,7 +358,6 @@ class _TripListContentState extends ConsumerState<TripListContent> {
     AsyncValue<List<TripWithStats>> tripsAsync,
     TripFilterState filter,
   ) {
-    final tableContent = _buildTableView(context, tripsAsync, filter);
     final loadedTrips = tripsAsync.value ?? const <TripWithStats>[];
     final visibleIds = loadedTrips.map((t) => t.trip.id).toList();
 
@@ -371,14 +370,21 @@ class _TripListContentState extends ConsumerState<TripListContent> {
       selectableIds: visibleIds,
       child: ValueListenableBuilder<SelectionState>(
         valueListenable: _selection,
-        builder: (context, selection, _) => selection.isActive
-            ? Column(
-                children: [
-                  _buildSelectionBar(loadedTrips, SelectionBarShell.pane),
-                  Expanded(child: tableContent),
-                ],
-              )
-            : tableContent,
+        builder: (context, selection, _) {
+          // Built inside the builder so the table's own rows re-render as
+          // checks change; building it outside left them on a stale
+          // selectedIds while only the bar updated.
+          final tableContent = _buildTableView(context, tripsAsync, filter);
+
+          return selection.isActive
+              ? Column(
+                  children: [
+                    _buildSelectionBar(loadedTrips, SelectionBarShell.pane),
+                    Expanded(child: tableContent),
+                  ],
+                )
+              : tableContent;
+        },
       ),
     );
   }

--- a/lib/shared/selection/selection_controller.dart
+++ b/lib/shared/selection/selection_controller.dart
@@ -45,13 +45,20 @@ class SelectionController extends ValueNotifier<SelectionState> {
 
   /// Enter selection mode as a side effect of long-press or modifier-click,
   /// checking [id]. Behaves as [toggle] when the mode is already active.
-  void enterImplicit(String id) {
+  ///
+  /// [seedId] is checked alongside [id] on entry: the row the surface was
+  /// already showing as current -- the highlighted row backing the detail
+  /// pane -- so a modifier-click adds to what the user sees selected instead
+  /// of discarding it, matching Finder. The anchor is still [id], so a
+  /// following shift-click extends from the row just clicked. Ignored once
+  /// the mode is active, where the checked set already holds the intent.
+  void enterImplicit(String id, {String? seedId}) {
     if (value.isActive) {
       toggle(id);
       return;
     }
     value = SelectionState(
-      checkedIds: {id},
+      checkedIds: {?seedId, id},
       isActive: true,
       enteredExplicitly: false,
       anchorId: id,

--- a/test/features/buddies/presentation/widgets/buddy_list_content_test.dart
+++ b/test/features/buddies/presentation/widgets/buddy_list_content_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -533,6 +535,109 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(pushedPath, '/buddies/b1');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Modifier and shift clicks seeded by the highlighted row.
+  //
+  // A plain click highlights a buddy without checking it, so the highlight is
+  // the user's on-screen selection. Shift and Cmd/Ctrl clicks must both treat
+  // it as the origin, the way the dive and site lists do.
+  // ---------------------------------------------------------------------------
+
+  group('selection seeded by the highlighted buddy', () {
+    List<BuddyWithDiveCount> fourBuddies() => [
+      _makeBuddy(id: 'b1', name: 'Aaa Buddy'),
+      _makeBuddy(id: 'b2', name: 'Bbb Buddy'),
+      _makeBuddy(id: 'b3', name: 'Ccc Buddy'),
+      _makeBuddy(id: 'b4', name: 'Ddd Buddy'),
+    ];
+
+    // Cmd on macOS, Control elsewhere -- mirrors
+    // SelectableListScope.isModifierPressed so this passes on the macOS dev
+    // machine and the Linux CI runner alike.
+    final modifierKey = defaultTargetPlatform == TargetPlatform.macOS
+        ? LogicalKeyboardKey.metaLeft
+        : LogicalKeyboardKey.controlLeft;
+
+    Future<DenseBuddyListTile Function(String)> pumpList(
+      WidgetTester tester,
+    ) async {
+      final overrides = await _buildPhoneOverrides(
+        buddies: fourBuddies(),
+        viewMode: ListViewMode.dense,
+        highlightedBuddyId: 'b2',
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const BuddyListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      return (String name) => tester
+          .widgetList<DenseBuddyListTile>(find.byType(DenseBuddyListTile))
+          .firstWhere((t) => t.buddy.name == name);
+    }
+
+    testWidgets('shift-tap extends from the highlighted buddy', (tester) async {
+      final tile = await pumpList(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.tap(find.text('Ddd Buddy'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(tile('Aaa Buddy').isChecked, isFalse);
+      expect(tile('Bbb Buddy').isChecked, isTrue);
+      expect(tile('Ccc Buddy').isChecked, isTrue);
+      expect(tile('Ddd Buddy').isChecked, isTrue);
+    });
+
+    testWidgets('modifier-tap checks the highlighted buddy too', (
+      tester,
+    ) async {
+      final tile = await pumpList(tester);
+
+      await tester.sendKeyDownEvent(modifierKey);
+      await tester.tap(find.text('Ddd Buddy'));
+      await tester.sendKeyUpEvent(modifierKey);
+      await tester.pumpAndSettle();
+
+      expect(tile('Bbb Buddy').isChecked, isTrue);
+      expect(tile('Ddd Buddy').isChecked, isTrue);
+      expect(tile('Aaa Buddy').isChecked, isFalse);
+      expect(tile('Ccc Buddy').isChecked, isFalse);
+    });
+
+    // Table rows carry an onDoubleTap, so onTap only resolves once the
+    // double-tap timer expires. The modifier has to stay held across that
+    // wait, because the handler reads the keyboard when the tap fires.
+    testWidgets('table mode: shift-tap extends from the tapped row', (
+      tester,
+    ) async {
+      final overrides = await _buildOverrides(buddies: fourBuddies());
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const BuddyListContent(showAppBar: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Aaa Buddy'));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.tap(find.text('Ccc Buddy'));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(find.text('3 selected'), findsOneWidget);
     });
   });
 }

--- a/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_list_content_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1092,6 +1093,97 @@ void main() {
         expect(tile('d2').isChecked, isFalse);
       },
     );
+
+    // Table rows carry an onDoubleTap, so onDiveTap only resolves once the
+    // double-tap timer expires, and the modifier has to stay held across that
+    // wait. The tap-down handler must not move the highlight in the meantime:
+    // that highlight is the anchor the shift-click extends from.
+    testWidgets('table mode: shift-tap extends from the tapped row', (
+      tester,
+    ) async {
+      final dives = fourDives();
+      final base = await getBaseOverrides();
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            ...base,
+            diveListViewModeProvider.overrideWith((ref) => ListViewMode.table),
+            highlightedDiveIdProvider.overrideWith((ref) => null),
+            allDivesForTableProvider.overrideWithValue(AsyncValue.data(dives)),
+            tableViewConfigProvider.overrideWith(
+              (ref) => _TestTableConfigNotifier(
+                TableViewConfig(
+                  columns: [
+                    TableColumnConfig(
+                      field: DiveField.siteName,
+                      isPinned: true,
+                    ),
+                    TableColumnConfig(field: DiveField.maxDepth),
+                  ],
+                ),
+              ),
+            ),
+          ],
+          child: const DiveListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Plain tap highlights the first row. Settle past the double-tap window
+      // so the next tap is not read as a double-tap.
+      await tester.tap(find.text('Aaa'));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.tap(find.text('Ccc'));
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(find.text('3 selected'), findsOneWidget);
+    });
+
+    testWidgets('modifier-tap checks the highlighted dive too', (tester) async {
+      // Cmd on macOS, Control elsewhere -- mirrors
+      // SelectableListScope.isModifierPressed so this passes on the macOS dev
+      // machine and the Linux CI runner alike.
+      final modifierKey = defaultTargetPlatform == TargetPlatform.macOS
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft;
+
+      final overrides = await _buildPhoneOverrides(
+        dives: fourDives(),
+        viewMode: ListViewMode.compact,
+        highlightedDiveId: 'd2',
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const DiveListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      CompactDiveListTile tile(String id) => tester
+          .widgetList<CompactDiveListTile>(find.byType(CompactDiveListTile))
+          .firstWhere((t) => t.diveId == id);
+      Finder tileFinder(String id) => find.byWidgetPredicate(
+        (w) => w is CompactDiveListTile && w.diveId == id,
+      );
+
+      await tester.sendKeyDownEvent(modifierKey);
+      await tester.tap(tileFinder('d4'));
+      await tester.sendKeyUpEvent(modifierKey);
+      await tester.pumpAndSettle();
+
+      // The highlighted row was the user's on-screen selection, so it joins
+      // the checked set rather than vanishing.
+      expect(tile('d2').isChecked, isTrue);
+      expect(tile('d4').isChecked, isTrue);
+      expect(tile('d1').isChecked, isFalse);
+      expect(tile('d3').isChecked, isFalse);
+    });
 
     testWidgets('compact view: long-press enters selection and tap toggles', (
       tester,

--- a/test/features/dive_sites/presentation/widgets/site_list_content_table_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_content_table_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -300,6 +302,132 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(pushedPath, '/sites/s1');
+    });
+
+    // Table mode used to ignore both modifiers, so the only way into a
+    // multi-row selection was long-press then tap. These drive the real
+    // gesture sequence: a plain tap highlights the row, then a modified tap
+    // on a later row builds the selection from it.
+    group('modifier clicks', () {
+      // Cmd on macOS, Control elsewhere -- mirrors
+      // SelectableListScope.isModifierPressed so this passes on the macOS dev
+      // machine and the Linux CI runner alike.
+      final modifierKey = defaultTargetPlatform == TargetPlatform.macOS
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft;
+
+      Future<void> pumpFourSites(WidgetTester tester) async {
+        final overrides = await _buildOverrides(
+          sites: [
+            _makeSite(id: 's1', name: 'Blue Hole'),
+            _makeSite(id: 's2', name: 'Coral Garden'),
+            _makeSite(id: 's3', name: 'Shark Point'),
+            _makeSite(id: 's4', name: 'Turtle Bay'),
+          ],
+        );
+        await tester.pumpWidget(
+          testApp(
+            overrides: overrides,
+            child: const SiteListContent(showAppBar: true),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Plain tap highlights the row without checking it. Settle past the
+        // double-tap window so the next tap is not read as a double-tap.
+        await tester.tap(find.text('Blue Hole'));
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pumpAndSettle();
+      }
+
+      // Table rows carry an onDoubleTap, so onTap only resolves once the
+      // double-tap timer expires. The modifier has to stay held across that
+      // wait, because the handler reads the keyboard when the tap fires.
+      Future<void> tapRowWithKey(
+        WidgetTester tester,
+        String rowText,
+        LogicalKeyboardKey key,
+      ) async {
+        await tester.sendKeyDownEvent(key);
+        await tester.tap(find.text(rowText));
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.sendKeyUpEvent(key);
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('shift-tap selects the span from the highlighted row', (
+        tester,
+      ) async {
+        await pumpFourSites(tester);
+
+        await tapRowWithKey(
+          tester,
+          'Shark Point',
+          LogicalKeyboardKey.shiftLeft,
+        );
+
+        expect(find.text('3 selected'), findsOneWidget);
+      });
+
+      testWidgets('modifier-tap checks the highlighted row too', (
+        tester,
+      ) async {
+        await pumpFourSites(tester);
+
+        await tapRowWithKey(tester, 'Shark Point', modifierKey);
+
+        expect(find.text('2 selected'), findsOneWidget);
+      });
+    });
+
+    // Table mode used to return before the SelectableListScope wrapper, so it
+    // had no keyboard handling at all: the only way out of selection mode was
+    // the bar's close button.
+    group('keyboard handling', () {
+      final selectAllKey = defaultTargetPlatform == TargetPlatform.macOS
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft;
+
+      Future<void> pumpThreeSitesInSelection(WidgetTester tester) async {
+        final overrides = await _buildOverrides(
+          sites: [
+            _makeSite(id: 's1', name: 'Blue Hole'),
+            _makeSite(id: 's2', name: 'Coral Garden'),
+            _makeSite(id: 's3', name: 'Shark Point'),
+          ],
+        );
+        await tester.pumpWidget(
+          testApp(
+            overrides: overrides,
+            child: const SiteListContent(showAppBar: true),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.text('Blue Hole'));
+        await tester.pumpAndSettle();
+        expect(find.text('1 selected'), findsOneWidget);
+      }
+
+      testWidgets('Escape exits selection mode', (tester) async {
+        await pumpThreeSitesInSelection(tester);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+        await tester.pumpAndSettle();
+
+        expect(find.text('1 selected'), findsNothing);
+      });
+
+      testWidgets('Ctrl/Cmd-A checks every visible row', (tester) async {
+        await pumpThreeSitesInSelection(tester);
+
+        await tester.sendKeyDownEvent(selectAllKey);
+        await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+        await tester.sendKeyUpEvent(selectAllKey);
+        await tester.pumpAndSettle();
+
+        expect(find.text('3 selected'), findsOneWidget);
+      });
     });
   });
 }

--- a/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
+++ b/test/features/dive_sites/presentation/widgets/site_list_content_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -859,6 +861,119 @@ void main() {
         expect(find.byType(FlutterMap), findsWidgets);
       },
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Modifier and shift clicks seeded by the highlighted row.
+  //
+  // A plain click highlights a site without checking it, so the highlight is
+  // the user's on-screen selection. Shift and Cmd/Ctrl clicks must both treat
+  // it as the origin, the way the dive list does.
+  // ---------------------------------------------------------------------------
+
+  group('selection seeded by the highlighted site', () {
+    List<SiteWithDiveCount> fourSites() => [
+      _makeSite(id: 's1', name: 'Alpha Site'),
+      _makeSite(id: 's2', name: 'Bravo Site'),
+      _makeSite(id: 's3', name: 'Charlie Site'),
+      _makeSite(id: 's4', name: 'Delta Site'),
+    ];
+
+    // Cmd on macOS, Control elsewhere -- mirrors
+    // SelectableListScope.isModifierPressed so the test passes on both the
+    // macOS dev machine and the Linux CI runner.
+    final modifierKey = defaultTargetPlatform == TargetPlatform.macOS
+        ? LogicalKeyboardKey.metaLeft
+        : LogicalKeyboardKey.controlLeft;
+
+    Future<CompactSiteListTile Function(String)> pumpList(
+      WidgetTester tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      final overrides = await _buildPhoneOverrides(
+        sites: fourSites(),
+        viewMode: ListViewMode.compact,
+        highlightedSiteId: 's2',
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const SiteListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      return (String name) => tester
+          .widgetList<CompactSiteListTile>(find.byType(CompactSiteListTile))
+          .firstWhere((t) => t.name == name);
+    }
+
+    testWidgets('shift-tap extends from the highlighted site', (tester) async {
+      final tile = await pumpList(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.tap(find.text('Delta Site'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pumpAndSettle();
+
+      expect(tile('Alpha Site').isSelected, isFalse);
+      expect(tile('Bravo Site').isSelected, isTrue);
+      expect(tile('Charlie Site').isSelected, isTrue);
+      expect(tile('Delta Site').isSelected, isTrue);
+    });
+
+    testWidgets('modifier-tap checks the highlighted site too', (tester) async {
+      final tile = await pumpList(tester);
+
+      await tester.sendKeyDownEvent(modifierKey);
+      await tester.tap(find.text('Delta Site'));
+      await tester.sendKeyUpEvent(modifierKey);
+      await tester.pumpAndSettle();
+
+      expect(tile('Bravo Site').isSelected, isTrue);
+      expect(tile('Delta Site').isSelected, isTrue);
+      expect(tile('Alpha Site').isSelected, isFalse);
+      expect(tile('Charlie Site').isSelected, isFalse);
+    });
+
+    // Detailed mode paints the highlight through SiteListTile.isSelected,
+    // which -- unlike the compact and dense tiles -- is not gated on being
+    // outside selection mode. A highlight left set there is what the user
+    // sees as "highlighted, but not selected".
+    testWidgets('detailed view leaves no highlighted-but-unchecked row', (
+      tester,
+    ) async {
+      _setMobileTestSurfaceSize(tester);
+      final overrides = await _buildPhoneOverrides(
+        sites: fourSites(),
+        viewMode: ListViewMode.detailed,
+        highlightedSiteId: 's2',
+      );
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const SiteListContent(showAppBar: false),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(modifierKey);
+      await tester.tap(find.text('Delta Site'));
+      await tester.sendKeyUpEvent(modifierKey);
+      await tester.pumpAndSettle();
+
+      for (final tile in tester.widgetList<SiteListTile>(
+        find.byType(SiteListTile),
+      )) {
+        expect(
+          tile.isSelected && !tile.isChecked,
+          isFalse,
+          reason:
+              '${tile.name} reads as highlighted while no bulk action '
+              'would touch it',
+        );
+      }
+    });
   });
 }
 

--- a/test/features/trips/presentation/widgets/trip_list_content_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_content_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
@@ -326,6 +328,55 @@ void main() {
       expect(find.text('Maldives Trip'), findsOneWidget);
       expect(find.text('Red Sea Safari'), findsOneWidget);
       expect(find.text('Indonesia Live'), findsOneWidget);
+    });
+
+    // The table must be built inside the selection listener, or it keeps the
+    // isSelectionMode and selectedIds it was first built with.
+    //
+    // Pointer gestures hide this: tap-down writes highlightedTripIdProvider,
+    // which the widget watches, so every press happens to rebuild the whole
+    // subtree. Ctrl/Cmd-A changes the selection without any pointer-down, so
+    // it is the gesture that actually exercises the listener -- the bar would
+    // report "3 selected" over rows still drawn with no checkboxes at all.
+    testWidgets('Ctrl/Cmd-A repaints the table rows, not just the bar', (
+      tester,
+    ) async {
+      final selectAllKey = defaultTargetPlatform == TargetPlatform.macOS
+          ? LogicalKeyboardKey.metaLeft
+          : LogicalKeyboardKey.controlLeft;
+
+      final trips = [
+        _makeTrip(id: 't1', name: 'Maldives Trip'),
+        _makeTrip(id: 't2', name: 'Red Sea Safari'),
+        _makeTrip(id: 't3', name: 'Indonesia Live'),
+      ];
+
+      final overrides = await _buildOverrides(trips: trips);
+
+      await tester.pumpWidget(
+        testApp(
+          overrides: overrides,
+          child: const TripListContent(showAppBar: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyDownEvent(selectAllKey);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(selectAllKey);
+      await tester.pumpAndSettle();
+
+      expect(find.text('3 selected'), findsOneWidget);
+
+      final checked = tester
+          .widgetList<Checkbox>(find.byType(Checkbox))
+          .where((c) => c.value ?? false)
+          .length;
+      expect(
+        checked,
+        3,
+        reason: 'rows must repaint as checked, not just the count in the bar',
+      );
     });
 
     testWidgets('shows empty state when no trips', (tester) async {

--- a/test/shared/selection/selection_controller_test.dart
+++ b/test/shared/selection/selection_controller_test.dart
@@ -79,6 +79,31 @@ void main() {
       expect(controller.value.anchorId, 'b');
     });
 
+    test('enterImplicit checks the seed alongside the given id', () {
+      final controller = SelectionController();
+      controller.enterImplicit('c', seedId: 'a');
+      expect(controller.value.checkedIds, {'a', 'c'});
+      expect(
+        controller.value.anchorId,
+        'c',
+        reason: 'the modifier-clicked row becomes the anchor, not the seed',
+      );
+      expect(controller.value.enteredExplicitly, isFalse);
+    });
+
+    test('enterImplicit ignores a seed equal to the id', () {
+      final controller = SelectionController();
+      controller.enterImplicit('a', seedId: 'a');
+      expect(controller.value.checkedIds, {'a'});
+    });
+
+    test('enterImplicit ignores the seed once the mode is active', () {
+      final controller = SelectionController();
+      controller.enterImplicit('a');
+      controller.enterImplicit('b', seedId: 'z');
+      expect(controller.value.checkedIds, {'a', 'b'});
+    });
+
     test('toggle adds then removes an id', () {
       final controller = SelectionController();
       controller.enterExplicit();


### PR DESCRIPTION
## Summary

Reported against Sites: highlight a site, then shift-click another, and only the second site becomes selected — the first stays highlighted but unchecked. Cmd-click behaved the same way. Dives was the working reference.

A plain click highlights a row and opens the detail pane without checking it, so to the user that highlight *is* the selection. Sites and Buddies never told the selection controller that — they called `extendTo` without `fallbackAnchorId`, so a shift-click with no anchor yet fell back to anchoring on the clicked row and selected only it. Dives passed the fallback, which is what made the surfaces disagree.

Fixing that exposed two further defects in table mode that had made shift-click there non-functional on every surface, Dives included.

## Changes

**Anchoring shift and modifier clicks on the highlighted row**

- `SelectionController.enterImplicit` takes an optional `seedId`, checked alongside the clicked row. The anchor stays on the clicked row, so a following shift-click extends from there (Finder semantics).
- Cmd/Ctrl-click now seeds the checked set with the highlighted row on dives, sites and buddies, instead of discarding a selection the user believes they made.
- Sites and buddies pass `fallbackAnchorId` on shift-click; entering selection mode clears the highlight so no row reads as highlighted-but-unchecked.
- Sites and buddies gained the shift/modifier handling in table mode that they never had.

**Table-mode tap-down no longer destroys the anchor**

Table rows carry an `onDoubleTap`, so `onTap` only resolves once the double-tap timer expires — while `onTapDown` fires immediately and moved the highlight, overwriting the anchor before the shift-click could read it. A modified click is a selection gesture, not a navigation one, so tap-down now leaves the highlight alone when shift or the platform modifier is held. This was broken in the dives table too.

**Table mode gets the same keyboard scope as list mode**

Every surface wrapped its list modes in `SelectableListScope` but returned the table scaffold before reaching it, so table mode had no Escape, no Ctrl/Cmd-A, no Android back handling and no pruning on filter change. Nothing listened to the `SelectionController` there either, so a selection made by shift-click landed in the state and repainted only when an unrelated rebuild happened to run.

- Table paths now return the scope wrapping a `ValueListenableBuilder`, with `pruneTo` in a post-frame callback: sites, dives, buddies, equipment, certifications, dive centers, courses.
- `selectableIds` comes from whichever list the surface actually renders in table mode — courses renders the raw list where its list modes render a status-filtered one — so Ctrl/Cmd-A cannot check an off-screen row.
- Trips already had the scope and is where the pattern comes from, but built its table outside the builder, so its rows kept the `isSelectionMode` and `selectedIds` they were first built with. All surfaces now build the table inside the builder.

  **Correction to an earlier version of this description**, which claimed trips' rows were plainly stale while the count bar refreshed. That overstated it. Trips' `onEntityTapDown` writes `highlightedTripIdProvider` unconditionally and the widget watches it, so every pointer-down incidentally rebuilds the whole subtree and refreshes the table with it — a first test driving long-press and tap passed against the unfixed code. The stale build is only reachable when the selection changes with no pointer-down: Ctrl/Cmd-A on the unfixed code reports "3 selected" over rows drawn with zero checkboxes. That is what the added test asserts.

## Test Plan

- [x] `flutter test` passes — 17369 passed, 0 failed, 17 skipped (plus the trips test added since)
- [x] `flutter analyze` passes — no issues
- [x] `dart format` clean
- [ ] Manual testing on: macOS (shift-click and Cmd-click in Sites/Dives/Buddies, list and table modes)

12 new tests, each verified failing before the fix and passing after:

| Area | Tests |
|---|---|
| `SelectionController` | 3 — seed checked with the id, seed equal to id, seed ignored once active |
| Sites list | 3 — shift range from highlight, cmd seeding, no highlighted-but-unchecked row in detailed view |
| Sites table | 4 — shift range, cmd seeding, Escape exits, Ctrl/Cmd-A checks all |
| Dives | 2 — cmd seeding, table shift range |
| Buddies | 3 — shift range, cmd seeding, table shift range |
| Trips | 1 — Ctrl/Cmd-A repaints rows, not just the count bar |

The Escape and Ctrl/Cmd-A tests were verified by swapping only the `SelectableListScope` for a `SizedBox` and leaving the repaint builder in place, so the red isolates the scope itself.

One note on writing table-mode tests: `pumpAndSettle()` alone returns immediately when no frames are scheduled, so the double-tap timer never fires and the tap looks silently ignored. These tests `pump(500ms)` after each tap, and hold the modifier across that wait because the handler reads the keyboard when the tap finally resolves.
