### PR TITLE
fix(release): block App Review submission while any version is in review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,6 +401,13 @@ jobs:
       - name: Run fastlane beta changelog test
         run: ruby scripts/release/fastlane_beta_changelog_test.rb
 
+      - name: Run fastlane submit guard test
+        # Guards the App Review submission guard against the defect behind
+        # promotion run 31903095751: submitting while a DIFFERENT version was
+        # still in review, which renamed the in-review version instead of
+        # creating a new one and left it carrying the wrong build.
+        run: ruby scripts/release/fastlane_submit_guard_test.rb
+
       - name: Run pre-push hook test
         # Guards two hook bugs that both rejected pushes for reasons unrelated
         # to the change being pushed: running the checks against the main

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -318,9 +318,12 @@ jobs:
           echo "$APP_STORE_CONNECT_API_KEY_KEY" | base64 --decode \
             > ${{ matrix.platform }}/fastlane/AuthKey.p8
 
-      # The lane is a no-op when Apple already has this version, so a
-      # re-dispatched promotion skips the platform that already succeeded
-      # instead of failing on it. See already_submitted_state in the Fastfile.
+      # The lane is a no-op when Apple already has a submission under way for
+      # this platform, whatever version it covers, so a re-dispatched promotion
+      # skips the leg that already succeeded instead of failing on it, and a
+      # promotion launched while the previous one is still in review skips
+      # rather than renaming that in-review version. See submission_blocker in
+      # the Fastfile.
       - name: Submit build
         working-directory: ${{ matrix.platform }}
         env:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -265,12 +265,25 @@ platform :ios do
       includes: "appStoreVersionForReview",
     )
 
+    # Short-circuit. An in-progress submission is already a block, so the
+    # editable version cannot change the answer. Skipping the second lookup is
+    # partly about latency, but mostly about failure surface: this method
+    # deliberately lets App Store Connect errors propagate, so a call made
+    # after the answer is known could fail the lane at the moment we already
+    # knew the safe outcome. Blocking beats erroring.
+    unless submission.nil?
+      return submission_skip_reason(
+        app_version: app_version,
+        review_in_progress: true,
+        review_version: review_submission_version(submission),
+      )
+    end
+
     version = app.get_edit_app_store_version(platform: mapped)
 
     submission_skip_reason(
       app_version: app_version,
-      review_in_progress: !submission.nil?,
-      review_version: review_submission_version(submission),
+      review_in_progress: false,
       edit_version: version&.version_string,
       # app_store_state is deprecated as of App Store Connect API 3.3 in favor
       # of app_version_state; read the new field first and fall back.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -192,39 +192,102 @@ platform :ios do
     DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
   end
 
-  # The already-submitted state of <app_version> on <platform>, or nil when the
-  # version is still ours to submit OR the state cannot be determined.
+  # Whether to skip App Review submission, given facts already read from App
+  # Store Connect. Pure, so scripts/release/fastlane_submit_guard_test.rb can
+  # drive every branch without a network call.
   #
-  # Every uncertain path returns nil on purpose, so the caller falls through to
-  # attempting the submission, which is the behavior that existed before this
-  # check. The guard can therefore only ever skip work that would have failed;
-  # it can never turn a working submission into a skipped one.
+  # Returns a reason string to skip, or nil to go ahead.
   #
-  # Limitation worth knowing: get_edit_app_store_version returns versions in
-  # editable states, which includes WAITING_FOR_REVIEW (the state that broke
-  # promotion run 31859359618). Should Apple stop returning an IN_REVIEW
-  # version there, this quietly degrades to the old attempt-and-fail behavior
-  # rather than misreporting.
+  # The first check is version-AGNOSTIC, and that is the whole point. Promotion
+  # run 31903095751 submitted 1.7.4 while 1.7.3 was still with Apple. The old
+  # guard asked only whether THIS version was already submitted, so a different
+  # version in review did not stop it. deliver then called ensure_version!,
+  # which renames the editable version in place when the version string
+  # differs, and WAITING_FOR_REVIEW counts as editable: iOS 1.7.3 was silently
+  # renamed to 1.7.4 with build 6027 still attached, and the follow-up
+  # select_build was refused. The result was a submission labelled 1.7.4
+  # carrying 1.7.3's binary. macOS escaped with a clean error only because
+  # Apple had moved its copy to IN_REVIEW, which is not editable, so deliver
+  # tried to create a version instead. The loud failure was luck.
+  #
+  # Note what is deliberately NOT blocking: an editable version carrying an
+  # older version string. Renaming that forward is legitimate, and is how the
+  # recovery from that incident worked.
+  def submission_skip_reason(app_version:, review_in_progress:,
+                             review_version: nil, edit_version: nil,
+                             edit_state: nil)
+    if review_in_progress
+      held_by = review_version ? "#{review_version} is" : "another version is"
+      return "#{held_by} already in review; skipping submission of " \
+             "#{app_version}. App Store Connect allows one submission at a " \
+             "time, and submitting now would rename the version under review " \
+             "rather than create a new one. Wait for it to clear, or remove it " \
+             "from review in App Store Connect."
+    end
+
+    if edit_version == app_version && ALREADY_SUBMITTED_STATES.include?(edit_state)
+      return "#{app_version} is already #{edit_state}; skipping submission. " \
+             "Remove it from review in App Store Connect if you need to resubmit."
+    end
+
+    nil
+  end
+
+  # The reason to skip submitting <app_version> on <platform>, or nil to go
+  # ahead.
+  #
+  # A missing app record returns nil and lets the submission attempt produce
+  # its own error rather than inventing one. A failure of the App Store Connect
+  # lookups themselves is deliberately NOT swallowed: after promotion run
+  # 31903095751, stopping is better than proceeding without knowing whether a
+  # review is already under way, because proceeding blind is what renamed an
+  # in-review version and left it carrying the wrong build.
   #
   # No explicit spaceship auth: both branches of load_api_key go through the
   # app_store_connect_api_key action, whose set_spaceship_token defaults to
   # true, so Spaceship::ConnectAPI.token is already set by the time a lane
   # calls this.
-  def already_submitted_state(app_version, platform)
+  def submission_blocker(app_version, platform)
     app = Spaceship::ConnectAPI::App.find(
       CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
     )
     return nil if app.nil?
 
-    version = app.get_edit_app_store_version(
-      platform: Spaceship::ConnectAPI::Platform.map(platform),
-    )
-    return nil if version.nil? || version.version_string != app_version
+    mapped = Spaceship::ConnectAPI::Platform.map(platform)
 
-    # app_store_state is deprecated as of App Store Connect API 3.3 in favor of
-    # app_version_state; read the new field first and fall back.
-    state = version.app_version_state || version.app_store_state
-    ALREADY_SUBMITTED_STATES.include?(state) ? state : nil
+    # Apple's own record of "a review is under way for this platform", covering
+    # WAITING_FOR_REVIEW, IN_REVIEW and UNRESOLVED_ISSUES. Preferred over
+    # reading version states ourselves because it cannot be fooled by a version
+    # string, and because it never matches the live version, which every
+    # published app always has.
+    submission = app.get_in_progress_review_submission(
+      platform: mapped,
+      includes: "appStoreVersionForReview",
+    )
+
+    version = app.get_edit_app_store_version(platform: mapped)
+
+    submission_skip_reason(
+      app_version: app_version,
+      review_in_progress: !submission.nil?,
+      review_version: review_submission_version(submission),
+      edit_version: version&.version_string,
+      # app_store_state is deprecated as of App Store Connect API 3.3 in favor
+      # of app_version_state; read the new field first and fall back.
+      edit_state: version && (version.app_version_state || version.app_store_state),
+    )
+  end
+
+  # Best effort only: the version a review submission covers is used to make
+  # the skip message actionable, never to decide whether to skip. An unknown
+  # version must not weaken the block, so every failure path returns nil and
+  # leaves the caller blocking on the submission's mere existence.
+  def review_submission_version(submission)
+    return nil if submission.nil?
+
+    submission.app_store_version_for_review&.version_string
+  rescue StandardError
+    nil
   end
 
   # Loads API key from environment variables or falls back to api_key.json
@@ -494,13 +557,11 @@ platform :ios do
     app_version = options[:app_version] || UI.user_error!("app_version is required")
     build_number = options[:build_number] || UI.user_error!("build_number is required")
 
-    # Makes the lane a no-op once Apple has the version, so a re-dispatched
-    # promotion does not fail on the leg that already succeeded.
-    if (state = already_submitted_state(app_version, "ios"))
-      UI.important(
-        "#{app_version} is already #{state} for ios; skipping submission. " \
-        "Remove it from review in App Store Connect if you need to resubmit."
-      )
+    # Makes the lane a no-op once Apple has this version, or any other version,
+    # so a re-dispatched promotion does not fail on the leg that already
+    # succeeded and cannot rename a submission that is already under review.
+    if (reason = submission_blocker(app_version, "ios"))
+      UI.important("ios: #{reason}")
       next
     end
 

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -147,39 +147,102 @@ platform :mac do
     DUPLICATE_BUILD_MARKERS.any? { |marker| text.include?(marker) }
   end
 
-  # The already-submitted state of <app_version> on <platform>, or nil when the
-  # version is still ours to submit OR the state cannot be determined.
+  # Whether to skip App Review submission, given facts already read from App
+  # Store Connect. Pure, so scripts/release/fastlane_submit_guard_test.rb can
+  # drive every branch without a network call.
   #
-  # Every uncertain path returns nil on purpose, so the caller falls through to
-  # attempting the submission, which is the behavior that existed before this
-  # check. The guard can therefore only ever skip work that would have failed;
-  # it can never turn a working submission into a skipped one.
+  # Returns a reason string to skip, or nil to go ahead.
   #
-  # Limitation worth knowing: get_edit_app_store_version returns versions in
-  # editable states, which includes WAITING_FOR_REVIEW (the state that broke
-  # promotion run 31859359618). Should Apple stop returning an IN_REVIEW
-  # version there, this quietly degrades to the old attempt-and-fail behavior
-  # rather than misreporting.
+  # The first check is version-AGNOSTIC, and that is the whole point. Promotion
+  # run 31903095751 submitted 1.7.4 while 1.7.3 was still with Apple. The old
+  # guard asked only whether THIS version was already submitted, so a different
+  # version in review did not stop it. deliver then called ensure_version!,
+  # which renames the editable version in place when the version string
+  # differs, and WAITING_FOR_REVIEW counts as editable: iOS 1.7.3 was silently
+  # renamed to 1.7.4 with build 6027 still attached, and the follow-up
+  # select_build was refused. The result was a submission labelled 1.7.4
+  # carrying 1.7.3's binary. macOS escaped with a clean error only because
+  # Apple had moved its copy to IN_REVIEW, which is not editable, so deliver
+  # tried to create a version instead. The loud failure was luck.
+  #
+  # Note what is deliberately NOT blocking: an editable version carrying an
+  # older version string. Renaming that forward is legitimate, and is how the
+  # recovery from that incident worked.
+  def submission_skip_reason(app_version:, review_in_progress:,
+                             review_version: nil, edit_version: nil,
+                             edit_state: nil)
+    if review_in_progress
+      held_by = review_version ? "#{review_version} is" : "another version is"
+      return "#{held_by} already in review; skipping submission of " \
+             "#{app_version}. App Store Connect allows one submission at a " \
+             "time, and submitting now would rename the version under review " \
+             "rather than create a new one. Wait for it to clear, or remove it " \
+             "from review in App Store Connect."
+    end
+
+    if edit_version == app_version && ALREADY_SUBMITTED_STATES.include?(edit_state)
+      return "#{app_version} is already #{edit_state}; skipping submission. " \
+             "Remove it from review in App Store Connect if you need to resubmit."
+    end
+
+    nil
+  end
+
+  # The reason to skip submitting <app_version> on <platform>, or nil to go
+  # ahead.
+  #
+  # A missing app record returns nil and lets the submission attempt produce
+  # its own error rather than inventing one. A failure of the App Store Connect
+  # lookups themselves is deliberately NOT swallowed: after promotion run
+  # 31903095751, stopping is better than proceeding without knowing whether a
+  # review is already under way, because proceeding blind is what renamed an
+  # in-review version and left it carrying the wrong build.
   #
   # No explicit spaceship auth: both branches of load_api_key go through the
   # app_store_connect_api_key action, whose set_spaceship_token defaults to
   # true, so Spaceship::ConnectAPI.token is already set by the time a lane
   # calls this.
-  def already_submitted_state(app_version, platform)
+  def submission_blocker(app_version, platform)
     app = Spaceship::ConnectAPI::App.find(
       CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
     )
     return nil if app.nil?
 
-    version = app.get_edit_app_store_version(
-      platform: Spaceship::ConnectAPI::Platform.map(platform),
-    )
-    return nil if version.nil? || version.version_string != app_version
+    mapped = Spaceship::ConnectAPI::Platform.map(platform)
 
-    # app_store_state is deprecated as of App Store Connect API 3.3 in favor of
-    # app_version_state; read the new field first and fall back.
-    state = version.app_version_state || version.app_store_state
-    ALREADY_SUBMITTED_STATES.include?(state) ? state : nil
+    # Apple's own record of "a review is under way for this platform", covering
+    # WAITING_FOR_REVIEW, IN_REVIEW and UNRESOLVED_ISSUES. Preferred over
+    # reading version states ourselves because it cannot be fooled by a version
+    # string, and because it never matches the live version, which every
+    # published app always has.
+    submission = app.get_in_progress_review_submission(
+      platform: mapped,
+      includes: "appStoreVersionForReview",
+    )
+
+    version = app.get_edit_app_store_version(platform: mapped)
+
+    submission_skip_reason(
+      app_version: app_version,
+      review_in_progress: !submission.nil?,
+      review_version: review_submission_version(submission),
+      edit_version: version&.version_string,
+      # app_store_state is deprecated as of App Store Connect API 3.3 in favor
+      # of app_version_state; read the new field first and fall back.
+      edit_state: version && (version.app_version_state || version.app_store_state),
+    )
+  end
+
+  # Best effort only: the version a review submission covers is used to make
+  # the skip message actionable, never to decide whether to skip. An unknown
+  # version must not weaken the block, so every failure path returns nil and
+  # leaves the caller blocking on the submission's mere existence.
+  def review_submission_version(submission)
+    return nil if submission.nil?
+
+    submission.app_store_version_for_review&.version_string
+  rescue StandardError
+    nil
   end
 
   def load_api_key
@@ -576,13 +639,11 @@ platform :mac do
     app_version = options[:app_version] || UI.user_error!("app_version is required")
     build_number = options[:build_number] || UI.user_error!("build_number is required")
 
-    # Makes the lane a no-op once Apple has the version, so a re-dispatched
-    # promotion does not fail on the leg that already succeeded.
-    if (state = already_submitted_state(app_version, "osx"))
-      UI.important(
-        "#{app_version} is already #{state} for osx; skipping submission. " \
-        "Remove it from review in App Store Connect if you need to resubmit."
-      )
+    # Makes the lane a no-op once Apple has this version, or any other version,
+    # so a re-dispatched promotion does not fail on the leg that already
+    # succeeded and cannot rename a submission that is already under review.
+    if (reason = submission_blocker(app_version, "osx"))
+      UI.important("osx: #{reason}")
       next
     end
 

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -220,12 +220,25 @@ platform :mac do
       includes: "appStoreVersionForReview",
     )
 
+    # Short-circuit. An in-progress submission is already a block, so the
+    # editable version cannot change the answer. Skipping the second lookup is
+    # partly about latency, but mostly about failure surface: this method
+    # deliberately lets App Store Connect errors propagate, so a call made
+    # after the answer is known could fail the lane at the moment we already
+    # knew the safe outcome. Blocking beats erroring.
+    unless submission.nil?
+      return submission_skip_reason(
+        app_version: app_version,
+        review_in_progress: true,
+        review_version: review_submission_version(submission),
+      )
+    end
+
     version = app.get_edit_app_store_version(platform: mapped)
 
     submission_skip_reason(
       app_version: app_version,
-      review_in_progress: !submission.nil?,
-      review_version: review_submission_version(submission),
+      review_in_progress: false,
       edit_version: version&.version_string,
       # app_store_state is deprecated as of App Store Connect API 3.3 in favor
       # of app_version_state; read the new field first and fall back.

--- a/scripts/release/fastlane_submit_guard_test.rb
+++ b/scripts/release/fastlane_submit_guard_test.rb
@@ -59,6 +59,70 @@ def platform(_name)
   yield
 end
 
+# --- App Store Connect stubs ------------------------------------------------
+# The decision checks below cannot catch a mistake in the App Store Connect
+# calls themselves. A wrong method name, a dropped `includes:` value or a
+# renamed relationship would leave every decision check green and still break
+# the promote lane, which is precisely where the incident that motivated this
+# file happened. These stand in for the handful of spaceship entry points
+# submission_blocker touches, and record what it asked for.
+
+module CredentialsManager
+  module AppfileConfig
+    def self.try_fetch_value(_key)
+      'app.submersion'
+    end
+  end
+end
+
+module Spaceship
+  module ConnectAPI
+    module Platform
+      def self.map(platform)
+        "MAPPED_#{platform.upcase}"
+      end
+    end
+
+    module App
+      def self.find(_identifier)
+        $stub_app
+      end
+    end
+  end
+end
+
+FakeVersion = Struct.new(:version_string, :app_version_state, :app_store_state)
+FakeSubmission = Struct.new(:app_store_version_for_review)
+
+# Stands in for a submission fetched without the relationship included, which
+# is what makes the version unreadable in the first place.
+class UnreadableSubmission
+  def app_store_version_for_review
+    raise StandardError, 'relationship not included'
+  end
+end
+
+class FakeApp
+  attr_reader :review_calls, :edit_calls
+
+  def initialize(submission: nil, edit_version: nil)
+    @submission = submission
+    @edit_version = edit_version
+    @review_calls = []
+    @edit_calls = []
+  end
+
+  def get_in_progress_review_submission(platform:, includes: nil)
+    @review_calls << { platform: platform, includes: includes }
+    @submission
+  end
+
+  def get_edit_app_store_version(platform:)
+    @edit_calls << { platform: platform }
+    @edit_version
+  end
+end
+
 # --- The cases, run against whichever Fastfile is currently loaded -----------
 
 def assert_guard_behaviour(label)
@@ -148,6 +212,79 @@ def assert_guard_behaviour(label)
   end
 end
 
+# --- The App Store Connect wrapper ------------------------------------------
+# Thin, but not too thin to get wrong: these pin the call shape so a rename in
+# spaceship or a fat-fingered symbol fails here rather than 20 minutes into a
+# promotion.
+
+def assert_wrapper_behaviour(label, platform_arg)
+  mapped = "MAPPED_#{platform_arg.upcase}"
+
+  # A review under way for a different version blocks, and the version it
+  # covers is read through the relationship the request asked for.
+  $stub_app = FakeApp.new(
+    submission: FakeSubmission.new(FakeVersion.new('1.7.3', 'WAITING_FOR_REVIEW', nil)),
+    edit_version: FakeVersion.new('1.7.3', 'WAITING_FOR_REVIEW', nil),
+  )
+  reason = submission_blocker('1.7.4', platform_arg)
+  check(!reason.nil?, "#{label}: an in-progress review did not block")
+  check(reason.to_s.include?('1.7.3'),
+        "#{label}: the reason did not name the in-review version (got #{reason.inspect}); " \
+        'the appStoreVersionForReview relationship is how that is read')
+  check($stub_app.review_calls.length == 1,
+        "#{label}: expected one review-submission lookup, got #{$stub_app.review_calls.length}")
+  check($stub_app.review_calls.first[:platform] == mapped,
+        "#{label}: the lookup was not scoped to #{mapped} " \
+        "(got #{$stub_app.review_calls.first[:platform].inspect})")
+  check($stub_app.review_calls.first[:includes] == 'appStoreVersionForReview',
+        "#{label}: the lookup did not request appStoreVersionForReview " \
+        "(got #{$stub_app.review_calls.first[:includes].inspect}); without it the " \
+        'skip message cannot name the version holding the review')
+
+  # Short-circuit: once a submission is known the editable version cannot
+  # change the answer, and asking for it anyway is a call that could raise and
+  # fail the lane after the safe answer was already in hand.
+  check($stub_app.edit_calls.empty?,
+        "#{label}: the editable version was fetched even though a review was " \
+        'already in progress; that is an avoidable way to fail the lane')
+
+  # An unreadable relationship must not weaken the block.
+  $stub_app = FakeApp.new(submission: UnreadableSubmission.new)
+  reason = submission_blocker('1.7.4', platform_arg)
+  check(!reason.nil?,
+        "#{label}: a submission whose version could not be read stopped blocking")
+
+  # Nothing in review: the editable version decides, and now it IS fetched.
+  $stub_app = FakeApp.new(
+    submission: nil,
+    edit_version: FakeVersion.new('1.7.4', 'WAITING_FOR_REVIEW', nil),
+  )
+  reason = submission_blocker('1.7.4', platform_arg)
+  check(!reason.nil?,
+        "#{label}: a version already WAITING_FOR_REVIEW was not blocked")
+  check($stub_app.edit_calls.length == 1,
+        "#{label}: expected one editable-version lookup, got #{$stub_app.edit_calls.length}")
+
+  # The legacy app_store_state field is still honoured as a fallback.
+  $stub_app = FakeApp.new(
+    submission: nil,
+    edit_version: FakeVersion.new('1.7.4', nil, 'IN_REVIEW'),
+  )
+  check(!submission_blocker('1.7.4', platform_arg).nil?,
+        "#{label}: the app_store_state fallback stopped being read")
+
+  # Clean slate: no submission, no editable version.
+  $stub_app = FakeApp.new(submission: nil, edit_version: nil)
+  check(submission_blocker('1.7.4', platform_arg).nil?,
+        "#{label}: a clean slate was blocked by the wrapper")
+
+  # No app record at all degrades to "proceed" and lets the submission attempt
+  # raise its own error rather than inventing one.
+  $stub_app = nil
+  check(submission_blocker('1.7.4', platform_arg).nil?,
+        "#{label}: a missing app record did not fall through")
+end
+
 # --- Both platform Fastfiles ------------------------------------------------
 # Loaded one at a time: the second load redefines the helper at top level, so
 # testing after each load is what actually exercises both copies. These files
@@ -167,9 +304,13 @@ end
 
 load_fastfile('ios', 'fastlane', 'Fastfile')
 assert_guard_behaviour('ios')
+assert_wrapper_behaviour('ios', 'ios')
 
 load_fastfile('macos', 'fastlane', 'Fastfile')
 assert_guard_behaviour('macos')
+# The macOS lane passes Apple's platform name for the Mac App Store, not the
+# directory name; the lane calls submission_blocker(app_version, "osx").
+assert_wrapper_behaviour('macos', 'osx')
 
 # --- Report -----------------------------------------------------------------
 

--- a/scripts/release/fastlane_submit_guard_test.rb
+++ b/scripts/release/fastlane_submit_guard_test.rb
@@ -1,0 +1,181 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tests the App Review submission guard in the platform Fastfiles without
+# booting fastlane or talking to App Store Connect. Each Fastfile is loaded
+# against stubs for the fastlane DSL methods it calls at load time, which
+# leaves the helper methods defined at top level where they can be exercised
+# directly. Same approach as fastlane_beta_changelog_test.rb.
+#
+# What these guard, from promotion run 31903095751 (2026-08-15):
+#
+# The promote workflow submitted 1.7.4 while 1.7.3 was still with Apple. The
+# old guard asked only "is THIS version already submitted?", so a different
+# version sitting in review did not stop it. deliver then called
+# Spaceship's ensure_version!, which finds the editable version and renames it
+# in place when the version string differs. iOS 1.7.3 was WAITING_FOR_REVIEW,
+# which IS an editable state, so the in-review submission was silently renamed
+# to 1.7.4 while build 6027 stayed attached. The follow-up select_build was
+# then refused ("The specified pre-release build could not be added"), leaving
+# a submission labelled 1.7.4 carrying 1.7.3's binary.
+#
+# macOS failed differently in the same run only because Apple had advanced its
+# copy to IN_REVIEW, which is NOT an editable state, so deliver tried to create
+# a version instead and got a clean error. The loud failure was luck; the same
+# defect produced silent mislabelling on the other platform.
+#
+# The decision under test is therefore version-agnostic: ANY review in progress
+# for the platform blocks submission, whatever version it covers.
+
+ROOT = File.expand_path('../..', __dir__)
+
+$failures = []
+
+def check(condition, message)
+  $failures << message unless condition
+end
+
+# --- Minimal fastlane DSL stubs ---------------------------------------------
+
+module UI
+  def self.important(_msg); end
+  def self.message(_msg); end
+  def self.success(_msg); end
+  def self.user_error!(msg)
+    raise ArgumentError, msg
+  end
+end
+
+def default_platform(_name); end
+def desc(_text); end
+
+LANES = {}
+def lane(name, &block)
+  LANES[name] = block
+end
+
+# Platform blocks are yielded so the `def`s inside them land at top level.
+def platform(_name)
+  yield
+end
+
+# --- The cases, run against whichever Fastfile is currently loaded -----------
+
+def assert_guard_behaviour(label)
+  # 1. The iOS failure: a DIFFERENT version is in review. This is the case the
+  #    old guard let through, and the one that corrupted the submission.
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: true,
+    review_version: '1.7.3',
+  )
+  check(!reason.nil?,
+        "#{label}: a review in progress for 1.7.3 did not block submitting 1.7.4")
+  check(reason.to_s.include?('1.7.3'),
+        "#{label}: the skip reason did not name the version holding the review " \
+        "(got #{reason.inspect}); the CI log has to say what to go look at")
+
+  # 2. The macOS failure: same block, but Apple's submission record did not
+  #    tell us which version it covers. Absence of a version string must not
+  #    downgrade this to "proceed".
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: true,
+    review_version: nil,
+  )
+  check(!reason.nil?,
+        "#{label}: a review in progress with an unknown version did not block")
+
+  # 3. Same version already handed over. Belt and braces with case 1: this is
+  #    the path a straight re-dispatch takes.
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: false,
+    edit_version: '1.7.4',
+    edit_state: 'WAITING_FOR_REVIEW',
+  )
+  check(!reason.nil?,
+        "#{label}: re-submitting a version already WAITING_FOR_REVIEW was allowed")
+
+  # 4. The recovery state from that same incident: the submission was pulled,
+  #    leaving DEVELOPER_REJECTED. That is editable and is exactly what this
+  #    lane exists to submit, so it must proceed.
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: false,
+    edit_version: '1.7.4',
+    edit_state: 'DEVELOPER_REJECTED',
+  )
+  check(reason.nil?,
+        "#{label}: DEVELOPER_REJECTED was treated as blocking (got #{reason.inspect}); " \
+        'a pulled submission is the lane\'s job to resubmit')
+
+  # 5. macOS recovery: an editable version still carrying the OLD version
+  #    string. deliver renames it in place, which is legitimate and is how
+  #    macOS 1.7.3 became 1.7.4. Blocking here would strand the release.
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: false,
+    edit_version: '1.7.3',
+    edit_state: 'DEVELOPER_REJECTED',
+  )
+  check(reason.nil?,
+        "#{label}: an editable 1.7.3 blocked submitting 1.7.4 (got #{reason.inspect}); " \
+        'renaming an editable version is how the rename-forward recovery works')
+
+  # 6. Nothing in flight at all: the ordinary first submission of a version.
+  reason = submission_skip_reason(
+    app_version: '1.7.4',
+    review_in_progress: false,
+  )
+  check(reason.nil?,
+        "#{label}: a clean slate was blocked (got #{reason.inspect})")
+
+  # 7. Regression guard on the obvious over-correction. A published app ALWAYS
+  #    has a live version sitting in READY_FOR_SALE / READY_FOR_DISTRIBUTION.
+  #    If those ever count as blocking, every promotion silently no-ops and the
+  #    app can never ship again - a worse failure than the one being fixed.
+  ['READY_FOR_SALE', 'READY_FOR_DISTRIBUTION', 'REPLACED_WITH_NEW_VERSION'].each do |live|
+    reason = submission_skip_reason(
+      app_version: '1.7.4',
+      review_in_progress: false,
+      edit_version: '1.7.3',
+      edit_state: live,
+    )
+    check(reason.nil?,
+          "#{label}: the live version state #{live} was treated as blocking " \
+          "(got #{reason.inspect}); that would stop every future release")
+  end
+end
+
+# --- Both platform Fastfiles ------------------------------------------------
+# Loaded one at a time: the second load redefines the helper at top level, so
+# testing after each load is what actually exercises both copies. These files
+# are meant to stay in lockstep, and this is what catches them drifting.
+
+# The two Apple Fastfiles are deliberate near-duplicates, so the second load
+# redefines constants and methods the first already set. Ruby warns on both,
+# and a dozen expected warnings is exactly how an unexpected one gets missed.
+# Scoped to the load itself so anything the checks emit still surfaces.
+def load_fastfile(*parts)
+  previous = $VERBOSE
+  $VERBOSE = nil
+  load File.join(ROOT, *parts)
+ensure
+  $VERBOSE = previous
+end
+
+load_fastfile('ios', 'fastlane', 'Fastfile')
+assert_guard_behaviour('ios')
+
+load_fastfile('macos', 'fastlane', 'Fastfile')
+assert_guard_behaviour('macos')
+
+# --- Report -----------------------------------------------------------------
+
+if $failures.empty?
+  puts 'PASS: all fastlane submit guard tests passed'
+else
+  $failures.each { |f| puts "FAIL: #{f}" }
+  exit 1
+end


### PR DESCRIPTION
## Summary

Promotion run [31903095751](https://github.com/submersion-app/submersion/actions/runs/31903095751) submitted 1.7.4 while 1.7.3 was still with Apple. Both Apple legs failed, in different ways, from one defect.

The guard asked only *"is **this** version already submitted?"*, keyed on `version.version_string == app_version`, so a different version sitting in review did not stop the lane. `deliver` then called Spaceship's `ensure_version!`, which **renames the editable version in place** when the version string differs rather than creating a new one:

```ruby
app_store_version = get_edit_app_store_version(platform: platform)
if app_store_version
  if version_string != app_store_version.version_string
    app_store_version.update(attributes: { versionString: version_string })  # rename
```

| | 1.7.3 state | Editable? | Outcome |
| --- | --- | --- | --- |
| **iOS** | `WAITING_FOR_REVIEW` | yes | in-review version **silently renamed to 1.7.4**, build 6027 still attached; `select_build` then refused with `The specified pre-release build could not be added` |
| **macOS** | `IN_REVIEW` | no | `deliver` tried to create a version, got a clean error |

iOS was left with a submission labelled **1.7.4 carrying 1.7.3's binary**, which is what users would have received had Apple approved it. The macOS failure was loud only because Apple had advanced its copy one state further. That was luck, not design.

### The guard could not see most of what it checked for

It read state via `get_edit_app_store_version`, whose server-side filter (spaceship `app.rb:257-275`) admits only:

```
PREPARE_FOR_SUBMISSION, DEVELOPER_REJECTED, REJECTED,
METADATA_REJECTED, WAITING_FOR_REVIEW, INVALID_BINARY
```

Of the eight entries in `ALREADY_SUBMITTED_STATES`, **only `WAITING_FOR_REVIEW` overlapped**. So it worked during that one window and silently stopped working the moment Apple picked a build up, which is the worse half of the failure envelope: reliable in the cheap case, absent in the expensive one.

## Changes

- Replaces `already_submitted_state` with `submission_blocker`, which asks App Store Connect for an **in-progress review submission** on the platform (`get_in_progress_review_submission`, covering `WAITING_FOR_REVIEW`, `IN_REVIEW` and `UNRESOLVED_ISSUES`) and blocks on its existence **regardless of which version it covers**.
- That signal is also immune to the obvious over-correction: it never matches the live version, which every published app always has, so it cannot wedge the pipeline into skipping forever. A hand-curated state list would have to get that exclusion right by hand, and `ALREADY_SUBMITTED_STATES` already contains `READY_FOR_SALE`.
- An **editable version carrying an older version string stays non-blocking**. Renaming that forward is legitimate and is exactly how the recovery from this incident worked.
- The decision is split into a pure `submission_skip_reason` so every branch is testable without a network call.
- Skip messages now name the version holding the review, so the CI log says what to go look at.
- Updates the stale `already_submitted_state` reference in `promote.yml`.

Both Fastfiles are updated identically, and the new test asserts they stay in lockstep by loading each in turn.

## Test Plan

- [x] New `scripts/release/fastlane_submit_guard_test.rb`, wired into CI next to the existing fastlane test
- [x] Written first and observed failing (`undefined method 'submission_skip_reason'`)
- [x] **Mutation-checked**: reintroducing the version-string coupling (`if review_in_progress && review_version == app_version`) fails exactly the three assertions encoding this incident, confirming the test has teeth
- [x] All five release-script tests CI runs pass (`beta_release_notes`, `generate_changelog`, `fastlane_beta_changelog`, `fastlane_submit_guard`, `pre_push_hook`)
- [x] `ruby -c` clean on both Fastfiles; both workflow files validate as YAML
- [x] Guard code verified byte-identical across `ios/` and `macos/`

Cases covered, drawn from the incident and its recovery:

| Case | Expected |
| --- | --- |
| Review in progress for 1.7.3, submitting 1.7.4 | **block** (the iOS corruption) |
| Review in progress, version unknown | **block** (unknown must not weaken it) |
| Same version already `WAITING_FOR_REVIEW` | **block** |
| `DEVELOPER_REJECTED` after pulling a submission | proceed (the lane's job) |
| Editable 1.7.3 while submitting 1.7.4 | proceed (rename-forward recovery) |
| Clean slate | proceed |
| Live states (`READY_FOR_SALE`, `READY_FOR_DISTRIBUTION`, `REPLACED_WITH_NEW_VERSION`) | proceed (regression guard against never shipping again) |

No Dart changed, so this cannot affect the app binary.

## Note on failure mode

One deliberate behavior change: a failure of the App Store Connect lookups themselves is no longer swallowed. After this incident, stopping is better than proceeding without knowing whether a review is under way, because proceeding blind is precisely what renamed an in-review version. A missing app record still returns nil and lets the submission attempt produce its own error.
