### PR TITLE
fix(dc): keep an Android BLE download going when pairing does not complete

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -772,6 +772,16 @@ jobs:
       - name: Build Android APK
         run: flutter build apk --release "${{ env.DART_DEFINES }}" -v
 
+      # The plugin's Kotlin JVM tests (BondPolicy, BondDiagnostics,
+      # BleScanDiagnostics, SerialReadBuffer) cover decision logic that no
+      # Dart test can reach. They run here rather than in their own job
+      # because android/gradlew is gitignored: the Gradle wrapper only
+      # exists once a Flutter Android build has injected it, which the APK
+      # step above has just done.
+      - name: Run libdivecomputer_plugin Kotlin unit tests
+        working-directory: android
+        run: ./gradlew :libdivecomputer_plugin:testDebugUnitTest
+
       # Guards against issue #318: a 4 KB-aligned native lib (liblibdc_jni.so)
       # silently shipped and crashed the app on Android 15+ 16 KB-page devices.
       # Fails the build if any 64-bit native library is not 16 KB-aligned.

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -698,10 +698,15 @@ class BleIoStream(
             }
         }
 
+        // NOT_EXPORTED: ACTION_BOND_STATE_CHANGED is only ever delivered by
+        // the platform, so nothing is lost by refusing broadcasts from other
+        // apps -- and it matches how UsbSerialIoStream registers its own
+        // receiver.
         val filter = IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
             context.registerReceiver(receiver, filter)
         }
 
@@ -742,7 +747,8 @@ class BleIoStream(
             NativeLogger.w(TAG, "BLE", "ensureBonded: $lastBondFailure")
             return false
         } catch (e: Exception) {
-            lastBondFailure = "pairing threw ${e.javaClass.simpleName}: ${e.message}"
+            lastBondFailure =
+                BondDiagnostics.describeThrownFailure(e.javaClass.simpleName, e.message)
             NativeLogger.e(TAG, "BLE", "ensureBonded: $lastBondFailure")
             return false
         } finally {
@@ -786,10 +792,12 @@ class BleIoStream(
             }
         }
 
+        // NOT_EXPORTED for the same reason as in ensureBonded above.
         val filter = IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
         } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
             context.registerReceiver(receiver, filter)
         }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -16,6 +16,7 @@ import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 // Client Characteristic Configuration Descriptor UUID for enabling notifications.
 private val CCCD_UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
@@ -56,6 +57,10 @@ private val UBLOX_CREDITS_UUID = UUID.fromString("2456e1b9-26e2-8f83-e744-f34f01
 private const val TIO_INITIAL_GRANT = 254
 // Balance at or below which the client tops the module back up.
 private const val TIO_REFILL_THRESHOLD = 32
+
+// Sentinel for "the bond-state broadcast carried no reason extra". Every
+// real UNBOND_REASON_* value is positive, so a negative cannot collide.
+private const val NO_REASON = -1
 
 // Preferred UUIDs for characteristic selection scoring (matching Darwin BleIoStream).
 // These ensure devices like Aqualung/Oceanic select the correct write and notify
@@ -164,6 +169,14 @@ class BleIoStream(
     // GATT status from the most recent disconnect. Exposed so that callers
     // can detect stale bond keys (status 5 = GATT_INSUFFICIENT_AUTHENTICATION).
     var lastDisconnectStatus = 0
+        private set
+
+    // Why the most recent ensureBonded() call did not produce a bond, or
+    // null if it succeeded or was never attempted. Exposed so the download
+    // path can name the reason in the line it logs when it carries on
+    // unbonded, instead of leaving a bare "bond failed" in the user's log.
+    @Volatile
+    var lastBondFailure: String? = null
         private set
 
     private val gattCallback = object : BluetoothGattCallback() {
@@ -636,6 +649,7 @@ class BleIoStream(
     // the pairing dialog (or timeout). Needs an active connection
     // because many BLE peripherals ignore pairing requests without one.
     fun ensureBonded(): Boolean {
+        lastBondFailure = null
         if (device.bondState == BluetoothDevice.BOND_BONDED) {
             NativeLogger.d(TAG, "BLE", "ensureBonded: already bonded")
             return true
@@ -643,6 +657,12 @@ class BleIoStream(
 
         NativeLogger.d(TAG, "BLE", "ensureBonded: initiating bonding for ${device.address}")
         val bondSemaphore = Semaphore(0)
+        // Android reports why a bond ended in the broadcast, not in the
+        // device state that survives it, so the reason has to be captured
+        // here. The broadcast arrives on the main thread while this method
+        // blocks on the download thread, so the handoff must be atomic;
+        // NO_REASON marks "the stack sent none".
+        val unbondReason = AtomicInteger(NO_REASON)
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(ctx: Context, intent: Intent) {
                 if (intent.action != BluetoothDevice.ACTION_BOND_STATE_CHANGED) return
@@ -661,7 +681,15 @@ class BleIoStream(
                     BluetoothDevice.EXTRA_BOND_STATE,
                     BluetoothDevice.BOND_NONE
                 )
-                NativeLogger.d(TAG, "BLE", "ensureBonded: bond state changed to $state")
+                // Absent on some stacks; NO_REASON cannot collide with a
+                // real UNBOND_REASON_* value, all of which are positive.
+                val reason = intent.getIntExtra(BondDiagnostics.EXTRA_REASON, NO_REASON)
+                if (reason != NO_REASON) unbondReason.set(reason)
+                NativeLogger.d(
+                    TAG, "BLE",
+                    "ensureBonded: bond state changed to " +
+                        BondDiagnostics.describeBondState(state)
+                )
                 if (state == BluetoothDevice.BOND_BONDED ||
                     state == BluetoothDevice.BOND_NONE
                 ) {
@@ -678,20 +706,44 @@ class BleIoStream(
         }
 
         try {
-            if (!device.createBond()) {
-                NativeLogger.e(TAG, "BLE", "ensureBonded: createBond() returned false")
+            // createBond() also returns false when a bond is already under
+            // way, which is what a user retrying a failed download every
+            // second produces. Failing instantly there would abandon a bond
+            // that is still running and could yet succeed, so wait for the
+            // in-flight attempt instead of starting a competing one.
+            if (!device.createBond() &&
+                !BondDiagnostics.bondAlreadyInProgress(device.bondState)
+            ) {
+                lastBondFailure = BondDiagnostics.describeRefusedRequest(device.bondState)
+                NativeLogger.w(TAG, "BLE", "ensureBonded: $lastBondFailure")
                 return false
             }
             // 30s timeout: user needs time to interact with pairing dialog.
             if (!bondSemaphore.tryAcquire(30, TimeUnit.SECONDS)) {
-                NativeLogger.e(TAG, "BLE", "ensureBonded: timeout waiting for bonding")
+                lastBondFailure =
+                    "pairing did not finish within 30s (device is " +
+                        "${BondDiagnostics.describeBondState(device.bondState)})"
+                NativeLogger.w(TAG, "BLE", "ensureBonded: $lastBondFailure")
                 return false
             }
-            val bonded = device.bondState == BluetoothDevice.BOND_BONDED
-            NativeLogger.d(TAG, "BLE", "ensureBonded: result=$bonded")
-            return bonded
+            val bondState = device.bondState
+            if (bondState == BluetoothDevice.BOND_BONDED) {
+                NativeLogger.d(TAG, "BLE", "ensureBonded: bonded")
+                return true
+            }
+            // The branch that fires when a computer refuses to pair. It
+            // previously reported only "result=false" at DEBUG, which left
+            // a refused pairing indistinguishable from a cancelled one in
+            // every bug report that reached this point (issue #1029).
+            lastBondFailure = BondDiagnostics.describeFailedAttempt(
+                bondState,
+                unbondReason.get().takeIf { it != NO_REASON }
+            )
+            NativeLogger.w(TAG, "BLE", "ensureBonded: $lastBondFailure")
+            return false
         } catch (e: Exception) {
-            NativeLogger.e(TAG, "BLE", "ensureBonded: failed: ${e.message}")
+            lastBondFailure = "pairing threw ${e.javaClass.simpleName}: ${e.message}"
+            NativeLogger.e(TAG, "BLE", "ensureBonded: $lastBondFailure")
             return false
         } finally {
             context.unregisterReceiver(receiver)

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondDiagnostics.kt
@@ -1,0 +1,107 @@
+package com.submersion.libdivecomputer
+
+// Explains why an Android BLE pairing attempt did not produce a bond.
+//
+// A tester reported eleven consecutive downloads failing with
+// "bond_failed / Failed to pair with device" and a debug log that carried
+// no other BLE line to go with them (issue #1029). The branch which
+// actually fires -- the bond ending on BOND_NONE rather than timing out --
+// reported only "ensureBonded: result=false" at DEBUG, recording neither
+// the state the bond ended in nor the reason Android supplied alongside it.
+// A pairing that the peripheral refused was therefore indistinguishable
+// from one the user dismissed, from one that never started.
+//
+// Framework-free so it can run as a JVM unit test; the Android bond
+// constants are duplicated here rather than referenced, as
+// BleScanDiagnostics does for the scan-failure codes.
+object BondDiagnostics {
+
+    // Mirrors android.bluetooth.BluetoothDevice bond states.
+    const val BOND_NONE = 10
+    const val BOND_BONDING = 11
+    const val BOND_BONDED = 12
+
+    // Mirrors the android.bluetooth.BluetoothDevice UNBOND_REASON_* values
+    // delivered in the ACTION_BOND_STATE_CHANGED reason extra. The extra and
+    // its constants are hidden API, so they are duplicated rather than
+    // referenced; the values are stable across releases.
+    const val UNBOND_REASON_AUTH_FAILED = 1
+    const val UNBOND_REASON_AUTH_REJECTED = 2
+    const val UNBOND_REASON_AUTH_CANCELED = 3
+    const val UNBOND_REASON_REMOTE_DEVICE_DOWN = 4
+    const val UNBOND_REASON_DISCOVERY_IN_PROGRESS = 5
+    const val UNBOND_REASON_AUTH_TIMEOUT = 6
+    const val UNBOND_REASON_REPEATED_ATTEMPTS = 7
+    const val UNBOND_REASON_REMOTE_AUTH_CANCELED = 8
+    const val UNBOND_REASON_REMOVED = 9
+
+    // BluetoothDevice.EXTRA_REASON is hidden API; the string it resolves to
+    // is public and stable, and reading the extra by name avoids reflection.
+    const val EXTRA_REASON = "android.bluetooth.device.extra.REASON"
+
+    /** Human-readable name for a BluetoothDevice bond state. */
+    fun describeBondState(state: Int): String = when (state) {
+        BOND_NONE -> "not bonded"
+        BOND_BONDING -> "bonding in progress"
+        BOND_BONDED -> "bonded"
+        else -> "unknown bond state ($state)"
+    }
+
+    /** Human-readable reason for an ACTION_BOND_STATE_CHANGED reason extra. */
+    fun describeUnbondReason(reason: Int): String = when (reason) {
+        UNBOND_REASON_AUTH_FAILED ->
+            "authentication failed"
+        UNBOND_REASON_AUTH_REJECTED ->
+            "the computer rejected the pairing request"
+        UNBOND_REASON_AUTH_CANCELED ->
+            "pairing was cancelled on this phone"
+        UNBOND_REASON_REMOTE_DEVICE_DOWN ->
+            "the computer stopped responding"
+        UNBOND_REASON_DISCOVERY_IN_PROGRESS ->
+            "a Bluetooth discovery was running"
+        UNBOND_REASON_AUTH_TIMEOUT ->
+            "pairing timed out"
+        UNBOND_REASON_REPEATED_ATTEMPTS ->
+            "too many pairing attempts in a row; Android is throttling them"
+        UNBOND_REASON_REMOTE_AUTH_CANCELED ->
+            "the computer cancelled pairing"
+        UNBOND_REASON_REMOVED ->
+            "the bond was removed"
+        else ->
+            "unknown pairing failure (reason $reason)"
+    }
+
+    /**
+     * True when a `false` from createBond() means a bond is already under
+     * way rather than that the request was refused.
+     *
+     * Android returns false from createBond() while a bond is in progress.
+     * A user tapping retry every second therefore produces a cascade:
+     * attempt N leaves the device in BOND_BONDING, and every attempt after
+     * it fails instantly without ever waiting for the bond still running.
+     */
+    fun bondAlreadyInProgress(bondState: Int): Boolean = bondState == BOND_BONDING
+
+    /**
+     * Message for a bond attempt that ran and did not end bonded, naming
+     * both the state it settled in and Android's reason where one was
+     * supplied. Some stacks omit the reason extra, so [unbondReason] is
+     * optional and its absence must not surface as "null".
+     */
+    fun describeFailedAttempt(bondState: Int, unbondReason: Int?): String {
+        val state = describeBondState(bondState)
+        return if (unbondReason == null) {
+            "pairing did not complete (ended $state; no reason reported)"
+        } else {
+            "pairing did not complete (ended $state: ${describeUnbondReason(unbondReason)})"
+        }
+    }
+
+    /**
+     * Message for a bond the Bluetooth stack declined to even start, which
+     * createBond() reports as a bare `false` with no broadcast to follow.
+     */
+    fun describeRefusedRequest(bondState: Int): String =
+        "createBond() was refused by the Bluetooth stack " +
+            "(device is ${describeBondState(bondState)})"
+}

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondDiagnostics.kt
@@ -104,4 +104,19 @@ object BondDiagnostics {
     fun describeRefusedRequest(bondState: Int): String =
         "createBond() was refused by the Bluetooth stack " +
             "(device is ${describeBondState(bondState)})"
+
+    /**
+     * Message for a pairing attempt that threw. [message] is
+     * Throwable.message, which is nullable often enough (SecurityException
+     * from a revoked permission, NullPointerException) that interpolating
+     * it directly would leave "null" in the log.
+     */
+    fun describeThrownFailure(exceptionName: String, message: String?): String {
+        val detail = message?.takeIf { it.isNotBlank() }
+        return if (detail == null) {
+            "pairing threw $exceptionName (no message)"
+        } else {
+            "pairing threw $exceptionName: $detail"
+        }
+    }
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondPolicy.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BondPolicy.kt
@@ -4,12 +4,13 @@ package com.submersion.libdivecomputer
 // (BluetoothDevice.createBond) with a dive computer before starting I/O.
 //
 // Most vendors keep the proactive bond: devices using encrypted BLE
-// services (e.g. Aqualung i300C on the Pelagic service) need an
-// established bond before the first read. Shearwater's protocol uses no
-// encrypted characteristics -- Shearwater Cloud connects without pairing
-// -- and a bond created by Submersion blocks Shearwater Cloud from
-// connecting until the user unpairs the computer in Android Bluetooth
-// settings (issue #910).
+// services (e.g. Aqualung i300C on the Pelagic service) have to pair
+// eventually, and bonding up front puts the system pairing dialog in
+// front of the user before the transfer starts rather than part-way
+// through it. Shearwater's protocol uses no encrypted characteristics --
+// Shearwater Cloud connects without pairing -- and a bond created by
+// Submersion blocks Shearwater Cloud from connecting until the user
+// unpairs the computer in Android Bluetooth settings (issue #910).
 //
 // Skipping the proactive bond cannot strand a download: if a device does
 // demand encryption mid-session, the Android stack pairs transparently
@@ -23,4 +24,27 @@ object BondPolicy {
     // Teric, Nerd, Peregrine, and Tern models.
     fun requiresProactiveBond(vendor: String): Boolean =
         vendor.trim().lowercase() !in vendorsWithoutProactiveBond
+
+    // Whether a proactive bond that did not complete should end the
+    // download. It never should, for any vendor.
+    //
+    // The bond attempt runs only after connectAndDiscover() has succeeded,
+    // so a failure here throws away a link that is already connected and
+    // whose services and write characteristic have already been resolved.
+    // Nothing in libdivecomputer's BLE protocols needs a bond: the Apple,
+    // Linux, and Windows backends never pair at all and download the same
+    // computers, and a peripheral that does demand encryption gets it
+    // anyway -- the Android stack pairs transparently during the first
+    // encrypted GATT operation, which is the same reasoning that makes
+    // skipping the bond safe for Shearwater above.
+    //
+    // Treating the bond as a hard prerequisite instead cost a tester every
+    // download attempt on a connection that had already been established
+    // (issue #1029).
+    //
+    // Parameterised by vendor so that hardware evidence for a specific
+    // vendor can reintroduce a hard requirement without reopening the
+    // question for every other computer.
+    @Suppress("UNUSED_PARAMETER")
+    fun bondFailureAbortsDownload(vendor: String): Boolean = false
 }

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerHostApiImpl.kt
@@ -387,21 +387,41 @@ class DiveComputerHostApiImpl(
             return
         }
 
-        // Ensure the device is bonded before starting the download.
-        // Devices using encrypted BLE services (e.g. Aqualung i300C on
-        // the Pelagic service) need an established bond. createBond()
+        // Bond the device before starting the download. Devices using
+        // encrypted BLE services (e.g. Aqualung i300C on the Pelagic
+        // service) have to pair sooner or later, and doing it here puts
+        // the system pairing dialog in front of the user before the
+        // transfer starts rather than part-way through it. createBond()
         // works here because we have an active GATT connection.
         // Shearwater devices are exempt: their protocol needs no bond,
         // and holding one blocks Shearwater Cloud until the user unpairs
         // (issue #910) -- see BondPolicy.
+        //
+        // A bond that does not complete is not fatal. By this point the
+        // link is connected and its services are discovered, and no other
+        // backend bonds at all, so giving up here would throw away a
+        // working connection over an optimisation -- which is what left a
+        // tester unable to download at all (issue #1029). A computer that
+        // really does require encryption still gets it: the Android stack
+        // pairs transparently during the first encrypted GATT operation,
+        // and if that fails the download reports the protocol error that
+        // actually describes the problem.
         if (BondPolicy.requiresProactiveBond(device.vendor)) {
             if (!bleStream.ensureBonded()) {
-                reportError("bond_failed", "Failed to pair with device")
-                bleStream.close()
-                LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
-                downloadSessionPtr = 0
-                activeBleStream = null
-                return
+                val reason = bleStream.lastBondFailure ?: "reason unavailable"
+                if (BondPolicy.bondFailureAbortsDownload(device.vendor)) {
+                    reportError("bond_failed", "Failed to pair with device: $reason")
+                    bleStream.close()
+                    LibdcWrapper.nativeDownloadSessionFree(sessionPtr)
+                    downloadSessionPtr = 0
+                    activeBleStream = null
+                    return
+                }
+                NativeLogger.w(
+                    TAG, "BLE",
+                    "Proactive bond with ${device.vendor} ${device.product} " +
+                        "did not complete ($reason); continuing unbonded"
+                )
             }
         } else {
             NativeLogger.d(

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondDiagnosticsTest.kt
@@ -102,6 +102,31 @@ class BondDiagnosticsTest {
     }
 
     @Test
+    fun aThrownPairingFailureNamesTheExceptionAndItsMessage() {
+        val description = BondDiagnostics.describeThrownFailure(
+            "SecurityException",
+            "BLUETOOTH_CONNECT permission denied"
+        )
+
+        assertTrue(description.contains("SecurityException"))
+        assertTrue(description.contains("BLUETOOTH_CONNECT permission denied"))
+    }
+
+    // Throwable.message is nullable, and interpolating it produced log text
+    // ending in ": null" -- the same defect already avoided for the absent
+    // reason extra.
+    @Test
+    fun aThrownPairingFailureWithoutAMessageDoesNotLogTheWordNull() {
+        val description = BondDiagnostics.describeThrownFailure(
+            "NullPointerException",
+            null
+        )
+
+        assertTrue(description.contains("NullPointerException"))
+        assertFalse(description.contains("null"))
+    }
+
+    @Test
     fun aBondRequestTheStackRefusedToStartIsDescribed() {
         val description = BondDiagnostics.describeRefusedRequest(BondDiagnostics.BOND_NONE)
 

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondDiagnosticsTest.kt
@@ -1,0 +1,111 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// JVM tests for the bond diagnostics used by BleIoStream.ensureBonded().
+//
+// A tester reported eleven consecutive "bond_failed / Failed to pair with
+// device" download failures whose debug log contained no other BLE line
+// (issue #1029), because the branch that actually fired logged at DEBUG
+// and recorded neither the bond state it ended on nor the reason Android
+// supplied. These tests pin the text that makes the next report
+// diagnosable.
+class BondDiagnosticsTest {
+
+    @Test
+    fun rejectedPairingIsDescribedInWords() {
+        val description = BondDiagnostics.describeUnbondReason(
+            BondDiagnostics.UNBOND_REASON_AUTH_REJECTED
+        )
+
+        assertTrue(description.contains("reject"))
+    }
+
+    @Test
+    fun eachKnownReasonHasItsOwnDescription() {
+        val known = listOf(
+            BondDiagnostics.UNBOND_REASON_AUTH_FAILED,
+            BondDiagnostics.UNBOND_REASON_AUTH_REJECTED,
+            BondDiagnostics.UNBOND_REASON_AUTH_CANCELED,
+            BondDiagnostics.UNBOND_REASON_REMOTE_DEVICE_DOWN,
+            BondDiagnostics.UNBOND_REASON_DISCOVERY_IN_PROGRESS,
+            BondDiagnostics.UNBOND_REASON_AUTH_TIMEOUT,
+            BondDiagnostics.UNBOND_REASON_REPEATED_ATTEMPTS,
+            BondDiagnostics.UNBOND_REASON_REMOTE_AUTH_CANCELED,
+            BondDiagnostics.UNBOND_REASON_REMOVED
+        )
+
+        val descriptions = known.map { BondDiagnostics.describeUnbondReason(it) }
+
+        assertEquals(known.size, descriptions.toSet().size)
+    }
+
+    @Test
+    fun unrecognizedReasonCodeIsStillReportedNumerically() {
+        val description = BondDiagnostics.describeUnbondReason(42)
+
+        assertTrue(description.contains("42"))
+    }
+
+    @Test
+    fun bondStatesAreDescribedInWords() {
+        assertTrue(
+            BondDiagnostics.describeBondState(BondDiagnostics.BOND_NONE)
+                .contains("not bonded")
+        )
+        assertTrue(
+            BondDiagnostics.describeBondState(BondDiagnostics.BOND_BONDING)
+                .contains("in progress")
+        )
+        assertTrue(
+            BondDiagnostics.describeBondState(BondDiagnostics.BOND_BONDED)
+                .contains("bonded")
+        )
+    }
+
+    // createBond() returns false when a bond is already under way, which is
+    // exactly what a user tapping retry every second produces: attempt N
+    // leaves the device in BOND_BONDING and attempt N+1 fails instantly
+    // without waiting for the bond that is still running.
+    @Test
+    fun aBondAlreadyUnderWayIsDistinguishedFromARefusedRequest() {
+        assertTrue(BondDiagnostics.bondAlreadyInProgress(BondDiagnostics.BOND_BONDING))
+        assertFalse(BondDiagnostics.bondAlreadyInProgress(BondDiagnostics.BOND_NONE))
+        assertFalse(BondDiagnostics.bondAlreadyInProgress(BondDiagnostics.BOND_BONDED))
+    }
+
+    @Test
+    fun failedAttemptNamesBothTheEndStateAndTheReason() {
+        val description = BondDiagnostics.describeFailedAttempt(
+            BondDiagnostics.BOND_NONE,
+            BondDiagnostics.UNBOND_REASON_AUTH_REJECTED
+        )
+
+        assertTrue(description.contains("not bonded"))
+        assertTrue(description.contains("reject"))
+    }
+
+    // Android omits the reason extra on some stacks; the state alone must
+    // still produce a usable line rather than the string "null".
+    @Test
+    fun failedAttemptWithoutAReasonStillDescribesTheEndState() {
+        val description = BondDiagnostics.describeFailedAttempt(
+            BondDiagnostics.BOND_NONE,
+            null
+        )
+
+        assertTrue(description.contains("not bonded"))
+        assertFalse(description.contains("null"))
+    }
+
+    @Test
+    fun aBondRequestTheStackRefusedToStartIsDescribed() {
+        val description = BondDiagnostics.describeRefusedRequest(BondDiagnostics.BOND_NONE)
+
+        assertTrue(description.contains("createBond"))
+        assertTrue(description.contains("not bonded"))
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondPolicyTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BondPolicyTest.kt
@@ -33,4 +33,25 @@ class BondPolicyTest {
         assertTrue(BondPolicy.requiresProactiveBond(""))
         assertTrue(BondPolicy.requiresProactiveBond("NoSuchVendor"))
     }
+
+    // A tester saw eleven consecutive downloads end at "bond_failed" on a
+    // connection that had already been established and had its services
+    // discovered (issue #1029). No other backend (Apple, Linux, Windows)
+    // bonds at all and the same computers download there, so a bond that
+    // will not complete must not be allowed to end the download.
+    @Test
+    fun aFailedProactiveBondNeverAbortsTheDownload() {
+        assertFalse(BondPolicy.bondFailureAbortsDownload("Aqualung"))
+        assertFalse(BondPolicy.bondFailureAbortsDownload("Mares"))
+        assertFalse(BondPolicy.bondFailureAbortsDownload("Suunto"))
+        assertFalse(BondPolicy.bondFailureAbortsDownload("NoSuchVendor"))
+        assertFalse(BondPolicy.bondFailureAbortsDownload(""))
+    }
+
+    // Vendors that never bond proactively cannot reach the failure path at
+    // all, so the answer has to hold for them too.
+    @Test
+    fun exemptVendorsAlsoNeverAbortOnBondFailure() {
+        assertFalse(BondPolicy.bondFailureAbortsDownload("Shearwater"))
+    }
 }


### PR DESCRIPTION
Fixes #1029.

A beta tester's log carried eleven consecutive `bond_failed` download
failures over BLE on Android and nothing that explained any of them.
Two separate defects were tangled together; this PR fixes one outright
and instruments the other.

## The download died on a working connection

`ensureBonded()` is called from `performBleDownload()` *after*
`connectAndDiscover()` has already returned true. At the moment we gave
up, the link was connected, the services were discovered, and the write
characteristic was resolved — and we tore all of it down because a bond
did not complete.

Nothing in libdivecomputer's BLE protocols needs that bond. There is no
pairing call anywhere in `darwin/Sources/LibDCDarwin/BleIoStream.swift`,
`linux/ble_io_stream.c`, or `windows/ble_io_stream.cc`, and those
platforms download the same computers. `BondPolicy`'s own comment
already said why that is safe:

> Skipping the proactive bond cannot strand a download: if a device does
> demand encryption mid-session, the Android stack pairs transparently
> during the first encrypted GATT operation.

If skipping a bond is safe, failing to establish one is too. Android was
the only backend treating an optimisation as a hard prerequisite.

A failed bond now logs a warning naming the reason and the download
continues on the existing connection.

## The failure left no evidence

`ensureBonded()` has four failure paths, and the one that fires here —
the bond settling on `BOND_NONE` rather than timing out — logged only
`ensureBonded: result=false` at **DEBUG**, and never read the reason
Android supplies in the bond-state broadcast. A pairing the computer
refused was indistinguishable from one the user dismissed, from one that
never started.

New `BondDiagnostics` (framework-free, in the style of
`BleScanDiagnostics`) maps the `UNBOND_REASON_*` codes and bond states to
plain language. `ensureBonded()` captures the reason extra, records it in
a new `lastBondFailure` property, and reports at WARN.

It also no longer fails instantly when `createBond()` returns false
merely because a bond is already in progress. That case compounds:
attempt N leaves the device in `BOND_BONDING`, so every retry after it
abandons a bond that is still running. The reporter's timestamps show
exactly that — seven failures at 1.2–1.7 s intervals.

## Reviewer notes

- **`bondFailureAbortsDownload(vendor)` returns `false` for every vendor,
  so its abort branch is unreachable today.** That is deliberate, not an
  oversight: it is the tested seam where per-vendor hardware evidence
  would land, mirroring how `requiresProactiveBond` carries the
  Shearwater exemption. Flagging it so it does not read as accidental
  dead code.
- **This does not explain why the reporter's computer refuses to pair.**
  The old code discarded that evidence. If the computer genuinely
  requires encryption the download may still fail — but with a protocol
  error naming the real cause, and a log line stating the pairing reason.
  The issue asks the reporter for their model and a fresh log.
- **The reporter's computer is not a Shearwater.** Their scan line
  `Unmatched device D8:AD:90:23:44:7C (454V)` lacks the `rssi=` suffix,
  dating the build between f131858d985 (2026-07-11) and b90d7dd616e
  (2026-08-10) — a range that already includes ccb3e874c40, the
  Shearwater bond exemption.

## Testing

- 10 new Kotlin unit tests (8 in `BondDiagnosticsTest`, 2 in
  `BondPolicyTest`); module total 44 passing, 0 failures.
- `flutter test`: 17,354 passed, 17 skipped, 0 failed.
- `flutter analyze` clean, `dart format` clean.

This PR also wires the plugin's Kotlin JVM tests into CI for the first
time. `BondPolicyTest`, `BleScanDiagnosticsTest` and
`SerialReadBufferTest` have never run in any workflow, so their coverage
has been nominal. They run inside `build-android` rather than a job of
their own because `android/gradlew` is gitignored and only exists once a
Flutter Android build has injected it, which that job's APK step already
does.

**No device here reproduces the pairing failure**, so the behavioural
half of this change is only validated by reasoning and by parity with
the three backends that never bond. It wants a real Android download
before it is trusted.
