### PR TITLE
fix(dive-computer): filter dives by computer id, not serial number

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -4118,6 +4118,72 @@ class AppDatabase extends _$AppDatabase {
     ''');
   }
 
+  /// Data self-heal: adopt each dive's computer attribution from its data-source
+  /// rows when `dives.computer_id` is null.
+  ///
+  /// The download path only began stamping `dives.computer_id` in v1.6 (commit
+  /// 9ddb281); before that every child row (profiles, tanks, data source)
+  /// carried the computer id but the parent dive did not. Those dives are
+  /// invisible to the "dives from this computer" filter, which keys on the
+  /// parent column (issue #1064), and to the consolidation service's
+  /// same-computer guard.
+  ///
+  /// Runs on every open; a cheap no-op once healed (the `IN` set is empty when
+  /// no dive is missing attribution). Local-only by design: the value is
+  /// derived from already-synced `dive_data_sources` rows, so every device
+  /// heals to the identical id independently. It never touches the dive's HLC,
+  /// so healing does not trigger a fleet re-sync.
+  ///
+  /// The primary source wins, with the source id as a tiebreak so devices
+  /// resolve a multi-source dive to the same computer rather than whichever row
+  /// SQLite happened to visit first.
+  ///
+  /// Runs after `ensurePerformanceIndexes` so the correlated subquery uses
+  /// idx_dive_data_sources_dive_id rather than scanning a million-row table on
+  /// a fresh or restored database. Order relative to
+  /// [_backfillMissingDataSources] is immaterial: the rows that helper
+  /// synthesizes carry no computer_id, so they never satisfy the `IN` set here.
+  Future<void> _backfillDiveComputerIds() async {
+    // PRAGMA-guarded like every other self-heal helper. beforeOpen runs for
+    // every open, including minimal old-schema test fixtures and databases
+    // caught mid-upgrade. Unlike _backfillMissingDataSources, which only names
+    // columns that have existed since those tables were created, this statement
+    // reads computer_id on both sides, so a table-existence check is not
+    // enough: PRAGMA table_info returns empty for a missing table, so probing
+    // the columns covers both cases.
+    final diveCols = await customSelect("PRAGMA table_info('dives')").get();
+    if (!diveCols.map((c) => c.read<String>('name')).contains('computer_id')) {
+      return;
+    }
+    final sourceCols = await customSelect(
+      "PRAGMA table_info('dive_data_sources')",
+    ).get();
+    final sourceColNames = sourceCols
+        .map((c) => c.read<String>('name'))
+        .toSet();
+    if (!sourceColNames.contains('computer_id') ||
+        !sourceColNames.contains('dive_id') ||
+        !sourceColNames.contains('is_primary')) {
+      return;
+    }
+
+    await customStatement('''
+      UPDATE dives SET computer_id = (
+        SELECT s.computer_id FROM dive_data_sources s
+        WHERE s.dive_id = dives.id AND s.computer_id IS NOT NULL
+        ORDER BY s.is_primary DESC, s.id
+        LIMIT 1
+      )
+      WHERE computer_id IS NULL
+        AND id IN (
+          SELECT dive_id FROM dive_data_sources WHERE computer_id IS NOT NULL
+        )
+    ''');
+  }
+
+  /// Test-only hook exercising the #1064 attribution self-heal directly.
+  Future<void> backfillDiveComputerIdsForTest() => _backfillDiveComputerIds();
+
   /// Copy each buddy's inline certification into a certifications row owned by
   /// that buddy (issue #553). Invoked from the onUpgrade blocks only (v109
   /// expand + the v110 contract safety-net), NEVER the beforeOpen backstop --
@@ -8113,6 +8179,13 @@ class AppDatabase extends _$AppDatabase {
         // subqueries hit idx_dive_profiles_dive_id / idx_dive_data_sources_dive_id
         // instead of full-scanning million-row tables on a fresh/restored DB.
         await _backfillMissingDataSources();
+
+        // Data self-heal (issue #1064): adopt dives.computer_id from the
+        // data-source rows for dives downloaded before v1.6 stamped it.
+        // Idempotent and local-only (derived from already-synced rows, no HLC
+        // bump). Also AFTER ensurePerformanceIndexes, for the same reason as
+        // the backfill above.
+        await _backfillDiveComputerIds();
       },
     );
   }

--- a/lib/core/database/performance_indexes.dart
+++ b/lib/core/database/performance_indexes.dart
@@ -64,6 +64,16 @@ const List<PerformanceIndex> kPerformanceIndexes = [
     name: 'idx_dives_course_id',
     ddl: 'CREATE INDEX IF NOT EXISTS idx_dives_course_id ON dives(course_id)',
   ),
+  // Attribution to a registered dive computer. Backs the "dives from this
+  // computer" filter axis (issue #1064) and the beforeOpen self-heal that
+  // adopts the column from dive_data_sources, which both drive off the null
+  // side of this column.
+  (
+    name: 'idx_dives_computer_id',
+    ddl:
+        'CREATE INDEX IF NOT EXISTS idx_dives_computer_id '
+        'ON dives(computer_id)',
+  ),
   (
     name: 'idx_dives_favorite',
     ddl:

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -388,23 +388,21 @@ class DeviceDetailPage extends ConsumerWidget {
     ref.read(diveComputerNotifierProvider.notifier).setFavorite(computer.id);
   }
 
+  /// Shows the dive list restricted to this computer.
+  ///
+  /// Filters on the computer id, not its serial number. Keying this on the
+  /// serial used to dead-end with a "no serial number" snackbar on every
+  /// computer whose firmware never reported one (issue #1064), even though the
+  /// dives were downloaded and attributed correctly.
   void _viewDivesFromComputer(
     BuildContext context,
     WidgetRef ref,
     DiveComputer computer,
   ) {
-    if (computer.serialNumber != null && computer.serialNumber!.isNotEmpty) {
-      ref.read(diveFilterProvider.notifier).state = DiveFilterState(
-        computerSerial: computer.serialNumber,
-      );
-      context.go('/dives');
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.diveComputer_detail_cannotFilterNoSerial),
-        ),
-      );
-    }
+    ref.read(diveFilterProvider.notifier).state = DiveFilterState(
+      computerId: computer.id,
+    );
+    context.go('/dives');
   }
 
   Future<void> _confirmReimportAll(

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2020,9 +2020,9 @@ class DiveRepository {
         args.add(Variable(diveId));
       }
     }
-    if (filter.computerSerial != null) {
-      clauses.add('d.dive_computer_serial = ?');
-      args.add(Variable(filter.computerSerial!));
+    if (filter.computerId != null) {
+      clauses.add('d.computer_id = ?');
+      args.add(Variable(filter.computerId!));
     }
     if (filter.minO2Percent != null || filter.maxO2Percent != null) {
       final tankClauses = <String>[];
@@ -3047,6 +3047,7 @@ class DiveRepository {
       diveComputerModel: row.diveComputerModel,
       diveComputerSerial: row.diveComputerSerial,
       diveComputerFirmware: row.diveComputerFirmware,
+      computerId: row.computerId,
       weightAmount: row.weightAmount,
       weightType: row.weightType != null
           ? WeightType.values.firstWhere(
@@ -3419,6 +3420,7 @@ class DiveRepository {
       diveComputerModel: row.diveComputerModel,
       diveComputerSerial: row.diveComputerSerial,
       diveComputerFirmware: row.diveComputerFirmware,
+      computerId: row.computerId,
       // Weight system fields
       weightAmount: row.weightAmount,
       weightType: row.weightType != null

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -94,6 +94,19 @@ class Dive extends Equatable {
   final String? diveComputerModel;
   final String? diveComputerSerial;
   final String? diveComputerFirmware;
+
+  /// Id of the registered [DiveComputer] this dive was downloaded from, i.e.
+  /// the `dives.computer_id` foreign key.
+  ///
+  /// This is the attribution key: unlike [diveComputerSerial], which is a
+  /// display/export snapshot that firmware may never report (issue #1064), it
+  /// is always set for a dive that came off a registered computer.
+  ///
+  /// Read-only projection. The insert/update companions deliberately omit the
+  /// column, so saving a dive never rewrites it: attribution is owned by the
+  /// download, consolidation, split, and reparse paths, which set it with
+  /// explicit intent.
+  final String? computerId;
   // Weight system fields (legacy single weight - kept for backward compatibility)
   final double? weightAmount; // kg
   final WeightType? weightType;
@@ -212,6 +225,7 @@ class Dive extends Equatable {
     this.diveComputerModel,
     this.diveComputerSerial,
     this.diveComputerFirmware,
+    this.computerId,
     this.weightAmount,
     this.weightType,
     this.weights = const [],
@@ -545,6 +559,7 @@ class Dive extends Equatable {
     String? diveComputerModel,
     String? diveComputerSerial,
     String? diveComputerFirmware,
+    String? computerId,
     double? weightAmount,
     WeightType? weightType,
     List<DiveWeight>? weights,
@@ -639,6 +654,7 @@ class Dive extends Equatable {
       diveComputerModel: diveComputerModel ?? this.diveComputerModel,
       diveComputerSerial: diveComputerSerial ?? this.diveComputerSerial,
       diveComputerFirmware: diveComputerFirmware ?? this.diveComputerFirmware,
+      computerId: computerId ?? this.computerId,
       weightAmount: weightAmount ?? this.weightAmount,
       weightType: weightType ?? this.weightType,
       weights: weights ?? this.weights,
@@ -736,6 +752,7 @@ class Dive extends Equatable {
     diveComputerModel,
     diveComputerSerial,
     diveComputerFirmware,
+    computerId,
     weightAmount,
     weightType,
     weights,

--- a/lib/features/dive_log/domain/models/dive_filter_state.dart
+++ b/lib/features/dive_log/domain/models/dive_filter_state.dart
@@ -28,7 +28,14 @@ class DiveFilterState {
   final int? minRating;
   final int? minBottomTimeMinutes;
   final int? maxBottomTimeMinutes;
-  final String? computerSerial;
+
+  /// Registered dive computer to restrict the list to, matched on
+  /// `dives.computer_id`.
+  ///
+  /// Keyed on the computer id rather than its serial number: firmware often
+  /// reports no serial, which used to leave those computers unfilterable
+  /// (issue #1064).
+  final String? computerId;
   final String? customFieldKey;
   final String? customFieldValue;
 
@@ -59,7 +66,7 @@ class DiveFilterState {
     this.minRating,
     this.minBottomTimeMinutes,
     this.maxBottomTimeMinutes,
-    this.computerSerial,
+    this.computerId,
     this.customFieldKey,
     this.customFieldValue,
     this.equipmentAttrKey,
@@ -88,7 +95,7 @@ class DiveFilterState {
       minRating != null ||
       minBottomTimeMinutes != null ||
       maxBottomTimeMinutes != null ||
-      computerSerial != null ||
+      computerId != null ||
       (customFieldKey != null && customFieldKey!.isNotEmpty) ||
       equipmentAttrKey != null;
 
@@ -112,7 +119,7 @@ class DiveFilterState {
     int? minRating,
     int? minBottomTimeMinutes,
     int? maxBottomTimeMinutes,
-    String? computerSerial,
+    String? computerId,
     String? customFieldKey,
     String? customFieldValue,
     String? equipmentAttrKey,
@@ -138,7 +145,7 @@ class DiveFilterState {
     bool clearMinRating = false,
     bool clearMinBottomTimeMinutes = false,
     bool clearMaxBottomTimeMinutes = false,
-    bool clearComputerSerial = false,
+    bool clearComputerId = false,
     bool clearCustomFieldKey = false,
     bool clearCustomFieldValue = false,
     bool clearEquipmentAttr = false,
@@ -179,9 +186,7 @@ class DiveFilterState {
       maxBottomTimeMinutes: clearMaxBottomTimeMinutes
           ? null
           : (maxBottomTimeMinutes ?? this.maxBottomTimeMinutes),
-      computerSerial: clearComputerSerial
-          ? null
-          : (computerSerial ?? this.computerSerial),
+      computerId: clearComputerId ? null : (computerId ?? this.computerId),
       customFieldKey: clearCustomFieldKey
           ? null
           : (customFieldKey ?? this.customFieldKey),
@@ -301,8 +306,8 @@ class DiveFilterState {
           return false;
         }
       }
-      if (computerSerial != null) {
-        if (dive.diveComputerSerial != computerSerial) return false;
+      if (computerId != null) {
+        if (dive.computerId != computerId) return false;
       }
       if (customFieldKey != null && customFieldKey!.isNotEmpty) {
         final hasMatch = dive.customFields.any((cf) {

--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -55,7 +55,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
   late int? _minRating;
   late int? _minDurationMinutes;
   late int? _maxDurationMinutes;
-  late String? _computerSerial;
+  late String? _computerId;
   double? _suitThicknessMin;
   double? _suitThicknessMax;
 
@@ -89,7 +89,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
     _minRating = filter.minRating;
     _minDurationMinutes = filter.minBottomTimeMinutes;
     _maxDurationMinutes = filter.maxBottomTimeMinutes;
-    _computerSerial = filter.computerSerial;
+    _computerId = filter.computerId;
     if (filter.equipmentAttrKey == 'thickness_mm') {
       _suitThicknessMin = filter.equipmentAttrMin;
       _suitThicknessMax = filter.equipmentAttrMax;
@@ -363,17 +363,12 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                     loading: () => const LinearProgressIndicator(),
                     error: (_, _) => const Text('Error loading computers'),
                     data: (computers) {
-                      // Only include computers with serial numbers,
-                      // deduplicated by serial.
-                      final seen = <String>{};
-                      final filterable = computers
-                          .where(
-                            (c) =>
-                                c.serialNumber != null &&
-                                seen.add(c.serialNumber!),
-                          )
-                          .toList();
-                      if (filterable.isEmpty) {
+                      // Every registered computer is offered. The list used to
+                      // be restricted to computers carrying a serial number,
+                      // which hid every device whose firmware never reports one
+                      // (issue #1064); attribution rides the computer id, which
+                      // is always present.
+                      if (computers.isEmpty) {
                         return Text(
                           'No dive computers registered',
                           style: Theme.of(context).textTheme.bodySmall
@@ -384,18 +379,16 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                               ),
                         );
                       }
-                      // Reset to null if the saved serial is not in the list.
-                      final validSerial =
-                          filterable.any(
-                            (c) => c.serialNumber == _computerSerial,
-                          )
-                          ? _computerSerial
+                      // Reset to null if the saved computer is no longer known
+                      // (deleted since the filter was set).
+                      final validId = computers.any((c) => c.id == _computerId)
+                          ? _computerId
                           : null;
-                      if (validSerial != _computerSerial) {
-                        _computerSerial = validSerial;
+                      if (validId != _computerId) {
+                        _computerId = validId;
                       }
                       return DropdownButtonFormField<String?>(
-                        initialValue: validSerial,
+                        initialValue: validId,
                         decoration: const InputDecoration(
                           hintText: 'All computers',
                           prefixIcon: Icon(Icons.watch),
@@ -405,15 +398,15 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                             value: null,
                             child: Text('All computers'),
                           ),
-                          ...filterable.map(
+                          ...computers.map(
                             (c) => DropdownMenuItem(
-                              value: c.serialNumber,
+                              value: c.id,
                               child: Text(c.displayName),
                             ),
                           ),
                         ],
                         onChanged: (value) {
-                          setState(() => _computerSerial = value);
+                          setState(() => _computerId = value);
                         },
                       );
                     },
@@ -919,7 +912,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
       minRating: _minRating,
       minBottomTimeMinutes: _minDurationMinutes,
       maxBottomTimeMinutes: _maxDurationMinutes,
-      computerSerial: _computerSerial,
+      computerId: _computerId,
       equipmentAttrKey: (_suitThicknessMin != null || _suitThicknessMax != null)
           ? 'thickness_mm'
           : null,

--- a/lib/features/statistics/data/dive_filter_sql.dart
+++ b/lib/features/statistics/data/dive_filter_sql.dart
@@ -175,9 +175,9 @@ import 'package:submersion/features/equipment/domain/constants/equipment_attribu
     params.add(filter.maxBottomTimeMinutes);
   }
 
-  if (filter.computerSerial != null) {
-    conditions.add('dive_computer_serial = ?');
-    params.add(filter.computerSerial);
+  if (filter.computerId != null) {
+    conditions.add('computer_id = ?');
+    params.add(filter.computerId);
   }
 
   // Custom fields: key match + optional value substring.

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "غير معروف",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "لا يمكن التصفية: لا يوجد رقم تسلسلي لهذا الكمبيوتر.",
   "diveComputer_detail_deleteDialogContent": "هل تريد حقا إزالة \"{name}\"؟ لن يؤدي هذا إلى حذف أي غطسات تم استيرادها من هذا الكمبيوتر.",
   "diveComputer_detail_deleteDialogTitle": "حذف الكمبيوتر؟",
   "diveComputer_detail_divesImported": "الغطسات المستوردة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Unbekannt",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "WLAN",
-  "diveComputer_detail_cannotFilterNoSerial": "Filtern nicht möglich: keine Seriennummer für diesen Computer.",
   "diveComputer_detail_deleteDialogContent": "Möchten Sie \"{name}\" wirklich entfernen? Dadurch werden keine von diesem Computer importierten Tauchgänge gelöscht.",
   "diveComputer_detail_deleteDialogTitle": "Computer löschen?",
   "diveComputer_detail_divesImported": "Importierte Tauchgänge",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -11927,7 +11927,6 @@
   "diveComputer_connectionType_unknown": "Unknown",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Cannot filter: no serial number for this computer.",
   "diveComputer_detail_deleteDialogContent": "Are you sure you want to remove \"{name}\"? This will not delete any dives that were imported from this computer.",
   "@diveComputer_detail_deleteDialogContent": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Desconocido",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "No se puede filtrar: sin numero de serie para este ordenador.",
   "diveComputer_detail_deleteDialogContent": "Seguro que quieres eliminar \"{name}\"? Esto no borrara las inmersiones importadas desde este ordenador.",
   "diveComputer_detail_deleteDialogTitle": "Eliminar ordenador?",
   "diveComputer_detail_divesImported": "Inmersiones importadas",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Inconnu",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Filtrage impossible : aucun numero de serie pour cet ordinateur.",
   "diveComputer_detail_deleteDialogContent": "Voulez-vous vraiment supprimer \"{name}\" ? Les plongees importees depuis cet ordinateur ne seront pas supprimees.",
   "diveComputer_detail_deleteDialogTitle": "Supprimer l'ordinateur ?",
   "diveComputer_detail_divesImported": "Plongees importees",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "לא ידוע",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "לא ניתן לסנן: אין מספר סידורי למחשב זה.",
   "diveComputer_detail_deleteDialogContent": "האם אתה בטוח שברצונך להסיר את \"{name}\"? פעולה זו לא תמחק צלילות שיובאו ממחשב זה.",
   "diveComputer_detail_deleteDialogTitle": "למחוק את המחשב?",
   "diveComputer_detail_divesImported": "צלילות שיובאו",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Ismeretlen",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Nem lehet szurni: nincs sorozatszam ehhez a szamitogephez.",
   "diveComputer_detail_deleteDialogContent": "Biztosan eltavolitod a(z) \"{name}\" eszkozt? Ez nem torli az errol a szamitogeprol importalt merulseket.",
   "diveComputer_detail_deleteDialogTitle": "Szamitogep torlese?",
   "diveComputer_detail_divesImported": "Importalt merulesek",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Sconosciuto",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Impossibile filtrare: nessun numero di serie per questo computer.",
   "diveComputer_detail_deleteDialogContent": "Vuoi davvero rimuovere \"{name}\"? Le immersioni importate da questo computer non verranno eliminate.",
   "diveComputer_detail_deleteDialogTitle": "Eliminare il computer?",
   "diveComputer_detail_divesImported": "Immersioni importate",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -31765,12 +31765,6 @@ abstract class AppLocalizations {
   /// **'Wi-Fi'**
   String get diveComputer_connectionType_wifi;
 
-  /// No description provided for @diveComputer_detail_cannotFilterNoSerial.
-  ///
-  /// In en, this message translates to:
-  /// **'Cannot filter: no serial number for this computer.'**
-  String get diveComputer_detail_cannotFilterNoSerial;
-
   /// No description provided for @diveComputer_detail_deleteDialogContent.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -18681,10 +18681,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'لا يمكن التصفية: لا يوجد رقم تسلسلي لهذا الكمبيوتر.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'هل تريد حقا إزالة \"$name\"؟ لن يؤدي هذا إلى حذف أي غطسات تم استيرادها من هذا الكمبيوتر.';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -18989,10 +18989,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'WLAN';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Filtern nicht möglich: keine Seriennummer für diesen Computer.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Möchten Sie \"$name\" wirklich entfernen? Dadurch werden keine von diesem Computer importierten Tauchgänge gelöscht.';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -18699,10 +18699,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Cannot filter: no serial number for this computer.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Are you sure you want to remove \"$name\"? This will not delete any dives that were imported from this computer.';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -19034,10 +19034,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'No se puede filtrar: sin numero de serie para este ordenador.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Seguro que quieres eliminar \"$name\"? Esto no borrara las inmersiones importadas desde este ordenador.';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -19090,10 +19090,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Filtrage impossible : aucun numero de serie pour cet ordinateur.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Voulez-vous vraiment supprimer \"$name\" ? Les plongees importees depuis cet ordinateur ne seront pas supprimees.';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -18546,10 +18546,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'לא ניתן לסנן: אין מספר סידורי למחשב זה.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'האם אתה בטוח שברצונך להסיר את \"$name\"? פעולה זו לא תמחק צלילות שיובאו ממחשב זה.';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -18966,10 +18966,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Nem lehet szurni: nincs sorozatszam ehhez a szamitogephez.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Biztosan eltavolitod a(z) \"$name\" eszkozt? Ez nem torli az errol a szamitogeprol importalt merulseket.';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -19021,10 +19021,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Impossibile filtrare: nessun numero di serie per questo computer.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Vuoi davvero rimuovere \"$name\"? Le immersioni importate da questo computer non verranno eliminate.';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -18870,10 +18870,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Filteren niet mogelijk: geen serienummer voor deze computer.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Weet je zeker dat je \"$name\" wilt verwijderen? Dit verwijdert geen duiken die van deze computer zijn geimporteerd.';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -19028,10 +19028,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial =>
-      'Nao e possivel filtrar: sem numero de serie para este computador.';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return 'Tem certeza de que deseja remover \"$name\"? Isto nao excluira os mergulhos importados deste computador.';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -18053,9 +18053,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveComputer_connectionType_wifi => 'Wi-Fi';
 
   @override
-  String get diveComputer_detail_cannotFilterNoSerial => '无法筛选:此电脑没有序列号。';
-
-  @override
   String diveComputer_detail_deleteDialogContent(String name) {
     return '确定要移除“$name”吗?这不会删除从此电脑导入的任何潜水记录。';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Onbekend",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Filteren niet mogelijk: geen serienummer voor deze computer.",
   "diveComputer_detail_deleteDialogContent": "Weet je zeker dat je \"{name}\" wilt verwijderen? Dit verwijdert geen duiken die van deze computer zijn geimporteerd.",
   "diveComputer_detail_deleteDialogTitle": "Computer verwijderen?",
   "diveComputer_detail_divesImported": "Geimporteerde duiken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "Desconhecido",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "Nao e possivel filtrar: sem numero de serie para este computador.",
   "diveComputer_detail_deleteDialogContent": "Tem certeza de que deseja remover \"{name}\"? Isto nao excluira os mergulhos importados deste computador.",
   "diveComputer_detail_deleteDialogTitle": "Excluir computador?",
   "diveComputer_detail_divesImported": "Mergulhos importados",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6055,7 +6055,6 @@
   "diveComputer_connectionType_unknown": "未知",
   "diveComputer_connectionType_usb": "USB",
   "diveComputer_connectionType_wifi": "Wi-Fi",
-  "diveComputer_detail_cannotFilterNoSerial": "无法筛选:此电脑没有序列号。",
   "diveComputer_detail_deleteDialogContent": "确定要移除“{name}”吗?这不会删除从此电脑导入的任何潜水记录。",
   "diveComputer_detail_deleteDialogTitle": "删除电脑?",
   "diveComputer_detail_divesImported": "已导入潜水",

--- a/test/core/database/dive_computer_id_backfill_test.dart
+++ b/test/core/database/dive_computer_id_backfill_test.dart
@@ -1,0 +1,203 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+import '../../helpers/test_database.dart';
+
+/// Issue #1064: dives downloaded before v1.6 stamped `dives.computer_id` carry
+/// the attribution only on their `dive_data_sources` rows, which made them
+/// invisible to the "dives from this computer" filter. The beforeOpen self-heal
+/// adopts the attribution from those rows.
+void main() {
+  late AppDatabase db;
+
+  const nowMs = 1750000000000;
+  final nowDt = DateTime.fromMillisecondsSinceEpoch(nowMs);
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> insertComputer(String id) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion.insert(
+            id: id,
+            name: 'Computer $id',
+            createdAt: nowMs,
+            updatedAt: nowMs,
+          ),
+        );
+  }
+
+  Future<void> insertDive(String id, {String? computerId}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: const Value(nowMs),
+            computerId: Value(computerId),
+            createdAt: const Value(nowMs),
+            updatedAt: const Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertSource(
+    String id, {
+    required String diveId,
+    String? computerId,
+    bool isPrimary = false,
+  }) async {
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion.insert(
+            id: id,
+            diveId: diveId,
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            importedAt: nowDt,
+            createdAt: nowDt,
+          ),
+        );
+  }
+
+  Future<String?> computerIdOf(String diveId) async {
+    final row = await (db.select(
+      db.dives,
+    )..where((d) => d.id.equals(diveId))).getSingle();
+    return row.computerId;
+  }
+
+  test('adopts the computer id from the dive data source row', () async {
+    await insertComputer('dc-a');
+    await insertDive('dive-legacy');
+    await insertSource(
+      'src-1',
+      diveId: 'dive-legacy',
+      computerId: 'dc-a',
+      isPrimary: true,
+    );
+
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-legacy'), 'dc-a');
+  });
+
+  test('leaves an already attributed dive alone', () async {
+    await insertComputer('dc-a');
+    await insertComputer('dc-b');
+    await insertDive('dive-attributed', computerId: 'dc-a');
+    await insertSource(
+      'src-1',
+      diveId: 'dive-attributed',
+      computerId: 'dc-b',
+      isPrimary: true,
+    );
+
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-attributed'), 'dc-a');
+  });
+
+  test('leaves a dive with no computer-bearing source null', () async {
+    await insertDive('dive-manual');
+    await insertSource('src-1', diveId: 'dive-manual', isPrimary: true);
+
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-manual'), isNull);
+  });
+
+  test('prefers the primary source when a dive has several', () async {
+    await insertComputer('dc-secondary');
+    await insertComputer('dc-primary');
+    await insertDive('dive-multi');
+    // Inserted secondary-first so a query that ignored is_primary would pick
+    // the wrong computer.
+    await insertSource(
+      'src-a-secondary',
+      diveId: 'dive-multi',
+      computerId: 'dc-secondary',
+    );
+    await insertSource(
+      'src-b-primary',
+      diveId: 'dive-multi',
+      computerId: 'dc-primary',
+      isPrimary: true,
+    );
+
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-multi'), 'dc-primary');
+  });
+
+  test('breaks ties on source id so every device resolves alike', () async {
+    await insertComputer('dc-x');
+    await insertComputer('dc-y');
+    await insertDive('dive-tie');
+    // Two non-primary sources: the lower source id wins, deterministically.
+    await insertSource('src-z', diveId: 'dive-tie', computerId: 'dc-y');
+    await insertSource('src-a', diveId: 'dive-tie', computerId: 'dc-x');
+
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-tie'), 'dc-x');
+  });
+
+  // beforeOpen runs against minimal old-schema fixtures too, which predate the
+  // computer_id columns. The PRAGMA guard must skip rather than raise
+  // "no such column".
+  test('skips a legacy schema that lacks the computer_id columns', () async {
+    final legacy = AppDatabase(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute(
+            'PRAGMA user_version = ${AppDatabase.currentSchemaVersion}',
+          );
+          rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+          rawDb.execute('''
+            CREATE TABLE dive_data_sources (
+              id TEXT NOT NULL PRIMARY KEY,
+              dive_id TEXT NOT NULL,
+              is_primary INTEGER NOT NULL DEFAULT 0,
+              imported_at INTEGER NOT NULL,
+              created_at INTEGER NOT NULL
+            )
+          ''');
+          rawDb.execute("INSERT INTO dives (id) VALUES ('legacy-dive')");
+        },
+      ),
+    );
+    addTearDown(legacy.close);
+
+    // Opening is what runs beforeOpen; reaching this query means it did not
+    // throw on the missing columns.
+    final rows = await legacy.customSelect('SELECT id FROM dives').get();
+
+    expect(rows.single.read<String>('id'), 'legacy-dive');
+  });
+
+  test('is idempotent across repeated opens', () async {
+    await insertComputer('dc-a');
+    await insertDive('dive-legacy');
+    await insertSource(
+      'src-1',
+      diveId: 'dive-legacy',
+      computerId: 'dc-a',
+      isPrimary: true,
+    );
+
+    await db.backfillDiveComputerIdsForTest();
+    await db.backfillDiveComputerIdsForTest();
+
+    expect(await computerIdOf('dive-legacy'), 'dc-a');
+  });
+}

--- a/test/features/dive_computer/presentation/pages/device_detail_page_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_detail_page_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_computer/presentation/pages/device_detail_page.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -392,7 +393,12 @@ void main() {
       expect(find.text('DOWNLOAD_PAGE'), findsOneWidget);
     });
 
-    testWidgets('view dives shows snackbar for null serial', (tester) async {
+    // Issue #1064: this used to dead-end with a "no serial number" snackbar on
+    // every computer whose firmware never reported one -- the reported case,
+    // covering Shearwater Petrel 3 / NERD / Perdix and the Suunto EON Core.
+    testWidgets('view dives navigates when the computer has no serial', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _buildTestWidget(computer: _makeComputer(serialNumber: null)),
       );
@@ -405,10 +411,13 @@ void main() {
       await tester.tap(find.text('View Dives from This Computer'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('no serial number'), findsOneWidget);
+      expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+      expect(find.textContaining('serial number'), findsNothing);
     });
 
-    testWidgets('view dives shows snackbar for empty serial', (tester) async {
+    testWidgets('view dives navigates when the serial is empty', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _buildTestWidget(computer: _makeComputer(serialNumber: '')),
       );
@@ -421,7 +430,7 @@ void main() {
       await tester.tap(find.text('View Dives from This Computer'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('no serial number'), findsOneWidget);
+      expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
     });
 
     testWidgets('view dives navigates when serial exists', (tester) async {
@@ -438,6 +447,29 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('DIVES_LIST_PAGE'), findsOneWidget);
+    });
+
+    testWidgets('view dives filters on the computer id, not its serial', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTestWidget(
+          computer: _makeComputer(id: 'comp-1', serialNumber: null),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('View Dives from This Computer'),
+        200,
+      );
+      await tester.tap(find.text('View Dives from This Computer'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.text('DIVES_LIST_PAGE')),
+      );
+      expect(container.read(diveFilterProvider).computerId, 'comp-1');
     });
   });
 }

--- a/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
@@ -42,6 +42,7 @@ void main() {
     int? diveNumber,
     String? diveComputerModel,
     String? diveComputerSerial,
+    String? computerId,
     double? maxDepth,
     double? avgDepth,
     int? duration,
@@ -68,6 +69,7 @@ void main() {
             diveNumber: Value(diveNumber),
             diveComputerModel: Value(diveComputerModel),
             diveComputerSerial: Value(diveComputerSerial),
+            computerId: Value(computerId),
             maxDepth: Value(maxDepth),
             avgDepth: Value(avgDepth),
             bottomTime: Value(duration),
@@ -1347,62 +1349,78 @@ void main() {
   // computerSerial filter in getDiveSummaries
   // ---------------------------------------------------------------------------
 
-  group('computerSerial filter', () {
-    test('filters dives by computer serial number', () async {
-      await insertTestDive(
-        id: 'dive-serial-a',
-        diveNumber: 1,
-        diveComputerSerial: 'SN-AAA',
-        diveComputerModel: 'Computer A',
-      );
-      await insertTestDive(
-        id: 'dive-serial-b',
-        diveNumber: 2,
-        diveComputerSerial: 'SN-BBB',
-        diveComputerModel: 'Computer B',
-      );
-      await insertTestDive(
-        id: 'dive-serial-a2',
-        diveNumber: 3,
-        diveComputerSerial: 'SN-AAA',
-        diveComputerModel: 'Computer A',
-      );
+  group('computerId filter', () {
+    test('filters dives by dive computer', () async {
+      await insertComputer(id: 'dc-a', name: 'Computer A');
+      await insertComputer(id: 'dc-b', name: 'Computer B');
+      await insertTestDive(id: 'dive-a', diveNumber: 1, computerId: 'dc-a');
+      await insertTestDive(id: 'dive-b', diveNumber: 2, computerId: 'dc-b');
+      await insertTestDive(id: 'dive-a2', diveNumber: 3, computerId: 'dc-a');
 
       final summaries = await repository.getDiveSummaries(
-        filter: const DiveFilterState(computerSerial: 'SN-AAA'),
+        filter: const DiveFilterState(computerId: 'dc-a'),
       );
 
       expect(summaries.length, equals(2));
       final ids = summaries.map((s) => s.id).toSet();
-      expect(ids, contains('dive-serial-a'));
-      expect(ids, contains('dive-serial-a2'));
-      expect(ids, isNot(contains('dive-serial-b')));
+      expect(ids, contains('dive-a'));
+      expect(ids, contains('dive-a2'));
+      expect(ids, isNot(contains('dive-b')));
     });
 
-    test('returns empty list when no dives match the serial', () async {
+    // Issue #1064: the filter used to key on dives.dive_computer_serial, so
+    // every computer whose firmware never reported a serial matched nothing.
+    test('filters dives whose computer reported no serial number', () async {
+      await insertComputer(id: 'dc-noserial', name: 'Petrel 3');
+      await insertTestDive(
+        id: 'dive-noserial-1',
+        diveNumber: 1,
+        computerId: 'dc-noserial',
+      );
+      await insertTestDive(
+        id: 'dive-noserial-2',
+        diveNumber: 2,
+        computerId: 'dc-noserial',
+      );
+      await insertTestDive(id: 'dive-manual', diveNumber: 3);
+
+      final summaries = await repository.getDiveSummaries(
+        filter: const DiveFilterState(computerId: 'dc-noserial'),
+      );
+
+      expect(summaries.map((s) => s.id).toSet(), {
+        'dive-noserial-1',
+        'dive-noserial-2',
+      });
+    });
+
+    test('returns empty list when no dives match the computer', () async {
+      await insertComputer(id: 'dc-c', name: 'Computer C');
       await insertTestDive(
         id: 'dive-no-match',
         diveNumber: 1,
-        diveComputerSerial: 'SN-CCC',
+        computerId: 'dc-c',
       );
 
       final summaries = await repository.getDiveSummaries(
-        filter: const DiveFilterState(computerSerial: 'SN-NONEXISTENT'),
+        filter: const DiveFilterState(computerId: 'dc-nonexistent'),
       );
 
       expect(summaries, isEmpty);
     });
 
-    test('returns all dives when computerSerial filter is null', () async {
+    test('returns all dives when computerId filter is null', () async {
+      await insertComputer(id: 'dc-1', name: 'Computer 1');
+      await insertComputer(id: 'dc-2', name: 'Computer 2');
       await insertTestDive(
         id: 'dive-unfiltered-1',
         diveNumber: 1,
-        diveComputerSerial: 'SN-111',
+        computerId: 'dc-1',
       );
       await insertTestDive(
         id: 'dive-unfiltered-2',
         diveNumber: 2,
-        diveComputerSerial: 'SN-222',
+        computerId: 'dc-2',
       );
 
       final summaries = await repository.getDiveSummaries(

--- a/test/features/dive_log/domain/models/dive_filter_state_test.dart
+++ b/test/features/dive_log/domain/models/dive_filter_state_test.dart
@@ -16,6 +16,7 @@ Dive _makeDive({
   String? diveTypeId,
   bool isFavorite = false,
   String? diveComputerSerial,
+  String? computerId,
   int? rating,
   Duration? duration,
   String? tripId,
@@ -29,6 +30,7 @@ Dive _makeDive({
     diveTypeIds: [diveTypeId ?? 'recreational'],
     isFavorite: isFavorite,
     diveComputerSerial: diveComputerSerial,
+    computerId: computerId,
     rating: rating,
     bottomTime: duration,
     tripId: tripId,
@@ -83,7 +85,7 @@ void main() {
         expect(filter.minRating, isNull);
         expect(filter.minBottomTimeMinutes, isNull);
         expect(filter.maxBottomTimeMinutes, isNull);
-        expect(filter.computerSerial, isNull);
+        expect(filter.computerId, isNull);
         expect(filter.customFieldKey, isNull);
         expect(filter.customFieldValue, isNull);
       });
@@ -96,8 +98,8 @@ void main() {
         expect(filter.hasActiveFilters, isFalse);
       });
 
-      test('returns true when computerSerial is set', () {
-        const filter = DiveFilterState(computerSerial: 'SN12345');
+      test('returns true when computerId is set', () {
+        const filter = DiveFilterState(computerId: 'computer-a');
 
         expect(filter.hasActiveFilters, isTrue);
       });
@@ -170,57 +172,57 @@ void main() {
     });
 
     group('copyWith', () {
-      test('sets computerSerial', () {
+      test('sets computerId', () {
         const original = DiveFilterState();
 
-        final updated = original.copyWith(computerSerial: 'SN999');
+        final updated = original.copyWith(computerId: 'computer-a');
 
-        expect(updated.computerSerial, 'SN999');
+        expect(updated.computerId, 'computer-a');
       });
 
-      test('preserves computerSerial when not specified', () {
-        const original = DiveFilterState(computerSerial: 'SN999');
+      test('preserves computerId when not specified', () {
+        const original = DiveFilterState(computerId: 'computer-a');
 
         final updated = original.copyWith(minRating: 3);
 
-        expect(updated.computerSerial, 'SN999');
+        expect(updated.computerId, 'computer-a');
         expect(updated.minRating, 3);
       });
 
-      test('clears computerSerial with clearComputerSerial', () {
-        const original = DiveFilterState(computerSerial: 'SN999');
+      test('clears computerId with clearComputerId', () {
+        const original = DiveFilterState(computerId: 'computer-a');
 
-        final updated = original.copyWith(clearComputerSerial: true);
+        final updated = original.copyWith(clearComputerId: true);
 
-        expect(updated.computerSerial, isNull);
+        expect(updated.computerId, isNull);
       });
 
-      test('clearComputerSerial takes precedence over new value', () {
-        const original = DiveFilterState(computerSerial: 'SN999');
+      test('clearComputerId takes precedence over new value', () {
+        const original = DiveFilterState(computerId: 'computer-a');
 
         final updated = original.copyWith(
-          computerSerial: 'SN111',
-          clearComputerSerial: true,
+          computerId: 'computer-b',
+          clearComputerId: true,
         );
 
-        expect(updated.computerSerial, isNull);
+        expect(updated.computerId, isNull);
       });
 
       test('sets and clears multiple fields simultaneously', () {
         const original = DiveFilterState(
           minRating: 3,
-          computerSerial: 'SN999',
+          computerId: 'computer-a',
           minBottomTimeMinutes: 30,
         );
 
         final updated = original.copyWith(
           clearMinRating: true,
           maxBottomTimeMinutes: 60,
-          clearComputerSerial: true,
+          clearComputerId: true,
         );
 
         expect(updated.minRating, isNull);
-        expect(updated.computerSerial, isNull);
+        expect(updated.computerId, isNull);
         expect(updated.minBottomTimeMinutes, 30);
         expect(updated.maxBottomTimeMinutes, 60);
       });
@@ -236,18 +238,33 @@ void main() {
         expect(result, hasLength(2));
       });
 
-      test('filters by computerSerial', () {
-        const filter = DiveFilterState(computerSerial: 'SN12345');
+      test('filters by computerId', () {
+        const filter = DiveFilterState(computerId: 'computer-a');
         final dives = [
-          _makeDive(id: 'd1', diveComputerSerial: 'SN12345'),
-          _makeDive(id: 'd2', diveComputerSerial: 'SN99999'),
-          _makeDive(id: 'd3'), // no serial
+          _makeDive(id: 'd1', computerId: 'computer-a'),
+          _makeDive(id: 'd2', computerId: 'computer-b'),
+          _makeDive(id: 'd3'), // not attributed to any computer
         ];
 
         final result = filter.apply(dives);
 
         expect(result, hasLength(1));
         expect(result.first.id, 'd1');
+      });
+
+      // Issue #1064: computers whose firmware never reports a serial were
+      // unfilterable. Attribution rides the computer id, never the serial.
+      test('filters by computerId when the dives carry no serial', () {
+        const filter = DiveFilterState(computerId: 'computer-a');
+        final dives = [
+          _makeDive(id: 'd1', computerId: 'computer-a'),
+          _makeDive(id: 'd2', computerId: 'computer-a'),
+          _makeDive(id: 'd3', computerId: 'computer-b'),
+        ];
+
+        final result = filter.apply(dives);
+
+        expect(result.map((d) => d.id), ['d1', 'd2']);
       });
 
       test('filters by minRating', () {
@@ -420,11 +437,11 @@ void main() {
       });
 
       test('combines multiple filters', () {
-        const filter = DiveFilterState(computerSerial: 'SN12345', minRating: 3);
+        const filter = DiveFilterState(computerId: 'computer-a', minRating: 3);
         final dives = [
-          _makeDive(id: 'd1', diveComputerSerial: 'SN12345', rating: 5),
-          _makeDive(id: 'd2', diveComputerSerial: 'SN12345', rating: 2),
-          _makeDive(id: 'd3', diveComputerSerial: 'SN999', rating: 5),
+          _makeDive(id: 'd1', computerId: 'computer-a', rating: 5),
+          _makeDive(id: 'd2', computerId: 'computer-a', rating: 2),
+          _makeDive(id: 'd3', computerId: 'computer-b', rating: 5),
         ];
 
         final result = filter.apply(dives);

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
@@ -48,13 +48,9 @@ void main() {
       createdAt: now,
       updatedAt: now,
     ),
-    DiveComputer(
-      id: 'c2',
-      name: 'Teric',
-      serialNumber: 'SN456',
-      createdAt: now,
-      updatedAt: now,
-    ),
+    // Issue #1064: firmware that never reports a serial. The dropdown used to
+    // drop these entirely, leaving them unfilterable.
+    DiveComputer(id: 'c2', name: 'Teric', createdAt: now, updatedAt: now),
   ];
 
   late AppDatabase db;
@@ -205,11 +201,11 @@ void main() {
   testWidgets('dive type, site and computer dropdowns write selections', (
     tester,
   ) async {
-    // Prefill a stale computer serial so the "reset unknown serial to null"
+    // Prefill a stale computer id so the "reset unknown computer to null"
     // branch runs before selection.
     final ref = await openSheet(
       tester,
-      initial: const DiveFilterState(computerSerial: 'GHOST'),
+      initial: const DiveFilterState(computerId: 'GHOST'),
     );
 
     Future<void> selectFrom(String hint, String option) async {
@@ -228,7 +224,28 @@ void main() {
     final applied = ref.read(filterProvider);
     expect(applied.diveTypeId, 'wreck');
     expect(applied.siteId, 'site-1');
-    expect(applied.computerSerial, 'SN123');
+    expect(applied.computerId, 'c1');
+  });
+
+  // Issue #1064: the dropdown was built from computers.where(serialNumber !=
+  // null), so a computer whose firmware never reported one was absent from the
+  // list and could not be filtered on at all.
+  testWidgets('computer dropdown offers computers that have no serial', (
+    tester,
+  ) async {
+    final ref = await openSheet(tester);
+
+    // Pass the unqualified finder: scrollTo probes it before the lazy ListView
+    // has built the row, and a `.first` finder throws on an empty match.
+    await scrollTo(tester, find.text('All computers'));
+    await tester.tap(find.text('All computers').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Teric').last, findsOneWidget);
+    await tester.tap(find.text('Teric').last);
+    await tester.pumpAndSettle();
+
+    await tapText(tester, 'Apply Filters');
+    expect(ref.read(filterProvider).computerId, 'c2');
   });
 
   testWidgets('depth, buddy and duration text fields write values', (

--- a/test/features/statistics/data/dive_filter_sql_test.dart
+++ b/test/features/statistics/data/dive_filter_sql_test.dart
@@ -31,7 +31,7 @@ void main() {
     int? rating,
     int? bottomTimeSeconds,
     bool favorite = false,
-    String? computerSerial,
+    String? computerId,
     String? buddy,
   }) async {
     await db
@@ -49,10 +49,26 @@ void main() {
             rating: Value(rating),
             bottomTime: Value(bottomTimeSeconds),
             isFavorite: Value(favorite),
-            diveComputerSerial: Value(computerSerial),
+            computerId: Value(computerId),
             buddy: Value(buddy),
             createdAt: Value(now),
             updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Registers a dive computer. Issue #1064: these carry no serial number,
+  /// mirroring the firmware that never reports one -- attribution must still
+  /// work.
+  Future<void> insertComputer(String id) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion.insert(
+            id: id,
+            name: 'Computer $id',
+            createdAt: now,
+            updatedAt: now,
           ),
         );
   }
@@ -378,6 +394,9 @@ void main() {
     await insertTag('night');
     await insertEquipment('eq1');
     await insertEquipment('eq2');
+    await insertComputer('dc-a');
+    await insertComputer('dc-b');
+    await insertComputer('dc-c');
 
     // --- Dives: deliberately varied so every axis below both includes and
     // excludes at least one dive (a filter that trivially matches
@@ -402,10 +421,10 @@ void main() {
       rating: 5,
       bottomTimeSeconds: 3300, // 55 min
       favorite: true,
-      computerSerial: 'BBB222',
+      computerId: 'dc-b',
       buddy: 'Bob Buddy',
     );
-    // d3: nulls across depth/rating/computerSerial, and no tanks/tags/
+    // d3: nulls across depth/rating/computerId, and no tanks/tags/
     // equipment/custom fields at all -- exercises every null-exclusion and
     // empty-membership branch on both sides.
     await insertDive(
@@ -422,7 +441,7 @@ void main() {
       maxDepth: 45.0,
       rating: 2,
       bottomTimeSeconds: 1200, // 20 min
-      computerSerial: 'AAA111',
+      computerId: 'dc-a',
     );
     // d5: two tanks (100% and 21%) so the O2 axis actually exercises
     // ANY-tank-matches semantics rather than a single-tank dive.
@@ -435,7 +454,7 @@ void main() {
       rating: 4,
       bottomTimeSeconds: 3600, // 60 min
       favorite: true,
-      computerSerial: 'CCC333',
+      computerId: 'dc-c',
     );
     await insertDive(
       'd6',
@@ -443,7 +462,7 @@ void main() {
       siteId: 's2',
       maxDepth: 25.0,
       bottomTimeSeconds: 480, // 8 min
-      computerSerial: 'BBB222',
+      computerId: 'dc-b',
     );
     await insertDive(
       'd7',
@@ -529,7 +548,7 @@ void main() {
       'minRating (null-exclusion)': const DiveFilterState(minRating: 4),
       'minBottomTimeMinutes': const DiveFilterState(minBottomTimeMinutes: 30),
       'maxBottomTimeMinutes': const DiveFilterState(maxBottomTimeMinutes: 20),
-      'computerSerial': const DiveFilterState(computerSerial: 'AAA111'),
+      'computerId': const DiveFilterState(computerId: 'dc-a'),
       'customFieldKey only': const DiveFilterState(customFieldKey: 'visMeters'),
       'customFieldKey + value substring': const DiveFilterState(
         customFieldKey: 'visMeters',
@@ -565,7 +584,7 @@ void main() {
 
     // Hand-verified expected sets for the axes prioritized by the review
     // (O2 any-tank, equipment any-match, multi-tag, custom field
-    // key/value, computerSerial, diveCenterId, depth/rating
+    // key/value, computerId, diveCenterId, depth/rating
     // null-exclusion), so a bug shared by BOTH apply() and the SQL builder
     // can't hide behind their mutual agreement.
     expect(await idsMatching(battery['siteId']!), {'d1', 'd4', 'd7'});
@@ -591,7 +610,7 @@ void main() {
       'd2',
       'd5',
     }, reason: 'ANY-tank semantics: d5 matches via its second (100%) tank');
-    expect(await idsMatching(battery['computerSerial']!), {'d4'});
+    expect(await idsMatching(battery['computerId']!), {'d4'});
     expect(
       await idsMatching(battery['buddyNameFilter']!),
       {'d1', 'd6'},


### PR DESCRIPTION
## Summary

Fixes #1064. "View Dives from This Computer" showed nothing for every dive
computer the reporter tested (Shearwater Petrel 3, NERD, Perdix, and Suunto EON
Core).

The issue title says "no dives", but the German snackbar in the reported
screenshot is `diveComputer_detail_cannotFilterNoSerial`: *"Cannot filter: no
serial number for this computer."* The button never ran a query at all. It was
gated on `DiveComputer.serialNumber`, which libdivecomputer leaves null for many
devices, and which is only persisted when `DownloadCompleteEvent.serialNumber`
comes back non-null.

The dives themselves were attributed correctly the whole time. On the very same
page, `rawDataCountProvider` queries `dive_data_sources WHERE computer_id = ?`
and finds them, which is why the "Reparse All Dives" button renders in the
reporter's screenshot.

Dive-to-computer attribution belongs to `dives.computer_id`, the foreign key.
The `dive_computer_serial` and `dive_computer_model` columns are display/export
snapshots, as the schema comment on the `Dives` table already says: *"for
display/export, separate from computerId relation"*. They are nullable, can
duplicate across devices, and also arrive from UDDF/FIT file imports with no
registered computer behind them, so they cannot key a relation.

## Changes

- Replace the `DiveFilterState.computerSerial` axis with `computerId`, keyed on
  the foreign key, across the shared WHERE-clause builder
  (`_buildFilterWhereClauses`, used by summaries, the filtered-id list, and the
  count) and the statistics `dive_filter_sql.dart`.
- Add `Dive.computerId` so the in-memory `apply()` path can evaluate the axis
  too. It is a read-only projection: the insert/update companions deliberately
  omit the column, so saving a dive never rewrites attribution (which is owned
  by the download, consolidation, split, and reparse paths). Both row-to-entity
  mappers populate it.
- `device_detail_page.dart` now filters on `computer.id` and navigates
  unconditionally; the "no serial number" dead end is gone.
- Fix the same bug in the dive filter sheet, which built its computer dropdown
  from `computers.where((c) => c.serialNumber != null)`. A user whose computers
  all lack serials saw "No dive computers registered" despite having several.
- Add a `beforeOpen` data self-heal, `_backfillDiveComputerIds()`, for legacy
  data. The download path only began stamping `dives.computer_id` in 9ddb281
  (2026-07-02); older dives carry the attribution only on their
  `dive_data_sources` rows and would otherwise still filter to an empty list. It
  adopts the id from the primary source row, with the source id as a tiebreak so
  every device resolves a multi-source dive identically. Modeled on the adjacent
  `_backfillMissingDataSources`: idempotent, local-only, derived from
  already-synced rows, no HLC bump, so it triggers no fleet re-sync.
  `beforeOpen` rather than an `onUpgrade` step for the reason the v149 backstop
  documents: a database arriving by restore or sync-adopt never runs
  `onUpgrade`. Guarded with `PRAGMA table_info` because it names `computer_id`
  on both tables and `beforeOpen` also runs against minimal old-schema fixtures.
- Add `idx_dives_computer_id`. Every other filterable FK on `dives` (`site_id`,
  `trip_id`, `dive_center_id`, `course_id`) already had one, and `computer_id`
  is now a filter axis exactly like those; the self-heal drives off the same
  column.
- Retire the now-unused `diveComputer_detail_cannotFilterNoSerial` string from
  all 11 locales and regenerate.

## Test Plan

- [x] `flutter test` passes (17781 passed, 17 skipped, 0 failed)
- [x] `flutter analyze` passes (whole project, no issues)
- [ ] Manual testing on: Android (the reported platform), with a dive computer
      that reports no serial

19 new or rewritten cases across six files:

- `test/core/database/dive_computer_id_backfill_test.dart` (new): the self-heal
  adopts from the primary source, leaves already-attributed and
  computer-less dives alone, breaks ties deterministically, is idempotent, and
  skips a legacy schema lacking the columns rather than raising "no such
  column".
- `device_detail_page_test.dart`: the previous cases asserted the bug ("view
  dives shows snackbar for null serial"); they now assert navigation succeeds
  and that the filter carries the computer id.
- `dive_filter_sheet_interactions_test.dart`: one fixture computer now has no
  serial, and a new case asserts it is offered in the dropdown and selectable.
- `dive_repository_new_methods_test.dart`: the SQL axis, including a dedicated
  case for a computer that reported no serial.
- `dive_filter_state_test.dart`: the in-memory axis.
- `dive_filter_sql_test.dart`: the parity battery, which asserts
  `buildFilteredDiveIdSubquery` and `DiveFilterState.apply()` select identical
  dive ids on every axis, now covers `computerId`. That invariant is what makes
  `Dive.computerId` mandatory rather than optional.
