### PR TITLE
fix(promote): target the Mac app record when submitting macOS for review

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -459,8 +459,11 @@ platform :ios do
       # promotion run 31850203979 died there with "Could not retrieve response
       # as fastlane runs in non-interactive mode". force skips that preview
       # confirmation only; run_precheck_before_submit still defaults to true,
-      # so Apple's content rules are checked as before. The legacy release
+      # so Apple's content rules are checked as before. The upload_screenshots
       # lane above has carried this flag since it was written.
+      #
+      # platform is left at deliver's default of "ios", which is correct here.
+      # The mac lane must set it explicitly; see the comment there.
       force: true,
       submit_for_review: true,
       automatic_release: false,

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -526,6 +526,16 @@ platform :mac do
     UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
     upload_to_app_store(
       api_key: api_key,
+      # deliver defaults platform to "ios" and otherwise infers it from the
+      # binary it is uploading. skip_binary_upload leaves nothing to infer
+      # from, so without this the mac lane drove the iOS app record instead:
+      # promotion run 31859359618 selected iOS build 6027 and App Store
+      # Connect refused to attach it to the iOS 1.7.3 version that the iOS
+      # job had submitted for review a minute earlier, with "A relationship
+      # value is not acceptable for the current resource state". This is the
+      # same inference gap the app_platform comment on
+      # distribute_testflight_beta above describes, for the same reason.
+      platform: "osx",
       app_version: app_version,
       build_number: build_number.to_s,
       skip_binary_upload: true,
@@ -541,7 +551,7 @@ platform :mac do
       # promotion run 31850203979 died there with "Could not retrieve response
       # as fastlane runs in non-interactive mode". force skips that preview
       # confirmation only; run_precheck_before_submit still defaults to true,
-      # so Apple's content rules are checked as before. The legacy release
+      # so Apple's content rules are checked as before. The upload_screenshots
       # lane above has carried this flag since it was written.
       force: true,
       submit_for_review: true,


### PR DESCRIPTION
## Problem

Follow-up to #1052. That fix worked: on
[run 31859359618](https://github.com/submersion-app/submersion/actions/runs/31859359618)
the **Submit iOS build** step passed for the first time and iOS 1.7.3 (6027)
went to App Review. The job then failed one step later, on macOS:

```
A relationship value is not acceptable for the current resource state.
 - The specified pre-release build could not be added.
 - /data/relationships/build
```

## Root cause

deliver's own summary table, printed inside the **`mac submit_existing`**
lane, gives it away:

```
| platform                                     | ios                    |
```

`deliver` defaults `platform` to `"ios"`, and otherwise infers it from the
binary it is uploading. `submit_existing` sets `skip_binary_upload: true`, so
there is no binary to infer from and the default stood.

So the macOS job drove the **iOS** app record. It selected iOS build 6027 and
tried to attach it to iOS version 1.7.3, which the iOS step had submitted for
review about a minute earlier in the same job. App Store Connect refuses build
changes on a version in Waiting for Review, which is exactly the error above.
fastlane's own "related issues" hint at the bottom of the log points at the
same state ("The app store version is in Waiting For Review").

The lane context in the same output confirms fastlane knew which lane it was
in even though deliver did not:

```
| PLATFORM_NAME    | mac                 |
| LANE_NAME        | mac submit_existing |
```

## Change

Adds `platform: "osx"` to the macOS `submit_existing` lane.

This file already solved the identical problem once. `distribute_testflight_beta`
passes `app_platform: "osx"` with a comment explaining that pilot cannot infer
the platform when `distribute_only` means there is no pkg. `upload_to_app_store`
needs the same treatment for the same reason. `upload_screenshots` already
passes `platform: 'osx'`; `release` and `upload_only` get away without it only
because they pass a `pkg:` to infer from. `submit_existing` was the one lane
that had neither a binary nor an explicit platform.

The iOS lane is deliberately left alone: `"ios"` is deliver's default and is
correct there. A comment now records that, so the asymmetry between the two
otherwise-identical lanes does not read as an oversight.

## Verification

Checked that the target build actually exists, rather than assuming `"osx"`
would resolve. Beta run 31836315089:

```
Waiting for processing on... app_id: 6757456915, app_version: 1.7.3,
  build_version: 6027, platform: MAC_OS
Successfully finished processing the build 1.7.3 - 6027 for MAC_OS
```

`ruby -c` passes on both Fastfiles.

Full verification is the next promotion dispatch, since this path only
executes against App Store Connect.

## Also in this PR

Corrects the lane named in the `force` comment that #1052 added to both files.
The precedent is `upload_screenshots`, not `release`. Copilot flagged this on
#1052 and it was correct; folding it in here rather than spending a separate PR
on a comment, since these are the same lines.

## Still outstanding

- **`promote-play`** failed again with `Precondition check failed`, unchanged
  and unrelated. Per `docs/developer/release-process.md` this is the documented
  consequence of not having Play production access yet.
- **Worth checking in App Store Connect:** before failing, the macOS job
  uploaded metadata to the iOS record ("Uploading metadata to App Store Connect
  for localized version 'en-US'"). It was the same release-notes text the iOS
  step had just uploaded, so this should be a no-op, but iOS 1.7.3 is in
  Waiting for Review and worth a glance to confirm it is still in the state you
  expect.

Refs #1051
