### PR TITLE
feat(promote): release iOS and macOS automatically on approval

### DIFF
--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -24,7 +24,7 @@ promote (workflow_dispatch, manual)
   -> Promote Beta (promote.yml)            copies the chosen beta's artifacts
        -> main-repo tag + stable release   + appcast.xml entry (stored sig)
        -> Play: track -> production        identical AAB, staged rollout
-       -> App Store: submit existing build then release manually on approval
+       -> App Store: submit existing build, releases on approval
        -> version-bump PR                  auto-merges; opens the next train
 ```
 
@@ -76,13 +76,21 @@ for App Review, and opens the version-bump PR (auto-merges on green CI).
 The five jobs are independent: a partial failure opens a tracking issue
 (`notify-failures`) and only the failed leg needs re-running.
 
-### Manual follow-ups after promoting
+### After promoting
 
-1. **App Store Connect:** press Release for iOS and macOS once Apple
-   approves (~24-48h). Submission is automated; the release button is
-   deliberately manual.
-2. That's it. The bump PR merges itself; the next merge to `main` starts
-   the next beta train.
+Nothing to do. iOS and macOS carry `automatic_release: true`, so both go
+live on their own once Apple approves (~24-48h); the bump PR merges itself,
+and the next merge to `main` starts the next beta train.
+
+Two things still want a human:
+
+- **A rejection.** Auto-release only covers the approved path. A rejected
+  version sits in App Store Connect until someone addresses it.
+- **A bad build.** There is no staged rollout to halt and no rollback once a
+  version is live. Recovering means pulling it and shipping a fix through
+  another review cycle. If that risk ever outweighs the convenience, set
+  `phased_release: true` in `ios/fastlane/Fastfile` for a haltable 7-day iOS
+  rollout, or put `automatic_release` back to `false` in both Fastfiles.
 
 ## Play Store state
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -529,11 +529,20 @@ platform :ios do
       # The mac lane must set it explicitly; see the comment there.
       force: true,
       submit_for_review: true,
-      automatic_release: false,
+      # Goes live the moment Apple approves, with no human gate. The other two
+      # channels already behave this way: Play promotes at rollout 1.0 and the
+      # desktop appcast publishes at promotion time, so the manual App Store
+      # button was the one thing holding the platforms out of sync.
+      #
+      # The trade, accepted deliberately: Apple's approval becomes the only
+      # gate, there is no staged rollout to halt, and undoing a live version
+      # means pulling it and submitting a fix through another review cycle.
+      # Switch to phased_release (iOS only) if that ever needs a safety valve.
+      automatic_release: true,
       precheck_include_in_app_purchases: false,
       submission_information: { add_id_info_uses_idfa: false },
     )
-    UI.success("Submitted for review; release manually in App Store Connect on approval.")
+    UI.success("Submitted for review; releases automatically once Apple approves.")
   end
 
   desc "Full release: capture screenshots, upload everything, and submit build"

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -618,11 +618,20 @@ platform :mac do
       # lane above has carried this flag since it was written.
       force: true,
       submit_for_review: true,
-      automatic_release: false,
+      # Goes live the moment Apple approves, with no human gate. The other two
+      # channels already behave this way: Play promotes at rollout 1.0 and the
+      # desktop appcast publishes at promotion time, so the manual App Store
+      # button was the one thing holding the platforms out of sync.
+      #
+      # The trade, accepted deliberately: Apple's approval becomes the only
+      # gate, there is no staged rollout to halt, and undoing a live version
+      # means pulling it and submitting a fix through another review cycle.
+      # The Mac App Store has no phased-release equivalent to fall back on.
+      automatic_release: true,
       precheck_include_in_app_purchases: false,
       submission_information: { add_id_info_uses_idfa: false },
     )
-    UI.success("Submitted for review; release manually in App Store Connect on approval.")
+    UI.success("Submitted for review; releases automatically once Apple approves.")
   end
 
   desc "Full release: capture screenshots, upload everything, and submit build"


### PR DESCRIPTION
## Why

The promote workflow submitted both Apple platforms for review and then
stopped, waiting for someone to press Release in App Store Connect.

The other two channels have never worked that way. Play promotes at
`rollout: 1.0` and the desktop appcast publishes at promotion time, both
during the promotion itself. The manual App Store button was the only thing
holding the platforms out of sync, sometimes by days.

## Change

`automatic_release: true` in the `submit_existing` lane of both Fastfiles, so
an approved version goes live on its own.

The legacy `release` and `upload_only` lanes stay at `false`. They pass
`submit_for_review: false` and are not part of the promotion path, so flipping
them would change behavior nobody asked about.

## The trade, stated plainly

This removes a human checkpoint, so it is worth being explicit rather than
burying it:

- Apple's approval becomes the **only** gate before 100% of users get the build.
- There is no staged rollout to halt.
- There is no rollback once a version is live. Recovering means pulling it and
  shipping a fix through another 24 to 48 hour review cycle.

Rejections are unaffected and still need a human.

`phased_release: true` remains available as an iOS-only safety valve (a
haltable 7-day rollout) if this ever needs revisiting. The Mac App Store has no
equivalent, which is noted in the macOS comment so the asymmetry is not
mistaken for an oversight.

## Docs

`release-process.md` asserted the opposite in two places, and both would have
become actively misleading:

- The pipeline diagram said `submit existing build then release manually on approval`.
- A "Manual follow-ups after promoting" section instructed the reader to press
  Release and called it "deliberately manual".

That section is now "After promoting", says nothing is required, and names the
two cases that still want a human (a rejection, and a bad build) along with how
to put the manual gate back.

## Verification

`ruby -c` on both Fastfiles. Confirmed only the two `submit_existing`
occurrences changed and the four legacy-lane ones did not. Swept the repo for
leftover claims that the release is manual; the only remaining hit is
`docs/superpowers/plans/2026-08-02-...md`, a dated implementation-plan record
that is deliberately left as written.

As with the rest of this series, the real proof is the next promotion, since
this path only executes against App Store Connect.

## Out of scope

`release-process.md:76` still says "The five jobs are independent", which went
slightly stale when #1055 made `submit-appstore` a two-leg matrix. Unrelated to
this change and left alone.
