### PR TITLE
feat(promote): make App Store submission re-dispatchable per platform

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -251,11 +251,27 @@ jobs:
         if: always()
         run: rm -f android/fastlane/play-store-key.json
 
+  # One job per Apple platform, not one job doing both in sequence. They were
+  # sequential steps until run 31859359618, where the iOS step succeeded, the
+  # macOS step failed, and re-running meant redoing the iOS submission that had
+  # already worked - which then failed too, because a version Apple already has
+  # cannot be resubmitted. Independent jobs make each platform separately
+  # retryable, matching how promote / promote-play / bump-pr already behave.
+  #
+  # fail-fast: false is the part that does the decoupling: without it, one leg
+  # failing cancels the other, which is the behavior being fixed.
+  #
+  # notify-failures still says `needs: submit-appstore` and needs no change: a
+  # matrix rolls up to its job id, and the roll-up fails if either leg fails.
   submit-appstore:
-    name: Submit existing builds for App Review
+    name: Submit ${{ matrix.platform }} build for App Review
     runs-on: macos-15
     needs: promote
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, macos]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -278,52 +294,35 @@ jobs:
           # the sanitizer. Truncated afterwards, in CHARACTERS (not bytes,
           # which could split a multi-byte UTF-8 sequence and produce invalid
           # text) below Apple's 4000-char limit.
-          mkdir -p ios/fastlane/metadata/en-US macos/fastlane/metadata/en-US
+          mkdir -p ${{ matrix.platform }}/fastlane/metadata/en-US
           gh release view "$TAG_NAME" --repo ${{ github.repository }} \
             --json body -q .body \
             | ./scripts/release/sanitize_apple_store_notes.py --report \
                 --fallback 'This release includes bug fixes and improvements.' \
             | python3 -c 'import sys; sys.stdout.write(sys.stdin.read()[:3900])' \
-            > ios/fastlane/metadata/en-US/release_notes.txt
-          cp ios/fastlane/metadata/en-US/release_notes.txt \
-            macos/fastlane/metadata/en-US/release_notes.txt
-          test -s ios/fastlane/metadata/en-US/release_notes.txt
+            > ${{ matrix.platform }}/fastlane/metadata/en-US/release_notes.txt
+          test -s ${{ matrix.platform }}/fastlane/metadata/en-US/release_notes.txt
 
-      - name: Setup Ruby (iOS)
+      - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
-          working-directory: ios
+          working-directory: ${{ matrix.platform }}
 
       - name: Setup App Store Connect API Key
         env:
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         run: |
-          mkdir -p ios/fastlane macos/fastlane
-          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > ios/fastlane/AuthKey.p8
-          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode > macos/fastlane/AuthKey.p8
+          mkdir -p ${{ matrix.platform }}/fastlane
+          echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode \
+            > ${{ matrix.platform }}/fastlane/AuthKey.p8
 
-      - name: Submit iOS build
-        working-directory: ios
-        env:
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: fastlane/AuthKey.p8
-        run: |
-          bundle exec fastlane submit_existing \
-            app_version:"${{ needs.promote.outputs.semver }}" \
-            build_number:"${{ needs.promote.outputs.build-number }}"
-
-      - name: Setup Ruby (macOS)
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-          working-directory: macos
-
-      - name: Submit macOS build
-        working-directory: macos
+      # The lane is a no-op when Apple already has this version, so a
+      # re-dispatched promotion skips the platform that already succeeded
+      # instead of failing on it. See already_submitted_state in the Fastfile.
+      - name: Submit build
+        working-directory: ${{ matrix.platform }}
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
@@ -335,7 +334,7 @@ jobs:
 
       - name: Cleanup sensitive files
         if: always()
-        run: rm -f ios/fastlane/AuthKey.p8 macos/fastlane/AuthKey.p8
+        run: rm -f ${{ matrix.platform }}/fastlane/AuthKey.p8
 
   bump-pr:
     name: Open the version bump PR

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -34,6 +34,24 @@ DUPLICATE_BUILD_MARKERS = [
   "bundle version must be higher than the previously uploaded version",
 ].freeze
 
+# App Store version states meaning the version is already out of our hands.
+# App Store Connect refuses build and metadata changes from any of these, so
+# submitting again cannot succeed; the only useful behavior is to skip.
+#
+# Rejected states are deliberately absent. REJECTED, DEVELOPER_REJECTED,
+# METADATA_REJECTED and INVALID_BINARY all need a fresh submission, which is
+# exactly what this lane is for.
+ALREADY_SUBMITTED_STATES = [
+  "WAITING_FOR_REVIEW",
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+  "ACCEPTED",
+].freeze
+
 platform :ios do
   # ============================================================================
   # Screenshot Lanes
@@ -172,6 +190,41 @@ platform :ios do
   def duplicate_build_error?(message)
     text = message.to_s
     DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
+  end
+
+  # The already-submitted state of <app_version> on <platform>, or nil when the
+  # version is still ours to submit OR the state cannot be determined.
+  #
+  # Every uncertain path returns nil on purpose, so the caller falls through to
+  # attempting the submission, which is the behavior that existed before this
+  # check. The guard can therefore only ever skip work that would have failed;
+  # it can never turn a working submission into a skipped one.
+  #
+  # Limitation worth knowing: get_edit_app_store_version returns versions in
+  # editable states, which includes WAITING_FOR_REVIEW (the state that broke
+  # promotion run 31859359618). Should Apple stop returning an IN_REVIEW
+  # version there, this quietly degrades to the old attempt-and-fail behavior
+  # rather than misreporting.
+  #
+  # No explicit spaceship auth: both branches of load_api_key go through the
+  # app_store_connect_api_key action, whose set_spaceship_token defaults to
+  # true, so Spaceship::ConnectAPI.token is already set by the time a lane
+  # calls this.
+  def already_submitted_state(app_version, platform)
+    app = Spaceship::ConnectAPI::App.find(
+      CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
+    )
+    return nil if app.nil?
+
+    version = app.get_edit_app_store_version(
+      platform: Spaceship::ConnectAPI::Platform.map(platform),
+    )
+    return nil if version.nil? || version.version_string != app_version
+
+    # app_store_state is deprecated as of App Store Connect API 3.3 in favor of
+    # app_version_state; read the new field first and fall back.
+    state = version.app_version_state || version.app_store_state
+    ALREADY_SUBMITTED_STATES.include?(state) ? state : nil
   end
 
   # Loads API key from environment variables or falls back to api_key.json
@@ -440,6 +493,16 @@ platform :ios do
     api_key = load_api_key
     app_version = options[:app_version] || UI.user_error!("app_version is required")
     build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    # Makes the lane a no-op once Apple has the version, so a re-dispatched
+    # promotion does not fail on the leg that already succeeded.
+    if (state = already_submitted_state(app_version, "ios"))
+      UI.important(
+        "#{app_version} is already #{state} for ios; skipping submission. " \
+        "Remove it from review in App Store Connect if you need to resubmit."
+      )
+      next
+    end
 
     UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
     upload_to_app_store(

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -34,6 +34,24 @@ DUPLICATE_BUILD_MARKERS = [
   "bundle version must be higher than the previously uploaded version",
 ].freeze
 
+# App Store version states meaning the version is already out of our hands.
+# App Store Connect refuses build and metadata changes from any of these, so
+# submitting again cannot succeed; the only useful behavior is to skip.
+#
+# Rejected states are deliberately absent. REJECTED, DEVELOPER_REJECTED,
+# METADATA_REJECTED and INVALID_BINARY all need a fresh submission, which is
+# exactly what this lane is for.
+ALREADY_SUBMITTED_STATES = [
+  "WAITING_FOR_REVIEW",
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+  "ACCEPTED",
+].freeze
+
 platform :mac do
   # ============================================================================
   # Helper Methods
@@ -127,6 +145,41 @@ platform :mac do
   def duplicate_build_error?(message)
     text = message.to_s
     DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
+  end
+
+  # The already-submitted state of <app_version> on <platform>, or nil when the
+  # version is still ours to submit OR the state cannot be determined.
+  #
+  # Every uncertain path returns nil on purpose, so the caller falls through to
+  # attempting the submission, which is the behavior that existed before this
+  # check. The guard can therefore only ever skip work that would have failed;
+  # it can never turn a working submission into a skipped one.
+  #
+  # Limitation worth knowing: get_edit_app_store_version returns versions in
+  # editable states, which includes WAITING_FOR_REVIEW (the state that broke
+  # promotion run 31859359618). Should Apple stop returning an IN_REVIEW
+  # version there, this quietly degrades to the old attempt-and-fail behavior
+  # rather than misreporting.
+  #
+  # No explicit spaceship auth: both branches of load_api_key go through the
+  # app_store_connect_api_key action, whose set_spaceship_token defaults to
+  # true, so Spaceship::ConnectAPI.token is already set by the time a lane
+  # calls this.
+  def already_submitted_state(app_version, platform)
+    app = Spaceship::ConnectAPI::App.find(
+      CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
+    )
+    return nil if app.nil?
+
+    version = app.get_edit_app_store_version(
+      platform: Spaceship::ConnectAPI::Platform.map(platform),
+    )
+    return nil if version.nil? || version.version_string != app_version
+
+    # app_store_state is deprecated as of App Store Connect API 3.3 in favor of
+    # app_version_state; read the new field first and fall back.
+    state = version.app_version_state || version.app_store_state
+    ALREADY_SUBMITTED_STATES.include?(state) ? state : nil
   end
 
   def load_api_key
@@ -522,6 +575,16 @@ platform :mac do
     api_key = load_api_key
     app_version = options[:app_version] || UI.user_error!("app_version is required")
     build_number = options[:build_number] || UI.user_error!("build_number is required")
+
+    # Makes the lane a no-op once Apple has the version, so a re-dispatched
+    # promotion does not fail on the leg that already succeeded.
+    if (state = already_submitted_state(app_version, "osx"))
+      UI.important(
+        "#{app_version} is already #{state} for osx; skipping submission. " \
+        "Remove it from review in App Store Connect if you need to resubmit."
+      )
+      next
+    end
 
     UI.message("Submitting #{app_version} (#{build_number}) for App Review...")
     upload_to_app_store(


### PR DESCRIPTION
> **Stacked on #1053.** Based on `worktree-fix-macos-deliver-platform` so the
> diff shows only this change. GitHub retargets to `main` automatically when
> #1053 merges.

## Problem

Run 31859359618 submitted iOS successfully and then failed on macOS. Recovering
meant re-dispatching, which would have redone the iOS submission that had
already worked, and that would have failed too: App Store Connect refuses build
and metadata changes once a version is in Waiting for Review. The actual
recovery was removing the version from review by hand in App Store Connect.

The other three promote jobs (`promote`, `promote-play`, `bump-pr`) are all
re-entrant by design. `submit-appstore` was the one that was not, in two
separate ways:

1. Submitting an already-submitted platform is fatal rather than a no-op.
2. iOS and macOS were sequential steps in one job, so iOS failing for *any*
   reason meant macOS never ran at all.

## Change 1: skip instead of fail

Both `submit_existing` lanes now query App Store Connect for the version's state
before submitting, and no-op when Apple already has it:

```
1.7.3 is already WAITING_FOR_REVIEW for osx; skipping submission.
Remove it from review in App Store Connect if you need to resubmit.
```

The check is deliberately one-directional. App not found, no editable version, a
version-string mismatch, or an unrecognized state all return `nil` and fall
through to attempting the submission, which is exactly the current behavior. **It
can only ever skip work that was going to fail; it cannot turn a working
submission into a skipped one.**

`REJECTED`, `DEVELOPER_REJECTED`, `METADATA_REJECTED` and `INVALID_BINARY` are
excluded from the skip list on purpose: those are precisely the states that need
a resubmission, which is what this lane is for.

## Change 2: one job per platform

`submit-appstore` becomes a two-leg matrix with `fail-fast: false`, so iOS
failing no longer prevents macOS from running. This also collapses the
duplicated iOS/macOS steps into one parameterized set, so the two platforms
cannot drift apart the way they did in #1052 and #1053.

`notify-failures` needs no change: a matrix rolls up to its job id, so
`needs: submit-appstore` still resolves and still reports failure if either leg
fails.

## Verification

The dangerous failure mode is an inverted comparison making the guard skip a
*real* submission, so I extracted `already_submitted_state` from each Fastfile
and exercised it against fakes rather than trusting a read:

```
19/19 passed
```

covering both directions: app-not-found / no-version / version-mismatch /
`PREPARE_FOR_SUBMISSION` / all four rejected states must **attempt**; all eight
declared submitted states must **skip**; plus the deprecated `app_store_state`
fallback and an unknown-state case. Run against both files, which are
byte-identical for this helper.

The spaceship API surface was checked against the pinned fastlane 2.232 source
rather than assumed:

- `Spaceship::ConnectAPI::App.find(bundle_id)` returns the app or `nil`
- `get_edit_app_store_version` filters for editable states, which **includes
  `WAITING_FOR_REVIEW`**, so it returns the submitted version rather than `nil`
- `Platform.map("osx")` maps to `MAC_OS`
- `app_version_state` supersedes `app_store_state`, deprecated as of API 3.3
- `app_store_connect_api_key` sets `Spaceship::ConnectAPI.token` by default, so
  no extra auth is needed in the lane

Also: `ruby -c` on both Fastfiles, and the workflow YAML parsed to confirm the
matrix expands to `[ios, macos]` and `notify-failures` still resolves.

There is no way to exercise the real App Store Connect path from CI without
submitting something, so end-to-end confirmation is the next promotion dispatch.

## Known limitation

`get_edit_app_store_version` returns versions in editable states. If Apple stops
returning an `IN_REVIEW` version there, the guard degrades to the current
attempt-and-fail behavior rather than misreporting. That is recorded in the
comment next to the helper.

## Out of scope

`promote-play` still fails with `Precondition check failed` and still needs the
Play production-access grant. Nothing here touches it.

Refs #1051
