### PR TITLE
fix(backup): self-heal an unusable custom backup location instead of bricking startup

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -639,14 +639,24 @@ class _StartupWrapperState extends State<StartupWrapper>
     } else {
       final info = await PackageInfo.fromPlatform();
       appVersion = '${info.version}.${info.buildNumber}';
-      // Arm any security-scoped bookmark for the custom location (and
-      // self-heal a stale one to the sandbox default) before the safety copy.
-      // Layer 1's fallback below still applies if writing to the armed path
-      // fails, so a pre-migration backup can never brick startup.
-      lease = await BackupService.resolveBackupsDirectoryLeased(prefs);
       service = PreMigrationBackupService(
         livePathProvider: () async => dbPath,
-        backupsDirProvider: () async => lease!.path,
+        // Resolve LAZILY, inside the provider. Resolution arms any
+        // security-scoped bookmark for the custom location and self-heals a
+        // dead one to the sandbox default, but it also touches the filesystem
+        // and can throw (an ejected volume, or a location that is no longer
+        // creatable). PreMigrationBackupService calls this provider inside the
+        // region guarded by fallbackBackupsDirProvider, so resolving here keeps
+        // any failure recoverable. Resolving eagerly instead would move the
+        // throw outside that guard, where it escapes as a bare
+        // FileSystemException rather than a BackupFailedException and strands
+        // startup on the terminal "Database upgrade failed" screen. Keeping it
+        // lazy is what makes "a pre-migration backup can never brick startup"
+        // actually hold.
+        backupsDirProvider: () async {
+          lease = await BackupService.resolveBackupsDirectoryLeased(prefs);
+          return lease!.path;
+        },
         fallbackBackupsDirProvider:
             BackupService.resolveDefaultBackupsDirectory,
         preferences: prefs,

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -1065,7 +1065,30 @@ class BackupService {
       // filesystem path -- SAF content:// locations were already handled
       // above). Security-scoped bookmarks are an Apple-only concept, so a bare
       // custom filesystem path here persists and works without scoping.
-      return BackupDirLease(await _ensureDir(custom), _noRelease);
+      try {
+        return BackupDirLease(await _ensureDir(custom), _noRelease);
+      } on FileSystemException {
+        // The stored path is not a directory this process can create or reach:
+        // an ejected SD card or unmounted network share, or a path fabricated
+        // by file_picker from a SAF tree whose document id has no
+        // "volume:path" shape. A Google Drive pick yields
+        // "/storage/emulated/0/acc=2;doc=encoded=...", which is not a
+        // content:// ref (so the guard above misses it) and which scoped
+        // storage refuses to mkdir with errno 13.
+        //
+        // Resolution runs before the pre-migration safety copy, outside
+        // PreMigrationBackupService's fallback, so throwing here strands the
+        // user on the terminal "Database upgrade failed" screen with no way
+        // back into settings to correct the location. Self-heal to the sandbox
+        // default instead, matching the Apple dead-bookmark and revoked
+        // SAF-grant branches: clearing the location stops it being retried and
+        // makes the settings subtitle revert, signaling a re-pick is needed.
+        await preferences.setBackupLocation(null);
+        return BackupDirLease(
+          await resolveDefaultBackupsDirectory(),
+          _noRelease,
+        );
+      }
     }
     final port = bookmarks ?? const _DefaultBackupBookmarkPort();
     final bytes = preferences.getBackupLocationBookmark();

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -1076,13 +1076,22 @@ class BackupService {
         // content:// ref (so the guard above misses it) and which scoped
         // storage refuses to mkdir with errno 13.
         //
-        // Resolution runs before the pre-migration safety copy, outside
-        // PreMigrationBackupService's fallback, so throwing here strands the
-        // user on the terminal "Database upgrade failed" screen with no way
-        // back into settings to correct the location. Self-heal to the sandbox
-        // default instead, matching the Apple dead-bookmark and revoked
-        // SAF-grant branches: clearing the location stops it being retried and
-        // makes the settings subtitle revert, signaling a re-pick is needed.
+        // Self-heal rather than propagate, matching the Apple dead-bookmark
+        // and revoked SAF-grant branches: clearing the location stops it being
+        // retried and makes the settings subtitle revert, signaling a re-pick
+        // is needed.
+        //
+        // Both callers need this to be total. Normal backups arrive via
+        // resolveBackupTargetLeased, and would otherwise throw on every
+        // scheduled and manual run for as long as the location stays dead. The
+        // pre-migration safety copy arrives through a provider that
+        // PreMigrationBackupService invokes inside its fallback guard, so an
+        // escaping exception is recoverable there today -- but only because
+        // StartupPage resolves lazily. When it resolved eagerly the throw
+        // landed outside that guard, surfaced as a bare FileSystemException
+        // instead of a BackupFailedException, and stranded startup on the
+        // terminal "Database upgrade failed" screen, which offers no route
+        // back into settings to correct the location.
         await preferences.setBackupLocation(null);
         return BackupDirLease(
           await resolveDefaultBackupsDirectory(),

--- a/test/features/backup/data/services/backup_service_leased_test.dart
+++ b/test/features/backup/data/services/backup_service_leased_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:submersion/core/services/backup_bookmark_service.dart';
@@ -282,6 +283,50 @@ void main() {
         expect(isSafRef(lease.path), isFalse);
         // The user's SAF choice must remain for normal (SAF) backups.
         expect(preferences.getSettings().backupLocation, safUri);
+        expect(port.resolveCalls, 0);
+        await lease.release(); // no-op; must not throw
+      },
+    );
+
+    // The #505 guard above keys on the `content://` scheme, which misses the
+    // case where the fabricated value already looks like an absolute path.
+    // file_picker's Android getFullPathFromTreeUri splits a SAF tree's
+    // document id on ':' and, when there is no "volume:path" shape, returns
+    // "${getExternalStorageDirectory()}/$docId". A Google Drive pick has the
+    // document id "acc=2;doc=encoded=<blob>", so the stored location becomes
+    // "/storage/emulated/0/acc=2;doc=encoded=...": not a content:// ref, and
+    // not a directory that scoped storage will let the app mkdir (errno 13).
+    //
+    // This resolution runs BEFORE the pre-migration safety copy, so throwing
+    // here escapes PreMigrationBackupService's fallback entirely and strands
+    // the user on the terminal "Database upgrade failed" screen, which offers
+    // no way back into settings to correct the location.
+    //
+    // Nesting the target under a regular file stands in for EACCES portably:
+    // create(recursive: true) throws ENOTDIR in the host VM.
+    test(
+      'non-Apple + uncreatable custom location -> default, setting cleared',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('lease_unwritable_');
+        addTearDown(() => tmp.delete(recursive: true));
+        final blocker = File(p.join(tmp.path, 'not-a-directory'));
+        await blocker.writeAsString('x');
+        await preferences.setBackupLocation(
+          p.join(blocker.path, 'acc=2;doc=encoded=JKazOe75G5_hCtZBVEzAmb0'),
+        );
+        BackupBookmarkService.debugSupportedOverride = false; // Android
+        final port = _FakeBookmarkPort();
+
+        final lease = await BackupService.resolveBackupsDirectoryLeased(
+          preferences,
+          bookmarks: port,
+        );
+
+        expect(lease.path, contains('Submersion'));
+        expect(lease.path, contains('Backups'));
+        // Self-healed like the Apple dead-bookmark and revoked-SAF-grant
+        // branches, so the dead location is not retried on the next launch.
+        expect(preferences.getSettings().backupLocation, isNull);
         expect(port.resolveCalls, 0);
         await lease.release(); // no-op; must not throw
       },

--- a/test/features/backup/data/services/pre_migration_dead_location_test.dart
+++ b/test/features/backup/data/services/pre_migration_dead_location_test.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import 'package:submersion/core/services/backup_bookmark_service.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+/// End-to-end guard for the startup path that upgrades a user's database when
+/// their stored custom backup location has become unusable.
+///
+/// Reported from the field on Android: the backup location was a path
+/// fabricated by file_picker from a Google Drive SAF tree
+/// (`/storage/emulated/0/acc=2;doc=encoded=...`). That is not a content://
+/// ref, so the scheme check for a SAF location does not catch it, and scoped
+/// storage refuses to mkdir it (errno 13). Resolving it threw a bare
+/// FileSystemException before the pre-migration safety copy ran, which escaped
+/// the BackupFailedException handler and left the app permanently on the
+/// terminal "Database upgrade failed" screen. There is no route back into
+/// settings from that screen, so the location could never be corrected.
+///
+/// This exercises the same wiring StartupPage uses (lazy leased resolution
+/// plus a sandbox fallback), so it fails if either the resolver stops
+/// self-healing or the resolution moves back outside the guarded region.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+  late BackupPreferences prefs;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('pmbs_dead_loc_');
+    // resolveDefaultBackupsDirectory() builds on the app documents directory.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async => tmp.path,
+        );
+    SharedPreferences.setMockInitialValues({});
+    prefs = BackupPreferences(await SharedPreferences.getInstance());
+    BackupBookmarkService.debugSupportedOverride = false; // Android
+  });
+
+  tearDown(() async {
+    BackupBookmarkService.debugSupportedOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    await tmp.delete(recursive: true);
+  });
+
+  test(
+    'unusable custom location still backs up and lets the migration proceed',
+    () async {
+      final livePath = p.join(tmp.path, 'submersion.db');
+      final seed = sqlite3.sqlite3.open(livePath);
+      try {
+        seed.execute('PRAGMA user_version = 63');
+        seed.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
+        seed.execute('INSERT INTO sentinel VALUES (42)');
+      } finally {
+        seed.dispose();
+      }
+
+      // Stand-in for the fabricated Drive path: nesting under a regular file
+      // makes create(recursive: true) fail in the host VM the way scoped
+      // storage fails the real one.
+      final blocker = File(p.join(tmp.path, 'not-a-directory'));
+      await blocker.writeAsString('x');
+      await prefs.setBackupLocation(
+        p.join(blocker.path, 'acc=2;doc=encoded=JKazOe75G5_hCtZBVEzAmb0'),
+      );
+
+      // Mirrors StartupPage._runPreMigrationBackup's wiring.
+      BackupDirLease? lease;
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => livePath,
+        backupsDirProvider: () async {
+          lease = await BackupService.resolveBackupsDirectoryLeased(prefs);
+          return lease!.path;
+        },
+        fallbackBackupsDirProvider:
+            BackupService.resolveDefaultBackupsDirectory,
+        preferences: prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'dead-location-id',
+      );
+
+      try {
+        await service.backupIfMigrationPending(
+          stored: 63,
+          target: 64,
+          appVersion: '1.6.0.1241',
+        );
+      } finally {
+        await lease?.release();
+      }
+
+      // The safety copy landed in the always-writable sandbox default.
+      final backupPath = p.join(
+        tmp.path,
+        'Submersion/Backups',
+        '20260412-081201000-v63-v64.db',
+      );
+      expect(
+        await File(backupPath).exists(),
+        isTrue,
+        reason: 'backup should fall back to the sandbox default',
+      );
+      expect(
+        await File(backupPath).readAsBytes(),
+        await File(livePath).readAsBytes(),
+      );
+
+      final records = prefs.getHistory();
+      expect(records, hasLength(1));
+      expect(records.single.type, BackupType.preMigration);
+
+      // The dead location is cleared, so the next launch does not retry it.
+      expect(prefs.getSettings().backupLocation, isNull);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

A field report on Android showed the app stuck permanently on the terminal
"Database upgrade failed" screen after updating:

```
PathAccessException: Creation failed, path =
'/storage/emulated/0/acc=2;doc=encoded=JKazOe75G5_hCtZBVEzAmb0bvtzzJfwufHPile-95nyjBHfj'
(OS Error: Permission denied, errno = 13)
```

That path was never a real directory. `file_picker`'s Android
`getFullPathFromTreeUri` (`FileUtils.kt:592-608`) takes a SAF tree's document
id, splits it on `:`, and when there is no `volume:path` shape falls through to
`"${Environment.getExternalStorageDirectory()}/$docId"`. A Google Drive pick has
the document id `acc=<n>;doc=encoded=<blob>`, so the stored backup location
became a plausible-looking absolute path that scoped storage refuses to `mkdir`.

This is #505 recurring in a form the fix for it cannot catch. #505 handles the
case where the fabricated value keeps its `content://` scheme, so `isSafRef`
matches. Here `file_picker` had already stripped the scheme, `isSafRef` returned
false, and the value walked straight through to the unguarded
`_ensureDir(custom)` on the bare-path branch.

Two things turned a bad setting into an unrecoverable app:

1. `resolveBackupsDirectoryLeased` self-heals a dead Apple bookmark
   (`backup_service.dart:1092-1095`) and a revoked SAF grant (`:1112-1118`), but
   the bare-path branch Android actually lands on (`:1063-1069`) had no guard.
2. `StartupPage` resolved the lease eagerly at `startup_page.dart:646`, before
   constructing `PreMigrationBackupService` and outside the `try` that converts
   failures into `BackupFailedException`. The service's fallback machinery,
   which exists precisely to keep a failed safety copy non-fatal
   (`pre_migration_backup_service.dart:130-134`), was never reached, and the raw
   `FileSystemException` escaped to the generic error state.

The resulting screen offers only Close, so an affected user cannot get back into
settings to correct the location, and cannot downgrade because Android ships
through Play.

Their normal backups were failing the same way, since `resolveBackupTargetLeased`
funnels non-SAF locations through the same resolver. Both recover on the next
launch after this lands.

## Changes

- `backup_service.dart`: guard the bare-path branch. On `FileSystemException`,
  clear the stored location and fall back to the sandbox default, matching the
  self-heal contract the Apple and SAF branches already had. Catching the base
  class also covers an ejected SD card (`PathNotFoundException`), a read-only
  mount, and ENOTDIR, not just the one errno seen in the report.
- `startup_page.dart`: resolve the lease lazily inside `backupsDirProvider` so it
  runs within the region `PreMigrationBackupService` guards with
  `fallbackBackupsDirProvider`. This restores the "a pre-migration backup can
  never brick startup" guarantee the surrounding comment already claimed. The
  existing `finally { await lease?.release(); }` still releases correctly, since
  assignment precedes any use.
- `backup_service_leased_test.dart`: new case asserting an uncreatable custom
  location resolves to the sandbox default and clears the setting.
- `pre_migration_dead_location_test.dart`: new end-to-end case over a seeded v63
  database, wired the way `StartupPage` wires it, asserting the safety copy lands
  in the fallback and the dead location is cleared. Fails if either the resolver
  stops self-healing or resolution moves back outside the guarded region.

Both tests were written first and observed failing. The unit test's RED was the
`FileSystemException` thrown from `_ensureDir` via `:1068`, matching the reported
stack. Nesting the target under a regular file stands in for EACCES portably in
the host VM.

## Test Plan

- [x] `flutter test` passes (17755 passed, 17 skipped)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] `dart format .` clean (3646 files, 0 changed)
- [x] Manual testing on: Android, pending a build on the Play test track

## Follow-ups not included here

Flagged rather than folded in, to keep this reviewable:

- `resolveBackupsDirectory` (`backup_service.dart:1004`) has the identical
  unguarded `create()` and does not check `isSafRef` at all. It currently has no
  production callers, only two test call sites, so it is latent rather than live.
  Worth guarding or removing.
- `universal_import_providers.dart:412` and `media/.../files_tab.dart:101` still
  call `FilePicker.getDirectoryPath()` ungated on Android and will receive the
  same fabricated paths on a cloud-provider pick. Neither persists the value, so
  neither can brick startup, but both will misbehave.
