### PR TITLE
Fix unreadable checklist titles, add filter and Excel export (#935)

### DIFF
--- a/lib/core/services/export/excel/excel_export_service.dart
+++ b/lib/core/services/export/excel/excel_export_service.dart
@@ -7,16 +7,19 @@ import 'package:intl/intl.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
 import 'package:submersion/core/services/export/shared/unit_converters.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 
 /// Handles Excel export with multiple worksheet sheets.
 class ExcelExportService {
   final _dateFormat = DateFormat('yyyy-MM-dd');
   final _timeFormat = DateFormat('HH:mm');
+  final _preDive = PreDiveExcelExportService();
 
   /// Export all dive data to Excel format and share via system sheet.
   ///
@@ -34,6 +37,8 @@ class ExcelExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) async {
     final bytes = await generateExcelBytes(
       dives: dives,
@@ -44,6 +49,8 @@ class ExcelExportService {
       pressureUnit: pressureUnit,
       volumeUnit: volumeUnit,
       dateFormat: dateFormat,
+      preDiveSessions: preDiveSessions,
+      preDiveItemsBySession: preDiveItemsBySession,
     );
 
     final dateStr = _dateFormat.format(DateTime.now());
@@ -66,10 +73,10 @@ class ExcelExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) async {
     final excel = xl.Excel.createExcel();
-
-    excel.delete('Sheet1');
 
     _buildDivesSheet(
       excel,
@@ -82,6 +89,12 @@ class ExcelExportService {
     );
     _buildSitesSheet(excel, sites, depthUnit);
     _buildEquipmentSheet(excel, equipment, dateFormat);
+    _preDive.buildSheets(
+      excel,
+      sessions: preDiveSessions,
+      itemsBySession: preDiveItemsBySession,
+      dateFormat: dateFormat,
+    );
     _buildStatisticsSheet(
       excel,
       dives,
@@ -91,6 +104,11 @@ class ExcelExportService {
       temperatureUnit,
       dateFormat,
     );
+
+    // Removed only once real sheets exist: the excel package will not delete a
+    // workbook's last remaining sheet, so deleting up front left a stray empty
+    // "Sheet1" in every export.
+    excel.delete('Sheet1');
 
     final bytes = excel.encode();
     if (bytes == null) {
@@ -110,6 +128,8 @@ class ExcelExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) async {
     final bytes = await generateExcelBytes(
       dives: dives,
@@ -120,6 +140,8 @@ class ExcelExportService {
       pressureUnit: pressureUnit,
       volumeUnit: volumeUnit,
       dateFormat: dateFormat,
+      preDiveSessions: preDiveSessions,
+      preDiveItemsBySession: preDiveItemsBySession,
     );
 
     final dateStr = _dateFormat.format(DateTime.now());

--- a/lib/core/services/export/excel/pre_dive_excel_export_service.dart
+++ b/lib/core/services/export/excel/pre_dive_excel_export_service.dart
@@ -1,0 +1,249 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:excel/excel.dart' as xl;
+import 'package:file_picker/file_picker.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/services/export/shared/unit_converters.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+
+/// Exports pre-dive checklist runs to a spreadsheet.
+///
+/// Two sheets, because the two questions divers ask of checklist history are
+/// different: "which runs happened and how did they end" (one row per run) and
+/// "what exactly was flagged, measured or skipped" (one row per item). The
+/// item sheet carries the notes and flags, which are the audit evidence.
+///
+/// Column headers are English constants, matching [ExcelExportService]: the
+/// workbook is an analysis target, not a UI surface.
+class PreDiveExcelExportService {
+  static const runsSheet = 'Checklist Runs';
+  static const itemsSheet = 'Checklist Items';
+
+  static const _mimeType =
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+  final _fileDateFormat = DateFormat('yyyy-MM-dd');
+  final _timeFormat = DateFormat('HH:mm');
+
+  /// Writes both sheets into an existing [excel] workbook, so the whole-library
+  /// export can carry checklist history alongside its other sheets.
+  void buildSheets(
+    xl.Excel excel, {
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) {
+    _buildRunsSheet(excel, sessions, itemsBySession, dateFormat);
+    _buildItemsSheet(excel, sessions, itemsBySession, dateFormat);
+  }
+
+  /// Builds a standalone checklist workbook.
+  List<int> generateBytes({
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) {
+    final excel = xl.Excel.createExcel();
+    buildSheets(
+      excel,
+      sessions: sessions,
+      itemsBySession: itemsBySession,
+      dateFormat: dateFormat,
+    );
+    // Deleted only after the real sheets exist: the excel package refuses to
+    // remove a workbook's last remaining sheet, so deleting first is a no-op
+    // that leaves a stray empty "Sheet1" in the output.
+    excel.delete('Sheet1');
+    return excel.encode() ?? const <int>[];
+  }
+
+  /// Writes the workbook to the documents directory and opens the system share
+  /// sheet. Share-only by contract; see [saveToFile] for the save path.
+  Future<String> exportToExcel({
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) {
+    final bytes = generateBytes(
+      sessions: sessions,
+      itemsBySession: itemsBySession,
+      dateFormat: dateFormat,
+    );
+    return saveAndShareFileBytes(bytes, _fileName(), _mimeType);
+  }
+
+  /// Prompts for a destination. Returns null when the diver cancelled, which
+  /// callers must treat as a no-op rather than as success.
+  Future<String?> saveToFile({
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) async {
+    final bytes = generateBytes(
+      sessions: sessions,
+      itemsBySession: itemsBySession,
+      dateFormat: dateFormat,
+    );
+    final result = await FilePicker.saveFile(
+      dialogTitle: 'Save Checklist Export',
+      fileName: _fileName(),
+      type: FileType.custom,
+      allowedExtensions: const ['xlsx'],
+      bytes: Uint8List.fromList(bytes),
+    );
+
+    if (result == null) return null;
+
+    // Only Android's picker writes the bytes itself; elsewhere saveFile just
+    // returns the chosen path.
+    if (!Platform.isAndroid) {
+      await File(result).writeAsBytes(Uint8List.fromList(bytes));
+    }
+
+    return result;
+  }
+
+  String _fileName() =>
+      'submersion_checklists_${_fileDateFormat.format(DateTime.now())}.xlsx';
+
+  void _buildRunsSheet(
+    xl.Excel excel,
+    List<PreDiveSession> sessions,
+    Map<String, List<PreDiveSessionItem>> itemsBySession,
+    DateFormatPreference dateFormat,
+  ) {
+    final sheet = excel[runsSheet];
+
+    _writeRow(sheet, 0, const [
+      'Checklist',
+      'Started',
+      'Completed',
+      'Status',
+      'Items',
+      'Resolved',
+      'Flagged',
+      'Linked Dive',
+      'Equipment Set',
+      'Notes',
+    ]);
+
+    for (var row = 0; row < sessions.length; row++) {
+      final session = sessions[row];
+      final items = itemsBySession[session.id] ?? const <PreDiveSessionItem>[];
+
+      _writeRow(sheet, row + 1, [
+        session.templateName,
+        _dateTime(session.startedAt, dateFormat),
+        _dateTime(session.completedAt, dateFormat),
+        _statusLabel(session.status),
+        items.length,
+        items.where((i) => i.isResolved).length,
+        items.where((i) => i.state == PreDiveItemState.flagged).length,
+        session.diveId ?? '',
+        session.equipmentSetName ?? '',
+        session.notes.replaceAll('\n', ' '),
+      ]);
+    }
+  }
+
+  void _buildItemsSheet(
+    xl.Excel excel,
+    List<PreDiveSession> sessions,
+    Map<String, List<PreDiveSessionItem>> itemsBySession,
+    DateFormatPreference dateFormat,
+  ) {
+    final sheet = excel[itemsSheet];
+
+    _writeRow(sheet, 0, const [
+      'Checklist',
+      'Started',
+      'Section',
+      'Item',
+      'Type',
+      'State',
+      'Value',
+      'Unit',
+      'Note',
+      'Completed At',
+      'Required',
+    ]);
+
+    // Rows follow the session order so a filtered export reads top-to-bottom
+    // in the same order as the list the diver exported from.
+    var row = 1;
+    for (final session in sessions) {
+      final items = itemsBySession[session.id] ?? const <PreDiveSessionItem>[];
+      for (final item in items) {
+        _writeRow(sheet, row++, [
+          session.templateName,
+          _dateTime(session.startedAt, dateFormat),
+          item.section ?? '',
+          item.title,
+          _typeLabel(item.itemType),
+          _stateLabel(item.state),
+          item.valueNumber ?? '',
+          item.valueUnit ?? '',
+          item.note.replaceAll('\n', ' '),
+          _dateTime(item.completedAt, dateFormat),
+          item.isRequired ? 'Yes' : 'No',
+        ]);
+      }
+    }
+  }
+
+  void _writeRow(xl.Sheet sheet, int rowIndex, List<dynamic> values) {
+    for (var col = 0; col < values.length; col++) {
+      sheet
+          .cell(
+            xl.CellIndex.indexByColumnRow(columnIndex: col, rowIndex: rowIndex),
+          )
+          .value = _toCellValue(
+        values[col],
+      );
+    }
+  }
+
+  /// Date and time together: two runs of the same checklist on the same day is
+  /// the normal case on a liveaboard, so the day alone does not identify a run.
+  String _dateTime(DateTime? value, DateFormatPreference dateFormat) {
+    if (value == null) return '';
+    return '${formatDateForExport(value, dateFormat)} '
+        '${_timeFormat.format(value)}';
+  }
+
+  String _statusLabel(PreDiveSessionStatus status) => switch (status) {
+    PreDiveSessionStatus.inProgress => 'In progress',
+    PreDiveSessionStatus.completed => 'Completed',
+    PreDiveSessionStatus.aborted => 'Aborted',
+  };
+
+  String _stateLabel(PreDiveItemState state) => switch (state) {
+    PreDiveItemState.pending => 'Pending',
+    PreDiveItemState.done => 'Done',
+    PreDiveItemState.skipped => 'Skipped',
+    PreDiveItemState.flagged => 'Flagged',
+  };
+
+  String _typeLabel(PreDiveItemType type) => switch (type) {
+    PreDiveItemType.check => 'Check',
+    PreDiveItemType.value => 'Value',
+    PreDiveItemType.equipmentSet => 'Equipment',
+  };
+
+  xl.CellValue _toCellValue(dynamic value) {
+    if (value == null || value == '') {
+      return xl.TextCellValue('');
+    } else if (value is int) {
+      return xl.IntCellValue(value);
+    } else if (value is double) {
+      return xl.DoubleCellValue(value);
+    } else {
+      return xl.TextCellValue(value.toString());
+    }
+  }
+}

--- a/lib/core/services/export/export_service.dart
+++ b/lib/core/services/export/export_service.dart
@@ -27,6 +27,7 @@ import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
@@ -157,6 +158,8 @@ class ExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) => _excel.exportToExcel(
     dives: dives,
     sites: sites,
@@ -166,6 +169,8 @@ class ExportService {
     pressureUnit: pressureUnit,
     volumeUnit: volumeUnit,
     dateFormat: dateFormat,
+    preDiveSessions: preDiveSessions,
+    preDiveItemsBySession: preDiveItemsBySession,
   );
 
   Future<List<int>> generateExcelBytes({
@@ -177,6 +182,8 @@ class ExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) => _excel.generateExcelBytes(
     dives: dives,
     sites: sites,
@@ -186,6 +193,8 @@ class ExportService {
     pressureUnit: pressureUnit,
     volumeUnit: volumeUnit,
     dateFormat: dateFormat,
+    preDiveSessions: preDiveSessions,
+    preDiveItemsBySession: preDiveItemsBySession,
   );
 
   Future<String?> saveExcelToFile({
@@ -197,6 +206,8 @@ class ExportService {
     required PressureUnit pressureUnit,
     required VolumeUnit volumeUnit,
     required DateFormatPreference dateFormat,
+    List<PreDiveSession> preDiveSessions = const [],
+    Map<String, List<PreDiveSessionItem>> preDiveItemsBySession = const {},
   }) => _excel.saveExcelToFile(
     dives: dives,
     sites: sites,
@@ -206,6 +217,8 @@ class ExportService {
     pressureUnit: pressureUnit,
     volumeUnit: volumeUnit,
     dateFormat: dateFormat,
+    preDiveSessions: preDiveSessions,
+    preDiveItemsBySession: preDiveItemsBySession,
   );
 
   // ==================== KML Export ====================

--- a/lib/features/pre_dive/data/repositories/pre_dive_session_repository.dart
+++ b/lib/features/pre_dive/data/repositories/pre_dive_session_repository.dart
@@ -152,6 +152,82 @@ class PreDiveSessionRepository {
     }
   }
 
+  /// Item tallies for every visible session in one aggregate query. A session
+  /// list renders a progress and flag badge per row; fetching each session's
+  /// items separately would be one query per row.
+  Future<Map<String, domain.PreDiveSessionStats>> getSessionStats({
+    String? diverId,
+  }) async {
+    try {
+      final sessions = _db.preDiveSessions;
+      final items = _db.preDiveSessionItems;
+
+      final total = items.id.count();
+      final resolved = items.id.count(
+        filter: items.state.equals(domain.PreDiveItemState.pending.name).not(),
+      );
+      final flagged = items.id.count(
+        filter: items.state.equals(domain.PreDiveItemState.flagged.name),
+      );
+
+      final query = _db.selectOnly(sessions).join([
+        leftOuterJoin(items, items.sessionId.equalsExp(sessions.id)),
+      ]);
+      query.addColumns([sessions.id, total, resolved, flagged]);
+      query.groupBy([sessions.id]);
+      if (diverId != null) {
+        query.where(
+          sessions.diverId.equals(diverId) | sessions.diverId.isNull(),
+        );
+      }
+
+      final rows = await query.get();
+      return {
+        for (final row in rows)
+          row.read(sessions.id)!: domain.PreDiveSessionStats(
+            total: row.read(total) ?? 0,
+            resolved: row.read(resolved) ?? 0,
+            flagged: row.read(flagged) ?? 0,
+          ),
+      };
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get pre-dive session stats',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Items for many sessions in one query, grouped by session id and sorted
+  /// within each group. Used by the checklist export, which would otherwise
+  /// issue one query per exported session.
+  Future<Map<String, List<domain.PreDiveSessionItem>>> getItemsForSessions(
+    List<String> sessionIds,
+  ) async {
+    if (sessionIds.isEmpty) return {};
+    try {
+      final rows =
+          await (_db.select(_db.preDiveSessionItems)
+                ..where((t) => t.sessionId.isIn(sessionIds))
+                ..orderBy([(t) => OrderingTerm.asc(t.sortOrder)]))
+              .get();
+      final grouped = <String, List<domain.PreDiveSessionItem>>{};
+      for (final row in rows) {
+        (grouped[row.sessionId] ??= []).add(_mapItem(row));
+      }
+      return grouped;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get pre-dive session items in bulk',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   Future<List<domain.PreDiveSession>> getAllSessions({String? diverId}) async {
     try {
       final query = _db.select(_db.preDiveSessions)

--- a/lib/features/pre_dive/domain/entities/pre_dive_session.dart
+++ b/lib/features/pre_dive/domain/entities/pre_dive_session.dart
@@ -26,6 +26,25 @@ enum PreDiveItemState {
       .firstWhere((e) => e.name == raw, orElse: () => PreDiveItemState.pending);
 }
 
+/// Item tallies for one session, aggregated in SQL so a list of sessions can
+/// render progress and flag badges without loading every item row.
+class PreDiveSessionStats extends Equatable {
+  final int total;
+  final int resolved;
+  final int flagged;
+
+  const PreDiveSessionStats({
+    this.total = 0,
+    this.resolved = 0,
+    this.flagged = 0,
+  });
+
+  bool get hasFlagged => flagged > 0;
+
+  @override
+  List<Object?> get props => [total, resolved, flagged];
+}
+
 /// A pre-dive checklist run. Completed/aborted sessions are immutable.
 class PreDiveSession extends Equatable {
   final String id;

--- a/lib/features/pre_dive/domain/models/pre_dive_session_filter.dart
+++ b/lib/features/pre_dive/domain/models/pre_dive_session_filter.dart
@@ -1,0 +1,100 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart' show DateTimeRange;
+
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+
+/// Facets for narrowing the pre-dive checklist session history.
+///
+/// Every facet is independent and an empty facet means "no restriction", so
+/// the default instance passes everything through. Sessions are matched on the
+/// snapshotted [PreDiveSession.templateName] rather than the template id:
+/// sessions are audit history and outlive the templates they were run from.
+class PreDiveSessionFilter extends Equatable {
+  final Set<String> templateNames;
+  final Set<PreDiveSessionStatus> statuses;
+  final bool flaggedOnly;
+  final DateTimeRange? dateRange;
+
+  const PreDiveSessionFilter({
+    this.templateNames = const {},
+    this.statuses = const {},
+    this.flaggedOnly = false,
+    this.dateRange,
+  });
+
+  bool get hasActiveFilters =>
+      templateNames.isNotEmpty ||
+      statuses.isNotEmpty ||
+      flaggedOnly ||
+      dateRange != null;
+
+  /// Narrows [sessions] to those matching every active facet.
+  ///
+  /// [stats] supplies the flag tallies, which live in an aggregate query
+  /// rather than on the session row. A session missing from [stats] cannot be
+  /// shown to be flagged, so `flaggedOnly` excludes it.
+  List<PreDiveSession> apply(
+    List<PreDiveSession> sessions,
+    Map<String, PreDiveSessionStats> stats,
+  ) {
+    if (!hasActiveFilters) return sessions;
+    return sessions.where((session) => _matches(session, stats)).toList();
+  }
+
+  bool _matches(
+    PreDiveSession session,
+    Map<String, PreDiveSessionStats> stats,
+  ) {
+    if (templateNames.isNotEmpty &&
+        !templateNames.contains(session.templateName)) {
+      return false;
+    }
+    if (statuses.isNotEmpty && !statuses.contains(session.status)) {
+      return false;
+    }
+    if (flaggedOnly && !(stats[session.id]?.hasFlagged ?? false)) {
+      return false;
+    }
+    final range = dateRange;
+    if (range != null) {
+      final startedAt = session.startedAt;
+      // The picker yields whole days, so the end day is inclusive: a run that
+      // started at 23:30 on the last selected day is still inside the range.
+      final endOfLastDay = DateTime(
+        range.end.year,
+        range.end.month,
+        range.end.day,
+      ).add(const Duration(days: 1));
+      final startOfFirstDay = DateTime(
+        range.start.year,
+        range.start.month,
+        range.start.day,
+      );
+      if (startedAt.isBefore(startOfFirstDay) ||
+          !startedAt.isBefore(endOfLastDay)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// [clearDateRange] exists because a null [dateRange] argument is
+  /// indistinguishable from an omitted one.
+  PreDiveSessionFilter copyWith({
+    Set<String>? templateNames,
+    Set<PreDiveSessionStatus>? statuses,
+    bool? flaggedOnly,
+    DateTimeRange? dateRange,
+    bool clearDateRange = false,
+  }) {
+    return PreDiveSessionFilter(
+      templateNames: templateNames ?? this.templateNames,
+      statuses: statuses ?? this.statuses,
+      flaggedOnly: flaggedOnly ?? this.flaggedOnly,
+      dateRange: clearDateRange ? null : (dateRange ?? this.dateRange),
+    );
+  }
+
+  @override
+  List<Object?> get props => [templateNames, statuses, flaggedOnly, dateRange];
+}

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -3,32 +3,117 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
-import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
+import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/start_session_sheet.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/export_destination_sheet.dart';
 
 /// Pre-dive checklist sessions: any in-progress run pinned on top with
 /// Resume, then history with status badges and linked-dive chips.
 class PreDiveSessionsPage extends ConsumerWidget {
   const PreDiveSessionsPage({super.key});
 
+  /// Exports whatever the filter currently shows, so the filter doubles as the
+  /// export selector. Share and save are a deliberate pair: a null return from
+  /// the save path means the diver cancelled, not that the export succeeded.
+  Future<void> _export(BuildContext context, WidgetRef ref) async {
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context);
+    final sessions =
+        ref.read(filteredPreDiveSessionsProvider).value ?? const [];
+
+    if (sessions.isEmpty) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.preDive_sessions_exportEmpty)),
+      );
+      return;
+    }
+
+    final destination = await showExportDestinationSheet(
+      context,
+      title: l10n.preDive_sessions_export,
+    );
+    if (destination == null) return;
+
+    final dateFormat = ref.read(settingsProvider).dateFormat;
+    final service = ref.read(preDiveExcelExportServiceProvider);
+
+    try {
+      final itemsBySession = await ref
+          .read(preDiveSessionRepositoryProvider)
+          .getItemsForSessions([for (final session in sessions) session.id]);
+
+      switch (destination) {
+        case ExportDestination.share:
+          await service.exportToExcel(
+            sessions: sessions,
+            itemsBySession: itemsBySession,
+            dateFormat: dateFormat,
+          );
+        case ExportDestination.saveToFile:
+          await service.saveToFile(
+            sessions: sessions,
+            itemsBySession: itemsBySession,
+            dateFormat: dateFormat,
+          );
+      }
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.preDive_sessions_exportFailed(e.toString())),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final sessionsAsync = ref.watch(preDiveSessionsProvider);
     final sessions = sessionsAsync.value;
+    final filter = ref.watch(preDiveSessionFilterProvider);
+    final filtered = ref.watch(filteredPreDiveSessionsProvider).value;
     final active = ref.watch(preDiveActiveSessionProvider).value;
 
-    final history = sessions == null
+    // The active run stays pinned whatever the filter says: it is a "resume
+    // this now" affordance, and a filter left on from an earlier session must
+    // not make an unfinished checklist look like it disappeared.
+    final history = filtered == null
         ? null
         : [
-            for (final s in sessions)
+            for (final s in filtered)
               if (s.id != active?.id) s,
           ];
+    final hiddenByFilter =
+        filter.hasActiveFilters && (sessions?.isNotEmpty ?? false);
 
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.preDive_sessions_title)),
+      appBar: AppBar(
+        title: Text(l10n.preDive_sessions_title),
+        actions: [
+          IconButton(
+            icon: Badge(
+              isLabelVisible: filter.hasActiveFilters,
+              child: const Icon(Icons.filter_list),
+            ),
+            tooltip: l10n.preDive_sessions_filter,
+            onPressed: () => showModalBottomSheet<void>(
+              context: context,
+              isScrollControlled: true,
+              backgroundColor: Colors.transparent,
+              builder: (_) => const PreDiveSessionFilterSheet(),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.grid_on),
+            tooltip: l10n.preDive_sessions_export,
+            onPressed: () => _export(context, ref),
+          ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => showStartSessionSheet(context),
         icon: const Icon(Icons.play_arrow),
@@ -40,19 +125,153 @@ class PreDiveSessionsPage extends ConsumerWidget {
                   ? Text(sessionsAsync.error.toString())
                   : const CircularProgressIndicator(),
             )
-          : ListView(
-              padding: const EdgeInsets.only(bottom: 88),
+          : Column(
               children: [
-                if (active != null) _ActiveSessionCard(session: active),
-                if (history != null && history.isEmpty && active == null)
-                  Padding(
-                    padding: const EdgeInsets.all(32),
-                    child: Center(child: Text(l10n.preDive_sessions_empty)),
+                if (filter.hasActiveFilters) const _ActiveFilterBar(),
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.only(bottom: 88),
+                    children: [
+                      if (active != null) _ActiveSessionCard(session: active),
+                      if (history != null &&
+                          history.isEmpty &&
+                          active == null) ...[
+                        if (hiddenByFilter)
+                          const _FilteredEmptyState()
+                        else
+                          Padding(
+                            padding: const EdgeInsets.all(32),
+                            child: Center(
+                              child: Text(l10n.preDive_sessions_empty),
+                            ),
+                          ),
+                      ],
+                      if (history != null)
+                        for (final session in history)
+                          _SessionTile(session: session),
+                    ],
                   ),
-                if (history != null)
-                  for (final session in history) _SessionTile(session: session),
+                ),
               ],
             ),
+    );
+  }
+}
+
+/// Dismissible chips for each active facet, so the diver can see and undo the
+/// filter without reopening the sheet.
+class _ActiveFilterBar extends ConsumerWidget {
+  const _ActiveFilterBar();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final filter = ref.watch(preDiveSessionFilterProvider);
+
+    void update(PreDiveSessionFilter next) =>
+        ref.read(preDiveSessionFilterProvider.notifier).state = next;
+
+    String statusLabel(PreDiveSessionStatus status) => switch (status) {
+      PreDiveSessionStatus.inProgress => l10n.preDive_sessions_statusInProgress,
+      PreDiveSessionStatus.completed => l10n.preDive_sessions_statusCompleted,
+      PreDiveSessionStatus.aborted => l10n.preDive_sessions_statusAborted,
+    };
+
+    final materialL10n = MaterialLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+      child: Row(
+        children: [
+          Expanded(
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                for (final name in filter.templateNames)
+                  Chip(
+                    label: Text(name),
+                    visualDensity: VisualDensity.compact,
+                    deleteIcon: const Icon(Icons.close, size: 16),
+                    onDeleted: () => update(
+                      filter.copyWith(
+                        templateNames: {...filter.templateNames}..remove(name),
+                      ),
+                    ),
+                  ),
+                for (final status in filter.statuses)
+                  Chip(
+                    label: Text(statusLabel(status)),
+                    visualDensity: VisualDensity.compact,
+                    deleteIcon: const Icon(Icons.close, size: 16),
+                    onDeleted: () => update(
+                      filter.copyWith(
+                        statuses: {...filter.statuses}..remove(status),
+                      ),
+                    ),
+                  ),
+                if (filter.flaggedOnly)
+                  Chip(
+                    label: Text(l10n.preDive_sessions_filterFlaggedChip),
+                    visualDensity: VisualDensity.compact,
+                    deleteIcon: const Icon(Icons.close, size: 16),
+                    onDeleted: () =>
+                        update(filter.copyWith(flaggedOnly: false)),
+                  ),
+                if (filter.dateRange != null)
+                  Chip(
+                    label: Text(
+                      '${materialL10n.formatMediumDate(filter.dateRange!.start)}'
+                      ' - '
+                      '${materialL10n.formatMediumDate(filter.dateRange!.end)}',
+                    ),
+                    visualDensity: VisualDensity.compact,
+                    deleteIcon: const Icon(Icons.close, size: 16),
+                    onDeleted: () =>
+                        update(filter.copyWith(clearDateRange: true)),
+                  ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: () => update(const PreDiveSessionFilter()),
+            child: Text(l10n.preDive_sessions_filterClearAll),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilteredEmptyState extends ConsumerWidget {
+  const _FilteredEmptyState();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        children: [
+          Icon(
+            Icons.filter_list_off,
+            size: 48,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            l10n.preDive_sessions_emptyFiltered,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () =>
+                ref.read(preDiveSessionFilterProvider.notifier).state =
+                    const PreDiveSessionFilter(),
+            child: Text(l10n.preDive_sessions_filterClearAll),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -65,11 +284,11 @@ class _ActiveSessionCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
-    final items = ref.watch(preDiveSessionItemsProvider(session.id)).value;
-    final resolved = items == null
-        ? 0
-        : ChecklistSessionEngine.resolvedCount(items);
-    final total = items?.length ?? 0;
+    final stats =
+        ref.watch(preDiveSessionStatsProvider).value?[session.id] ??
+        const PreDiveSessionStats();
+    final resolved = stats.resolved;
+    final total = stats.total;
 
     return Card(
       margin: const EdgeInsets.all(12),
@@ -156,48 +375,59 @@ class _SessionTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final theme = Theme.of(context);
-    final items = ref.watch(preDiveSessionItemsProvider(session.id)).value;
-    final flagged = items == null
-        ? 0
-        : ChecklistSessionEngine.flaggedCount(items);
+    final flagged =
+        ref.watch(preDiveSessionStatsProvider).value?[session.id]?.flagged ?? 0;
     final startedDate = MaterialLocalizations.of(
       context,
     ).formatMediumDate(session.startedAt);
 
+    final hasLinkedDive = session.diveId != null;
+
+    // Only fixed-width widgets belong in ListTile.trailing: the tile lays the
+    // trailing widget out against the full tile width and gives the title
+    // column whatever is left, so a text-bearing chip here starves the title
+    // down to one glyph per line in longer locales (issue #935).
     return ListTile(
       leading: Icon(switch (session.status) {
         PreDiveSessionStatus.inProgress => Icons.pending_outlined,
         PreDiveSessionStatus.completed => Icons.check_circle_outline,
         PreDiveSessionStatus.aborted => Icons.cancel_outlined,
       }),
-      title: Text(session.templateName),
-      subtitle: Text(
-        [
-          startedDate,
-          _statusLabel(context),
-          if (flagged > 0) l10n.preDive_runner_flaggedBadge(flagged),
-        ].join(' - '),
+      title: Text(
+        session.templateName,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
       ),
-      trailing: Row(
+      isThreeLine: hasLinkedDive,
+      subtitle: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (session.diveId != null)
+          Text(
+            [
+              startedDate,
+              _statusLabel(context),
+              if (flagged > 0) l10n.preDive_runner_flaggedBadge(flagged),
+            ].join(' - '),
+          ),
+          if (hasLinkedDive)
             ActionChip(
               avatar: const Icon(Icons.scuba_diving, size: 18),
               label: Text(l10n.preDive_sessions_linkedDive),
               visualDensity: VisualDensity.compact,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               onPressed: () => context.push('/dives/${session.diveId}'),
             ),
-          PopupMenuButton<String>(
-            onSelected: (value) {
-              if (value == 'delete') _confirmDelete(context, ref);
-            },
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'delete',
-                child: Text(l10n.preDive_sessions_delete),
-              ),
-            ],
+        ],
+      ),
+      trailing: PopupMenuButton<String>(
+        onSelected: (value) {
+          if (value == 'delete') _confirmDelete(context, ref);
+        },
+        itemBuilder: (context) => [
+          PopupMenuItem(
+            value: 'delete',
+            child: Text(l10n.preDive_sessions_delete),
           ),
         ],
       ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -19,11 +19,17 @@ class PreDiveSessionsPage extends ConsumerWidget {
   /// Exports whatever the filter currently shows, so the filter doubles as the
   /// export selector. Share and save are a deliberate pair: a null return from
   /// the save path means the diver cancelled, not that the export succeeded.
-  Future<void> _export(BuildContext context, WidgetRef ref) async {
+  ///
+  /// [sessions] is resolved by the caller, which knows whether the list has
+  /// loaded: a pending or failed load must not reach here and be reported as
+  /// "nothing to export".
+  Future<void> _export(
+    BuildContext context,
+    WidgetRef ref,
+    List<PreDiveSession> sessions,
+  ) async {
     final l10n = context.l10n;
     final messenger = ScaffoldMessenger.of(context);
-    final sessions =
-        ref.read(filteredPreDiveSessionsProvider).value ?? const [];
 
     if (sessions.isEmpty) {
       messenger.showSnackBar(
@@ -110,7 +116,12 @@ class PreDiveSessionsPage extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.grid_on),
             tooltip: l10n.preDive_sessions_export,
-            onPressed: () => _export(context, ref),
+            // Disabled until the list resolves. While it is loading or in
+            // error there is nothing meaningful to export, and offering the
+            // action would report a pending load as an empty history.
+            onPressed: filtered == null
+                ? null
+                : () => _export(context, ref, filtered),
           ),
         ],
       ),

--- a/lib/features/pre_dive/presentation/pages/pre_dive_templates_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_templates_page.dart
@@ -95,41 +95,51 @@ class _TemplateTile extends ConsumerWidget {
       if (template.category != null) template.category!,
       if (template.strictOrder) l10n.preDive_templates_strictOrderBadge,
     ];
+    final subtitleText = subtitleParts.isEmpty
+        ? (template.description.isEmpty ? null : template.description)
+        : subtitleParts.join(' - ');
+
+    // The built-in badge sits in the subtitle rather than in trailing: a
+    // ListTile measures its trailing widget against the full tile width, so a
+    // translated badge label there starves the title column (issue #935).
     return ListTile(
       leading: Icon(template.isBuiltIn ? Icons.lock_outline : Icons.fact_check),
-      title: Text(template.name),
-      subtitle: subtitleParts.isEmpty
-          ? (template.description.isEmpty ? null : Text(template.description))
-          : Text(subtitleParts.join(' - ')),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (template.isBuiltIn)
-            Chip(
-              label: Text(l10n.preDive_templates_builtInBadge),
-              visualDensity: VisualDensity.compact,
+      title: Text(template.name, maxLines: 2, overflow: TextOverflow.ellipsis),
+      isThreeLine: template.isBuiltIn && subtitleText != null,
+      subtitle: subtitleText == null && !template.isBuiltIn
+          ? null
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (subtitleText != null) Text(subtitleText),
+                if (template.isBuiltIn)
+                  Chip(
+                    label: Text(l10n.preDive_templates_builtInBadge),
+                    visualDensity: VisualDensity.compact,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+              ],
             ),
-          PopupMenuButton<String>(
-            onSelected: (value) {
-              switch (value) {
-                case 'clone':
-                  _clone(context, ref);
-                case 'delete':
-                  _confirmDelete(context, ref);
-              }
-            },
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'clone',
-                child: Text(l10n.preDive_templates_clone),
-              ),
-              if (!template.isBuiltIn)
-                PopupMenuItem(
-                  value: 'delete',
-                  child: Text(l10n.preDive_templates_delete),
-                ),
-            ],
+      trailing: PopupMenuButton<String>(
+        onSelected: (value) {
+          switch (value) {
+            case 'clone':
+              _clone(context, ref);
+            case 'delete':
+              _confirmDelete(context, ref);
+          }
+        },
+        itemBuilder: (context) => [
+          PopupMenuItem(
+            value: 'clone',
+            child: Text(l10n.preDive_templates_clone),
           ),
+          if (!template.isBuiltIn)
+            PopupMenuItem(
+              value: 'delete',
+              child: Text(l10n.preDive_templates_delete),
+            ),
         ],
       ),
       onTap: template.isBuiltIn

--- a/lib/features/pre_dive/presentation/providers/pre_dive_providers.dart
+++ b/lib/features/pre_dive/presentation/providers/pre_dive_providers.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_template_repository.dart';
@@ -6,6 +7,7 @@ import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_
     as domain;
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart'
     as domain;
+import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
 
 final preDiveTemplateRepositoryProvider = Provider<PreDiveTemplateRepository>(
   (ref) => PreDiveTemplateRepository(),
@@ -13,6 +15,12 @@ final preDiveTemplateRepositoryProvider = Provider<PreDiveTemplateRepository>(
 
 final preDiveSessionRepositoryProvider = Provider<PreDiveSessionRepository>(
   (ref) => PreDiveSessionRepository(),
+);
+
+/// Injected rather than constructed at the call site so a test can observe
+/// what the checklist export was actually handed.
+final preDiveExcelExportServiceProvider = Provider<PreDiveExcelExportService>(
+  (ref) => PreDiveExcelExportService(),
 );
 
 final preDiveTemplatesProvider =
@@ -52,6 +60,17 @@ final preDiveSessionsProvider = FutureProvider<List<domain.PreDiveSession>>((
   return repository.getAllSessions(diverId: diverId);
 });
 
+/// Item tallies for every session, keyed by session id. One aggregate query
+/// serves the whole list, so a session row never fetches its own items just to
+/// show progress or a flag badge.
+final preDiveSessionStatsProvider =
+    FutureProvider<Map<String, domain.PreDiveSessionStats>>((ref) async {
+      final repository = ref.watch(preDiveSessionRepositoryProvider);
+      final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
+      ref.invalidateSelfWhen(repository.watchSessionsChanges());
+      return repository.getSessionStats(diverId: diverId);
+    });
+
 final preDiveActiveSessionProvider = FutureProvider<domain.PreDiveSession?>((
   ref,
 ) async {
@@ -59,6 +78,35 @@ final preDiveActiveSessionProvider = FutureProvider<domain.PreDiveSession?>((
   final diverId = await ref.watch(validatedCurrentDiverIdProvider.future);
   ref.invalidateSelfWhen(repository.watchSessionsChanges());
   return repository.getActiveSession(diverId: diverId);
+});
+
+/// Facets narrowing the session history. Ephemeral by design, matching the
+/// dive-list and trip-list filters: a filter is a view of the current screen,
+/// not a stored preference.
+final preDiveSessionFilterProvider = StateProvider<PreDiveSessionFilter>(
+  (ref) => const PreDiveSessionFilter(),
+);
+
+/// Sessions surviving the active filter, newest first.
+final filteredPreDiveSessionsProvider =
+    Provider<AsyncValue<List<domain.PreDiveSession>>>((ref) {
+      final sessionsAsync = ref.watch(preDiveSessionsProvider);
+      final filter = ref.watch(preDiveSessionFilterProvider);
+      final stats =
+          ref.watch(preDiveSessionStatsProvider).value ??
+          const <String, domain.PreDiveSessionStats>{};
+      return sessionsAsync.whenData(
+        (sessions) => filter.apply(sessions, stats),
+      );
+    });
+
+/// Distinct checklist names present in the history, sorted, for the filter
+/// picker. Names come from the sessions themselves so runs of a since-deleted
+/// template remain selectable.
+final preDiveSessionTemplateNamesProvider = Provider<List<String>>((ref) {
+  final sessions = ref.watch(preDiveSessionsProvider).value ?? const [];
+  final names = {for (final session in sessions) session.templateName};
+  return names.toList()..sort();
 });
 
 final preDiveSessionProvider =

--- a/lib/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart
+++ b/lib/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/app_date_picker.dart';
+
+/// Bottom sheet for narrowing the pre-dive checklist session history.
+///
+/// Edits are held locally so the list behind the sheet does not churn while
+/// the diver is still choosing; the provider is written once on Apply.
+class PreDiveSessionFilterSheet extends ConsumerStatefulWidget {
+  const PreDiveSessionFilterSheet({super.key});
+
+  @override
+  ConsumerState<PreDiveSessionFilterSheet> createState() =>
+      _PreDiveSessionFilterSheetState();
+}
+
+class _PreDiveSessionFilterSheetState
+    extends ConsumerState<PreDiveSessionFilterSheet> {
+  late Set<String> _templateNames;
+  late Set<PreDiveSessionStatus> _statuses;
+  late bool _flaggedOnly;
+  DateTimeRange? _dateRange;
+
+  @override
+  void initState() {
+    super.initState();
+    final filter = ref.read(preDiveSessionFilterProvider);
+    _templateNames = {...filter.templateNames};
+    _statuses = {...filter.statuses};
+    _flaggedOnly = filter.flaggedOnly;
+    _dateRange = filter.dateRange;
+  }
+
+  String _statusLabel(PreDiveSessionStatus status) {
+    return switch (status) {
+      PreDiveSessionStatus.inProgress =>
+        context.l10n.preDive_sessions_statusInProgress,
+      PreDiveSessionStatus.completed =>
+        context.l10n.preDive_sessions_statusCompleted,
+      PreDiveSessionStatus.aborted =>
+        context.l10n.preDive_sessions_statusAborted,
+    };
+  }
+
+  Future<void> _pickDateRange() async {
+    final now = DateTime.now();
+    final range = await showAppDateRangePicker(
+      context: context,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(now.year + 1, 12, 31),
+      initialDateRange: _dateRange,
+    );
+    if (range != null) setState(() => _dateRange = range);
+  }
+
+  void _clearAll() {
+    setState(() {
+      _templateNames = {};
+      _statuses = {};
+      _flaggedOnly = false;
+      _dateRange = null;
+    });
+  }
+
+  void _apply() {
+    ref
+        .read(preDiveSessionFilterProvider.notifier)
+        .state = PreDiveSessionFilter(
+      templateNames: _templateNames,
+      statuses: _statuses,
+      flaggedOnly: _flaggedOnly,
+      dateRange: _dateRange,
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final templateNames = ref.watch(preDiveSessionTemplateNamesProvider);
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, scrollController) {
+        return Container(
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+          ),
+          // Transparent Material so the tiles inside paint their ink above this
+          // decorated container (Flutter asserts on a ListTile whose nearest
+          // decorated ancestor precedes its Material).
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              children: [
+                Container(
+                  margin: const EdgeInsets.symmetric(vertical: 12),
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          l10n.preDive_sessions_filterTitle,
+                          style: theme.textTheme.titleLarge,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: _clearAll,
+                        child: Text(l10n.preDive_sessions_filterClearAll),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(),
+                Expanded(
+                  child: ListView(
+                    controller: scrollController,
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      if (templateNames.isNotEmpty) ...[
+                        _SectionLabel(l10n.preDive_sessions_filterChecklist),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: [
+                            for (final name in templateNames)
+                              FilterChip(
+                                label: Text(name),
+                                selected: _templateNames.contains(name),
+                                onSelected: (selected) => setState(() {
+                                  if (selected) {
+                                    _templateNames = {..._templateNames, name};
+                                  } else {
+                                    _templateNames = {..._templateNames}
+                                      ..remove(name);
+                                  }
+                                }),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: 24),
+                      ],
+                      _SectionLabel(l10n.preDive_sessions_filterStatus),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final status in PreDiveSessionStatus.values)
+                            FilterChip(
+                              label: Text(_statusLabel(status)),
+                              selected: _statuses.contains(status),
+                              onSelected: (selected) => setState(() {
+                                if (selected) {
+                                  _statuses = {..._statuses, status};
+                                } else {
+                                  _statuses = {..._statuses}..remove(status);
+                                }
+                              }),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      _SectionLabel(l10n.preDive_sessions_filterDateRange),
+                      ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.date_range),
+                        title: Text(
+                          _dateRange == null
+                              ? l10n.preDive_sessions_filterAnyDate
+                              : '${MaterialLocalizations.of(context).formatMediumDate(_dateRange!.start)}'
+                                    ' - '
+                                    '${MaterialLocalizations.of(context).formatMediumDate(_dateRange!.end)}',
+                        ),
+                        trailing: _dateRange == null
+                            ? null
+                            : IconButton(
+                                icon: const Icon(Icons.clear),
+                                onPressed: () =>
+                                    setState(() => _dateRange = null),
+                              ),
+                        onTap: _pickDateRange,
+                      ),
+                      const SizedBox(height: 8),
+                      SwitchListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(l10n.preDive_sessions_filterFlaggedOnly),
+                        value: _flaggedOnly,
+                        onChanged: (value) =>
+                            setState(() => _flaggedOnly = value),
+                      ),
+                      const SizedBox(height: 80),
+                    ],
+                  ),
+                ),
+                SafeArea(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(48),
+                      ),
+                      onPressed: _apply,
+                      child: Text(l10n.preDive_sessions_filterApply),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String label;
+
+  const _SectionLabel(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(label, style: Theme.of(context).textTheme.titleSmall),
+    );
+  }
+}

--- a/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
+++ b/lib/features/pre_dive/presentation/widgets/session_item_tile.dart
@@ -87,6 +87,14 @@ class SessionItemTile extends StatelessWidget {
         ),
       if (item.notes.isNotEmpty)
         Text(item.notes, style: theme.textTheme.bodySmall),
+      // Completion time belongs in the subtitle, not in trailing: a ListTile
+      // measures its trailing widget against the full tile width, so anything
+      // text-bearing there eats into the item title (issue #935).
+      if (item.completedAt != null)
+        Text(
+          TimeOfDay.fromDateTime(item.completedAt!).format(context),
+          style: theme.textTheme.bodySmall,
+        ),
     ];
 
     final dimmed = !actionable && item.state == PreDiveItemState.pending;
@@ -101,16 +109,9 @@ class SessionItemTile extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: subtitleChildren,
             ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (item.completedAt != null)
-            Text(
-              TimeOfDay.fromDateTime(item.completedAt!).format(context),
-              style: theme.textTheme.bodySmall,
-            ),
-          if (showMenu)
-            PopupMenuButton<String>(
+      trailing: !showMenu
+          ? null
+          : PopupMenuButton<String>(
               onSelected: (value) {
                 switch (value) {
                   case 'skip':
@@ -145,8 +146,6 @@ class SessionItemTile extends StatelessWidget {
                   ),
               ],
             ),
-        ],
-      ),
       enabled: actionable,
       onTap: actionable
           ? (item.itemType == PreDiveItemType.value ? onEditValue : onDone)

--- a/lib/features/settings/presentation/providers/export_providers.dart
+++ b/lib/features/settings/presentation/providers/export_providers.dart
@@ -38,6 +38,7 @@ import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
 import 'package:submersion/features/dive_log/domain/services/profile_event_mapper.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 
 /// Load per-tank pressure data for a list of dives.
 ///
@@ -489,6 +490,12 @@ class ExportNotifier extends StateNotifier<ExportState> {
       final dives = await _ref.read(divesProvider.future);
       final sites = await _ref.read(sitesProvider.future);
       final equipment = await _ref.read(allEquipmentProvider.future);
+      // Checklist runs ride along in the workbook. Fetched in bulk: one query
+      // for the runs, one for every item across them.
+      final preDiveSessions = await _ref.read(preDiveSessionsProvider.future);
+      final preDiveItems = await _ref
+          .read(preDiveSessionRepositoryProvider)
+          .getItemsForSessions([for (final s in preDiveSessions) s.id]);
 
       if (dives.isEmpty && sites.isEmpty && equipment.isEmpty) {
         state = state.copyWith(
@@ -511,6 +518,8 @@ class ExportNotifier extends StateNotifier<ExportState> {
         pressureUnit: settings.pressureUnit,
         volumeUnit: settings.volumeUnit,
         dateFormat: settings.dateFormat,
+        preDiveSessions: preDiveSessions,
+        preDiveItemsBySession: preDiveItems,
       );
 
       state = state.copyWith(
@@ -586,6 +595,12 @@ class ExportNotifier extends StateNotifier<ExportState> {
       final dives = await _ref.read(divesProvider.future);
       final sites = await _ref.read(sitesProvider.future);
       final equipment = await _ref.read(allEquipmentProvider.future);
+      // Checklist runs ride along in the workbook. Fetched in bulk: one query
+      // for the runs, one for every item across them.
+      final preDiveSessions = await _ref.read(preDiveSessionsProvider.future);
+      final preDiveItems = await _ref
+          .read(preDiveSessionRepositoryProvider)
+          .getItemsForSessions([for (final s in preDiveSessions) s.id]);
 
       if (dives.isEmpty && sites.isEmpty && equipment.isEmpty) {
         state = state.copyWith(
@@ -608,6 +623,8 @@ class ExportNotifier extends StateNotifier<ExportState> {
         pressureUnit: settings.pressureUnit,
         volumeUnit: settings.volumeUnit,
         dateFormat: settings.dateFormat,
+        preDiveSessions: preDiveSessions,
+        preDiveItemsBySession: preDiveItems,
       );
 
       if (path == null) {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "الغطسة المرتبطة",
   "preDive_sessions_delete": "حذف",
   "preDive_sessions_deleteConfirm": "هل تريد حذف سجل قائمة التحقق هذا؟",
+  "preDive_sessions_filter": "تصفية",
+  "preDive_sessions_filterTitle": "تصفية عمليات قوائم التحقق",
+  "preDive_sessions_filterChecklist": "قائمة التحقق",
+  "preDive_sessions_filterStatus": "الحالة",
+  "preDive_sessions_filterFlaggedOnly": "العمليات المعلَّمة فقط",
+  "preDive_sessions_filterDateRange": "النطاق الزمني",
+  "preDive_sessions_filterAnyDate": "أي تاريخ",
+  "preDive_sessions_filterClearAll": "مسح الكل",
+  "preDive_sessions_filterApply": "تطبيق",
+  "preDive_sessions_filterFlaggedChip": "المعلَّمة فقط",
+  "preDive_sessions_emptyFiltered": "لا توجد عمليات قوائم تحقق تطابق هذه المرشحات",
+  "preDive_sessions_export": "تصدير إلى Excel",
+  "preDive_sessions_exportEmpty": "لا توجد عمليات قوائم تحقق للتصدير",
+  "preDive_sessions_exportFailed": "فشل التصدير: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "بدء قائمة تحقق ما قبل الغوص",
   "preDive_start_template": "قائمة التحقق",
   "preDive_start_equipmentSet": "طقم المعدات",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Verknüpfter Tauchgang",
   "preDive_sessions_delete": "Löschen",
   "preDive_sessions_deleteConfirm": "Diesen Checklisten-Eintrag löschen?",
+  "preDive_sessions_filter": "Filtern",
+  "preDive_sessions_filterTitle": "Checklisten-Durchläufe filtern",
+  "preDive_sessions_filterChecklist": "Checkliste",
+  "preDive_sessions_filterStatus": "Status",
+  "preDive_sessions_filterFlaggedOnly": "Nur markierte Durchläufe",
+  "preDive_sessions_filterDateRange": "Zeitraum",
+  "preDive_sessions_filterAnyDate": "Beliebiges Datum",
+  "preDive_sessions_filterClearAll": "Alle zurücksetzen",
+  "preDive_sessions_filterApply": "Anwenden",
+  "preDive_sessions_filterFlaggedChip": "Nur markierte",
+  "preDive_sessions_emptyFiltered": "Keine Checklisten-Durchläufe entsprechen diesen Filtern",
+  "preDive_sessions_export": "Nach Excel exportieren",
+  "preDive_sessions_exportEmpty": "Keine Checklisten-Durchläufe zum Exportieren",
+  "preDive_sessions_exportFailed": "Export fehlgeschlagen: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Checkliste vor dem Tauchgang starten",
   "preDive_start_template": "Checkliste",
   "preDive_start_equipmentSet": "Ausrüstungsset",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1529,6 +1529,27 @@
   "preDive_sessions_linkedDive": "Linked dive",
   "preDive_sessions_delete": "Delete",
   "preDive_sessions_deleteConfirm": "Delete this checklist record?",
+  "preDive_sessions_filter": "Filter",
+  "preDive_sessions_filterTitle": "Filter checklist runs",
+  "preDive_sessions_filterChecklist": "Checklist",
+  "preDive_sessions_filterStatus": "Status",
+  "preDive_sessions_filterFlaggedOnly": "Flagged runs only",
+  "preDive_sessions_filterDateRange": "Date range",
+  "preDive_sessions_filterAnyDate": "Any date",
+  "preDive_sessions_filterClearAll": "Clear all",
+  "preDive_sessions_filterApply": "Apply",
+  "preDive_sessions_filterFlaggedChip": "Flagged only",
+  "preDive_sessions_emptyFiltered": "No checklist runs match these filters",
+  "preDive_sessions_export": "Export to Excel",
+  "preDive_sessions_exportEmpty": "No checklist runs to export",
+  "preDive_sessions_exportFailed": "Export failed: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Start pre-dive checklist",
   "preDive_start_template": "Checklist",
   "preDive_start_equipmentSet": "Equipment set",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Inmersión vinculada",
   "preDive_sessions_delete": "Eliminar",
   "preDive_sessions_deleteConfirm": "¿Eliminar este registro de lista de verificación?",
+  "preDive_sessions_filter": "Filtrar",
+  "preDive_sessions_filterTitle": "Filtrar listas realizadas",
+  "preDive_sessions_filterChecklist": "Lista de verificación",
+  "preDive_sessions_filterStatus": "Estado",
+  "preDive_sessions_filterFlaggedOnly": "Solo con incidencias",
+  "preDive_sessions_filterDateRange": "Intervalo de fechas",
+  "preDive_sessions_filterAnyDate": "Cualquier fecha",
+  "preDive_sessions_filterClearAll": "Borrar todo",
+  "preDive_sessions_filterApply": "Aplicar",
+  "preDive_sessions_filterFlaggedChip": "Solo incidencias",
+  "preDive_sessions_emptyFiltered": "Ninguna lista coincide con estos filtros",
+  "preDive_sessions_export": "Exportar a Excel",
+  "preDive_sessions_exportEmpty": "No hay listas para exportar",
+  "preDive_sessions_exportFailed": "Error al exportar: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Iniciar lista previa a la inmersión",
   "preDive_start_template": "Lista de verificación",
   "preDive_start_equipmentSet": "Conjunto de equipo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Plongée liée",
   "preDive_sessions_delete": "Supprimer",
   "preDive_sessions_deleteConfirm": "Supprimer cet enregistrement de checklist ?",
+  "preDive_sessions_filter": "Filtrer",
+  "preDive_sessions_filterTitle": "Filtrer les checklists effectuées",
+  "preDive_sessions_filterChecklist": "Checklist",
+  "preDive_sessions_filterStatus": "Statut",
+  "preDive_sessions_filterFlaggedOnly": "Uniquement les anomalies",
+  "preDive_sessions_filterDateRange": "Période",
+  "preDive_sessions_filterAnyDate": "Toutes les dates",
+  "preDive_sessions_filterClearAll": "Tout effacer",
+  "preDive_sessions_filterApply": "Appliquer",
+  "preDive_sessions_filterFlaggedChip": "Anomalies uniquement",
+  "preDive_sessions_emptyFiltered": "Aucune checklist ne correspond à ces filtres",
+  "preDive_sessions_export": "Exporter vers Excel",
+  "preDive_sessions_exportEmpty": "Aucune checklist à exporter",
+  "preDive_sessions_exportFailed": "Échec de l'export : {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Démarrer la checklist pré-plongée",
   "preDive_start_template": "Checklist",
   "preDive_start_equipmentSet": "Ensemble d'équipement",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "צלילה מקושרת",
   "preDive_sessions_delete": "מחיקה",
   "preDive_sessions_deleteConfirm": "למחוק את רשומת רשימת הבדיקה הזו?",
+  "preDive_sessions_filter": "סינון",
+  "preDive_sessions_filterTitle": "סינון רשימות בדיקה שבוצעו",
+  "preDive_sessions_filterChecklist": "רשימת בדיקה",
+  "preDive_sessions_filterStatus": "סטטוס",
+  "preDive_sessions_filterFlaggedOnly": "רק ריצות מסומנות",
+  "preDive_sessions_filterDateRange": "טווח תאריכים",
+  "preDive_sessions_filterAnyDate": "כל תאריך",
+  "preDive_sessions_filterClearAll": "נקה הכול",
+  "preDive_sessions_filterApply": "החל",
+  "preDive_sessions_filterFlaggedChip": "מסומנות בלבד",
+  "preDive_sessions_emptyFiltered": "אין רשימות בדיקה התואמות למסננים אלה",
+  "preDive_sessions_export": "ייצוא ל-Excel",
+  "preDive_sessions_exportEmpty": "אין רשימות בדיקה לייצוא",
+  "preDive_sessions_exportFailed": "הייצוא נכשל: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "התחלת רשימת בדיקה לפני צלילה",
   "preDive_start_template": "רשימת בדיקה",
   "preDive_start_equipmentSet": "סט ציוד",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Kapcsolt merülés",
   "preDive_sessions_delete": "Törlés",
   "preDive_sessions_deleteConfirm": "Törli ezt az ellenőrzőlista-bejegyzést?",
+  "preDive_sessions_filter": "Szűrés",
+  "preDive_sessions_filterTitle": "Ellenőrzőlista-futtatások szűrése",
+  "preDive_sessions_filterChecklist": "Ellenőrzőlista",
+  "preDive_sessions_filterStatus": "Állapot",
+  "preDive_sessions_filterFlaggedOnly": "Csak megjelölt futtatások",
+  "preDive_sessions_filterDateRange": "Dátumtartomány",
+  "preDive_sessions_filterAnyDate": "Bármely dátum",
+  "preDive_sessions_filterClearAll": "Összes törlése",
+  "preDive_sessions_filterApply": "Alkalmaz",
+  "preDive_sessions_filterFlaggedChip": "Csak megjelölt",
+  "preDive_sessions_emptyFiltered": "Nincs a szűrőknek megfelelő ellenőrzőlista-futtatás",
+  "preDive_sessions_export": "Exportálás Excelbe",
+  "preDive_sessions_exportEmpty": "Nincs exportálható futtatás",
+  "preDive_sessions_exportFailed": "Az exportálás sikertelen: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Merülés előtti ellenőrzőlista indítása",
   "preDive_start_template": "Ellenőrzőlista",
   "preDive_start_equipmentSet": "Felszereléskészlet",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Immersione collegata",
   "preDive_sessions_delete": "Elimina",
   "preDive_sessions_deleteConfirm": "Eliminare questo record di checklist?",
+  "preDive_sessions_filter": "Filtra",
+  "preDive_sessions_filterTitle": "Filtra le checklist eseguite",
+  "preDive_sessions_filterChecklist": "Checklist",
+  "preDive_sessions_filterStatus": "Stato",
+  "preDive_sessions_filterFlaggedOnly": "Solo con segnalazioni",
+  "preDive_sessions_filterDateRange": "Intervallo di date",
+  "preDive_sessions_filterAnyDate": "Qualsiasi data",
+  "preDive_sessions_filterClearAll": "Cancella tutto",
+  "preDive_sessions_filterApply": "Applica",
+  "preDive_sessions_filterFlaggedChip": "Solo segnalazioni",
+  "preDive_sessions_emptyFiltered": "Nessuna checklist corrisponde a questi filtri",
+  "preDive_sessions_export": "Esporta in Excel",
+  "preDive_sessions_exportEmpty": "Nessuna checklist da esportare",
+  "preDive_sessions_exportFailed": "Esportazione non riuscita: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Avvia checklist pre-immersione",
   "preDive_start_template": "Checklist",
   "preDive_start_equipmentSet": "Set di attrezzatura",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -4109,6 +4109,90 @@ abstract class AppLocalizations {
   /// **'Delete this checklist record?'**
   String get preDive_sessions_deleteConfirm;
 
+  /// No description provided for @preDive_sessions_filter.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter'**
+  String get preDive_sessions_filter;
+
+  /// No description provided for @preDive_sessions_filterTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter checklist runs'**
+  String get preDive_sessions_filterTitle;
+
+  /// No description provided for @preDive_sessions_filterChecklist.
+  ///
+  /// In en, this message translates to:
+  /// **'Checklist'**
+  String get preDive_sessions_filterChecklist;
+
+  /// No description provided for @preDive_sessions_filterStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Status'**
+  String get preDive_sessions_filterStatus;
+
+  /// No description provided for @preDive_sessions_filterFlaggedOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Flagged runs only'**
+  String get preDive_sessions_filterFlaggedOnly;
+
+  /// No description provided for @preDive_sessions_filterDateRange.
+  ///
+  /// In en, this message translates to:
+  /// **'Date range'**
+  String get preDive_sessions_filterDateRange;
+
+  /// No description provided for @preDive_sessions_filterAnyDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Any date'**
+  String get preDive_sessions_filterAnyDate;
+
+  /// No description provided for @preDive_sessions_filterClearAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all'**
+  String get preDive_sessions_filterClearAll;
+
+  /// No description provided for @preDive_sessions_filterApply.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get preDive_sessions_filterApply;
+
+  /// No description provided for @preDive_sessions_filterFlaggedChip.
+  ///
+  /// In en, this message translates to:
+  /// **'Flagged only'**
+  String get preDive_sessions_filterFlaggedChip;
+
+  /// No description provided for @preDive_sessions_emptyFiltered.
+  ///
+  /// In en, this message translates to:
+  /// **'No checklist runs match these filters'**
+  String get preDive_sessions_emptyFiltered;
+
+  /// No description provided for @preDive_sessions_export.
+  ///
+  /// In en, this message translates to:
+  /// **'Export to Excel'**
+  String get preDive_sessions_export;
+
+  /// No description provided for @preDive_sessions_exportEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No checklist runs to export'**
+  String get preDive_sessions_exportEmpty;
+
+  /// No description provided for @preDive_sessions_exportFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Export failed: {error}'**
+  String preDive_sessions_exportFailed(String error);
+
   /// No description provided for @preDive_start_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2381,6 +2381,51 @@ class AppLocalizationsAr extends AppLocalizations {
       'هل تريد حذف سجل قائمة التحقق هذا؟';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'بدء قائمة تحقق ما قبل الغوص';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2381,48 +2381,49 @@ class AppLocalizationsAr extends AppLocalizations {
       'هل تريد حذف سجل قائمة التحقق هذا؟';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'تصفية';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'تصفية عمليات قوائم التحقق';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'قائمة التحقق';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'الحالة';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'العمليات المعلَّمة فقط';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'النطاق الزمني';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'أي تاريخ';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'مسح الكل';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'تطبيق';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'المعلَّمة فقط';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'لا توجد عمليات قوائم تحقق تطابق هذه المرشحات';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'تصدير إلى Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty =>
+      'لا توجد عمليات قوائم تحقق للتصدير';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'فشل التصدير: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2436,6 +2436,51 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diesen Checklisten-Eintrag löschen?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Checkliste vor dem Tauchgang starten';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2436,48 +2436,49 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diesen Checklisten-Eintrag löschen?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filtern';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'Checklisten-Durchläufe filtern';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'Checkliste';
 
   @override
   String get preDive_sessions_filterStatus => 'Status';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Nur markierte Durchläufe';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Zeitraum';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Beliebiges Datum';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Alle zurücksetzen';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Anwenden';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Nur markierte';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Keine Checklisten-Durchläufe entsprechen diesen Filtern';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Nach Excel exportieren';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty =>
+      'Keine Checklisten-Durchläufe zum Exportieren';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Export fehlgeschlagen: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2385,6 +2385,51 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preDive_sessions_deleteConfirm => 'Delete this checklist record?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Start pre-dive checklist';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2436,48 +2436,48 @@ class AppLocalizationsEs extends AppLocalizations {
       '¿Eliminar este registro de lista de verificación?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filtrar';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'Filtrar listas realizadas';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'Lista de verificación';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'Estado';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Solo con incidencias';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Intervalo de fechas';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Cualquier fecha';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Borrar todo';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Aplicar';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Solo incidencias';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Ninguna lista coincide con estos filtros';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Exportar a Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'No hay listas para exportar';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Error al exportar: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2436,6 +2436,51 @@ class AppLocalizationsEs extends AppLocalizations {
       '¿Eliminar este registro de lista de verificación?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Iniciar lista previa a la inmersión';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2438,48 +2438,49 @@ class AppLocalizationsFr extends AppLocalizations {
       'Supprimer cet enregistrement de checklist ?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filtrer';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle =>
+      'Filtrer les checklists effectuées';
 
   @override
   String get preDive_sessions_filterChecklist => 'Checklist';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'Statut';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Uniquement les anomalies';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Période';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Toutes les dates';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Tout effacer';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Appliquer';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Anomalies uniquement';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Aucune checklist ne correspond à ces filtres';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Exporter vers Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'Aucune checklist à exporter';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Échec de l\'export : $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2438,6 +2438,51 @@ class AppLocalizationsFr extends AppLocalizations {
       'Supprimer cet enregistrement de checklist ?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Démarrer la checklist pré-plongée';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2360,6 +2360,51 @@ class AppLocalizationsHe extends AppLocalizations {
       'למחוק את רשומת רשימת הבדיקה הזו?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'התחלת רשימת בדיקה לפני צלילה';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2360,48 +2360,48 @@ class AppLocalizationsHe extends AppLocalizations {
       'למחוק את רשומת רשימת הבדיקה הזו?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'סינון';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'סינון רשימות בדיקה שבוצעו';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'רשימת בדיקה';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'סטטוס';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'רק ריצות מסומנות';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'טווח תאריכים';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'כל תאריך';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'נקה הכול';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'החל';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'מסומנות בלבד';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'אין רשימות בדיקה התואמות למסננים אלה';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'ייצוא ל-Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'אין רשימות בדיקה לייצוא';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'הייצוא נכשל: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2419,48 +2419,49 @@ class AppLocalizationsHu extends AppLocalizations {
       'Törli ezt az ellenőrzőlista-bejegyzést?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Szűrés';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle =>
+      'Ellenőrzőlista-futtatások szűrése';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'Ellenőrzőlista';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'Állapot';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Csak megjelölt futtatások';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Dátumtartomány';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Bármely dátum';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Összes törlése';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Alkalmaz';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Csak megjelölt';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Nincs a szűrőknek megfelelő ellenőrzőlista-futtatás';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Exportálás Excelbe';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'Nincs exportálható futtatás';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Az exportálás sikertelen: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2419,6 +2419,51 @@ class AppLocalizationsHu extends AppLocalizations {
       'Törli ezt az ellenőrzőlista-bejegyzést?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Merülés előtti ellenőrzőlista indítása';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2429,48 +2429,48 @@ class AppLocalizationsIt extends AppLocalizations {
       'Eliminare questo record di checklist?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filtra';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'Filtra le checklist eseguite';
 
   @override
   String get preDive_sessions_filterChecklist => 'Checklist';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'Stato';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Solo con segnalazioni';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Intervallo di date';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Qualsiasi data';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Cancella tutto';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Applica';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Solo segnalazioni';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Nessuna checklist corrisponde a questi filtri';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Esporta in Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'Nessuna checklist da esportare';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Esportazione non riuscita: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2429,6 +2429,51 @@ class AppLocalizationsIt extends AppLocalizations {
       'Eliminare questo record di checklist?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Avvia checklist pre-immersione';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2414,6 +2414,51 @@ class AppLocalizationsNl extends AppLocalizations {
       'Deze checklistregistratie verwijderen?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Pre-dive checklist starten';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2414,10 +2414,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Deze checklistregistratie verwijderen?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filteren';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'Checklistsessies filteren';
 
   @override
   String get preDive_sessions_filterChecklist => 'Checklist';
@@ -2426,36 +2426,37 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preDive_sessions_filterStatus => 'Status';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Alleen gemarkeerde sessies';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Datumbereik';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Elke datum';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Alles wissen';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Toepassen';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Alleen gemarkeerd';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Geen checklistsessies voldoen aan deze filters';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Exporteren naar Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty =>
+      'Geen checklistsessies om te exporteren';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Exporteren mislukt: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2431,48 +2431,48 @@ class AppLocalizationsPt extends AppLocalizations {
       'Excluir este registro de lista de verificação?';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => 'Filtrar';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => 'Filtrar listas realizadas';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => 'Lista de verificação';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => 'Estado';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => 'Apenas com ocorrências';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => 'Intervalo de datas';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => 'Qualquer data';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => 'Limpar tudo';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => 'Aplicar';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => 'Apenas ocorrências';
 
   @override
   String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+      'Nenhuma lista corresponde a estes filtros';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => 'Exportar para Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => 'Nenhuma lista para exportar';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return 'Falha na exportação: $error';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2431,6 +2431,51 @@ class AppLocalizationsPt extends AppLocalizations {
       'Excluir este registro de lista de verificação?';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => 'Iniciar lista de verificação pré-mergulho';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2292,6 +2292,51 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preDive_sessions_deleteConfirm => '要删除此检查清单记录吗？';
 
   @override
+  String get preDive_sessions_filter => 'Filter';
+
+  @override
+  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+
+  @override
+  String get preDive_sessions_filterChecklist => 'Checklist';
+
+  @override
+  String get preDive_sessions_filterStatus => 'Status';
+
+  @override
+  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+
+  @override
+  String get preDive_sessions_filterDateRange => 'Date range';
+
+  @override
+  String get preDive_sessions_filterAnyDate => 'Any date';
+
+  @override
+  String get preDive_sessions_filterClearAll => 'Clear all';
+
+  @override
+  String get preDive_sessions_filterApply => 'Apply';
+
+  @override
+  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+
+  @override
+  String get preDive_sessions_emptyFiltered =>
+      'No checklist runs match these filters';
+
+  @override
+  String get preDive_sessions_export => 'Export to Excel';
+
+  @override
+  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+
+  @override
+  String preDive_sessions_exportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get preDive_start_title => '开始潜前检查清单';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2292,48 +2292,47 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preDive_sessions_deleteConfirm => '要删除此检查清单记录吗？';
 
   @override
-  String get preDive_sessions_filter => 'Filter';
+  String get preDive_sessions_filter => '筛选';
 
   @override
-  String get preDive_sessions_filterTitle => 'Filter checklist runs';
+  String get preDive_sessions_filterTitle => '筛选检查清单记录';
 
   @override
-  String get preDive_sessions_filterChecklist => 'Checklist';
+  String get preDive_sessions_filterChecklist => '检查清单';
 
   @override
-  String get preDive_sessions_filterStatus => 'Status';
+  String get preDive_sessions_filterStatus => '状态';
 
   @override
-  String get preDive_sessions_filterFlaggedOnly => 'Flagged runs only';
+  String get preDive_sessions_filterFlaggedOnly => '仅显示有标记的记录';
 
   @override
-  String get preDive_sessions_filterDateRange => 'Date range';
+  String get preDive_sessions_filterDateRange => '日期范围';
 
   @override
-  String get preDive_sessions_filterAnyDate => 'Any date';
+  String get preDive_sessions_filterAnyDate => '任意日期';
 
   @override
-  String get preDive_sessions_filterClearAll => 'Clear all';
+  String get preDive_sessions_filterClearAll => '全部清除';
 
   @override
-  String get preDive_sessions_filterApply => 'Apply';
+  String get preDive_sessions_filterApply => '应用';
 
   @override
-  String get preDive_sessions_filterFlaggedChip => 'Flagged only';
+  String get preDive_sessions_filterFlaggedChip => '仅有标记';
 
   @override
-  String get preDive_sessions_emptyFiltered =>
-      'No checklist runs match these filters';
+  String get preDive_sessions_emptyFiltered => '没有符合这些筛选条件的检查清单记录';
 
   @override
-  String get preDive_sessions_export => 'Export to Excel';
+  String get preDive_sessions_export => '导出到 Excel';
 
   @override
-  String get preDive_sessions_exportEmpty => 'No checklist runs to export';
+  String get preDive_sessions_exportEmpty => '没有可导出的检查清单记录';
 
   @override
   String preDive_sessions_exportFailed(String error) {
-    return 'Export failed: $error';
+    return '导出失败：$error';
   }
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Gekoppelde duik",
   "preDive_sessions_delete": "Verwijderen",
   "preDive_sessions_deleteConfirm": "Deze checklistregistratie verwijderen?",
+  "preDive_sessions_filter": "Filteren",
+  "preDive_sessions_filterTitle": "Checklistsessies filteren",
+  "preDive_sessions_filterChecklist": "Checklist",
+  "preDive_sessions_filterStatus": "Status",
+  "preDive_sessions_filterFlaggedOnly": "Alleen gemarkeerde sessies",
+  "preDive_sessions_filterDateRange": "Datumbereik",
+  "preDive_sessions_filterAnyDate": "Elke datum",
+  "preDive_sessions_filterClearAll": "Alles wissen",
+  "preDive_sessions_filterApply": "Toepassen",
+  "preDive_sessions_filterFlaggedChip": "Alleen gemarkeerd",
+  "preDive_sessions_emptyFiltered": "Geen checklistsessies voldoen aan deze filters",
+  "preDive_sessions_export": "Exporteren naar Excel",
+  "preDive_sessions_exportEmpty": "Geen checklistsessies om te exporteren",
+  "preDive_sessions_exportFailed": "Exporteren mislukt: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Pre-dive checklist starten",
   "preDive_start_template": "Checklist",
   "preDive_start_equipmentSet": "Uitrustingsset",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -841,6 +841,27 @@
   "preDive_sessions_linkedDive": "Mergulho vinculado",
   "preDive_sessions_delete": "Excluir",
   "preDive_sessions_deleteConfirm": "Excluir este registro de lista de verificação?",
+  "preDive_sessions_filter": "Filtrar",
+  "preDive_sessions_filterTitle": "Filtrar listas realizadas",
+  "preDive_sessions_filterChecklist": "Lista de verificação",
+  "preDive_sessions_filterStatus": "Estado",
+  "preDive_sessions_filterFlaggedOnly": "Apenas com ocorrências",
+  "preDive_sessions_filterDateRange": "Intervalo de datas",
+  "preDive_sessions_filterAnyDate": "Qualquer data",
+  "preDive_sessions_filterClearAll": "Limpar tudo",
+  "preDive_sessions_filterApply": "Aplicar",
+  "preDive_sessions_filterFlaggedChip": "Apenas ocorrências",
+  "preDive_sessions_emptyFiltered": "Nenhuma lista corresponde a estes filtros",
+  "preDive_sessions_export": "Exportar para Excel",
+  "preDive_sessions_exportEmpty": "Nenhuma lista para exportar",
+  "preDive_sessions_exportFailed": "Falha na exportação: {error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "Iniciar lista de verificação pré-mergulho",
   "preDive_start_template": "Lista de verificação",
   "preDive_start_equipmentSet": "Conjunto de equipamentos",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -935,6 +935,27 @@
   "preDive_sessions_linkedDive": "关联潜水",
   "preDive_sessions_delete": "删除",
   "preDive_sessions_deleteConfirm": "要删除此检查清单记录吗？",
+  "preDive_sessions_filter": "筛选",
+  "preDive_sessions_filterTitle": "筛选检查清单记录",
+  "preDive_sessions_filterChecklist": "检查清单",
+  "preDive_sessions_filterStatus": "状态",
+  "preDive_sessions_filterFlaggedOnly": "仅显示有标记的记录",
+  "preDive_sessions_filterDateRange": "日期范围",
+  "preDive_sessions_filterAnyDate": "任意日期",
+  "preDive_sessions_filterClearAll": "全部清除",
+  "preDive_sessions_filterApply": "应用",
+  "preDive_sessions_filterFlaggedChip": "仅有标记",
+  "preDive_sessions_emptyFiltered": "没有符合这些筛选条件的检查清单记录",
+  "preDive_sessions_export": "导出到 Excel",
+  "preDive_sessions_exportEmpty": "没有可导出的检查清单记录",
+  "preDive_sessions_exportFailed": "导出失败：{error}",
+  "@preDive_sessions_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "preDive_start_title": "开始潜前检查清单",
   "preDive_start_template": "检查清单",
   "preDive_start_equipmentSet": "装备套装",

--- a/test/core/services/export/excel/excel_export_service_test.dart
+++ b/test/core/services/export/excel/excel_export_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:excel/excel.dart' as xl;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';
@@ -77,6 +78,26 @@ void main() {
       // XLSX files start with PK zip header
       expect(bytes[0], 0x50); // 'P'
       expect(bytes[1], 0x4B); // 'K'
+    });
+
+    test('workbook carries no stray default sheet', () async {
+      final bytes = await service.generateExcelBytes(
+        dives: [makeDive(id: 'd1', diveNumber: 1, maxDepth: 20.0)],
+        sites: const [],
+        equipment: const [],
+        depthUnit: DepthUnit.meters,
+        temperatureUnit: TemperatureUnit.celsius,
+        pressureUnit: PressureUnit.bar,
+        volumeUnit: VolumeUnit.liters,
+        dateFormat: DateFormatPreference.yyyymmdd,
+      );
+
+      final excel = xl.Excel.decodeBytes(bytes);
+
+      // The excel package will not delete a workbook's last remaining sheet,
+      // so the default sheet has to be removed after the real ones exist.
+      expect(excel.tables.keys, isNot(contains('Sheet1')));
+      expect(excel.tables.keys, contains('Dives'));
     });
 
     test('generates Excel with null bottomTime', () async {

--- a/test/core/services/export/excel/pre_dive_excel_export_service_test.dart
+++ b/test/core/services/export/excel/pre_dive_excel_export_service_test.dart
@@ -1,0 +1,241 @@
+import 'package:excel/excel.dart' as xl;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_checklist_template.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+
+void main() {
+  late PreDiveExcelExportService service;
+
+  setUp(() => service = PreDiveExcelExportService());
+
+  final started = DateTime(2026, 3, 15, 8, 30);
+  final completed = DateTime(2026, 3, 15, 8, 52);
+
+  PreDiveSession session({
+    String id = 's1',
+    String name = 'CCR Build',
+    PreDiveSessionStatus status = PreDiveSessionStatus.completed,
+    String? diveId,
+    String? equipmentSetName,
+    String notes = '',
+  }) => PreDiveSession(
+    id: id,
+    templateName: name,
+    status: status,
+    diveId: diveId,
+    equipmentSetName: equipmentSetName,
+    notes: notes,
+    startedAt: started,
+    completedAt: status == PreDiveSessionStatus.inProgress ? null : completed,
+    createdAt: started,
+    updatedAt: completed,
+  );
+
+  PreDiveSessionItem item({
+    String id = 'i1',
+    String sessionId = 's1',
+    String title = 'Check cells',
+    String? section,
+    PreDiveItemState state = PreDiveItemState.done,
+    PreDiveItemType type = PreDiveItemType.check,
+    double? valueNumber,
+    String? valueUnit,
+    String note = '',
+    bool required = false,
+    DateTime? completedAt,
+  }) => PreDiveSessionItem(
+    id: id,
+    sessionId: sessionId,
+    title: title,
+    section: section,
+    state: state,
+    itemType: type,
+    valueNumber: valueNumber,
+    valueUnit: valueUnit,
+    note: note,
+    isRequired: required,
+    completedAt: completedAt,
+    sortOrder: 0,
+    createdAt: started,
+    updatedAt: started,
+  );
+
+  /// Reads a decoded sheet back as rows of plain strings so assertions can
+  /// talk about content rather than about cell objects.
+  List<List<String>> rowsOf(xl.Excel excel, String sheetName) {
+    final sheet = excel.tables[sheetName]!;
+    return [
+      for (final row in sheet.rows)
+        [for (final cell in row) cell?.value?.toString() ?? ''],
+    ];
+  }
+
+  xl.Excel decode(List<int> bytes) => xl.Excel.decodeBytes(bytes);
+
+  test('produces a runs sheet and an items sheet', () {
+    final bytes = service.generateBytes(
+      sessions: [session()],
+      itemsBySession: {
+        's1': [item()],
+      },
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final excel = decode(bytes);
+
+    expect(excel.tables.keys, contains(PreDiveExcelExportService.runsSheet));
+    expect(excel.tables.keys, contains(PreDiveExcelExportService.itemsSheet));
+    // The default sheet the excel package creates must not survive.
+    expect(excel.tables.keys, isNot(contains('Sheet1')));
+  });
+
+  test('runs sheet carries one row per session under a header row', () {
+    final bytes = service.generateBytes(
+      sessions: [
+        session(id: 's1', name: 'CCR Build'),
+        session(id: 's2', name: 'BWRAF', status: PreDiveSessionStatus.aborted),
+      ],
+      itemsBySession: const {},
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final rows = rowsOf(decode(bytes), PreDiveExcelExportService.runsSheet);
+
+    expect(rows.first.first, 'Checklist');
+    expect(rows, hasLength(3));
+    expect(rows[1].first, 'CCR Build');
+    expect(rows[2].first, 'BWRAF');
+  });
+
+  test('runs sheet reports tallies, status and linkage', () {
+    final bytes = service.generateBytes(
+      sessions: [session(diveId: 'dive-42', equipmentSetName: 'CCR set')],
+      itemsBySession: {
+        's1': [
+          item(id: 'i1', state: PreDiveItemState.done),
+          item(id: 'i2', state: PreDiveItemState.flagged),
+          item(id: 'i3', state: PreDiveItemState.pending),
+        ],
+      },
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final rows = rowsOf(decode(bytes), PreDiveExcelExportService.runsSheet);
+    final header = rows.first;
+    final run = rows[1];
+    String cell(String column) => run[header.indexOf(column)];
+
+    expect(cell('Status'), 'Completed');
+    expect(cell('Items'), '3');
+    expect(cell('Resolved'), '2');
+    expect(cell('Flagged'), '1');
+    expect(cell('Linked Dive'), 'dive-42');
+    expect(cell('Equipment Set'), 'CCR set');
+    expect(cell('Started'), contains('2026-03-15'));
+  });
+
+  test('items sheet carries one row per item, keyed back to its run', () {
+    final bytes = service.generateBytes(
+      sessions: [session(id: 's1', name: 'CCR Build')],
+      itemsBySession: {
+        's1': [
+          item(id: 'i1', title: 'Check cells', section: 'Electronics'),
+          item(id: 'i2', title: 'Check scrubber', section: 'Scrubber'),
+        ],
+      },
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final rows = rowsOf(decode(bytes), PreDiveExcelExportService.itemsSheet);
+    final header = rows.first;
+
+    expect(rows, hasLength(3));
+    expect(rows[1][header.indexOf('Checklist')], 'CCR Build');
+    expect(rows[1][header.indexOf('Section')], 'Electronics');
+    expect(rows[1][header.indexOf('Item')], 'Check cells');
+    expect(rows[2][header.indexOf('Item')], 'Check scrubber');
+  });
+
+  test('items sheet records the flag note, state and measured value', () {
+    final bytes = service.generateBytes(
+      sessions: [session()],
+      itemsBySession: {
+        's1': [
+          item(
+            id: 'i1',
+            title: 'Cell 1 mV',
+            type: PreDiveItemType.value,
+            state: PreDiveItemState.flagged,
+            valueNumber: 8.2,
+            valueUnit: 'mV',
+            note: 'Reading low, replaced cell',
+            required: true,
+            completedAt: completed,
+          ),
+        ],
+      },
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final rows = rowsOf(decode(bytes), PreDiveExcelExportService.itemsSheet);
+    final header = rows.first;
+    String cell(String column) => rows[1][header.indexOf(column)];
+
+    // The note and flag are the audit evidence a checklist export exists for.
+    expect(cell('State'), 'Flagged');
+    expect(cell('Note'), 'Reading low, replaced cell');
+    expect(cell('Value'), '8.2');
+    expect(cell('Unit'), 'mV');
+    expect(cell('Required'), 'Yes');
+    expect(cell('Completed At'), isNotEmpty);
+  });
+
+  test('a session with no items still appears on the runs sheet', () {
+    final bytes = service.generateBytes(
+      sessions: [session()],
+      itemsBySession: const {},
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final excel = decode(bytes);
+    final runs = rowsOf(excel, PreDiveExcelExportService.runsSheet);
+    final items = rowsOf(excel, PreDiveExcelExportService.itemsSheet);
+
+    expect(runs, hasLength(2));
+    expect(runs[1][runs.first.indexOf('Items')], '0');
+    // Header only: no orphan item rows invented for it.
+    expect(items, hasLength(1));
+  });
+
+  test('an in-progress run leaves the completed column empty', () {
+    final bytes = service.generateBytes(
+      sessions: [session(status: PreDiveSessionStatus.inProgress)],
+      itemsBySession: const {},
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    final rows = rowsOf(decode(bytes), PreDiveExcelExportService.runsSheet);
+
+    expect(rows[1][rows.first.indexOf('Completed')], isEmpty);
+    expect(rows[1][rows.first.indexOf('Status')], 'In progress');
+  });
+
+  test('generates a valid xlsx container for an empty export', () {
+    final bytes = service.generateBytes(
+      sessions: const [],
+      itemsBySession: const {},
+      dateFormat: DateFormatPreference.yyyymmdd,
+    );
+
+    expect(bytes, isNotEmpty);
+    // xlsx is a zip: "PK" magic number.
+    expect(bytes[0], 0x50);
+    expect(bytes[1], 0x4B);
+    expect(
+      rowsOf(decode(bytes), PreDiveExcelExportService.runsSheet),
+      hasLength(1),
+    );
+  });
+}

--- a/test/features/pre_dive/data/repositories/pre_dive_session_repository_test.dart
+++ b/test/features/pre_dive/data/repositories/pre_dive_session_repository_test.dart
@@ -34,6 +34,14 @@ void main() {
 
   final now = DateTime.now();
 
+  Future<void> insertDiver(String id) async {
+    final db = DatabaseService.instance.database;
+    await db.customStatement(
+      'INSERT INTO divers (id, name, created_at, updated_at) '
+      "VALUES ('$id', '$id', 0, 0)",
+    );
+  }
+
   Future<void> insertDive(String id) async {
     final db = DatabaseService.instance.database;
     await db.customStatement(
@@ -165,6 +173,76 @@ void main() {
     expect((await repository.getActiveSession())!.id, s2.id);
     await repository.abortSession(s2.id);
     expect(await repository.getActiveSession(), isNull);
+  });
+
+  test(
+    'getSessionStats counts totals, resolved and flagged per session',
+    () async {
+      final s1 = await start();
+      final s1Items = await repository.getItemsForSession(s1.id);
+      await repository.updateItemState(
+        sessionId: s1.id,
+        itemId: s1Items[0].id,
+        state: domain.PreDiveItemState.flagged,
+      );
+      await repository.completeSession(s1.id);
+
+      final s2 = await start();
+      final s2Items = await repository.getItemsForSession(s2.id);
+      await repository.updateItemState(
+        sessionId: s2.id,
+        itemId: s2Items[0].id,
+        state: domain.PreDiveItemState.done,
+      );
+      await repository.updateItemState(
+        sessionId: s2.id,
+        itemId: s2Items[1].id,
+        state: domain.PreDiveItemState.skipped,
+      );
+
+      final stats = await repository.getSessionStats();
+
+      // s1: one flagged (which also counts as resolved), one still pending.
+      expect(stats[s1.id]!.total, 2);
+      expect(stats[s1.id]!.resolved, 1);
+      expect(stats[s1.id]!.flagged, 1);
+      // s2: done + skipped are both resolved, neither is flagged.
+      expect(stats[s2.id]!.total, 2);
+      expect(stats[s2.id]!.resolved, 2);
+      expect(stats[s2.id]!.flagged, 0);
+    },
+  );
+
+  test('getSessionStats omits sessions belonging to another diver', () async {
+    await insertDiver('me');
+    await insertDiver('someone-else');
+    // An unscoped session stays visible to every diver.
+    final mine = await start();
+    final theirs = await repository.startSession(
+      template: template(),
+      items: [draft('A')],
+      diverId: 'someone-else',
+    );
+
+    final stats = await repository.getSessionStats(diverId: 'me');
+
+    expect(stats.containsKey(mine.id), isTrue);
+    expect(stats.containsKey(theirs.id), isFalse);
+  });
+
+  test('getItemsForSessions returns items grouped by session id', () async {
+    final s1 = await start();
+    final s2 = await start();
+
+    final grouped = await repository.getItemsForSessions([s1.id, s2.id]);
+
+    expect(grouped[s1.id]!.map((i) => i.title).toList(), ['A', 'B']);
+    expect(grouped[s2.id]!.map((i) => i.title).toList(), ['A', 'B']);
+  });
+
+  test('getItemsForSessions returns an empty map for no ids', () async {
+    await start();
+    expect(await repository.getItemsForSessions([]), isEmpty);
   });
 
   test('deleteSession tombstones session and items', () async {

--- a/test/features/pre_dive/domain/models/pre_dive_session_filter_test.dart
+++ b/test/features/pre_dive/domain/models/pre_dive_session_filter_test.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart' show DateTimeRange;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
+
+void main() {
+  PreDiveSession session(
+    String id, {
+    String name = 'CCR Build',
+    PreDiveSessionStatus status = PreDiveSessionStatus.completed,
+    DateTime? startedAt,
+  }) {
+    final at = startedAt ?? DateTime(2026, 3, 15, 9);
+    return PreDiveSession(
+      id: id,
+      templateName: name,
+      status: status,
+      startedAt: at,
+      createdAt: at,
+      updatedAt: at,
+    );
+  }
+
+  const noStats = <String, PreDiveSessionStats>{};
+
+  group('hasActiveFilters', () {
+    test('is false for a default filter', () {
+      expect(const PreDiveSessionFilter().hasActiveFilters, isFalse);
+    });
+
+    test('is true when any single facet is set', () {
+      expect(
+        const PreDiveSessionFilter(
+          templateNames: {'CCR Build'},
+        ).hasActiveFilters,
+        isTrue,
+      );
+      expect(
+        const PreDiveSessionFilter(
+          statuses: {PreDiveSessionStatus.aborted},
+        ).hasActiveFilters,
+        isTrue,
+      );
+      expect(
+        const PreDiveSessionFilter(flaggedOnly: true).hasActiveFilters,
+        isTrue,
+      );
+      expect(
+        PreDiveSessionFilter(
+          dateRange: DateTimeRange(
+            start: DateTime(2026, 1, 1),
+            end: DateTime(2026, 2, 1),
+          ),
+        ).hasActiveFilters,
+        isTrue,
+      );
+    });
+  });
+
+  group('apply', () {
+    test('returns every session when no facet is set', () {
+      final sessions = [session('a'), session('b')];
+
+      expect(const PreDiveSessionFilter().apply(sessions, noStats), sessions);
+    });
+
+    test('keeps only sessions whose template name was selected', () {
+      final ccr = session('a', name: 'CCR Build');
+      final bwraf = session('b', name: 'BWRAF');
+
+      final result = const PreDiveSessionFilter(
+        templateNames: {'CCR Build'},
+      ).apply([ccr, bwraf], noStats);
+
+      expect(result, [ccr]);
+    });
+
+    test('treats multiple selected template names as a union', () {
+      final ccr = session('a', name: 'CCR Build');
+      final bwraf = session('b', name: 'BWRAF');
+      final gue = session('c', name: 'GUE EDGE');
+
+      final result = const PreDiveSessionFilter(
+        templateNames: {'CCR Build', 'GUE EDGE'},
+      ).apply([ccr, bwraf, gue], noStats);
+
+      expect(result, [ccr, gue]);
+    });
+
+    test('keeps only sessions in a selected status', () {
+      final done = session('a', status: PreDiveSessionStatus.completed);
+      final aborted = session('b', status: PreDiveSessionStatus.aborted);
+
+      final result = const PreDiveSessionFilter(
+        statuses: {PreDiveSessionStatus.aborted},
+      ).apply([done, aborted], noStats);
+
+      expect(result, [aborted]);
+    });
+
+    test('flaggedOnly keeps sessions with at least one flagged item', () {
+      final clean = session('a');
+      final flagged = session('b');
+      const stats = {
+        'a': PreDiveSessionStats(total: 3, resolved: 3),
+        'b': PreDiveSessionStats(total: 3, resolved: 3, flagged: 1),
+      };
+
+      final result = const PreDiveSessionFilter(
+        flaggedOnly: true,
+      ).apply([clean, flagged], stats);
+
+      expect(result, [flagged]);
+    });
+
+    test('flaggedOnly drops sessions with no stats entry', () {
+      // A session whose tallies have not loaded cannot be proven flagged, and
+      // showing it would misreport the safety-review view.
+      final unknown = session('a');
+
+      final result = const PreDiveSessionFilter(
+        flaggedOnly: true,
+      ).apply([unknown], noStats);
+
+      expect(result, isEmpty);
+    });
+
+    test('date range includes sessions on both boundary days', () {
+      final onStart = session('a', startedAt: DateTime(2026, 3, 1, 6));
+      final middle = session('b', startedAt: DateTime(2026, 3, 15, 12));
+      final onEnd = session('c', startedAt: DateTime(2026, 3, 31, 23, 30));
+      final after = session('d', startedAt: DateTime(2026, 4, 1, 0, 30));
+      final before = session('e', startedAt: DateTime(2026, 2, 28, 23, 30));
+
+      final result = PreDiveSessionFilter(
+        dateRange: DateTimeRange(
+          start: DateTime(2026, 3, 1),
+          end: DateTime(2026, 3, 31),
+        ),
+      ).apply([onStart, middle, onEnd, after, before], noStats);
+
+      expect(result, [onStart, middle, onEnd]);
+    });
+
+    test('combines facets as an intersection', () {
+      final match = session(
+        'a',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.completed,
+        startedAt: DateTime(2026, 3, 10),
+      );
+      final wrongTemplate = session(
+        'b',
+        name: 'BWRAF',
+        status: PreDiveSessionStatus.completed,
+        startedAt: DateTime(2026, 3, 10),
+      );
+      final wrongStatus = session(
+        'c',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.aborted,
+        startedAt: DateTime(2026, 3, 10),
+      );
+      final outOfRange = session(
+        'd',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.completed,
+        startedAt: DateTime(2026, 5, 10),
+      );
+      const stats = {
+        'a': PreDiveSessionStats(total: 2, resolved: 2, flagged: 1),
+        'b': PreDiveSessionStats(total: 2, resolved: 2, flagged: 1),
+        'c': PreDiveSessionStats(total: 2, resolved: 2, flagged: 1),
+        'd': PreDiveSessionStats(total: 2, resolved: 2, flagged: 1),
+      };
+
+      final result = PreDiveSessionFilter(
+        templateNames: const {'CCR Build'},
+        statuses: const {PreDiveSessionStatus.completed},
+        flaggedOnly: true,
+        dateRange: DateTimeRange(
+          start: DateTime(2026, 3, 1),
+          end: DateTime(2026, 3, 31),
+        ),
+      ).apply([match, wrongTemplate, wrongStatus, outOfRange], stats);
+
+      expect(result, [match]);
+    });
+  });
+
+  group('copyWith', () {
+    test('replaces individual facets', () {
+      const original = PreDiveSessionFilter(templateNames: {'CCR Build'});
+
+      final updated = original.copyWith(flaggedOnly: true);
+
+      expect(updated.templateNames, {'CCR Build'});
+      expect(updated.flaggedOnly, isTrue);
+    });
+
+    test('clearDateRange removes a range that copyWith cannot null out', () {
+      final original = PreDiveSessionFilter(
+        dateRange: DateTimeRange(
+          start: DateTime(2026, 1, 1),
+          end: DateTime(2026, 2, 1),
+        ),
+      );
+
+      expect(original.copyWith(clearDateRange: true).dateRange, isNull);
+      // Omitting the flag must preserve the existing range.
+      expect(original.copyWith(flaggedOnly: true).dateRange, isNotNull);
+    });
+  });
+}

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -3,11 +3,61 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
+import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
 import 'package:submersion/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_app.dart';
+
+/// Captures what the page handed the exporter, without writing any file.
+class _RecordingExcelExporter extends PreDiveExcelExportService {
+  List<PreDiveSession>? sharedSessions;
+  List<PreDiveSession>? savedSessions;
+
+  @override
+  Future<String> exportToExcel({
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) async {
+    sharedSessions = sessions;
+    return '/tmp/checklists.xlsx';
+  }
+
+  @override
+  Future<String?> saveToFile({
+    required List<PreDiveSession> sessions,
+    required Map<String, List<PreDiveSessionItem>> itemsBySession,
+    required DateFormatPreference dateFormat,
+  }) async {
+    savedSessions = sessions;
+    return '/tmp/checklists.xlsx';
+  }
+}
+
+/// Serves the bulk item fetch without a database, and records which runs the
+/// page asked for.
+class _StubSessionRepository implements PreDiveSessionRepository {
+  List<String>? requestedIds;
+
+  @override
+  Future<Map<String, List<PreDiveSessionItem>>> getItemsForSessions(
+    List<String> sessionIds,
+  ) async {
+    requestedIds = sessionIds;
+    return {for (final id in sessionIds) id: const []};
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 void main() {
   final now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
@@ -51,19 +101,39 @@ void main() {
           ).overrideWith((ref) async => entry.value),
       ];
 
+  // The page reads tallies from the aggregate stats provider. Deriving them
+  // from the same item fixtures (via the same engine the repository query
+  // mirrors) keeps these tests asserting computed counts rather than numbers
+  // typed into the override.
+  dynamic statsOverrideFor(Map<String, List<PreDiveSessionItem>> byId) =>
+      preDiveSessionStatsProvider.overrideWith(
+        (ref) async => {
+          for (final entry in byId.entries)
+            entry.key: PreDiveSessionStats(
+              total: entry.value.length,
+              resolved: ChecklistSessionEngine.resolvedCount(entry.value),
+              flagged: ChecklistSessionEngine.flaggedCount(entry.value),
+            ),
+        },
+      );
+
   Future<void> pumpPage(
     WidgetTester tester, {
     PreDiveSession? active,
     required List<PreDiveSession> sessions,
     Map<String, List<PreDiveSessionItem>> items = const {},
+    Locale locale = const Locale('en'),
+    List<dynamic> extraOverrides = const [],
   }) async {
     await tester.pumpWidget(
       testApp(
-        locale: const Locale('en'),
+        locale: locale,
         overrides: [
           preDiveActiveSessionProvider.overrideWith((ref) async => active),
           preDiveSessionsProvider.overrideWith((ref) async => sessions),
+          statsOverrideFor(items),
           ...itemOverridesFor(items),
+          ...extraOverrides,
         ],
         child: const PreDiveSessionsPage(),
       ),
@@ -210,6 +280,288 @@ void main() {
     expect(find.text('Linked dive'), findsOneWidget);
     expect(find.byType(ActionChip), findsOneWidget);
     expect(find.byIcon(Icons.scuba_diving), findsOneWidget);
+  });
+
+  testWidgets(
+    'session title keeps its width on a narrow phone in German (#935)',
+    (tester) async {
+      // The German "Verknuepfter Tauchgang" chip is far wider than the English
+      // "Linked dive". A ListTile measures its trailing widget against the full
+      // tile width first, so anything wide there starves the title column and
+      // the name degrades to one glyph per line.
+      await tester.binding.setSurfaceSize(const Size(360, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      const longName = 'CCR rEvo - Modifiziert';
+      await pumpPage(
+        tester,
+        locale: const Locale('de'),
+        sessions: [
+          session(
+            'w1',
+            name: longName,
+            status: PreDiveSessionStatus.completed,
+            diveId: 'dive-42',
+          ),
+        ],
+        items: {
+          'w1': [item('w1', 0, PreDiveItemState.done)],
+        },
+      );
+
+      final titleSize = tester.getSize(find.text(longName));
+
+      expect(
+        titleSize.width,
+        greaterThan(150),
+        reason:
+            'Title collapsed to ${titleSize.width}px wide on a 360px screen; '
+            'the linked-dive chip is starving the ListTile text column.',
+      );
+    },
+  );
+
+  group('filtering', () {
+    Future<void> pumpTwoChecklists(WidgetTester tester) => pumpPage(
+      tester,
+      sessions: [
+        session('a', name: 'CCR Build', status: PreDiveSessionStatus.completed),
+        session('b', name: 'BWRAF', status: PreDiveSessionStatus.aborted),
+      ],
+      items: {
+        'a': [item('a', 0, PreDiveItemState.flagged)],
+        'b': [item('b', 0, PreDiveItemState.done)],
+      },
+    );
+
+    testWidgets('filter icon opens the filter sheet', (tester) async {
+      await pumpTwoChecklists(tester);
+
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Filter checklist runs'), findsOneWidget);
+      // Checklist names are offered from the runs actually present.
+      expect(find.widgetWithText(FilterChip, 'CCR Build'), findsOneWidget);
+      expect(find.widgetWithText(FilterChip, 'BWRAF'), findsOneWidget);
+    });
+
+    testWidgets('applying a checklist filter hides the other runs', (
+      tester,
+    ) async {
+      await pumpTwoChecklists(tester);
+      expect(find.text('BWRAF'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, 'CCR Build'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      // Scoped to the list rows: the active-filter bar also renders the
+      // selected checklist name as a chip.
+      expect(find.widgetWithText(ListTile, 'CCR Build'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'BWRAF'), findsNothing);
+    });
+
+    testWidgets('dismissing the active filter chip restores the full list', (
+      tester,
+    ) async {
+      await pumpTwoChecklists(tester);
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, 'CCR Build'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(ListTile, 'BWRAF'), findsNothing);
+
+      // The bar chip carries the facet name and a close affordance.
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(ListTile, 'BWRAF'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'CCR Build'), findsOneWidget);
+    });
+
+    testWidgets('filtered empty state appears when nothing matches', (
+      tester,
+    ) async {
+      await pumpPage(
+        tester,
+        sessions: [
+          session(
+            'a',
+            name: 'CCR Build',
+            status: PreDiveSessionStatus.completed,
+          ),
+        ],
+        items: {
+          'a': [item('a', 0, PreDiveItemState.done)],
+        },
+      );
+
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+      // The switch sits below the sheet's initial fold.
+      await tester.scrollUntilVisible(
+        find.text('Flagged runs only'),
+        200,
+        scrollable: find.byType(Scrollable).last,
+      );
+      // No run has a flagged item, so this filter matches nothing.
+      await tester.tap(find.text('Flagged runs only'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('No checklist runs match these filters'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.filter_list_off), findsOneWidget);
+      // The unfiltered empty copy must not be shown: runs do exist.
+      expect(find.text('No checklist runs yet'), findsNothing);
+    });
+
+    testWidgets('an in-progress run stays pinned while a filter is active', (
+      tester,
+    ) async {
+      final active = session(
+        'live',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.inProgress,
+      );
+      await pumpPage(
+        tester,
+        active: active,
+        sessions: [
+          active,
+          session('old', name: 'BWRAF', status: PreDiveSessionStatus.completed),
+        ],
+        items: {
+          'live': [item('live', 0, PreDiveItemState.pending)],
+          'old': [item('old', 0, PreDiveItemState.done)],
+        },
+      );
+
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, 'BWRAF'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      // Filtering to a different checklist must not strand the running one.
+      expect(find.text('Resume'), findsOneWidget);
+    });
+  });
+
+  group('export', () {
+    testWidgets('exports the filtered set, not the whole history', (
+      tester,
+    ) async {
+      final exporter = _RecordingExcelExporter();
+      final repo = _StubSessionRepository();
+
+      await pumpPage(
+        tester,
+        sessions: [
+          session(
+            'a',
+            name: 'CCR Build',
+            status: PreDiveSessionStatus.completed,
+          ),
+          session('b', name: 'BWRAF', status: PreDiveSessionStatus.completed),
+        ],
+        items: {
+          'a': [item('a', 0, PreDiveItemState.done)],
+          'b': [item('b', 0, PreDiveItemState.done)],
+        },
+        extraOverrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          preDiveExcelExportServiceProvider.overrideWithValue(exporter),
+          preDiveSessionRepositoryProvider.overrideWithValue(repo),
+        ],
+      );
+
+      await tester.tap(find.byIcon(Icons.filter_list));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilterChip, 'CCR Build'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.grid_on));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Share'));
+      await tester.pumpAndSettle();
+
+      // The filter doubles as the export selector.
+      expect(exporter.sharedSessions?.map((s) => s.templateName).toList(), [
+        'CCR Build',
+      ]);
+      // Item rows were fetched in one bulk call for exactly those runs.
+      expect(repo.requestedIds, ['a']);
+    });
+
+    testWidgets('choosing Save routes to the save path, not share', (
+      tester,
+    ) async {
+      final exporter = _RecordingExcelExporter();
+
+      await pumpPage(
+        tester,
+        sessions: [
+          session(
+            'a',
+            name: 'CCR Build',
+            status: PreDiveSessionStatus.completed,
+          ),
+        ],
+        items: {
+          'a': [item('a', 0, PreDiveItemState.done)],
+        },
+        extraOverrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          preDiveExcelExportServiceProvider.overrideWithValue(exporter),
+          preDiveSessionRepositoryProvider.overrideWithValue(
+            _StubSessionRepository(),
+          ),
+        ],
+      );
+
+      await tester.tap(find.byIcon(Icons.grid_on));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save to File'));
+      await tester.pumpAndSettle();
+
+      expect(exporter.savedSessions, isNotNull);
+      expect(exporter.sharedSessions, isNull);
+    });
+
+    testWidgets('exporting an empty list reports it instead of writing', (
+      tester,
+    ) async {
+      final exporter = _RecordingExcelExporter();
+
+      await pumpPage(
+        tester,
+        sessions: [],
+        extraOverrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          preDiveExcelExportServiceProvider.overrideWithValue(exporter),
+        ],
+      );
+
+      await tester.tap(find.byIcon(Icons.grid_on));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No checklist runs to export'), findsOneWidget);
+      expect(exporter.sharedSessions, isNull);
+      expect(exporter.savedSessions, isNull);
+    });
   });
 
   testWidgets('loading spinner shows while sessions are pending', (

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -541,6 +541,35 @@ void main() {
       expect(exporter.sharedSessions, isNull);
     });
 
+    testWidgets('export action is disabled while sessions are still loading', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: [
+            preDiveActiveSessionProvider.overrideWith((ref) async => null),
+            // Never completes: holds the provider in its loading state.
+            preDiveSessionsProvider.overrideWith(
+              (ref) => Completer<List<PreDiveSession>>().future,
+            ),
+          ],
+          child: const PreDiveSessionsPage(),
+        ),
+      );
+      await tester.pump();
+
+      final button = tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.grid_on),
+          matching: find.byType(IconButton),
+        ),
+      );
+
+      // A pending load must not be reported as "nothing to export".
+      expect(button.onPressed, isNull);
+    });
+
     testWidgets('exporting an empty list reports it instead of writing', (
       tester,
     ) async {

--- a/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_templates_page_test.dart
@@ -62,11 +62,12 @@ void main() {
 
   Future<void> pumpPage(
     WidgetTester tester,
-    List<PreDiveChecklistTemplate> templates,
-  ) async {
+    List<PreDiveChecklistTemplate> templates, {
+    Locale locale = const Locale('en'),
+  }) async {
     await tester.pumpWidget(
       testApp(
-        locale: const Locale('en'),
+        locale: locale,
         overrides: [
           preDiveTemplatesProvider.overrideWith((ref) async => templates),
         ],
@@ -96,6 +97,32 @@ void main() {
     );
     await tester.pumpAndSettle();
   }
+
+  testWidgets('template name keeps its width beside the built-in badge', (
+    tester,
+  ) async {
+    // Same ListTile.trailing hazard as issue #935 on the sessions page: the
+    // trailing widget is measured against the full tile width, so a badge with
+    // a translated label eats into the title column. "Predefinita" (it) is the
+    // longest translation of the built-in badge.
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const longName = 'CCR rEvo - Modificato per acque fredde';
+    await pumpPage(tester, [
+      template(longName, builtIn: true),
+    ], locale: const Locale('it'));
+
+    final titleSize = tester.getSize(find.text(longName));
+
+    expect(
+      titleSize.width,
+      greaterThan(150),
+      reason:
+          'Template name collapsed to ${titleSize.width}px wide on a 360px '
+          'screen; the built-in badge is starving the ListTile text column.',
+    );
+  });
 
   testWidgets('renders built-in badge and user templates', (tester) async {
     await pumpPage(tester, [

--- a/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
+++ b/test/features/pre_dive/presentation/widgets/session_item_tile_test.dart
@@ -92,6 +92,39 @@ void main() {
   }
 
   group('state rendering', () {
+    testWidgets('long item title keeps its width beside the completion time', (
+      tester,
+    ) async {
+      // Guards the ListTile.trailing hazard behind issue #935: the trailing
+      // widget is measured against the full tile width before the title column
+      // gets what is left.
+      await tester.binding.setSurfaceSize(const Size(360, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      const longTitle =
+          'Verify both oxygen cells read within 2 mV of each '
+          'other before closing the loop';
+      await pumpTile(
+        tester,
+        s: session(),
+        it: item(
+          title: longTitle,
+          state: PreDiveItemState.done,
+          completedAt: now,
+        ),
+      );
+
+      final titleSize = tester.getSize(find.text(longTitle));
+
+      expect(
+        titleSize.width,
+        greaterThan(150),
+        reason:
+            'Item title collapsed to ${titleSize.width}px wide on a 360px '
+            'screen; the trailing row is starving the text column.',
+      );
+    });
+
     testWidgets('pending item shows unchecked icon and title', (tester) async {
       await pumpTile(tester, s: session(), it: item());
       expect(find.text('Check air'), findsOneWidget);


### PR DESCRIPTION
Closes #935.

The reporter (German UI, v1.7.3) found the pre-dive checklist list unreadable, and asked for a filter and an Excel export. All three are addressed here.

## 1. The unreadable title

`_SessionTile` put a `Row` containing an `ActionChip` with a translated label
("Verknüpfter Tauchgang") into `ListTile.trailing`. `_RenderListTile` lays the
trailing widget out against the *full* tile width and gives the title column
whatever is left, so on a phone the remainder clamped to zero and the checklist
name rendered one glyph per line.

The English label ("Linked dive") happens to fit, which is why this shipped. The
framework does assert on it — but behind an `assert`, so it fires in debug and
degrades silently in a release build.

Fix: nothing text-bearing stays in `trailing`. The linked-dive chip moves into
the subtitle, `trailing` keeps only the fixed-width overflow menu, and the title
gains `maxLines: 2` + ellipsis so any future regression degrades to an ellipsis
rather than a vertical column.

Auditing the sibling widgets for the same pattern found two more, both confirmed
by test before changing anything:

| Widget | Title width on a 360px screen, before |
| --- | --- |
| `_SessionTile` (sessions page, de) | framework assert; collapses to ~1 glyph |
| `_TemplateTile` (templates page, it) | 26.9px — silent, no assert fires |
| `SessionItemTile` (runner) | 125.2px — cramped, not collapsed |

Each is now covered by a test asserting the rendered title is wider than 150px
on that same 360px screen.

The templates-page case is the nastier variant: the trailing badge does not
consume the *entire* width, so Flutter's assertion never fires and it degrades
silently even in debug.

## 2. Filter

New `PreDiveSessionFilter` (checklist name, status, flagged-only, date range),
following the established dive-list/trip-list pattern: an immutable filter
object with `apply`, an ephemeral `StateProvider`, a derived
`filteredPreDiveSessionsProvider`, a bottom sheet, an active-filter chip bar and
an `Icons.filter_list_off` empty state.

Two deliberate choices:

- Filtering matches the snapshotted `templateName`, not `templateId`. Sessions
  are audit history and outlive the templates they were run from, so runs of a
  deleted template stay selectable.
- The in-progress run stays pinned regardless of the filter. Losing sight of an
  unfinished checklist because a filter was left on from last week is a real
  hazard on a boat; it is a "resume this now" affordance, not history.

Supporting this needed flag counts for every row, which also removed a pre-existing
N+1: `_SessionTile` was watching `preDiveSessionItemsProvider(session.id)` **per
row** — one query and one subscription per session, unbounded. Replaced with a
single `getSessionStats()` aggregate (`GROUP BY sessionId`).

## 3. Excel export

New `PreDiveExcelExportService` writing two sheets:

- **Checklist Runs** — one row per run: checklist, started, completed, status,
  items, resolved, flagged, linked dive, equipment set, notes.
- **Checklist Items** — one row per item: section, item, type, state, value,
  unit, note, completed-at, required. The notes and flags are the audit evidence
  a checklist export exists for.

Reachable from two places:

- The sessions page app bar, exporting **the currently filtered set** — so the
  filter doubles as the export selector. Share and Save are offered as the
  deliberate pair via the shared `showExportDestinationSheet`; a null return from
  the save path is treated as cancellation, never as success.
- The Transfer page's whole-library workbook, which now carries the same two
  sheets. Items are fetched via a single bulk `getItemsForSessions()` rather than
  one query per run.

## Incidental fix: every Excel export shipped a stray empty sheet

While decoding workbooks in the new tests, `excel_export_service.dart` turned out
to call `excel.delete('Sheet1')` *before* any real sheet exists. The `excel`
package refuses to delete a workbook's last remaining sheet, so that call was a
no-op and every Excel export the app has produced carried an empty `Sheet1`.
Moved the delete after the sheets are built, with a regression test. The existing
test only asserted the bytes start with `PK`, which is why it went unnoticed.

## Tests

- Width-regression tests for all three tiles, asserting the rendered
  `RenderBox` width rather than mere presence — a `findsOneWidget` passes happily
  while text renders vertically.
- `PreDiveSessionFilter.apply` per facet, combined, and the boundary-day
  behaviour of the date range.
- Repository tests for `getSessionStats` (including diver scoping) and
  `getItemsForSessions`.
- Excel tests decode the workbook back and assert sheet names, header columns and
  cell content.
- Page tests for filter apply/dismiss/empty-state, active-run pinning, and that
  the export receives the filtered set and routes Share vs Save correctly.

Filter and export page tests were mutation-verified: neutering `filter.apply`
fails the three narrowing tests, and filtering the active card fails the pinning
test.

New UI strings added to all 11 locales.
