### PR TITLE
fix(maps): stop pinch zoom from rotating the map

### DIFF
--- a/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
+++ b/lib/features/dashboard/presentation/widgets/recent_sites_map_card.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dashboard/presentation/providers/dashboard_p
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -74,9 +75,7 @@ class _RecentSitesMapCardState extends ConsumerState<RecentSitesMapCard> {
                       initialCenter: points.first,
                       initialZoom: 11,
                       initialCameraFit: fit,
-                      interactionOptions: const InteractionOptions(
-                        flags: InteractiveFlag.all,
-                      ),
+                      interactionOptions: rotatableMapInteraction,
                     ),
                     children: [
                       TileLayer(

--- a/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_map_page.dart
@@ -15,6 +15,7 @@ import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_list_scaffold.dart';
 
@@ -213,6 +214,7 @@ class _DiveCenterMapPageState extends ConsumerState<DiveCenterMapPage>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onTap: (_, _) {
                 ref
                     .read(mapListSelectionProvider('dive-centers').notifier)

--- a/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
+++ b/lib/features/dive_centers/presentation/widgets/dive_center_map_content.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/dive_centers/presentation/providers/dive_cen
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -206,6 +207,7 @@ class _DiveCenterMapContentState extends ConsumerState<DiveCenterMapContent>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onMapReady: () {
                 _mapReady = true;
               },

--- a/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_locations_map.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/gps_log/presentation/widgets/gps_track_polyl
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/submersion_tile_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Marker colors for the GPS entry/exit fixes, matching the values the dive
@@ -236,9 +237,9 @@ class _DiveLocationsMapState extends ConsumerState<DiveLocationsMap> {
                 _framedOn = trackRuns;
               },
               initialCameraFit: fit,
-              interactionOptions: InteractionOptions(
-                flags: interactive ? InteractiveFlag.all : InteractiveFlag.none,
-              ),
+              interactionOptions: interactive
+                  ? rotatableMapInteraction
+                  : const InteractionOptions(flags: InteractiveFlag.none),
             ),
             children: [
               submersionTileLayer(ref),

--- a/lib/features/dive_log/presentation/widgets/dive_map_content.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_map_content.dart
@@ -18,6 +18,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -297,6 +298,7 @@ class _DiveMapContentState extends ConsumerState<DiveMapContent>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onMapReady: () {
                 _mapReady = true;
               },

--- a/lib/features/dive_sites/presentation/pages/site_map_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_map_page.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
@@ -251,6 +252,7 @@ class _SiteMapPageState extends ConsumerState<SiteMapPage>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onTap: (_, _) {
                 ref.read(mapListSelectionProvider('sites').notifier).deselect();
                 setState(() => _selectedBuiltInId = null);

--- a/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
+++ b/lib/features/dive_sites/presentation/widgets/match_sites_map.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/maps/data/services/tile_cache_service.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 
 /// Map for the Match-Sites review: shows the focused dive's GPS point plus its
@@ -64,9 +65,7 @@ class _MatchSitesMapState extends ConsumerState<MatchSitesMap> {
               initialCenter: pts.first,
               initialZoom: 13,
               initialCameraFit: fit,
-              interactionOptions: const InteractionOptions(
-                flags: InteractiveFlag.all,
-              ),
+              interactionOptions: rotatableMapInteraction,
             ),
             children: [
               TileLayer(

--- a/lib/features/dive_sites/presentation/widgets/site_map_content.dart
+++ b/lib/features/dive_sites/presentation/widgets/site_map_content.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_controls.
 import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/shared/widgets/map_list_layout/map_info_card.dart';
@@ -286,6 +287,7 @@ class _SiteMapContentState extends ConsumerState<SiteMapContent>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onMapReady: () {
                 _mapReady = true;
               },

--- a/lib/features/gps_log/presentation/pages/gps_track_detail_page.dart
+++ b/lib/features/gps_log/presentation/pages/gps_track_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/gps_log/presentation/widgets/track_stats_hea
 import 'package:submersion/features/gps_log/presentation/widgets/track_timeline_scrubber.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/submersion_tile_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -460,6 +461,7 @@ class _TrackMapState extends ConsumerState<_TrackMap> {
                 initialCameraFit: camera.fit,
                 initialCenter: camera.center ?? const LatLng(0, 0),
                 initialZoom: camera.zoom ?? 13.0,
+                interactionOptions: rotatableMapInteraction,
               ),
               children: [
                 submersionTileLayer(ref),

--- a/lib/features/gps_log/presentation/pages/gps_track_map_page.dart
+++ b/lib/features/gps_log/presentation/pages/gps_track_map_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/gps_log/presentation/widgets/track_camera.da
 import 'package:submersion/features/gps_log/presentation/widgets/track_row_labels.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/submersion_tile_layer.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -260,6 +261,7 @@ class _OverviewMapState extends ConsumerState<_OverviewMap> {
           initialCameraFit: camera.fit,
           initialCenter: camera.center ?? const LatLng(0, 0),
           initialZoom: camera.zoom ?? 13.0,
+          interactionOptions: rotatableMapInteraction,
         ),
         children: [
           submersionTileLayer(ref),

--- a/lib/features/maps/presentation/pages/dive_activity_map_page.dart
+++ b/lib/features/maps/presentation/pages/dive_activity_map_page.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/maps/presentation/widgets/heat_map_layer.dar
 import 'package:submersion/features/maps/presentation/providers/map_tile_providers.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_attribution.dart';
 import 'package:submersion/features/maps/presentation/widgets/map_compass_button.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
 import 'package:submersion/features/maps/presentation/widgets/trackpad_zoom_map.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/providers/map_list_selection_provider.dart';
@@ -264,6 +265,7 @@ class _DiveActivityMapPageState extends ConsumerState<DiveActivityMapPage>
               initialZoom: zoom,
               minZoom: 2.0,
               maxZoom: 18.0,
+              interactionOptions: rotatableMapInteraction,
               onTap: (_, _) {
                 ref.read(mapListSelectionProvider('dives').notifier).deselect();
               },

--- a/lib/features/maps/presentation/widgets/map_interaction_options.dart
+++ b/lib/features/maps/presentation/widgets/map_interaction_options.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_map/flutter_map.dart';
+
+/// Interaction settings for the maps that allow two-finger rotation.
+///
+/// `flutter_map` looks like it already guards rotation: [InteractionOptions]
+/// ships a `rotationThreshold` of 20 degrees. It does not. The threshold is
+/// only ever consulted while a multi-finger gesture race is running, and
+/// `enableMultiFingerGestureRace` defaults to false, so the rotate handler runs
+/// on every scale update and engages the moment the angle between the fingers
+/// is anything but zero. Two fingers never spread at a perfectly constant
+/// angle, so every pinch twisted the map a few degrees (issue #1067).
+///
+/// Turning the race on makes those thresholds live, so the first few
+/// millimetres of a two-finger gesture decide what it is: a pinch commits to
+/// zoom and pan, and a twist has to reach [_rotationThresholdDegrees] before it
+/// rotates anything. The trade-off is that a gesture can no longer start as a
+/// zoom and become a rotation partway through, which is the whole point.
+///
+/// Maps that should never rotate do not need this; they clear
+/// [InteractiveFlag.rotate] instead, which skips the rotate handler outright.
+const InteractionOptions rotatableMapInteraction = InteractionOptions(
+  enableMultiFingerGestureRace: true,
+  rotationThreshold: _rotationThresholdDegrees,
+  // Once a twist is deliberate enough to win, hand the rest of the gesture
+  // back to zoom and pan so the same two fingers can still do everything. Only
+  // the reverse order is blocked, which is what stops the incidental rotation.
+  rotationWinGestures: MultiFingerGesture.all,
+  pinchZoomThreshold: _pinchZoomThresholdZoomLevels,
+  pinchMoveThreshold: _pinchMoveThresholdPixels,
+);
+
+/// How far the line between two fingers must twist before the gesture counts
+/// as a rotation. Roughly the deliberate quarter-turn of the wrist that Google
+/// Maps asks for, and far beyond the few degrees a pinch wobbles through.
+const double _rotationThresholdDegrees = 15.0;
+
+/// How far a pinch must scale before it counts as a zoom, in zoom levels.
+///
+/// `flutter_map` defaults this to 0.5, which is a 41% change in finger
+/// separation: with the race enabled that would leave the map inert for most
+/// of a pinch. 0.05 is about 3.5%, so zoom claims the gesture almost
+/// immediately and rotation loses cleanly.
+const double _pinchZoomThresholdZoomLevels = 0.05;
+
+/// How far the midpoint between two fingers must travel before the gesture
+/// counts as a two-finger pan, in logical pixels. Lowered from the package
+/// default of 40 for the same reason as the zoom threshold: under a race, a
+/// large threshold reads as lag.
+const double _pinchMoveThresholdPixels = 12.0;

--- a/test/features/maps/presentation/widgets/map_interaction_options_test.dart
+++ b/test/features/maps/presentation/widgets/map_interaction_options_test.dart
@@ -1,0 +1,175 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:submersion/features/maps/presentation/widgets/map_interaction_options.dart';
+
+/// A point along a two-finger gesture: how far apart the fingers have spread
+/// relative to where they started, and how far the line between them has
+/// twisted, both measured from the start of the gesture.
+typedef _Waypoint = ({double scale, double twistDegrees});
+
+void main() {
+  Future<MapController> pumpMap(
+    WidgetTester tester,
+    InteractionOptions interactionOptions,
+  ) async {
+    final controller = MapController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 400,
+              height: 400,
+              child: FlutterMap(
+                mapController: controller,
+                options: MapOptions(
+                  initialCenter: const LatLng(0, 0),
+                  initialZoom: 5,
+                  minZoom: 1,
+                  maxZoom: 18,
+                  interactionOptions: interactionOptions,
+                ),
+                children: const [],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return controller;
+  }
+
+  /// Interpolates a straight run of waypoints, so a gesture grows the way a
+  /// real hand does instead of teleporting to its end state in one update.
+  List<_Waypoint> ramp({
+    required double toScale,
+    required double toTwist,
+    double fromScale = 1.0,
+    double fromTwist = 0.0,
+    int steps = 10,
+  }) => [
+    for (var step = 1; step <= steps; step++)
+      (
+        scale: fromScale + (toScale - fromScale) * step / steps,
+        twistDegrees: fromTwist + (toTwist - fromTwist) * step / steps,
+      ),
+  ];
+
+  /// Drives one continuous two-finger gesture through [waypoints]. The fingers
+  /// stay symmetric about [center], so the focal point never moves and only
+  /// the scale and twist under test can win the gesture race.
+  Future<void> twoFingerGesture(
+    WidgetTester tester,
+    Offset center,
+    List<_Waypoint> waypoints,
+  ) async {
+    const startRadius = 60.0;
+    // Flutter derives ScaleUpdateDetails.rotation from atan2 of the line
+    // between the pointers, which is discontinuous at +/- pi. Starting the
+    // fingers on the vertical axis rather than the horizontal one keeps the
+    // measurement away from that branch cut, so a 10 degree twist reads as 10
+    // degrees instead of wrapping to -350.
+    const startAngleDegrees = 90.0;
+
+    Offset fingerOffset(_Waypoint waypoint) {
+      final radians =
+          (startAngleDegrees + waypoint.twistDegrees) * math.pi / 180;
+      final radius = startRadius * waypoint.scale;
+      return Offset(radius * math.cos(radians), radius * math.sin(radians));
+    }
+
+    final start = fingerOffset((scale: 1.0, twistDegrees: 0.0));
+    final first = await tester.startGesture(center - start, pointer: 1);
+    final second = await tester.startGesture(center + start, pointer: 2);
+    await tester.pump();
+
+    for (final waypoint in waypoints) {
+      final offset = fingerOffset(waypoint);
+      await first.moveTo(center - offset);
+      await second.moveTo(center + offset);
+      await tester.pump();
+    }
+
+    await first.up();
+    await second.up();
+    await tester.pump();
+  }
+
+  Offset mapCenter(WidgetTester tester) =>
+      tester.getCenter(find.byType(FlutterMap));
+
+  testWidgets('flutter_map defaults rotate on any twist while pinching', (
+    tester,
+  ) async {
+    // Characterizes the upstream behaviour rotatableMapInteraction exists to
+    // correct (issue #1067): InteractionOptions ships rotationThreshold: 20
+    // but enableMultiFingerGestureRace: false, and with the race off that
+    // threshold is never consulted, so a 10 degree wobble rotates the map.
+    // This also proves the gesture below is capable of rotating a map, so the
+    // next test cannot pass for the wrong reason.
+    final controller = await pumpMap(tester, const InteractionOptions());
+
+    await twoFingerGesture(
+      tester,
+      mapCenter(tester),
+      ramp(toScale: 2.0, toTwist: 10),
+    );
+
+    expect(controller.camera.rotation.abs(), greaterThan(1.0));
+  });
+
+  group('rotatableMapInteraction', () {
+    testWidgets('a pinch with an incidental twist does not rotate the map', (
+      tester,
+    ) async {
+      final controller = await pumpMap(tester, rotatableMapInteraction);
+      final startZoom = controller.camera.zoom;
+
+      await twoFingerGesture(
+        tester,
+        mapCenter(tester),
+        ramp(toScale: 2.0, toTwist: 10),
+      );
+
+      expect(controller.camera.rotation, 0.0);
+      expect(controller.camera.zoom, greaterThan(startZoom));
+    });
+
+    testWidgets('a deliberate twist past the threshold rotates the map', (
+      tester,
+    ) async {
+      final controller = await pumpMap(tester, rotatableMapInteraction);
+
+      await twoFingerGesture(
+        tester,
+        mapCenter(tester),
+        ramp(toScale: 1.0, toTwist: 45),
+      );
+
+      expect(controller.camera.rotation.abs(), greaterThan(1.0));
+    });
+
+    testWidgets('zooming still works after a twist has won the gesture', (
+      tester,
+    ) async {
+      // Rotation deliberately hands the rest of the gesture back to zoom and
+      // pan: once the twist is intentional, spreading the same two fingers
+      // should still zoom. Only the reverse order is blocked.
+      final controller = await pumpMap(tester, rotatableMapInteraction);
+      final startZoom = controller.camera.zoom;
+
+      await twoFingerGesture(tester, mapCenter(tester), [
+        ...ramp(toScale: 1.0, toTwist: 45),
+        ...ramp(fromScale: 1.0, fromTwist: 45, toScale: 1.8, toTwist: 45),
+      ]);
+
+      expect(controller.camera.rotation.abs(), greaterThan(1.0));
+      expect(controller.camera.zoom, greaterThan(startZoom));
+    });
+  });
+}


### PR DESCRIPTION
Closes #1067

## The problem

Pinching to zoom on the dive sites map also twists it a few degrees, which reads as nervous, jittery behaviour. Reported on Android 1.7.4.6051.

## Root cause

Not our code: a `flutter_map` default that looks protective and isn't.

`InteractionOptions` ships `rotationThreshold: 20.0` alongside `enableMultiFingerGestureRace: false`. With the race off, `_getMultiFingerGestureFlags` short-circuits to `MultiFingerGesture.all`, so `_handleScalePinchRotate` runs on **every** scale update and engages the moment `details.rotation` is non-zero. `rotationThreshold` is only ever read inside `_determineMultiFingerGestureWinner`, which that gate skips entirely.

It is a 20 degree deadband that behaves like a 0 degree one. The package's own doc comment says so: *"if `enableMultiFingerGestureRace` is false then rotate cannot win."*

Two fingers never spread at a perfectly constant angle, so every pinch rotated the map. The new test measures it: a pinch with a 10 degree incidental wobble rotated the map by 9.99999999999999 degrees.

Every map that left `interactionOptions` unset or passed `InteractiveFlag.all` inherited this, which is 11 maps, not one. They are the maps that host `MapCompassButton`.

## The fix

A shared `rotatableMapInteraction` constant, applied to all 11 rotatable maps.

| Setting | Package default | This PR |
| --- | --- | --- |
| `enableMultiFingerGestureRace` | `false` | `true` |
| `rotationThreshold` | 20 degrees (inert) | 15 degrees (live) |
| `pinchZoomThreshold` | 0.5 zoom levels | 0.05 |
| `pinchMoveThreshold` | 40 px | 12 px |
| `rotationWinGestures` | `rotate` | `all` |

The lowered zoom and pan thresholds are load-bearing, not tidying. Under a race **nothing moves until something wins**, and 0.5 zoom levels is a 41% change in finger separation, so keeping the defaults would have swapped the jitter for a map that ignores the start of every pinch.

`rotationWinGestures: all` makes it deliberately asymmetric: once a twist is intentional enough to win, the same two fingers can still zoom and pan. Only the reverse order is blocked, which is precisely what stops the incidental rotation.

## Behaviour changes

- The race is winner-take-all per gesture, so **a pinch can no longer become a rotation partway through**. That is the trade the issue asks for, and it is slightly stricter than Google Maps, which permits simultaneous twist-and-spread.
- Deliberate two-finger rotation still works, and `MapCompassButton` still resets it.
- Untouched: single-finger drag (`_dragMode`), double-tap zoom, scroll wheel, and cursor/keyboard rotation on desktop (flutter_map does not gate that on `InteractiveFlag.rotate`). Trackpad gestures are also unaffected, since `TrackpadZoomMap` wins the arena before flutter_map's scale recognizer sees them.
- Maps that should never rotate are unaffected: they clear `InteractiveFlag.rotate`, which skips the rotate handler outright.

## Known edge

`_getZoomForScale` clamps to the camera zoom range, so at min or max zoom a pinch can never win the race and a twist can. Still strictly better than the old behaviour, which rotated at any angle at any zoom, and two-finger pan usually wins first anyway.

## Maps changed

`site_map_content`, `site_map_page`, `dive_map_content`, `dive_locations_map`, `dive_center_map_content`, `dive_center_map_page`, `dive_activity_map_page`, `gps_track_map_page`, `gps_track_detail_page`, `match_sites_map`, `recent_sites_map_card`.

All 18 `FlutterMap` sites in the app now declare their interaction explicitly.

## Testing

New `map_interaction_options_test.dart` drives real two-finger gestures through the actual recognizer:

- a pinch with an incidental twist does not rotate the map (the bug)
- a deliberate twist past the threshold does rotate
- zooming still works after a twist has won the gesture
- a characterization test pinning flutter_map's default, so we find out if upstream ever fixes it, and so the test above cannot pass vacuously

The fingers start on the **vertical** axis deliberately: `atan2`'s branch cut at +/- pi makes a horizontally-placed 10 degree twist report as -350 degrees, which would have made the deadband test fail even with a correct fix.

Verified: 4/4 new tests green, `flutter analyze` clean across the project, `dart format` clean, full suite 17,774 passed / 0 failed.

## Not verified

The 15 degree deadband is reasoned, not measured on hardware. The tests prove the logic through the real recognizer path, but whether 15 degrees feels right under a thumb is a device call. It is a one-line constant if it wants adjusting.
