### PR TITLE
Visually regroup the trip story page

### DIFF
--- a/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
@@ -69,14 +69,16 @@ class TripStoryDayCard extends ConsumerWidget {
         opacity: _isPlanned ? 0.85 : 1,
         child: Padding(
           padding: const EdgeInsets.all(16),
+          // Three zones with deliberate visual weight: a tinted day-at-a-glance
+          // band (stats + rhythm), the untinted dive rows as the dominant
+          // middle, and captioned photo/species clusters at the tail. Gaps
+          // follow the grouping: tight inside a zone, 16 between zones.
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (day.dives.isNotEmpty) ...[
-                _DayStatStrip(day: day, units: units),
+                _DaySummaryBand(day: day, units: units),
                 const SizedBox(height: 12),
-                DayRhythmBar(dives: day.dives),
-                const SizedBox(height: 8),
                 ...day.dives.mapIndexed(
                   (index, dive) => DiveListItem(
                     summary: DiveSummary.fromDive(dive),
@@ -91,17 +93,74 @@ class TripStoryDayCard extends ConsumerWidget {
                 ),
               ],
               if (day.media.isNotEmpty) ...[
-                const SizedBox(height: 12),
+                const SizedBox(height: 16),
+                _SectionCaption(text: context.l10n.trips_photos_sectionTitle),
+                const SizedBox(height: 6),
                 _PhotoStrip(tripId: tripId, media: day.media),
               ],
               if (day.sightings.isNotEmpty) ...[
-                const SizedBox(height: 12),
+                const SizedBox(height: 16),
+                _SectionCaption(
+                  text: context.l10n.trips_detail_stat_speciesSeen,
+                ),
+                const SizedBox(height: 6),
                 _SightingChips(day: day),
               ],
               if (_isPlanned) _PlannedExtras(day: day, units: units),
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// The day-at-a-glance cluster: stat strip plus 24h rhythm bar, visually
+/// bounded by a subtle tint so it reads as one summary unit above the dive
+/// rows rather than as loose siblings of them.
+class _DaySummaryBand extends StatelessWidget {
+  final TripStoryDay day;
+  final UnitFormatter units;
+
+  const _DaySummaryBand({required this.day, required this.units});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('day-summary-band'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _DayStatStrip(day: day, units: units),
+          const SizedBox(height: 10),
+          DayRhythmBar(dives: day.dives),
+        ],
+      ),
+    );
+  }
+}
+
+/// Tiny muted heading over a tail-of-card cluster (photos, species) so those
+/// strips stop reading as unlabeled debris after the dive rows.
+class _SectionCaption extends StatelessWidget {
+  final String text;
+
+  const _SectionCaption({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      text,
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.5,
       ),
     );
   }

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_header.dart
@@ -13,8 +13,11 @@ import 'package:submersion/features/trips/presentation/providers/surface_day_wea
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Two compact lines - "Day 3 - Wed, Jul 8" plus the day-type/port/sites
-/// subtitle - on an opaque surface so day cards scroll underneath cleanly.
+/// A leading day-number badge plus two compact lines - "Wed, Jul 8" and the
+/// day-type/port/sites subtitle - on an opaque tinted band
+/// (surfaceContainer, one step above the page surface) so the sticky headers
+/// read as chapter anchors and day cards scroll underneath cleanly. The badge
+/// echoes the map's primary-colored day pins, tying header and pin together.
 /// Days with logged weather get a trailing badge: conditions icon plus air
 /// temperature in the diver's temperature unit.
 ///
@@ -68,21 +71,22 @@ class TripStoryDayHeader extends ConsumerWidget {
     final weatherBadge = _weatherBadge(context, theme, units, weather);
 
     return Material(
-      color: theme.colorScheme.surface,
+      color: theme.colorScheme.surfaceContainer,
       child: ConstrainedBox(
         constraints: const BoxConstraints(minHeight: minHeight),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
           child: Row(
             children: [
+              _DayNumberBadge(dayNumber: day.dayNumber),
+              const SizedBox(width: 10),
               Expanded(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      '${context.l10n.trips_story_dayLabel(day.dayNumber)}'
-                      ' - ${DateFormat.MMMEd().format(day.date)}',
+                      DateFormat.MMMEd().format(day.date),
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),
@@ -165,5 +169,48 @@ class TripStoryDayHeader extends ConsumerWidget {
       return precipitation.localizedName(l10n);
     }
     return weather.cloudCover?.localizedName(l10n);
+  }
+}
+
+/// Round day-number chip leading the header, echoing the map's day pins so
+/// the sticky headers give the story a scannable chapter rhythm. Visually it
+/// is just the number; assistive tech hears the full "Day N" label instead.
+class _DayNumberBadge extends StatelessWidget {
+  final int dayNumber;
+
+  const _DayNumberBadge({required this.dayNumber});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: context.l10n.trips_story_dayLabel(dayNumber),
+      excludeSemantics: true,
+      // A Container given an alignment fills loose bounded constraints (here
+      // the whole band height); unbounding it makes it shrink-wrap the number
+      // while still honoring the minimum size below.
+      child: UnconstrainedBox(
+        child: Container(
+          key: const Key('day-number-badge'),
+          // Min sizes with padding (not a fixed box) so scaled accessibility
+          // text grows the badge instead of clipping the number; the near-round
+          // corner radius keeps it pill-shaped if it does grow.
+          constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(999),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            '$dayNumber',
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.onPrimaryContainer,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
@@ -272,7 +272,9 @@ class TripStatStrip extends ConsumerWidget {
     ];
 
     return Container(
-      color: theme.colorScheme.surface,
+      // One tonal step above the page surface: welds the strip to the map
+      // above it so the two read as a single trip-summary region.
+      color: theme.colorScheme.surfaceContainerLow,
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         children: [

--- a/lib/features/trips/presentation/widgets/story/trip_story_view.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_view.dart
@@ -251,9 +251,9 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
     // not: it carries _dayKeys[index], which _onScroll and _scrollToDay read
     // positions from, and they skip days whose key context is unmounted -- so
     // dropping it would quietly take those days out of active-day resolution.
-    // Its 8px bottom inset is also the gap between consecutive chapters, and
-    // is painted in the same surface color as the headers, so it separates
-    // them rather than showing as a blank band.
+    // Its 8px bottom inset is also the gap between consecutive chapters; the
+    // headers carry a surfaceContainer tint, so the page-surface gap reads as
+    // air between one chapter's card and the next chapter's tinted band.
     final body = SliverPadding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
       sliver: SliverToBoxAdapter(
@@ -303,14 +303,14 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
       // underway. The card hides itself once the flight departs.
       if (trip.returnFlightAt != null && trip.isInProgress)
         SliverPadding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
           sliver: SliverToBoxAdapter(
             child: TripFlightCountdownCard(tripId: trip.id),
           ),
         ),
       if (trip.isLiveaboard)
         SliverPadding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
           sliver: SliverToBoxAdapter(child: TripVesselSection(tripId: trip.id)),
         ),
       for (var index = 0; index < story.days.length; index++)
@@ -350,6 +350,12 @@ class _TripStoryViewState extends ConsumerState<TripStoryView>
                   context.l10n.trips_story_checklistProgress(
                     story.checklist.done,
                     story.checklist.total,
+                  ),
+                  // Match the notes card's section title so the two closers
+                  // read as one family (ListTile would otherwise swap in its
+                  // own font role).
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
                 children: [

--- a/test/features/trips/presentation/widgets/story/trip_story_day_card_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_card_test.dart
@@ -103,6 +103,97 @@ void main() {
     expect(find.byType(DiveListItem), findsOneWidget);
   });
 
+  testWidgets('stats and rhythm bar share one tinted summary band', (
+    tester,
+  ) async {
+    final dive = createTestDiveWithBottomTime(
+      id: 'd1',
+      diveNumber: 42,
+      bottomTime: const Duration(minutes: 47),
+      maxDepth: 28.0,
+    );
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+      dives: [dive],
+    );
+    await pumpCard(tester, day);
+
+    // The day-at-a-glance cluster: stat strip and rhythm bar live inside one
+    // tinted container so they group as a unit, distinct from the dive rows.
+    final band = find.byKey(const Key('day-summary-band'));
+    expect(band, findsOneWidget);
+    expect(
+      find.descendant(of: band, matching: find.byType(DayRhythmBar)),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: band, matching: find.textContaining('Dives')),
+      findsOneWidget,
+    );
+    final context = tester.element(band);
+    final container = tester.widget<Container>(
+      find
+          .ancestor(
+            of: find.byType(DayRhythmBar),
+            matching: find.byType(Container),
+          )
+          .first,
+    );
+    final decoration = container.decoration as BoxDecoration?;
+    expect(
+      decoration?.color,
+      Theme.of(context).colorScheme.surfaceContainerLow,
+    );
+    // The dive rows stay outside the band: they are the primary content.
+    expect(
+      find.descendant(of: band, matching: find.byType(DiveListItem)),
+      findsNothing,
+    );
+  });
+
+  testWidgets('photo strip carries a Photos caption', (tester) async {
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+      dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
+      media: [_media('m1')],
+    );
+    await pumpCard(tester, day);
+
+    expect(find.text('Photos'), findsOneWidget);
+  });
+
+  testWidgets('sighting chips carry a Species seen caption', (tester) async {
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+      dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
+      sightings: [_sighting('s1', 'Turtle')],
+    );
+    await pumpCard(tester, day);
+
+    expect(find.text('Species seen'), findsOneWidget);
+  });
+
+  testWidgets('no captions render for a day without photos or sightings', (
+    tester,
+  ) async {
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+      dives: [Dive(id: 'd1', dateTime: DateTime(2026, 3, 8, 9))],
+    );
+    await pumpCard(tester, day);
+
+    expect(find.text('Photos'), findsNothing);
+    expect(find.text('Species seen'), findsNothing);
+  });
+
   testWidgets('surface day renders no card body', (tester) async {
     // The whole day is now its sticky header - title, date, and the "Surface
     // day" label all live there, leaving the card with nothing to draw.

--- a/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_day_header_test.dart
@@ -78,7 +78,7 @@ Future<void> pumpHeader(
 }
 
 void main() {
-  testWidgets('shows the day number and date', (tester) async {
+  testWidgets('shows the day number badge and date', (tester) async {
     final day = TripStoryDay(
       date: DateTime(2026, 3, 8),
       dayNumber: 2,
@@ -86,9 +86,52 @@ void main() {
     );
     await pumpHeader(tester, day);
 
-    expect(find.textContaining('Day 2'), findsOneWidget);
+    // The day number lives in the leading badge; the title is the date alone,
+    // so the number is not announced or drawn twice.
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('day-number-badge')),
+        matching: find.text('2'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Day 2'), findsNothing);
     // MMMEd for en locale: "Sun, Mar 8".
     expect(find.textContaining('Mar 8'), findsOneWidget);
+  });
+
+  testWidgets('day number badge keeps the "Day N" screen-reader label', (
+    tester,
+  ) async {
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+    );
+    await pumpHeader(tester, day);
+
+    // Visually the badge is a bare "2"; assistive tech still hears "Day 2".
+    expect(find.bySemanticsLabel('Day 2'), findsOneWidget);
+  });
+
+  testWidgets('header band is tinted to anchor its chapter', (tester) async {
+    final day = TripStoryDay(
+      date: DateTime(2026, 3, 8),
+      dayNumber: 2,
+      kind: TripStoryDayKind.past,
+    );
+    await pumpHeader(tester, day);
+
+    final material = tester.widget<Material>(
+      find
+          .descendant(
+            of: find.byType(TripStoryDayHeader),
+            matching: find.byType(Material),
+          )
+          .first,
+    );
+    final context = tester.element(find.byType(TripStoryDayHeader));
+    expect(material.color, Theme.of(context).colorScheme.surfaceContainer);
   });
 
   testWidgets('subtitle joins day type, port, and site names', (tester) async {
@@ -147,8 +190,8 @@ void main() {
     );
     await pumpHeader(tester, day);
 
-    // Only the title line renders.
-    expect(find.byType(Text), findsOneWidget);
+    // Only the badge number and the title line render.
+    expect(find.byType(Text), findsNWidgets(2));
   });
 
   group('surface day', () {
@@ -163,10 +206,18 @@ void main() {
       longitude: -68.2,
     );
 
-    testWidgets('gets the same title line as any other day', (tester) async {
+    testWidgets('gets the same badge and title line as any other day', (
+      tester,
+    ) async {
       await pumpHeader(tester, surfaceDay());
 
-      expect(find.textContaining('Day 2'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('day-number-badge')),
+          matching: find.text('2'),
+        ),
+        findsOneWidget,
+      );
       expect(find.textContaining('Mar 8'), findsOneWidget);
     });
 
@@ -181,7 +232,7 @@ void main() {
       // lesser, smaller entry than the dive day above or below it.
       await pumpHeader(tester, surfaceDay());
       final surfaceStyle = tester
-          .widget<Text>(find.textContaining('Day 2'))
+          .widget<Text>(find.textContaining('Mar 8'))
           .style;
 
       await pumpHeader(
@@ -199,7 +250,7 @@ void main() {
           ],
         ),
       );
-      final diveStyle = tester.widget<Text>(find.textContaining('Day 2')).style;
+      final diveStyle = tester.widget<Text>(find.textContaining('Mar 8')).style;
 
       expect(surfaceStyle, diveStyle);
       expect(surfaceStyle?.fontWeight, FontWeight.bold);

--- a/test/features/trips/presentation/widgets/story/trip_story_map_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_map_header_test.dart
@@ -200,6 +200,24 @@ void main() {
     expect(find.text('Sites visited'), findsNothing);
   });
 
+  testWidgets('stat strip renders as a tinted band', (tester) async {
+    // The tint visually welds the strip to the map above it, bounding the
+    // trip-summary region instead of floating the numbers on the page surface.
+    final stats = TripWithStats(trip: _trip(), diveCount: 14);
+    await pumpStrip(tester, stats);
+
+    final container = tester.widget<Container>(
+      find
+          .descendant(
+            of: find.byType(TripStatStrip),
+            matching: find.byType(Container),
+          )
+          .first,
+    );
+    final context = tester.element(find.byType(TripStatStrip));
+    expect(container.color, Theme.of(context).colorScheme.surfaceContainerLow);
+  });
+
   testWidgets('map markers expose a 48x48 button with a semantics label', (
     tester,
   ) async {

--- a/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_view_test.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/checklists/domain/entities/trip_checklist_item.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/trips/domain/entities/liveaboard_details.dart';
@@ -326,7 +327,50 @@ void main() {
         tester.getTopLeft(find.byWidget(element.widget)).dy,
     ];
     expect(pinnedTops, anyElement(closeTo(180.0, 1.0)));
-    expect(find.textContaining('Day 1 -'), findsNothing);
+    // The first day's header (its badge shows "Mar 25") has been pushed out.
+    expect(find.textContaining('Mar 25'), findsNothing);
+  });
+
+  testWidgets('checklist and notes closers share the section title style', (
+    tester,
+  ) async {
+    // Both end-of-story cards must read as the same family: the checklist
+    // ExpansionTile's title gets the notes card's bold section-title style
+    // instead of the ListTile default.
+    final trip = Trip(
+      id: 'trip-1',
+      name: 'Bonaire',
+      startDate: DateTime(2026, 3, 27),
+      endDate: DateTime(2026, 3, 28),
+      tripType: TripType.resort,
+      notes: 'Great vis all week',
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    );
+    final story = buildTripStory(
+      trip: trip,
+      dives: [_dive('d1', DateTime(2026, 3, 27, 9))],
+      itineraryDays: [],
+      mediaByDiveId: {},
+      sightingsByDiveId: {},
+      checklistItems: [
+        TripChecklistItem(
+          id: 'c1',
+          tripId: 'trip-1',
+          title: 'Pack fins',
+          isDone: true,
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      ],
+      today: DateTime(2026, 6, 1),
+    );
+    await pumpView(tester, story);
+
+    final notesStyle = tester.widget<Text>(find.text('Notes')).style;
+    final checklistStyle = tester.widget<Text>(find.text('1 of 1 done')).style;
+    expect(checklistStyle?.fontWeight, FontWeight.bold);
+    expect(checklistStyle?.fontSize, notesStyle?.fontSize);
   });
 
   testWidgets('surface days get the same sticky header as dive days', (
@@ -350,7 +394,14 @@ void main() {
     // Tall harness viewport: all three days are mounted, and every one of them
     // contributes a sticky header, surface day included.
     expect(find.byType(TripStoryDayHeader), findsNWidgets(3));
-    expect(find.textContaining('Day 2 -'), findsOneWidget);
+    // The surface day's header carries the same day-number badge as dive days.
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('day-number-badge')).at(1),
+        matching: find.text('2'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Surface day'), findsOneWidget);
   });
 

--- a/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
+++ b/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
@@ -88,8 +88,17 @@ void main() {
     );
 
     expect(find.byType(TripStoryDayCard), findsNWidgets(2));
-    expect(find.textContaining('Day 1'), findsWidgets);
-    expect(find.textContaining('Day 2'), findsWidgets);
+    // The day number lives in each sticky header's leading badge now.
+    final badges = find.byKey(const Key('day-number-badge'));
+    expect(badges, findsNWidgets(2));
+    expect(
+      find.descendant(of: badges.at(0), matching: find.text('1')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: badges.at(1), matching: find.text('2')),
+      findsOneWidget,
+    );
     expect(find.byType(DiveListItem), findsNWidgets(2));
   });
 


### PR DESCRIPTION
## Summary

The trip story (trip detail Overview tab) showed a good amount of data but read as one flat, busy pile: uniform gaps everywhere, sticky day headers in the same color as the page, and photo/species strips trailing the dive rows with no labels. This PR restructures the page with a three-tier visual grouping system while keeping every piece of data visible.

- **Day headers become chapter anchors.** Each sticky header now sits on a `surfaceContainer` tinted band and leads with a round day-number badge that echoes the map's primary-colored day pins. The title text is now just the date; the badge carries a "Day N" semantics label so screen readers hear exactly what they heard before.
- **Day cards split into three zones.** The day stat strip and 24h rhythm bar merge into one `surfaceContainerLow` "day at a glance" band; the dive rows stay untinted as the dominant middle zone; photos and species group under small muted captions reusing the existing "Photos" and "Species seen" strings (no new ARB keys).
- **The trip-level stat strip is tinted** with the same `surfaceContainerLow`, welding it to the map above so the two read as one trip-summary region (both narrow and wide layouts, since the same widget serves both).
- **Closers unified.** The checklist ExpansionTile title now matches the notes card's bold section-title style instead of the ListTile default, and the flight-countdown and vessel cards get consistent bottom spacing.

No schema, provider, navigation, or l10n changes. The whole redesign reassigns roles within the Material 3 surface-container ladder, so light and dark themes are handled for free.

## Notes for review

- A `Container` given an `alignment` fills loose bounded constraints, so the day-number badge would have silently stretched to the full band height; `UnconstrainedBox` makes it shrink-wrap while min-size constraints keep it a 28px chip that still grows under scaled accessibility text (the existing min-height and text-scale tests cover both directions).
- The day `GlobalKey` placement and `PinnedHeaderSliver` self-sizing from the scroll-polish PR are untouched.

## Testing

- New widget tests: header badge and semantics label, header tint, day summary band composition and tint, Photos / Species seen captions (presence and absence), stat strip tint, checklist/notes title-style parity.
- Updated tests that asserted the old "Day N - date" title format (header, view, overview tab).
- Full trips suite green (571 tests), `flutter analyze --fatal-infos` clean, `dart format` clean.