### PR TITLE
fix(dive-computer): stop logging phantom 0 m samples on Divesoft Liberty

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -54,6 +54,12 @@ typedef struct {
     libdc_parsed_dive_t *dive;
     int has_pending_sample;
     unsigned int current_gasmix;  // active gas index, carried across samples
+    // Deco obligation, likewise carried: it is state the computer holds, not a
+    // reading it retakes, so it stands until the computer reports a new one.
+    unsigned int current_deco_type;
+    unsigned int current_deco_time;
+    double current_deco_depth;
+    unsigned int current_deco_tts;
     libdc_sample_t current_sample;
     // GPS reported as profile samples (see DC_SAMPLE_LOCATION below). Fixes
     // are only collected here and resolved once the whole profile has been
@@ -207,7 +213,13 @@ static void sample_callback(dc_sample_type_t type,
         push_sample(state);
         state->has_pending_sample = 1;
         state->current_sample.time_ms = value->time;
-        state->current_sample.depth = 0.0;
+        // NAN, not 0.0: libdivecomputer opens a sample for every timestamp in
+        // the log, and several families stamp records that carry no depth
+        // (Divesoft logs O2-cell, battery, GPS and tissue records on their own
+        // second). Defaulting to 0.0 turned every one of those into a sample at
+        // the surface. fill_missing_depths() resolves the NANs once the whole
+        // profile is known -- no NAN depth ever leaves this file.
+        state->current_sample.depth = NAN;
         state->current_sample.temperature = NAN;
         state->current_sample.pressure = NAN;
         state->current_sample.tank = UINT32_MAX;
@@ -222,10 +234,15 @@ static void sample_callback(dc_sample_type_t type,
         }
         state->current_sample.cns = NAN;
         state->current_sample.rbt = UINT32_MAX;
-        state->current_sample.deco_type = UINT32_MAX;
-        state->current_sample.deco_time = 0;
-        state->current_sample.deco_depth = NAN;
-        state->current_sample.deco_tts = UINT32_MAX;
+        // Carry the deco state forward for the same reason as the gas: a
+        // record that carries no deco field is not the computer saying the
+        // obligation cleared. Divesoft reports deco only on its POINT_1
+        // records, so resetting here dropped the diver out of deco on every
+        // other sample and hid the deco stop entirely.
+        state->current_sample.deco_type = state->current_deco_type;
+        state->current_sample.deco_time = state->current_deco_time;
+        state->current_sample.deco_depth = state->current_deco_depth;
+        state->current_sample.deco_tts = state->current_deco_tts;
         break;
     case DC_SAMPLE_DEPTH:
         state->current_sample.depth = value->depth;
@@ -271,6 +288,10 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.rbt = value->rbt;
         break;
     case DC_SAMPLE_DECO:
+        state->current_deco_type = value->deco.type;
+        state->current_deco_time = value->deco.time;
+        state->current_deco_depth = value->deco.depth;
+        state->current_deco_tts = value->deco.tts;
         state->current_sample.deco_type = value->deco.type;
         state->current_sample.deco_time = value->deco.time;
         state->current_sample.deco_depth = value->deco.depth;
@@ -305,6 +326,65 @@ static void sample_callback(dc_sample_type_t type,
         break;
     default:
         break;
+    }
+}
+
+// Resolve the depths left as NAN by the profile walk (see DC_SAMPLE_TIME).
+// Must run after the final push_sample(), because a gap is filled from the
+// samples on both sides of it.
+//
+// Depth is the one sample field with no null representation downstream
+// (ProfileSample.depthMeters is non-nullable, and dive_profiles.depth is
+// written unconditionally), so a value has to be chosen here. Linear
+// interpolation in time is the honest one: it keeps the diver on the path the
+// computer actually recorded between the two depths it reported. Repeating the
+// previous depth instead would flatten the trace and then jump, and the
+// ascent-rate calculator smooths over a ~15 s window -- one such step becomes a
+// sustained false rate spread across it, which is exactly how a fabricated
+// sample turns into a rapid-ascent safety finding.
+static void fill_missing_depths(sample_state_t *state) {
+    libdc_parsed_dive_t *dive = state->dive;
+    unsigned int count = dive->sample_count;
+    unsigned int prev = UINT32_MAX;  // last sample with a reported depth
+
+    for (unsigned int i = 0; i < count; i++) {
+        if (isnan(dive->samples[i].depth)) {
+            continue;
+        }
+        if (prev == UINT32_MAX) {
+            // Leading gap: nothing earlier to interpolate from, so hold the
+            // first reported depth. The dive starts at the surface anyway.
+            for (unsigned int j = 0; j < i; j++) {
+                dive->samples[j].depth = dive->samples[i].depth;
+            }
+        } else {
+            unsigned int t0 = dive->samples[prev].time_ms;
+            unsigned int t1 = dive->samples[i].time_ms;
+            double d0 = dive->samples[prev].depth;
+            double d1 = dive->samples[i].depth;
+            for (unsigned int j = prev + 1; j < i; j++) {
+                double fraction = t1 > t0
+                    ? (double)(dive->samples[j].time_ms - t0) / (double)(t1 - t0)
+                    : 0.0;
+                dive->samples[j].depth = d0 + (d1 - d0) * fraction;
+            }
+        }
+        prev = i;
+    }
+
+    if (prev == UINT32_MAX) {
+        // The computer reported no depth anywhere in this profile. Nothing can
+        // be inferred, but a NAN must not escape: it would reach the platform
+        // layers as a null depth or a broken chart axis.
+        for (unsigned int i = 0; i < count; i++) {
+            dive->samples[i].depth = 0.0;
+        }
+        return;
+    }
+
+    // Trailing gap: hold the last reported depth.
+    for (unsigned int i = prev + 1; i < count; i++) {
+        dive->samples[i].depth = dive->samples[prev].depth;
     }
 }
 
@@ -467,10 +547,14 @@ static int extract_dive_fields(dc_parser_t *parser, libdc_parsed_dive_t *dive) {
     sample_state_t sample_state = {0};
     sample_state.dive = dive;
     sample_state.current_gasmix = UINT32_MAX;  // 0 is a valid gas index
+    sample_state.current_deco_type = UINT32_MAX;  // no obligation reported yet
+    sample_state.current_deco_depth = NAN;
+    sample_state.current_deco_tts = UINT32_MAX;
     sample_state.has_field_entry = has_field_entry;
     sample_state.has_field_exit = has_field_exit;
     dc_parser_samples_foreach(parser, sample_callback, &sample_state);
     push_sample(&sample_state);
+    fill_missing_depths(&sample_state);
     resolve_sample_locations(&sample_state);
 
     return 0;

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -135,6 +135,10 @@ typedef struct {
 
 typedef struct {
     unsigned int time_ms;      // milliseconds since dive start
+    // Always finite -- depth has no "unavailable" sentinel, unlike every other
+    // field here. Samples the computer logged without a depth are filled in
+    // from their neighbours before this struct is returned (fill_missing_depths
+    // in libdc_download.c).
     double depth;              // meters
     double temperature;        // celsius (NAN if unavailable)
     double pressure;           // bar (NAN if unavailable)

--- a/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
+++ b/packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c
@@ -3,6 +3,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libdivecomputer/parser.h>
+#include "checksum.h"
 #include "libdc_wrapper.h"
 
 /* Load a binary file into a malloc'd buffer. On success returns the byte count
@@ -358,6 +360,246 @@ static void test_parse_ratio_ix3m_late_fix_is_exit(void) {
     free(blob);
 }
 
+/* --- Divesoft Liberty synthetic dive --------------------------------------
+   The Divesoft log is a stream of 16-byte records, each stamped with its own
+   second. Only LREC_POINT records carry a depth; measurement records (O2
+   cells, battery, AI pressure, GPS) and tissue-state records advance the clock
+   without one. libdivecomputer opens a new sample for every distinct
+   timestamp, so a second holding only a measurement record reaches the wrapper
+   as DC_SAMPLE_TIME with no DC_SAMPLE_DEPTH behind it. A CCR like the Liberty
+   logs those constantly. Layout constants mirror divesoft_freedom_parser.c. */
+
+#define DS_HEADER_SIZE 64
+#define DS_RECORD_SIZE 16
+#define DS_SIGNATURE_V2 0x45566944 /* "DiVE" */
+#define DS_LREC_POINT 0
+#define DS_LREC_MEASURE 7
+#define DS_POINT_1 0
+#define DS_MEASURE_ID_BATTERY 1
+#define DS_MEASURE_ID_GPS 4
+#define DS_STMODE_CCR 2
+#define DIVESOFT_LIBERTY_MODEL 10
+
+/* Record header word: type in bits 0-3, timestamp in bits 4-20, id in 21-30. */
+static unsigned int ds_flags(unsigned int type, unsigned int timestamp,
+                             unsigned int id) {
+    return (type & 0x0F) | ((timestamp & 0x1FFFF) << 4) | ((id & 0x3FF) << 21);
+}
+
+static unsigned char *ds_record(unsigned char *blob, unsigned int idx) {
+    return blob + DS_HEADER_SIZE + idx * DS_RECORD_SIZE;
+}
+
+static void ds_put_header(unsigned char *blob, unsigned int divetime_s,
+                          unsigned int maxdepth_cm) {
+    put_u32le(blob + 0, DS_SIGNATURE_V2);
+    put_u32le(blob + 12, divetime_s);
+    blob[18] = DS_STMODE_CCR;
+    put_u16le(blob + 24, 200);          /* minimum temperature, 0.1 C */
+    put_u16le(blob + 28, maxdepth_cm);
+    put_u16le(blob + 32, 1013);         /* surface pressure, mbar */
+    put_u16le(blob + 38, maxdepth_cm / 2);
+    put_u16le(blob + 4, checksum_crc16r_ansi(blob + 6, DS_HEADER_SIZE - 6,
+                                             0xFFFF, 0x0000));
+}
+
+/* A general log record: depth, plus the deco state carried by POINT_1. */
+static void ds_put_point(unsigned char *blob, unsigned int idx,
+                         unsigned int time_s, unsigned int depth_cm,
+                         unsigned int ceiling_cm, unsigned int ndl_min) {
+    unsigned char *rec = ds_record(blob, idx);
+    put_u32le(rec + 0, ds_flags(DS_LREC_POINT, time_s, DS_POINT_1));
+    put_u16le(rec + 4, depth_cm);
+    put_u16le(rec + 6, 0);  /* ppO2 */
+    /* misc: NDL in bits 0-9, TTS in 10-19, temperature (0.1 C) in 20-29. */
+    put_u32le(rec + 8, (ndl_min & 0x3FF) | ((200u & 0x3FF) << 20));
+    put_u16le(rec + 12, ceiling_cm);
+}
+
+/* A measurement record the parser reads no sample values from: it only moves
+   the clock, which is exactly the case that used to fabricate a 0 m sample. */
+static void ds_put_measure_battery(unsigned char *blob, unsigned int idx,
+                                   unsigned int time_s) {
+    unsigned char *rec = ds_record(blob, idx);
+    put_u32le(rec + 0, ds_flags(DS_LREC_MEASURE, time_s, DS_MEASURE_ID_BATTERY));
+}
+
+/* Seconds logged without a depth must be filled from the surrounding samples,
+   never reported as 0 m. A fabricated surface sample mid-dive both draws a
+   spike to the surface on the profile and, because the ascent-rate smoother
+   spreads it across a 15 s window, invents rapid-ascent violations. The deco
+   state is likewise only reported on POINT_1 records and has to persist across
+   the gap, or the dive stops showing as being in deco. */
+static void test_parse_divesoft_liberty_depth_gap(void) {
+    const unsigned int nrecords = 6;
+    const unsigned int size = DS_HEADER_SIZE + nrecords * DS_RECORD_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    ds_put_header(blob, 20, 2000);
+    ds_put_point(blob, 0, 0, 0, 0, 99);        /* surface, no deco */
+    ds_put_point(blob, 1, 10, 1000, 300, 0);   /* 10 m, deco stop at 3 m */
+    ds_put_measure_battery(blob, 2, 11);       /* no depth, no deco */
+    ds_put_point(blob, 3, 12, 1200, 300, 0);   /* 12 m */
+    ds_put_measure_battery(blob, 4, 13);       /* no depth, no deco */
+    ds_put_point(blob, 5, 20, 2000, 300, 0);   /* 20 m */
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Divesoft", "Liberty", DIVESOFT_LIBERTY_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    if (rc != 0) {
+        fprintf(stderr, "FAIL: parse returned %d: %s\n", rc, err);
+        free(blob);
+        assert(0 && "libdc_parse_raw_dive failed for Divesoft Liberty");
+    }
+
+    assert(result.sample_count == 6);
+    assert(result.samples[2].time_ms == 11000);
+    assert(result.samples[4].time_ms == 13000);
+
+    /* Interpolated from the neighbouring points, not zeroed: 10 m -> 12 m over
+       two seconds puts the missing second at 11 m, and 12 m -> 20 m over eight
+       seconds puts the next one at 13 m. */
+    assert(fabs(result.samples[2].depth - 11.0) < 1e-6);
+    assert(fabs(result.samples[4].depth - 13.0) < 1e-6);
+
+    /* Reported depths stay untouched. */
+    assert(fabs(result.samples[1].depth - 10.0) < 1e-6);
+    assert(fabs(result.samples[3].depth - 12.0) < 1e-6);
+    assert(fabs(result.samples[5].depth - 20.0) < 1e-6);
+
+    /* Deco obligation persists across the gap. */
+    assert(result.samples[2].deco_type == DC_DECO_DECOSTOP);
+    assert(fabs(result.samples[2].deco_depth - 3.0) < 1e-6);
+    assert(result.samples[4].deco_type == DC_DECO_DECOSTOP);
+
+    /* ...but is not invented before the computer first reports one. */
+    assert(result.samples[0].deco_type == DC_DECO_NDL);
+
+    printf("PASS: test_parse_divesoft_liberty_depth_gap\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* Gaps at the ends of the profile have only one neighbour to work from, so
+   they hold that neighbour's depth. A dive whose log opens or closes with a
+   measurement record must not begin or end with a phantom 0 m sample. */
+static void test_parse_divesoft_liberty_edge_gaps(void) {
+    const unsigned int nrecords = 4;
+    const unsigned int size = DS_HEADER_SIZE + nrecords * DS_RECORD_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    ds_put_header(blob, 30, 1800);
+    ds_put_measure_battery(blob, 0, 0);        /* leading gap */
+    ds_put_point(blob, 1, 10, 1500, 0, 5);     /* 15 m */
+    ds_put_point(blob, 2, 20, 1800, 0, 5);     /* 18 m */
+    ds_put_measure_battery(blob, 3, 30);       /* trailing gap */
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Divesoft", "Liberty", DIVESOFT_LIBERTY_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(result.sample_count == 4);
+    assert(fabs(result.samples[0].depth - 15.0) < 1e-6);
+    assert(fabs(result.samples[3].depth - 18.0) < 1e-6);
+
+    printf("PASS: test_parse_divesoft_liberty_edge_gaps\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* A profile that never reports a depth has nothing to interpolate from. It
+   must still produce finite depths -- NAN is an internal marker, and letting
+   one reach the platform layers would store a NULL depth or crash a chart. */
+static void test_parse_divesoft_liberty_no_depth_at_all(void) {
+    const unsigned int nrecords = 2;
+    const unsigned int size = DS_HEADER_SIZE + nrecords * DS_RECORD_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    ds_put_header(blob, 10, 0);
+    ds_put_measure_battery(blob, 0, 0);
+    ds_put_measure_battery(blob, 1, 10);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Divesoft", "Liberty", DIVESOFT_LIBERTY_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(result.sample_count == 2);
+    for (unsigned int i = 0; i < result.sample_count; i++) {
+        assert(!isnan(result.samples[i].depth));
+        assert(result.samples[i].depth == 0.0);
+    }
+
+    printf("PASS: test_parse_divesoft_liberty_no_depth_at_all\n");
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
+/* The Liberty logs a satellite fix as a measurement record inside the profile
+   (DC_SAMPLE_LOCATION), the same channel as Ratio, OSTC 4 and Halcyon, and
+   never as DC_FIELD_LOCATION. Coordinates are microdegrees. */
+static void ds_put_measure_gps(unsigned char *blob, unsigned int idx,
+                               unsigned int time_s, int latitude_e6,
+                               int longitude_e6) {
+    unsigned char *rec = ds_record(blob, idx);
+    put_u32le(rec + 0, ds_flags(DS_LREC_MEASURE, time_s, DS_MEASURE_ID_GPS));
+    put_u32le(rec + 4, (unsigned int)latitude_e6);
+    put_u32le(rec + 8, (unsigned int)longitude_e6);
+}
+
+/* A Liberty's GPS fixes must reach the dive-level entry/exit positions, which
+   is what dive-site matching reads. This is the same wiring issue #926 fixed
+   for Ratio; the Divesoft family shares it. */
+static void test_parse_divesoft_liberty_gps(void) {
+    const unsigned int nrecords = 5;
+    const unsigned int size = DS_HEADER_SIZE + nrecords * DS_RECORD_SIZE;
+    unsigned char *blob = (unsigned char *)calloc(1, size);
+    assert(blob != NULL);
+
+    ds_put_header(blob, 20, 2000);
+    ds_put_measure_gps(blob, 0, 0, 36040000, 14320000);
+    ds_put_point(blob, 1, 0, 0, 0, 99);
+    ds_put_point(blob, 2, 10, 2000, 0, 20);
+    ds_put_measure_gps(blob, 3, 19, 36045000, 14325000);
+    ds_put_point(blob, 4, 20, 100, 0, 99);
+
+    libdc_parsed_dive_t result;
+    char err[256] = {0};
+
+    int rc = libdc_parse_raw_dive("Divesoft", "Liberty", DIVESOFT_LIBERTY_MODEL,
+                                  blob, size, &result, err, sizeof(err));
+    assert(rc == 0);
+
+    assert(fabs(result.entry_latitude - 36.04) < 1e-7);
+    assert(fabs(result.entry_longitude - 14.32) < 1e-7);
+    assert(fabs(result.exit_latitude - 36.045) < 1e-7);
+    assert(fabs(result.exit_longitude - 14.325) < 1e-7);
+
+    printf("PASS: test_parse_divesoft_liberty_gps (entry=%.5f,%.5f exit=%.5f,%.5f)\n",
+           result.entry_latitude, result.entry_longitude,
+           result.exit_latitude, result.exit_longitude);
+
+    free(result.samples);
+    free(result.events);
+    free(blob);
+}
+
 int main(void) {
     test_null_args();
     test_load_fixture_missing();
@@ -368,6 +610,10 @@ int main(void) {
     test_parse_ratio_ix3m_null_island_ignored();
     test_parse_ratio_ix3m_returns_to_entry();
     test_parse_ratio_ix3m_late_fix_is_exit();
+    test_parse_divesoft_liberty_depth_gap();
+    test_parse_divesoft_liberty_edge_gaps();
+    test_parse_divesoft_liberty_no_depth_at_all();
+    test_parse_divesoft_liberty_gps();
     printf("\nAll parse_raw_dive tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

A Divesoft Liberty owner reported on ScubaBoard that a desktop download shows "the depth jumping to 0 all the time and therefore also not recognizing deco". The Divesoft parser is fine; the wrapper's sample handling is not.

`dc_parser_samples_foreach` is a delta stream: `DC_SAMPLE_TIME` separates records and every other callback fires only for the fields that exist at that timestamp. `sample_callback` reset each new sample to an "unavailable" sentinel (`NAN` / `UINT32_MAX`) for every field **except depth, which reset to a real `0.0` m** — there is no null depth to fall back on, since `ProfileSample.depthMeters` and `dive_profiles.depth` are non-nullable. So "unknown" was stored as "at the surface".

Divesoft's log is 16-byte records each stamped with its own second, and only `LREC_POINT` records carry depth (`divesoft_freedom_parser.c:911`). `LREC_MEASURE` (O2 cells, battery, AI pressure, GPS), `LREC_STATE` (tissue saturation — emits nothing at all) and event records still advance the clock. Every second holding one of those and no point record became a phantom surface sample. A CCR like the Liberty writes them constantly, which is why the profile is shredded rather than occasionally notched.

The deco half is the same defect: `DC_SAMPLE_DECO` is emitted only on `POINT_1` records (`:923-946`), so those interleaved rows also reset `deco_type` and read as "not in deco" — and `instrument_sample.dart:83` is `inDeco: point.decoType == 2`.

This is not Divesoft-only. Any family that logs mixed record types on distinct seconds hits it; Divesoft is simply the one that does it on nearly every second.

## Changes

- `libdc_download.c`: unreported depth is marked `NAN` during the profile walk, and a new `fill_missing_depths()` pass resolves every marker after the final `push_sample()` — linear interpolation in time between the surrounding reported depths, held flat past either end, `0.0` only when a profile reports no depth anywhere. No `NAN` depth leaves the C layer, so the four platform marshallers and the non-nullable pigeon contract are untouched.
- Interpolation rather than repeating the previous depth is deliberate: `AscentRateCalculator` smooths over a ~15 s centred window, so a flat run followed by a step becomes a sustained false rate spread across that window — the exact mechanism that turns a fabricated sample into a rapid-ascent safety finding.
- `libdc_download.c`: the deco obligation is now carried forward the way the active gas index already was. A record with no deco field is not the computer clearing the stop, and every libdivecomputer parser that emits deco also emits an explicit `DC_DECO_NDL` when it clears, so the carried state is always superseded rather than sticking.
- `libdc_wrapper.h`: document that `depth` is always finite, unlike every other field in `libdc_sample_t`.
- `test_parse_raw_dive.c`: four native regression tests over synthetic Divesoft blobs — gap interpolation with deco persistence, leading/trailing edge gaps, a profile with no depth at all, and Liberty GPS reaching the dive-level entry/exit positions.

One file covers every platform (iOS symlinks it; Android/Linux/Windows compile the same path), and `extract_dive_fields` is the shared choke point for both download and re-parse — so **dives already downloaded with the zero rows repair via "Re-parse raw data"**, without re-downloading from the computer.

The same reporter also asked whether the Liberty's GPS fixes can match or create dive sites. That already works — the Divesoft family reports fixes as `DC_SAMPLE_LOCATION`, handled since #945/#951 (`fixes #926`), and `site_matching_service.dart` matches on `entryLocation ?? exitLocation` or creates a site. It merged after `v1.7.2.4977`, so it is unreleased rather than missing. `test_parse_divesoft_liberty_gps` pins that path for this family specifically.

## Test Plan

- [x] `flutter analyze` passes (`No issues found!`, run in the worktree)
- [x] Native suite passes: `100% tests passed out of 8` via `ctest` on `packages/libdivecomputer_plugin/test/native`, including the four new cases
- [x] `test_parse_divesoft_liberty_depth_gap` fails on `main` with depth `0.0` where `11.0` is expected — it reproduces the reported screenshot before it guards it
- [x] The real-hardware Cressi Leonardo fixture (159 samples) parses unchanged, guarding families that report a depth on every sample
- [ ] Manual testing on: not run against Liberty hardware — no device available; the synthetic blobs exercise the same parser and wrapper path

Build/run the native tests with:

```
cmake -S packages/libdivecomputer_plugin/test/native -B build/native
cmake --build build/native -j 8 && ctest --test-dir build/native --output-on-failure
```

No Dart changed, so the pre-push hook skipped the local test stage; CI runs the full suite.
