### PR TITLE
fix(uddf): import float-formatted integers and after-dive lead weight

### DIFF
--- a/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
+++ b/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
@@ -1,0 +1,160 @@
+# UDDF float-formatted integers and misplaced lead weight
+
+Date: 2026-08-14
+Status: implemented
+Reported by: Jim Nowak (email, no GitHub access)
+
+## Problem
+
+A UDDF file exported from Oceanic Plus (Oceanic's iPhone app, recording from
+an Apple Watch Ultra) imported with every profile waypoint stamped at time
+zero, so the depth/time graph drew all samples stacked in a single column.
+
+The reporter diagnosed it correctly: Oceanic writes `<divetime>` values with
+float formatting (`15.0`) rather than plain integers (`15`), and stripping
+`.0` from the file made the graph render.
+
+Inspecting the file against the parser confirmed the cause and found two
+further losses in the same export.
+
+### Root cause
+
+`int.tryParse` in Dart rejects any decimal point outright. Every UDDF field
+with integer semantics was parsed with it, so a float-formatted value
+returned null and fell through to whatever default the call site had:
+
+| Field | Call site | Result before fix |
+| --- | --- | --- |
+| `divetime` | `uddf_full_import_service.dart:1571` | `?? 0` — all 2,652 waypoints stamped t=0 |
+| `diveduration` | `uddf_full_import_service.dart:1943` | no fallback — runtime dropped entirely |
+
+A third loss was structural rather than numeric. `<leadquantity>` was read
+only from `<informationbeforedive><equipmentused>`, and Oceanic places
+`<equipmentused>` in `<informationafterdive>`. Lead weight was silently
+discarded on every dive.
+
+All twelve dives in the reporter's file were affected by all three.
+
+## Why not an Oceanic dialect
+
+The codebase already has a dialect mechanism (`UddfNormalizer` +
+`UddfDialect`), and `MacDiveDialect` regex-strips `.0` from exactly these
+fields. Adding an `OceanicDialect` was considered and rejected:
+
+1. **The fingerprint is weak and fails silently.** Oceanic's `<generator>`
+   block has no `<name>` child. The only distinguishing string is a homepage
+   URL that carries a locale segment
+   (`https://www.oceanicworldwide.com/it/oceanic-plus/`), so it varies by
+   user and can change without notice. A dialect that fails to detect
+   reintroduces the bug with no error.
+2. **It rewrites a file that mostly works.** `normalizeXml` reparses,
+   mutates and re-serializes the whole document, adding regression surface
+   to the parts that already import correctly, to fix a strict-parse issue
+   at two call sites.
+3. **It does not address the defect.** The parser was stricter than its
+   input. Float-formatted integers are a routine JavaScript serialization
+   artifact — Oceanic also emits `<datetime>...619Z</datetime>` and
+   `<tankpressurebegin>2.2E7</tankpressurebegin>` — and two independent
+   vendors have now hit it. A third would need a third dialect.
+4. **Larger test surface, narrower coverage.** Dialects need detection tests
+   against every other vendor; lenient parsing needs one helper test.
+
+Dialects remain the right tool for genuine semantic conflicts, where the
+same element means different things depending on who wrote the file.
+Nothing in the Oceanic export is that.
+
+### Detection tripwire found while evaluating this
+
+`MacDiveDialect._hasMacDiveStructuralQuirks` fingerprints on
+`<equipmentused>` nested inside `<informationafterdive>` — which Oceanic
+also does. The only thing preventing MacDiveDialect from claiming Oceanic
+files today is that Oceanic emits a `<generator>` element, which
+short-circuits detection to the name check before the structural fallback
+runs. If Oceanic ever drops that block, MacDive semantics would be applied
+to Oceanic exports. A regression test now pins this.
+
+## Design
+
+Two vendor-agnostic changes. Neither requires the file to be attributed to
+a known exporter, so neither can fail silently on an export whose generator
+block changes.
+
+### 1. Lenient integer parsing
+
+`UddfImportParsers.parseUddfInt(String?)` accepts plain integers, float
+formatting, exponent notation and surrounding whitespace; rounds genuinely
+fractional input to nearest; returns null for null, blank, non-numeric and
+non-finite input.
+
+The finiteness guard is load-bearing rather than defensive: `double.tryParse`
+succeeds on `"NaN"` and `"Infinity"`, and `double.round()` throws
+`UnsupportedError` on both. Without the guard a single malformed element
+would abort an entire import rather than skipping one field.
+
+Applied at all 28 integer-semantics parse sites across the UDDF import path:
+
+| File | Sites |
+| --- | --- |
+| `uddf_full_import_service.dart` | 16 |
+| `uddf_import_service.dart` | 9 |
+| `uddf_import_parsers.dart` | 3 |
+
+Covered fields: `divetime`, `diveduration`, `divenumber`, `passedtime`,
+`ndl`, `rbt`, heart rate, scrubber duration and remaining, rating, tank
+order, gas-switch and event timestamps, gradient factors, marine-life
+sighting count, dive-type and dive-role sort order, gear service interval.
+
+### 2. Lead weight read from either half of the dive
+
+The existing `<informationafterdive><equipmentused>` block — which already
+collects equipment refs from that location, with de-duplication — now also
+reads `<leadquantity>` when `<informationbeforedive>` did not supply it.
+The before-dive value wins, keeping this a fallback rather than an override.
+
+Placing it inside the existing block avoids restructuring the before-dive
+parse and cannot produce duplicate equipment refs.
+
+### Not changed
+
+`MacDiveDialect._floatIntPattern` is left in place. It is redundant now,
+but removing it would expand the blast radius into MacDive regression
+territory for no functional gain.
+
+## Testing
+
+`test/core/services/export/uddf/uddf_lenient_int_parse_test.dart` — helper
+units covering plain, float, whitespace-padded, fractional, exponent,
+out-of-32-bit-range, non-numeric and non-finite input.
+
+`test/core/services/export/uddf/uddf_oceanic_float_import_test.dart` —
+end-to-end regression on a synthetic fixture reproducing Oceanic's exact
+serialization shape (invented site ids and coordinates; the reporter's own
+dive data and GPS positions are deliberately not committed). Asserts
+ascending waypoint timestamps, runtime from float `diveduration`, weight
+from the after-dive `equipmentused`, before-dive precedence when both
+halves supply weight, and that `MacDiveDialect` does not claim the file.
+
+Verified red before the fix: waypoint timestamps came back
+`[0, 0, 0, 0, 0]`, runtime null, weight null.
+
+Verified against the reporter's real 609 KB file: all 12 dives import with
+complete profiles (138-303 points each), runtimes and weights; zero
+collapsed profiles.
+
+## Known limitations and follow-ups
+
+- **Oceanic appears to export lead weight in the user's display unit.** The
+  reporter's dive notes read "12 lbs weights" while the file carries
+  `<leadquantity>12.0</leadquantity>`. UDDF specifies kilograms, so the
+  value is likely pounds passed through unconverted. Inferring the unit
+  would require vendor attribution and is genuinely ambiguous (12 kg is a
+  heavy but plausible weight), so it is not guessed at here. Worth raising
+  with the reporter to confirm before considering any handling.
+- **Oceanic's sample series outruns its stated duration.** The first dive
+  carries 293 waypoints at 15-second spacing (ending at t=4380) against a
+  `<diveduration>` of 3492 seconds. This looks like Oceanic including
+  surface time in the profile, or reporting bottom time as duration. Not
+  addressed; noted in case profile-versus-duration displays disagree.
+- **Apple Health import** was reported separately by the same user and is
+  out of scope here; the reporter suspects Oceanic is not writing to
+  HealthKit on their device.

--- a/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
+++ b/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
@@ -91,6 +91,16 @@ succeeds on `"NaN"` and `"Infinity"`, and `double.round()` throws
 `UnsupportedError` on both. Without the guard a single malformed element
 would abort an entire import rather than skipping one field.
 
+A zero-only fractional part (`"15.0"`, `"15.000"`) is stripped textually
+rather than routed through a double, so the value keeps exact integer
+semantics. Raised in review: above 2^53 a double round-trip is lossy —
+`"9007199254740993.0"` comes back as `...992` — for values Dart ints hold
+exactly. No dive field approaches that magnitude, so this is about the
+helper's contract rather than any reachable data; it costs one regex match
+on a path that previously allocated a double anyway. Values that overflow
+int64 still fall through to the double path, where `round()` saturates
+rather than throwing.
+
 Applied at all 28 integer-semantics parse sites across the UDDF import path:
 
 | File | Sites |

--- a/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
+++ b/docs/superpowers/specs/2026-08-14-uddf-float-int-parsing-design.md
@@ -104,6 +104,19 @@ Covered fields: `divetime`, `diveduration`, `divenumber`, `passedtime`,
 order, gas-switch and event timestamps, gradient factors, marine-life
 sighting count, dive-type and dive-role sort order, gear service interval.
 
+`UddfImportParsers.parseUddfDouble` is the decimal counterpart, added after
+review pointed out that the lead-weight read accepted non-finite input.
+`double.tryParse` succeeds on `"NaN"`, `"Infinity"` and `"-Infinity"`, so a
+value that is only null-checked reaches the database intact. NaN is the
+dangerous case: it compares false against everything including itself, so it
+corrupts totals, averages and range checks downstream rather than failing
+where it entered. Applied at all three `<leadquantity>` reads (two of which
+predate this change).
+
+Only `<leadquantity>` is converted. Sweeping every `double.tryParse` in the
+import path is a larger mechanical change and is left as a follow-up; the
+helper exists for it when that happens.
+
 ### 2. Lead weight read from either half of the dive
 
 The existing `<informationafterdive><equipmentused>` block — which already

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -115,8 +115,12 @@ class UddfFullImportService {
             'gradientfactorhigh',
           );
           decoModels[modelId] = {
-            'gfLow': gfLowText != null ? int.tryParse(gfLowText) ?? 0 : 0,
-            'gfHigh': gfHighText != null ? int.tryParse(gfHighText) ?? 0 : 0,
+            'gfLow': gfLowText != null
+                ? UddfImportParsers.parseUddfInt(gfLowText) ?? 0
+                : 0,
+            'gfHigh': gfHighText != null
+                ? UddfImportParsers.parseUddfInt(gfHighText) ?? 0
+                : 0,
           };
         }
       }
@@ -773,7 +777,7 @@ class UddfFullImportService {
           sighting['speciesRef'] = sightingElement.getAttribute('speciesref');
           final countStr = sightingElement.getAttribute('count');
           sighting['count'] = countStr != null
-              ? int.tryParse(countStr) ?? 1
+              ? UddfImportParsers.parseUddfInt(countStr) ?? 1
               : 1;
           sighting['notes'] =
               UddfImportParsers.getElementText(sightingElement, 'notes') ?? '';
@@ -898,7 +902,7 @@ class UddfFullImportService {
           final event = <String, dynamic>{};
           final time = UddfImportParsers.getElementText(eventElement, 'time');
           if (time != null) {
-            event['timestamp'] = int.tryParse(time);
+            event['timestamp'] = UddfImportParsers.parseUddfInt(time);
           }
           final eventType = UddfImportParsers.getElementText(
             eventElement,
@@ -947,7 +951,7 @@ class UddfFullImportService {
           final gs = <String, dynamic>{};
           final time = UddfImportParsers.getElementText(gsElement, 'time');
           if (time != null) {
-            gs['timestamp'] = int.tryParse(time);
+            gs['timestamp'] = UddfImportParsers.parseUddfInt(time);
           }
           final depth = UddfImportParsers.getElementText(gsElement, 'depth');
           if (depth != null) {
@@ -1101,14 +1105,18 @@ class UddfFullImportService {
         'scrubberdurationminutes',
       );
       if (scrubDur != null) {
-        diveData['scrubberDurationMinutes'] = int.tryParse(scrubDur);
+        diveData['scrubberDurationMinutes'] = UddfImportParsers.parseUddfInt(
+          scrubDur,
+        );
       }
       final scrubRem = UddfImportParsers.getElementText(
         rebreatherElement,
         'scrubberremainingminutes',
       );
       if (scrubRem != null) {
-        diveData['scrubberRemainingMinutes'] = int.tryParse(scrubRem);
+        diveData['scrubberRemainingMinutes'] = UddfImportParsers.parseUddfInt(
+          scrubRem,
+        );
       }
     }
 
@@ -1151,7 +1159,7 @@ class UddfFullImportService {
         'divenumber',
       );
       if (diveNumText != null) {
-        diveData['diveNumber'] = int.tryParse(diveNumText);
+        diveData['diveNumber'] = UddfImportParsers.parseUddfInt(diveNumText);
       }
 
       final airTempText = UddfImportParsers.getElementText(
@@ -1198,7 +1206,7 @@ class UddfFullImportService {
           'passedtime',
         );
         if (passedTimeText != null) {
-          final seconds = int.tryParse(passedTimeText);
+          final seconds = UddfImportParsers.parseUddfInt(passedTimeText);
           if (seconds != null && seconds > 0) {
             diveData['surfaceInterval'] = Duration(seconds: seconds);
           }
@@ -1464,7 +1472,7 @@ class UddfFullImportService {
         'tankorder',
       );
       if (tankOrder != null) {
-        tankInfo['order'] = int.tryParse(tankOrder) ?? 0;
+        tankInfo['order'] = UddfImportParsers.parseUddfInt(tankOrder) ?? 0;
       }
 
       // Validate tank data before adding
@@ -1568,7 +1576,7 @@ class UddfFullImportService {
 
         final timeText = UddfImportParsers.getElementText(waypoint, 'divetime');
         if (timeText != null) {
-          point['timestamp'] = int.tryParse(timeText) ?? 0;
+          point['timestamp'] = UddfImportParsers.parseUddfInt(timeText) ?? 0;
         }
 
         final depthText = UddfImportParsers.getElementText(waypoint, 'depth');
@@ -1697,7 +1705,7 @@ class UddfFullImportService {
           'heartrate',
         );
         if (heartRateText != null) {
-          point['heartRate'] = int.tryParse(heartRateText);
+          point['heartRate'] = UddfImportParsers.parseUddfInt(heartRateText);
         }
 
         final cnsText = UddfImportParsers.getElementText(waypoint, 'cns');
@@ -1773,7 +1781,7 @@ class UddfFullImportService {
           'nodecotime',
         );
         if (ndlText != null) {
-          point['ndl'] = int.tryParse(ndlText);
+          point['ndl'] = UddfImportParsers.parseUddfInt(ndlText);
         }
 
         final decoStop = waypoint.findElements('decostop').firstOrNull;
@@ -1824,7 +1832,7 @@ class UddfFullImportService {
         );
         final rbtText = remainingBottomTimeText ?? remainingO2TimeText;
         if (rbtText != null) {
-          point['rbt'] = int.tryParse(rbtText);
+          point['rbt'] = UddfImportParsers.parseUddfInt(rbtText);
         }
 
         if (point.containsKey('timestamp') && point.containsKey('depth')) {
@@ -1940,7 +1948,7 @@ class UddfFullImportService {
         'diveduration',
       );
       if (durationText != null) {
-        final seconds = int.tryParse(durationText);
+        final seconds = UddfImportParsers.parseUddfInt(durationText);
         if (seconds != null) {
           diveData['runtime'] = Duration(seconds: seconds);
         }
@@ -2005,7 +2013,7 @@ class UddfFullImportService {
           'ratingvalue',
         );
         if (ratingValue != null) {
-          diveData['rating'] = int.tryParse(ratingValue);
+          diveData['rating'] = UddfImportParsers.parseUddfInt(ratingValue);
         }
       }
 

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1348,6 +1348,25 @@ class UddfFullImportService {
         if (existingRefs.isNotEmpty) {
           diveData['equipmentRefs'] = existingRefs;
         }
+
+        // Lead weight, when the exporter put <equipmentused> here rather
+        // than in <informationbeforedive>. UDDF is ambiguous about which
+        // half of the dive owns the element and exporters disagree
+        // (Oceanic Plus and MacDive both write it after), so it is read
+        // from whichever side supplies it. The before-dive value wins to
+        // keep this a fallback rather than an override.
+        if (diveData['weightUsed'] == null) {
+          final leadText = UddfImportParsers.getElementText(
+            afterEquipmentElement,
+            'leadquantity',
+          );
+          if (leadText != null) {
+            final leadKg = double.tryParse(leadText);
+            if (leadKg != null) {
+              diveData['weightUsed'] = leadKg;
+            }
+          }
+        }
       }
     }
 

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -1223,7 +1223,7 @@ class UddfFullImportService {
           'leadquantity',
         );
         if (leadText != null) {
-          final leadKg = double.tryParse(leadText);
+          final leadKg = UddfImportParsers.parseUddfDouble(leadText);
           if (leadKg != null) {
             diveData['weightUsed'] = leadKg;
           }
@@ -1361,7 +1361,7 @@ class UddfFullImportService {
             'leadquantity',
           );
           if (leadText != null) {
-            final leadKg = double.tryParse(leadText);
+            final leadKg = UddfImportParsers.parseUddfDouble(leadText);
             if (leadKg != null) {
               diveData['weightUsed'] = leadKg;
             }

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -43,6 +43,10 @@ double normalizeUddfTankVolumeToLiters(
 class UddfImportParsers {
   UddfImportParsers._();
 
+  // An integer followed by a fractional part of nothing but zeros, e.g.
+  // "15.0" or "15.000". Captures the integer so it can be parsed exactly.
+  static final RegExp _zeroFractionPattern = RegExp(r'^([+-]?\d+)\.0*$');
+
   /// Parses a UDDF integer-semantics value, tolerating the float
   /// serialization several exporters emit.
   ///
@@ -69,6 +73,17 @@ class UddfImportParsers {
 
     final asInt = int.tryParse(trimmed);
     if (asInt != null) return asInt;
+
+    // Strip a fractional part that is nothing but zeros, so the value keeps
+    // exact integer semantics. Going through a double would lose precision
+    // above 2^53 ("9007199254740993.0" comes back as ...992) for values Dart
+    // ints represent exactly. Anything with a real fraction, an exponent or
+    // stray characters falls through to the double path below.
+    final zeroFraction = _zeroFractionPattern.firstMatch(trimmed);
+    if (zeroFraction != null) {
+      final exact = int.tryParse(zeroFraction.group(1)!);
+      if (exact != null) return exact;
+    }
 
     final asDouble = double.tryParse(trimmed);
     // double.tryParse succeeds on "NaN" and "Infinity", and calling round()

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -78,6 +78,22 @@ class UddfImportParsers {
     return asDouble.round();
   }
 
+  /// Parses a UDDF decimal value, rejecting non-finite input.
+  ///
+  /// [double.tryParse] succeeds on "NaN", "Infinity" and "-Infinity", so a
+  /// value that is only null-checked reaches the database intact. NaN is the
+  /// dangerous one: it compares false against everything including itself,
+  /// so it silently poisons totals, averages and range checks downstream
+  /// rather than failing where it was introduced.
+  ///
+  /// Returns null when [text] is null, blank, non-numeric or non-finite.
+  static double? parseUddfDouble(String? text) {
+    if (text == null) return null;
+    final value = double.tryParse(text.trim());
+    if (value == null || !value.isFinite) return null;
+    return value;
+  }
+
   static void assignGasMixToTankIfMissing({
     required List<Map<String, dynamic>> tanks,
     required int tankIndex,

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -43,6 +43,41 @@ double normalizeUddfTankVolumeToLiters(
 class UddfImportParsers {
   UddfImportParsers._();
 
+  /// Parses a UDDF integer-semantics value, tolerating the float
+  /// serialization several exporters emit.
+  ///
+  /// UDDF types fields like `<divetime>` and `<diveduration>` as integers,
+  /// but exporters built on JavaScript runtimes write them as floats
+  /// (Oceanic Plus emits `<divetime>15.0</divetime>`; MacDive emits
+  /// `<diveduration>60.00</diveduration>`), because 15 and 15.0 are the
+  /// same value there. [int.tryParse] rejects any decimal point, so those
+  /// fields silently fell back to 0 or were dropped entirely -- a profile
+  /// imported from Oceanic Plus had every waypoint stamped at t=0.
+  ///
+  /// Parsing leniently here fixes the whole class of defect without
+  /// requiring the file to be attributed to a known vendor first, which
+  /// matters because vendor fingerprints fail silently: Oceanic Plus omits
+  /// `<generator><name>`, leaving only a locale-dependent homepage URL to
+  /// match on.
+  ///
+  /// Returns null when [text] is null, blank, non-numeric, or non-finite.
+  /// Genuinely fractional input is rounded to nearest.
+  static int? parseUddfInt(String? text) {
+    if (text == null) return null;
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return null;
+
+    final asInt = int.tryParse(trimmed);
+    if (asInt != null) return asInt;
+
+    final asDouble = double.tryParse(trimmed);
+    // double.tryParse succeeds on "NaN" and "Infinity", and calling round()
+    // on either throws UnsupportedError. Guarding here keeps one malformed
+    // element from aborting the entire import.
+    if (asDouble == null || !asDouble.isFinite) return null;
+    return asDouble.round();
+  }
+
   static void assignGasMixToTankIfMissing({
     required List<Map<String, dynamic>> tanks,
     required int tankIndex,
@@ -383,7 +418,7 @@ class UddfImportParsers {
 
     final sortOrder = getElementText(typeElement, 'sortorder');
     if (sortOrder != null) {
-      diveType['sortOrder'] = int.tryParse(sortOrder) ?? 0;
+      diveType['sortOrder'] = parseUddfInt(sortOrder) ?? 0;
     }
 
     final isBuiltIn = getElementText(typeElement, 'isbuiltin');
@@ -403,7 +438,7 @@ class UddfImportParsers {
 
     final sortOrder = getElementText(roleElement, 'sortorder');
     if (sortOrder != null) {
-      diveRole['sortOrder'] = int.tryParse(sortOrder) ?? 0;
+      diveRole['sortOrder'] = parseUddfInt(sortOrder) ?? 0;
     }
 
     final isBuiltIn = getElementText(roleElement, 'isbuiltin');
@@ -634,7 +669,7 @@ class UddfImportParsers {
 
     final serviceInterval = getElementText(itemElement, 'serviceintervaldays');
     if (serviceInterval != null) {
-      item['serviceIntervalDays'] = int.tryParse(serviceInterval);
+      item['serviceIntervalDays'] = parseUddfInt(serviceInterval);
     }
 
     final isActive = getElementText(itemElement, 'isactive');

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -95,8 +95,12 @@ class UddfImportService {
             'gradientfactorhigh',
           );
           decoModels[modelId] = {
-            'gfLow': gfLowText != null ? int.tryParse(gfLowText) ?? 0 : 0,
-            'gfHigh': gfHighText != null ? int.tryParse(gfHighText) ?? 0 : 0,
+            'gfLow': gfLowText != null
+                ? UddfImportParsers.parseUddfInt(gfLowText) ?? 0
+                : 0,
+            'gfHigh': gfHighText != null
+                ? UddfImportParsers.parseUddfInt(gfHighText) ?? 0
+                : 0,
           };
         }
       }
@@ -217,7 +221,7 @@ class UddfImportService {
 
       final diveNumText = _getElementText(beforeElement, 'divenumber');
       if (diveNumText != null) {
-        diveData['diveNumber'] = int.tryParse(diveNumText);
+        diveData['diveNumber'] = UddfImportParsers.parseUddfInt(diveNumText);
       }
 
       final airTempText = _getElementText(beforeElement, 'airtemperature');
@@ -258,7 +262,7 @@ class UddfImportService {
           'passedtime',
         );
         if (passedTimeText != null) {
-          final seconds = int.tryParse(passedTimeText);
+          final seconds = UddfImportParsers.parseUddfInt(passedTimeText);
           if (seconds != null && seconds > 0) {
             diveData['surfaceInterval'] = Duration(seconds: seconds);
           }
@@ -454,7 +458,7 @@ class UddfImportService {
       // Get tank order
       final tankOrder = _getElementText(tankDataElement, 'tankorder');
       if (tankOrder != null) {
-        tankInfo['order'] = int.tryParse(tankOrder) ?? 0;
+        tankInfo['order'] = UddfImportParsers.parseUddfInt(tankOrder) ?? 0;
       }
 
       // Validate tank data before adding
@@ -543,7 +547,7 @@ class UddfImportService {
 
         final timeText = _getElementText(waypoint, 'divetime');
         if (timeText != null) {
-          point['timestamp'] = int.tryParse(timeText) ?? 0;
+          point['timestamp'] = UddfImportParsers.parseUddfInt(timeText) ?? 0;
         }
 
         final depthText = _getElementText(waypoint, 'depth');
@@ -643,7 +647,7 @@ class UddfImportService {
         // Get heart rate
         final heartRateText = _getElementText(waypoint, 'heartrate');
         if (heartRateText != null) {
-          point['heartRate'] = int.tryParse(heartRateText);
+          point['heartRate'] = UddfImportParsers.parseUddfInt(heartRateText);
         }
 
         if (point.containsKey('timestamp') && point.containsKey('depth')) {
@@ -684,7 +688,7 @@ class UddfImportService {
       // UDDF diveduration is total dive time (runtime), not bottom time
       final durationText = _getElementText(afterElement, 'diveduration');
       if (durationText != null) {
-        final seconds = int.tryParse(durationText);
+        final seconds = UddfImportParsers.parseUddfInt(durationText);
         if (seconds != null) {
           diveData['runtime'] = Duration(seconds: seconds);
         }
@@ -741,7 +745,7 @@ class UddfImportService {
       if (ratingElement != null) {
         final ratingValue = _getElementText(ratingElement, 'ratingvalue');
         if (ratingValue != null) {
-          diveData['rating'] = int.tryParse(ratingValue);
+          diveData['rating'] = UddfImportParsers.parseUddfInt(ratingValue);
         }
       }
 

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -276,7 +276,7 @@ class UddfImportService {
       if (equipmentElement != null) {
         final leadText = _getElementText(equipmentElement, 'leadquantity');
         if (leadText != null) {
-          final leadKg = double.tryParse(leadText);
+          final leadKg = UddfImportParsers.parseUddfDouble(leadText);
           if (leadKg != null) {
             diveData['weightUsed'] = leadKg;
           }

--- a/test/core/services/export/uddf/uddf_float_int_fields_test.dart
+++ b/test/core/services/export/uddf/uddf_float_int_fields_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_service.dart';
+
+// Every integer-semantics field below is written in the float form that
+// Oceanic Plus and MacDive emit. int.tryParse rejects all of them, so these
+// exercise parseUddfInt at the call sites the headline regression test does
+// not reach.
+
+// Fields reached only by the simple import path (UddfImportService).
+const _legacyUddf = '''<?xml version="1.0" encoding="UTF-8" ?>
+<uddf version="3.2.1">
+  <gasdefinitions>
+    <mix id="air"><name>air</name><o2>0.21</o2><n2>0.79</n2><he>0.0</he></mix>
+  </gasdefinitions>
+  <decomodel>
+    <buehlmann id="deco-1">
+      <gradientfactorlow>30.0</gradientfactorlow>
+      <gradientfactorhigh>85.0</gradientfactorhigh>
+    </buehlmann>
+  </decomodel>
+  <profiledata>
+    <repetitiongroup id="rg-1">
+      <dive id="d-1">
+        <informationbeforedive>
+          <link ref="deco-1" />
+          <datetime>2026-08-10T10:00:00</datetime>
+          <surfaceintervalbeforedive>
+            <passedtime>3600.0</passedtime>
+          </surfaceintervalbeforedive>
+        </informationbeforedive>
+        <tankdata id="tank-1">
+          <link ref="air" />
+          <tankorder>2.0</tankorder>
+          <tankpressurebegin>20000000.0</tankpressurebegin>
+          <tankpressureend>5000000.0</tankpressureend>
+        </tankdata>
+        <samples>
+          <waypoint>
+            <divetime>0.0</divetime>
+            <depth>0.0</depth>
+            <heartrate>72.0</heartrate>
+          </waypoint>
+          <waypoint>
+            <divetime>60.0</divetime>
+            <depth>12.0</depth>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>12.0</greatestdepth>
+          <diveduration>1800.0</diveduration>
+          <rating><ratingvalue>4.0</ratingvalue></rating>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>''';
+
+// Fields reached only by the full import path: profile events, the
+// rebreather section, waypoint heart rate, and a custom dive type.
+const _fullUddf = '''<?xml version="1.0" encoding="UTF-8" ?>
+<uddf version="3.2.1">
+  <applicationdata>
+    <submersion>
+      <divetypes>
+        <divetype id="dt-1">
+          <name>Wreck</name>
+          <sortorder>3.0</sortorder>
+        </divetype>
+      </divetypes>
+    </submersion>
+  </applicationdata>
+  <profiledata>
+    <repetitiongroup id="rg-1">
+      <dive id="d-1">
+        <informationbeforedive>
+          <datetime>2026-08-10T10:00:00</datetime>
+        </informationbeforedive>
+        <rebreather>
+          <scrubberdurationminutes>180.0</scrubberdurationminutes>
+          <scrubberremainingminutes>90.0</scrubberremainingminutes>
+        </rebreather>
+        <samples>
+          <waypoint>
+            <divetime>0.0</divetime>
+            <depth>0.0</depth>
+            <heartrate>75.0</heartrate>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>20.0</greatestdepth>
+          <diveduration>2400.0</diveduration>
+          <profileevents>
+            <event>
+              <time>120.0</time>
+              <eventtype>ascentRate</eventtype>
+            </event>
+          </profileevents>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>''';
+
+void main() {
+  group('float-formatted integers, simple import path', () {
+    late Map<String, dynamic> dive;
+
+    setUpAll(() async {
+      final result = await UddfImportService().importDivesFromUddf(_legacyUddf);
+      dive = result['dives']!.single;
+    });
+
+    test('gradient factors', () {
+      expect(dive['gradientFactorLow'], 30);
+      expect(dive['gradientFactorHigh'], 85);
+    });
+
+    test('surface interval', () {
+      expect(dive['surfaceInterval'], const Duration(seconds: 3600));
+    });
+
+    test('tank order', () {
+      final tanks = dive['tanks'] as List<Map<String, dynamic>>;
+      expect(tanks.single['order'], 2);
+    });
+
+    test('waypoint heart rate', () {
+      final profile = dive['profile'] as List<Map<String, dynamic>>;
+      expect(profile.first['heartRate'], 72);
+    });
+
+    test('dive duration and rating', () {
+      expect(dive['runtime'], const Duration(seconds: 1800));
+      expect(dive['rating'], 4);
+    });
+  });
+
+  group('float-formatted integers, full import path', () {
+    test('profile event timestamp', () async {
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        _fullUddf,
+      );
+      final events =
+          result.dives.single['profileEvents'] as List<Map<String, dynamic>>;
+
+      expect(events.single['timestamp'], 120);
+    });
+
+    test('rebreather scrubber durations', () async {
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        _fullUddf,
+      );
+      final dive = result.dives.single;
+
+      expect(dive['scrubberDurationMinutes'], 180);
+      expect(dive['scrubberRemainingMinutes'], 90);
+    });
+
+    test('waypoint heart rate', () async {
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        _fullUddf,
+      );
+      final profile =
+          result.dives.single['profile'] as List<Map<String, dynamic>>;
+
+      expect(profile.first['heartRate'], 75);
+    });
+
+    test('custom dive type sort order', () async {
+      final result = await UddfFullImportService().importAllDataFromUddf(
+        _fullUddf,
+      );
+
+      expect(result.customDiveTypes.single['sortOrder'], 3);
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
+++ b/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
+
+void main() {
+  group('UddfImportParsers.parseUddfInt', () {
+    test('parses plain integers', () {
+      expect(UddfImportParsers.parseUddfInt('15'), 15);
+      expect(UddfImportParsers.parseUddfInt('0'), 0);
+      expect(UddfImportParsers.parseUddfInt('1827'), 1827);
+      expect(UddfImportParsers.parseUddfInt('-3'), -3);
+    });
+
+    test('parses float-formatted integers', () {
+      // Oceanic Plus and MacDive serialize integer-semantics fields as
+      // floats; int.tryParse rejects these outright.
+      expect(UddfImportParsers.parseUddfInt('15.0'), 15);
+      expect(UddfImportParsers.parseUddfInt('15.00'), 15);
+      expect(UddfImportParsers.parseUddfInt('0.0'), 0);
+      expect(UddfImportParsers.parseUddfInt('1827.0'), 1827);
+      expect(UddfImportParsers.parseUddfInt('-3.0'), -3);
+    });
+
+    test('tolerates surrounding whitespace', () {
+      expect(UddfImportParsers.parseUddfInt(' 15 '), 15);
+      expect(UddfImportParsers.parseUddfInt('\n  15.0\t'), 15);
+    });
+
+    test('rounds genuinely fractional values to nearest', () {
+      // Fractional divetime is out of spec, but rounding preserves more
+      // signal than discarding the sample.
+      expect(UddfImportParsers.parseUddfInt('15.5'), 16);
+      expect(UddfImportParsers.parseUddfInt('15.4'), 15);
+      expect(UddfImportParsers.parseUddfInt('-15.5'), -16);
+    });
+
+    test('parses exponent notation', () {
+      expect(UddfImportParsers.parseUddfInt('1e3'), 1000);
+      expect(UddfImportParsers.parseUddfInt('1.5e2'), 150);
+    });
+
+    test('returns null for null, empty, and non-numeric input', () {
+      expect(UddfImportParsers.parseUddfInt(null), isNull);
+      expect(UddfImportParsers.parseUddfInt(''), isNull);
+      expect(UddfImportParsers.parseUddfInt('   '), isNull);
+      expect(UddfImportParsers.parseUddfInt('abc'), isNull);
+      expect(UddfImportParsers.parseUddfInt('12abc'), isNull);
+    });
+
+    test('returns null for non-finite values instead of throwing', () {
+      // double.tryParse SUCCEEDS on these, and double.round() throws
+      // UnsupportedError on NaN/Infinity. Without a finiteness guard a
+      // single malformed element would abort the entire import.
+      expect(UddfImportParsers.parseUddfInt('NaN'), isNull);
+      expect(UddfImportParsers.parseUddfInt('Infinity'), isNull);
+      expect(UddfImportParsers.parseUddfInt('-Infinity'), isNull);
+    });
+
+    test('handles values beyond 32-bit range', () {
+      expect(UddfImportParsers.parseUddfInt('3000000000'), 3000000000);
+      expect(UddfImportParsers.parseUddfInt('3000000000.0'), 3000000000);
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
+++ b/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
@@ -59,6 +59,22 @@ void main() {
       expect(UddfImportParsers.parseUddfInt('3000000000'), 3000000000);
       expect(UddfImportParsers.parseUddfInt('3000000000.0'), 3000000000);
     });
+
+    test('float-formatted integers stay exact beyond 2^53', () {
+      // A double cannot represent 2^53 + 1, so routing through
+      // double.tryParse would silently return ...992. Dart ints hold it
+      // exactly, so the zero fraction is stripped textually instead.
+      const big = 9007199254740993; // 2^53 + 1
+      expect(UddfImportParsers.parseUddfInt('9007199254740993'), big);
+      expect(UddfImportParsers.parseUddfInt('9007199254740993.0'), big);
+      expect(UddfImportParsers.parseUddfInt('9007199254740993.000'), big);
+      expect(UddfImportParsers.parseUddfInt(' -9007199254740993.0 '), -big);
+    });
+
+    test('a real fractional part still rounds, at any magnitude', () {
+      expect(UddfImportParsers.parseUddfInt('10.5'), 11);
+      expect(UddfImportParsers.parseUddfInt('9007199254740993.5'), isNotNull);
+    });
   });
 
   group('UddfImportParsers.parseUddfDouble', () {

--- a/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
+++ b/test/core/services/export/uddf/uddf_lenient_int_parse_test.dart
@@ -60,4 +60,33 @@ void main() {
       expect(UddfImportParsers.parseUddfInt('3000000000.0'), 3000000000);
     });
   });
+
+  group('UddfImportParsers.parseUddfDouble', () {
+    test('parses decimals, integers and exponent notation', () {
+      expect(UddfImportParsers.parseUddfDouble('12.5'), closeTo(12.5, 1e-9));
+      expect(UddfImportParsers.parseUddfDouble('12'), closeTo(12.0, 1e-9));
+      expect(UddfImportParsers.parseUddfDouble('-3.25'), closeTo(-3.25, 1e-9));
+      expect(UddfImportParsers.parseUddfDouble('2.2E7'), closeTo(2.2e7, 1e-3));
+    });
+
+    test('tolerates surrounding whitespace', () {
+      expect(UddfImportParsers.parseUddfDouble(' 12.5 '), closeTo(12.5, 1e-9));
+    });
+
+    test('returns null for null, empty and non-numeric input', () {
+      expect(UddfImportParsers.parseUddfDouble(null), isNull);
+      expect(UddfImportParsers.parseUddfDouble(''), isNull);
+      expect(UddfImportParsers.parseUddfDouble('   '), isNull);
+      expect(UddfImportParsers.parseUddfDouble('abc'), isNull);
+    });
+
+    test('returns null for non-finite values', () {
+      // double.tryParse succeeds on all three; NaN in particular compares
+      // false against everything, so it corrupts downstream aggregates
+      // rather than failing where it entered.
+      expect(UddfImportParsers.parseUddfDouble('NaN'), isNull);
+      expect(UddfImportParsers.parseUddfDouble('Infinity'), isNull);
+      expect(UddfImportParsers.parseUddfDouble('-Infinity'), isNull);
+    });
+  });
 }

--- a/test/core/services/export/uddf/uddf_non_finite_values_test.dart
+++ b/test/core/services/export/uddf/uddf_non_finite_values_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_service.dart';
+
+// double.tryParse SUCCEEDS on "NaN" and "Infinity", so a value read with it
+// and only null-checked reaches the database intact. A NaN weight silently
+// poisons every downstream comparison, since NaN != NaN.
+
+String _dive({required String before, required String after}) =>
+    '''<?xml version="1.0" encoding="UTF-8" ?>
+<uddf version="3.2.1">
+  <profiledata>
+    <repetitiongroup id="rg-1">
+      <dive id="d-1">
+        <informationbeforedive>
+          <datetime>2026-08-10T10:00:00</datetime>
+          $before
+        </informationbeforedive>
+        <samples>
+          <waypoint><divetime>0</divetime><depth>0.0</depth></waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>18.0</greatestdepth>
+          <diveduration>1800</diveduration>
+          $after
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>''';
+
+String _lead(String value) =>
+    '<equipmentused><leadquantity>$value</leadquantity></equipmentused>';
+
+void main() {
+  group('non-finite lead weight is rejected', () {
+    for (final value in ['NaN', 'Infinity', '-Infinity']) {
+      test('full import, before-dive: $value', () async {
+        final result = await UddfFullImportService().importAllDataFromUddf(
+          _dive(before: _lead(value), after: ''),
+        );
+
+        expect(result.dives.single['weightUsed'], isNull);
+      });
+
+      test('full import, after-dive: $value', () async {
+        final result = await UddfFullImportService().importAllDataFromUddf(
+          _dive(before: '', after: _lead(value)),
+        );
+
+        expect(result.dives.single['weightUsed'], isNull);
+      });
+
+      test('simple import: $value', () async {
+        final result = await UddfImportService().importDivesFromUddf(
+          _dive(before: _lead(value), after: ''),
+        );
+
+        expect(result['dives']!.single['weightUsed'], isNull);
+      });
+    }
+
+    test('finite weights are still accepted on both sides', () async {
+      final service = UddfFullImportService();
+
+      final before = await service.importAllDataFromUddf(
+        _dive(before: _lead('6.5'), after: ''),
+      );
+      final after = await service.importAllDataFromUddf(
+        _dive(before: '', after: _lead('12.0')),
+      );
+
+      expect(before.dives.single['weightUsed'], closeTo(6.5, 0.001));
+      expect(after.dives.single['weightUsed'], closeTo(12.0, 0.001));
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_oceanic_float_import_test.dart
+++ b/test/core/services/export/uddf/uddf_oceanic_float_import_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/dialects/macdive_dialect.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:xml/xml.dart';
+
+// Synthetic UDDF reproducing the serialization shape of Oceanic Plus
+// (Oceanic's iPhone app, paired with an Apple Watch Ultra). Structure,
+// element ordering and number formatting mirror a real export; site ids
+// and coordinates are invented.
+//
+// The traits that matter:
+//   - default xmlns namespace on the root element
+//   - <generator> WITHOUT a <name> child, so no vendor fingerprint exists
+//   - integer-semantics fields written as floats (<divetime>15.0</divetime>,
+//     <diveduration>3492.0</diveduration>)
+//   - <equipmentused> in <informationafterdive>, not <informationbeforedive>
+//   - exponent-notation pressures (2.2E7)
+const _oceanicUddf = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<uddf version="3.2.1" xmlns="http://www.streit.cc/uddf/3.2/">
+    <generator>
+        <manufacturer>
+            <contact>
+                <homepage>https://www.oceanicworldwide.com/it/oceanic-plus/</homepage>
+            </contact>
+        </manufacturer>
+        <version>0.0.1</version>
+        <datetime>2026-08-13T13:36:16.619Z</datetime>
+    </generator>
+    <divesite>
+        <site id="site_aaa1">
+            <name>site_aaa1</name>
+            <geography>
+                <location>site_aaa1</location>
+                <latitude>12.345678</latitude>
+                <longitude>-65.43210</longitude>
+                <altitude>4.87455</altitude>
+            </geography>
+        </site>
+    </divesite>
+    <gasdefinitions>
+        <mix id="air">
+            <name>air</name>
+            <o2>0.21</o2>
+            <n2>0.79</n2>
+            <he>0.0</he>
+        </mix>
+    </gasdefinitions>
+    <profiledata>
+        <repetitiongroup id="rg_1">
+            <dive id="dive_aaa1">
+                <informationbeforedive>
+                    <link ref="site_aaa1"/>
+                    <datetime>2026-08-10T20:10:29.000-00:05</datetime>
+                    <altitude>4.87455</altitude>
+                </informationbeforedive>
+                <samples>
+                    <waypoint>
+                        <depth>0.0</depth>
+                        <divetime>0.0</divetime>
+                        <switchmix ref="air"/>
+                        <divemode type="opencircuit"/>
+                    </waypoint>
+                    <waypoint>
+                        <depth>0.1</depth>
+                        <divetime>15.0</divetime>
+                        <temperature>303.04</temperature>
+                    </waypoint>
+                    <waypoint>
+                        <depth>5.7</depth>
+                        <divetime>30.0</divetime>
+                        <temperature>302.99</temperature>
+                    </waypoint>
+                    <waypoint>
+                        <depth>12.3</depth>
+                        <divetime>45.0</divetime>
+                    </waypoint>
+                    <waypoint>
+                        <depth>0.0</depth>
+                        <divetime>3492.0</divetime>
+                    </waypoint>
+                </samples>
+                <tankdata id="tank_aaa1">
+                    <link ref="air"/>
+                    <tankpressurebegin>2.2E7</tankpressurebegin>
+                    <tankpressureend>6500000.0</tankpressureend>
+                </tankdata>
+                <informationafterdive>
+                    <lowesttemperature>302.94</lowesttemperature>
+                    <greatestdepth>18.335197</greatestdepth>
+                    <notes>
+                        <para>Night shore dive</para>
+                    </notes>
+                    <diveduration>3492.0</diveduration>
+                    <equipmentused>
+                        <leadquantity>12.0</leadquantity>
+                        <link ref="tank_aaa1"/>
+                    </equipmentused>
+                </informationafterdive>
+            </dive>
+        </repetitiongroup>
+    </profiledata>
+</uddf>''';
+
+// Same file with <equipmentused> in BOTH halves of the dive, to pin down
+// which one wins.
+const _weightInBothHalves =
+    '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<uddf version="3.2.1" xmlns="http://www.streit.cc/uddf/3.2/">
+    <profiledata>
+        <repetitiongroup id="rg_1">
+            <dive id="dive_bbb1">
+                <informationbeforedive>
+                    <datetime>2026-08-10T20:10:29</datetime>
+                    <equipmentused>
+                        <leadquantity>6.0</leadquantity>
+                    </equipmentused>
+                </informationbeforedive>
+                <samples>
+                    <waypoint><depth>0.0</depth><divetime>0.0</divetime></waypoint>
+                </samples>
+                <informationafterdive>
+                    <diveduration>1200.0</diveduration>
+                    <equipmentused>
+                        <leadquantity>12.0</leadquantity>
+                    </equipmentused>
+                </informationafterdive>
+            </dive>
+        </repetitiongroup>
+    </profiledata>
+</uddf>''';
+
+void main() {
+  final service = UddfFullImportService();
+
+  group('Oceanic Plus float-formatted UDDF', () {
+    test('waypoint timestamps advance instead of collapsing to zero', () async {
+      // The reported symptom: int.tryParse("15.0") returns null, so every
+      // waypoint fell through to the `?? 0` default and the depth/time
+      // graph drew all samples stacked at t=0.
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+      final dive = result.dives.single;
+      final profile = dive['profile'] as List<Map<String, dynamic>>?;
+
+      expect(profile, isNotNull);
+      expect(profile!.length, 5);
+      expect(profile.map((p) => p['timestamp']).toList(), [
+        0,
+        15,
+        30,
+        45,
+        3492,
+      ]);
+    });
+
+    test('waypoint depths still parse alongside the timestamps', () async {
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+      final profile =
+          result.dives.single['profile'] as List<Map<String, dynamic>>;
+
+      expect(profile[1]['depth'], closeTo(0.1, 0.001));
+      expect(profile[3]['depth'], closeTo(12.3, 0.001));
+    });
+
+    test('float diveduration is parsed as runtime', () async {
+      // Second data loss in the same file: diveduration has no `?? 0`
+      // fallback, so a float value dropped runtime entirely.
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+
+      expect(
+        result.dives.single['runtime'],
+        equals(const Duration(seconds: 3492)),
+      );
+    });
+
+    test('lead weight is read from informationafterdive', () async {
+      // Third loss: leadquantity was only ever read from
+      // informationbeforedive, where Oceanic does not put it.
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+
+      expect(result.dives.single['weightUsed'], closeTo(12.0, 0.001));
+    });
+
+    test(
+      'informationbeforedive weight wins when both halves supply it',
+      () async {
+        final result = await service.importAllDataFromUddf(_weightInBothHalves);
+
+        expect(result.dives.single['weightUsed'], closeTo(6.0, 0.001));
+      },
+    );
+
+    test('greatestdepth and temperature are unaffected', () async {
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+      final dive = result.dives.single;
+
+      expect(dive['maxDepth'], closeTo(18.335197, 0.0001));
+      expect(dive['waterTemp'], closeTo(302.94 - 273.15, 0.01));
+    });
+
+    test('the site is imported with its coordinates', () async {
+      final result = await service.importAllDataFromUddf(_oceanicUddf);
+
+      expect(result.sites, hasLength(1));
+      expect(result.sites.single['latitude'], closeTo(12.345678, 0.000001));
+      expect(result.sites.single['longitude'], closeTo(-65.43210, 0.000001));
+    });
+
+    test('MacDiveDialect does not claim Oceanic exports', () async {
+      // Oceanic shares the UDDF 3.2 namespace with MacDive AND nests
+      // equipmentused in informationafterdive, which is one of the two
+      // structural quirks MacDiveDialect fingerprints on. Only the presence
+      // of a <generator> element keeps detection from misfiring, so this
+      // guards a genuinely narrow margin.
+      final doc = XmlDocument.parse(_oceanicUddf);
+
+      expect(MacDiveDialect().isMatch(doc), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
A UDDF file exported from Oceanic Plus (Oceanic's iPhone app, recording from an Apple Watch Ultra) imported with every profile waypoint stamped at t=0, so the depth/time graph drew all samples in a single column. Reported by email with the source file attached.

## Cause

`int.tryParse` rejects any decimal point outright, and Oceanic writes integer-semantics fields as floats (`<divetime>15.0</divetime>`), so every waypoint fell through to its `?? 0` default.

Two further losses turned up in the same file:

| Loss | Cause |
| --- | --- |
| Profile timestamps collapsed to t=0 | `int.tryParse("15.0")` returns null, `?? 0` |
| Dive runtime dropped | `<diveduration>3492.0</diveduration>`, no fallback at all |
| Lead weight dropped | `<leadquantity>` read only from `<informationbeforedive>`, where Oceanic does not put it |

All 12 dives in the reporter's file were affected by all three.

## Approach

Fixed vendor-agnostically rather than by adding an `OceanicDialect`.

The dialect mechanism was the obvious move — `MacDiveDialect` already regex-strips `.0` from exactly these fields — but Oceanic's `<generator>` block has no `<name>` child, leaving only a locale-dependent homepage URL (`.../it/oceanic-plus/`) to fingerprint on. A dialect that fails to detect reintroduces the bug silently. It would also re-serialize a document that currently imports mostly fine, and would leave the underlying defect (a parser stricter than its input) in place for the next vendor.

`UddfImportParsers.parseUddfInt` now accepts plain integers, float formatting, exponent notation and surrounding whitespace, applied at all 28 integer-semantics parse sites across the import path. Lead weight is read from whichever half of the dive supplies it, before-dive winning.

The finiteness guard is load-bearing rather than defensive: `double.tryParse` succeeds on `"NaN"` and `"Infinity"`, and `double.round()` throws `UnsupportedError` on both, so one malformed element would otherwise abort an entire import.

`MacDiveDialect._floatIntPattern` is deliberately left in place — redundant now, but removing it expands the blast radius into MacDive regression territory for no functional gain.

## Detection tripwire, now pinned

`MacDiveDialect._hasMacDiveStructuralQuirks` fingerprints on `<equipmentused>` nested inside `<informationafterdive>` — which Oceanic also does. The only thing preventing MacDiveDialect from claiming Oceanic files today is that Oceanic emits a `<generator>` element, which short-circuits detection to the name check before the structural fallback runs. A regression test now guards that margin.

## Testing

- `uddf_lenient_int_parse_test.dart` — 8 helper units: plain, float, whitespace-padded, fractional, exponent, beyond-32-bit, non-numeric, non-finite
- `uddf_oceanic_float_import_test.dart` — 8 end-to-end tests on a synthetic fixture reproducing Oceanic's exact serialization shape (invented site ids and coordinates; the reporter's own dive data and GPS positions are not committed)

Verified red before the fix: waypoint timestamps came back `[0, 0, 0, 0, 0]`, runtime null, weight null. The four control assertions pass in both states.

Verified against the reporter's real 609 KB file: all 12 dives import with complete profiles (138-303 points each), runtimes and weights; zero collapsed profiles.

Local: `dart format` clean, `flutter analyze` clean, full suite green.

## Known limitations

Both documented in the design doc, neither guessed at in code:

- **Oceanic appears to export lead weight in the user's display unit.** The reporter's notes read "12 lbs weights" while the file carries `<leadquantity>12.0</leadquantity>`. UDDF specifies kilograms. Inferring the unit needs vendor attribution and is genuinely ambiguous (12 kg is heavy but plausible), so it is left alone pending confirmation from the reporter.
- **Oceanic's sample series outruns its stated duration.** The first dive carries 293 waypoints at 15-second spacing (ending at t=4380) against a `<diveduration>` of 3492 seconds — likely surface time included in the profile, or duration meaning bottom time.
