### PR TITLE
fix(promote): skip deliver's HTML preview prompt when submitting for review

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -453,6 +453,15 @@ platform :ios do
       # whatsNew on a new version. Only files present are uploaded, and that is
       # the only metadata file provided.
       skip_metadata: false,
+      # Required BECAUSE skip_metadata is false. deliver renders the metadata
+      # it is about to upload to fastlane/Preview.html and blocks on "Does the
+      # Preview look okay for you?", which no one can answer on a CI runner:
+      # promotion run 31850203979 died there with "Could not retrieve response
+      # as fastlane runs in non-interactive mode". force skips that preview
+      # confirmation only; run_precheck_before_submit still defaults to true,
+      # so Apple's content rules are checked as before. The legacy release
+      # lane above has carried this flag since it was written.
+      force: true,
       submit_for_review: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -535,6 +535,15 @@ platform :mac do
       # whatsNew on a new version. Only files present are uploaded, and that is
       # the only metadata file provided.
       skip_metadata: false,
+      # Required BECAUSE skip_metadata is false. deliver renders the metadata
+      # it is about to upload to fastlane/Preview.html and blocks on "Does the
+      # Preview look okay for you?", which no one can answer on a CI runner:
+      # promotion run 31850203979 died there with "Could not retrieve response
+      # as fastlane runs in non-interactive mode". force skips that preview
+      # confirmation only; run_precheck_before_submit still defaults to true,
+      # so Apple's content rules are checked as before. The legacy release
+      # lane above has carried this flag since it was written.
+      force: true,
       submit_for_review: true,
       automatic_release: false,
       precheck_include_in_app_purchases: false,


### PR DESCRIPTION
## Problem

The `submit-appstore` leg of **Promote Beta** has failed on both promotions
that have reached it. Most recently on
[run 31850203979](https://github.com/submersion-app/submersion/actions/runs/31850203979)
(build 6027, `v1.7.3.6027`):

```
[23:25:33]: Successfully set the version to '1.7.3'
[23:25:33]: Loading './fastlane/metadata/en-US/release_notes.txt'...
[23:25:33]: Verifying the upload via the HTML file can be disabled by either adding
[23:25:33]: `force true` to your Deliverfile or using `fastlane deliver --force`
[23:25:34]: Does the Preview on path './fastlane/Preview.html' look okay for you?
[23:25:34]: Could not retrieve response as fastlane runs in non-interactive mode
```

Nothing was submitted, on either platform. The macOS step never ran at all,
because the job aborts at the iOS step.

## Root cause

`8bf5338` flipped `skip_metadata` from `true` to `false` in the
`submit_existing` lanes so that Apple gets the `whatsNew` string it requires
on a new version. That is correct, but it also moves `deliver` onto its
`upload_metadata` path, which calls `validate_html`: it renders the pending
metadata to `fastlane/Preview.html` and blocks on a "does this look okay?"
confirmation. On a GitHub runner there is nobody to answer, so `deliver`
crashes before uploading anything.

`force` was still at its `false` default (visible in the deliver summary table
in the run log). It is not a "skip safety checks" flag: it suppresses the HTML
preview confirmation and nothing else. `run_precheck_before_submit` still
defaults to `true`, so Apple's content rules are validated exactly as before.

Worth noting this is precedent drift rather than a novel bug. The legacy
`upload_screenshots` and `release` lanes in these same two files have carried
`force: true` since they were written (`ios/fastlane/Fastfile:77` even
comments it as "Skip HTML preview and y/n confirmation prompt").
`submit_existing` was added later and never picked it up, which stayed
invisible while its `skip_metadata` was still `true`.

## Change

Adds `force: true` to the `submit_existing` lane in both
`ios/fastlane/Fastfile` and `macos/fastlane/Fastfile`, with a comment tying it
to the `skip_metadata: false` above it so the two do not drift apart again.

Both files needed it: the macOS submission has never actually executed, so it
would have hit the identical wall on the next run.

## Verification

`ruby -c` passes on both Fastfiles. The flag is not a guess: the failure
message in the log names `force` as the fix, and the same option is already
passed to the same `upload_to_app_store` action elsewhere in these files in
lanes that have run in production.

Full verification is the next promotion dispatch, since this code path only
executes against App Store Connect.

## Not covered by this PR

Run 31850203979 had three problems. This PR fixes one of them.

- **`promote-play` failed** with `Google Api Error: Invalid request -
  Precondition check failed.` Build 6027 is genuinely on the `alpha` track, so
  the source release resolved fine; the failure is on the production side.
  This is the state already documented in `docs/developer/release-process.md`
  (lines 89 and 107): the app has no Play production access yet, so the
  promotion leg cannot succeed. No code change can fix it.
- **Bump PR #1050 is stuck.** Its CodeQL and CI/CD runs are sitting at
  `action_required` (awaiting workflow approval), so auto-merge cannot fire.
  `pubspec.yaml` is still at `1.7.3+120`, which keeps the beta train closed.
  The previous bump PR (#842) ran its checks normally, so this is new.

## Recovery order

1. Approve the queued workflow runs on #1050 so the bump lands and reopens the
   beta train.
2. Merge this PR.
3. Re-dispatch **Promote Beta** with `build-number: 6027`. Use a fresh
   dispatch, not "Re-run failed jobs": per the release docs, a re-run replays
   the workflow definition pinned at the original run and would not include
   this fix. The workflow is re-entrant, so the existing release is verified by
   checksum and left untouched, and the bump PR step skips itself.

Refs #1051
