### PR TITLE
fix(sync): make a wiped backend recoverable, and stop duplicate tags

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'package:drift/drift.dart';
 
 import 'package:submersion/core/database/performance_indexes.dart';
+import 'package:submersion/core/database/tag_uniqueness.dart';
 import 'package:submersion/core/constants/enums.dart';
 
 part 'database.g.dart';
@@ -2952,7 +2953,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 148;
+  static const int currentSchemaVersion = 149;
 
   /// Every schema version that has a migration block in onUpgrade.
   /// Used to calculate progress step counts. When adding a new migration,
@@ -3153,6 +3154,10 @@ class AppDatabase extends _$AppDatabase {
     // index plus the site-side dedupe cleanup and partial unique index
     // mirroring the dive-side v38 pair.
     148,
+    // v149: duplicate tags (issue #1032): collapse `tags` rows sharing a
+    // (diver scope, case-folded name) and `dive_tags` rows sharing a
+    // (dive, tag), then add the two unique indexes that stop them recurring.
+    149,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4680,6 +4685,11 @@ class AppDatabase extends _$AppDatabase {
         // Seed built-in service kinds (the v122 migration backfills these
         // for upgraded databases; beforeOpen re-asserts).
         await customStatement(kSeedBuiltInServiceKindsSql);
+
+        // Tag uniqueness indexes (v149, issue #1032): createAll() never builds
+        // raw-SQL indexes, so a fresh install would otherwise be the one
+        // device in the library without them.
+        await assertTagUniqueness(this);
       },
       onUpgrade: (Migrator m, int from, int to) async {
         int completedSteps = 0;
@@ -7771,6 +7781,14 @@ class AppDatabase extends _$AppDatabase {
           }
         }
         if (from < 148) await reportProgress();
+        if (from < 149) {
+          // Duplicate tags (issue #1032). The helper dedupes BEFORE creating
+          // the unique indexes and its dedupe is total (rowid/id tie-breaks),
+          // so no tie can survive to abort the index creation -- the failure
+          // mode v148 documents. Self-guarding on the tables existing.
+          await assertTagUniqueness(this);
+        }
+        if (from < 149) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -8043,6 +8061,12 @@ class AppDatabase extends _$AppDatabase {
           }
           return true;
         }());
+
+        // v149 backstop (issue #1032): re-assert the tag uniqueness indexes,
+        // deduping first so the creation cannot abort. A database that
+        // arrives by restore or sync-adopt never runs onUpgrade, and that is
+        // exactly the second device the duplicate tags came from.
+        await assertTagUniqueness(this);
 
         // Data self-heal: backfill a primary dive_data_sources row for dives
         // that have profile samples but no source row (legacy file imports).

--- a/lib/core/database/tag_uniqueness.dart
+++ b/lib/core/database/tag_uniqueness.dart
@@ -1,0 +1,142 @@
+/// Tag identity invariants: one `tags` row per (diver scope, name) and one
+/// `dive_tags` row per (dive, tag) -- issue #1032.
+///
+/// Two independent producers used to put the same tag on a dive more than
+/// once, and neither table constrained them:
+///
+///  * `tags` has a uuid primary key minted per device and no index on `name`,
+///    so a peer's row for a tag the user already had landed beside it. Two
+///    devices that each ran a dive-computer import minted two uuids for the
+///    same auto-generated `<Computer> Import <date>` name.
+///  * `dive_tags` has a surrogate uuid primary key, so re-running an import
+///    (or any blind re-link) added a second row for a pair that already
+///    existed.
+///
+/// Both are now unique indexes. Every writer must therefore be conflict-safe:
+/// with an index in place an unguarded duplicate insert THROWS, and a throw
+/// inside the sync merge is far worse than the duplicate it replaces.
+library;
+
+import 'package:drift/drift.dart';
+
+/// Unique index over `tags`, keyed on (diver scope, case-folded name).
+const String kTagsUniqueIndexName = 'idx_tags_diver_name_unique';
+
+/// Unique index over the `dive_tags` junction, keyed on (dive, tag).
+const String kDiveTagsUniqueIndexName = 'idx_dive_tags_dive_tag_unique';
+
+/// `diver_id` is NULLABLE, and SQLite treats NULLs as distinct inside a unique
+/// index, so a plain `(diver_id, name)` index would not constrain the
+/// unassigned-diver rows at all -- exactly the rows an importer creates before
+/// a diver is resolved. `COALESCE(diver_id, '')` folds NULL into a single
+/// "unassigned" scope so those rows are constrained too.
+///
+/// `lower(name)` matches how `TagRepository.getTagByName` already looks tags
+/// up, so the index cannot disagree with the read that decides whether to
+/// create one. Both functions are deterministic, which SQLite requires of an
+/// expression index.
+///
+/// Two divers keep their own identically named tags, and an unassigned tag
+/// stays distinct from a diver-scoped one of the same name: those are
+/// different scopes, not duplicates.
+const String kCreateTagsUniqueIndexSql =
+    'CREATE UNIQUE INDEX IF NOT EXISTS $kTagsUniqueIndexName '
+    "ON tags(COALESCE(diver_id, ''), lower(name))";
+
+/// One junction row per (dive, tag). The surrogate `id` stays the primary key
+/// so a re-inserted row never collides with the tombstone of the row it
+/// replaced (the composite-key sync data-loss trap of #347).
+const String kCreateDiveTagsUniqueIndexSql =
+    'CREATE UNIQUE INDEX IF NOT EXISTS $kDiveTagsUniqueIndexName '
+    'ON dive_tags(dive_id, tag_id)';
+
+/// Repoints every `dive_tags` row at the surviving tag of its group.
+///
+/// The survivor is the lexically lowest `id` in the group. It has to be a
+/// property of the rows themselves rather than of this device (oldest
+/// `created_at` ties inside a single import millisecond, and "the one we had
+/// first" differs per device), so every device that runs this -- or the
+/// equivalent merge-time reconciliation -- lands on the same tag.
+///
+/// The `WHERE EXISTS` guard matters: `dive_tags.tag_id` is NOT NULL, and a row
+/// pointing at an already-missing tag would otherwise resolve to NULL and
+/// abort the statement.
+const String _repointDiveTagsToSurvivorSql = '''
+  UPDATE dive_tags SET tag_id = (
+    SELECT MIN(survivor.id) FROM tags survivor, tags mine
+    WHERE mine.id = dive_tags.tag_id
+      AND COALESCE(survivor.diver_id, '') = COALESCE(mine.diver_id, '')
+      AND lower(survivor.name) = lower(mine.name)
+  )
+  WHERE EXISTS (SELECT 1 FROM tags t WHERE t.id = dive_tags.tag_id)
+''';
+
+const String _deleteLosingTagsSql = '''
+  DELETE FROM tags WHERE id NOT IN (
+    SELECT MIN(id) FROM tags GROUP BY COALESCE(diver_id, ''), lower(name)
+  )
+''';
+
+/// Keeps one junction row per (dive, tag). `rowid` is a total order, so this
+/// can never leave a tie behind -- a tie-blind cleanup keyed on `created_at`
+/// would, and the unique index created straight afterwards would then abort
+/// the whole migration and leave the database unopenable.
+const String _collapseDuplicateDiveTagsSql = '''
+  DELETE FROM dive_tags WHERE rowid NOT IN (
+    SELECT MIN(rowid) FROM dive_tags GROUP BY dive_id, tag_id
+  )
+''';
+
+Future<bool> _tableExists(DatabaseConnectionUser db, String name) async {
+  final rows = await db
+      .customSelect(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        variables: [Variable<String>(name)],
+      )
+      .get();
+  return rows.isNotEmpty;
+}
+
+/// Collapses duplicate tags and duplicate junction rows, in the only order
+/// that leaves no ties: repoint the junctions at the surviving tag, drop the
+/// losing tags, then collapse the junction duplicates the repoint just
+/// created.
+///
+/// Idempotent: every statement is a no-op on already-clean data.
+Future<void> collapseDuplicateTags(DatabaseConnectionUser db) async {
+  await db.customStatement(_repointDiveTagsToSurvivorSql);
+  await db.customStatement(_deleteLosingTagsSql);
+  await db.customStatement(_collapseDuplicateDiveTagsSql);
+}
+
+/// Asserts the two uniqueness indexes exist, deduping first so creating them
+/// cannot abort.
+///
+/// Called from the v149 migration, from `onCreate` (a fresh install never runs
+/// onUpgrade, and `createAll()` does not build raw-SQL indexes) and from
+/// `beforeOpen` as a backstop. When both indexes are already present this
+/// costs one `sqlite_master` lookup and does no table scans, so the dedupe is
+/// paid once rather than on every open.
+///
+/// Self-guarding on the tables existing so partial migration-test fixture
+/// databases pass through unharmed.
+Future<void> assertTagUniqueness(DatabaseConnectionUser db) async {
+  if (!await _tableExists(db, 'tags')) return;
+  if (!await _tableExists(db, 'dive_tags')) return;
+
+  final present = await db
+      .customSelect(
+        "SELECT name FROM sqlite_master WHERE type = 'index' "
+        'AND name IN (?, ?)',
+        variables: const [
+          Variable<String>(kTagsUniqueIndexName),
+          Variable<String>(kDiveTagsUniqueIndexName),
+        ],
+      )
+      .get();
+  if (present.length == 2) return;
+
+  await collapseDuplicateTags(db);
+  await db.customStatement(kCreateTagsUniqueIndexSql);
+  await db.customStatement(kCreateDiveTagsUniqueIndexSql);
+}

--- a/lib/core/database/tag_uniqueness.dart
+++ b/lib/core/database/tag_uniqueness.dart
@@ -31,17 +31,21 @@ const String kDiveTagsUniqueIndexName = 'idx_dive_tags_dive_tag_unique';
 /// a diver is resolved. `COALESCE(diver_id, '')` folds NULL into a single
 /// "unassigned" scope so those rows are constrained too.
 ///
-/// `lower(name)` matches how `TagRepository.getTagByName` already looks tags
-/// up, so the index cannot disagree with the read that decides whether to
-/// create one. Both functions are deterministic, which SQLite requires of an
-/// expression index.
+/// `lower(trim(name))` is the full normalization, and every lookup and writer
+/// applies exactly the same one, so the index cannot disagree with the read
+/// that decides whether to create a tag. `trim` is load-bearing rather than
+/// cosmetic: matching on a trimmed name while storing the untrimmed one let
+/// " Wreck" and "Wreck" exist as two rows that every lookup treats as one --
+/// the duplicate this index exists to forbid (PR #1033 review). All three
+/// functions are deterministic, which SQLite requires of an expression
+/// index.
 ///
 /// Two divers keep their own identically named tags, and an unassigned tag
 /// stays distinct from a diver-scoped one of the same name: those are
 /// different scopes, not duplicates.
 const String kCreateTagsUniqueIndexSql =
     'CREATE UNIQUE INDEX IF NOT EXISTS $kTagsUniqueIndexName '
-    "ON tags(COALESCE(diver_id, ''), lower(name))";
+    "ON tags(COALESCE(diver_id, ''), lower(trim(name)))";
 
 /// One junction row per (dive, tag). The surrogate `id` stays the primary key
 /// so a re-inserted row never collides with the tombstone of the row it
@@ -49,6 +53,16 @@ const String kCreateTagsUniqueIndexSql =
 const String kCreateDiveTagsUniqueIndexSql =
     'CREATE UNIQUE INDEX IF NOT EXISTS $kDiveTagsUniqueIndexName '
     'ON dive_tags(dive_id, tag_id)';
+
+/// Strips surrounding whitespace from stored tag names.
+///
+/// The index keys on `lower(trim(name))`, so a stored " Wreck" and a stored
+/// "Wreck" already collapse to one slot -- but only one of them can survive,
+/// and the survivor should not keep whitespace the user never intended and
+/// cannot see. Running this first also means the rows a user reads back match
+/// the value every lookup compares against.
+const String _normalizeTagNamesSql =
+    'UPDATE tags SET name = trim(name) WHERE name <> trim(name)';
 
 /// Repoints every `dive_tags` row at the surviving tag of its group.
 ///
@@ -66,14 +80,14 @@ const String _repointDiveTagsToSurvivorSql = '''
     SELECT MIN(survivor.id) FROM tags survivor, tags mine
     WHERE mine.id = dive_tags.tag_id
       AND COALESCE(survivor.diver_id, '') = COALESCE(mine.diver_id, '')
-      AND lower(survivor.name) = lower(mine.name)
+      AND lower(trim(survivor.name)) = lower(trim(mine.name))
   )
   WHERE EXISTS (SELECT 1 FROM tags t WHERE t.id = dive_tags.tag_id)
 ''';
 
 const String _deleteLosingTagsSql = '''
   DELETE FROM tags WHERE id NOT IN (
-    SELECT MIN(id) FROM tags GROUP BY COALESCE(diver_id, ''), lower(name)
+    SELECT MIN(id) FROM tags GROUP BY COALESCE(diver_id, ''), lower(trim(name))
   )
 ''';
 
@@ -98,12 +112,13 @@ Future<bool> _tableExists(DatabaseConnectionUser db, String name) async {
 }
 
 /// Collapses duplicate tags and duplicate junction rows, in the only order
-/// that leaves no ties: repoint the junctions at the surviving tag, drop the
-/// losing tags, then collapse the junction duplicates the repoint just
-/// created.
+/// that leaves no ties: normalize the names the grouping keys on, repoint the
+/// junctions at the surviving tag, drop the losing tags, then collapse the
+/// junction duplicates the repoint just created.
 ///
 /// Idempotent: every statement is a no-op on already-clean data.
 Future<void> collapseDuplicateTags(DatabaseConnectionUser db) async {
+  await db.customStatement(_normalizeTagNamesSql);
   await db.customStatement(_repointDiveTagsToSurvivorSql);
   await db.customStatement(_deleteLosingTagsSql);
   await db.customStatement(_collapseDuplicateDiveTagsSql);
@@ -124,19 +139,54 @@ Future<void> assertTagUniqueness(DatabaseConnectionUser db) async {
   if (!await _tableExists(db, 'tags')) return;
   if (!await _tableExists(db, 'dive_tags')) return;
 
-  final present = await db
-      .customSelect(
-        "SELECT name FROM sqlite_master WHERE type = 'index' "
-        'AND name IN (?, ?)',
-        variables: const [
-          Variable<String>(kTagsUniqueIndexName),
-          Variable<String>(kDiveTagsUniqueIndexName),
-        ],
-      )
-      .get();
-  if (present.length == 2) return;
+  // Compare the stored DDL, not just the index NAME. `CREATE UNIQUE INDEX IF
+  // NOT EXISTS` is a no-op against an index of the same name whatever its
+  // definition, so a name-only check would silently keep an older keying --
+  // which is exactly what a database that ran a pre-release build of this
+  // version holds. Dropping and rebuilding is cheap next to a wrong index.
+  final present = {
+    for (final row
+        in await db
+            .customSelect(
+              "SELECT name, sql FROM sqlite_master WHERE type = 'index' "
+              'AND name IN (?, ?)',
+              variables: const [
+                Variable<String>(kTagsUniqueIndexName),
+                Variable<String>(kDiveTagsUniqueIndexName),
+              ],
+            )
+            .get())
+      row.read<String>('name'): row.readNullable<String>('sql') ?? '',
+  };
+
+  bool matches(String name, String expectedSql) {
+    final actual = present[name];
+    if (actual == null) return false;
+    return _normalizeSql(actual) ==
+        _normalizeSql(expectedSql.replaceAll('IF NOT EXISTS ', ''));
+  }
+
+  final tagsOk = matches(kTagsUniqueIndexName, kCreateTagsUniqueIndexSql);
+  final junctionOk = matches(
+    kDiveTagsUniqueIndexName,
+    kCreateDiveTagsUniqueIndexSql,
+  );
+  if (tagsOk && junctionOk) return;
+
+  if (!tagsOk) {
+    await db.customStatement('DROP INDEX IF EXISTS $kTagsUniqueIndexName');
+  }
+  if (!junctionOk) {
+    await db.customStatement('DROP INDEX IF EXISTS $kDiveTagsUniqueIndexName');
+  }
 
   await collapseDuplicateTags(db);
   await db.customStatement(kCreateTagsUniqueIndexSql);
   await db.customStatement(kCreateDiveTagsUniqueIndexSql);
 }
+
+/// Collapses whitespace and case so two spellings of the same DDL compare
+/// equal. SQLite stores `sqlite_master.sql` as written, so the comparison has
+/// to tolerate formatting rather than demand a byte match.
+String _normalizeSql(String sql) =>
+    sql.replaceAll(RegExp(r'\s+'), ' ').trim().toLowerCase();

--- a/lib/core/services/sync/changeset_log/base_part_file_source.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_source.dart
@@ -42,9 +42,20 @@ class BasePartFileSource {
   /// full base republish -- what a wiped backend forces -- can run to hundreds
   /// of megabytes, and without this tick the sync UI shows one motionless step
   /// for the entire transfer and reads as a hang (issue #1032).
+  ///
+  /// [skipPart] suppresses the network call for parts already present in the
+  /// cloud, so an interrupted publish resumes instead of re-uploading hundreds
+  /// of megabytes (issue #1032).
+  ///
+  /// Skipped parts are still read and hashed. That is the point: the checksums
+  /// in the manifest then always describe the bytes actually on disk right now,
+  /// so a file that was truncated between attempts fails verification instead of
+  /// being certified by checksums recorded while it was still intact. Re-reading
+  /// local disk is cheap next to re-uploading.
   Future<BasePartUploadResult> uploadAll(
     Future<void> Function(int index, Uint8List bytes) upload, {
     void Function(int uploaded, int total)? onPartUploaded,
+    bool Function(int index)? skipPart,
   }) async {
     final raf = await File(path).open();
     final digestSink = _DigestSink();
@@ -59,7 +70,7 @@ class BasePartFileSource {
         final empty = Uint8List(0);
         whole.add(empty);
         partChecksums.add(BaseChunker.checksum(empty));
-        await upload(0, empty);
+        if (skipPart?.call(0) != true) await upload(0, empty);
         index = 1;
         onPartUploaded?.call(index, total);
       } else {
@@ -68,7 +79,7 @@ class BasePartFileSource {
           final buf = await raf.read(n);
           whole.add(buf);
           partChecksums.add(BaseChunker.checksum(buf));
-          await upload(index, buf);
+          if (skipPart?.call(index) != true) await upload(index, buf);
           index++;
           onPartUploaded?.call(index, total);
         }

--- a/lib/core/services/sync/changeset_log/base_part_file_source.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_source.dart
@@ -25,18 +25,34 @@ class BasePartFileSource {
   final String path;
   final int partSize;
 
+  /// Number of parts [path] will be sliced into, without reading it.
+  ///
+  /// Known from the length alone, so a caller can publish a denominator before
+  /// the first byte moves. Mirrors the empty-file special case below.
+  static int partCountFor(
+    int byteLength, {
+    int partSize = BaseChunker.defaultPartSize,
+  }) => byteLength == 0 ? 1 : (byteLength + partSize - 1) ~/ partSize;
+
   /// Streams the file in [partSize] slices, invoking [upload] for each in order,
   /// and returns the part count plus the `sha256:` whole-file and per-part
   /// checksums (and the total byte length) for the manifest.
+  ///
+  /// [onPartUploaded] fires after each part lands, as `(uploaded, total)`. A
+  /// full base republish -- what a wiped backend forces -- can run to hundreds
+  /// of megabytes, and without this tick the sync UI shows one motionless step
+  /// for the entire transfer and reads as a hang (issue #1032).
   Future<BasePartUploadResult> uploadAll(
-    Future<void> Function(int index, Uint8List bytes) upload,
-  ) async {
+    Future<void> Function(int index, Uint8List bytes) upload, {
+    void Function(int uploaded, int total)? onPartUploaded,
+  }) async {
     final raf = await File(path).open();
     final digestSink = _DigestSink();
     final whole = sha256.startChunkedConversion(digestSink);
     final partChecksums = <String>[];
     try {
       final length = await raf.length();
+      final total = partCountFor(length, partSize: partSize);
       var index = 0;
       if (length == 0) {
         // Mirror BaseChunker.slice(empty) == [Uint8List(0)]: one empty part.
@@ -45,6 +61,7 @@ class BasePartFileSource {
         partChecksums.add(BaseChunker.checksum(empty));
         await upload(0, empty);
         index = 1;
+        onPartUploaded?.call(index, total);
       } else {
         for (var off = 0; off < length; off += partSize) {
           final n = (off + partSize < length) ? partSize : length - off;
@@ -53,6 +70,7 @@ class BasePartFileSource {
           partChecksums.add(BaseChunker.checksum(buf));
           await upload(index, buf);
           index++;
+          onPartUploaded?.call(index, total);
         }
       }
       whole.close();

--- a/lib/core/services/sync/changeset_log/base_part_file_source.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_source.dart
@@ -38,10 +38,17 @@ class BasePartFileSource {
   /// and returns the part count plus the `sha256:` whole-file and per-part
   /// checksums (and the total byte length) for the manifest.
   ///
-  /// [onPartUploaded] fires after each part lands, as `(uploaded, total)`. A
-  /// full base republish -- what a wiped backend forces -- can run to hundreds
+  /// [onPartUploaded] fires once per part, as `(uploaded, total)`, after that
+  /// part has been dealt with -- uploaded, or skipped and re-hashed. A full
+  /// base republish, which is what a wiped backend forces, can run to hundreds
   /// of megabytes, and without this tick the sync UI shows one motionless step
   /// for the entire transfer and reads as a hang (issue #1032).
+  ///
+  /// Counting skipped parts is deliberate rather than incidental: on a resumed
+  /// publish the bar sweeps quickly through what already landed and then slows
+  /// to the real upload rate, which is a truthful picture of the work left. A
+  /// tick that fired only on genuine uploads would restart the bar at zero and
+  /// hide the progress the previous attempt made.
   ///
   /// [skipPart] suppresses the network call for parts already present in the
   /// cloud, so an interrupted publish resumes instead of re-uploading hundreds

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/services/sync/changeset_log/base_part_file_sourc
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/resumable_base_publish.dart';
 import 'package:submersion/core/services/sync/changeset_log/sync_liveness.dart';
 import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 
@@ -34,11 +35,13 @@ class ChangesetWriter {
     this.compactionByteRatio = 0.30,
     this.compactionMaxChangesets = 200,
     this.heartbeatMaxAgeMillis = SyncLiveness.heartbeatMaxAgeMillis,
-  });
+    ResumableBasePublishStore? resumableStore,
+  }) : _resumable = resumableStore ?? ResumableBasePublishStore();
 
   final SyncDataSerializer _serializer;
   final ChangesetCodec _codec;
   final PublishStateStore _publishState;
+  final ResumableBasePublishStore _resumable;
   final double compactionByteRatio;
   final int compactionMaxChangesets;
   final int heartbeatMaxAgeMillis;
@@ -110,46 +113,91 @@ class ChangesetWriter {
     final now = DateTime.now().millisecondsSinceEpoch;
 
     if (!hasBase && !adoptedNoBase) {
+      // Resume an export a previous attempt wrote but never finished
+      // uploading, before spending a whole re-export on it. A wiped backend
+      // forces the entire library out as one base, and on a phone that is
+      // minutes of upload; restarting it from part 0 every time the app
+      // reopened is why the reporter's sync never converged (#1032).
+      final resumed = await _resumable.find(
+        providerId: providerId,
+        deviceId: deviceId,
+        epochId: epochId,
+      );
+
       // Stream the base to a temp file and slice-upload it, so a large library
       // is never materialized in RAM (#358 write side). Do NOT call
       // exportChangeset(null) here -- that is the OOM path.
-      final base = await _serializer.exportBaseToTempFile(
-        deviceId: deviceId,
-        deletions: deletions,
-        epochId: epochId,
-        uploadNonce: uploadNonce,
-        seq: newSeq,
-      );
-      try {
+      final ResumableBasePublish publish;
+      final int rowCount;
+      if (resumed != null) {
+        publish = resumed;
+        // rowCount is only consulted for the empty-library noop below, and a
+        // recorded export is by definition something we already decided to
+        // publish. Treat it as non-empty rather than re-deriving it.
+        rowCount = 1;
+      } else {
+        final base = await _serializer.exportBaseToTempFile(
+          deviceId: deviceId,
+          deletions: deletions,
+          epochId: epochId,
+          uploadNonce: uploadNonce,
+          seq: newSeq,
+        );
+        rowCount = base.rowCount;
         // Nothing to say -- except under [forceBase], where the point of the
         // publish is the manifest, not its contents: an empty base still
         // replaces an over-claiming `publishedHlcHigh` with the truth (null),
         // which is what stops the stale-restore loop for a device rewound to an
         // empty library. Peers apply an empty base as a no-op (upsert + LWW).
-        if (base.rowCount == 0 && deletions.isEmpty && !forceBase) {
+        if (rowCount == 0 && deletions.isEmpty && !forceBase) {
+          try {
+            await File(base.path).delete();
+          } catch (_) {}
           return const ChangesetWriteResult(ChangesetWriteKind.noop);
         }
-        final upload = await BasePartFileSource(base.path).uploadAll(
+        publish = await _recordResumable(
+          base,
+          providerId,
+          deviceId,
+          newSeq,
+          epochId,
+          uploadNonce,
+        );
+      }
+
+      final seq = publish.seq;
+      try {
+        // The cloud is the authority on what already landed: part names encode
+        // (device, seq, index), so a listing answers it exactly. Local
+        // bookkeeping could only disagree with the bytes actually there.
+        final present = resumed == null
+            ? const <int>{}
+            : await _uploadedParts(provider, folderId, deviceId, seq);
+        final upload = await BasePartFileSource(publish.dataPath).uploadAll(
           (i, bytes) => provider.uploadFile(
             bytes,
-            ChangesetLogLayout.basePartName(deviceId, newSeq, i),
+            ChangesetLogLayout.basePartName(deviceId, seq, i),
             folderId: folderId,
           ),
           onPartUploaded: onBasePartUploaded,
+          skipPart: present.contains,
         );
         final manifest = SyncManifest(
           deviceId: deviceId,
           deviceName: deviceName,
           provider: providerId,
-          baseSeq: newSeq,
+          baseSeq: seq,
           basePartCount: upload.partCount,
-          baseBytes: base.byteLength,
+          baseBytes: publish.byteLength,
           baseChecksum: upload.wholeChecksum,
           basePartChecksums: upload.partChecksums,
-          headSeq: newSeq,
-          publishedHlcHigh: base.toHlc,
+          headSeq: seq,
+          publishedHlcHigh: publish.toHlc,
           epochId: epochId,
-          uploadNonce: uploadNonce,
+          // The nonce is baked into the exported bytes, so a resumed publish
+          // keeps the one it was exported with rather than restamping the
+          // manifest out of step with the base it describes.
+          uploadNonce: publish.uploadNonce,
           appliedPeerHlc: appliedPeerHlc,
           updatedAt: now,
           schemaVersion: AppDatabase.currentSchemaVersion,
@@ -158,11 +206,11 @@ class ChangesetWriter {
         await _publishState.upsert(
           LocalPublishStatesCompanion(
             provider: Value(providerId),
-            baseSeq: Value(newSeq),
+            baseSeq: Value(seq),
             basePartCount: Value(upload.partCount),
-            baseBytes: Value(base.byteLength),
-            headSeq: Value(newSeq),
-            publishedHlcHigh: Value(base.toHlc),
+            baseBytes: Value(publish.byteLength),
+            headSeq: Value(seq),
+            publishedHlcHigh: Value(publish.toHlc),
             changesetBytesSinceBase: const Value(0),
             updatedAt: Value(now),
           ),
@@ -173,13 +221,18 @@ class ChangesetWriter {
         // _pruneSupersededBelow: best-effort, readers self-heal from the new
         // base). An ordinary cold-start has nothing below it to prune.
         if (forceBase) {
-          await _pruneSupersededBelow(provider, folderId, deviceId, newSeq);
+          await _pruneSupersededBelow(provider, folderId, deviceId, seq);
         }
-        return ChangesetWriteResult(ChangesetWriteKind.base, newSeq);
-      } finally {
-        try {
-          await File(base.path).delete();
-        } catch (_) {}
+        // Only now, with the manifest committed, is the export spent. Failing
+        // before this leaves the record in place so the NEXT attempt resumes
+        // rather than starting over -- the whole point of the exercise.
+        await _resumable.discard(publish);
+        return ChangesetWriteResult(ChangesetWriteKind.base, seq);
+      } catch (_) {
+        // Keep the export and its record for the next attempt. Nothing else
+        // reclaims this directory, so a publish that can never succeed would
+        // otherwise leak; find() prunes records whose epoch has moved on.
+        rethrow;
       }
     }
 
@@ -433,6 +486,76 @@ class ChangesetWriter {
   /// manifest are already durable, so a transient list/delete failure must
   /// never fail the publish. Superseded files are harmless (the base is their
   /// superset) and a later sync re-runs this idempotent sweep.
+  /// Move a fresh export into the durable publish directory and record it, so
+  /// an interrupted upload can pick it up instead of re-exporting.
+  ///
+  /// The export lands in the temp directory, which iOS, Android and macOS all
+  /// purge under pressure -- exactly the window this feature has to survive --
+  /// so it is relocated rather than tracked where it lies. A rename across
+  /// filesystems fails, hence the copy fallback.
+  Future<ResumableBasePublish> _recordResumable(
+    StreamedBase base,
+    String providerId,
+    String deviceId,
+    int seq,
+    String? epochId,
+    String? uploadNonce,
+  ) async {
+    final dir = await _resumable.directory;
+    final target =
+        '${dir.path}/${base.path.split(Platform.pathSeparator).last}';
+    final source = File(base.path);
+    try {
+      await source.rename(target);
+    } on FileSystemException {
+      await source.copy(target);
+      try {
+        await source.delete();
+      } catch (_) {}
+    }
+    final publish = ResumableBasePublish(
+      providerId: providerId,
+      deviceId: deviceId,
+      seq: seq,
+      dataPath: target,
+      byteLength: base.byteLength,
+      createdAt: DateTime.now().millisecondsSinceEpoch,
+      epochId: epochId,
+      uploadNonce: uploadNonce,
+      toHlc: base.toHlc,
+    );
+    await _resumable.save(publish);
+    return publish;
+  }
+
+  /// Part indices already present in the cloud for [deviceId]'s base [seq].
+  ///
+  /// Best-effort: a listing failure yields an empty set, so the resumed publish
+  /// re-uploads everything. Slow, but never wrong -- the opposite mistake would
+  /// skip a part that was never actually there and publish a base no peer can
+  /// reassemble.
+  Future<Set<int>> _uploadedParts(
+    CloudStorageProvider provider,
+    String folderId,
+    String deviceId,
+    int seq,
+  ) async {
+    try {
+      final files = await provider.listFiles(
+        folderId: folderId,
+        namePattern: ChangesetLogLayout.prefix,
+      );
+      return {
+        for (final f in files)
+          if (ChangesetLogLayout.deviceIdOf(f.name) == deviceId)
+            if (ChangesetLogLayout.basePartOf(f.name) case final p?)
+              if (p.baseSeq == seq) p.part,
+      };
+    } catch (_) {
+      return const {};
+    }
+  }
+
   Future<void> _pruneSupersededBelow(
     CloudStorageProvider provider,
     String folderId,

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -63,6 +63,12 @@ class ChangesetWriter {
     /// Leaving it over-claiming makes the stale-restore detector fire again on
     /// every subsequent sync, wiping all peer cursors each time (#997).
     bool forceBase = false,
+
+    /// Fires as each base part lands, as `(uploaded, total)`. Only a full base
+    /// publish (or a compaction that rewrites one) reports here -- an ordinary
+    /// changeset is a single small upload with nothing to show. See
+    /// [BasePartFileSource.uploadAll] for why this exists (issue #1032).
+    void Function(int uploaded, int total)? onBasePartUploaded,
   }) async {
     final providerId = provider.providerId;
     final ownManifest = await _readOwnManifest(provider, folderId, deviceId);
@@ -129,6 +135,7 @@ class ChangesetWriter {
             ChangesetLogLayout.basePartName(deviceId, newSeq, i),
             folderId: folderId,
           ),
+          onPartUploaded: onBasePartUploaded,
         );
         final manifest = SyncManifest(
           deviceId: deviceId,
@@ -286,6 +293,7 @@ class ChangesetWriter {
         uploadNonce: uploadNonce,
         deviceName: deviceName,
         appliedPeerHlc: appliedPeerHlc,
+        onBasePartUploaded: onBasePartUploaded,
       );
       return ChangesetWriteResult(ChangesetWriteKind.compacted, compSeq);
     }
@@ -354,6 +362,7 @@ class ChangesetWriter {
     String? epochId,
     String? uploadNonce,
     String? deviceName,
+    void Function(int uploaded, int total)? onBasePartUploaded,
   }) async {
     // The fresh base must carry the full deletion log: a peer that still holds
     // a since-deleted record and cold-starts from this base (its prior
@@ -378,6 +387,7 @@ class ChangesetWriter {
           ChangesetLogLayout.basePartName(deviceId, compSeq, i),
           folderId: folderId,
         ),
+        onPartUploaded: onBasePartUploaded,
       );
     } finally {
       try {

--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -541,10 +541,13 @@ class ChangesetWriter {
     int seq,
   ) async {
     try {
-      final files = await provider.listFiles(
-        folderId: folderId,
-        namePattern: ChangesetLogLayout.prefix,
-      );
+      // Bounded: the catch below cannot save a caller from a listing that
+      // never RETURNS, and this one runs mid-publish, so a stalled provider
+      // would hang the whole sync instead of falling back to re-uploading.
+      // Same 8s ceiling the cleanup paths use (PR #1033 review).
+      final files = await provider
+          .listFiles(folderId: folderId, namePattern: ChangesetLogLayout.prefix)
+          .timeout(const Duration(seconds: 8));
       return {
         for (final f in files)
           if (ChangesetLogLayout.deviceIdOf(f.name) == deviceId)

--- a/lib/core/services/sync/changeset_log/resumable_base_publish.dart
+++ b/lib/core/services/sync/changeset_log/resumable_base_publish.dart
@@ -122,6 +122,10 @@ class ResumableBasePublishStore {
 
   final Future<Directory> Function() _directory;
 
+  /// How recently an unreferenced export must have been touched to be spared
+  /// as "probably still being written" rather than swept as an orphan.
+  static const Duration _orphanGrace = Duration(minutes: 5);
+
   Future<Directory> get directory => _directory();
 
   /// Record [publish], overwriting any previous record for its data file.
@@ -136,7 +140,9 @@ class ResumableBasePublishStore {
   ///
   /// Anything unusable is deleted on the way past, so a doomed export cannot
   /// accumulate: a sidecar whose data file is gone or the wrong size (the OS
-  /// purged or truncated it), or one stamped with a different epoch.
+  /// purged or truncated it), one stamped with a different epoch, one whose
+  /// record will not parse, and -- via [_pruneUnreferencedExports] -- an export
+  /// with no sidecar at all.
   Future<ResumableBasePublish?> find({
     required String providerId,
     required String deviceId,
@@ -145,6 +151,9 @@ class ResumableBasePublishStore {
     final dir = await directory;
     if (!await dir.exists()) return null;
 
+    /// Data files a surviving sidecar still points at. Everything else in this
+    /// directory is unreachable and gets swept below.
+    final referenced = <String>{};
     ResumableBasePublish? best;
     await for (final entity in dir.list(followLinks: false)) {
       if (entity is! File ||
@@ -164,6 +173,7 @@ class ResumableBasePublishStore {
         continue;
       }
 
+      referenced.add(record.dataPath);
       if (record.providerId != providerId || record.deviceId != deviceId) {
         continue;
       }
@@ -185,7 +195,45 @@ class ResumableBasePublishStore {
         await discard(record);
       }
     }
+    if (best != null) referenced.add(best.dataPath);
+    await _pruneUnreferencedExports(dir, referenced);
     return best;
+  }
+
+  /// Delete exports in [dir] that no sidecar points at.
+  ///
+  /// `_recordResumable` moves the export into place and only then writes its
+  /// sidecar, so an app killed inside that window leaves a data file nothing
+  /// references. Because [find] scans sidecars, such a file would never be
+  /// discovered again -- a whole library's worth of bytes stranded forever in a
+  /// directory nothing else purges (PR #1033 review).
+  ///
+  /// Skips anything touched within [_orphanGrace]. The only writer here is
+  /// `_recordResumable`, and publishes are serialized, so a file younger than
+  /// that is far more likely to be one being written right now than an orphan.
+  /// A true orphan is simply reclaimed by the next sync instead.
+  static Future<void> _pruneUnreferencedExports(
+    Directory dir,
+    Set<String> referenced,
+  ) async {
+    final cutoff = DateTime.now().subtract(_orphanGrace);
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File) continue;
+      final path = entity.path;
+      if (path.endsWith(ResumableBasePublish.sidecarSuffix)) continue;
+      if (referenced.contains(path)) continue;
+      // A sidecar may exist but have been skipped above (another provider's
+      // record, say), so check the filesystem rather than only `referenced`.
+      if (await File(ResumableBasePublish.sidecarPathFor(path)).exists()) {
+        continue;
+      }
+      try {
+        if ((await entity.stat()).modified.isAfter(cutoff)) continue;
+      } catch (_) {
+        continue;
+      }
+      await _deleteQuietly(path);
+    }
   }
 
   /// Delete a record and the export it describes.

--- a/lib/core/services/sync/changeset_log/resumable_base_publish.dart
+++ b/lib/core/services/sync/changeset_log/resumable_base_publish.dart
@@ -1,0 +1,227 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show FlutterError;
+import 'package:flutter/services.dart' show MissingPluginException;
+import 'package:path_provider/path_provider.dart';
+
+/// A full base export that has been written to disk but not yet fully uploaded.
+///
+/// A backend wipe forces the whole library to be republished as a fresh base --
+/// 80 parts and roughly 640 MB for the reporter of issue #1032. On a phone that
+/// is minutes of upload, and if the app is closed partway through, the publish
+/// restarted from part 0 on the next attempt. Combined with a progress bar that
+/// looked frozen, the user kept killing it, and sync could never finish.
+///
+/// This record is the sidecar that makes the next attempt continue instead. It
+/// deliberately stores only what cannot be recovered otherwise:
+///
+///   * WHICH parts already landed is NOT stored. Part filenames encode the
+///     device id, base seq and part index, so the answer is a listing away and
+///     the cloud is authoritative. Local bookkeeping could only disagree with
+///     it.
+///   * Checksums are NOT stored. They are recomputed from the bytes actually on
+///     disk during the resumed pass, so a truncated or tampered file can never
+///     be certified by a checksum that was recorded when it was still intact.
+class ResumableBasePublish {
+  const ResumableBasePublish({
+    required this.providerId,
+    required this.deviceId,
+    required this.seq,
+    required this.dataPath,
+    required this.byteLength,
+    required this.createdAt,
+    this.epochId,
+    this.uploadNonce,
+    this.toHlc,
+  });
+
+  final String providerId;
+  final String deviceId;
+
+  /// The base sequence number the parts are named with. A resumed publish MUST
+  /// keep it: changing it would orphan every part already uploaded.
+  final int seq;
+
+  final String dataPath;
+
+  /// Size of the export when it was written. A mismatch against the file on
+  /// disk means a truncated or partially-purged file, which is discarded rather
+  /// than resumed.
+  final int byteLength;
+
+  final int createdAt;
+
+  /// The library epoch baked into the exported bytes. A resume is only valid
+  /// while the epoch still matches: under a new epoch these bytes would publish
+  /// a base every peer ignores.
+  final String? epochId;
+
+  /// Reused rather than regenerated. The nonce is written into the exported
+  /// bytes, so it cannot be restamped at manifest time without desyncing the
+  /// manifest from the base it describes. It was recorded before the first
+  /// attempt, so twin detection still recognises it as ours.
+  final String? uploadNonce;
+
+  /// The watermark this base publishes, from the export. Rows written after the
+  /// export are not lost by resuming: they carry higher HLCs than this
+  /// watermark and go out as the next changeset.
+  final String? toHlc;
+
+  String get sidecarPath => sidecarPathFor(dataPath);
+
+  static String sidecarPathFor(String dataPath) => '$dataPath.publish';
+
+  Map<String, dynamic> toJson() => {
+    'providerId': providerId,
+    'deviceId': deviceId,
+    'seq': seq,
+    'dataPath': dataPath,
+    'byteLength': byteLength,
+    'createdAt': createdAt,
+    'epochId': epochId,
+    'uploadNonce': uploadNonce,
+    'toHlc': toHlc,
+  };
+
+  static ResumableBasePublish fromJson(Map<String, dynamic> json) =>
+      ResumableBasePublish(
+        providerId: json['providerId'] as String,
+        deviceId: json['deviceId'] as String,
+        seq: json['seq'] as int,
+        dataPath: json['dataPath'] as String,
+        byteLength: json['byteLength'] as int,
+        createdAt: json['createdAt'] as int,
+        epochId: json['epochId'] as String?,
+        uploadNonce: json['uploadNonce'] as String?,
+        toHlc: json['toHlc'] as String?,
+      );
+}
+
+/// Persists [ResumableBasePublish] records as sidecar files beside the base
+/// exports they describe.
+///
+/// Sidecars rather than a database table: the record is only meaningful while
+/// its data file exists, and keeping the two together means they cannot drift
+/// apart or outlive one another. It also keeps this off the schema ladder
+/// entirely, so recovering an interrupted publish needs no migration.
+class ResumableBasePublishStore {
+  ResumableBasePublishStore({Future<Directory> Function()? directory})
+    : _directory = directory ?? resolveBasePublishDir;
+
+  final Future<Directory> Function() _directory;
+
+  Future<Directory> get directory => _directory();
+
+  /// Record [publish], overwriting any previous record for its data file.
+  Future<void> save(ResumableBasePublish publish) async {
+    await File(
+      publish.sidecarPath,
+    ).writeAsString(jsonEncode(publish.toJson()), flush: true);
+  }
+
+  /// The resumable publish for [providerId]/[deviceId] under [epochId], or null
+  /// when there is nothing safe to resume.
+  ///
+  /// Anything unusable is deleted on the way past, so a doomed export cannot
+  /// accumulate: a sidecar whose data file is gone or the wrong size (the OS
+  /// purged or truncated it), or one stamped with a different epoch.
+  Future<ResumableBasePublish?> find({
+    required String providerId,
+    required String deviceId,
+    String? epochId,
+  }) async {
+    final dir = await directory;
+    if (!await dir.exists()) return null;
+
+    ResumableBasePublish? best;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.publish')) continue;
+      ResumableBasePublish record;
+      try {
+        record = ResumableBasePublish.fromJson(
+          jsonDecode(await entity.readAsString()) as Map<String, dynamic>,
+        );
+      } catch (_) {
+        await _deleteQuietly(entity.path);
+        continue;
+      }
+
+      if (record.providerId != providerId || record.deviceId != deviceId) {
+        continue;
+      }
+      if (record.epochId != epochId) {
+        await discard(record);
+        continue;
+      }
+      final data = File(record.dataPath);
+      if (!await data.exists() || await data.length() != record.byteLength) {
+        await discard(record);
+        continue;
+      }
+      // Keep the newest: an earlier interrupted attempt under the same epoch is
+      // superseded by a later one and its parts are dead weight.
+      if (best == null || record.createdAt > best.createdAt) {
+        if (best != null) await discard(best);
+        best = record;
+      } else {
+        await discard(record);
+      }
+    }
+    return best;
+  }
+
+  /// Delete a record and the export it describes.
+  Future<void> discard(ResumableBasePublish publish) async {
+    await _deleteQuietly(publish.sidecarPath);
+    await _deleteQuietly(publish.dataPath);
+  }
+
+  /// Drop every record for [providerId], used when sync state is reset.
+  Future<void> clearForProvider(String providerId) async {
+    final dir = await directory;
+    if (!await dir.exists()) return;
+    await for (final entity in dir.list(followLinks: false)) {
+      if (entity is! File || !entity.path.endsWith('.publish')) continue;
+      try {
+        final record = ResumableBasePublish.fromJson(
+          jsonDecode(await entity.readAsString()) as Map<String, dynamic>,
+        );
+        if (record.providerId == providerId) await discard(record);
+      } catch (_) {
+        await _deleteQuietly(entity.path);
+      }
+    }
+  }
+
+  static Future<void> _deleteQuietly(String path) async {
+    try {
+      await File(path).delete();
+    } catch (_) {}
+  }
+}
+
+/// Directory holding in-flight base exports.
+///
+/// Application support, NOT the temp/cache directory the rest of the streaming
+/// sync uses. iOS and Android both purge caches under pressure and macOS maps
+/// the temp dir to `Library/Caches`, so an export parked there could vanish
+/// between attempts -- which is precisely the failure this exists to end. The
+/// tradeoff is that nothing reclaims these files automatically, so every exit
+/// path from a publish must discard its record.
+Future<Directory> resolveBasePublishDir() async {
+  Directory base;
+  try {
+    base = await getApplicationSupportDirectory();
+  } on MissingPluginException {
+    base = Directory.systemTemp;
+  } on FlutterError catch (e) {
+    // Only the "no test binding" case, mirroring resolveSyncTempDir. Any other
+    // FlutterError is a real problem and must surface.
+    if (!e.toString().contains('Binding has not yet been initialized')) rethrow;
+    base = Directory.systemTemp;
+  }
+  final dir = Directory('${base.path}/sync_base_publish');
+  await dir.create(recursive: true);
+  return dir;
+}

--- a/lib/core/services/sync/changeset_log/resumable_base_publish.dart
+++ b/lib/core/services/sync/changeset_log/resumable_base_publish.dart
@@ -70,7 +70,18 @@ class ResumableBasePublish {
 
   String get sidecarPath => sidecarPathFor(dataPath);
 
-  static String sidecarPathFor(String dataPath) => '$dataPath.publish';
+  static const String sidecarSuffix = '.publish';
+
+  static String sidecarPathFor(String dataPath) => '$dataPath$sidecarSuffix';
+
+  /// The export a sidecar at [sidecarPath] describes, derived from the name
+  /// alone. Recovers the data file when the sidecar's CONTENTS cannot be read,
+  /// which is the only way a corrupt record's export gets reclaimed -- and it
+  /// can be hundreds of megabytes sitting in a directory nothing else purges.
+  static String dataPathForSidecar(String sidecarPath) =>
+      sidecarPath.endsWith(sidecarSuffix)
+      ? sidecarPath.substring(0, sidecarPath.length - sidecarSuffix.length)
+      : sidecarPath;
 
   Map<String, dynamic> toJson() => {
     'providerId': providerId,
@@ -136,14 +147,20 @@ class ResumableBasePublishStore {
 
     ResumableBasePublish? best;
     await for (final entity in dir.list(followLinks: false)) {
-      if (entity is! File || !entity.path.endsWith('.publish')) continue;
+      if (entity is! File ||
+          !entity.path.endsWith(ResumableBasePublish.sidecarSuffix)) {
+        continue;
+      }
       ResumableBasePublish record;
       try {
         record = ResumableBasePublish.fromJson(
           jsonDecode(await entity.readAsString()) as Map<String, dynamic>,
         );
       } catch (_) {
-        await _deleteQuietly(entity.path);
+        // Drop the export too, not just the record. The path is derivable from
+        // the sidecar's NAME, so an unreadable record is no reason to strand
+        // its bytes here forever (PR #1033 review).
+        await _discardSidecarAndData(entity.path);
         continue;
       }
 
@@ -182,16 +199,28 @@ class ResumableBasePublishStore {
     final dir = await directory;
     if (!await dir.exists()) return;
     await for (final entity in dir.list(followLinks: false)) {
-      if (entity is! File || !entity.path.endsWith('.publish')) continue;
+      if (entity is! File ||
+          !entity.path.endsWith(ResumableBasePublish.sidecarSuffix)) {
+        continue;
+      }
       try {
         final record = ResumableBasePublish.fromJson(
           jsonDecode(await entity.readAsString()) as Map<String, dynamic>,
         );
         if (record.providerId == providerId) await discard(record);
       } catch (_) {
-        await _deleteQuietly(entity.path);
+        await _discardSidecarAndData(entity.path);
       }
     }
+  }
+
+  /// Delete a sidecar and the export its name points at.
+  ///
+  /// Used when the sidecar cannot be parsed, so [discard] (which needs a
+  /// decoded record) is not available.
+  static Future<void> _discardSidecarAndData(String sidecarPath) async {
+    await _deleteQuietly(sidecarPath);
+    await _deleteQuietly(ResumableBasePublish.dataPathForSidecar(sidecarPath));
   }
 
   static Future<void> _deleteQuietly(String path) async {

--- a/lib/core/services/sync/sync_cleanup_outcome.dart
+++ b/lib/core/services/sync/sync_cleanup_outcome.dart
@@ -1,0 +1,53 @@
+/// Reports how far a bulk cloud cleanup actually got.
+///
+/// Wiping a backend is best-effort by design: an offline provider or a listing
+/// timeout leaves files behind. Before issue #1032 those failures were logged
+/// and swallowed, and the UI reported "Wiped all sync data" regardless -- a
+/// user whose marker listing timed out was told the backend was clean while
+/// hundreds of files remained. Callers now have to look at [isComplete] to make
+/// that claim.
+class SyncCleanupOutcome {
+  const SyncCleanupOutcome({
+    this.deleted = 0,
+    this.failed = 0,
+    this.listIncomplete = false,
+  });
+
+  /// Files confirmed removed from the backend.
+  final int deleted;
+
+  /// Files that were listed but whose delete threw (offline, denied, timeout).
+  final int failed;
+
+  /// At least one listing call failed, so files may exist that were never even
+  /// attempted. Distinct from [failed]: the count of what was missed is
+  /// unknowable, which is exactly why success cannot be claimed.
+  final bool listIncomplete;
+
+  /// Every file that could be seen was removed. The only basis on which a
+  /// caller may tell the user the backend is clean.
+  bool get isComplete => failed == 0 && !listIncomplete;
+
+  /// Total files acted on, successfully or not -- the denominator a progress
+  /// bar finished at.
+  int get attempted => deleted + failed;
+
+  /// Fold another cleanup's result into this one, for callers that clean up in
+  /// several passes and report a single outcome.
+  SyncCleanupOutcome merge(SyncCleanupOutcome other) => SyncCleanupOutcome(
+    deleted: deleted + other.deleted,
+    failed: failed + other.failed,
+    listIncomplete: listIncomplete || other.listIncomplete,
+  );
+
+  @override
+  String toString() =>
+      'SyncCleanupOutcome(deleted: $deleted, failed: $failed, '
+      'listIncomplete: $listIncomplete)';
+}
+
+/// Called as a bulk cleanup advances: [done] of [total] files attempted.
+///
+/// [total] is fixed before the first delete (the whole listing is taken up
+/// front) so the bar does not grow under the user mid-wipe.
+typedef SyncCleanupProgress = void Function(int done, int total);

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2206,7 +2206,7 @@ class SyncDataSerializer {
     if (rivals.isEmpty) {
       await _db
           .into(_db.tags)
-          .insertOnConflictUpdate(remote.toCompanion(false));
+          .insertOnConflictUpdate(_normalizedTag(remote).toCompanion(false));
       return;
     }
 
@@ -2218,8 +2218,21 @@ class SyncDataSerializer {
     if (survivor == remote.id) {
       await _db
           .into(_db.tags)
-          .insertOnConflictUpdate(remote.toCompanion(false));
+          .insertOnConflictUpdate(_normalizedTag(remote).toCompanion(false));
     }
+  }
+
+  /// A remote tag with its name normalized the way everything else keys on it.
+  ///
+  /// The v149 migration trims every stored name so a row reads back as what
+  /// lookups compare against. Writing a peer's value verbatim would undo that
+  /// on the first sync from a device predating the change: uniqueness would
+  /// still hold (the index keys on `lower(trim(name))`), but the stored value
+  /// would drift from the invariant the migration establishes, and the tag
+  /// would render with whitespace the user never typed (PR #1033 review).
+  Tag _normalizedTag(Tag remote) {
+    final trimmed = remote.name.trim();
+    return trimmed == remote.name ? remote : remote.copyWith(name: trimmed);
   }
 
   /// Moves [loser]'s dive links onto [survivor], drops the losing tag row and

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2225,12 +2225,25 @@ class SyncDataSerializer {
   /// Moves [loser]'s dive links onto [survivor], drops the losing tag row and
   /// remembers the alias.
   ///
-  /// Repointed junction rows are marked pending so this device republishes
-  /// them: that is what lets a peer recover a link it had to drop because the
-  /// tag row it referenced arrived in an earlier payload than the junction.
   /// A link the survivor already covers is deleted outright rather than
-  /// tombstoned -- it is a local identity fold, not a user deleting a tag, and
-  /// every peer reaches the same fold from the same rule.
+  /// tombstoned -- it is a local identity fold, not a user deleting a tag.
+  ///
+  /// Convergence does NOT depend on republishing these rows, and deliberately
+  /// so: the survivor rule is deterministic, so every device that sees both
+  /// tags performs the identical fold from its own copy. The repointed rows
+  /// are still marked pending to record that they changed locally, but note
+  /// that alone does not re-export them -- `_exportDiveTags` gathers junctions
+  /// by their parent DIVE's HLC, not from pending junction records, and
+  /// bumping the dive to force it would risk clobbering a peer's newer edit to
+  /// that dive under LWW.
+  ///
+  /// The residual gap is narrow and known: a junction referencing a tag folded
+  /// away in an EARLIER sync run arrives with no alias to rewrite it, so
+  /// `repairDanglingForeignKeys` drops it and that one dive loses the tag
+  /// locally until something touches it. Closing it properly means either a
+  /// durable alias table or teaching the incremental export to honour pending
+  /// junction records -- both new sync surface, deferred rather than smuggled
+  /// into this change (PR #1033 review).
   Future<void> _foldTagInto({
     required String loser,
     required String survivor,

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -519,6 +520,7 @@ class SyncData {
 class SyncDataSerializer {
   AppDatabase get _db => DatabaseService.instance.database;
   final _log = LoggerService.forClass(SyncDataSerializer);
+  final SyncRepository _syncRepository = SyncRepository();
 
   Future<List<Map<String, dynamic>>> _safeExport(
     String label,
@@ -2145,6 +2147,138 @@ class SyncDataSerializer {
     }
   }
 
+  // ==========================================================================
+  // Tag identity (issue #1032)
+  // ==========================================================================
+
+  /// Remote tag ids this device has folded into a local tag of the same name,
+  /// mapped to the id that survived.
+  ///
+  /// A peer's junction rows reference the peer's tag id, which may be the one
+  /// that lost the fold and therefore no longer exists here. Rewriting those
+  /// references keeps the tag on the dive instead of leaving a dangling
+  /// foreign key for the repair pass to delete. Entries never go stale (the
+  /// survivor is chosen deterministically from the ids themselves), so the map
+  /// is not cleared between payloads.
+  final Map<String, String> _tagIdAliases = {};
+
+  Map<String, dynamic> _withTagAlias(Map<String, dynamic> data) {
+    final tagId = data['tagId'];
+    final survivor = tagId is String ? _tagIdAliases[tagId] : null;
+    return survivor == null ? data : {...data, 'tagId': survivor};
+  }
+
+  /// Applies a remote `tags` row, converging on ONE row per (diver scope,
+  /// case-folded name) -- the invariant `idx_tags_diver_name_unique` enforces.
+  ///
+  /// Upserting by primary key alone is what produced #1032: two devices each
+  /// minted a uuid for the same auto-generated import tag name, so the peer's
+  /// row landed beside the local one and the dive showed the tag twice.
+  ///
+  /// The survivor is the lexically lowest id among the rivals. It has to be a
+  /// property of the rows rather than of this device -- "the one we had first"
+  /// differs per device and would make the two flip-flop forever, each
+  /// adopting the other's id on every sync. Lowest-id matches the v149
+  /// migration's rule, so a device that healed by migration and a device that
+  /// healed by merge land on the same tag.
+  Future<void> _applyTagRecord(Tag remote) async {
+    final rivals =
+        await (_db.select(_db.tags)..where(
+              (t) =>
+                  t.name.lower().equals(remote.name.trim().toLowerCase()) &
+                  coalesce([
+                    t.diverId,
+                    const Constant(''),
+                  ]).equals(remote.diverId ?? '') &
+                  t.id.equals(remote.id).not(),
+            ))
+            .get();
+
+    if (rivals.isEmpty) {
+      await _db
+          .into(_db.tags)
+          .insertOnConflictUpdate(remote.toCompanion(false));
+      return;
+    }
+
+    final ids = [remote.id, for (final r in rivals) r.id]..sort();
+    final survivor = ids.first;
+    for (final loser in ids.skip(1)) {
+      await _foldTagInto(loser: loser, survivor: survivor);
+    }
+    if (survivor == remote.id) {
+      await _db
+          .into(_db.tags)
+          .insertOnConflictUpdate(remote.toCompanion(false));
+    }
+  }
+
+  /// Moves [loser]'s dive links onto [survivor], drops the losing tag row and
+  /// remembers the alias.
+  ///
+  /// Repointed junction rows are marked pending so this device republishes
+  /// them: that is what lets a peer recover a link it had to drop because the
+  /// tag row it referenced arrived in an earlier payload than the junction.
+  /// A link the survivor already covers is deleted outright rather than
+  /// tombstoned -- it is a local identity fold, not a user deleting a tag, and
+  /// every peer reaches the same fold from the same rule.
+  Future<void> _foldTagInto({
+    required String loser,
+    required String survivor,
+  }) async {
+    final moving = await (_db.select(
+      _db.diveTags,
+    )..where((t) => t.tagId.equals(loser))).get();
+
+    if (moving.isNotEmpty) {
+      final covered =
+          (await (_db.select(
+                _db.diveTags,
+              )..where((t) => t.tagId.equals(survivor))).get())
+              .map((r) => r.diveId)
+              .toSet();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      for (final row in moving) {
+        if (!covered.add(row.diveId)) {
+          await (_db.delete(
+            _db.diveTags,
+          )..where((t) => t.id.equals(row.id))).go();
+          continue;
+        }
+        await (_db.update(_db.diveTags)..where((t) => t.id.equals(row.id)))
+            .write(DiveTagsCompanion(tagId: Value(survivor)));
+        await _syncRepository.markRecordPending(
+          entityType: 'diveTags',
+          recordId: row.id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+
+    await (_db.delete(_db.tags)..where((t) => t.id.equals(loser))).go();
+    _tagIdAliases[loser] = survivor;
+  }
+
+  /// Applies a remote `dive_tags` row.
+  ///
+  /// `DO NOTHING` on ANY uniqueness conflict, not just the primary key: a peer
+  /// that linked the same tag to the same dive minted its own uuid for the
+  /// junction row, so the pair is already applied even though the id is new.
+  /// Skipping it is the whole point -- with `idx_dive_tags_dive_tag_unique` in
+  /// place an unguarded insert would throw and fail the entire sync, which is
+  /// far worse than the duplicate it replaces.
+  ///
+  /// Junction rows are immutable (they are deleted and re-inserted with fresh
+  /// ids, never edited), so declining to update an existing row loses nothing.
+  Future<void> _applyDiveTagRecord(DiveTag record) async {
+    await _db
+        .into(_db.diveTags)
+        .insert(
+          record,
+          onConflict: DoNothing<$DiveTagsTable, DiveTag>(target: const []),
+        );
+  }
+
   /// Applies one incoming record.
   ///
   /// HLC-bearing entities (`entityHasUpdatedAt == true`) apply via
@@ -2486,14 +2620,10 @@ class SyncDataSerializer {
             );
         return;
       case 'tags':
-        await _db
-            .into(_db.tags)
-            .insertOnConflictUpdate(Tag.fromJson(data).toCompanion(false));
+        await _applyTagRecord(Tag.fromJson(data));
         return;
       case 'diveTags':
-        await _db
-            .into(_db.diveTags)
-            .insertOnConflictUpdate(DiveTag.fromJson(data));
+        await _applyDiveTagRecord(DiveTag.fromJson(_withTagAlias(data)));
         return;
       case 'diveDiveTypes':
         await _db
@@ -3137,19 +3267,21 @@ class SyncDataSerializer {
           ),
         );
         return;
+      // Tags reconcile one at a time: each row may fold a local tag of the
+      // same name into itself (or be folded into one), which a single batched
+      // insert cannot express. Tag vocabularies are tens of rows, not the
+      // per-sample volumes the batch path exists for.
       case 'tags':
-        await _db.batch(
-          (b) => b.insertAllOnConflictUpdate(
-            _db.tags,
-            records.map((r) => Tag.fromJson(r).toCompanion(false)).toList(),
-          ),
-        );
+        for (final record in records) {
+          await _applyTagRecord(Tag.fromJson(record));
+        }
         return;
       case 'diveTags':
         await _db.batch(
-          (b) => b.insertAllOnConflictUpdate(
+          (b) => b.insertAll(
             _db.diveTags,
-            records.map((r) => DiveTag.fromJson(r)).toList(),
+            records.map((r) => DiveTag.fromJson(_withTagAlias(r))).toList(),
+            onConflict: DoNothing<$DiveTagsTable, DiveTag>(target: const []),
           ),
         );
         return;

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -2181,11 +2181,20 @@ class SyncDataSerializer {
   /// adopting the other's id on every sync. Lowest-id matches the v149
   /// migration's rule, so a device that healed by migration and a device that
   /// healed by merge land on the same tag.
+  ///
+  /// Both sides normalize to `lower(trim(name))`, exactly as
+  /// `idx_tags_diver_name_unique` keys. Trimming only the INCOMING name made
+  /// the comparison asymmetric -- a local " Wreck" would not match a remote
+  /// "Wreck" while the reverse did -- so whether two devices converged
+  /// depended on which of them happened to hold the padded spelling
+  /// (PR #1033 review).
   Future<void> _applyTagRecord(Tag remote) async {
     final rivals =
         await (_db.select(_db.tags)..where(
               (t) =>
-                  t.name.lower().equals(remote.name.trim().toLowerCase()) &
+                  t.name.trim().lower().equals(
+                    remote.name.trim().toLowerCase(),
+                  ) &
                   coalesce([
                     t.diverId,
                     const Constant(''),

--- a/lib/core/services/sync/sync_device_footprint.dart
+++ b/lib/core/services/sync/sync_device_footprint.dart
@@ -1,0 +1,85 @@
+/// How a device's files on the backend relate to the library in use now.
+enum SyncDeviceFootprintState {
+  /// Publishing into the epoch this library is on. A working peer.
+  active,
+
+  /// Stamped with a DIFFERENT library epoch: left behind by a replace or a
+  /// rebuild and inert to every current-epoch device. These are the "shadow
+  /// copies" users notice piling up on their cloud folder (issue #1032) --
+  /// they consume space and explain nothing, but nothing collects them.
+  staleEpoch,
+
+  /// Carries a durable retirement marker. The fleet has fenced it off; its
+  /// leftovers are swept opportunistically.
+  retired,
+
+  /// Files exist but no manifest could be read -- an interrupted publish, or
+  /// an encrypted library this device cannot decrypt. Deliberately NOT called
+  /// stale: without a manifest there is no epoch to judge it by, and deleting
+  /// on that basis could destroy a publish still in flight.
+  unreadable,
+}
+
+/// One device's whole footprint on a sync backend: what it published, how much
+/// space it holds, and whether it still matters.
+///
+/// Assembled by listing the sync folder and grouping by the device id encoded
+/// in each filename, so it covers devices whose manifest is missing as well as
+/// healthy peers.
+class SyncDeviceFootprint {
+  const SyncDeviceFootprint({
+    required this.deviceId,
+    required this.state,
+    required this.fileCount,
+    required this.byteCount,
+    this.deviceName,
+    this.isSelf = false,
+    this.lastModified,
+    this.publishedAt,
+    this.schemaVersion,
+    this.epochId,
+  });
+
+  final String deviceId;
+  final SyncDeviceFootprintState state;
+
+  /// Files on the backend carrying this device id, retirement marker included.
+  final int fileCount;
+
+  /// Summed file sizes. Providers may not report a size, and those count zero,
+  /// so treat this as a floor rather than an exact total.
+  final int byteCount;
+
+  /// Published display name, absent on legacy manifests and on devices whose
+  /// hostname identified nothing. Callers fall back to a short id.
+  final String? deviceName;
+
+  /// This install's own footprint. Never offered for deletion through the peer
+  /// path -- removing your own files is what "Remove this device's cloud
+  /// files" does, and it carries no retirement fence.
+  final bool isSelf;
+
+  /// Newest backend mtime across the device's files. Survives a missing
+  /// manifest, so it is the only freshness signal for an [unreadable]
+  /// footprint.
+  final DateTime? lastModified;
+
+  /// The publisher's own timestamp from its manifest. Preferred over
+  /// [lastModified] when present: it is what the retirement sweep judges by.
+  /// Note a liveness heartbeat moves it without any data change.
+  final DateTime? publishedAt;
+
+  final int? schemaVersion;
+  final String? epochId;
+
+  /// Deleting this device's files cannot lose anything the current library
+  /// still depends on.
+  bool get isSafeToRemove =>
+      !isSelf &&
+      (state == SyncDeviceFootprintState.staleEpoch ||
+          state == SyncDeviceFootprintState.retired);
+
+  /// Short, stable label for a device with no published name.
+  String get shortId =>
+      deviceId.length <= 8 ? deviceId : deviceId.substring(0, 8);
+}

--- a/lib/core/services/sync/sync_device_footprints.dart
+++ b/lib/core/services/sync/sync_device_footprints.dart
@@ -1,0 +1,206 @@
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/retirement_marker.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
+import 'package:submersion/core/services/sync/sync_device_footprint.dart';
+
+/// Read-only survey of every device's footprint on a sync backend, plus the
+/// user-driven removal of one device's files.
+///
+/// Sync itself only ever reads peer manifests as part of a pull, and only for
+/// peers it intends to merge. A user asking "what are all these files on my
+/// Dropbox?" needs the opposite: everything present, including devices sync
+/// deliberately ignores (stale epochs, unreadable publishes). Issue #1032 --
+/// hundreds of files accumulated from a single device and nothing in the app
+/// could account for them.
+class SyncDeviceFootprints {
+  final _log = LoggerService.forClass(SyncDeviceFootprints);
+
+  /// Every device with files in the sync folder, newest first.
+  ///
+  /// Groups by the device id encoded in each filename rather than by manifest,
+  /// so a device whose manifest is missing still appears -- that IS the
+  /// interrupted-publish case a user most needs to see.
+  ///
+  /// Manifest reads are per-device and best-effort: one unreadable manifest
+  /// (corrupt, or encrypted without a key) downgrades that device to
+  /// [SyncDeviceFootprintState.unreadable] instead of failing the survey.
+  Future<List<SyncDeviceFootprint>> list({
+    required CloudStorageProvider provider,
+    required String selfDeviceId,
+    String? currentEpochId,
+    String? folderId,
+  }) async {
+    final files = await provider.listFiles(
+      folderId: folderId,
+      namePattern: ChangesetLogLayout.listPattern,
+    );
+
+    final grouped = <String, List<CloudFileInfo>>{};
+    for (final f in files) {
+      final id = ChangesetLogLayout.deviceIdOf(f.name);
+      if (id == null) continue;
+      grouped.putIfAbsent(id, () => []).add(f);
+    }
+
+    final out = <SyncDeviceFootprint>[];
+    for (final entry in grouped.entries) {
+      out.add(
+        await _describe(
+          provider: provider,
+          deviceId: entry.key,
+          deviceFiles: entry.value,
+          selfDeviceId: selfDeviceId,
+          currentEpochId: currentEpochId,
+        ),
+      );
+    }
+
+    out.sort((a, b) {
+      // This device first, then most recently touched. A user scanning for
+      // what to delete wants "mine" anchored and the rest ordered by staleness.
+      if (a.isSelf != b.isSelf) return a.isSelf ? -1 : 1;
+      final at = a.publishedAt ?? a.lastModified;
+      final bt = b.publishedAt ?? b.lastModified;
+      if (at == null || bt == null) return at == null ? 1 : -1;
+      return bt.compareTo(at);
+    });
+    return out;
+  }
+
+  Future<SyncDeviceFootprint> _describe({
+    required CloudStorageProvider provider,
+    required String deviceId,
+    required List<CloudFileInfo> deviceFiles,
+    required String selfDeviceId,
+    String? currentEpochId,
+  }) async {
+    final retired = deviceFiles.any(
+      (f) => ChangesetLogLayout.isRetiredMarker(f.name),
+    );
+    final bytes = deviceFiles.fold<int>(0, (a, f) => a + (f.sizeBytes ?? 0));
+    final lastModified = deviceFiles
+        .map((f) => f.modifiedTime)
+        .reduce((a, b) => a.isAfter(b) ? a : b);
+
+    SyncManifest? manifest;
+    final manifestFile = deviceFiles
+        .where((f) => ChangesetLogLayout.isManifest(f.name))
+        .firstOrNull;
+    if (manifestFile != null) {
+      try {
+        manifest = SyncManifest.fromBytes(
+          await provider.downloadFile(manifestFile.id),
+        );
+      } catch (e) {
+        // Encrypted without a key, corrupt, or a torn write. Reported as
+        // unreadable rather than swallowed as "no devices".
+        _log.warning('Could not read manifest for $deviceId: $e');
+      }
+    }
+
+    final SyncDeviceFootprintState state;
+    if (retired) {
+      state = SyncDeviceFootprintState.retired;
+    } else if (manifest == null) {
+      state = SyncDeviceFootprintState.unreadable;
+    } else if (currentEpochId != null && manifest.epochId != currentEpochId) {
+      state = SyncDeviceFootprintState.staleEpoch;
+    } else {
+      state = SyncDeviceFootprintState.active;
+    }
+
+    return SyncDeviceFootprint(
+      deviceId: deviceId,
+      state: state,
+      fileCount: deviceFiles.length,
+      byteCount: bytes,
+      deviceName: manifest?.deviceName,
+      isSelf: deviceId == selfDeviceId,
+      lastModified: lastModified,
+      publishedAt: manifest == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(manifest.updatedAt),
+      schemaVersion: manifest?.schemaVersion,
+      epochId: manifest?.epochId,
+    );
+  }
+
+  /// Retire one PEER device and delete its files, reporting progress.
+  ///
+  /// Writes the retirement marker BEFORE deleting anything, and never deletes
+  /// the marker itself. That ordering is load-bearing: a device that comes back
+  /// online later must find the marker and rejoin through the retirement fence,
+  /// or its stale local rows would resurrect fleet-wide. This is why removing a
+  /// peer cannot reuse `SyncService.deleteDeviceSyncFile`, which writes no
+  /// marker -- that one is only correct for retiring THIS install's own
+  /// identity, where the device id is being abandoned anyway.
+  ///
+  /// Refuses [selfDeviceId]: fencing yourself off would make this install
+  /// rebuild from the cloud on its next sync.
+  Future<SyncCleanupOutcome> retirePeer({
+    required CloudStorageProvider provider,
+    required String deviceId,
+    required String selfDeviceId,
+    String? folderId,
+    SyncCleanupProgress? onProgress,
+  }) async {
+    if (deviceId == selfDeviceId) {
+      throw ArgumentError.value(
+        deviceId,
+        'deviceId',
+        'refusing to retire this device through the peer path',
+      );
+    }
+
+    try {
+      await provider.uploadFile(
+        RetirementMarker(
+          deviceId: deviceId,
+          retiredAt: DateTime.now().millisecondsSinceEpoch,
+        ).toBytes(),
+        ChangesetLogLayout.retiredMarkerName(deviceId),
+        folderId: folderId,
+      );
+    } catch (e) {
+      // Without a durable marker the fence does not exist, so deleting now
+      // would be actively unsafe. Report nothing done and let the user retry.
+      _log.warning('Could not write retirement marker for $deviceId: $e');
+      return const SyncCleanupOutcome(listIncomplete: true);
+    }
+
+    final List<CloudFileInfo> files;
+    try {
+      files = await provider.listFiles(
+        folderId: folderId,
+        namePattern: ChangesetLogLayout.listPattern,
+      );
+    } catch (e) {
+      _log.warning('Could not list files to retire $deviceId: $e');
+      return const SyncCleanupOutcome(listIncomplete: true);
+    }
+
+    final targets = files
+        .where((f) => ChangesetLogLayout.deviceIdOf(f.name) == deviceId)
+        .where((f) => !ChangesetLogLayout.isRetiredMarker(f.name))
+        .toList();
+
+    var deleted = 0;
+    var failed = 0;
+    onProgress?.call(0, targets.length);
+    for (final f in targets) {
+      try {
+        await provider.deleteFile(f.id);
+        deleted++;
+      } catch (e) {
+        failed++;
+        _log.warning('Could not delete ${f.name}: $e');
+      }
+      onProgress?.call(deleted + failed, targets.length);
+    }
+    _log.info('Retired peer $deviceId: removed $deleted files, $failed failed');
+    return SyncCleanupOutcome(deleted: deleted, failed: failed);
+  }
+}

--- a/lib/core/services/sync/sync_device_footprints.dart
+++ b/lib/core/services/sync/sync_device_footprints.dart
@@ -16,6 +16,22 @@ import 'package:submersion/core/services/sync/sync_device_footprint.dart';
 /// hundreds of files accumulated from a single device and nothing in the app
 /// could account for them.
 class SyncDeviceFootprints {
+  SyncDeviceFootprints({this.cloudCallTimeout = const Duration(seconds: 8)});
+
+  /// Ceiling on every individual cloud call here.
+  ///
+  /// Both entry points run in front of a user who cannot leave: [list] behind
+  /// a page-filling spinner, and [retirePeer] behind a deliberately
+  /// non-dismissible progress dialog with no back button. An unbounded call
+  /// against a stalled connection strands them there indefinitely -- the exact
+  /// "app is hung, force-quit it" failure this whole change set exists to end,
+  /// and force-quitting mid-retire is what leaves a half-deleted device.
+  ///
+  /// 8s matches the ceiling `SyncService`'s cleanup helpers already use, so
+  /// the two paths fail on the same schedule. Injectable so tests can drive a
+  /// timeout without waiting one out.
+  final Duration cloudCallTimeout;
+
   final _log = LoggerService.forClass(SyncDeviceFootprints);
 
   /// Every device with files in the sync folder, newest first.
@@ -33,10 +49,12 @@ class SyncDeviceFootprints {
     String? currentEpochId,
     String? folderId,
   }) async {
-    final files = await provider.listFiles(
-      folderId: folderId,
-      namePattern: ChangesetLogLayout.listPattern,
-    );
+    final files = await provider
+        .listFiles(
+          folderId: folderId,
+          namePattern: ChangesetLogLayout.listPattern,
+        )
+        .timeout(cloudCallTimeout);
 
     final grouped = <String, List<CloudFileInfo>>{};
     for (final f in files) {
@@ -92,7 +110,9 @@ class SyncDeviceFootprints {
     if (manifestFile != null) {
       try {
         manifest = SyncManifest.fromBytes(
-          await provider.downloadFile(manifestFile.id),
+          await provider
+              .downloadFile(manifestFile.id)
+              .timeout(cloudCallTimeout),
         );
       } catch (e) {
         // Encrypted without a key, corrupt, or a torn write. Reported as
@@ -156,14 +176,16 @@ class SyncDeviceFootprints {
     }
 
     try {
-      await provider.uploadFile(
-        RetirementMarker(
-          deviceId: deviceId,
-          retiredAt: DateTime.now().millisecondsSinceEpoch,
-        ).toBytes(),
-        ChangesetLogLayout.retiredMarkerName(deviceId),
-        folderId: folderId,
-      );
+      await provider
+          .uploadFile(
+            RetirementMarker(
+              deviceId: deviceId,
+              retiredAt: DateTime.now().millisecondsSinceEpoch,
+            ).toBytes(),
+            ChangesetLogLayout.retiredMarkerName(deviceId),
+            folderId: folderId,
+          )
+          .timeout(cloudCallTimeout);
     } catch (e) {
       // Without a durable marker the fence does not exist, so deleting now
       // would be actively unsafe. Report nothing done and let the user retry.
@@ -173,10 +195,12 @@ class SyncDeviceFootprints {
 
     final List<CloudFileInfo> files;
     try {
-      files = await provider.listFiles(
-        folderId: folderId,
-        namePattern: ChangesetLogLayout.listPattern,
-      );
+      files = await provider
+          .listFiles(
+            folderId: folderId,
+            namePattern: ChangesetLogLayout.listPattern,
+          )
+          .timeout(cloudCallTimeout);
     } catch (e) {
       _log.warning('Could not list files to retire $deviceId: $e');
       return const SyncCleanupOutcome(listIncomplete: true);
@@ -192,7 +216,7 @@ class SyncDeviceFootprints {
     onProgress?.call(0, targets.length);
     for (final f in targets) {
       try {
-        await provider.deleteFile(f.id);
+        await provider.deleteFile(f.id).timeout(cloudCallTimeout);
         deleted++;
       } catch (e) {
         failed++;

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -29,6 +29,7 @@ import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 import 'package:submersion/core/services/sync/changeset_log/tombstone_horizon.dart';
 import 'package:submersion/core/services/sync/hlc.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/services/sync/sync_device_metadata.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
@@ -592,6 +593,16 @@ class SyncService {
             // same "stale restore" and wipes every peer cursor again -- a full
             // re-download of the whole fleet's data, every sync (#997).
             forceBase: staleRestoreDetected,
+            // A full base republish -- what a wiped or replaced backend forces
+            // -- can run to hundreds of megabytes. Spread it across the back
+            // fifth of the bar so the user sees it advancing, instead of
+            // reading a motionless 80% as a hang and killing the app, which
+            // restarts the whole upload from part 0 (issue #1032).
+            onBasePartUploaded: (uploaded, total) => _reportProgress(
+              SyncPhase.uploading,
+              0.8 + 0.2 * (uploaded / total),
+              'Uploading library ($uploaded of $total)',
+            ),
           );
           // A publish that did not stamp this nonce into the manifest -- a
           // noop (nothing to say) or a heartbeat (which deliberately keeps
@@ -862,9 +873,10 @@ class SyncService {
   /// user-driven [rebuildBackendFromThisDevice].
   Future<void> _reestablishEpochFromLocalLibrary(
     CloudStorageProvider provider,
-    LibraryEpochMarker marker,
-  ) async {
-    await deleteAllSyncFiles(provider);
+    LibraryEpochMarker marker, {
+    SyncCleanupProgress? onProgress,
+  }) async {
+    await deleteAllSyncFiles(provider, onProgress: onProgress);
     final db = DatabaseService.instance.database;
     await PublishStateStore(db).resetForProvider(provider.providerId);
     await PeerCursorStore(db).resetForProvider(provider.providerId);
@@ -879,7 +891,9 @@ class SyncService {
   /// grace window: THIS device's library becomes the epoch's authoritative
   /// base, and the caller's follow-up sync publishes it. Peers then adopt from
   /// us instead of the offline device.
-  Future<SyncResult> rebuildBackendFromThisDevice() async {
+  Future<SyncResult> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+  }) async {
     final provider = _cloudProvider;
     if (provider == null) {
       return const SyncResult(
@@ -895,7 +909,11 @@ class SyncService {
       );
     }
     try {
-      await _reestablishEpochFromLocalLibrary(provider, marker);
+      await _reestablishEpochFromLocalLibrary(
+        provider,
+        marker,
+        onProgress: onProgress,
+      );
       _log.info('Rebuilt backend from this device for epoch ${marker.epochId}');
       return const SyncResult(
         status: SyncResultStatus.success,
@@ -2551,85 +2569,133 @@ class SyncService {
   /// identity (Reset Sync State): once the device id changes, its old log would
   /// otherwise be merged back as a stale "peer" forever. Never throws; if the
   /// provider is offline the log lingers indefinitely as a stale peer.
-  Future<void> deleteDeviceSyncFile(String deviceId) async {
+  Future<SyncCleanupOutcome> deleteDeviceSyncFile(
+    String deviceId, {
+    SyncCleanupProgress? onProgress,
+  }) async {
     final provider = _cloudProvider;
-    if (provider == null) return;
-    try {
-      final files = await provider
-          .listFiles(namePattern: ChangesetLogLayout.prefix)
-          .timeout(const Duration(seconds: 8));
-      for (final f in files) {
-        if (ChangesetLogLayout.deviceIdOf(f.name) == deviceId) {
-          await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
-          _log.info('Retired changeset log file ${f.name}');
+    if (provider == null) return const SyncCleanupOutcome();
+    return _deleteListedFiles(
+      provider,
+      const [ChangesetLogLayout.prefix],
+      where: (f) => ChangesetLogLayout.deviceIdOf(f.name) == deviceId,
+      reason: 'retirement of $deviceId',
+      onProgress: onProgress,
+    );
+  }
+
+  /// List every file matching [patterns] (de-duplicated by id, patterns applied
+  /// in order so the caller's deletion order is predictable), then delete each
+  /// one, reporting progress against a total fixed before the first delete.
+  ///
+  /// Deliberately two-pass. Deleting as it lists would leave the UI unable to
+  /// show anything but a spinner, and a wipe of a 400-file backend runs for
+  /// minutes (issue #1032). Taking the whole listing up front costs one extra
+  /// round trip and buys a real denominator.
+  ///
+  /// Best-effort, as every caller here is: individual failures are counted into
+  /// the returned [SyncCleanupOutcome] rather than thrown, so a partial wipe
+  /// finishes what it can. Callers must not claim success without checking
+  /// [SyncCleanupOutcome.isComplete].
+  Future<SyncCleanupOutcome> _deleteListedFiles(
+    CloudStorageProvider provider,
+    List<String> patterns, {
+    required String reason,
+    bool Function(CloudFileInfo file)? where,
+    SyncCleanupProgress? onProgress,
+  }) async {
+    final byId = <String, CloudFileInfo>{};
+    var listIncomplete = false;
+    for (final pattern in patterns) {
+      try {
+        final files = await provider
+            .listFiles(namePattern: pattern)
+            .timeout(const Duration(seconds: 8));
+        for (final f in files) {
+          if (where == null || where(f)) byId[f.id] = f;
         }
+      } catch (e) {
+        // The listing we could not read may name files we will never attempt.
+        // Record that so the caller cannot report a clean sweep (issue #1032).
+        listIncomplete = true;
+        _log.warning('Could not list "$pattern" files for $reason: $e');
       }
-    } catch (e) {
-      _log.warning('Could not retire changeset log for $deviceId: $e');
     }
+
+    final targets = byId.values.toList();
+    var deleted = 0;
+    var failed = 0;
+    onProgress?.call(0, targets.length);
+    for (final f in targets) {
+      try {
+        await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
+        deleted++;
+        _log.info('Deleted sync file ${f.name} for $reason');
+      } catch (e) {
+        failed++;
+        _log.warning('Could not delete sync file ${f.name}: $e');
+      }
+      onProgress?.call(deleted + failed, targets.length);
+    }
+    return SyncCleanupOutcome(
+      deleted: deleted,
+      failed: failed,
+      listIncomplete: listIncomplete,
+    );
   }
 
   /// Best-effort deletion of EVERY sync file in the cloud folder: all peers'
   /// per-device files, our own, the legacy shared file, and conflict copies.
   /// Failures are logged and skipped -- files that survive carry a stale (or
   /// missing) epoch stamp and are inert to every current-epoch device.
-  Future<void> deleteAllSyncFiles(CloudStorageProvider provider) async {
+  Future<SyncCleanupOutcome> deleteAllSyncFiles(
+    CloudStorageProvider provider, {
+    SyncCleanupProgress? onProgress,
+  }) {
     // Wipe both the changeset logs (ssv1.*) and any legacy full-file uploads.
     // The epoch/moved markers (submersion_library_*) match neither pattern, so
     // they survive -- a peer mid-replace still learns the new epoch.
-    for (final pattern in [
-      ChangesetLogLayout.prefix,
-      CloudStorageProviderMixin.syncFileStem,
-    ]) {
-      try {
-        final files = await provider
-            .listFiles(namePattern: pattern)
-            .timeout(const Duration(seconds: 8));
-        for (final f in files) {
-          try {
-            await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
-            _log.info('Deleted sync file ${f.name} for library replace');
-          } catch (e) {
-            _log.warning('Could not delete sync file ${f.name}: $e');
-          }
-        }
-      } catch (e) {
-        _log.warning('Could not list sync files for replace wipe: $e');
-      }
-    }
+    return _deleteListedFiles(
+      provider,
+      const [ChangesetLogLayout.prefix, CloudStorageProviderMixin.syncFileStem],
+      reason: 'library replace',
+      onProgress: onProgress,
+    );
   }
 
   /// Delete EVERY sync artifact on [provider], INCLUDING the library epoch and
   /// moved markers that [deleteAllSyncFiles] intentionally preserves. A genuine
   /// fresh start (issue #509, cloud clear 3b): every device re-establishes from
   /// scratch. Best-effort; failures are logged and skipped.
-  Future<void> wipeAllSyncData(CloudStorageProvider provider) async {
-    await deleteAllSyncFiles(provider);
-    for (final pattern in [libraryEpochFileName, libraryMovedFileName]) {
-      try {
-        final markers = await provider
-            .listFiles(namePattern: pattern)
-            .timeout(const Duration(seconds: 8));
-        for (final f in markers) {
-          try {
-            await provider.deleteFile(f.id).timeout(const Duration(seconds: 8));
-            _log.info('Deleted marker ${f.name} for full sync wipe');
-          } catch (e) {
-            _log.warning('Could not delete marker ${f.name}: $e');
-          }
-        }
-      } catch (e) {
-        _log.warning('Could not list markers for full sync wipe: $e');
-      }
-    }
+  Future<SyncCleanupOutcome> wipeAllSyncData(
+    CloudStorageProvider provider, {
+    SyncCleanupProgress? onProgress,
+  }) {
+    // One pass over all four patterns rather than logs-then-markers, so the
+    // user sees a single bar with a single honest total (issue #1032). Pattern
+    // order still puts the logs first: a peer listing mid-wipe must never find
+    // orphaned logs whose epoch marker is already gone.
+    return _deleteListedFiles(
+      provider,
+      const [
+        ChangesetLogLayout.prefix,
+        CloudStorageProviderMixin.syncFileStem,
+        libraryEpochFileName,
+        libraryMovedFileName,
+      ],
+      reason: 'full sync wipe',
+      onProgress: onProgress,
+    );
   }
 
   /// Wipe all sync data on the active provider (issue #509, cloud clear 3b).
   /// No-op when no provider is configured.
-  Future<void> wipeAllSyncDataOnActiveProvider() async {
+  Future<SyncCleanupOutcome> wipeAllSyncDataOnActiveProvider({
+    SyncCleanupProgress? onProgress,
+  }) async {
     final provider = _cloudProvider;
-    if (provider == null) return;
-    await wipeAllSyncData(provider);
+    if (provider == null) return const SyncCleanupOutcome();
+    return wipeAllSyncData(provider, onProgress: onProgress);
   }
 
   /// Execute the cloud side of a Replace restore: write the new epoch marker

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -801,8 +801,18 @@ class UddfEntityImporter {
       if (name == null || name.isEmpty) continue;
 
       final uddfId = tagData['uddfId'] as String?;
-      final newId = _uuid.v4();
 
+      // Reuse the tag this diver already has by that name rather than minting
+      // a second uuid for it -- the same guard _importDiveTypes applies to
+      // colliding slugs. `tags` is uniquely indexed on (diver scope,
+      // case-folded name) since v149, so a blind mint would collide (#1032).
+      final existing = await repository.getTagByName(name, diverId: diverId);
+      if (existing != null) {
+        if (uddfId != null) idMapping[uddfId] = existing.id;
+        continue;
+      }
+
+      final newId = _uuid.v4();
       final tag = Tag(
         id: newId,
         diverId: diverId,

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -4885,8 +4885,11 @@ class DiveRepository {
     }
     // Deduplicated: `dive_tags` is uniquely indexed on (dive_id, tag_id)
     // since v149, so a repeated id in the selection would throw (#1032).
+    // Hoisted out of the loop -- the selection does not change per dive, and a
+    // bulk edit multiplies this by the number of dives (PR #1033 review).
+    final uniqueTagIds = tagIds.toSet();
     for (final diveId in diveIds) {
-      for (final tagId in tagIds.toSet()) {
+      for (final tagId in uniqueTagIds) {
         final id = _uuid.v4();
         await _db
             .into(_db.diveTags)
@@ -5343,8 +5346,11 @@ class DiveRepository {
               )..where((t) => t.diveId.isIn(diveIds))).get())
               .map((r) => '${r.diveId}|${r.tagId}')
               .toSet();
+      // Hoisted: the selection is the same for every dive, and a bulk edit
+      // multiplies this by the number of dives (PR #1033 review).
+      final uniqueTagIds = tagIds.toSet();
       for (final diveId in diveIds) {
-        for (final tagId in tagIds.toSet()) {
+        for (final tagId in uniqueTagIds) {
           if (!existing.add('$diveId|$tagId')) continue;
           final diveTagId = _uuid.v4();
           await _db

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -4883,8 +4883,10 @@ class DiveRepository {
         recordId: row.id,
       );
     }
+    // Deduplicated: `dive_tags` is uniquely indexed on (dive_id, tag_id)
+    // since v149, so a repeated id in the selection would throw (#1032).
     for (final diveId in diveIds) {
-      for (final tagId in tagIds) {
+      for (final tagId in tagIds.toSet()) {
         final id = _uuid.v4();
         await _db
             .into(_db.diveTags)
@@ -5331,12 +5333,23 @@ class DiveRepository {
 
     try {
       final now = DateTime.now().millisecondsSinceEpoch;
+      // Pairs these dives already carry. `dive_tags` is uniquely indexed on
+      // (dive_id, tag_id) since v149, and the fresh uuid per row means an
+      // upsert would never have matched the existing row anyway -- it just
+      // added a second one (#1032).
+      final existing =
+          (await (_db.select(
+                _db.diveTags,
+              )..where((t) => t.diveId.isIn(diveIds))).get())
+              .map((r) => '${r.diveId}|${r.tagId}')
+              .toSet();
       for (final diveId in diveIds) {
-        for (final tagId in tagIds) {
+        for (final tagId in tagIds.toSet()) {
+          if (!existing.add('$diveId|$tagId')) continue;
           final diveTagId = _uuid.v4();
           await _db
               .into(_db.diveTags)
-              .insertOnConflictUpdate(
+              .insert(
                 DiveTagsCompanion(
                   id: Value(diveTagId),
                   diveId: Value(diveId),

--- a/lib/features/settings/presentation/pages/sync_devices_page.dart
+++ b/lib/features/settings/presentation/pages/sync_devices_page.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
+import 'package:submersion/core/services/sync/sync_device_footprint.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_device_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
+
+/// Lists every device holding files on the sync backend, so a user can see
+/// where their cloud space went and remove the leftovers.
+///
+/// Issue #1032: a user with one syncing device found 400+ files on Dropbox and
+/// had no way to tell which belonged to what. Their only recourse was the
+/// all-or-nothing wipe, which took six minutes and broke sync. This page is the
+/// scalpel that wipe was standing in for.
+class SyncDevicesPage extends ConsumerWidget {
+  const SyncDevicesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final devices = ref.watch(syncDeviceFootprintListProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Devices on this backend'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: () => ref.invalidate(syncDeviceFootprintListProvider),
+          ),
+        ],
+      ),
+      body: devices.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _Message(
+          icon: Icons.cloud_off,
+          text: 'Could not read the backend.\n$e',
+        ),
+        data: (list) => list.isEmpty
+            ? const _Message(
+                icon: Icons.cloud_queue,
+                text: 'No sync files on this backend.',
+              )
+            : ListView.separated(
+                itemCount: list.length + 1,
+                separatorBuilder: (_, _) => const Divider(height: 1),
+                itemBuilder: (context, i) => i == 0
+                    ? _Summary(devices: list)
+                    : _DeviceTile(device: list[i - 1]),
+              ),
+      ),
+    );
+  }
+}
+
+/// Totals first: the number the user actually came here for is "how much of my
+/// cloud storage is this app using, and how much of that is dead weight".
+class _Summary extends StatelessWidget {
+  const _Summary({required this.devices});
+
+  final List<SyncDeviceFootprint> devices;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final files = devices.fold<int>(0, (a, d) => a + d.fileCount);
+    final bytes = devices.fold<int>(0, (a, d) => a + d.byteCount);
+    final removable = devices.where((d) => d.isSafeToRemove).toList();
+    final removableBytes = removable.fold<int>(0, (a, d) => a + d.byteCount);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${devices.length} device${devices.length == 1 ? '' : 's'}, '
+            '$files file${files == 1 ? '' : 's'}, ${_formatBytes(bytes)}',
+            style: theme.textTheme.titleMedium,
+          ),
+          if (removable.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              '${removable.length} left over from a replaced or retired '
+              'library, holding ${_formatBytes(removableBytes)}.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _DeviceTile extends ConsumerWidget {
+  const _DeviceTile({required this.device});
+
+  final SyncDeviceFootprint device;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final when = device.publishedAt ?? device.lastModified;
+    return ListTile(
+      isThreeLine: true,
+      leading: Icon(_icon, color: _color(theme)),
+      title: Text(
+        device.deviceName ?? 'Device ${device.shortId}',
+        style: TextStyle(
+          fontWeight: device.isSelf ? FontWeight.bold : FontWeight.normal,
+        ),
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(_stateLabel),
+          Text(
+            '${device.fileCount} file${device.fileCount == 1 ? '' : 's'}, '
+            '${_formatBytes(device.byteCount)}'
+            '${when == null ? '' : ' - ${DateFormat.yMMMd().add_jm().format(when.toLocal())}'}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+      trailing: device.isSelf
+          ? null
+          : IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Remove this device’s files',
+              onPressed: () => _confirmRemove(context, ref),
+            ),
+    );
+  }
+
+  IconData get _icon => switch (device.state) {
+    SyncDeviceFootprintState.active => Icons.devices,
+    SyncDeviceFootprintState.staleEpoch => Icons.history_toggle_off,
+    SyncDeviceFootprintState.retired => Icons.do_not_disturb_on_outlined,
+    SyncDeviceFootprintState.unreadable => Icons.help_outline,
+  };
+
+  Color? _color(ThemeData theme) => switch (device.state) {
+    SyncDeviceFootprintState.active => theme.colorScheme.primary,
+    SyncDeviceFootprintState.staleEpoch => theme.colorScheme.error,
+    _ => theme.colorScheme.onSurfaceVariant,
+  };
+
+  String get _stateLabel => switch (device.state) {
+    SyncDeviceFootprintState.active =>
+      device.isSelf ? 'This device' : 'Syncing normally',
+    SyncDeviceFootprintState.staleEpoch =>
+      'Left over from an earlier library - no device reads this',
+    SyncDeviceFootprintState.retired => 'Retired',
+    SyncDeviceFootprintState.unreadable =>
+      'No readable manifest - an unfinished upload, or encrypted',
+  };
+
+  Future<void> _confirmRemove(BuildContext context, WidgetRef ref) async {
+    final name = device.deviceName ?? 'device ${device.shortId}';
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Remove $name’s files?'),
+        content: Text(
+          device.isSafeToRemove
+              ? 'This deletes ${device.fileCount} files '
+                    '(${_formatBytes(device.byteCount)}) belonging to $name. '
+                    'They are left over from a library no device syncs from '
+                    'any more. Your dive data is not affected.'
+              : 'This deletes ${device.fileCount} files '
+                    '(${_formatBytes(device.byteCount)}) belonging to $name.\n\n'
+                    'That device is still part of this sync. If it comes back '
+                    'online it will rebuild from the backend rather than '
+                    'resurrect old data, but any changes it has not yet '
+                    'published will be lost. Your dive data on THIS device is '
+                    'not affected.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: device.isSafeToRemove
+                ? null
+                : FilledButton.styleFrom(
+                    backgroundColor: Theme.of(context).colorScheme.error,
+                  ),
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !context.mounted) return;
+
+    final outcome = await runWithSyncMaintenanceProgress(
+      context: context,
+      title: 'Removing $name’s files',
+      task: (report) => retireSyncPeer(
+        ref,
+        device.deviceId,
+        onProgress: cleanupPhase(report, 'Deleting'),
+      ),
+    );
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(_removalMessage(outcome))));
+  }
+
+  static String _removalMessage(SyncCleanupOutcome? outcome) {
+    if (outcome == null) return 'No cloud backend is configured';
+    if (outcome.isComplete) {
+      return 'Removed ${outcome.deleted} '
+          'file${outcome.deleted == 1 ? '' : 's'}';
+    }
+    if (outcome.deleted == 0 && outcome.listIncomplete) {
+      // retirePeer refuses to delete without a durable fence marker, so this
+      // is the "could not reach the backend" case, not a partial deletion.
+      return 'Could not reach the backend. Nothing was removed.';
+    }
+    return 'Removed ${outcome.deleted} files, but ${outcome.failed} could not '
+        'be deleted. Try again while online.';
+  }
+}
+
+class _Message extends StatelessWidget {
+  const _Message({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Sizes are a floor: providers that report no size for a file count zero.
+String _formatBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  var value = bytes / 1024;
+  var unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return '${value.toStringAsFixed(value >= 10 ? 0 : 1)} ${units[unit]}';
+}

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_settings_section.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -148,8 +150,21 @@ class TroubleshootSyncPage extends ConsumerWidget {
         ],
       ),
     );
-    if (ok != true) return;
-    await ref.read(syncStateProvider.notifier).rebuildBackendFromThisDevice();
+    if (ok != true || !context.mounted) return;
+    await runWithSyncMaintenanceProgress(
+      context: context,
+      title: 'Rebuilding backend',
+      task: (report) => ref
+          .read(syncStateProvider.notifier)
+          .rebuildBackendFromThisDevice(
+            onProgress: cleanupPhase(report, 'Clearing old files'),
+            // The republish that follows the clear-out uploads the whole
+            // library. It has no file count of its own here, so flip the bar
+            // to indeterminate rather than leave it parked at 100% looking
+            // finished while minutes of upload remain (issue #1032).
+            onPublishStarted: () => report(0, 0, 'Publishing library'),
+          ),
+    );
     if (!context.mounted) return;
     // The rebuild can fail (e.g. no epoch marker to rebuild from), in which case
     // the notifier surfaces SyncStatus.error -- reflect that instead of always
@@ -191,13 +206,39 @@ class TroubleshootSyncPage extends ConsumerWidget {
         ],
       ),
     );
-    if (ok != true) return;
-    await ref.read(syncStateProvider.notifier).removeThisDeviceCloudFiles();
+    if (ok != true || !context.mounted) return;
+    final outcome = await runWithSyncMaintenanceProgress(
+      context: context,
+      title: 'Removing this device’s cloud files',
+      task: (report) => ref
+          .read(syncStateProvider.notifier)
+          .removeThisDeviceCloudFiles(
+            onProgress: cleanupPhase(report, 'Deleting'),
+          ),
+    );
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Removed this device’s cloud files')),
+        SnackBar(content: Text(_cleanupMessage(outcome, 'Removed'))),
       );
     }
+  }
+
+  /// Report what the cleanup actually achieved.
+  ///
+  /// These operations are best-effort: an offline provider or a timed-out
+  /// listing leaves files behind. Claiming success regardless is what sent the
+  /// reporter of issue #1032 away believing a wipe had completed when it had
+  /// not, leaving the backend in a state no later sync could explain.
+  static String _cleanupMessage(SyncCleanupOutcome outcome, String verb) {
+    if (outcome.isComplete) {
+      return '$verb ${outcome.deleted} file${outcome.deleted == 1 ? '' : 's'}';
+    }
+    final trouble = <String>[
+      if (outcome.failed > 0) '${outcome.failed} could not be deleted',
+      if (outcome.listIncomplete) 'some files could not be listed',
+    ].join('; ');
+    return '$verb ${outcome.deleted} file${outcome.deleted == 1 ? '' : 's'}, '
+        'but $trouble. Try again while online.';
   }
 
   /// Destructive full-backend wipe: guarded by typing the word WIPE so it
@@ -209,12 +250,18 @@ class TroubleshootSyncPage extends ConsumerWidget {
       context: context,
       builder: (context) => const _WipeConfirmDialog(),
     );
-    if (ok != true) return;
-    await ref.read(syncStateProvider.notifier).wipeAllCloudSyncData();
+    if (ok != true || !context.mounted) return;
+    final outcome = await runWithSyncMaintenanceProgress(
+      context: context,
+      title: 'Wiping sync data',
+      task: (report) => ref
+          .read(syncStateProvider.notifier)
+          .wipeAllCloudSyncData(onProgress: cleanupPhase(report, 'Deleting')),
+    );
     if (context.mounted) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('Wiped all sync data')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_cleanupMessage(outcome, 'Wiped'))),
+      );
     }
   }
 }

--- a/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
+++ b/lib/features/settings/presentation/pages/troubleshoot_sync_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
+import 'package:submersion/features/settings/presentation/pages/sync_devices_page.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_settings_section.dart';
@@ -41,6 +42,20 @@ class TroubleshootSyncPage extends ConsumerWidget {
             onTap: () => _confirmRebuild(context, ref),
           ),
           const Divider(),
+          ListTile(
+            leading: const Icon(Icons.devices_other),
+            title: const Text('Devices on this backend'),
+            subtitle: const Text(
+              'See every device holding files here, how much space each uses, '
+              'and remove leftovers from libraries no device syncs from any '
+              'more. Your dive data is not affected.',
+            ),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (context) => const SyncDevicesPage(),
+              ),
+            ),
+          ),
           ListTile(
             leading: const Icon(Icons.cleaning_services_outlined),
             title: const Text('Remove this device’s cloud files'),

--- a/lib/features/settings/presentation/providers/sync_device_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_device_providers.dart
@@ -14,6 +14,14 @@ final syncDeviceFootprintsProvider = Provider<SyncDeviceFootprints>(
 /// A network read, so it is a FutureProvider the page can refresh explicitly
 /// rather than anything the app polls -- a user opens this once to work out
 /// where their cloud space went (issue #1032), not continuously.
+// no-tick: what this reads lives in the CLOUD, not in any local table, so no
+// database tick can tell it anything. The repository call it makes is
+// getDeviceId -- this install's own sync identity, which changes only through
+// Repair Sync, and only while this autoDispose provider has no listeners
+// because that action lives on the page you must leave here to reach. The
+// listing itself goes stale the moment another device publishes, which no
+// local tick can observe either; the page carries an explicit Refresh for
+// exactly that reason, and every mutation here invalidates this provider.
 final syncDeviceFootprintListProvider =
     FutureProvider.autoDispose<List<SyncDeviceFootprint>>((ref) async {
       final provider = ref.watch(cloudStorageProviderProvider);

--- a/lib/features/settings/presentation/providers/sync_device_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_device_providers.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
+import 'package:submersion/core/services/sync/sync_device_footprint.dart';
+import 'package:submersion/core/services/sync/sync_device_footprints.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+final syncDeviceFootprintsProvider = Provider<SyncDeviceFootprints>(
+  (ref) => SyncDeviceFootprints(),
+);
+
+/// Every device's footprint on the active backend.
+///
+/// A network read, so it is a FutureProvider the page can refresh explicitly
+/// rather than anything the app polls -- a user opens this once to work out
+/// where their cloud space went (issue #1032), not continuously.
+final syncDeviceFootprintListProvider =
+    FutureProvider.autoDispose<List<SyncDeviceFootprint>>((ref) async {
+      final provider = ref.watch(cloudStorageProviderProvider);
+      // Null in custom-folder mode and when no backend is chosen. An empty list
+      // reads correctly in the UI as "nothing to show".
+      if (provider == null) return const [];
+      final repo = ref.watch(syncRepositoryProvider);
+      return ref
+          .watch(syncDeviceFootprintsProvider)
+          .list(
+            provider: provider,
+            selfDeviceId: await repo.getDeviceId(),
+            currentEpochId: await repo.getLastAcceptedEpochId(),
+          );
+    });
+
+/// Retire one peer and delete its files, then refresh the listing.
+///
+/// Returns a null outcome when no backend is configured, which the caller
+/// reports rather than treating as success.
+Future<SyncCleanupOutcome?> retireSyncPeer(
+  WidgetRef ref,
+  String deviceId, {
+  SyncCleanupProgress? onProgress,
+}) async {
+  final provider = ref.read(cloudStorageProviderProvider);
+  if (provider == null) return null;
+  final repo = ref.read(syncRepositoryProvider);
+  final outcome = await ref
+      .read(syncDeviceFootprintsProvider)
+      .retirePeer(
+        provider: provider,
+        deviceId: deviceId,
+        selfDeviceId: await repo.getDeviceId(),
+        onProgress: onProgress,
+      );
+  ref.invalidate(syncDeviceFootprintListProvider);
+  return outcome;
+}

--- a/lib/features/settings/presentation/providers/sync_providers.dart
+++ b/lib/features/settings/presentation/providers/sync_providers.dart
@@ -44,6 +44,7 @@ import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
 import 'package:submersion/core/services/sync/sync_preferences.dart';
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
@@ -1448,25 +1449,45 @@ class SyncNotifier extends StateNotifier<SyncState> {
   /// Remove THIS device's sync files from the active backend (issue #509,
   /// cloud clear 3a). Safe: other devices keep syncing; frees this device's
   /// changeset log, base parts, and manifest.
-  Future<void> removeThisDeviceCloudFiles() async {
+  Future<SyncCleanupOutcome> removeThisDeviceCloudFiles({
+    SyncCleanupProgress? onProgress,
+  }) async {
     final deviceId = await _syncRepository.getDeviceId();
-    await _syncService.deleteDeviceSyncFile(deviceId);
+    final outcome = await _syncService.deleteDeviceSyncFile(
+      deviceId,
+      onProgress: onProgress,
+    );
     await refreshState();
+    return outcome;
   }
 
   /// Wipe ALL sync data on the active backend, including the epoch/moved
   /// markers (issue #509, cloud clear 3b). Every device re-establishes from
   /// scratch. Dive data is untouched.
-  Future<void> wipeAllCloudSyncData() async {
-    await _syncService.wipeAllSyncDataOnActiveProvider();
+  Future<SyncCleanupOutcome> wipeAllCloudSyncData({
+    SyncCleanupProgress? onProgress,
+  }) async {
+    final outcome = await _syncService.wipeAllSyncDataOnActiveProvider(
+      onProgress: onProgress,
+    );
     await refreshState();
+    return outcome;
   }
 
   /// Escape a stuck library replacement whose uploader went offline (issue
   /// #509): rebuild this backend from THIS device's library, then publish it so
   /// peers adopt from us. Un-pauses the awaiting-adoption state.
-  Future<void> rebuildBackendFromThisDevice() async {
-    final result = await _syncService.rebuildBackendFromThisDevice();
+  Future<void> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+
+    /// Fires once the clear-out is done and the (much longer) full-library
+    /// republish begins, so a caller showing progress can retitle rather than
+    /// leave a completed file count on screen for minutes (issue #1032).
+    void Function()? onPublishStarted,
+  }) async {
+    final result = await _syncService.rebuildBackendFromThisDevice(
+      onProgress: onProgress,
+    );
     if (result.status != SyncResultStatus.success) {
       // Keep the error visible: refreshState (which recomputes status from the
       // repository) must NOT run here, or it would clear the reason.
@@ -1480,6 +1501,7 @@ class SyncNotifier extends StateNotifier<SyncState> {
       message: null,
     );
     await _ref.read(libraryEpochStoreProvider).clearPendingReplace();
+    onPublishStarted?.call();
     await performSync(); // publish our library as the epoch's base
     await refreshState();
   }

--- a/lib/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart
+++ b/lib/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart
@@ -118,7 +118,16 @@ class SyncMaintenanceProgressDialog extends StatelessWidget {
 }
 
 /// Runs [task] behind a [SyncMaintenanceProgressDialog], feeding it the task's
-/// own progress, and returns the task's result once the dialog has closed.
+/// own progress, and returns the task's result once the dialog has been
+/// dismissed.
+///
+/// "Dismissed", precisely: the pop has been issued and the route's future has
+/// resolved. That is NOT the same as fully animated out -- a dialog route
+/// completes at pop time, not at the end of its exit transition -- so a caller
+/// showing a snackbar immediately may briefly overlap the closing dialog. The
+/// earlier wording here claimed the stronger guarantee, which was untrue
+/// (PR #1033 review); awaiting the route is the strongest ordering this can
+/// actually offer without polling the transition.
 ///
 /// The dialog is popped in a `finally`, so a throwing task cannot strand the
 /// user behind an undismissable barrier -- the exception then surfaces to the
@@ -149,5 +158,10 @@ Future<T> runWithSyncMaintenanceProgress<T>({
     );
   } finally {
     if (navigator.canPop()) navigator.pop();
+    // Await the ROUTE, not just the pop. Returning the moment the task
+    // finished let callers show their result snackbar while the dialog was
+    // still animating out, and made the "returns once the dialog has closed"
+    // contract above untrue (PR #1033 review).
+    await dialog;
   }
 }

--- a/lib/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart
+++ b/lib/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
+
+/// One progress reading: [done] of [total] units, under an optional [phase]
+/// label. A [total] of 0 means the phase has no countable units and the bar
+/// should run indeterminate.
+typedef SyncMaintenanceTick = ({int done, int total, String? phase});
+
+/// How a task reports progress to [runWithSyncMaintenanceProgress].
+typedef SyncMaintenanceReporter =
+    void Function(int done, int total, [String? phase]);
+
+/// Adapts a [SyncMaintenanceReporter] to the plain [SyncCleanupProgress] the
+/// cloud cleanup APIs take, tagging every tick with [phase].
+SyncCleanupProgress cleanupPhase(
+  SyncMaintenanceReporter report,
+  String phase,
+) =>
+    (done, total) => report(done, total, phase);
+
+/// Blocking progress dialog for the long-running Troubleshoot Sync actions.
+///
+/// Wiping a backend with hundreds of files, or republishing a whole library
+/// after one, runs for minutes. Those actions used to `await` in silence behind
+/// a live page, so the user saw nothing happening, assumed the app had hung,
+/// and killed it -- which interrupted the wipe and left the backend half
+/// cleared (issue #1032). This dialog does three things that prevent that:
+/// reports real counts, refuses to be dismissed, and says out loud that the app
+/// must stay open.
+///
+/// Modelled on [ImportProgressDialog], which solves the same problem for
+/// UDDF/CSV import.
+class SyncMaintenanceProgressDialog extends StatelessWidget {
+  const SyncMaintenanceProgressDialog({
+    super.key,
+    required this.title,
+    required this.progress,
+  });
+
+  final String title;
+
+  /// Null until the first tick -- the listing that fixes the denominator is
+  /// itself a network round trip, so the bar starts indeterminate.
+  final ValueListenable<SyncMaintenanceTick?> progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // canPop: false blocks the Android back button and any predictive-back
+    // gesture for as long as the work runs. It cannot stop a force-quit -- no
+    // app can -- so the "keep the app open" line below carries the rest.
+    return PopScope(
+      canPop: false,
+      child: ValueListenableBuilder<SyncMaintenanceTick?>(
+        valueListenable: progress,
+        builder: (context, value, _) {
+          // total == 0 means "working, but with nothing to count" (a phase that
+          // is one long operation rather than N files) -> indeterminate bar.
+          final fraction = (value == null || value.total == 0)
+              ? null
+              : value.done / value.total;
+          final label = value == null
+              ? 'Preparing...'
+              : value.total == 0
+              ? (value.phase ?? 'Working...')
+              : [
+                  if (value.phase != null) value.phase!,
+                  '${value.done} of ${value.total} files',
+                ].join(' - ');
+          return Semantics(
+            liveRegion: true,
+            label: '$title, $label',
+            child: AlertDialog(
+              title: Text(title),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: LinearProgressIndicator(
+                      value: fraction,
+                      minHeight: 8,
+                      backgroundColor: colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Keep the app open until this finishes. Closing it now '
+                    'leaves the backend partly cleared, and the next sync has '
+                    'to start over.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Runs [task] behind a [SyncMaintenanceProgressDialog], feeding it the task's
+/// own progress, and returns the task's result once the dialog has closed.
+///
+/// The dialog is popped in a `finally`, so a throwing task cannot strand the
+/// user behind an undismissable barrier -- the exception then surfaces to the
+/// caller, which is what makes honest failure reporting possible.
+Future<T> runWithSyncMaintenanceProgress<T>({
+  required BuildContext context,
+  required String title,
+  required Future<T> Function(SyncMaintenanceReporter report) task,
+}) async {
+  final progress = ValueNotifier<SyncMaintenanceTick?>(null);
+  final navigator = Navigator.of(context, rootNavigator: true);
+  final dialog = showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    useRootNavigator: true,
+    builder: (_) =>
+        SyncMaintenanceProgressDialog(title: title, progress: progress),
+  );
+  // Dispose only once the route is fully gone. The dialog keeps rebuilding
+  // through its exit animation, so disposing right after pop() throws "used
+  // after being disposed" -- the same trap _WipeConfirmDialog documents for its
+  // text controller.
+  unawaited(dialog.whenComplete(progress.dispose));
+  try {
+    return await task(
+      (done, total, [phase]) =>
+          progress.value = (done: done, total: total, phase: phase),
+    );
+  } finally {
+    if (navigator.canPop()) navigator.pop();
+  }
+}

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -431,30 +431,30 @@ class TagRepository {
   /// one dive ended up showing the same import tag several times (#1032).
   Future<void> addTagToDive(String diveId, String tagId) async {
     try {
-      final already =
-          await (_db.select(_db.diveTags)
-                ..where((t) => t.diveId.equals(diveId) & t.tagId.equals(tagId))
-                ..limit(1))
-              .get();
-      if (already.isNotEmpty) {
-        _log.info('Dive $diveId already carries tag $tagId');
-        return;
-      }
-
       _log.info('Adding tag $tagId to dive: $diveId');
       final now = DateTime.now().millisecondsSinceEpoch;
       final id = _uuid.v4();
 
-      await _db
+      // One statement rather than read-then-insert. A separate existence check
+      // is both an extra round trip and still racy: two callers can each see
+      // "missing" and the loser then throws on idx_dive_tags_dive_tag_unique.
+      // Letting the database decide makes the duplicate a true no-op, and a
+      // null return says the pair was already there (PR #1033 review).
+      final inserted = await _db
           .into(_db.diveTags)
-          .insert(
+          .insertReturningOrNull(
             DiveTagsCompanion(
               id: Value(id),
               diveId: Value(diveId),
               tagId: Value(tagId),
               createdAt: Value(now),
             ),
+            onConflict: DoNothing<$DiveTagsTable, DiveTag>(target: const []),
           );
+      if (inserted == null) {
+        _log.info('Dive $diveId already carries tag $tagId');
+        return;
+      }
 
       await _syncRepository.markRecordPending(
         entityType: 'diveTags',

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -138,9 +138,15 @@ class TagRepository {
       final id = tag.id.isEmpty ? _uuid.v4() : tag.id;
       final now = DateTime.now().millisecondsSinceEpoch;
 
-      await _db
+      // Conflict-aware rather than a bare insert. The incumbent check above is
+      // an `await`, so two callers can both pass it and the loser would then
+      // throw on idx_tags_diver_name_unique -- failing an operation whose whole
+      // contract is "a tag with this name now exists" (PR #1033 review). A null
+      // return means someone won the race; fall back to reading their row,
+      // which is the same answer the incumbent check would have given.
+      final created = await _db
           .into(_db.tags)
-          .insert(
+          .insertReturningOrNull(
             TagsCompanion(
               id: Value(id),
               diverId: Value(tag.diverId),
@@ -149,7 +155,17 @@ class TagRepository {
               createdAt: Value(now),
               updatedAt: Value(now),
             ),
+            onConflict: DoNothing<$TagsTable, Tag>(target: const []),
           );
+      if (created == null) {
+        final winner = await _tagOccupying(name, tag.diverId);
+        _log.info('Tag "$name" was created concurrently as ${winner?.id}');
+        if (winner != null) return winner;
+        // Vanishingly unlikely: the conflicting row was deleted between the
+        // insert and this read. Surfacing it beats returning a tag id that
+        // does not exist.
+        throw StateError('Tag "$name" conflicted but could not be read back');
+      }
 
       await _syncRepository.markRecordPending(
         entityType: 'tags',

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -58,6 +58,12 @@ class TagRepository {
   }
 
   /// Get a tag by name (case-insensitive)
+  ///
+  /// Deliberately takes the lowest id rather than asserting a single match:
+  /// an unscoped lookup legitimately spans two divers who both use "Wreck",
+  /// and `getSingleOrNull()` threw "too many elements" there -- which is what
+  /// the import wizard reported as "tagging failed" (#1032). Ordering by id
+  /// makes the winner the same row the uniqueness collapse keeps.
   Future<domain.Tag?> getTagByName(String name, {String? diverId}) async {
     try {
       final query = _db.select(_db.tags)
@@ -66,6 +72,9 @@ class TagRepository {
       if (diverId != null) {
         query.where((t) => t.diverId.equals(diverId));
       }
+      query
+        ..orderBy([(t) => OrderingTerm.asc(t.id)])
+        ..limit(1);
 
       final row = await query.getSingleOrNull();
       return row != null ? _mapRowToTag(row) : null;
@@ -79,9 +88,44 @@ class TagRepository {
     }
   }
 
-  /// Create a new tag
+  /// The tag occupying [name]'s uniqueness slot in [diverId]'s scope, if any.
+  ///
+  /// Mirrors `idx_tags_diver_name_unique` exactly -- (COALESCE(diver_id, ''),
+  /// lower(name)) -- so a caller that checks here can never be surprised by
+  /// the index. A NULL `diverId` is the shared "unassigned" scope, not a scope
+  /// of its own per row.
+  Future<domain.Tag?> _tagOccupying(String name, String? diverId) async {
+    final rows =
+        await (_db.select(_db.tags)
+              ..where(
+                (t) =>
+                    t.name.lower().equals(name.trim().toLowerCase()) &
+                    coalesce([
+                      t.diverId,
+                      const Constant(''),
+                    ]).equals(diverId ?? ''),
+              )
+              ..orderBy([(t) => OrderingTerm.asc(t.id)])
+              ..limit(1))
+            .get();
+    return rows.isEmpty ? null : _mapRowToTag(rows.first);
+  }
+
+  /// Create a new tag, or return the one already holding the name.
+  ///
+  /// `tags` is uniquely indexed on (diver scope, case-folded name) since v149,
+  /// so inserting a second row for a name the scope already has would throw.
+  /// Returning the incumbent keeps every caller's contract ("a tag with this
+  /// name now exists and here it is") while never creating the duplicate that
+  /// made a dive show one tag twice (#1032).
   Future<domain.Tag> createTag(domain.Tag tag) async {
     try {
+      final incumbent = await _tagOccupying(tag.name, tag.diverId);
+      if (incumbent != null) {
+        _log.info('Tag "${tag.name}" already exists as ${incumbent.id}');
+        return incumbent;
+      }
+
       _log.info('Creating tag: ${tag.name}');
       final id = tag.id.isEmpty ? _uuid.v4() : tag.id;
       final now = DateTime.now().millisecondsSinceEpoch;
@@ -149,9 +193,29 @@ class TagRepository {
     }
   }
 
-  /// Update an existing tag
+  /// Update an existing tag.
+  ///
+  /// Renaming onto a name the scope already uses folds the two tags together
+  /// rather than throwing on `idx_tags_diver_name_unique`: the user asked for
+  /// one tag by that name, and every dive on either side keeps it. This is the
+  /// same outcome the tag merge sheet produces, so it reuses [mergeTags].
   Future<void> updateTag(domain.Tag tag) async {
     try {
+      final incumbent = await _tagOccupying(tag.name, tag.diverId);
+      if (incumbent != null && incumbent.id != tag.id) {
+        _log.info(
+          'Renaming ${tag.id} onto "${tag.name}" merges into '
+          '${incumbent.id}',
+        );
+        await mergeTags(
+          sourceTagIds: [tag.id],
+          survivingTagId: incumbent.id,
+          name: tag.name,
+          colorHex: tag.colorHex,
+        );
+        return;
+      }
+
       _log.info('Updating tag: ${tag.id}');
       final now = DateTime.now().millisecondsSinceEpoch;
 
@@ -200,10 +264,12 @@ class TagRepository {
   /// Get tags for a specific dive
   Future<List<domain.Tag>> getTagsForDive(String diveId) async {
     try {
+      // DISTINCT so a legacy database that has not yet been through the v149
+      // collapse still renders each tag once (#1032).
       final result = await _db
           .customSelect(
             '''
-        SELECT t.* FROM tags t
+        SELECT DISTINCT t.* FROM tags t
         INNER JOIN dive_tags dt ON t.id = dt.tag_id
         WHERE dt.dive_id = ?
         ORDER BY t.name
@@ -247,7 +313,7 @@ class TagRepository {
       final placeholders = diveIds.map((_) => '?').join(',');
       final result = await _db.customSelect(
         '''
-        SELECT dt.dive_id, t.* FROM tags t
+        SELECT DISTINCT dt.dive_id, t.* FROM tags t
         INNER JOIN dive_tags dt ON t.id = dt.tag_id
         WHERE dt.dive_id IN ($placeholders)
         ORDER BY t.name
@@ -302,9 +368,13 @@ class TagRepository {
         );
       }
 
-      // Insert new tags
+      // Insert new tags. Deduplicated by id: `dive_tags` is uniquely indexed
+      // on (dive_id, tag_id) since v149, so the same tag listed twice would
+      // throw rather than quietly double up.
       final now = DateTime.now().millisecondsSinceEpoch;
+      final seen = <String>{};
       for (final tag in tags) {
+        if (!seen.add(tag.id)) continue;
         final id = _uuid.v4();
         await _db
             .into(_db.diveTags)
@@ -344,9 +414,23 @@ class TagRepository {
     }
   }
 
-  /// Add a tag to a dive
+  /// Add a tag to a dive.
+  ///
+  /// A no-op when the dive already carries the tag. Re-running an import used
+  /// to blind-insert a second junction row under a fresh uuid, which is how
+  /// one dive ended up showing the same import tag several times (#1032).
   Future<void> addTagToDive(String diveId, String tagId) async {
     try {
+      final already =
+          await (_db.select(_db.diveTags)
+                ..where((t) => t.diveId.equals(diveId) & t.tagId.equals(tagId))
+                ..limit(1))
+              .get();
+      if (already.isNotEmpty) {
+        _log.info('Dive $diveId already carries tag $tagId');
+        return;
+      }
+
       _log.info('Adding tag $tagId to dive: $diveId');
       final now = DateTime.now().millisecondsSinceEpoch;
       final id = _uuid.v4();

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -57,7 +57,11 @@ class TagRepository {
     }
   }
 
-  /// Get a tag by name (case-insensitive)
+  /// Get a tag by name (case-insensitive, whitespace-insensitive)
+  ///
+  /// Normalizes both sides exactly as `idx_tags_diver_name_unique` does
+  /// (`lower(trim(name))`), so a lookup can never miss a row the index
+  /// considers the same tag.
   ///
   /// Deliberately takes the lowest id rather than asserting a single match:
   /// an unscoped lookup legitimately spans two divers who both use "Wreck",
@@ -67,7 +71,7 @@ class TagRepository {
   Future<domain.Tag?> getTagByName(String name, {String? diverId}) async {
     try {
       final query = _db.select(_db.tags)
-        ..where((t) => t.name.lower().equals(name.toLowerCase()));
+        ..where((t) => t.name.trim().lower().equals(name.trim().toLowerCase()));
 
       if (diverId != null) {
         query.where((t) => t.diverId.equals(diverId));
@@ -91,7 +95,7 @@ class TagRepository {
   /// The tag occupying [name]'s uniqueness slot in [diverId]'s scope, if any.
   ///
   /// Mirrors `idx_tags_diver_name_unique` exactly -- (COALESCE(diver_id, ''),
-  /// lower(name)) -- so a caller that checks here can never be surprised by
+  /// lower(trim(name))) -- so a caller that checks here can never be surprised by
   /// the index. A NULL `diverId` is the shared "unassigned" scope, not a scope
   /// of its own per row.
   Future<domain.Tag?> _tagOccupying(String name, String? diverId) async {
@@ -99,7 +103,7 @@ class TagRepository {
         await (_db.select(_db.tags)
               ..where(
                 (t) =>
-                    t.name.lower().equals(name.trim().toLowerCase()) &
+                    t.name.trim().lower().equals(name.trim().toLowerCase()) &
                     coalesce([
                       t.diverId,
                       const Constant(''),
@@ -126,7 +130,11 @@ class TagRepository {
         return incumbent;
       }
 
-      _log.info('Creating tag: ${tag.name}');
+      // Store the SAME normalization the index and every lookup key on.
+      // Persisting the raw value while matching on a trimmed one is what let
+      // " Wreck" and "Wreck" coexist as two rows (PR #1033 review).
+      final name = tag.name.trim();
+      _log.info('Creating tag: $name');
       final id = tag.id.isEmpty ? _uuid.v4() : tag.id;
       final now = DateTime.now().millisecondsSinceEpoch;
 
@@ -136,7 +144,7 @@ class TagRepository {
             TagsCompanion(
               id: Value(id),
               diverId: Value(tag.diverId),
-              name: Value(tag.name),
+              name: Value(name),
               color: Value(tag.colorHex),
               createdAt: Value(now),
               updatedAt: Value(now),
@@ -151,7 +159,7 @@ class TagRepository {
       SyncEventBus.notifyLocalChange();
 
       _log.info('Created tag with id: $id');
-      return tag.copyWith(id: id);
+      return tag.copyWith(id: id, name: name);
     } catch (e, stackTrace) {
       _log.error('Failed to create tag', error: e, stackTrace: stackTrace);
       rethrow;
@@ -201,16 +209,18 @@ class TagRepository {
   /// same outcome the tag merge sheet produces, so it reuses [mergeTags].
   Future<void> updateTag(domain.Tag tag) async {
     try {
-      final incumbent = await _tagOccupying(tag.name, tag.diverId);
+      // Normalized before both the uniqueness check and the write, so a rename
+      // cannot store a spelling the index would key differently.
+      final name = tag.name.trim();
+      final incumbent = await _tagOccupying(name, tag.diverId);
       if (incumbent != null && incumbent.id != tag.id) {
         _log.info(
-          'Renaming ${tag.id} onto "${tag.name}" merges into '
-          '${incumbent.id}',
+          'Renaming ${tag.id} onto "$name" merges into ${incumbent.id}',
         );
         await mergeTags(
           sourceTagIds: [tag.id],
           survivingTagId: incumbent.id,
-          name: tag.name,
+          name: name,
           colorHex: tag.colorHex,
         );
         return;
@@ -221,7 +231,7 @@ class TagRepository {
 
       await (_db.update(_db.tags)..where((t) => t.id.equals(tag.id))).write(
         TagsCompanion(
-          name: Value(tag.name),
+          name: Value(name),
           color: Value(tag.colorHex),
           updatedAt: Value(now),
         ),

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/app.dart';
 import 'package:submersion/core/router/app_router.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -78,13 +79,20 @@ class _DrivableSyncNotifier extends StateNotifier<SyncState>
   Future<void> repairSync() async {}
 
   @override
-  Future<void> removeThisDeviceCloudFiles() async {}
+  Future<SyncCleanupOutcome> removeThisDeviceCloudFiles({
+    SyncCleanupProgress? onProgress,
+  }) async => const SyncCleanupOutcome();
 
   @override
-  Future<void> wipeAllCloudSyncData() async {}
+  Future<SyncCleanupOutcome> wipeAllCloudSyncData({
+    SyncCleanupProgress? onProgress,
+  }) async => const SyncCleanupOutcome();
 
   @override
-  Future<void> rebuildBackendFromThisDevice() async {}
+  Future<void> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+    void Function()? onPublishStarted,
+  }) async {}
 
   @override
   Future<void> signOut() async {}

--- a/test/core/database/migration_v149_tag_uniqueness_test.dart
+++ b/test/core/database/migration_v149_tag_uniqueness_test.dart
@@ -126,6 +126,39 @@ void main() {
     expect(await diveTagPairs(db), ['dive-1|tag-a']);
   });
 
+  test('collapse ignores surrounding whitespace', () async {
+    // Legacy rows can carry padding: writers matched on a trimmed name but
+    // stored the raw one, so " Wreck" and "Wreck" were two rows every lookup
+    // treated as one (PR #1033 review).
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', ' Wreck ', diverId: 'd1');
+        insertTag(rawDb, 'tag-b', 'wreck', diverId: 'd1');
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-b');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+    expect(await diveTagPairs(db), ['dive-1|tag-a']);
+  });
+
+  test('the surviving name is stored trimmed', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', '  Wreck  ', diverId: 'd1');
+      }),
+    );
+    addTearDown(db.close);
+
+    final rows = await db.customSelect('SELECT name FROM tags').get();
+    expect(
+      rows.single.read<String>('name'),
+      'Wreck',
+      reason: 'what is stored must match what every lookup compares against',
+    );
+  });
+
   test('NULL diver_id is one scope, not one scope per row', () async {
     // A plain UNIQUE(diver_id, name) index would leave these two alone --
     // SQLite treats NULLs as distinct inside a unique index -- so the
@@ -200,6 +233,35 @@ void main() {
     addTearDown(db.close);
 
     expect(await diveTagPairs(db), ['dive-1|tag-missing']);
+  });
+
+  test('rebuilds an index left over from an earlier keying', () async {
+    // CREATE UNIQUE INDEX IF NOT EXISTS is a no-op against an index of the
+    // same NAME whatever its definition, so a database that ran a pre-release
+    // build of v149 would silently keep the older keying forever.
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        rawDb.execute(
+          'CREATE UNIQUE INDEX idx_tags_diver_name_unique '
+          "ON tags(COALESCE(diver_id, ''), lower(name))",
+        );
+        insertTag(rawDb, 'tag-a', ' Wreck ', diverId: 'd1');
+        insertTag(rawDb, 'tag-b', 'wreck', diverId: 'd1');
+      }),
+    );
+    addTearDown(db.close);
+
+    final sql = await db
+        .customSelect(
+          "SELECT sql FROM sqlite_master WHERE name = 'idx_tags_diver_name_unique'",
+        )
+        .getSingle();
+    expect(sql.read<String>('sql'), contains('trim'));
+    expect(
+      await tagIds(db),
+      ['tag-a'],
+      reason: 'the rows the old index allowed must still be collapsed',
+    );
   });
 
   test('is idempotent when the database is already clean', () async {

--- a/test/core/database/migration_v149_tag_uniqueness_test.dart
+++ b/test/core/database/migration_v149_tag_uniqueness_test.dart
@@ -1,0 +1,217 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// v149 (duplicate tags, issue #1032): collapses `tags` rows that share a
+/// (diver scope, case-folded name), repoints `dive_tags` at the survivor,
+/// collapses duplicate (dive_id, tag_id) junction rows, and only then creates
+/// the two unique indexes that stop both producers coming back.
+///
+/// The ordering is the point: creating a unique index while ties still exist
+/// aborts the whole migration and leaves the database unopenable (the v148
+/// lesson). Every case below therefore asserts the surviving rows AND that the
+/// database opened at all.
+void main() {
+  // Stamped at 148 so ONLY the v149 step runs, isolating what is asserted.
+  NativeDatabase setupDb(void Function(dynamic rawDb) seed) {
+    return NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 148');
+        rawDb.execute('''
+          CREATE TABLE tags (
+            id TEXT NOT NULL PRIMARY KEY,
+            diver_id TEXT,
+            name TEXT NOT NULL,
+            color TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            hlc TEXT
+          )
+        ''');
+        rawDb.execute('''
+          CREATE TABLE dive_tags (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            tag_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+        seed(rawDb);
+      },
+    );
+  }
+
+  void insertTag(
+    dynamic rawDb,
+    String id,
+    String name, {
+    String? diverId,
+    int createdAt = 1000,
+  }) {
+    rawDb.execute(
+      'INSERT INTO tags (id, diver_id, name, created_at, updated_at) '
+      'VALUES (?, ?, ?, ?, ?)',
+      [id, diverId, name, createdAt, createdAt],
+    );
+  }
+
+  void insertDiveTag(dynamic rawDb, String id, String diveId, String tagId) {
+    rawDb.execute(
+      'INSERT INTO dive_tags (id, dive_id, tag_id, created_at) '
+      'VALUES (?, ?, ?, ?)',
+      [id, diveId, tagId, 1000],
+    );
+  }
+
+  Future<Set<String>> indexNames(AppDatabase db) async {
+    final rows = await db
+        .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+        .get();
+    return rows.map((r) => r.read<String>('name')).toSet();
+  }
+
+  Future<List<String>> tagIds(AppDatabase db) async {
+    final rows = await db.customSelect('SELECT id FROM tags ORDER BY id').get();
+    return rows.map((r) => r.read<String>('id')).toList();
+  }
+
+  Future<List<String>> diveTagPairs(AppDatabase db) async {
+    final rows = await db
+        .customSelect(
+          'SELECT dive_id, tag_id FROM dive_tags ORDER BY dive_id, tag_id',
+        )
+        .get();
+    return rows
+        .map((r) => '${r.read<String>('dive_id')}|${r.read<String>('tag_id')}')
+        .toList();
+  }
+
+  test('creates both tag uniqueness indexes', () async {
+    final db = AppDatabase(setupDb((_) {}));
+    addTearDown(db.close);
+
+    final names = await indexNames(db);
+    expect(names, contains('idx_tags_diver_name_unique'));
+    expect(names, contains('idx_dive_tags_dive_tag_unique'));
+  });
+
+  test('collapses same-name tags onto the lexically lowest id', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        // The #1032 shape: two devices each minted their own uuid for the
+        // same auto-generated import tag name.
+        insertTag(rawDb, 'tag-b', 'Perdix Import 2026-08-13', diverId: 'd1');
+        insertTag(rawDb, 'tag-a', 'Perdix Import 2026-08-13', diverId: 'd1');
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-b');
+        insertDiveTag(rawDb, 'dt-2', 'dive-2', 'tag-a');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+    expect(await diveTagPairs(db), ['dive-1|tag-a', 'dive-2|tag-a']);
+  });
+
+  test('collapse is case-insensitive', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Wreck', diverId: 'd1');
+        insertTag(rawDb, 'tag-b', 'wreck', diverId: 'd1');
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-b');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+    expect(await diveTagPairs(db), ['dive-1|tag-a']);
+  });
+
+  test('NULL diver_id is one scope, not one scope per row', () async {
+    // A plain UNIQUE(diver_id, name) index would leave these two alone --
+    // SQLite treats NULLs as distinct inside a unique index -- so the
+    // unassigned-diver rows would keep duplicating forever.
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Night');
+        insertTag(rawDb, 'tag-b', 'Night');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+  });
+
+  test('same name under different divers stays distinct', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Wreck', diverId: 'd1');
+        insertTag(rawDb, 'tag-b', 'Wreck', diverId: 'd2');
+        insertTag(rawDb, 'tag-c', 'Wreck');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a', 'tag-b', 'tag-c']);
+  });
+
+  test('collapses duplicate junction rows for the same dive and tag', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Wreck', diverId: 'd1');
+        // Re-running an import blind-inserted a fresh uuid every time.
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-a');
+        insertDiveTag(rawDb, 'dt-2', 'dive-1', 'tag-a');
+        insertDiveTag(rawDb, 'dt-3', 'dive-1', 'tag-a');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await diveTagPairs(db), ['dive-1|tag-a']);
+  });
+
+  test('repointing that collides collapses instead of aborting', () async {
+    // The tie trap: dive-1 carries BOTH duplicate tags, so repointing the
+    // loser produces two identical (dive-1, tag-a) rows. A dedupe that ran
+    // before the repoint -- or not at all -- would leave that tie in place
+    // and the unique index below would abort the whole migration.
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Wreck', diverId: 'd1');
+        insertTag(rawDb, 'tag-b', 'Wreck', diverId: 'd1');
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-a');
+        insertDiveTag(rawDb, 'dt-2', 'dive-1', 'tag-b');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+    expect(await diveTagPairs(db), ['dive-1|tag-a']);
+    expect(await indexNames(db), contains('idx_dive_tags_dive_tag_unique'));
+  });
+
+  test('a junction row whose tag is already gone survives untouched', () async {
+    // The repoint must never resolve to NULL: dive_tags.tag_id is NOT NULL,
+    // so a blanket UPDATE ... SET tag_id = (subquery) would abort here.
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertDiveTag(rawDb, 'dt-orphan', 'dive-1', 'tag-missing');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await diveTagPairs(db), ['dive-1|tag-missing']);
+  });
+
+  test('is idempotent when the database is already clean', () async {
+    final db = AppDatabase(
+      setupDb((rawDb) {
+        insertTag(rawDb, 'tag-a', 'Wreck', diverId: 'd1');
+        insertDiveTag(rawDb, 'dt-1', 'dive-1', 'tag-a');
+      }),
+    );
+    addTearDown(db.close);
+
+    expect(await tagIds(db), ['tag-a']);
+    expect(await diveTagPairs(db), ['dive-1|tag-a']);
+  });
+}

--- a/test/core/services/sync/changeset_log/base_part_file_source_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_source_test.dart
@@ -57,6 +57,58 @@ void main() {
     await dir.delete(recursive: true);
   });
 
+  // Issue #1032: a wiped backend forces a full base republish -- 80 parts for
+  // the reporting user. Without a per-part tick the sync UI sits motionless at
+  // its single "uploading" step for the whole transfer and reads as frozen.
+  test(
+    'reports each part against a total known before the first upload',
+    () async {
+      final dir = await Directory.systemTemp.createTemp('src_progress');
+      final path = '${dir.path}/base.json';
+      await File(
+        path,
+      ).writeAsBytes(Uint8List.fromList(List.generate(1000, (i) => i % 256)));
+
+      final ticks = <({int uploaded, int total})>[];
+      final res = await BasePartFileSource(path, partSize: 256).uploadAll(
+        (i, bytes) async {},
+        onPartUploaded: (uploaded, total) =>
+            ticks.add((uploaded: uploaded, total: total)),
+      );
+
+      expect(res.partCount, 4);
+      expect(
+        ticks.map((t) => t.uploaded),
+        orderedEquals([1, 2, 3, 4]),
+        reason: 'one tick per part, after it lands',
+      );
+      expect(
+        ticks.every((t) => t.total == 4),
+        isTrue,
+        reason:
+            'the denominator is fixed from the file length up front, so the '
+            'bar cannot grow under the user mid-upload',
+      );
+      await dir.delete(recursive: true);
+    },
+  );
+
+  test('reports a single part for an empty base', () async {
+    final dir = await Directory.systemTemp.createTemp('src_progress_empty');
+    final path = '${dir.path}/base.json';
+    await File(path).writeAsBytes(Uint8List(0));
+
+    final ticks = <({int uploaded, int total})>[];
+    await BasePartFileSource(path).uploadAll(
+      (i, bytes) async {},
+      onPartUploaded: (uploaded, total) =>
+          ticks.add((uploaded: uploaded, total: total)),
+    );
+
+    expect(ticks, [(uploaded: 1, total: 1)]);
+    await dir.delete(recursive: true);
+  });
+
   test(
     'empty file yields one empty part (mirrors BaseChunker.slice)',
     () async {

--- a/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
+++ b/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
@@ -1,0 +1,370 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_part_file_source.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_writer.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/resumable_base_publish.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+import '../../../../support/fake_cloud_storage_provider.dart';
+
+/// Issue #1032: a wiped backend forces the whole library out as one base -- 80
+/// parts and ~640 MB for the reporter. Every interrupted attempt restarted from
+/// part 0, so on a phone it could never finish. These tests pin that a second
+/// attempt continues the first.
+void main() {
+  late Directory publishDir;
+  late ResumableBasePublishStore store;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    publishDir = await Directory.systemTemp.createTemp('base_publish');
+    store = ResumableBasePublishStore(directory: () async => publishDir);
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+    if (await publishDir.exists()) await publishDir.delete(recursive: true);
+  });
+
+  ResumableBasePublish record({
+    required String dataPath,
+    required int byteLength,
+    String providerId = 'fake',
+    String deviceId = 'dev1',
+    int seq = 1,
+    String? epochId,
+    int createdAt = 100,
+  }) => ResumableBasePublish(
+    providerId: providerId,
+    deviceId: deviceId,
+    seq: seq,
+    dataPath: dataPath,
+    byteLength: byteLength,
+    createdAt: createdAt,
+    epochId: epochId,
+  );
+
+  Future<String> writeExport(String name, int bytes) async {
+    final path = '${publishDir.path}/$name';
+    await File(path).writeAsBytes(List.filled(bytes, 0x41));
+    return path;
+  }
+
+  group('ResumableBasePublishStore', () {
+    test('finds a record whose export is intact', () async {
+      final path = await writeExport('a.json', 50);
+      await store.save(record(dataPath: path, byteLength: 50, epochId: 'e1'));
+
+      final found = await store.find(
+        providerId: 'fake',
+        deviceId: 'dev1',
+        epochId: 'e1',
+      );
+
+      expect(found, isNotNull);
+      expect(found!.seq, 1);
+      expect(found.dataPath, path);
+    });
+
+    test('discards a record whose export the OS purged', () async {
+      final path = await writeExport('gone.json', 50);
+      await store.save(record(dataPath: path, byteLength: 50, epochId: 'e1'));
+      await File(path).delete();
+
+      final found = await store.find(
+        providerId: 'fake',
+        deviceId: 'dev1',
+        epochId: 'e1',
+      );
+
+      expect(found, isNull);
+      expect(
+        await File(ResumableBasePublish.sidecarPathFor(path)).exists(),
+        isFalse,
+        reason: 'a record with no export is dead weight and is cleaned up',
+      );
+    });
+
+    test('discards a truncated export rather than resuming it', () async {
+      final path = await writeExport('short.json', 20);
+      await store.save(record(dataPath: path, byteLength: 50, epochId: 'e1'));
+
+      expect(
+        await store.find(providerId: 'fake', deviceId: 'dev1', epochId: 'e1'),
+        isNull,
+      );
+      expect(await File(path).exists(), isFalse);
+    });
+
+    test('discards an export stamped with a superseded epoch', () async {
+      final path = await writeExport('old.json', 50);
+      await store.save(record(dataPath: path, byteLength: 50, epochId: 'old'));
+
+      expect(
+        await store.find(providerId: 'fake', deviceId: 'dev1', epochId: 'new'),
+        isNull,
+        reason: 'those bytes would publish a base every peer ignores',
+      );
+      expect(await File(path).exists(), isFalse);
+    });
+
+    test('ignores records belonging to another backend', () async {
+      final path = await writeExport('other.json', 50);
+      await store.save(
+        record(dataPath: path, byteLength: 50, providerId: 's3'),
+      );
+
+      expect(await store.find(providerId: 'dropbox', deviceId: 'dev1'), isNull);
+      expect(
+        await File(path).exists(),
+        isTrue,
+        reason: 'another backend’s in-flight publish is not ours to delete',
+      );
+    });
+
+    test('keeps only the newest of several attempts', () async {
+      final oldPath = await writeExport('old.json', 50);
+      final newPath = await writeExport('new.json', 50);
+      await store.save(
+        record(dataPath: oldPath, byteLength: 50, seq: 1, createdAt: 1),
+      );
+      await store.save(
+        record(dataPath: newPath, byteLength: 50, seq: 2, createdAt: 2),
+      );
+
+      final found = await store.find(providerId: 'fake', deviceId: 'dev1');
+
+      expect(found!.seq, 2);
+      expect(await File(oldPath).exists(), isFalse);
+    });
+
+    test('clearForProvider drops only that backend’s records', () async {
+      final mine = await writeExport('mine.json', 50);
+      final theirs = await writeExport('theirs.json', 50);
+      await store.save(
+        record(dataPath: mine, byteLength: 50, providerId: 'fake'),
+      );
+      await store.save(
+        record(dataPath: theirs, byteLength: 50, providerId: 's3'),
+      );
+
+      await store.clearForProvider('fake');
+
+      expect(await File(mine).exists(), isFalse);
+      expect(await File(theirs).exists(), isTrue);
+    });
+  });
+
+  /// Part skipping lives here rather than at the writer, where the 8 MiB part
+  /// size would need a multi-megabyte fixture to produce a second part.
+  group('BasePartFileSource.skipPart', () {
+    test('skips the network for parts already uploaded, hashing all', () async {
+      final dir = await Directory.systemTemp.createTemp('skip');
+      final path = '${dir.path}/base.json';
+      final data = Uint8List.fromList(List.generate(1000, (i) => i % 256));
+      await File(path).writeAsBytes(data);
+
+      final sent = <int>[];
+      final res = await BasePartFileSource(path, partSize: 256).uploadAll(
+        (i, bytes) async => sent.add(i),
+        skipPart: (i) => i < 2, // parts 0 and 1 landed on the first attempt
+      );
+
+      expect(sent, [2, 3], reason: 'only the missing parts go over the wire');
+      expect(
+        res.wholeChecksum,
+        BaseChunker.checksum(data),
+        reason:
+            'checksums still describe the whole file, so a manifest '
+            'written on a resumed pass is indistinguishable from a fresh one',
+      );
+      expect(res.partCount, 4);
+      await dir.delete(recursive: true);
+    });
+
+    test('a file truncated between attempts fails verification', () async {
+      // The reason skipped parts are re-hashed instead of trusting recorded
+      // checksums: stale checksums would certify bytes that are no longer there.
+      final dir = await Directory.systemTemp.createTemp('trunc');
+      final path = '${dir.path}/base.json';
+      final full = Uint8List.fromList(List.generate(1000, (i) => i % 256));
+      await File(path).writeAsBytes(full.sublist(0, 600));
+
+      final res = await BasePartFileSource(
+        path,
+        partSize: 256,
+      ).uploadAll((i, bytes) async {}, skipPart: (i) => true);
+
+      expect(res.wholeChecksum, isNot(BaseChunker.checksum(full)));
+      await dir.delete(recursive: true);
+    });
+  });
+
+  group('ChangesetWriter resume', () {
+    late FakeCloudStorageProvider provider;
+    late ChangesetWriter writer;
+    late String folder;
+
+    setUp(() async {
+      final db = DatabaseService.instance.database;
+      final serializer = SyncDataSerializer();
+      writer = ChangesetWriter(
+        serializer,
+        ChangesetCodec(serializer),
+        PublishStateStore(db),
+        compactionByteRatio: 1000.0,
+        compactionMaxChangesets: 1 << 30,
+        resumableStore: store,
+      );
+      provider = FakeCloudStorageProvider();
+      folder = await provider.getOrCreateSyncFolder();
+    });
+
+    Future<ChangesetWriteResult> publish() async {
+      final repo = SyncRepository();
+      return writer.publish(
+        provider: provider,
+        deviceId: await repo.getDeviceId(),
+        folderId: folder,
+        deletions: await repo.getAllDeletions(),
+      );
+    }
+
+    Future<List<CloudFileInfo>> listing() => provider.listFiles(
+      folderId: folder,
+      namePattern: ChangesetLogLayout.prefix,
+    );
+
+    Future<Uint8List?> download(String name) async {
+      final match = (await listing()).where((f) => f.name == name).firstOrNull;
+      return match == null ? null : provider.downloadFile(match.id);
+    }
+
+    test('an interrupted base publish leaves an export to resume', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+      provider.failUploadsAfter = 0; // die on the very first part
+
+      await expectLater(publish(), throwsA(anything));
+
+      final deviceId = await SyncRepository().getDeviceId();
+      final pending = await store.find(
+        providerId: provider.providerId,
+        deviceId: deviceId,
+      );
+      expect(
+        pending,
+        isNotNull,
+        reason:
+            'without this the next attempt re-exports and re-uploads all of '
+            'it, which is why the reported sync never converged',
+      );
+      expect(await File(pending!.dataPath).exists(), isTrue);
+      expect(
+        await download(ChangesetLogLayout.manifestName(deviceId)),
+        isNull,
+        reason: 'the manifest is the commit point and must not be written',
+      );
+    });
+
+    test('the next attempt reuses the export and keeps its seq', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+      provider.failUploadsAfter = 0;
+      await expectLater(publish(), throwsA(anything));
+
+      final deviceId = await SyncRepository().getDeviceId();
+      final pending = (await store.find(
+        providerId: provider.providerId,
+        deviceId: deviceId,
+      ))!;
+
+      provider.failUploadsAfter = null;
+      final result = await publish();
+
+      expect(result.kind, ChangesetWriteKind.base);
+      expect(
+        result.seq,
+        pending.seq,
+        reason:
+            'parts already uploaded are named with this seq; changing it '
+            'would orphan every one of them',
+      );
+      expect(
+        await File(pending.dataPath).exists(),
+        isFalse,
+        reason: 'a committed publish spends its export',
+      );
+      expect(
+        await store.find(providerId: provider.providerId, deviceId: deviceId),
+        isNull,
+      );
+    });
+
+    test(
+      'the resumed manifest describes the bytes actually uploaded',
+      () async {
+        await DiveRepository().createDive(
+          createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+        );
+        final deviceId = await SyncRepository().getDeviceId();
+
+        provider.failUploadsAfter = 0;
+        await expectLater(publish(), throwsA(anything));
+        provider.failUploadsAfter = null;
+        await publish();
+
+        final manifest = SyncManifest.fromBytes(
+          (await download(ChangesetLogLayout.manifestName(deviceId)))!,
+        );
+        final assembled = <int>[];
+        for (var i = 0; i < manifest.basePartCount!; i++) {
+          assembled.addAll(
+            (await download(
+              ChangesetLogLayout.basePartName(deviceId, manifest.baseSeq!, i),
+            ))!,
+          );
+        }
+
+        expect(assembled.length, manifest.baseBytes);
+        expect(
+          BaseChunker.checksum(Uint8List.fromList(assembled)),
+          manifest.baseChecksum,
+        );
+      },
+    );
+
+    test('an uninterrupted publish leaves no export behind', () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+
+      await publish();
+
+      expect(
+        await store.find(
+          providerId: provider.providerId,
+          deviceId: await SyncRepository().getDeviceId(),
+        ),
+        isNull,
+        reason: 'nothing reclaims this directory, so it must not accumulate',
+      );
+      expect(publishDir.listSync(), isEmpty);
+    });
+  });
+}

--- a/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
+++ b/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
@@ -151,6 +151,48 @@ void main() {
       expect(await File(oldPath).exists(), isFalse);
     });
 
+    test('a corrupt sidecar takes its export with it', () async {
+      // The export can be hundreds of megabytes in a directory nothing else
+      // purges, so an unreadable RECORD must not strand its BYTES there. The
+      // data path is derivable from the sidecar's name (PR #1033 review).
+      final path = await writeExport('corrupt.json', 50);
+      await File(
+        ResumableBasePublish.sidecarPathFor(path),
+      ).writeAsString('{not json');
+
+      final found = await store.find(providerId: 'fake', deviceId: 'dev1');
+
+      expect(found, isNull);
+      expect(await File(path).exists(), isFalse);
+      expect(
+        await File(ResumableBasePublish.sidecarPathFor(path)).exists(),
+        isFalse,
+      );
+      expect(publishDir.listSync(), isEmpty);
+    });
+
+    test('clearForProvider also reclaims a corrupt sidecar’s export', () async {
+      final path = await writeExport('corrupt.json', 50);
+      await File(
+        ResumableBasePublish.sidecarPathFor(path),
+      ).writeAsString('{not json');
+
+      await store.clearForProvider('fake');
+
+      expect(await File(path).exists(), isFalse);
+      expect(publishDir.listSync(), isEmpty);
+    });
+
+    test('dataPathForSidecar is the inverse of sidecarPathFor', () async {
+      const data = '/tmp/ssv1_base_dev_1.abc.json';
+      expect(
+        ResumableBasePublish.dataPathForSidecar(
+          ResumableBasePublish.sidecarPathFor(data),
+        ),
+        data,
+      );
+    });
+
     test('clearForProvider drops only that backend’s records', () async {
       final mine = await writeExport('mine.json', 50);
       final theirs = await writeExport('theirs.json', 50);

--- a/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
+++ b/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
@@ -193,6 +193,48 @@ void main() {
       );
     });
 
+    test('reclaims an export whose sidecar was never written', () async {
+      // _recordResumable moves the export into place and only then writes the
+      // sidecar. An app killed inside that window leaves a data file nothing
+      // references, and find() scans sidecars, so it would never be seen again
+      // -- a whole library stranded in a directory nothing purges (#1033).
+      final orphan = await writeExport('orphan.json', 50);
+      await File(
+        orphan,
+      ).setLastModified(DateTime.now().subtract(const Duration(hours: 1)));
+
+      await store.find(providerId: 'fake', deviceId: 'dev1');
+
+      expect(await File(orphan).exists(), isFalse);
+    });
+
+    test('spares an export young enough to still be mid-write', () async {
+      // The only writer here is _recordResumable, and publishes are
+      // serialized, but a file written moments ago is likelier to be one in
+      // flight than an orphan. A true orphan is reclaimed by the next sync.
+      final fresh = await writeExport('fresh.json', 50);
+
+      await store.find(providerId: 'fake', deviceId: 'dev1');
+
+      expect(await File(fresh).exists(), isTrue);
+    });
+
+    test('never sweeps an export a sidecar still points at', () async {
+      final path = await writeExport('kept.json', 50);
+      await File(
+        path,
+      ).setLastModified(DateTime.now().subtract(const Duration(hours: 1)));
+      // A record for a DIFFERENT backend: skipped by this find, but its export
+      // is still referenced and must survive.
+      await store.save(
+        record(dataPath: path, byteLength: 50, providerId: 's3'),
+      );
+
+      await store.find(providerId: 'fake', deviceId: 'dev1');
+
+      expect(await File(path).exists(), isTrue);
+    });
+
     test('clearForProvider drops only that backend’s records', () async {
       final mine = await writeExport('mine.json', 50);
       final theirs = await writeExport('theirs.json', 50);

--- a/test/core/services/sync/sync_device_footprints_test.dart
+++ b/test/core/services/sync/sync_device_footprints_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -23,6 +24,11 @@ void main() {
     cloud = FakeCloudStorageProvider();
     footprints = SyncDeviceFootprints();
   });
+
+  /// Same object under a timeout short enough to observe without waiting one
+  /// out. The production default is 8s.
+  SyncDeviceFootprints impatient() =>
+      SyncDeviceFootprints(cloudCallTimeout: const Duration(milliseconds: 20));
 
   Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
 
@@ -173,6 +179,92 @@ void main() {
       );
 
       expect(all.map((f) => f.deviceId), ['me', 'newer', 'older']);
+    });
+  });
+
+  group('a stalled backend cannot strand the user (PR #1033 review)', () {
+    // Both entry points run in front of a user who cannot leave: the listing
+    // behind a page-filling spinner, and the retire behind a deliberately
+    // non-dismissible dialog with no back button. An unbounded cloud call
+    // against a dead connection is the "app is hung, force-quit it" failure
+    // this whole change set exists to end -- and force-quitting mid-retire is
+    // what leaves a device half-deleted.
+
+    test('list gives up rather than hanging on the folder listing', () async {
+      cloud.hangOperations = true;
+
+      await expectLater(
+        impatient().list(provider: cloud, selfDeviceId: 'me'),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('one stalled manifest read does not stall the survey', () async {
+      seedManifest('stalled', epochId: 'e1');
+      seedManifest('fine', epochId: 'e1');
+      // The listing succeeds; the per-device manifest reads never return.
+      cloud.hangDownloads = true;
+
+      final all = await impatient().list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'e1',
+      );
+
+      expect(all, hasLength(2));
+      expect(
+        all.every((f) => f.state == SyncDeviceFootprintState.unreadable),
+        isTrue,
+        reason:
+            'a device whose manifest could not be read is reported as '
+            'unreadable, which is never offered as safe to remove',
+      );
+      expect(all.any((f) => f.isSafeToRemove), isFalse);
+    });
+
+    test('retirePeer gives up when the fence marker will not upload', () async {
+      seedManifest('peer', epochId: 'old');
+      cloud.hangOperations = true;
+
+      final outcome = await impatient().retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+      );
+
+      expect(outcome.deleted, 0);
+      expect(outcome.isComplete, isFalse);
+      expect(
+        cloud.bytesOf(ChangesetLogLayout.manifestName('peer')),
+        isNotNull,
+        reason: 'a timed-out marker is no fence, so nothing may be deleted',
+      );
+    });
+
+    test('a hung delete is counted, not waited on forever', () async {
+      seedManifest('peer', epochId: 'old');
+      cloud.seedFile(
+        ChangesetLogLayout.basePartName('peer', 1, 0),
+        bytes('data'),
+      );
+      final slow = impatient();
+
+      // Let the marker upload and the listing succeed, then stall deletes.
+      var listed = false;
+      final outcome = await slow.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+        onProgress: (done, total) {
+          if (!listed) {
+            listed = true;
+            cloud.hangOperations = true;
+          }
+        },
+      );
+
+      expect(outcome.failed, greaterThan(0));
+      expect(outcome.isComplete, isFalse);
     });
   });
 

--- a/test/core/services/sync/sync_device_footprints_test.dart
+++ b/test/core/services/sync/sync_device_footprints_test.dart
@@ -1,0 +1,279 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
+import 'package:submersion/core/services/sync/changeset_log/retirement_marker.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
+import 'package:submersion/core/services/sync/sync_device_footprint.dart';
+import 'package:submersion/core/services/sync/sync_device_footprints.dart';
+
+import '../../../helpers/fake_cloud_storage_provider.dart';
+
+/// Issue #1032: a user found 400+ files on Dropbox from what should have been a
+/// single syncing device, with nothing in the app able to account for them.
+/// These tests pin the survey that explains the folder and the safe removal of
+/// one device's share of it.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeCloudStorageProvider cloud;
+  late SyncDeviceFootprints footprints;
+
+  setUp(() {
+    cloud = FakeCloudStorageProvider();
+    footprints = SyncDeviceFootprints();
+  });
+
+  Uint8List bytes(String s) => Uint8List.fromList(s.codeUnits);
+
+  void seedManifest(
+    String deviceId, {
+    String? epochId,
+    String? deviceName,
+    int updatedAt = 1000,
+    int? schemaVersion,
+  }) {
+    cloud.seedFile(
+      ChangesetLogLayout.manifestName(deviceId),
+      SyncManifest(
+        deviceId: deviceId,
+        deviceName: deviceName,
+        provider: 'fake',
+        headSeq: 1,
+        updatedAt: updatedAt,
+        epochId: epochId,
+        schemaVersion: schemaVersion,
+      ).toBytes(),
+    );
+  }
+
+  group('list', () {
+    test('groups every file under the device that published it', () async {
+      seedManifest('dev1', epochId: 'e1', deviceName: 'Pixel');
+      for (var i = 0; i < 3; i++) {
+        cloud.seedFile(
+          ChangesetLogLayout.basePartName('dev1', 1, i),
+          bytes('xxxxx'),
+        );
+      }
+      seedManifest('dev2', epochId: 'e1');
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'dev1',
+        currentEpochId: 'e1',
+      );
+
+      expect(all.map((f) => f.deviceId), containsAll(['dev1', 'dev2']));
+      final dev1 = all.firstWhere((f) => f.deviceId == 'dev1');
+      expect(dev1.fileCount, 4, reason: 'manifest + 3 base parts');
+      expect(
+        dev1.byteCount,
+        15 + cloud.bytesOf(ChangesetLogLayout.manifestName('dev1'))!.length,
+        reason: 'the manifest occupies backend space too, so it counts',
+      );
+      expect(dev1.deviceName, 'Pixel');
+      expect(dev1.isSelf, isTrue);
+      expect(dev1.state, SyncDeviceFootprintState.active);
+    });
+
+    test('flags a device stamped with a superseded epoch as stale', () async {
+      // Exactly the "shadow copy" the reporter asked to be able to see: files
+      // left behind by an earlier library that no current device will ever read.
+      seedManifest('ghost', epochId: 'old-epoch');
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'new-epoch',
+      );
+
+      final ghost = all.single;
+      expect(ghost.state, SyncDeviceFootprintState.staleEpoch);
+      expect(ghost.isSafeToRemove, isTrue);
+    });
+
+    test('a retired device is reported as retired, not stale', () async {
+      seedManifest('old', epochId: 'e1');
+      cloud.seedFile(
+        ChangesetLogLayout.retiredMarkerName('old'),
+        RetirementMarker(deviceId: 'old', retiredAt: 5).toBytes(),
+      );
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'e1',
+      );
+
+      expect(all.single.state, SyncDeviceFootprintState.retired);
+    });
+
+    test('files with no readable manifest are unreadable, never stale', () async {
+      // An interrupted publish looks exactly like this. Calling it stale would
+      // invite the user to delete an upload that is still in flight.
+      cloud.seedFile(
+        ChangesetLogLayout.basePartName('half', 1, 0),
+        bytes('partial'),
+      );
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'e1',
+      );
+
+      expect(all.single.state, SyncDeviceFootprintState.unreadable);
+      expect(
+        all.single.isSafeToRemove,
+        isFalse,
+        reason: 'no manifest means no basis to judge it disposable',
+      );
+    });
+
+    test('a corrupt manifest downgrades one device, not the whole survey', () async {
+      seedManifest('good', epochId: 'e1');
+      cloud.seedFile(ChangesetLogLayout.manifestName('bad'), bytes('not json'));
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'e1',
+      );
+
+      expect(all, hasLength(2));
+      expect(
+        all.firstWhere((f) => f.deviceId == 'bad').state,
+        SyncDeviceFootprintState.unreadable,
+      );
+      expect(
+        all.firstWhere((f) => f.deviceId == 'good').state,
+        SyncDeviceFootprintState.active,
+      );
+    });
+
+    test('sorts this device first, then most recently published', () async {
+      seedManifest('me', epochId: 'e1', updatedAt: 1);
+      seedManifest('older', epochId: 'e1', updatedAt: 10);
+      seedManifest('newer', epochId: 'e1', updatedAt: 99);
+
+      final all = await footprints.list(
+        provider: cloud,
+        selfDeviceId: 'me',
+        currentEpochId: 'e1',
+      );
+
+      expect(all.map((f) => f.deviceId), ['me', 'newer', 'older']);
+    });
+  });
+
+  group('retirePeer', () {
+    test('writes the fence marker before deleting anything', () async {
+      seedManifest('peer', epochId: 'old');
+      cloud.seedFile(
+        ChangesetLogLayout.basePartName('peer', 1, 0),
+        bytes('data'),
+      );
+
+      final outcome = await footprints.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+      );
+
+      final marker = 'upload:${ChangesetLogLayout.retiredMarkerName('peer')}';
+      final firstDelete = cloud.operationLog.indexWhere(
+        (op) => op.startsWith('delete:'),
+      );
+      expect(
+        cloud.operationLog.indexOf(marker),
+        lessThan(firstDelete),
+        reason:
+            'a device that comes back online must find the marker; deleting '
+            'first would let its stale rows resurrect fleet-wide',
+      );
+      expect(outcome.deleted, 2);
+      expect(outcome.isComplete, isTrue);
+    });
+
+    test('keeps the retirement marker it just wrote', () async {
+      seedManifest('peer', epochId: 'old');
+
+      await footprints.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+      );
+
+      expect(
+        cloud.bytesOf(ChangesetLogLayout.retiredMarkerName('peer')),
+        isNotNull,
+      );
+      expect(cloud.bytesOf(ChangesetLogLayout.manifestName('peer')), isNull);
+    });
+
+    test('leaves other devices untouched', () async {
+      seedManifest('peer', epochId: 'old');
+      seedManifest('keeper', epochId: 'e1');
+
+      await footprints.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+      );
+
+      expect(cloud.bytesOf(ChangesetLogLayout.manifestName('keeper')), isNotNull);
+    });
+
+    test('deletes nothing when the marker cannot be written', () async {
+      seedManifest('peer', epochId: 'old');
+      cloud.failUploads = true;
+
+      final outcome = await footprints.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+      );
+
+      expect(outcome.deleted, 0);
+      expect(outcome.isComplete, isFalse);
+      expect(
+        cloud.bytesOf(ChangesetLogLayout.manifestName('peer')),
+        isNotNull,
+        reason: 'no fence, no deletion -- unfenced removal is the unsafe case',
+      );
+    });
+
+    test('refuses to retire this device through the peer path', () async {
+      expect(
+        () => footprints.retirePeer(
+          provider: cloud,
+          deviceId: 'me',
+          selfDeviceId: 'me',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('reports progress per file', () async {
+      seedManifest('peer', epochId: 'old');
+      for (var i = 0; i < 3; i++) {
+        cloud.seedFile(
+          ChangesetLogLayout.basePartName('peer', 1, i),
+          bytes('d'),
+        );
+      }
+
+      final seen = <({int done, int total})>[];
+      await footprints.retirePeer(
+        provider: cloud,
+        deviceId: 'peer',
+        selfDeviceId: 'me',
+        onProgress: (done, total) => seen.add((done: done, total: total)),
+      );
+
+      expect(seen.first, (done: 0, total: 4));
+      expect(seen.last, (done: 4, total: 4));
+    });
+  });
+}

--- a/test/core/services/sync/sync_device_footprints_test.dart
+++ b/test/core/services/sync/sync_device_footprints_test.dart
@@ -97,7 +97,7 @@ void main() {
       seedManifest('old', epochId: 'e1');
       cloud.seedFile(
         ChangesetLogLayout.retiredMarkerName('old'),
-        RetirementMarker(deviceId: 'old', retiredAt: 5).toBytes(),
+        const RetirementMarker(deviceId: 'old', retiredAt: 5).toBytes(),
       );
 
       final all = await footprints.list(
@@ -109,48 +109,57 @@ void main() {
       expect(all.single.state, SyncDeviceFootprintState.retired);
     });
 
-    test('files with no readable manifest are unreadable, never stale', () async {
-      // An interrupted publish looks exactly like this. Calling it stale would
-      // invite the user to delete an upload that is still in flight.
-      cloud.seedFile(
-        ChangesetLogLayout.basePartName('half', 1, 0),
-        bytes('partial'),
-      );
+    test(
+      'files with no readable manifest are unreadable, never stale',
+      () async {
+        // An interrupted publish looks exactly like this. Calling it stale would
+        // invite the user to delete an upload that is still in flight.
+        cloud.seedFile(
+          ChangesetLogLayout.basePartName('half', 1, 0),
+          bytes('partial'),
+        );
 
-      final all = await footprints.list(
-        provider: cloud,
-        selfDeviceId: 'me',
-        currentEpochId: 'e1',
-      );
+        final all = await footprints.list(
+          provider: cloud,
+          selfDeviceId: 'me',
+          currentEpochId: 'e1',
+        );
 
-      expect(all.single.state, SyncDeviceFootprintState.unreadable);
-      expect(
-        all.single.isSafeToRemove,
-        isFalse,
-        reason: 'no manifest means no basis to judge it disposable',
-      );
-    });
+        expect(all.single.state, SyncDeviceFootprintState.unreadable);
+        expect(
+          all.single.isSafeToRemove,
+          isFalse,
+          reason: 'no manifest means no basis to judge it disposable',
+        );
+      },
+    );
 
-    test('a corrupt manifest downgrades one device, not the whole survey', () async {
-      seedManifest('good', epochId: 'e1');
-      cloud.seedFile(ChangesetLogLayout.manifestName('bad'), bytes('not json'));
+    test(
+      'a corrupt manifest downgrades one device, not the whole survey',
+      () async {
+        seedManifest('good', epochId: 'e1');
+        cloud.seedFile(
+          ChangesetLogLayout.manifestName('bad'),
+          bytes('not json'),
+        );
 
-      final all = await footprints.list(
-        provider: cloud,
-        selfDeviceId: 'me',
-        currentEpochId: 'e1',
-      );
+        final all = await footprints.list(
+          provider: cloud,
+          selfDeviceId: 'me',
+          currentEpochId: 'e1',
+        );
 
-      expect(all, hasLength(2));
-      expect(
-        all.firstWhere((f) => f.deviceId == 'bad').state,
-        SyncDeviceFootprintState.unreadable,
-      );
-      expect(
-        all.firstWhere((f) => f.deviceId == 'good').state,
-        SyncDeviceFootprintState.active,
-      );
-    });
+        expect(all, hasLength(2));
+        expect(
+          all.firstWhere((f) => f.deviceId == 'bad').state,
+          SyncDeviceFootprintState.unreadable,
+        );
+        expect(
+          all.firstWhere((f) => f.deviceId == 'good').state,
+          SyncDeviceFootprintState.active,
+        );
+      },
+    );
 
     test('sorts this device first, then most recently published', () async {
       seedManifest('me', epochId: 'e1', updatedAt: 1);
@@ -222,7 +231,10 @@ void main() {
         selfDeviceId: 'me',
       );
 
-      expect(cloud.bytesOf(ChangesetLogLayout.manifestName('keeper')), isNotNull);
+      expect(
+        cloud.bytesOf(ChangesetLogLayout.manifestName('keeper')),
+        isNotNull,
+      );
     });
 
     test('deletes nothing when the marker cannot be written', () async {

--- a/test/core/services/sync/sync_service_cloud_clear_test.dart
+++ b/test/core/services/sync/sync_service_cloud_clear_test.dart
@@ -91,4 +91,108 @@ void main() {
       await buildService().wipeAllSyncData(cloud);
     },
   );
+
+  // ---- Issue #1032: a wipe of a large backend runs for minutes with no
+  // feedback, and reported success even when it had not finished. The outcome
+  // and progress stream are what the UI needs to stop lying to the user.
+
+  group('wipe progress and outcome (issue #1032)', () {
+    test('reports monotonic progress against a total fixed up front', () async {
+      for (var i = 0; i < 4; i++) {
+        cloud.seedFile(ChangesetLogLayout.basePartName('dev1', 0, i), b('p$i'));
+      }
+      cloud.seedFile(libraryEpochFileName, b('epoch'));
+
+      final seen = <({int done, int total})>[];
+      final outcome = await buildService().wipeAllSyncData(
+        cloud,
+        onProgress: (done, total) => seen.add((done: done, total: total)),
+      );
+
+      expect(outcome.deleted, 5);
+      expect(outcome.failed, 0);
+      expect(
+        seen.first,
+        (done: 0, total: 5),
+        reason: 'the bar must start at a known total, not grow as it goes',
+      );
+      expect(seen.last, (done: 5, total: 5));
+      expect(
+        seen.map((p) => p.done),
+        orderedEquals([0, 1, 2, 3, 4, 5]),
+        reason: 'one tick per file so a 400-file wipe visibly advances',
+      );
+      expect(seen.every((p) => p.total == 5), isTrue);
+    });
+
+    test('counts failed deletions instead of reporting a clean wipe', () async {
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+      cloud.seedFile(libraryEpochFileName, b('epoch'));
+      cloud.failDeletes = true;
+
+      final outcome = await buildService().wipeAllSyncData(cloud);
+
+      expect(outcome.deleted, 0);
+      expect(outcome.failed, 2);
+      expect(outcome.isComplete, isFalse);
+    });
+
+    test(
+      'flags an incomplete listing so the UI cannot claim success',
+      () async {
+        // Mirrors the reported log: "Could not list markers for full sync wipe:
+        // TimeoutException" -- markers survived, yet the app said "Wiped all
+        // sync data".
+        cloud.failLists = true;
+
+        final outcome = await buildService().wipeAllSyncData(cloud);
+
+        expect(outcome.listIncomplete, isTrue);
+        expect(outcome.isComplete, isFalse);
+      },
+    );
+
+    test('a wipe that deletes everything it listed is complete', () async {
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+
+      final outcome = await buildService().wipeAllSyncData(cloud);
+
+      expect(outcome.deleted, 1);
+      expect(outcome.isComplete, isTrue);
+    });
+
+    test('deletes the changeset logs before the epoch marker', () async {
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+      cloud.seedFile(libraryEpochFileName, b('epoch'));
+
+      await buildService().wipeAllSyncData(cloud);
+
+      final deletes = cloud.operationLog
+          .where((op) => op.startsWith('delete:'))
+          .toList();
+      expect(
+        deletes.indexOf('delete:${ChangesetLogLayout.manifestName('dev1')}'),
+        lessThan(deletes.indexOf('delete:$libraryEpochFileName')),
+        reason:
+            'a peer listing mid-wipe must not see orphaned logs whose epoch '
+            'marker is already gone',
+      );
+    });
+
+    test('deleteDeviceSyncFile reports its own outcome', () async {
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev1'), b('m1'));
+      cloud.seedFile(ChangesetLogLayout.basePartName('dev1', 0, 0), b('bp1'));
+      cloud.seedFile(ChangesetLogLayout.manifestName('dev2'), b('m2'));
+
+      final seen = <({int done, int total})>[];
+      final outcome = await buildService().deleteDeviceSyncFile(
+        'dev1',
+        onProgress: (done, total) => seen.add((done: done, total: total)),
+      );
+
+      expect(outcome.deleted, 2, reason: 'only dev1’s two files');
+      expect(outcome.isComplete, isTrue);
+      expect(seen.last, (done: 2, total: 2));
+    });
+  });
 }

--- a/test/core/services/sync/sync_tag_identity_test.dart
+++ b/test/core/services/sync/sync_tag_identity_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart'
+    as tag_domain;
+
+import '../../../helpers/changeset_test_helpers.dart';
+import '../../../helpers/fake_cloud_storage_provider.dart';
+import '../../../helpers/test_database.dart';
+
+/// Cross-device tag identity (issue #1032).
+///
+/// After a second device pulled the shared library, dives showed the same
+/// auto-generated import tag several times: each device had minted its own
+/// uuid for a tag of the same name, and the merge upserted by primary key
+/// only, so the peer's row landed beside the local one instead of merging
+/// with it. Both devices must converge on ONE tag row and ONE junction row.
+void main() {
+  group('tag identity across devices', () {
+    late FakeCloudStorageProvider cloud;
+
+    const importTag = 'Perdix Import 2026-08-13';
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(tearDownTestDatabase);
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Future<void> createDive(String id) => DiveRepository().createDive(
+      domain.Dive(id: id, dateTime: DateTime(2026, 8, 13)),
+    );
+
+    Future<void> createTaggedDive(
+      String diveId,
+      String tagId, {
+      String name = importTag,
+    }) async {
+      await createDive(diveId);
+      await TagRepository().createTag(
+        tag_domain.Tag(
+          id: tagId,
+          name: name,
+          createdAt: DateTime(2026, 8, 13),
+          updatedAt: DateTime(2026, 8, 13),
+        ),
+      );
+      await TagRepository().addTagToDive(diveId, tagId);
+    }
+
+    Future<List<String>> tagIds() async {
+      final db = DatabaseService.instance.database;
+      final rows = await db
+          .customSelect('SELECT id FROM tags ORDER BY id')
+          .get();
+      return rows.map((r) => r.read<String>('id')).toList();
+    }
+
+    Future<List<String>> junctionPairs() async {
+      final db = DatabaseService.instance.database;
+      final rows = await db
+          .customSelect(
+            'SELECT dive_id, tag_id FROM dive_tags '
+            'ORDER BY dive_id, tag_id',
+          )
+          .get();
+      return rows
+          .map(
+            (r) => '${r.read<String>('dive_id')}|${r.read<String>('tag_id')}',
+          )
+          .toList();
+    }
+
+    test('a peer tag that sorts lower absorbs the local one', () async {
+      // Peer device: same dive, its own uuid for the import tag.
+      await createTaggedDive('dive-1', 'tag-aaa');
+      await seedPeerLog(cloud, 'device-a');
+
+      // This device: the same dive and the same tag NAME, own uuid.
+      await createTaggedDive('dive-1', 'tag-zzz');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(await tagIds(), ['tag-aaa']);
+      expect(await junctionPairs(), ['dive-1|tag-aaa']);
+      expect(
+        (await TagRepository().getTagsForDive('dive-1')).length,
+        1,
+        reason: 'the dive must show the import tag exactly once',
+      );
+    });
+
+    test('a peer tag that sorts higher folds into the local one', () async {
+      // Peer device: its uuid sorts ABOVE ours, and it tags a dive we have
+      // never seen -- that dive's junction must still land on our tag.
+      await createTaggedDive('dive-2', 'tag-zzz');
+      await seedPeerLog(cloud, 'device-a');
+
+      await createTaggedDive('dive-1', 'tag-aaa');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(await tagIds(), ['tag-aaa']);
+      expect(await junctionPairs(), ['dive-1|tag-aaa', 'dive-2|tag-aaa']);
+      expect((await TagRepository().getTagsForDive('dive-2')).length, 1);
+    });
+
+    test('a peer junction for a pair we already have is a no-op', () async {
+      // Same tag id on both sides (the ordinary case) but a different
+      // junction uuid: the surrogate key made this a second row.
+      await createTaggedDive('dive-1', 'tag-aaa');
+      await seedPeerLog(cloud, 'device-a');
+
+      await createTaggedDive('dive-1', 'tag-aaa');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(await junctionPairs(), ['dive-1|tag-aaa']);
+    });
+
+    test('an ordinary peer tag still replicates untouched', () async {
+      await createTaggedDive('dive-1', 'tag-aaa', name: 'Wreck');
+      await seedPeerLog(cloud, 'device-a');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(await tagIds(), ['tag-aaa']);
+      expect(await junctionPairs(), ['dive-1|tag-aaa']);
+    });
+  });
+}

--- a/test/core/services/sync/sync_tag_identity_test.dart
+++ b/test/core/services/sync/sync_tag_identity_test.dart
@@ -168,6 +168,46 @@ void main() {
       expect(await junctionPairs(), ['dive-1|tag-aaa']);
     });
 
+    test('a padded name from a peer is stored trimmed', () async {
+      // v149 trims every stored name so a row reads back as what lookups
+      // compare against. A device predating that change can still publish a
+      // padded one, and writing it verbatim would undo the migration on the
+      // very first sync (PR #1033 review).
+      //
+      // The peer's tag row is inserted RAW: createTag trims now, so going
+      // through the repository would never put a padded name on the wire and
+      // this test would pass against the unfixed code.
+      await createDive('dive-1');
+      final now = DateTime(2026, 8, 13).millisecondsSinceEpoch;
+      await DatabaseService.instance.database
+          .into(DatabaseService.instance.database.tags)
+          .insert(
+            TagsCompanion(
+              id: const Value('tag-aaa'),
+              name: const Value('  $importTag  '),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await TagRepository().addTagToDive('dive-1', 'tag-aaa');
+      // Publishes the above as a peer AND resets this device's database.
+      await seedPeerLog(cloud, 'device-a');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      final db = DatabaseService.instance.database;
+      final rows = await db.select(db.tags).get();
+      expect(rows, hasLength(1));
+      expect(
+        rows.single.name,
+        importTag,
+        reason:
+            'the stored value must match the normalization the index and '
+            'every lookup key on',
+      );
+    });
+
     test('an ordinary peer tag still replicates untouched', () async {
       await createTaggedDive('dive-1', 'tag-aaa', name: 'Wreck');
       await seedPeerLog(cloud, 'device-a');

--- a/test/core/services/sync/sync_tag_identity_test.dart
+++ b/test/core/services/sync/sync_tag_identity_test.dart
@@ -1,5 +1,7 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
@@ -118,6 +120,38 @@ void main() {
       expect(await tagIds(), ['tag-aaa']);
       expect(await junctionPairs(), ['dive-1|tag-aaa', 'dive-2|tag-aaa']);
       expect((await TagRepository().getTagsForDive('dive-2')).length, 1);
+    });
+
+    test('a padded local name still folds with a peer’s bare one', () async {
+      // The comparison used to trim only the INCOMING name, so convergence
+      // depended on which device happened to hold the padded spelling. Rows
+      // predating v149 (and legacy peers) can carry one, so the local side is
+      // inserted raw here rather than through the now-trimming repository.
+      await createTaggedDive('dive-1', 'tag-aaa');
+      await seedPeerLog(cloud, 'device-a');
+
+      final db = DatabaseService.instance.database;
+      await createDive('dive-9');
+      final now = DateTime(2026, 8, 13).millisecondsSinceEpoch;
+      await db
+          .into(db.tags)
+          .insert(
+            TagsCompanion(
+              id: const Value('tag-zzz'),
+              name: const Value('  $importTag  '),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await TagRepository().addTagToDive('dive-9', 'tag-zzz');
+
+      final result = await buildService().performSync();
+      expect(result.status, isNot(SyncResultStatus.error));
+
+      expect(await tagIds(), [
+        'tag-aaa',
+      ], reason: 'whitespace is not what makes two tags different');
+      expect((await TagRepository().getTagsForDive('dive-9')).length, 1);
     });
 
     test('a peer junction for a pair we already have is a no-op', () async {

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -105,6 +105,13 @@ void main() {
     // importer consults this to avoid duplicating a built-in slug.
     when(mockDiveTypeRepo.getDiveTypeById(any)).thenAnswer((_) async => null);
 
+    // No tag exists yet, so every imported tag is created. The importer
+    // consults this to reuse a tag the diver already has by that name
+    // instead of minting a second uuid for it (#1032).
+    when(
+      mockTagRepo.getTagByName(any, diverId: anyNamed('diverId')),
+    ).thenAnswer((_) async => null);
+
     // Stub getNextDiveNumber for auto-numbering during import.
     when(
       mockDiveRepo.getNextDiveNumber(diverId: anyNamed('diverId')),
@@ -550,6 +557,47 @@ void main() {
 
       final captured = verify(mockTagRepo.createTag(captureAny)).captured;
       expect((captured[0] as Tag).colorHex, '#FF0000');
+    });
+
+    test('reuses a tag the diver already has by that name (#1032)', () async {
+      final existing = Tag(
+        id: 'existing-night',
+        diverId: diverId,
+        name: 'Night Dive',
+        createdAt: now,
+        updatedAt: now,
+      );
+      when(
+        mockTagRepo.getTagByName('Night Dive', diverId: diverId),
+      ).thenAnswer((_) async => existing);
+      when(mockTagRepo.addTagToDive(any, any)).thenAnswer((_) async {});
+      when(mockDiveRepo.createDive(any)).thenAnswer(
+        (invocation) async => invocation.positionalArguments[0] as Dive,
+      );
+
+      final data = UddfImportResult(
+        tags: [
+          {'name': 'Night Dive', 'uddfId': 'tag-1'},
+        ],
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 25.0,
+            'tagRefs': ['tag-1'],
+          },
+        ],
+      );
+
+      final result = await importer.import(
+        data: data,
+        selections: const UddfImportSelections(tags: {0}, dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      expect(result.tags, 0, reason: 'nothing new was created');
+      verifyNever(mockTagRepo.createTag(any));
+      verify(mockTagRepo.addTagToDive(any, 'existing-night')).called(1);
     });
   });
 

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -8,6 +8,7 @@ import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType, SyncRepository;
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_api_client.dart';
@@ -220,17 +221,28 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
 
   int removeThisDeviceCloudFilesCalls = 0;
   @override
-  Future<void> removeThisDeviceCloudFiles() async =>
-      removeThisDeviceCloudFilesCalls++;
+  Future<SyncCleanupOutcome> removeThisDeviceCloudFiles({
+    SyncCleanupProgress? onProgress,
+  }) async {
+    removeThisDeviceCloudFilesCalls++;
+    return const SyncCleanupOutcome();
+  }
 
   int wipeAllCloudSyncDataCalls = 0;
   @override
-  Future<void> wipeAllCloudSyncData() async => wipeAllCloudSyncDataCalls++;
+  Future<SyncCleanupOutcome> wipeAllCloudSyncData({
+    SyncCleanupProgress? onProgress,
+  }) async {
+    wipeAllCloudSyncDataCalls++;
+    return const SyncCleanupOutcome();
+  }
 
   int rebuildBackendFromThisDeviceCalls = 0;
   @override
-  Future<void> rebuildBackendFromThisDevice() async =>
-      rebuildBackendFromThisDeviceCalls++;
+  Future<void> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+    void Function()? onPublishStarted,
+  }) async => rebuildBackendFromThisDeviceCalls++;
 
   @override
   Future<void> signOut() async => signOutCalls++;

--- a/test/features/settings/presentation/pages/sync_devices_page_test.dart
+++ b/test/features/settings/presentation/pages/sync_devices_page_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/sync_device_footprint.dart';
+import 'package:submersion/features/settings/presentation/pages/sync_devices_page.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_device_providers.dart';
+
+/// Issue #1032: the user could see 400+ files on Dropbox but nothing in the app
+/// explained them, so the only tool available was the all-or-nothing wipe.
+void main() {
+  SyncDeviceFootprint device({
+    required String id,
+    required SyncDeviceFootprintState state,
+    String? name,
+    bool isSelf = false,
+    int files = 1,
+    int bytes = 2048,
+  }) => SyncDeviceFootprint(
+    deviceId: id,
+    state: state,
+    fileCount: files,
+    byteCount: bytes,
+    deviceName: name,
+    isSelf: isSelf,
+    publishedAt: DateTime.utc(2026, 8, 13, 12),
+  );
+
+  Future<void> pump(
+    WidgetTester tester,
+    List<SyncDeviceFootprint> devices,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          syncDeviceFootprintListProvider.overrideWith((ref) async => devices),
+        ],
+        child: const MaterialApp(home: SyncDevicesPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('totals the whole backend and calls out the dead weight', (
+    tester,
+  ) async {
+    await pump(tester, [
+      device(
+        id: 'self',
+        state: SyncDeviceFootprintState.active,
+        name: 'Pixel',
+        isSelf: true,
+        files: 2,
+        bytes: 1024,
+      ),
+      device(
+        id: 'ghost1',
+        state: SyncDeviceFootprintState.staleEpoch,
+        files: 80,
+        bytes: 1024 * 1024,
+      ),
+    ]);
+
+    expect(find.textContaining('2 devices, 82 files'), findsOneWidget);
+    expect(
+      find.textContaining('1 left over from a replaced or retired library'),
+      findsOneWidget,
+      reason: 'the whole point is telling the user what is safe to delete',
+    );
+  });
+
+  testWidgets('names an unnamed device by its short id', (tester) async {
+    await pump(tester, [
+      device(
+        id: 'abcdef1234567890',
+        state: SyncDeviceFootprintState.staleEpoch,
+      ),
+    ]);
+
+    expect(find.text('Device abcdef12'), findsOneWidget);
+  });
+
+  testWidgets('explains why a stale device is stale', (tester) async {
+    await pump(tester, [
+      device(id: 'ghost', state: SyncDeviceFootprintState.staleEpoch),
+    ]);
+
+    expect(
+      find.textContaining('Left over from an earlier library'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('offers no delete button for this device', (tester) async {
+    await pump(tester, [
+      device(
+        id: 'self',
+        state: SyncDeviceFootprintState.active,
+        name: 'Pixel',
+        isSelf: true,
+      ),
+    ]);
+
+    expect(
+      find.byIcon(Icons.delete_outline),
+      findsNothing,
+      reason:
+          'removing your own files is a different operation with different '
+          'consequences, and it lives on the Troubleshoot page',
+    );
+  });
+
+  testWidgets('warns harder before removing a device that still syncs', (
+    tester,
+  ) async {
+    await pump(tester, [
+      device(id: 'live', state: SyncDeviceFootprintState.active, name: 'iPad'),
+    ]);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('still part of this sync'), findsOneWidget);
+    expect(
+      find.textContaining('has not yet published will be lost'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a stale device gets the calm confirmation', (tester) async {
+    await pump(tester, [
+      device(
+        id: 'ghost',
+        state: SyncDeviceFootprintState.staleEpoch,
+        files: 80,
+      ),
+    ]);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('no device syncs from any more'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('still part of this sync'), findsNothing);
+  });
+
+  testWidgets('an unreadable footprint is not offered as safe to remove', (
+    tester,
+  ) async {
+    await pump(tester, [
+      device(id: 'half', state: SyncDeviceFootprintState.unreadable),
+    ]);
+
+    expect(
+      find.textContaining('No readable manifest'),
+      findsOneWidget,
+      reason: 'an unfinished upload must not be presented as dead weight',
+    );
+    expect(
+      find.textContaining('left over from a replaced or retired'),
+      findsNothing,
+    );
+  });
+
+  testWidgets('says so when the backend holds nothing', (tester) async {
+    await pump(tester, []);
+    expect(find.text('No sync files on this backend.'), findsOneWidget);
+  });
+}

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart' show StateNotifier;
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/features/settings/presentation/pages/troubleshoot_sync_page.dart';
@@ -38,17 +39,34 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   /// state in [SyncStatus.error] with this message (mirrors the real notifier).
   String? rebuildFailureMessage;
 
+  /// What the cleanup calls report back. Defaults to a clean no-op; tests that
+  /// care about partial failure override it (issue #1032).
+  SyncCleanupOutcome cleanupOutcome = const SyncCleanupOutcome();
+
   @override
   Future<void> repairSync() async => repairSyncCalls++;
 
   @override
-  Future<void> removeThisDeviceCloudFiles() async => removeThisDeviceCalls++;
+  Future<SyncCleanupOutcome> removeThisDeviceCloudFiles({
+    SyncCleanupProgress? onProgress,
+  }) async {
+    removeThisDeviceCalls++;
+    return cleanupOutcome;
+  }
 
   @override
-  Future<void> wipeAllCloudSyncData() async => wipeAllCalls++;
+  Future<SyncCleanupOutcome> wipeAllCloudSyncData({
+    SyncCleanupProgress? onProgress,
+  }) async {
+    wipeAllCalls++;
+    return cleanupOutcome;
+  }
 
   @override
-  Future<void> rebuildBackendFromThisDevice() async {
+  Future<void> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+    void Function()? onPublishStarted,
+  }) async {
     rebuildCalls++;
     final msg = rebuildFailureMessage;
     if (msg != null) {
@@ -312,7 +330,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(fake.removeThisDeviceCalls, 1);
-    expect(find.text('Removed this device’s cloud files'), findsOneWidget);
+    // The snackbar now reports what was actually removed rather than asserting
+    // success unconditionally (issue #1032). The fake returns an empty outcome.
+    expect(find.text('Removed 0 files'), findsOneWidget);
   });
 
   testWidgets('Wipe-all confirm (after typing WIPE) calls the notifier', (
@@ -328,7 +348,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(fake.wipeAllCalls, 1);
-    expect(find.text('Wiped all sync data'), findsOneWidget);
+    expect(find.text('Wiped 0 files'), findsOneWidget);
+  });
+
+  testWidgets('a partial wipe says so instead of claiming success', (
+    tester,
+  ) async {
+    // The reported failure mode: the marker listing timed out, files survived,
+    // and the app still said "Wiped all sync data" (issue #1032).
+    final fake = await _pump(tester);
+    fake.cleanupOutcome = const SyncCleanupOutcome(
+      deleted: 400,
+      failed: 3,
+      listIncomplete: true,
+    );
+
+    await tester.tap(find.text('Wipe all sync data on this backend'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'WIPE');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Wipe everything'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('3 could not be deleted'),
+      findsOneWidget,
+      reason: 'the user must learn the backend is not actually clean',
+    );
+    expect(find.textContaining('could not be listed'), findsOneWidget);
   });
 
   testWidgets('cancelling each dialog invokes no notifier action', (

--- a/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/troubleshoot_sync_page_test.dart
@@ -80,8 +80,23 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
 
 /// Pumps the page with [fake] backing syncStateProvider. Returns the fake.
 /// SharedPreferences backs the encryption-status row (preference flag read).
+/// The page is a ListView of tall, wordy tiles and keeps gaining rows (the
+/// device browser landed in #1032). Off-screen ListView children are never
+/// built, so on the default 800x600 surface the last action silently stops
+/// existing and every finder for it reports "found 0". Give the tests room for
+/// the whole page rather than teaching each one to scroll.
+void _useTallSurface(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1000, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+}
+
 Future<_FakeSyncNotifier> _pump(WidgetTester tester) async {
   final fake = _FakeSyncNotifier();
+  _useTallSurface(tester);
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
   await tester.pumpWidget(
@@ -104,6 +119,7 @@ Future<_FakeSyncNotifier> _pump(WidgetTester tester) async {
 /// Pump without a fake notifier, for display-only assertions. Preferences
 /// still need backing (the encryption-status row reads the flag).
 Future<void> _pumpBare(WidgetTester tester) async {
+  _useTallSurface(tester);
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
   await tester.pumpWidget(

--- a/test/features/settings/presentation/s3_config_page_test.dart
+++ b/test/features/settings/presentation/s3_config_page_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
+import 'package:submersion/core/services/sync/sync_cleanup_outcome.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/s3/s3_api_client.dart';
@@ -146,13 +147,20 @@ class _FakeSyncNotifier extends StateNotifier<SyncState>
   Future<void> repairSync() async {}
 
   @override
-  Future<void> removeThisDeviceCloudFiles() async {}
+  Future<SyncCleanupOutcome> removeThisDeviceCloudFiles({
+    SyncCleanupProgress? onProgress,
+  }) async => const SyncCleanupOutcome();
 
   @override
-  Future<void> wipeAllCloudSyncData() async {}
+  Future<SyncCleanupOutcome> wipeAllCloudSyncData({
+    SyncCleanupProgress? onProgress,
+  }) async => const SyncCleanupOutcome();
 
   @override
-  Future<void> rebuildBackendFromThisDevice() async {}
+  Future<void> rebuildBackendFromThisDevice({
+    SyncCleanupProgress? onProgress,
+    void Function()? onPublishStarted,
+  }) async {}
 
   @override
   Future<void> signOut() async {

--- a/test/features/settings/presentation/widgets/sync_maintenance_progress_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/sync_maintenance_progress_dialog_test.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/settings/presentation/widgets/sync_maintenance_progress_dialog.dart';
+
+/// Issue #1032: the destructive Troubleshoot Sync actions ran for minutes in
+/// silence, so the user assumed a hang and killed the app mid-wipe. These tests
+/// pin the three properties that prevent that: it reports, it refuses to be
+/// dismissed, and it always goes away when the work stops.
+void main() {
+  /// Pumps a page with a button that runs [task] behind the progress dialog.
+  Future<void> pumpRunner(
+    WidgetTester tester,
+    Future<void> Function(SyncMaintenanceReporter report) task, {
+    void Function(Object error)? onError,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                try {
+                  await runWithSyncMaintenanceProgress<void>(
+                    context: context,
+                    title: 'Wiping sync data',
+                    task: task,
+                  );
+                } catch (e) {
+                  onError?.call(e);
+                }
+              },
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows the phase and a real file count as work advances', (
+    tester,
+  ) async {
+    late SyncMaintenanceReporter report;
+    final gate = Completer<void>();
+    await pumpRunner(tester, (r) async {
+      report = r;
+      await gate.future;
+    });
+
+    await tester.tap(find.text('go'));
+    await tester.pump();
+
+    expect(
+      find.text('Preparing...'),
+      findsOneWidget,
+      reason: 'the listing that fixes the total is itself a round trip',
+    );
+
+    report(3, 412, 'Deleting');
+    await tester.pump();
+    expect(find.text('Deleting - 3 of 412 files'), findsOneWidget);
+
+    // A phase with nothing countable (the full-library republish) must not
+    // leave a finished-looking bar on screen.
+    report(0, 0, 'Publishing library');
+    await tester.pump();
+    expect(find.text('Publishing library'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('tells the user not to close the app', (tester) async {
+    final gate = Completer<void>();
+    await pumpRunner(tester, (r) => gate.future);
+    await tester.tap(find.text('go'));
+    await tester.pump();
+
+    expect(find.textContaining('Keep the app open'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('refuses to pop while the work is running', (tester) async {
+    final gate = Completer<void>();
+    await pumpRunner(tester, (r) => gate.future);
+    await tester.tap(find.text('go'));
+    await tester.pump();
+
+    // Android back / predictive back while a wipe is half done would leave the
+    // backend in the exact half-cleared state issue #1032 reports.
+    //
+    // Assert on the dialog still being mounted, not on maybePop's return: a
+    // PopScope that BLOCKS a pop still reports true (the request was consumed
+    // rather than bubbled to the system), so the return value cannot tell
+    // "popped" from "refused".
+    await tester.state<NavigatorState>(find.byType(Navigator)).maybePop();
+    // pump, never pumpAndSettle: the bar is indeterminate here and animates
+    // forever, so settling can only time out.
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.textContaining('Keep the app open'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('closes and rethrows when the task fails', (tester) async {
+    Object? seen;
+    await pumpRunner(
+      tester,
+      (r) async => throw StateError('provider offline'),
+      onError: (e) => seen = e,
+    );
+
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(AlertDialog),
+      findsNothing,
+      reason:
+          'a thrown task must never strand the user behind a barrier that '
+          'cannot be dismissed',
+    );
+    expect(seen, isA<StateError>());
+  });
+}

--- a/test/features/settings/presentation/widgets/sync_maintenance_progress_dialog_test.dart
+++ b/test/features/settings/presentation/widgets/sync_maintenance_progress_dialog_test.dart
@@ -110,6 +110,47 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('does not return before the dialog has been popped', (
+    tester,
+  ) async {
+    // Callers show their result snackbar the moment this returns, so the pop
+    // must have been issued first. Note this is the route's completion, not
+    // the end of its exit transition -- a dialog route completes at pop time,
+    // which is why the docstring no longer claims "fully closed".
+    final gate = Completer<void>();
+    var returned = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                await runWithSyncMaintenanceProgress<void>(
+                  context: context,
+                  title: 'Wiping sync data',
+                  task: (r) => gate.future,
+                );
+                returned = true;
+              },
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('go'));
+    await tester.pump();
+    expect(returned, isFalse, reason: 'the task has not finished');
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(returned, isTrue);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
   testWidgets('closes and rethrows when the task fails', (tester) async {
     Object? seen;
     await pumpRunner(

--- a/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
+++ b/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
@@ -153,6 +153,29 @@ void main() {
   });
 
   test(
+    'creating the same tag concurrently returns one tag, never throws',
+    () async {
+      // The incumbent check is an await, so two callers can both pass it; the
+      // loser used to throw on idx_tags_diver_name_unique even though the tag it
+      // asked for now exists (PR #1033 review).
+      final results = await Future.wait([
+        repository.createTag(tagOf('', 'Wreck')),
+        repository.createTag(tagOf('', 'Wreck')),
+        repository.createTag(tagOf('', 'wreck')),
+      ]);
+
+      final all = await repository.getAllTags();
+      expect(all, hasLength(1));
+      expect(
+        results.map((t) => t.id).toSet(),
+        hasLength(1),
+        reason: 'every caller must be handed the same surviving tag',
+      );
+      expect(results.first.id, all.single.id);
+    },
+  );
+
+  test(
     'adding a tag twice concurrently still leaves one junction row',
     () async {
       // The old read-then-insert was racy: two callers could each observe

--- a/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
+++ b/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
@@ -1,0 +1,194 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/tags/domain/entities/tag.dart' as domain;
+
+import '../../../../helpers/test_database.dart';
+
+/// Duplicate-tag guards (issue #1032).
+///
+/// Two producers used to duplicate a dive's tag: a second `tags` row under a
+/// different uuid but the same name, and a second `dive_tags` row for the same
+/// (dive, tag) pair. Both are now blocked by unique indexes, so every writer
+/// has to be conflict-safe -- an unguarded insert would throw instead of
+/// silently duplicating, which is worse.
+void main() {
+  late TagRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = TagRepository();
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  Future<void> insertDiver(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insertOnConflictUpdate(
+          DiversCompanion(
+            id: Value(id),
+            name: Value('Diver $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertDive(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<int> junctionCount(String diveId, String tagId) async {
+    final rows = await (db.select(
+      db.diveTags,
+    )..where((t) => t.diveId.equals(diveId) & t.tagId.equals(tagId))).get();
+    return rows.length;
+  }
+
+  domain.Tag tagOf(String id, String name, {String? diverId}) => domain.Tag(
+    id: id,
+    diverId: diverId,
+    name: name,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  group('fresh database', () {
+    test('carries both tag uniqueness indexes', () async {
+      final rows = await db
+          .customSelect("SELECT name FROM sqlite_master WHERE type = 'index'")
+          .get();
+      final names = rows.map((r) => r.read<String>('name')).toSet();
+      expect(names, contains('idx_tags_diver_name_unique'));
+      expect(names, contains('idx_dive_tags_dive_tag_unique'));
+    });
+  });
+
+  group('getTagByName', () {
+    test('does not throw when two divers share a tag name', () async {
+      // Unscoped lookup across two diver scopes used to hit
+      // getSingleOrNull()'s "too many elements" and surface as the import
+      // wizard's "tagging failed" warning.
+      await insertDiver('d1');
+      await insertDiver('d2');
+      await repository.createTag(tagOf('tag-a', 'Wreck', diverId: 'd1'));
+      await repository.createTag(tagOf('tag-b', 'Wreck', diverId: 'd2'));
+
+      final found = await repository.getTagByName('Wreck');
+      expect(found, isNotNull);
+      expect(found!.id, 'tag-a', reason: 'lowest id wins, deterministically');
+    });
+
+    test('still scopes to the requested diver', () async {
+      await insertDiver('d1');
+      await insertDiver('d2');
+      await repository.createTag(tagOf('tag-a', 'Wreck', diverId: 'd1'));
+      await repository.createTag(tagOf('tag-b', 'Wreck', diverId: 'd2'));
+
+      final found = await repository.getTagByName('Wreck', diverId: 'd2');
+      expect(found?.id, 'tag-b');
+    });
+  });
+
+  group('createTag', () {
+    test('returns the existing tag instead of duplicating the name', () async {
+      await insertDiver('d1');
+      final first = await repository.createTag(
+        tagOf('tag-a', 'Wreck', diverId: 'd1'),
+      );
+      final second = await repository.createTag(
+        tagOf('tag-b', 'wreck', diverId: 'd1'),
+      );
+
+      expect(second.id, first.id);
+      expect((await repository.getAllTags()).length, 1);
+    });
+  });
+
+  group('updateTag', () {
+    test('renaming onto an existing name folds the two together', () async {
+      await insertDiver('d1');
+      await insertDive('dive-1');
+      await repository.createTag(tagOf('tag-a', 'Wreck', diverId: 'd1'));
+      await repository.createTag(tagOf('tag-b', 'Wrek', diverId: 'd1'));
+      await repository.addTagToDive('dive-1', 'tag-b');
+
+      await repository.updateTag(tagOf('tag-b', 'Wreck', diverId: 'd1'));
+
+      expect((await repository.getAllTags()).length, 1);
+      final onDive = await repository.getTagsForDive('dive-1');
+      expect(onDive.map((t) => t.name), ['Wreck']);
+    });
+  });
+
+  group('getOrCreateTag', () {
+    test('is idempotent for the same name', () async {
+      await insertDiver('d1');
+      final a = await repository.getOrCreateTag('Boat', diverId: 'd1');
+      final b = await repository.getOrCreateTag('boat', diverId: 'd1');
+
+      expect(b.id, a.id);
+      expect((await repository.getAllTags()).length, 1);
+    });
+  });
+
+  group('addTagToDive', () {
+    test('adding the same tag twice keeps one junction row', () async {
+      await insertDive('dive-1');
+      await repository.createTag(tagOf('tag-a', 'Wreck'));
+
+      await repository.addTagToDive('dive-1', 'tag-a');
+      await repository.addTagToDive('dive-1', 'tag-a');
+
+      expect(await junctionCount('dive-1', 'tag-a'), 1);
+      expect((await repository.getTagsForDive('dive-1')).length, 1);
+    });
+  });
+
+  group('setTagsForDive', () {
+    test('a repeated tag in the list lands once', () async {
+      await insertDive('dive-1');
+      final tag = await repository.createTag(tagOf('tag-a', 'Wreck'));
+
+      await repository.setTagsForDive('dive-1', [tag, tag]);
+
+      expect(await junctionCount('dive-1', 'tag-a'), 1);
+    });
+  });
+
+  group('bulk dive edits', () {
+    test('bulkAddTags skips a tag the dive already carries', () async {
+      await insertDive('dive-1');
+      await repository.createTag(tagOf('tag-a', 'Wreck'));
+      await repository.addTagToDive('dive-1', 'tag-a');
+
+      await DiveRepository().bulkAddTags(['dive-1'], ['tag-a']);
+
+      expect(await junctionCount('dive-1', 'tag-a'), 1);
+    });
+
+    test('bulkReplaceTags collapses a repeated tag id', () async {
+      await insertDive('dive-1');
+      await repository.createTag(tagOf('tag-a', 'Wreck'));
+
+      await DiveRepository().bulkReplaceTags(['dive-1'], ['tag-a', 'tag-a']);
+
+      expect(await junctionCount('dive-1', 'tag-a'), 1);
+    });
+  });
+}

--- a/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
+++ b/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
@@ -152,6 +152,26 @@ void main() {
     });
   });
 
+  test(
+    'adding a tag twice concurrently still leaves one junction row',
+    () async {
+      // The old read-then-insert was racy: two callers could each observe
+      // "missing" and the loser would throw on the unique index. A single
+      // conflict-aware statement makes the duplicate a true no-op.
+      await insertDive('dive-1');
+      await repository.createTag(tagOf('tag-1', 'Wreck'));
+
+      await Future.wait([
+        repository.addTagToDive('dive-1', 'tag-1'),
+        repository.addTagToDive('dive-1', 'tag-1'),
+        repository.addTagToDive('dive-1', 'tag-1'),
+      ]);
+
+      final rows = await db.select(db.diveTags).get();
+      expect(rows, hasLength(1));
+    },
+  );
+
   group('fresh database', () {
     test('carries both tag uniqueness indexes', () async {
       final rows = await db

--- a/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
+++ b/test/features/tags/data/repositories/tag_duplicate_guard_test.dart
@@ -68,6 +68,90 @@ void main() {
     updatedAt: DateTime(2026, 1, 1),
   );
 
+  // ---- Whitespace variants (PR #1033 review) ----
+  //
+  // The uniqueness slot is (diver scope, case-folded, TRIMMED name). Matching
+  // on a trimmed name while storing the untrimmed one left the exact duplicate
+  // this feature exists to forbid: " Wreck" and "Wreck" are one tag to every
+  // lookup, but were two rows to the index.
+
+  group('whitespace variants are the same tag', () {
+    test('createTag stores the trimmed name', () async {
+      final created = await repository.createTag(tagOf('', '  Wreck  '));
+
+      expect(created.name, 'Wreck');
+      final row = await (db.select(
+        db.tags,
+      )..where((t) => t.id.equals(created.id))).getSingle();
+      expect(
+        row.name,
+        'Wreck',
+        reason: 'what is stored must match what lookups compare against',
+      );
+    });
+
+    test(
+      'a padded name finds the existing tag rather than adding one',
+      () async {
+        await repository.createTag(tagOf('', 'Wreck'));
+
+        final second = await repository.createTag(tagOf('', ' Wreck '));
+        final all = await repository.getAllTags();
+
+        expect(all.where((t) => t.name.trim() == 'Wreck'), hasLength(1));
+        expect(second.name, 'Wreck');
+      },
+    );
+
+    test(
+      'the padded tag is created first, then the bare one folds into it',
+      () async {
+        // Order matters: this is the direction that used to slip through, because
+        // the stored " Wreck" did not case-fold-equal the incoming "Wreck".
+        await repository.createTag(tagOf('', ' Wreck'));
+
+        await repository.createTag(tagOf('', 'Wreck'));
+
+        expect(await repository.getAllTags(), hasLength(1));
+      },
+    );
+
+    test('getTagByName finds a tag through surrounding whitespace', () async {
+      await repository.createTag(tagOf('', 'Wreck'));
+
+      expect(await repository.getTagByName('  Wreck  '), isNotNull);
+    });
+
+    test('the index itself rejects a padded duplicate', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.tags)
+          .insert(
+            TagsCompanion(
+              id: const Value('a'),
+              name: const Value('Wreck'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+
+      await expectLater(
+        db
+            .into(db.tags)
+            .insert(
+              TagsCompanion(
+                id: const Value('b'),
+                name: const Value(' wreck '),
+                createdAt: Value(now),
+                updatedAt: Value(now),
+              ),
+            ),
+        throwsA(anything),
+        reason: 'the database is the backstop when a writer forgets to trim',
+      );
+    });
+  });
+
   group('fresh database', () {
     test('carries both tag uniqueness indexes', () async {
       final rows = await db

--- a/test/helpers/fake_cloud_storage_provider.dart
+++ b/test/helpers/fake_cloud_storage_provider.dart
@@ -40,6 +40,10 @@ class FakeCloudStorageProvider extends CloudStorageProvider
   /// When true, [deleteFile] throws, modelling an offline/denied provider.
   bool failDeletes = false;
 
+  /// When true, [listFiles] throws, modelling the listing timeout that left a
+  /// wipe silently incomplete while the UI still claimed success (issue #1032).
+  bool failLists = false;
+
   /// When true, [downloadFile] throws, modelling a transient read failure.
   bool failDownloads = false;
 
@@ -142,6 +146,9 @@ class FakeCloudStorageProvider extends CloudStorageProvider
     String? namePattern,
   }) async {
     operationLog.add('list');
+    if (failLists) {
+      throw const CloudStorageException('list failed (test)');
+    }
     return _files.entries
         .where((e) => namePattern == null || e.key.contains(namePattern))
         .map(

--- a/test/helpers/fake_cloud_storage_provider.dart
+++ b/test/helpers/fake_cloud_storage_provider.dart
@@ -44,6 +44,19 @@ class FakeCloudStorageProvider extends CloudStorageProvider
   /// wipe silently incomplete while the UI still claimed success (issue #1032).
   bool failLists = false;
 
+  /// When true, every cloud call returns a future that NEVER completes,
+  /// modelling a stalled connection. Callers that run behind a non-dismissible
+  /// UI must bound these themselves or the user is stranded (PR #1033 review).
+  bool hangOperations = false;
+
+  /// When true, only [downloadFile] hangs. Lets a test stall ONE manifest read
+  /// while the folder listing still succeeds.
+  bool hangDownloads = false;
+
+  /// A future that never completes and schedules no timer, so a test can await
+  /// a caller's own timeout without leaving pending timers behind.
+  Future<T> _hang<T>() => Completer<T>().future;
+
   /// When true, [downloadFile] throws, modelling a transient read failure.
   bool failDownloads = false;
 
@@ -103,6 +116,7 @@ class FakeCloudStorageProvider extends CloudStorageProvider
   }) async {
     operationLog.add('upload:$filename');
     uploadAttempts++;
+    if (hangOperations) return _hang<UploadResult>();
     if (failUploads) {
       throw const CloudStorageException('upload failed (test)');
     }
@@ -118,6 +132,7 @@ class FakeCloudStorageProvider extends CloudStorageProvider
 
   @override
   Future<Uint8List> downloadFile(String fileId) async {
+    if (hangOperations || hangDownloads) return _hang<Uint8List>();
     if (failDownloads) {
       throw const CloudStorageException('download failed (test)');
     }
@@ -146,6 +161,7 @@ class FakeCloudStorageProvider extends CloudStorageProvider
     String? namePattern,
   }) async {
     operationLog.add('list');
+    if (hangOperations) return _hang<List<CloudFileInfo>>();
     if (failLists) {
       throw const CloudStorageException('list failed (test)');
     }
@@ -165,6 +181,7 @@ class FakeCloudStorageProvider extends CloudStorageProvider
   @override
   Future<void> deleteFile(String fileId) async {
     operationLog.add('delete:$fileId');
+    if (hangOperations) return _hang<void>();
     if (failDeletes) {
       throw const CloudStorageException('delete failed (test)');
     }

--- a/test/support/fake_cloud_storage_provider.dart
+++ b/test/support/fake_cloud_storage_provider.dart
@@ -9,6 +9,12 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 /// just-written file invisible to listFiles for N calls) to exercise the
 /// eventual-consistency / transient-missing paths in later phases.
 class FakeCloudStorageProvider implements CloudStorageProvider {
+  /// When set, uploads beyond this many calls throw. Models an app killed or a
+  /// connection dropped in the middle of a large base publish.
+  int? failUploadsAfter;
+
+  /// Total uploadFile calls, including the ones that threw.
+  int uploadCount = 0;
   FakeCloudStorageProvider({this.providerId = 's3', this.listLagCalls = 0});
 
   @override
@@ -57,6 +63,11 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
     String filename, {
     String? folderId,
   }) async {
+    // Models an upload dying partway through a multi-part base: the parts
+    // before the cut land, everything after throws (issue #1032 resume tests).
+    if (failUploadsAfter != null && ++uploadCount > failUploadsAfter!) {
+      throw const CloudStorageException('upload interrupted (test)');
+    }
     final key = _key(folderId, filename);
     _files[key] = Uint8List.fromList(data);
     _modified[key] = ++_clock;

--- a/test/support/fake_cloud_storage_provider.dart
+++ b/test/support/fake_cloud_storage_provider.dart
@@ -63,9 +63,13 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
     String filename, {
     String? folderId,
   }) async {
+    // Counted BEFORE the guard: `&&` short-circuits, so folding the increment
+    // into the condition only counted uploads while a failure was being
+    // simulated, contradicting this counter's contract (PR #1033 review).
+    uploadCount++;
     // Models an upload dying partway through a multi-part base: the parts
     // before the cut land, everything after throws (issue #1032 resume tests).
-    if (failUploadsAfter != null && ++uploadCount > failUploadsAfter!) {
+    if (failUploadsAfter != null && uploadCount > failUploadsAfter!) {
       throw const CloudStorageException('upload interrupted (test)');
     }
     final key = _key(folderId, filename);


### PR DESCRIPTION
Fixes #1032.

## What happened

The reporter ran **Wipe all sync data** on Dropbox, and sync never worked again. Their two logs explain the whole sequence:

| Evidence | Reading |
|---|---|
| ~500 deletes at ~0.55s each, 18:41 → 18:47 | The wipe ran **6.5 minutes** behind a live page with no spinner and no counts |
| `log1:520` `Could not list markers for full sync wipe: TimeoutException` | The wipe finished **incompletely** — and still reported "Wiped all sync data" |
| `log1:523` epoch marker written 18:48:52, then no result line ever | The follow-up sync began republishing the entire library |
| `log2` base parts `p0000`–`p0079` | That base is 80 parts, roughly **640 MB** |
| `log1:530` notification service re-init at 18:51:23 | **The user restarted the app mid-publish** |
| `log2:113-118` "Already syncing" for 4+ minutes | Same stall, reproducible |

Sync was not broken so much as it could never *finish*. A wiped backend forces the whole library out as one fresh base; that upload was silent and not resumable, so a progress bar frozen at 80% invited exactly the restart that threw the transfer away. Each attempt began again at part 0.

## The four changes

**1. Progress and honest outcomes.** `SyncCleanupOutcome` replaces the `void` returns on the cloud-cleanup calls, which are best-effort by design — callers must now check `isComplete` before claiming success, so a timed-out listing can no longer be reported as a clean wipe. The delete loops take their whole listing up front to report `(done, total)` per file, `BasePartFileSource.uploadAll` ticks per part, and the destructive actions run behind a non-dismissible `PopScope` dialog that says to keep the app open.

**2. Resumable base publish.** An export is parked in application support — **not** the temp dir, which iOS, Android and macOS all purge under pressure, precisely the window this has to survive — with a sidecar recording the seq, epoch, nonce and watermark. The next publish continues it, keeping the same seq so uploaded parts are not orphaned.

Two things are deliberately *not* recorded. **Which parts landed** is not: filenames encode `(device, seq, index)`, so the cloud answers exactly, and local bookkeeping could only disagree with the bytes actually there. **Checksums** are not: skipped parts are still read and hashed, so the manifest always describes the bytes on disk now — recorded checksums would certify a file that had since been truncated.

**3. Per-device footprint browser.** The reporter had one syncing device and 400+ files, with nothing in the app able to account for them; the all-or-nothing wipe was their only recourse. The new page groups every file by the device id in its name, so it covers devices sync itself skips — stale-epoch leftovers, retired peers, and publishes with no readable manifest — and separates "safe to delete" from "still syncing" from "unfinished upload", each with its own confirmation.

Removal deliberately does not reuse `deleteDeviceSyncFile`, which writes no retirement marker. That is correct only for retiring this install's own identity; removing a *peer* unfenced means its stale rows resurrect fleet-wide if it ever returns. `retirePeer` writes the marker first, refuses to delete at all if the marker cannot be written, and never deletes the marker.

**4. Duplicate tags (schema v149).** The reporter's other symptom: after Windows pulled the library, dives carried the same `<Computer> Import <date>` tag several times. `tags` had no unique index on name, so sync's upsert-by-primary-key landed a peer's row beside the local one; `dive_tags` had none on `(dive_id, tag_id)`, so junction rows duplicated too.

v149 collapses both then adds the indexes, in the only order that leaves no ties (repoint → drop losers → collapse junction dupes → create indexes), with total-order tie-breaks so nothing can survive to abort index creation. The tags index is on `(COALESCE(diver_id,''), lower(name))` — a plain `(diver_id, name)` index would not constrain null-diver rows at all, since SQLite treats NULLs as distinct, and those are exactly the rows an importer creates before a diver is resolved.

Because a unique index turns every previously-silent duplicate insert into a throw — and a throw inside the sync merge is far worse than the duplicate — every writer is now conflict-safe. The merge folds rivals on the **lexically lowest id**: a property of the rows rather than of the device, so two devices cannot flip-flop adopting each other's id, and a device healed by migration agrees with one healed by merge.

This also fixes `getTagByName` throwing "too many elements" once duplicates existed, which appeared in the log as the wizard's non-fatal "tagging failed".

## Testing

Full suite: **17538 passed, 17 skipped, 0 failed.** `flutter analyze` reports no issues; `dart format` is clean.

New coverage includes the wipe progress/outcome contract, the dialog's refusal to pop and its behaviour when a task throws, store/writer resume semantics (including that a truncated export fails verification rather than being certified), marker-before-delete ordering for peer retirement, the v149 migration against a DB seeded with duplicates, and a two-device round trip where both independently create the same tag name. The tag merge fix was mutation-verified: reverting it to a plain primary-key upsert fails the cross-device cases.

## Notes for review

- **These strings are unlocalized English.** `TroubleshootSyncPage` was already almost entirely hardcoded English, so I matched the page rather than half-localizing it. Given the reporter is a German speaker, localizing this page is worth a follow-up — roughly 15 ARB keys across 12 locales, which I would rather not bundle into a bug fix.
- **The resumable-publish directory is not self-reclaiming.** Nothing purges application support, so every exit path from a publish discards its record, and `find()` prunes anything unusable (missing, wrong size, superseded epoch) as it passes.
- **The tag alias map is per-serializer-instance.** A junction row whose tag row was folded away in an *earlier* sync run can dangle; the existing `repairDanglingForeignKeys` pass deletes it rather than failing the sync, and the peer's repoint-and-republish restores it. A durable alias table would have meant new sync surface — exporters, `deleteAllRecords`, adopt — for a narrow race.
