### PR TITLE
fix(pre-dive): restore manual checklist-to-dive linking (#1066)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -43,6 +43,9 @@ import 'package:submersion/features/dive_log/presentation/providers/profile_anal
 import 'package:submersion/features/dive_log/presentation/pages/fullscreen_profile_page.dart';
 import 'package:submersion/features/dive_log/presentation/utils/sac_normalization.dart';
 import 'package:submersion/features/planner/presentation/providers/plan_overlay_provider.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/widgets/link_session_picker.dart';
 import 'package:submersion/shared/widgets/export_destination_sheet.dart';
 import 'package:submersion/shared/widgets/master_detail/detail_scroll_retainer.dart';
 import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.dart';
@@ -683,12 +686,66 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     return children;
   }
 
+  /// Overflow entry for the pre-dive checklist link (#1066). PR #913 removed
+  /// the dive-detail pre-dive card, and with it the only way to attach a run
+  /// completed the evening before -- outside the auto-linker's three-hour
+  /// window -- to the dive it was run for. The label doubles as the indicator:
+  /// "Unlink" only appears when something is attached.
+  PopupMenuItem<String> _preDiveLinkMenuItem(
+    BuildContext context,
+    PreDiveSession? linked,
+  ) {
+    return PopupMenuItem(
+      value: linked == null ? 'linkPreDive' : 'unlinkPreDive',
+      child: ListTile(
+        leading: Icon(
+          linked == null ? Icons.fact_check_outlined : Icons.link_off,
+        ),
+        title: Text(
+          linked == null
+              ? context.l10n.preDive_link_linkChecklist
+              : context.l10n.preDive_link_unlinkChecklist,
+        ),
+        contentPadding: EdgeInsets.zero,
+      ),
+    );
+  }
+
+  Future<void> _linkPreDiveChecklist(BuildContext context, Dive dive) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final confirmation = context.l10n.preDive_link_linked;
+    final sessionId = await showLinkSessionPicker(
+      context,
+      diverId: dive.diverId,
+    );
+    if (sessionId == null) return;
+    await ref
+        .read(preDiveSessionRepositoryProvider)
+        .linkToDive(sessionId, dive.id);
+    // Nothing on this page renders the link, so the snackbar is the only
+    // evidence the write happened.
+    messenger.showSnackBar(SnackBar(content: Text(confirmation)));
+  }
+
+  Future<void> _unlinkPreDiveChecklist(
+    BuildContext context,
+    PreDiveSession linked,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final confirmation = context.l10n.preDive_link_unlinked;
+    await ref.read(preDiveSessionRepositoryProvider).unlinkFromDive(linked.id);
+    messenger.showSnackBar(SnackBar(content: Text(confirmation)));
+  }
+
   Widget _buildContent(BuildContext context, WidgetRef ref, Dive dive) {
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
     final computerReadingsAsync = ref.watch(diveDataSourcesProvider(dive.id));
     final hasRawData =
         ref.watch(diveHasRawDataProvider(dive.id)).valueOrNull ?? false;
+    final linkedPreDive = ref
+        .watch(preDiveSessionForDiveProvider(dive.id))
+        .value;
 
     final builders = _sectionBuilders(
       context: context,
@@ -802,6 +859,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 case 'logNearMiss':
                   context.push('/incidents/new?diveId=$diveId');
                   break;
+                case 'linkPreDive':
+                  _linkPreDiveChecklist(context, dive);
+                  break;
+                case 'unlinkPreDive':
+                  _unlinkPreDiveChecklist(context, linkedPreDive!);
+                  break;
                 case 'delete':
                   _showDeleteConfirmation(context, ref);
                   break;
@@ -824,6 +887,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
+              _preDiveLinkMenuItem(context, linkedPreDive),
               if (hasRawData)
                 PopupMenuItem(
                   value: 'reparse',
@@ -862,6 +926,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     bool hasRawData = false,
   }) {
     final colorScheme = Theme.of(context).colorScheme;
+    final linkedPreDive = ref
+        .watch(preDiveSessionForDiveProvider(dive.id))
+        .value;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -972,6 +1039,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 case 'logNearMiss':
                   context.push('/incidents/new?diveId=$diveId');
                   break;
+                case 'linkPreDive':
+                  _linkPreDiveChecklist(context, dive);
+                  break;
+                case 'unlinkPreDive':
+                  _unlinkPreDiveChecklist(context, linkedPreDive!);
+                  break;
                 case 'delete':
                   _showDeleteConfirmation(context, ref);
                   break;
@@ -1009,6 +1082,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   contentPadding: EdgeInsets.zero,
                 ),
               ),
+              _preDiveLinkMenuItem(context, linkedPreDive),
               if (hasRawData)
                 PopupMenuItem(
                   value: 'reparse',

--- a/lib/features/pre_dive/data/repositories/pre_dive_session_repository.dart
+++ b/lib/features/pre_dive/data/repositories/pre_dive_session_repository.dart
@@ -316,6 +316,30 @@ class PreDiveSessionRepository {
     }
   }
 
+  /// Dives that already have a checklist run attached, across all divers.
+  ///
+  /// The manual link picker (#1066) subtracts these from its candidates so a
+  /// hand-made link keeps the one-run-per-dive rule [ChecklistDiveLinker]
+  /// enforces; a second run on the same dive would leave the older one
+  /// invisible from the dive side, since [getSessionForDive] returns only the
+  /// latest.
+  Future<Set<String>> getLinkedDiveIds() async {
+    try {
+      final query = _db.selectOnly(_db.preDiveSessions, distinct: true)
+        ..addColumns([_db.preDiveSessions.diveId])
+        ..where(_db.preDiveSessions.diveId.isNotNull());
+      final rows = await query.get();
+      return {for (final row in rows) ?row.read(_db.preDiveSessions.diveId)};
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get linked dive ids',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Mutates one item's run state. completedAt is stamped at tap time when
   /// leaving pending and cleared when resetting to pending. Value/note
   /// parameters are only written when provided so partial updates preserve

--- a/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
+++ b/lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/domain/models/pre_dive_session_filter.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/widgets/link_dive_picker.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/pre_dive_session_filter_sheet.dart';
 import 'package:submersion/features/pre_dive/presentation/widgets/start_session_sheet.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -353,6 +354,17 @@ class _SessionTile extends ConsumerWidget {
     };
   }
 
+  /// Attaches this run to a dive the diver picks (#1066). The automatic
+  /// linker only reaches back three hours from the dive, so a build check run
+  /// the evening before is only ever linked by hand.
+  Future<void> _link(BuildContext context, WidgetRef ref) async {
+    final diveId = await showLinkDivePicker(context);
+    if (diveId == null) return;
+    await ref
+        .read(preDiveSessionRepositoryProvider)
+        .linkToDive(session.id, diveId);
+  }
+
   Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {
     final l10n = context.l10n;
     final confirmed = await showDialog<bool>(
@@ -433,9 +445,28 @@ class _SessionTile extends ConsumerWidget {
       ),
       trailing: PopupMenuButton<String>(
         onSelected: (value) {
-          if (value == 'delete') _confirmDelete(context, ref);
+          switch (value) {
+            case 'link':
+              _link(context, ref);
+            case 'unlink':
+              ref
+                  .read(preDiveSessionRepositoryProvider)
+                  .unlinkFromDive(session.id);
+            case 'delete':
+              _confirmDelete(context, ref);
+          }
         },
         itemBuilder: (context) => [
+          if (hasLinkedDive)
+            PopupMenuItem(
+              value: 'unlink',
+              child: Text(l10n.preDive_link_unlinkDive),
+            )
+          else
+            PopupMenuItem(
+              value: 'link',
+              child: Text(l10n.preDive_link_linkToDive),
+            ),
           PopupMenuItem(
             value: 'delete',
             child: Text(l10n.preDive_sessions_delete),

--- a/lib/features/pre_dive/presentation/providers/pre_dive_providers.dart
+++ b/lib/features/pre_dive/presentation/providers/pre_dive_providers.dart
@@ -1,5 +1,7 @@
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_template_repository.dart';
@@ -134,4 +136,48 @@ final preDiveSessionForDiveProvider =
       final repository = ref.watch(preDiveSessionRepositoryProvider);
       ref.invalidateSelfWhen(repository.watchSessionsChanges());
       return repository.getSessionForDive(diveId);
+    });
+
+/// How many recent dives the manual link picker offers before the diver
+/// searches. Enough to cover "the dive I just logged" without paging a large
+/// log into a dialog.
+const kPreDiveLinkRecentDiveCount = 50;
+
+/// Recent dives the manual link picker offers as its default list (#1066).
+/// Summaries rather than hydrated dives: the rows show only number, date and
+/// site, so a large log must not pay full hydration to fill one dialog.
+final preDiveLinkCandidateDivesProvider =
+    FutureProvider.autoDispose<List<DiveSummary>>((ref) async {
+      final repository = ref.watch(diveRepositoryProvider);
+      final diverId = ref.watch(currentDiverIdProvider);
+      ref.invalidateSelfWhen(repository.watchDivesChanges());
+      return repository.getDiveSummaries(
+        diverId: diverId,
+        limit: kPreDiveLinkRecentDiveCount,
+      );
+    });
+
+/// Dives the link picker must not offer, because a run is already attached.
+///
+/// Subscribed rather than read once: a sync pull can attach a run to a dive
+/// while the picker is open, and a stale set here is not a cosmetic staleness
+/// but the double-link this set exists to prevent.
+final preDiveLinkedDiveIdsProvider = FutureProvider.autoDispose<Set<String>>((
+  ref,
+) async {
+  final repository = ref.watch(preDiveSessionRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchSessionsChanges());
+  return repository.getLinkedDiveIds();
+});
+
+/// Checklist runs not yet attached to a dive, newest first (#1066).
+///
+/// The diver filter is exact-match (null selects unscoped runs only), matching
+/// [ChecklistDiveLinker], so a manual link cannot cross a diver boundary the
+/// automatic linker respects.
+final preDiveUnlinkedSessionsProvider = FutureProvider.autoDispose
+    .family<List<domain.PreDiveSession>, String?>((ref, diverId) async {
+      final repository = ref.watch(preDiveSessionRepositoryProvider);
+      ref.invalidateSelfWhen(repository.watchSessionsChanges());
+      return repository.getUnlinkedSessions(diverId: diverId);
     });

--- a/lib/features/pre_dive/presentation/widgets/link_dive_picker.dart
+++ b/lib/features/pre_dive/presentation/widgets/link_dive_picker.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/debounced_search_results.dart';
+
+/// Picks the dive a completed checklist run should be attached to (#1066).
+///
+/// Recent dives are offered without typing, which covers "the dive I just
+/// logged"; typing hands over to the shared dive search so a run recorded long
+/// after the fact still reaches an older dive. Returns the chosen dive id, or
+/// null when the diver dismissed the picker.
+Future<String?> showLinkDivePicker(BuildContext context) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) => const _LinkDivePicker(),
+  );
+}
+
+class _LinkDivePicker extends ConsumerStatefulWidget {
+  const _LinkDivePicker();
+
+  @override
+  ConsumerState<_LinkDivePicker> createState() => _LinkDivePickerState();
+}
+
+class _LinkDivePickerState extends ConsumerState<_LinkDivePicker> {
+  final _controller = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    // Dives that already carry a run are not candidates: ChecklistDiveLinker
+    // keeps one run per dive, and getSessionForDive only surfaces the latest,
+    // so a second hand-made link would hide the first.
+    final takenAsync = ref.watch(preDiveLinkedDiveIdsProvider);
+
+    return AlertDialog(
+      title: Text(l10n.preDive_link_linkToDive),
+      // A dialog sizes to its content, and the results list is unbounded, so
+      // the body needs an explicit box for the ListView to scroll inside.
+      content: SizedBox(
+        width: 420,
+        height: 420,
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              autofocus: false,
+              decoration: InputDecoration(
+                prefixIcon: const Icon(Icons.search),
+                labelText: l10n.preDive_link_searchDives,
+              ),
+              onChanged: (value) => setState(() => _query = value),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: takenAsync.when(
+                // Gated rather than defaulted to an empty set: an unresolved
+                // exclusion list would briefly offer dives that are taken.
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error: (error, _) => Center(child: Text(error.toString())),
+                data: (taken) => DebouncedSearchResults<DiveSummary>(
+                  query: _query,
+                  watchProvider: (ref, query) =>
+                      ref.watch(diveSearchProvider(query)),
+                  emptyQueryBuilder: (context) => _RecentDives(taken: taken),
+                  // A search whose every hit is already taken is, to the
+                  // diver, a search with no results: say so rather than
+                  // rendering an empty list under a query that matched.
+                  dataBuilder: (context, dives) {
+                    final offerable = _offerable(dives, taken);
+                    return offerable.isEmpty
+                        ? _noMatches(context, _query)
+                        : _DiveList(dives: offerable);
+                  },
+                  emptyBuilder: _noMatches,
+                  errorBuilder: (context, error) =>
+                      Center(child: Text(error.toString())),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.common_action_cancel),
+        ),
+      ],
+    );
+  }
+}
+
+List<DiveSummary> _offerable(List<DiveSummary> dives, Set<String> taken) => [
+  for (final dive in dives)
+    if (!taken.contains(dive.id)) dive,
+];
+
+Widget _noMatches(BuildContext context, String query) => Center(
+  child: Text(
+    context.l10n.preDive_link_noDivesMatch(query),
+    textAlign: TextAlign.center,
+  ),
+);
+
+/// The default list, shown until the diver types.
+class _RecentDives extends ConsumerWidget {
+  final Set<String> taken;
+
+  const _RecentDives({required this.taken});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recent = ref.watch(preDiveLinkCandidateDivesProvider);
+
+    return recent.when(
+      data: (dives) {
+        final offerable = _offerable(dives, taken);
+        return offerable.isEmpty
+            ? Center(child: Text(context.l10n.preDive_link_noDives))
+            : _DiveList(dives: offerable);
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text(error.toString())),
+    );
+  }
+}
+
+class _DiveList extends StatelessWidget {
+  final List<DiveSummary> dives;
+
+  const _DiveList({required this.dives});
+
+  @override
+  Widget build(BuildContext context) {
+    final materialL10n = MaterialLocalizations.of(context);
+
+    return ListView.builder(
+      itemCount: dives.length,
+      itemBuilder: (context, index) {
+        final dive = dives[index];
+        final date = materialL10n.formatMediumDate(
+          dive.entryTime ?? dive.dateTime,
+        );
+        // Number and site identify the dive; the date is the fallback identity
+        // for a dive that has neither, so it must not also be the title then.
+        final parts = [
+          if (dive.diveNumber != null) '#${dive.diveNumber}',
+          ?dive.siteName,
+        ].where((part) => part.isNotEmpty).toList();
+
+        return ListTile(
+          dense: true,
+          leading: const Icon(Icons.scuba_diving),
+          title: Text(parts.isEmpty ? date : parts.join(' - ')),
+          subtitle: parts.isEmpty ? null : Text(date),
+          onTap: () => Navigator.of(context).pop(dive.id),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/pre_dive/presentation/widgets/link_session_picker.dart
+++ b/lib/features/pre_dive/presentation/widgets/link_session_picker.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Picks the checklist run to attach to a dive (#1066), from the dive's own
+/// overflow menu. Only runs not already attached to another dive are offered,
+/// scoped to [diverId] exactly, the same boundary the automatic linker keeps.
+/// Returns the chosen session id, or null when the diver dismissed the picker.
+Future<String?> showLinkSessionPicker(BuildContext context, {String? diverId}) {
+  return showDialog<String>(
+    context: context,
+    builder: (_) => _LinkSessionPicker(diverId: diverId),
+  );
+}
+
+class _LinkSessionPicker extends ConsumerWidget {
+  final String? diverId;
+
+  const _LinkSessionPicker({required this.diverId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final sessions = ref.watch(preDiveUnlinkedSessionsProvider(diverId));
+
+    return AlertDialog(
+      title: Text(l10n.preDive_link_linkChecklist),
+      content: SizedBox(
+        width: 420,
+        height: 360,
+        child: sessions.when(
+          data: (runs) => runs.isEmpty
+              ? Center(child: Text(l10n.preDive_link_noUnlinkedSessions))
+              : _SessionList(sessions: runs),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (error, _) => Center(child: Text(error.toString())),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.common_action_cancel),
+        ),
+      ],
+    );
+  }
+}
+
+class _SessionList extends StatelessWidget {
+  final List<PreDiveSession> sessions;
+
+  const _SessionList({required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    final materialL10n = MaterialLocalizations.of(context);
+
+    return ListView.builder(
+      itemCount: sessions.length,
+      itemBuilder: (context, index) {
+        final session = sessions[index];
+        // Runs are audit records: the time they were run is what identifies
+        // one CCR build check from the evening before against another.
+        final when = session.completedAt ?? session.startedAt;
+
+        return ListTile(
+          dense: true,
+          leading: Icon(switch (session.status) {
+            PreDiveSessionStatus.inProgress => Icons.pending_outlined,
+            PreDiveSessionStatus.completed => Icons.check_circle_outline,
+            PreDiveSessionStatus.aborted => Icons.cancel_outlined,
+          }),
+          title: Text(session.templateName),
+          subtitle: Text(
+            '${materialL10n.formatMediumDate(when)} - '
+            '${TimeOfDay.fromDateTime(when).format(context)}',
+          ),
+          onTap: () => Navigator.of(context).pop(session.id),
+        );
+      },
+    );
+  }
+}

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "ملغاة",
   "preDive_sessions_statusInProgress": "قيد التنفيذ",
   "preDive_sessions_linkedDive": "الغطسة المرتبطة",
+  "preDive_link_linkToDive": "الربط بغطسة",
+  "preDive_link_unlinkDive": "إلغاء ربط الغطسة",
+  "preDive_link_linkChecklist": "ربط قائمة تحقق ما قبل الغوص",
+  "preDive_link_unlinkChecklist": "إلغاء ربط قائمة تحقق ما قبل الغوص",
+  "preDive_link_searchDives": "البحث في الغطسات",
+  "preDive_link_noDives": "لا توجد غطسات للربط",
+  "preDive_link_noDivesMatch": "لا توجد غطسات تطابق \"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "لا توجد قوائم تحقق غير مرتبطة",
+  "preDive_link_linked": "تم ربط قائمة التحقق بهذه الغطسة",
+  "preDive_link_unlinked": "تم إلغاء ربط قائمة التحقق بهذه الغطسة",
   "preDive_sessions_delete": "حذف",
   "preDive_sessions_deleteConfirm": "هل تريد حذف سجل قائمة التحقق هذا؟",
   "preDive_sessions_filter": "تصفية",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Abgebrochen",
   "preDive_sessions_statusInProgress": "In Bearbeitung",
   "preDive_sessions_linkedDive": "Verknüpfter Tauchgang",
+  "preDive_link_linkToDive": "Mit Tauchgang verknüpfen",
+  "preDive_link_unlinkDive": "Tauchgang trennen",
+  "preDive_link_linkChecklist": "Checkliste verknüpfen",
+  "preDive_link_unlinkChecklist": "Checkliste trennen",
+  "preDive_link_searchDives": "Tauchgänge suchen",
+  "preDive_link_noDives": "Keine Tauchgänge zum Verknüpfen",
+  "preDive_link_noDivesMatch": "Keine Tauchgänge für „{query}“",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Keine unverknüpften Checklisten-Durchläufe",
+  "preDive_link_linked": "Checkliste mit diesem Tauchgang verknüpft",
+  "preDive_link_unlinked": "Checkliste von diesem Tauchgang getrennt",
   "preDive_sessions_delete": "Löschen",
   "preDive_sessions_deleteConfirm": "Diesen Checklisten-Eintrag löschen?",
   "preDive_sessions_filter": "Filtern",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1527,6 +1527,23 @@
   "preDive_sessions_statusAborted": "Aborted",
   "preDive_sessions_statusInProgress": "In progress",
   "preDive_sessions_linkedDive": "Linked dive",
+  "preDive_link_linkToDive": "Link to dive",
+  "preDive_link_unlinkDive": "Unlink dive",
+  "preDive_link_linkChecklist": "Link pre-dive checklist",
+  "preDive_link_unlinkChecklist": "Unlink pre-dive checklist",
+  "preDive_link_searchDives": "Search dives",
+  "preDive_link_noDives": "No dives to link to",
+  "preDive_link_noDivesMatch": "No dives match \"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "No unlinked checklist runs",
+  "preDive_link_linked": "Checklist linked to this dive",
+  "preDive_link_unlinked": "Checklist unlinked from this dive",
   "preDive_sessions_delete": "Delete",
   "preDive_sessions_deleteConfirm": "Delete this checklist record?",
   "preDive_sessions_filter": "Filter",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Abandonada",
   "preDive_sessions_statusInProgress": "En curso",
   "preDive_sessions_linkedDive": "Inmersión vinculada",
+  "preDive_link_linkToDive": "Vincular a inmersión",
+  "preDive_link_unlinkDive": "Desvincular inmersión",
+  "preDive_link_linkChecklist": "Vincular lista previa",
+  "preDive_link_unlinkChecklist": "Desvincular lista previa",
+  "preDive_link_searchDives": "Buscar inmersiones",
+  "preDive_link_noDives": "No hay inmersiones para vincular",
+  "preDive_link_noDivesMatch": "Ninguna inmersión coincide con «{query}»",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "No hay listas sin vincular",
+  "preDive_link_linked": "Lista vinculada a esta inmersión",
+  "preDive_link_unlinked": "Lista desvinculada de esta inmersión",
   "preDive_sessions_delete": "Eliminar",
   "preDive_sessions_deleteConfirm": "¿Eliminar este registro de lista de verificación?",
   "preDive_sessions_filter": "Filtrar",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Abandonnée",
   "preDive_sessions_statusInProgress": "En cours",
   "preDive_sessions_linkedDive": "Plongée liée",
+  "preDive_link_linkToDive": "Lier à une plongée",
+  "preDive_link_unlinkDive": "Dissocier la plongée",
+  "preDive_link_linkChecklist": "Lier une checklist pré-plongée",
+  "preDive_link_unlinkChecklist": "Dissocier la checklist pré-plongée",
+  "preDive_link_searchDives": "Rechercher des plongées",
+  "preDive_link_noDives": "Aucune plongée à lier",
+  "preDive_link_noDivesMatch": "Aucune plongée ne correspond à «{query}»",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Aucune checklist non liée",
+  "preDive_link_linked": "Checklist liée à cette plongée",
+  "preDive_link_unlinked": "Checklist dissociée de cette plongée",
   "preDive_sessions_delete": "Supprimer",
   "preDive_sessions_deleteConfirm": "Supprimer cet enregistrement de checklist ?",
   "preDive_sessions_filter": "Filtrer",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "בוטלה",
   "preDive_sessions_statusInProgress": "בתהליך",
   "preDive_sessions_linkedDive": "צלילה מקושרת",
+  "preDive_link_linkToDive": "קישור לצלילה",
+  "preDive_link_unlinkDive": "בטל קישור צלילה",
+  "preDive_link_linkChecklist": "קישור רשימת בדיקה לפני צלילה",
+  "preDive_link_unlinkChecklist": "ביטול קישור רשימת בדיקה לפני צלילה",
+  "preDive_link_searchDives": "חיפוש צלילות",
+  "preDive_link_noDives": "אין צלילות לקישור",
+  "preDive_link_noDivesMatch": "אין צלילות התואמות ל-\"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "אין הרצות רשימת בדיקה ללא קישור",
+  "preDive_link_linked": "רשימת הבדיקה קושרה לצלילה זו",
+  "preDive_link_unlinked": "קישור רשימת הבדיקה לצלילה זו בוטל",
   "preDive_sessions_delete": "מחיקה",
   "preDive_sessions_deleteConfirm": "למחוק את רשומת רשימת הבדיקה הזו?",
   "preDive_sessions_filter": "סינון",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Megszakítva",
   "preDive_sessions_statusInProgress": "Folyamatban",
   "preDive_sessions_linkedDive": "Kapcsolt merülés",
+  "preDive_link_linkToDive": "Merüléshez kapcsolás",
+  "preDive_link_unlinkDive": "Merülés leválasztása",
+  "preDive_link_linkChecklist": "Ellenőrzőlista kapcsolása",
+  "preDive_link_unlinkChecklist": "Ellenőrzőlista leválasztása",
+  "preDive_link_searchDives": "Merülések keresése",
+  "preDive_link_noDives": "Nincs kapcsolható merülés",
+  "preDive_link_noDivesMatch": "Nincs a következőre illeszkedő merülés: „{query}”",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Nincs kapcsolatlan ellenőrzőlista-futtatás",
+  "preDive_link_linked": "Ellenőrzőlista ehhez a merüléshez kapcsolva",
+  "preDive_link_unlinked": "Ellenőrzőlista leválasztva erről a merülésről",
   "preDive_sessions_delete": "Törlés",
   "preDive_sessions_deleteConfirm": "Törli ezt az ellenőrzőlista-bejegyzést?",
   "preDive_sessions_filter": "Szűrés",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Interrotta",
   "preDive_sessions_statusInProgress": "In corso",
   "preDive_sessions_linkedDive": "Immersione collegata",
+  "preDive_link_linkToDive": "Collega a immersione",
+  "preDive_link_unlinkDive": "Scollega immersione",
+  "preDive_link_linkChecklist": "Collega checklist pre-immersione",
+  "preDive_link_unlinkChecklist": "Scollega checklist pre-immersione",
+  "preDive_link_searchDives": "Cerca immersioni",
+  "preDive_link_noDives": "Nessuna immersione da collegare",
+  "preDive_link_noDivesMatch": "Nessuna immersione corrisponde a \"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Nessuna checklist non collegata",
+  "preDive_link_linked": "Checklist collegata a questa immersione",
+  "preDive_link_unlinked": "Checklist scollegata da questa immersione",
   "preDive_sessions_delete": "Elimina",
   "preDive_sessions_deleteConfirm": "Eliminare questo record di checklist?",
   "preDive_sessions_filter": "Filtra",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -4097,6 +4097,66 @@ abstract class AppLocalizations {
   /// **'Linked dive'**
   String get preDive_sessions_linkedDive;
 
+  /// No description provided for @preDive_link_linkToDive.
+  ///
+  /// In en, this message translates to:
+  /// **'Link to dive'**
+  String get preDive_link_linkToDive;
+
+  /// No description provided for @preDive_link_unlinkDive.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlink dive'**
+  String get preDive_link_unlinkDive;
+
+  /// No description provided for @preDive_link_linkChecklist.
+  ///
+  /// In en, this message translates to:
+  /// **'Link pre-dive checklist'**
+  String get preDive_link_linkChecklist;
+
+  /// No description provided for @preDive_link_unlinkChecklist.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlink pre-dive checklist'**
+  String get preDive_link_unlinkChecklist;
+
+  /// No description provided for @preDive_link_searchDives.
+  ///
+  /// In en, this message translates to:
+  /// **'Search dives'**
+  String get preDive_link_searchDives;
+
+  /// No description provided for @preDive_link_noDives.
+  ///
+  /// In en, this message translates to:
+  /// **'No dives to link to'**
+  String get preDive_link_noDives;
+
+  /// No description provided for @preDive_link_noDivesMatch.
+  ///
+  /// In en, this message translates to:
+  /// **'No dives match \"{query}\"'**
+  String preDive_link_noDivesMatch(String query);
+
+  /// No description provided for @preDive_link_noUnlinkedSessions.
+  ///
+  /// In en, this message translates to:
+  /// **'No unlinked checklist runs'**
+  String get preDive_link_noUnlinkedSessions;
+
+  /// No description provided for @preDive_link_linked.
+  ///
+  /// In en, this message translates to:
+  /// **'Checklist linked to this dive'**
+  String get preDive_link_linked;
+
+  /// No description provided for @preDive_link_unlinked.
+  ///
+  /// In en, this message translates to:
+  /// **'Checklist unlinked from this dive'**
+  String get preDive_link_unlinked;
+
   /// No description provided for @preDive_sessions_delete.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2374,6 +2374,39 @@ class AppLocalizationsAr extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'الغطسة المرتبطة';
 
   @override
+  String get preDive_link_linkToDive => 'الربط بغطسة';
+
+  @override
+  String get preDive_link_unlinkDive => 'إلغاء ربط الغطسة';
+
+  @override
+  String get preDive_link_linkChecklist => 'ربط قائمة تحقق ما قبل الغوص';
+
+  @override
+  String get preDive_link_unlinkChecklist =>
+      'إلغاء ربط قائمة تحقق ما قبل الغوص';
+
+  @override
+  String get preDive_link_searchDives => 'البحث في الغطسات';
+
+  @override
+  String get preDive_link_noDives => 'لا توجد غطسات للربط';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'لا توجد غطسات تطابق \"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => 'لا توجد قوائم تحقق غير مرتبطة';
+
+  @override
+  String get preDive_link_linked => 'تم ربط قائمة التحقق بهذه الغطسة';
+
+  @override
+  String get preDive_link_unlinked => 'تم إلغاء ربط قائمة التحقق بهذه الغطسة';
+
+  @override
   String get preDive_sessions_delete => 'حذف';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2429,6 +2429,40 @@ class AppLocalizationsDe extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Verknüpfter Tauchgang';
 
   @override
+  String get preDive_link_linkToDive => 'Mit Tauchgang verknüpfen';
+
+  @override
+  String get preDive_link_unlinkDive => 'Tauchgang trennen';
+
+  @override
+  String get preDive_link_linkChecklist => 'Checkliste verknüpfen';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Checkliste trennen';
+
+  @override
+  String get preDive_link_searchDives => 'Tauchgänge suchen';
+
+  @override
+  String get preDive_link_noDives => 'Keine Tauchgänge zum Verknüpfen';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Keine Tauchgänge für „$query“';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions =>
+      'Keine unverknüpften Checklisten-Durchläufe';
+
+  @override
+  String get preDive_link_linked => 'Checkliste mit diesem Tauchgang verknüpft';
+
+  @override
+  String get preDive_link_unlinked =>
+      'Checkliste von diesem Tauchgang getrennt';
+
+  @override
   String get preDive_sessions_delete => 'Löschen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2379,6 +2379,38 @@ class AppLocalizationsEn extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Linked dive';
 
   @override
+  String get preDive_link_linkToDive => 'Link to dive';
+
+  @override
+  String get preDive_link_unlinkDive => 'Unlink dive';
+
+  @override
+  String get preDive_link_linkChecklist => 'Link pre-dive checklist';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Unlink pre-dive checklist';
+
+  @override
+  String get preDive_link_searchDives => 'Search dives';
+
+  @override
+  String get preDive_link_noDives => 'No dives to link to';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'No dives match \"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => 'No unlinked checklist runs';
+
+  @override
+  String get preDive_link_linked => 'Checklist linked to this dive';
+
+  @override
+  String get preDive_link_unlinked => 'Checklist unlinked from this dive';
+
+  @override
   String get preDive_sessions_delete => 'Delete';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2429,6 +2429,38 @@ class AppLocalizationsEs extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Inmersión vinculada';
 
   @override
+  String get preDive_link_linkToDive => 'Vincular a inmersión';
+
+  @override
+  String get preDive_link_unlinkDive => 'Desvincular inmersión';
+
+  @override
+  String get preDive_link_linkChecklist => 'Vincular lista previa';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Desvincular lista previa';
+
+  @override
+  String get preDive_link_searchDives => 'Buscar inmersiones';
+
+  @override
+  String get preDive_link_noDives => 'No hay inmersiones para vincular';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Ninguna inmersión coincide con «$query»';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => 'No hay listas sin vincular';
+
+  @override
+  String get preDive_link_linked => 'Lista vinculada a esta inmersión';
+
+  @override
+  String get preDive_link_unlinked => 'Lista desvinculada de esta inmersión';
+
+  @override
   String get preDive_sessions_delete => 'Eliminar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2431,6 +2431,39 @@ class AppLocalizationsFr extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Plongée liée';
 
   @override
+  String get preDive_link_linkToDive => 'Lier à une plongée';
+
+  @override
+  String get preDive_link_unlinkDive => 'Dissocier la plongée';
+
+  @override
+  String get preDive_link_linkChecklist => 'Lier une checklist pré-plongée';
+
+  @override
+  String get preDive_link_unlinkChecklist =>
+      'Dissocier la checklist pré-plongée';
+
+  @override
+  String get preDive_link_searchDives => 'Rechercher des plongées';
+
+  @override
+  String get preDive_link_noDives => 'Aucune plongée à lier';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Aucune plongée ne correspond à «$query»';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => 'Aucune checklist non liée';
+
+  @override
+  String get preDive_link_linked => 'Checklist liée à cette plongée';
+
+  @override
+  String get preDive_link_unlinked => 'Checklist dissociée de cette plongée';
+
+  @override
   String get preDive_sessions_delete => 'Supprimer';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2353,6 +2353,40 @@ class AppLocalizationsHe extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'צלילה מקושרת';
 
   @override
+  String get preDive_link_linkToDive => 'קישור לצלילה';
+
+  @override
+  String get preDive_link_unlinkDive => 'בטל קישור צלילה';
+
+  @override
+  String get preDive_link_linkChecklist => 'קישור רשימת בדיקה לפני צלילה';
+
+  @override
+  String get preDive_link_unlinkChecklist =>
+      'ביטול קישור רשימת בדיקה לפני צלילה';
+
+  @override
+  String get preDive_link_searchDives => 'חיפוש צלילות';
+
+  @override
+  String get preDive_link_noDives => 'אין צלילות לקישור';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'אין צלילות התואמות ל-\"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions =>
+      'אין הרצות רשימת בדיקה ללא קישור';
+
+  @override
+  String get preDive_link_linked => 'רשימת הבדיקה קושרה לצלילה זו';
+
+  @override
+  String get preDive_link_unlinked => 'קישור רשימת הבדיקה לצלילה זו בוטל';
+
+  @override
   String get preDive_sessions_delete => 'מחיקה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2412,6 +2412,41 @@ class AppLocalizationsHu extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Kapcsolt merülés';
 
   @override
+  String get preDive_link_linkToDive => 'Merüléshez kapcsolás';
+
+  @override
+  String get preDive_link_unlinkDive => 'Merülés leválasztása';
+
+  @override
+  String get preDive_link_linkChecklist => 'Ellenőrzőlista kapcsolása';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Ellenőrzőlista leválasztása';
+
+  @override
+  String get preDive_link_searchDives => 'Merülések keresése';
+
+  @override
+  String get preDive_link_noDives => 'Nincs kapcsolható merülés';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Nincs a következőre illeszkedő merülés: „$query”';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions =>
+      'Nincs kapcsolatlan ellenőrzőlista-futtatás';
+
+  @override
+  String get preDive_link_linked =>
+      'Ellenőrzőlista ehhez a merüléshez kapcsolva';
+
+  @override
+  String get preDive_link_unlinked =>
+      'Ellenőrzőlista leválasztva erről a merülésről';
+
+  @override
   String get preDive_sessions_delete => 'Törlés';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2422,6 +2422,41 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Immersione collegata';
 
   @override
+  String get preDive_link_linkToDive => 'Collega a immersione';
+
+  @override
+  String get preDive_link_unlinkDive => 'Scollega immersione';
+
+  @override
+  String get preDive_link_linkChecklist => 'Collega checklist pre-immersione';
+
+  @override
+  String get preDive_link_unlinkChecklist =>
+      'Scollega checklist pre-immersione';
+
+  @override
+  String get preDive_link_searchDives => 'Cerca immersioni';
+
+  @override
+  String get preDive_link_noDives => 'Nessuna immersione da collegare';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Nessuna immersione corrisponde a \"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions =>
+      'Nessuna checklist non collegata';
+
+  @override
+  String get preDive_link_linked => 'Checklist collegata a questa immersione';
+
+  @override
+  String get preDive_link_unlinked =>
+      'Checklist scollegata da questa immersione';
+
+  @override
   String get preDive_sessions_delete => 'Elimina';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2407,6 +2407,38 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Gekoppelde duik';
 
   @override
+  String get preDive_link_linkToDive => 'Koppelen aan duik';
+
+  @override
+  String get preDive_link_unlinkDive => 'Duik ontkoppelen';
+
+  @override
+  String get preDive_link_linkChecklist => 'Pre-dive checklist koppelen';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Pre-dive checklist ontkoppelen';
+
+  @override
+  String get preDive_link_searchDives => 'Duiken zoeken';
+
+  @override
+  String get preDive_link_noDives => 'Geen duiken om te koppelen';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Geen duiken komen overeen met \"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => 'Geen ongekoppelde checklists';
+
+  @override
+  String get preDive_link_linked => 'Checklist gekoppeld aan deze duik';
+
+  @override
+  String get preDive_link_unlinked => 'Checklist ontkoppeld van deze duik';
+
+  @override
   String get preDive_sessions_delete => 'Verwijderen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2424,6 +2424,41 @@ class AppLocalizationsPt extends AppLocalizations {
   String get preDive_sessions_linkedDive => 'Mergulho vinculado';
 
   @override
+  String get preDive_link_linkToDive => 'Vincular a mergulho';
+
+  @override
+  String get preDive_link_unlinkDive => 'Desvincular mergulho';
+
+  @override
+  String get preDive_link_linkChecklist => 'Vincular lista de verificação';
+
+  @override
+  String get preDive_link_unlinkChecklist => 'Desvincular lista de verificação';
+
+  @override
+  String get preDive_link_searchDives => 'Procurar mergulhos';
+
+  @override
+  String get preDive_link_noDives => 'Não há mergulhos para vincular';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return 'Nenhum mergulho corresponde a \"$query\"';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions =>
+      'Não há listas de verificação sem vínculo';
+
+  @override
+  String get preDive_link_linked =>
+      'Lista de verificação vinculada a este mergulho';
+
+  @override
+  String get preDive_link_unlinked =>
+      'Lista de verificação desvinculada deste mergulho';
+
+  @override
   String get preDive_sessions_delete => 'Excluir';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2286,6 +2286,38 @@ class AppLocalizationsZh extends AppLocalizations {
   String get preDive_sessions_linkedDive => '关联潜水';
 
   @override
+  String get preDive_link_linkToDive => '关联到潜水';
+
+  @override
+  String get preDive_link_unlinkDive => '取消关联潜水';
+
+  @override
+  String get preDive_link_linkChecklist => '关联潜前检查清单';
+
+  @override
+  String get preDive_link_unlinkChecklist => '取消关联潜前检查清单';
+
+  @override
+  String get preDive_link_searchDives => '搜索潜水';
+
+  @override
+  String get preDive_link_noDives => '没有可关联的潜水';
+
+  @override
+  String preDive_link_noDivesMatch(String query) {
+    return '没有与“$query”匹配的潜水';
+  }
+
+  @override
+  String get preDive_link_noUnlinkedSessions => '没有未关联的检查清单记录';
+
+  @override
+  String get preDive_link_linked => '检查清单已关联到此潜水';
+
+  @override
+  String get preDive_link_unlinked => '已取消检查清单与此潜水的关联';
+
+  @override
   String get preDive_sessions_delete => '删除';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Afgebroken",
   "preDive_sessions_statusInProgress": "Bezig",
   "preDive_sessions_linkedDive": "Gekoppelde duik",
+  "preDive_link_linkToDive": "Koppelen aan duik",
+  "preDive_link_unlinkDive": "Duik ontkoppelen",
+  "preDive_link_linkChecklist": "Pre-dive checklist koppelen",
+  "preDive_link_unlinkChecklist": "Pre-dive checklist ontkoppelen",
+  "preDive_link_searchDives": "Duiken zoeken",
+  "preDive_link_noDives": "Geen duiken om te koppelen",
+  "preDive_link_noDivesMatch": "Geen duiken komen overeen met \"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Geen ongekoppelde checklists",
+  "preDive_link_linked": "Checklist gekoppeld aan deze duik",
+  "preDive_link_unlinked": "Checklist ontkoppeld van deze duik",
   "preDive_sessions_delete": "Verwijderen",
   "preDive_sessions_deleteConfirm": "Deze checklistregistratie verwijderen?",
   "preDive_sessions_filter": "Filteren",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -845,6 +845,23 @@
   "preDive_sessions_statusAborted": "Interrompida",
   "preDive_sessions_statusInProgress": "Em andamento",
   "preDive_sessions_linkedDive": "Mergulho vinculado",
+  "preDive_link_linkToDive": "Vincular a mergulho",
+  "preDive_link_unlinkDive": "Desvincular mergulho",
+  "preDive_link_linkChecklist": "Vincular lista de verificação",
+  "preDive_link_unlinkChecklist": "Desvincular lista de verificação",
+  "preDive_link_searchDives": "Procurar mergulhos",
+  "preDive_link_noDives": "Não há mergulhos para vincular",
+  "preDive_link_noDivesMatch": "Nenhum mergulho corresponde a \"{query}\"",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "Não há listas de verificação sem vínculo",
+  "preDive_link_linked": "Lista de verificação vinculada a este mergulho",
+  "preDive_link_unlinked": "Lista de verificação desvinculada deste mergulho",
   "preDive_sessions_delete": "Excluir",
   "preDive_sessions_deleteConfirm": "Excluir este registro de lista de verificação?",
   "preDive_sessions_filter": "Filtrar",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -939,6 +939,23 @@
   "preDive_sessions_statusAborted": "已中止",
   "preDive_sessions_statusInProgress": "进行中",
   "preDive_sessions_linkedDive": "关联潜水",
+  "preDive_link_linkToDive": "关联到潜水",
+  "preDive_link_unlinkDive": "取消关联潜水",
+  "preDive_link_linkChecklist": "关联潜前检查清单",
+  "preDive_link_unlinkChecklist": "取消关联潜前检查清单",
+  "preDive_link_searchDives": "搜索潜水",
+  "preDive_link_noDives": "没有可关联的潜水",
+  "preDive_link_noDivesMatch": "没有与“{query}”匹配的潜水",
+  "@preDive_link_noDivesMatch": {
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "preDive_link_noUnlinkedSessions": "没有未关联的检查清单记录",
+  "preDive_link_linked": "检查清单已关联到此潜水",
+  "preDive_link_unlinked": "已取消检查清单与此潜水的关联",
   "preDive_sessions_delete": "删除",
   "preDive_sessions_deleteConfirm": "要删除此检查清单记录吗？",
   "preDive_sessions_filter": "筛选",

--- a/test/features/dive_log/presentation/pages/dive_detail_pre_dive_link_menu_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_pre_dive_link_menu_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Issue #1066: PR #913 removed the dive-detail pre-dive card, and with it the
+/// only way to attach a checklist run completed the night before to the dive
+/// it was run for. The overflow menu carries that affordance now, in both the
+/// full-page and embedded (master-detail) app bars.
+class _StubSessionRepository implements PreDiveSessionRepository {
+  /// Every link write in order. A null diveId is an unlink.
+  final List<({String sessionId, String? diveId})> linkWrites = [];
+
+  @override
+  Future<void> linkToDive(String sessionId, String diveId) async =>
+      linkWrites.add((sessionId: sessionId, diveId: diveId));
+
+  @override
+  Future<void> unlinkFromDive(String sessionId) async =>
+      linkWrites.add((sessionId: sessionId, diveId: null));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  final startedAt = DateTime(2026, 3, 27, 19, 40);
+
+  PreDiveSession session(String id, {String name = 'CCR Build Check'}) =>
+      PreDiveSession(
+        id: id,
+        templateName: name,
+        status: PreDiveSessionStatus.completed,
+        startedAt: startedAt,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+      );
+
+  Future<_StubSessionRepository> pumpDetail(
+    WidgetTester tester, {
+    required bool embedded,
+    PreDiveSession? linked,
+    List<PreDiveSession> unlinked = const [],
+  }) async {
+    final dive = createTestDiveWithBottomTime();
+    final overrides = await getBaseOverrides(linkedPreDiveSession: linked);
+    final repo = _StubSessionRepository();
+
+    final router = GoRouter(
+      initialLocation: '/detail',
+      routes: [
+        GoRoute(
+          path: '/detail',
+          builder: (context, state) {
+            final page = DiveDetailPage(diveId: dive.id, embedded: embedded);
+            // Embedded mode renders no Scaffold of its own; in production it
+            // always sits inside MasterDetailScaffold's, which is what the
+            // confirmation snackbar presents to.
+            return embedded ? Scaffold(body: page) : page;
+          },
+        ),
+      ],
+    );
+
+    // The detail page intentionally overflows its fixed test viewport; that is
+    // not what this test asserts, so swallow only overflow errors.
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details.toString().contains('overflowed')) return;
+      originalOnError?.call(details);
+    };
+    addTearDown(() => FlutterError.onError = originalOnError);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          preDiveSessionRepositoryProvider.overrideWithValue(repo),
+          preDiveUnlinkedSessionsProvider.overrideWith(
+            (ref, diverId) async => unlinked,
+          ),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    return repo;
+  }
+
+  Future<void> openMenu(WidgetTester tester) async {
+    // The header overflow menu is the last more_vert on the page (a source bar,
+    // when present, renders earlier).
+    await tester.tap(find.byIcon(Icons.more_vert).last);
+    await tester.pumpAndSettle();
+  }
+
+  for (final embedded in [false, true]) {
+    final label = embedded ? 'embedded app bar' : 'full-page app bar';
+
+    testWidgets('$label: offers Link pre-dive checklist when none is linked', (
+      tester,
+    ) async {
+      await pumpDetail(tester, embedded: embedded);
+      await openMenu(tester);
+
+      expect(find.text('Link pre-dive checklist'), findsOneWidget);
+      expect(find.text('Unlink pre-dive checklist'), findsNothing);
+    });
+
+    testWidgets('$label: choosing a run links it to this dive', (tester) async {
+      final repo = await pumpDetail(
+        tester,
+        embedded: embedded,
+        unlinked: [session('s1')],
+      );
+
+      await openMenu(tester);
+      await tester.tap(find.text('Link pre-dive checklist'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('CCR Build Check'));
+      await tester.pumpAndSettle();
+
+      expect(repo.linkWrites, [(sessionId: 's1', diveId: 'test-dive-1')]);
+    });
+
+    testWidgets('$label: offers Unlink once a run is attached', (tester) async {
+      final repo = await pumpDetail(
+        tester,
+        embedded: embedded,
+        linked: session('s1'),
+      );
+
+      await openMenu(tester);
+      expect(find.text('Link pre-dive checklist'), findsNothing);
+
+      await tester.tap(find.text('Unlink pre-dive checklist'));
+      await tester.pumpAndSettle();
+
+      expect(repo.linkWrites, [(sessionId: 's1', diveId: null)]);
+    });
+  }
+}

--- a/test/features/pre_dive/data/repositories/pre_dive_session_repository_test.dart
+++ b/test/features/pre_dive/data/repositories/pre_dive_session_repository_test.dart
@@ -166,6 +166,21 @@ void main() {
     expect(await repository.getUnlinkedSessions(), hasLength(1));
   });
 
+  test('getLinkedDiveIds reports which dives are already spoken for', () async {
+    // The manual link picker (#1066) must not offer a dive that already has a
+    // run, the same one-to-one rule ChecklistDiveLinker enforces.
+    await insertDive('dive-1');
+    await insertDive('dive-2');
+    expect(await repository.getLinkedDiveIds(), isEmpty);
+
+    final session = await start();
+    await repository.linkToDive(session.id, 'dive-1');
+    expect(await repository.getLinkedDiveIds(), {'dive-1'});
+
+    await repository.unlinkFromDive(session.id);
+    expect(await repository.getLinkedDiveIds(), isEmpty);
+  });
+
   test('getActiveSession returns latest inProgress only', () async {
     final s1 = await start();
     await repository.completeSession(s1.id);

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/pre_dive/data/repositories/pre_dive_session_repository.dart';
 import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
 import 'package:submersion/features/pre_dive/domain/services/checklist_session_engine.dart';
@@ -43,9 +44,12 @@ class _RecordingExcelExporter extends PreDiveExcelExportService {
 }
 
 /// Serves the bulk item fetch without a database, and records which runs the
-/// page asked for.
+/// page asked for plus any dive-link writes it made.
 class _StubSessionRepository implements PreDiveSessionRepository {
   List<String>? requestedIds;
+
+  /// Every link write in order. A null diveId is an unlink.
+  final List<({String sessionId, String? diveId})> linkWrites = [];
 
   @override
   Future<Map<String, List<PreDiveSessionItem>>> getItemsForSessions(
@@ -54,6 +58,24 @@ class _StubSessionRepository implements PreDiveSessionRepository {
     requestedIds = sessionIds;
     return {for (final id in sessionIds) id: const []};
   }
+
+  /// No writes reach this fake from outside the test, so the tick the link
+  /// providers subscribe to never has anything to report.
+  @override
+  Stream<void> watchSessionsChanges() => const Stream.empty();
+
+  @override
+  Future<Set<String>> getLinkedDiveIds() async => {
+    for (final write in linkWrites) ?write.diveId,
+  };
+
+  @override
+  Future<void> linkToDive(String sessionId, String diveId) async =>
+      linkWrites.add((sessionId: sessionId, diveId: diveId));
+
+  @override
+  Future<void> unlinkFromDive(String sessionId) async =>
+      linkWrites.add((sessionId: sessionId, diveId: null));
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -665,6 +687,115 @@ void main() {
 
     // Dialog dismissed; no repository call made.
     expect(find.text('Delete this checklist record?'), findsNothing);
+  });
+
+  group('manual dive linking (#1066)', () {
+    DiveSummary diveSummary(String id, {int? number, String? site}) {
+      final at = DateTime(2026, 8, 14, 9, 30);
+      return DiveSummary(
+        id: id,
+        diveNumber: number,
+        dateTime: at,
+        siteName: site,
+        sortTimestamp: at.millisecondsSinceEpoch,
+      );
+    }
+
+    /// Pumps one completed run and returns the repository stub so the test can
+    /// assert on the link write the menu actually made.
+    Future<_StubSessionRepository> pumpOneRun(
+      WidgetTester tester, {
+      String? diveId,
+      List<DiveSummary> candidates = const [],
+    }) async {
+      final repo = _StubSessionRepository();
+      await pumpPage(
+        tester,
+        sessions: [
+          session(
+            's1',
+            name: 'CCR Build',
+            status: PreDiveSessionStatus.completed,
+            diveId: diveId,
+          ),
+        ],
+        items: {
+          's1': [item('s1', 0, PreDiveItemState.done)],
+        },
+        extraOverrides: [
+          preDiveSessionRepositoryProvider.overrideWithValue(repo),
+          preDiveLinkCandidateDivesProvider.overrideWith(
+            (ref) async => candidates,
+          ),
+        ],
+      );
+      return repo;
+    }
+
+    testWidgets('an unlinked run offers Link to dive', (tester) async {
+      await pumpOneRun(tester);
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Link to dive'), findsOneWidget);
+      expect(find.text('Unlink dive'), findsNothing);
+    });
+
+    testWidgets('a run already linked offers Unlink dive instead', (
+      tester,
+    ) async {
+      await pumpOneRun(tester, diveId: 'dive-42');
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unlink dive'), findsOneWidget);
+      expect(find.text('Link to dive'), findsNothing);
+    });
+
+    testWidgets('picking a dive writes the link', (tester) async {
+      final repo = await pumpOneRun(
+        tester,
+        candidates: [diveSummary('dive-42', number: 42, site: 'Blue Hole')],
+      );
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Link to dive'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.textContaining('Blue Hole'));
+      await tester.pumpAndSettle();
+
+      expect(repo.linkWrites, [(sessionId: 's1', diveId: 'dive-42')]);
+    });
+
+    testWidgets('cancelling the picker writes nothing', (tester) async {
+      final repo = await pumpOneRun(
+        tester,
+        candidates: [diveSummary('dive-42', number: 42, site: 'Blue Hole')],
+      );
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Link to dive'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(repo.linkWrites, isEmpty);
+    });
+
+    testWidgets('Unlink dive clears the link', (tester) async {
+      final repo = await pumpOneRun(tester, diveId: 'dive-42');
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Unlink dive'));
+      await tester.pumpAndSettle();
+
+      expect(repo.linkWrites, [(sessionId: 's1', diveId: null)]);
+    });
   });
 
   testWidgets('tapping Resume navigates to the session runner route', (

--- a/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
+++ b/test/features/pre_dive/presentation/pages/pre_dive_sessions_page_test.dart
@@ -46,6 +46,17 @@ class _RecordingExcelExporter extends PreDiveExcelExportService {
 /// Serves the bulk item fetch without a database, and records which runs the
 /// page asked for plus any dive-link writes it made.
 class _StubSessionRepository implements PreDiveSessionRepository {
+  /// Current dive link per session, seeded from the same fixtures the page
+  /// renders. The real query reads stored state, so a fake built only from
+  /// this test's own writes would answer differently for a run that arrived
+  /// already linked.
+  final Map<String, String?> _diveIdBySession;
+
+  _StubSessionRepository({List<PreDiveSession> seed = const []})
+    : _diveIdBySession = {
+        for (final session in seed) session.id: session.diveId,
+      };
+
   List<String>? requestedIds;
 
   /// Every link write in order. A null diveId is an unlink.
@@ -64,18 +75,24 @@ class _StubSessionRepository implements PreDiveSessionRepository {
   @override
   Stream<void> watchSessionsChanges() => const Stream.empty();
 
+  /// Current links only, matching the real query. Folding [linkWrites]
+  /// instead would keep reporting a dive as taken after it was unlinked.
   @override
   Future<Set<String>> getLinkedDiveIds() async => {
-    for (final write in linkWrites) ?write.diveId,
+    for (final diveId in _diveIdBySession.values) ?diveId,
   };
 
   @override
-  Future<void> linkToDive(String sessionId, String diveId) async =>
-      linkWrites.add((sessionId: sessionId, diveId: diveId));
+  Future<void> linkToDive(String sessionId, String diveId) async {
+    linkWrites.add((sessionId: sessionId, diveId: diveId));
+    _diveIdBySession[sessionId] = diveId;
+  }
 
   @override
-  Future<void> unlinkFromDive(String sessionId) async =>
-      linkWrites.add((sessionId: sessionId, diveId: null));
+  Future<void> unlinkFromDive(String sessionId) async {
+    linkWrites.add((sessionId: sessionId, diveId: null));
+    _diveIdBySession[sessionId] = null;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -708,17 +725,16 @@ void main() {
       String? diveId,
       List<DiveSummary> candidates = const [],
     }) async {
-      final repo = _StubSessionRepository();
+      final run = session(
+        's1',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.completed,
+        diveId: diveId,
+      );
+      final repo = _StubSessionRepository(seed: [run]);
       await pumpPage(
         tester,
-        sessions: [
-          session(
-            's1',
-            name: 'CCR Build',
-            status: PreDiveSessionStatus.completed,
-            diveId: diveId,
-          ),
-        ],
+        sessions: [run],
         items: {
           's1': [item('s1', 0, PreDiveItemState.done)],
         },
@@ -795,6 +811,75 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(repo.linkWrites, [(sessionId: 's1', diveId: null)]);
+    });
+
+    testWidgets('the excluded set tracks current links, not link history', (
+      tester,
+    ) async {
+      // A dive spoken for by another run must not be offered, and unlinking
+      // that run must hand the dive back. Both directions matter: the picker
+      // is the only thing standing between a hand-made link and the
+      // one-run-per-dive rule ChecklistDiveLinker enforces.
+      final taken = session(
+        'taken',
+        name: 'Reef Check',
+        status: PreDiveSessionStatus.completed,
+        diveId: 'dive-42',
+      );
+      final free = session(
+        'free',
+        name: 'CCR Build',
+        status: PreDiveSessionStatus.completed,
+      );
+      final repo = _StubSessionRepository(seed: [taken, free]);
+
+      await pumpPage(
+        tester,
+        sessions: [taken, free],
+        items: {
+          'taken': [item('taken', 0, PreDiveItemState.done)],
+          'free': [item('free', 0, PreDiveItemState.done)],
+        },
+        extraOverrides: [
+          preDiveSessionRepositoryProvider.overrideWithValue(repo),
+          preDiveLinkCandidateDivesProvider.overrideWith(
+            (ref) async => [
+              diveSummary('dive-42', number: 42, site: 'Blue Hole'),
+              diveSummary('dive-7', number: 7, site: 'Ginnie Springs'),
+            ],
+          ),
+        ],
+      );
+
+      Future<void> openMenuFor(String name) async {
+        await tester.tap(
+          find.descendant(
+            of: find.widgetWithText(ListTile, name),
+            matching: find.byType(PopupMenuButton<String>),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      // Blue Hole belongs to the Reef Check run, so it is not on offer.
+      await openMenuFor('CCR Build');
+      await tester.tap(find.text('Link to dive'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Blue Hole'), findsNothing);
+      expect(find.textContaining('Ginnie Springs'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Release it.
+      await openMenuFor('Reef Check');
+      await tester.tap(find.text('Unlink dive'));
+      await tester.pumpAndSettle();
+
+      // Now it is claimable again.
+      await openMenuFor('CCR Build');
+      await tester.tap(find.text('Link to dive'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Blue Hole'), findsOneWidget);
     });
   });
 

--- a/test/features/pre_dive/presentation/widgets/link_dive_picker_test.dart
+++ b/test/features/pre_dive/presentation/widgets/link_dive_picker_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/widgets/link_dive_picker.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The picker that restores manual checklist-to-dive linking (issue #1066).
+/// Recent dives are offered without typing; the shared dive search takes over
+/// once the diver types, so an older dive stays reachable.
+void main() {
+  DiveSummary summary(String id, {int? number, String? site, DateTime? when}) {
+    final at = when ?? DateTime(2026, 8, 14, 9, 30);
+    return DiveSummary(
+      id: id,
+      diveNumber: number,
+      dateTime: at,
+      siteName: site,
+      sortTimestamp: at.millisecondsSinceEpoch,
+    );
+  }
+
+  /// Opens the picker from a host button and records what it returned, so a
+  /// test can assert on the value handed back to the caller rather than on
+  /// picker internals.
+  Future<List<String?>> pumpPicker(
+    WidgetTester tester, {
+    required List<DiveSummary> recent,
+    Map<String, List<DiveSummary>> searchResults = const {},
+    Set<String> alreadyLinked = const {},
+  }) async {
+    final returned = <String?>[];
+
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        overrides: [
+          preDiveLinkCandidateDivesProvider.overrideWith((ref) async => recent),
+          preDiveLinkedDiveIdsProvider.overrideWith(
+            (ref) async => alreadyLinked,
+          ),
+          diveSearchProvider.overrideWith(
+            (ref, query) async => searchResults[query] ?? const <DiveSummary>[],
+          ),
+        ],
+        child: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async =>
+                returned.add(await showLinkDivePicker(context)),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    return returned;
+  }
+
+  testWidgets('offers recent dives before anything is typed', (tester) async {
+    await pumpPicker(
+      tester,
+      recent: [
+        summary('d1', number: 412, site: 'Blue Hole'),
+        summary(
+          'd2',
+          number: 411,
+          site: "Devil's Den",
+          when: DateTime(2026, 8, 12, 8, 0),
+        ),
+      ],
+    );
+
+    expect(find.text('Link to dive'), findsOneWidget);
+    expect(find.textContaining('#412'), findsOneWidget);
+    expect(find.textContaining('Blue Hole'), findsOneWidget);
+    expect(find.textContaining("Devil's Den"), findsOneWidget);
+  });
+
+  testWidgets('typing replaces the recent list with search results', (
+    tester,
+  ) async {
+    await pumpPicker(
+      tester,
+      recent: [summary('d1', number: 412, site: 'Blue Hole')],
+      searchResults: {
+        'ginnie': [
+          summary(
+            'd9',
+            number: 300,
+            site: 'Ginnie Springs',
+            when: DateTime(2024, 5, 1, 11, 0),
+          ),
+        ],
+      },
+    );
+
+    await tester.enterText(find.byType(TextField), 'ginnie');
+    // One plain frame first: the debounce timer is armed in didUpdateWidget,
+    // so a pump(duration) here would advance the clock before the timer even
+    // exists and it would never fire.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Ginnie Springs'), findsOneWidget);
+    expect(find.textContaining('Blue Hole'), findsNothing);
+  });
+
+  testWidgets('choosing a dive closes the picker and returns its id', (
+    tester,
+  ) async {
+    final returned = await pumpPicker(
+      tester,
+      recent: [summary('dive-42', number: 42, site: 'Blue Hole')],
+    );
+
+    await tester.tap(find.textContaining('Blue Hole'));
+    await tester.pumpAndSettle();
+
+    expect(returned, ['dive-42']);
+  });
+
+  testWidgets('an empty dive log says so instead of showing a bare list', (
+    tester,
+  ) async {
+    await pumpPicker(tester, recent: []);
+
+    expect(find.text('No dives to link to'), findsOneWidget);
+  });
+
+  testWidgets('a search that matches nothing reports it', (tester) async {
+    await pumpPicker(
+      tester,
+      recent: [summary('d1', number: 412, site: 'Blue Hole')],
+      searchResults: const {},
+    );
+
+    await tester.enterText(find.byType(TextField), 'nowhere');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No dives match "nowhere"'), findsOneWidget);
+  });
+
+  testWidgets('a dive that already has a checklist run is not offered', (
+    tester,
+  ) async {
+    // ChecklistDiveLinker holds one run per dive; linking a second by hand
+    // would leave the older run invisible from the dive side.
+    await pumpPicker(
+      tester,
+      recent: [
+        summary('d1', number: 412, site: 'Blue Hole'),
+        summary('d2', number: 411, site: "Devil's Den"),
+      ],
+      alreadyLinked: {'d1'},
+    );
+
+    expect(find.textContaining('Blue Hole'), findsNothing);
+    expect(find.textContaining("Devil's Den"), findsOneWidget);
+  });
+
+  testWidgets('search results drop dives that already have a run', (
+    tester,
+  ) async {
+    await pumpPicker(
+      tester,
+      recent: const [],
+      alreadyLinked: {'d9'},
+      searchResults: {
+        'ginnie': [
+          summary('d9', number: 300, site: 'Ginnie Springs'),
+          summary('d10', number: 301, site: 'Ginnie Ballroom'),
+        ],
+      },
+    );
+
+    await tester.enterText(find.byType(TextField), 'ginnie');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Ginnie Springs'), findsNothing);
+    expect(find.textContaining('Ginnie Ballroom'), findsOneWidget);
+  });
+
+  testWidgets(
+    'a search whose every hit is taken reports it, not a blank list',
+    (tester) async {
+      await pumpPicker(
+        tester,
+        recent: const [],
+        alreadyLinked: {'d9'},
+        searchResults: {
+          'ginnie': [summary('d9', number: 300, site: 'Ginnie Springs')],
+        },
+      );
+
+      await tester.enterText(find.byType(TextField), 'ginnie');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No dives match "ginnie"'), findsOneWidget);
+    },
+  );
+
+  testWidgets('dismissing without choosing returns null', (tester) async {
+    final returned = await pumpPicker(
+      tester,
+      recent: [summary('d1', number: 412, site: 'Blue Hole')],
+    );
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(returned, [null]);
+  });
+}

--- a/test/features/pre_dive/presentation/widgets/link_session_picker_test.dart
+++ b/test/features/pre_dive/presentation/widgets/link_session_picker_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/features/pre_dive/presentation/widgets/link_session_picker.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The dive-side half of manual linking (issue #1066): from a dive, attach a
+/// checklist run that was completed the evening before and so fell outside the
+/// auto-linker's window.
+void main() {
+  PreDiveSession session(
+    String id, {
+    String name = 'CCR Build Check',
+    DateTime? startedAt,
+    PreDiveSessionStatus status = PreDiveSessionStatus.completed,
+  }) {
+    final at = startedAt ?? DateTime(2026, 8, 13, 19, 40);
+    return PreDiveSession(
+      id: id,
+      templateName: name,
+      status: status,
+      startedAt: at,
+      createdAt: at,
+      updatedAt: at,
+    );
+  }
+
+  Future<List<String?>> pumpPicker(
+    WidgetTester tester, {
+    required List<PreDiveSession> unlinked,
+    String? diverId,
+  }) async {
+    final returned = <String?>[];
+
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        overrides: [
+          preDiveUnlinkedSessionsProvider(
+            diverId,
+          ).overrideWith((ref) async => unlinked),
+        ],
+        child: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async => returned.add(
+              await showLinkSessionPicker(context, diverId: diverId),
+            ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    return returned;
+  }
+
+  testWidgets('lists unlinked runs with their name and date', (tester) async {
+    await pumpPicker(
+      tester,
+      unlinked: [
+        session('s1'),
+        session('s2', name: 'BWRAF', startedAt: DateTime(2026, 8, 10, 7, 15)),
+      ],
+    );
+
+    expect(find.text('Link pre-dive checklist'), findsOneWidget);
+    expect(find.text('CCR Build Check'), findsOneWidget);
+    expect(find.text('BWRAF'), findsOneWidget);
+  });
+
+  testWidgets('choosing a run closes the picker and returns its id', (
+    tester,
+  ) async {
+    final returned = await pumpPicker(tester, unlinked: [session('s1')]);
+
+    await tester.tap(find.text('CCR Build Check'));
+    await tester.pumpAndSettle();
+
+    expect(returned, ['s1']);
+  });
+
+  testWidgets('no unlinked runs says so instead of showing an empty list', (
+    tester,
+  ) async {
+    await pumpPicker(tester, unlinked: []);
+
+    expect(find.text('No unlinked checklist runs'), findsOneWidget);
+  });
+
+  testWidgets('the diver scope is passed through to the query', (tester) async {
+    // Sessions are diver-scoped by exact match, matching the auto-linker, so
+    // the picker must ask for the dive's diver rather than the whole history.
+    await pumpPicker(
+      tester,
+      diverId: 'diver-7',
+      unlinked: [session('s1', name: 'Diver 7 Run')],
+    );
+
+    expect(find.text('Diver 7 Run'), findsOneWidget);
+  });
+
+  testWidgets('dismissing without choosing returns null', (tester) async {
+    final returned = await pumpPicker(tester, unlinked: [session('s1')]);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(returned, [null]);
+  });
+}

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -21,6 +21,8 @@ import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/tissue_color_schemes.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/pre_dive/domain/entities/pre_dive_session.dart';
+import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
 import 'package:submersion/core/utils/coordinates/coordinate_format.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/weather/presentation/providers/weather_providers.dart';
@@ -512,9 +514,14 @@ Dive createTestDiveWithBottomTime({
 }
 
 /// Common provider overrides for widget tests
+/// [linkedPreDiveSession] seeds the pre-dive checklist run the dive-detail
+/// overflow menu sees. Parameterized rather than stacked as a second override
+/// because Riverpod refuses to override the same family twice in one
+/// container.
 Future<List<Override>> getBaseOverrides({
   MockSettingsNotifier? settingsNotifier,
   http.Client? weatherHttpClient,
+  PreDiveSession? linkedPreDiveSession,
 }) async {
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
@@ -533,6 +540,12 @@ Future<List<Override>> getBaseOverrides({
     // timer at teardown.
     diveOpenFindingsCountProvider.overrideWith(
       (ref, diveId) => Stream.value(0),
+    ),
+    // The dive-detail overflow menu asks whether a pre-dive checklist run is
+    // attached (#1066); without this the family reaches the real repository
+    // and a database that widget tests do not have.
+    preDiveSessionForDiveProvider.overrideWith(
+      (ref, diveId) async => linkedPreDiveSession,
     ),
     // Weather/elevation lookups must never hit the network in widget tests;
     // the default stub fails fast so altitude auto-fill resolves to null.


### PR DESCRIPTION
## Summary

Fixes #1066.

PR #913 removed the Pre-Dive Check card from the dive detail page, and its own
description records the consequence: *"The link/unlink affordance goes away with
the card. It was the only place to attach an existing checklist session to a
logged dive, or detach one."*

Automatic linking survived, but `ChecklistDiveLinker` only reaches back three
hours from the dive start. The reporter builds a CCR the evening before, so
their checklist run can never fall in that window. Since v1.7.4.6062 there has
been no way at all to attach it.

This restores manual linking in two overflow menus rather than bringing the card
back, so the decluttering #913 was after still stands.

## Changes

| File | Change |
| --- | --- |
| `lib/features/pre_dive/presentation/widgets/link_dive_picker.dart` | New. Recent 50 dives, handing over to the shared `diveSearchProvider` once the diver types |
| `lib/features/pre_dive/presentation/widgets/link_session_picker.dart` | New. Unlinked runs, scoped to the dive's diver by exact match |
| `lib/features/pre_dive/presentation/pages/pre_dive_sessions_page.dart` | `_SessionTile` menu gains Link to dive / Unlink dive |
| `lib/features/dive_log/presentation/pages/dive_detail_page.dart` | Both overflow menus gain Link / Unlink pre-dive checklist |
| `lib/features/pre_dive/data/repositories/pre_dive_session_repository.dart` | New `getLinkedDiveIds()` |
| `lib/features/pre_dive/presentation/providers/pre_dive_providers.dart` | Three new providers for the pickers |
| `lib/l10n/arb/app_*.arb` (11 locales) + generated | Ten new keys, translated |
| `test/helpers/mock_providers.dart` | `getBaseOverrides` stubs `preDiveSessionForDiveProvider` |

### Where the affordance lives now

- **Sessions page.** Each run's overflow menu offers `Link to dive` or
  `Unlink dive`, whichever its current state calls for. Linking opens the dive
  picker.
- **Dive detail.** Both menus (full-page app bar and the embedded master-detail
  header) offer `Link pre-dive checklist` or `Unlink pre-dive checklist`. The
  label is also the indicator, since nothing on that page renders the link any
  more, and a snackbar confirms the write for the same reason.

The dive picker reuses `DebouncedSearchResults.emptyQueryBuilder` for the
recent-dives default, so search stays on the existing SQL-bounded,
diver-scoped `diveSearchProvider` rather than a second query path.

## Two things worth a reviewer's attention

**The one-run-per-dive invariant.** `ChecklistDiveLinker` states it outright
("One-to-one: never steal onto a dive that already has a session"), and
`getSessionForDive` returns only the latest run. A picker that offered every
recent dive would let a second hand-made link leave the first run invisible from
the dive side. Hence `getLinkedDiveIds()`, subtracted from both the recent list
and the search results. A search whose every hit is already taken reports no
matches rather than rendering a blank list.

**Change ticks on the new providers.** `test/architecture/provider_change_tick_test.dart`
caught the first draft, which skipped them on the theory that a dialog is too
short-lived to go stale. That was wrong: a sync pull can attach a run while the
picker is open, and a stale taken-dive set is not cosmetic staleness but exactly
the double link the set exists to prevent. Both providers now subscribe, to
`watchDivesChanges()` and `watchSessionsChanges()` respectively.

## Deliberately out of scope

There is no "open this checklist" entry on the dive. Link and unlink are
restored; viewing the run from the dive side would mean reintroducing the card
#913 removed on purpose. Easy to add as a third menu entry if wanted.

## Test Plan

- [x] `flutter test` passes: 17796 passed, 17 skipped, 0 failed
- [x] `flutter analyze` passes: No issues found
- [x] `dart format lib/ test/`: 0 files changed
- [x] `test/l10n` ARB parity across all 11 locales: 74 passed
- [ ] Manual testing on: not yet run on device

New coverage, each case written first and watched fail:

| Test | Cases |
| --- | --- |
| `dive_detail_pre_dive_link_menu_test.dart` | 6 (offer / link / unlink, in both app bars) |
| `link_dive_picker_test.dart` | 9 (recent, search, exclusion, empty states, return value) |
| `link_session_picker_test.dart` | 5 |
| `pre_dive_sessions_page_test.dart` | 5 added |
| `pre_dive_session_repository_test.dart` | 1 added for `getLinkedDiveIds` |

Two harness fixes were needed, both because the test was unrealistic rather than
the code wrong: `DebouncedSearchResults` arms its debounce timer in
`didUpdateWidget`, so a test needs a bare `pump()` before `pump(duration)` or the
clock advances before the timer exists; and the embedded dive-detail harness
pumped the page with no `Scaffold`, where production always nests it inside
`MasterDetailScaffold`'s.
