### PR TITLE
Dependency sweep: 63 packages, geocoding 5.x, and sqlite3 3.x with SQLCipher via build hook

### DIFF
--- a/integration_test/db_security_test.dart
+++ b/integration_test/db_security_test.dart
@@ -5,7 +5,6 @@ import 'package:integration_test/integration_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' show OpenMode;
 
-import 'package:submersion/core/database/sqlcipher_setup.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/security/database_encryption_migrator.dart';
 import 'package:submersion/core/services/security/database_locked_exception.dart';
@@ -13,9 +12,14 @@ import 'package:submersion/core/services/security/database_security_sidecar.dart
 import 'package:submersion/core/services/security/database_security_service.dart';
 import 'package:submersion/core/services/sync/crypto/keyslots.dart';
 
-/// The only place the REAL SQLCipher runs under test: `flutter test` on the
-/// host loads the system SQLite (no cipher), so encrypted opens, the export
-/// choreography, and the key derivation are proven here, on-device.
+/// Proves the encryption lifecycle end to end on a real device: encrypted
+/// opens, the export choreography, and the key derivation.
+///
+/// Host `flutter test` used to load the system SQLite with no cipher, which
+/// made this the ONLY place real SQLCipher ran. That is no longer true --
+/// sqlite3 3.x bundles a prebuilt SQLCipher through its build hook, so the
+/// host suite links the cipher too (see sqlcipher_setup_test.dart). This
+/// remains on-device coverage for the real platform storage stack.
 ///
 /// Single testWidgets body on purpose: a second app launch in one
 /// integration-test file hangs on macOS.
@@ -27,7 +31,6 @@ void main() {
   testWidgets('full encryption lifecycle against real SQLCipher', (
     tester,
   ) async {
-    setupSqlcipher();
     final tmp = await Directory.systemTemp.createTemp('dbsec_integration');
     addTearDown(() => tmp.delete(recursive: true));
     final dbPath = '${tmp.path}/submersion.db';
@@ -40,12 +43,12 @@ void main() {
     expect(
       probe.select('PRAGMA cipher_version'),
       isNotEmpty,
-      reason: 'sqlcipher_flutter_libs must be the linked sqlite3',
+      reason: 'the sqlite3 build hook must have selected the SQLCipher build',
     );
     probe.execute('CREATE TABLE t (v TEXT)');
     probe.execute("INSERT INTO t VALUES ('dive-1')");
     probe.execute('PRAGMA user_version = 7');
-    probe.dispose();
+    probe.close();
     expect(isEncryptedDatabaseFile(dbPath), false);
 
     // 1. Security + key derivation from the sidecar credential.
@@ -98,7 +101,7 @@ void main() {
     expect(DatabaseService.getStoredSchemaVersion(dbPath, keyHex: keyHex), 7);
     final keyed = DatabaseService.openRaw(dbPath, keyHex: keyHex);
     expect(keyed.select('SELECT v FROM t').first.values.first, 'dive-1');
-    keyed.dispose();
+    keyed.close();
 
     // 4. Portable backup: decrypt-export produces a plaintext file.
     final backupPath = '${tmp.path}/backup.db';
@@ -120,7 +123,7 @@ void main() {
     expect(DatabaseService.getStoredSchemaVersion(dbPath), 7);
     final plain = DatabaseService.openRaw(dbPath);
     expect(plain.select('SELECT v FROM t').first.values.first, 'dive-1');
-    plain.dispose();
+    plain.close();
 
     svc.resetForTesting();
   });

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -62,8 +62,9 @@ PODS:
   - gal (1.0.0):
     - Flutter
     - FlutterMacOS
-  - geocoding_ios (1.0.5):
+  - geocoding_darwin (0.0.1):
     - Flutter
+    - FlutterMacOS
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -118,7 +119,7 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.4.8):
     - Flutter
-  - photo_manager (3.9.0):
+  - photo_manager (3.12.0):
     - Flutter
     - FlutterMacOS
   - printing (1.0.0):
@@ -137,14 +138,6 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - SQLCipher (4.10.0):
-    - SQLCipher/standard (= 4.10.0)
-  - SQLCipher/common (4.10.0)
-  - SQLCipher/standard (4.10.0):
-    - SQLCipher/common
-  - sqlcipher_flutter_libs (0.0.1):
-    - Flutter
-    - SQLCipher (~> 4.10.0)
   - submersion_ocr (0.1.0):
     - Flutter
     - FlutterMacOS
@@ -171,7 +164,7 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - gal (from `.symlinks/plugins/gal/darwin`)
-  - geocoding_ios (from `.symlinks/plugins/geocoding_ios/ios`)
+  - geocoding_darwin (from `.symlinks/plugins/geocoding_darwin/darwin`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - health (from `.symlinks/plugins/health/ios`)
@@ -190,7 +183,6 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
-  - sqlcipher_flutter_libs (from `.symlinks/plugins/sqlcipher_flutter_libs/ios`)
   - submersion_ocr (from `.symlinks/plugins/submersion_ocr/darwin`)
   - submersion_transcoder (from `.symlinks/plugins/submersion_transcoder/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -210,7 +202,6 @@ SPEC REPOS:
     - ObjectBox
     - PromisesObjC
     - SDWebImage
-    - SQLCipher
     - SwiftyGif
 
 EXTERNAL SOURCES:
@@ -234,8 +225,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_web_auth_2/ios"
   gal:
     :path: ".symlinks/plugins/gal/darwin"
-  geocoding_ios:
-    :path: ".symlinks/plugins/geocoding_ios/ios"
+  geocoding_darwin:
+    :path: ".symlinks/plugins/geocoding_darwin/darwin"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_sign_in_ios:
@@ -272,8 +263,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
-  sqlcipher_flutter_libs:
-    :path: ".symlinks/plugins/sqlcipher_flutter_libs/ios"
   submersion_ocr:
     :path: ".symlinks/plugins/submersion_ocr/darwin"
   submersion_transcoder:
@@ -300,7 +289,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
   gal: baecd024ebfd13c441269ca7404792a7152fde89
-  geocoding_ios: 33776c9ebb98d037b5e025bb0e7537f6dd19646e
+  geocoding_darwin: 968545604e6896deeef55517d53a81b3b9801971
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_sign_in_ios: 000870aa06da9b28d1d0bf7ef70ff0213059dd28
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
@@ -318,22 +307,20 @@ SPEC CHECKSUMS:
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   pdfium_flutter: e5a6e881af0b182d5b0465ebad23a8a20caa28d4
   permission_handler_apple: 92d754bbaa7361d436db2d6c3c1c2a0fdcec462e
-  photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
-  printing: 54ff03f28fe9ba3aa93358afb80a8595a071dd07
+  photo_manager: c303e4476f6c220274119f0212a7753e45edd4a2
+  printing: a8960104e6c1a2b4bd3483a2f79c69be60830d08
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
-  sqlcipher_flutter_libs: ae224763b087bffb3a5955fe295a1c460d458cb1
   submersion_ocr: c16e8aa86fee22293c92688fcf97c5293b6b159f
   submersion_transcoder: c0bc7bb59ce039c73dcd24cb7797b390cfd2dab6
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
-  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
+  workmanager_apple: 1fc2a64e6a63ed3540fbb91b65f0c0d501881248
 
 PODFILE CHECKSUM: bf695f1d88cb8e6048580a51c30afd927d095aa6
 

--- a/lib/core/database/background_database_connection.dart
+++ b/lib/core/database/background_database_connection.dart
@@ -18,9 +18,6 @@ import 'package:submersion/core/database/sqlcipher_setup.dart';
 /// Strings, so they cross the isolate boundary.
 DatabaseConnection Function() _openerFor(String path, String? keyHex) {
   return () {
-    // Fresh isolate: the sqlite3 loader override is per-isolate state and
-    // must be re-applied here or Android loads the non-cipher system lib.
-    setupSqlcipher();
     return DatabaseConnection(
       NativeDatabase(
         File(path),

--- a/lib/core/database/sqlcipher_setup.dart
+++ b/lib/core/database/sqlcipher_setup.dart
@@ -1,22 +1,12 @@
-import 'dart:io';
-
-import 'package:sqlcipher_flutter_libs/sqlcipher_flutter_libs.dart';
-import 'package:sqlite3/open.dart';
-
-/// Applies the per-isolate sqlite3 loader override needed for SQLCipher.
+/// SQLCipher helpers.
 ///
-/// `open.overrideFor` is per-isolate state: call this in EVERY isolate that
-/// opens the database — the main isolate (bootstrap), the drift worker
-/// isolate opener, and the Workmanager headless isolate.
-///
-/// Only Android needs an explicit override with sqlcipher_flutter_libs; on
-/// iOS/macOS the pod links SQLCipher, and on Windows/Linux the bundled
-/// library is picked up by the default loader. Idempotent.
-void setupSqlcipher() {
-  if (Platform.isAndroid) {
-    open.overrideFor(OperatingSystem.android, openCipherOnAndroid);
-  }
-}
+/// There is no loader setup to do any more. sqlite3 3.x selects the native
+/// library through its build hook (`hooks: user_defines: sqlite3: source:
+/// sqlcipher` in pubspec.yaml), so SQLCipher is linked at build time for every
+/// isolate. The old `setupSqlcipher()` override existed only because sqlite3
+/// 2.x resolved the library at runtime, per isolate, via
+/// `package:sqlite3/open.dart` -- an API 3.x removed.
+library;
 
 /// The PRAGMA that keys a SQLCipher connection with a raw (already
 /// KDF-stretched) 32-byte key, given as 64 hex chars. Must be the first
@@ -24,5 +14,5 @@ void setupSqlcipher() {
 ///
 /// Top-level here (not on DatabaseService) so the drift worker isolate and
 /// the encryption migrator can build it without importing
-/// database_service.dart — that file imports both of them.
+/// database_service.dart -- that file imports both of them.
 String cipherKeyPragma(String keyHex) => 'PRAGMA key = "x\'$keyHex\'"';

--- a/lib/core/services/background_service.dart
+++ b/lib/core/services/background_service.dart
@@ -5,7 +5,6 @@ import 'package:workmanager/workmanager.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart'
     show CloudProviderType;
-import 'package:submersion/core/database/sqlcipher_setup.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/headless_cloud_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -33,8 +32,6 @@ const String kBackupTask = 'com.submersion.backup';
 Future<bool> prepareHeadlessDatabaseKey({
   required SharedPreferences prefs,
 }) async {
-  // Fresh isolate: re-apply the per-isolate sqlite3 loader override.
-  setupSqlcipher();
   final security = DatabaseSecurityService.instance;
   await security.configure(prefs: prefs);
   if (!security.encryptionEnabled) return true;

--- a/lib/core/services/database_migration_service.dart
+++ b/lib/core/services/database_migration_service.dart
@@ -578,7 +578,7 @@ class DatabaseMigrationService {
         debugInfo?.writeln('DEBUG: Parsed status: "$status"');
         return status == 'ok';
       } finally {
-        db.dispose();
+        db.close();
         // Small delay to ensure SQLite fully releases the file lock
         await Future.delayed(const Duration(milliseconds: 50));
       }
@@ -725,7 +725,7 @@ class DatabaseMigrationService {
         buddyCount: buddyCount,
       );
     } finally {
-      db.dispose();
+      db.close();
       await Future.delayed(const Duration(milliseconds: 50));
     }
   }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -417,7 +417,7 @@ class DatabaseService {
       }
       rethrow;
     } finally {
-      db.dispose();
+      db.close();
     }
   }
 
@@ -438,7 +438,7 @@ class DatabaseService {
       try {
         db.execute(cipherKeyPragma(keyHex));
       } catch (_) {
-        db.dispose();
+        db.close();
         rethrow;
       }
     }
@@ -468,7 +468,7 @@ class DatabaseService {
       try {
         db.select('PRAGMA user_version');
       } finally {
-        db.dispose();
+        db.close();
       }
       return true;
     } on sqlite3.SqliteException {

--- a/lib/core/services/location_service.dart
+++ b/lib/core/services/location_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io' show Platform, HttpClient;
+import 'dart:ui' show Locale;
 
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:geolocator/geolocator.dart';
@@ -50,42 +51,27 @@ class LocationService {
     '&accept-language=en',
   );
 
-  /// The platform geocoder answers in the DEVICE locale unless pinned,
-  /// which stored 'Spanien' on German phones and 'España' on Spanish ones
-  /// for the same country (#214). Pin once per process.
+  /// The platform geocoder answers in the DEVICE locale unless a locale is
+  /// supplied, which stored 'Spanien' on German phones and 'España' on
+  /// Spanish ones for the same country (#214).
   ///
-  /// Memoizes the in-flight future rather than a bool so concurrent callers
-  /// share one `setLocaleIdentifier` call instead of racing past a flag that
-  /// is only set after the await.
-  static Future<void>? _geocoderLocalePin;
+  /// geocoding 5 takes the locale per call, which retires the old
+  /// pin-once-per-process memo. Do NOT pin via `Geocoding(locale: ...)`
+  /// instead: that constructor parameter is dropped upstream (the redirecting
+  /// constructor never forwards it to the field), so it would silently
+  /// reintroduce #214.
+  static const Locale _geocoderLocale = Locale('en');
 
   /// Routes reverse geocoding through the platform geocoder.
   ///
   /// True on mobile in production. `Platform.isIOS`/`isAndroid` are
   /// natively-resolved statics with no override hook, so the mobile branch
   /// is otherwise unreachable on a desktop test host -- including the
-  /// locale pin below, whose single-call and retry-after-failure contracts
-  /// are the part of #214 most worth asserting.
+  /// English-locale contract below, the part of #214 most worth asserting.
   @visibleForTesting
   static bool debugForceNativeGeocoder = false;
 
   static bool get _useNativeGeocoder => debugForceNativeGeocoder || _isMobile;
-
-  /// Resets the memoized locale pin. Tests only.
-  @visibleForTesting
-  static void debugResetGeocoderLocalePin() => _geocoderLocalePin = null;
-
-  /// Pin the platform geocoder to English, at most once per process.
-  ///
-  /// A failed attempt clears the memo so a later call retries. Callers treat
-  /// a failed pin as non-fatal: geocoding still runs, just unpinned.
-  static Future<void> _pinGeocoderLocale() {
-    return _geocoderLocalePin ??= Future<void>(() => setLocaleIdentifier('en'))
-        .onError<Object>((error, stackTrace) {
-          _geocoderLocalePin = null;
-          Error.throwWithStackTrace(error, stackTrace);
-        });
-  }
 
   static final _log = LoggerService.forClass(LocationService);
   static LocationService? _instance;
@@ -247,10 +233,13 @@ class LocationService {
       // Try native geocoding first (works on iOS/Android)
       if (_useNativeGeocoder) {
         try {
-          await _pinGeocoderLocale();
-          final placemarks = await placemarkFromCoordinates(
+          // Built per call rather than cached in a static: construction only
+          // asks the platform factory for an implementation, and a cached
+          // instance would outlive the per-test factory fakes.
+          final placemarks = await Geocoding().placemarkFromCoordinates(
             latitude,
             longitude,
+            locale: _geocoderLocale,
           );
           if (placemarks.isNotEmpty) {
             final place = placemarks.first;

--- a/lib/core/services/media_store/network_status_service.dart
+++ b/lib/core/services/media_store/network_status_service.dart
@@ -18,9 +18,11 @@ class NetworkStatusService {
       ConnectivityResult.vpn,
     };
     if (results.any(unmetered.contains)) return NetworkKind.unmetered;
-    if (results.contains(ConnectivityResult.mobile)) {
-      return NetworkKind.cellular;
-    }
+    // Satellite (added in connectivity_plus 7) is metered and expensive, so it
+    // shares the cellular policy. Classifying it as offline instead would make
+    // a working link look like no link and block transfers outright.
+    const metered = {ConnectivityResult.mobile, ConnectivityResult.satellite};
+    if (results.any(metered.contains)) return NetworkKind.cellular;
     return NetworkKind.offline;
   }
 

--- a/lib/core/services/security/database_encryption_migrator.dart
+++ b/lib/core/services/security/database_encryption_migrator.dart
@@ -41,7 +41,7 @@ Future<void> sqlcipherExport({
     db.execute('PRAGMA target.user_version = $v');
     db.execute('DETACH DATABASE target');
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -616,7 +616,7 @@ class BackupService {
 
         return BackupValidationResult.valid(sizeBytes: sizeBytes);
       } finally {
-        testDb.dispose();
+        testDb.close();
       }
     } catch (e) {
       return BackupValidationResult.invalid('File is not a valid database: $e');

--- a/lib/features/dive_roles/presentation/providers/dive_role_providers.dart
+++ b/lib/features/dive_roles/presentation/providers/dive_role_providers.dart
@@ -64,14 +64,18 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
   }
 
   Future<void> _loadDiveRoles() async {
+    // Every assignment is mounted-guarded, matching _silentReloadDiveRoles:
+    // this runs after the await in _initializeAndLoad, so the notifier can
+    // already be disposed by the time the first one lands.
+    if (!mounted) return;
     state = const AsyncValue.loading();
     try {
       final roles = await _repository.getAllDiveRoles(
         diverId: _validatedDiverId,
       );
-      state = AsyncValue.data(roles);
+      if (mounted) state = AsyncValue.data(roles);
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (mounted) state = AsyncValue.error(e, st);
     }
   }
 
@@ -91,6 +95,18 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
     }
   }
 
+  /// Refreshes [allDiveRolesProvider] after a write, if this notifier is still
+  /// alive.
+  ///
+  /// The provider is `autoDispose`, and a mutation usually runs from a dialog
+  /// whose route can drop this notifier's last listener while the write is
+  /// still in flight -- touching `_ref` afterwards throws. Skipping the
+  /// invalidate then costs nothing: `allDiveRolesProvider` self-invalidates
+  /// from `watchDiveRolesChanges()`, so the committed row still reaches the UI.
+  void _refreshAllDiveRoles() {
+    if (mounted) _ref.invalidate(allDiveRolesProvider);
+  }
+
   /// Add a custom dive role by name. Throws if no valid diver profile exists.
   Future<DiveRole> addDiveRoleByName(String name) async {
     final validatedId = await _ref.read(validatedCurrentDiverIdProvider.future);
@@ -102,7 +118,7 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
       diverId: validatedId,
     );
     await _loadDiveRoles();
-    _ref.invalidate(allDiveRolesProvider);
+    _refreshAllDiveRoles();
     return created;
   }
 
@@ -110,14 +126,14 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
   Future<void> renameDiveRole(String id, String name) async {
     await _repository.renameDiveRole(id, name);
     await _loadDiveRoles();
-    _ref.invalidate(allDiveRolesProvider);
+    _refreshAllDiveRoles();
   }
 
   /// Delete a custom dive role (built-in roles cannot be deleted)
   Future<void> deleteDiveRole(String id) async {
     await _repository.deleteDiveRole(id);
     await _loadDiveRoles();
-    _ref.invalidate(allDiveRolesProvider);
+    _refreshAllDiveRoles();
   }
 
   /// Check if a dive role is referenced by any dive

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -112,6 +112,15 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
   // resolver — becomes a Future error caught by FutureBuilder's hasError
   // branch in [build] instead of escaping initState/didUpdateWidget.
   Future<_Resolution> _resolve() async {
+    // Yield before the first `ref` touch. Both callers (initState and
+    // didUpdateWidget) run inside the build phase, and an `async` body still
+    // executes synchronously up to its first await -- so reading a provider
+    // here initialized it mid-build. Riverpod 3.3.2 marks the enclosing
+    // ProviderScope dirty when that happens, which Flutter rejects with
+    // "setState() or markNeedsBuild() called during build". Surfaced by the
+    // shrinking-gallery case in photo_viewer_gallery_change_test.dart, where
+    // an invalidate rebuilds the gallery and fires didUpdateWidget.
+    await null;
     final registry = ref.read(mediaSourceResolverRegistryProvider);
     final resolver = registry.resolverFor(widget.item.sourceType);
     // A PDF tile draws page 1. Rendering is the only way raw document bytes

--- a/lib/features/universal_import/data/services/macdive_db_reader.dart
+++ b/lib/features/universal_import/data/services/macdive_db_reader.dart
@@ -41,7 +41,7 @@ class MacDiveDbReader {
         final tables = rows.map<String>((r) => r['name'] as String).toSet();
         return _requiredTables.every(tables.contains);
       } finally {
-        db.dispose();
+        db.close();
       }
     } catch (_) {
       return false;
@@ -141,7 +141,7 @@ class MacDiveDbReader {
           diversByPk: {for (final d in divers) d.pk: d},
         );
       } finally {
-        db.dispose();
+        db.close();
       }
     } finally {
       _deleteTempFile(tmpFile);

--- a/lib/features/universal_import/data/services/shearwater_db_reader.dart
+++ b/lib/features/universal_import/data/services/shearwater_db_reader.dart
@@ -135,7 +135,7 @@ ORDER BY dd.DiveDate
       try {
         return _listTables(db);
       } finally {
-        db.dispose();
+        db.close();
       }
     } catch (_) {
       return const <String>{};
@@ -159,7 +159,7 @@ ORDER BY dd.DiveDate
         final tables = _listTables(db);
         return _requiredTables.every((t) => tables.contains(t));
       } finally {
-        db.dispose();
+        db.close();
       }
     } catch (_) {
       return false;
@@ -182,7 +182,7 @@ ORDER BY dd.DiveDate
         final rows = db.select(_query);
         return rows.map(_rowToRawDive).toList();
       } finally {
-        db.dispose();
+        db.close();
       }
     } finally {
       _deleteTempFile(tempFile);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
 import 'package:submersion/app.dart';
-import 'package:submersion/core/database/sqlcipher_setup.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/presentation/pages/startup_page.dart';
 import 'package:submersion/features/data_quality/presentation/providers/quality_detector_toggles.dart';
@@ -33,10 +32,6 @@ void main() {
 Future<void> _bootstrap() async {
   // coverage:ignore-end
   WidgetsFlutterBinding.ensureInitialized();
-
-  // SQLCipher loader override for this (main) isolate — must run before
-  // anything can touch the database, including the startup schema probe.
-  setupSqlcipher();
 
   // Route uncaught Flutter framework and platform errors into the debug log so
   // future crashes are diagnosable from the user-shared log (issue #318).

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -13,7 +13,6 @@
 #include <libdivecomputer_plugin/libdivecomputer_plugin.h>
 #include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
 #include <printing/printing_plugin.h>
-#include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_to_front/window_to_front_plugin.h>
 
@@ -39,9 +38,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) printing_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
   printing_plugin_register_with_registrar(printing_registrar);
-  g_autoptr(FlPluginRegistrar) sqlcipher_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlcipher_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -10,7 +10,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   libdivecomputer_plugin
   objectbox_flutter_libs
   printing
-  sqlcipher_flutter_libs
   url_launcher_linux
   window_to_front
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,6 +18,7 @@ import flutter_local_notifications
 import flutter_secure_storage_darwin
 import flutter_web_auth_2
 import gal
+import geocoding_darwin
 import geolocator_apple
 import google_sign_in_ios
 import libdivecomputer_plugin
@@ -36,6 +37,7 @@ import submersion_transcoder
 import url_launcher_macos
 import video_player_avfoundation
 import window_to_front
+import workmanager_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AutoUpdaterMacosPlugin.register(with: registry.registrar(forPlugin: "AutoUpdaterMacosPlugin"))
@@ -51,6 +53,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
+  GeocodingDarwinPlugin.register(with: registry.registrar(forPlugin: "GeocodingDarwinPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   LibdivecomputerPlugin.register(with: registry.registrar(forPlugin: "LibdivecomputerPlugin"))
@@ -69,4 +72,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))
+  WorkmanagerPlugin.register(with: registry.registrar(forPlugin: "WorkmanagerPlugin"))
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -31,7 +31,6 @@ import printing
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
-import sqlcipher_flutter_libs
 import submersion_ocr
 import submersion_transcoder
 import url_launcher_macos
@@ -66,7 +65,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   SubmersionOcrPlugin.register(with: registry.registrar(forPlugin: "SubmersionOcrPlugin"))
   SubmersionTranscoderPlugin.register(with: registry.registrar(forPlugin: "SubmersionTranscoderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -39,6 +39,9 @@ PODS:
   - gal (1.0.0):
     - Flutter
     - FlutterMacOS
+  - geocoding_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -83,7 +86,7 @@ PODS:
   - pdfium_flutter (0.1.5):
     - Flutter
     - FlutterMacOS
-  - photo_manager (3.9.0):
+  - photo_manager (3.12.0):
     - Flutter
     - FlutterMacOS
   - printing (1.0.0):
@@ -98,14 +101,6 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
-  - SQLCipher (4.10.0):
-    - SQLCipher/standard (= 4.10.0)
-  - SQLCipher/common (4.10.0)
-  - SQLCipher/standard (4.10.0):
-    - SQLCipher/common
-  - sqlcipher_flutter_libs (0.0.1):
-    - FlutterMacOS
-    - SQLCipher (~> 4.10.0)
   - submersion_ocr (0.1.0):
     - Flutter
     - FlutterMacOS
@@ -118,6 +113,8 @@ PODS:
     - Flutter
     - FlutterMacOS
   - window_to_front (0.0.4):
+    - FlutterMacOS
+  - workmanager_apple (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
@@ -135,6 +132,7 @@ DEPENDENCIES:
   - flutter_web_auth_2 (from `Flutter/ephemeral/.symlinks/plugins/flutter_web_auth_2/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - gal (from `Flutter/ephemeral/.symlinks/plugins/gal/darwin`)
+  - geocoding_darwin (from `Flutter/ephemeral/.symlinks/plugins/geocoding_darwin/darwin`)
   - geolocator_apple (from `Flutter/ephemeral/.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
   - libdivecomputer_plugin (from `Flutter/ephemeral/.symlinks/plugins/libdivecomputer_plugin/macos`)
@@ -147,12 +145,12 @@ DEPENDENCIES:
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
-  - sqlcipher_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/sqlcipher_flutter_libs/macos`)
   - submersion_ocr (from `Flutter/ephemeral/.symlinks/plugins/submersion_ocr/darwin`)
   - submersion_transcoder (from `Flutter/ephemeral/.symlinks/plugins/submersion_transcoder/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - video_player_avfoundation (from `Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin`)
   - window_to_front (from `Flutter/ephemeral/.symlinks/plugins/window_to_front/macos`)
+  - workmanager_apple (from `Flutter/ephemeral/.symlinks/plugins/workmanager_apple/macos`)
 
 SPEC REPOS:
   trunk:
@@ -165,7 +163,6 @@ SPEC REPOS:
     - ObjectBox
     - PromisesObjC
     - Sparkle
-    - SQLCipher
 
 EXTERNAL SOURCES:
   auto_updater_macos:
@@ -196,6 +193,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
   gal:
     :path: Flutter/ephemeral/.symlinks/plugins/gal/darwin
+  geocoding_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/geocoding_darwin/darwin
   geolocator_apple:
     :path: Flutter/ephemeral/.symlinks/plugins/geolocator_apple/darwin
   google_sign_in_ios:
@@ -220,8 +219,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   sqflite_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
-  sqlcipher_flutter_libs:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqlcipher_flutter_libs/macos
   submersion_ocr:
     :path: Flutter/ephemeral/.symlinks/plugins/submersion_ocr/darwin
   submersion_transcoder:
@@ -232,6 +229,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/video_player_avfoundation/darwin
   window_to_front:
     :path: Flutter/ephemeral/.symlinks/plugins/window_to_front/macos
+  workmanager_apple:
+    :path: Flutter/ephemeral/.symlinks/plugins/workmanager_apple/macos
 
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
@@ -250,6 +249,7 @@ SPEC CHECKSUMS:
   flutter_web_auth_2: 7fe624ff12ddcb4c19e5dbcd56c9e9ea4899d967
   FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
   gal: baecd024ebfd13c441269ca7404792a7152fde89
+  geocoding_darwin: 968545604e6896deeef55517d53a81b3b9801971
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_sign_in_ios: 000870aa06da9b28d1d0bf7ef70ff0213059dd28
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d
@@ -262,20 +262,19 @@ SPEC CHECKSUMS:
   objectbox_flutter_libs: f51d18f6a4b5965c218843373b7dc5ed5e3a2008
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   pdfium_flutter: e5a6e881af0b182d5b0465ebad23a8a20caa28d4
-  photo_manager: 25fd77df14f4f0ba5ef99e2c61814dde77e2bceb
-  printing: c4cf83c78fd684f9bc318e6aadc18972aa48f617
+  photo_manager: c303e4476f6c220274119f0212a7753e45edd4a2
+  printing: 7916ffaaede65713863e621de9a4742d9fa723b9
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   Sparkle: a346a4341537c625955751ed3ae4b340b68551fa
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
-  sqlcipher_flutter_libs: 01ead34db27ae5e49987cae46c8a34199eb22cfe
   submersion_ocr: c16e8aa86fee22293c92688fcf97c5293b6b159f
   submersion_transcoder: c0bc7bb59ce039c73dcd24cb7797b390cfd2dab6
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
   video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
   window_to_front: 2d7d31f268d0b13b7e63b26e31eb0a2e9612239e
+  workmanager_apple: 573f1503f9752eadd70a35bb478dfd2a103c4d18
 
 PODFILE CHECKSUM: 0d4775a85943993b4da68489f245c9442f1b3a74
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,26 +13,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "12.1.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: ff4bd291778c7417fe53fe24ee0d0a1f1ffe281a2d4ea887e7094f16e36eace7
+      sha256: "445b77e2054fa3e8c8a8ef1b5e9e6b23bb8028fffd34b5e60eaef315b7750674"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.3"
   animated_stack_widget:
     dependency: transitive
     description:
@@ -380,10 +380,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   dbus:
     dependency: transitive
     description:
@@ -428,18 +428,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.3"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   equatable:
     dependency: "direct main"
     description:
@@ -691,10 +691,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -769,16 +769,8 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  freezed:
-    dependency: "direct dev"
-    description:
-      name: freezed
-      sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.5"
   freezed_annotation:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: freezed_annotation
       sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
@@ -1183,18 +1175,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.0"
+    version: "6.14.1"
   latlong2:
     dependency: "direct main"
     description:
@@ -1362,6 +1354,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.3"
   nested:
     dependency: transitive
     description:
@@ -1630,10 +1630,10 @@ packages:
     dependency: transitive
     description:
       name: pigeon
-      sha256: "2a4bfd279fac52b115818e93f5409d07955f7b3718d303fd5f100981be4de386"
+      sha256: "04cfefc8add8b47ddf9ccac8b92bb4edeb67c87f185c623ba0db118ac99334ad"
       url: "https://pub.dev"
     source: hosted
-    version: "26.3.2"
+    version: "26.3.4"
   platform:
     dependency: transitive
     description:
@@ -1750,34 +1750,34 @@ packages:
     dependency: "direct main"
     description:
       name: riverpod
-      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: e55bc08c084a424e1bbdc303fe8ea75daafe4269b68fd0e0f6f1678413715b66
+      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.9"
+    version: "1.0.0-dev.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "16471a1260b94e939394d78f1c63a9350936ac4a68c9fbdab40be47268c0b04f"
+      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "6f9220534d7a353b53c875ea191a84d28cb4e52ac420a66a1bd7318329d977b0"
+      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   rxdart:
     dependency: transitive
     description:
@@ -1983,30 +1983,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
-  sqlcipher_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlcipher_flutter_libs
-      sha256: dd1fcc74d5baf3c36ad53e2652b2d06c9f8747494a3ccde0076e88b159dfe622
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.8"
   sqlite3:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.1"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -124,34 +124,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -164,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.6"
+    version: "8.12.7"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -276,10 +276,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.3.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: "direct dev"
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: "direct main"
     description:
@@ -444,10 +444,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   excel_community:
     dependency: "direct main"
     description:
@@ -492,10 +492,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "11.0.3"
   file_selector_linux:
     dependency: transitive
     description:
@@ -569,18 +569,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      sha256: "1de7849213b4c73c85aca7e0ac687a9a5d82ccdb594366b9dcc26cb6a2189cd2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.2"
   flutter_contacts:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: f668066af6cad0cc1d91719560edc1e552993dcafb12cb687ca8690b858b993d
+      sha256: "3a018a04ffc88f8555068f86b7750c7cbc758e9ebccafa985f91353bcb6df496"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.1"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -606,10 +606,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
+      sha256: "1447ba911c60f2ba3f25dae1af151ec187162566b0f57e37771bf0b400f013ad"
       url: "https://pub.dev"
     source: hosted
-    version: "22.0.1"
+    version: "22.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -622,10 +622,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
+      sha256: "43c3761d916c9bd3d5c7ebbc44d82f4990329840c0c5d62ad5260cc1b5d399bd"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "12.2.0"
   flutter_local_notifications_web:
     dependency: transitive
     description:
@@ -651,10 +651,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: "03b71c02806ff20c3718d108cbbb3638142ebafe368d8ce2dd22a33344bcb02b"
+      sha256: ce1debbb29cade61964334b2a19c7c76e5bb2ef7dacf126c6424ee44036232f8
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "8.3.1"
   flutter_map_marker_cluster:
     dependency: "direct main"
     description:
@@ -715,18 +715,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      sha256: "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_secure_storage_web:
     dependency: transitive
     description:
@@ -752,10 +752,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_web_auth_2
-      sha256: "8f9303471dcd96670878c9b7c0c4e14c37595b2add67465f6a868f17a5872dfc"
+      sha256: a7655829251ee63aae64a748f8512f36670d8eba4657b0055cdf5ef304a9d164
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.1.0"
   flutter_web_auth_2_platform_interface:
     dependency: "direct dev"
     description:
@@ -802,10 +802,10 @@ packages:
     dependency: "direct main"
     description:
       name: gal
-      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      sha256: f71e79840fe023a21f2f949771375444b6efcd34b9e625d5f4f5504971380a77
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   geoclue:
     dependency: transitive
     description:
@@ -818,34 +818,34 @@ packages:
     dependency: "direct main"
     description:
       name: geocoding
-      sha256: "606be036287842d779d7ec4e2f6c9435fc29bbbd3c6da6589710f981d8852895"
+      sha256: "40f845e0a5505d4b47da991057f2ab25cd1c68bc4570255c7d4cfbb03a952063"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   geocoding_android:
     dependency: transitive
     description:
       name: geocoding_android
-      sha256: ba810da90d6633cbb82bbab630e5b4a3b7d23503263c00ae7f1ef0316dcae5b9
+      sha256: "17e88a69bb0e1ae44597d70df2d2fbdb2f503672cf665421a16ab56ab97e4ead"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
-  geocoding_ios:
+    version: "5.1.0"
+  geocoding_darwin:
     dependency: transitive
     description:
-      name: geocoding_ios
-      sha256: "18ab1c8369e2b0dcb3a8ccc907319334f35ee8cf4cfef4d9c8e23b13c65cb825"
+      name: geocoding_darwin
+      sha256: ac9c85dc6fbb1afa6fea9be0c174a782132b19c01c0e44c4204d7fe8974ac96b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "1.0.2"
   geocoding_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: geocoding_platform_interface
-      sha256: "8c2c8226e5c276594c2e18bfe88b19110ed770aeb7c1ab50ede570be8b92229b"
+      sha256: "5164b8871705af7573698b3aa0746337faf818d72b488988741bcc7aeedd2f6e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "5.0.0"
   geolocator:
     dependency: "direct main"
     description:
@@ -914,10 +914,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
+      sha256: d7a3576cb312649eaa51f2356450aed686085fb58fcdebda5b359aa951eef7ea
       url: "https://pub.dev"
     source: hosted
-    version: "17.3.0"
+    version: "17.5.0"
   google_cloud:
     dependency: transitive
     description:
@@ -930,10 +930,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      sha256: e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -954,10 +954,10 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: df5c15533814ed20b7d9e1c5a40a73f174e5d5017bd2669b1c72fb6596fde812
+      sha256: "57782125965ca87b03d42a147d40b046f1fd6a09141a58913e1b86671a5ef22e"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.11"
+    version: "7.2.16"
   google_sign_in_ios:
     dependency: transitive
     description:
@@ -994,10 +994,10 @@ packages:
     dependency: "direct main"
     description:
       name: googleapis_auth
-      sha256: "1417d8846663df5e7b77ca56591c5edd442c66ffc9c01ab036e138a21a148e86"
+      sha256: ea53b290aaf1fdff615c8d79091b02c9150ff81c48f7f3b7460598c444f3c50a
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.3"
   graphs:
     dependency: transitive
     description:
@@ -1026,10 +1026,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   html:
     dependency: transitive
     description:
@@ -1074,18 +1074,18 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+17"
+    version: "0.8.13+19"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1159,18 +1159,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1242,14 +1250,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
-  lists:
-    dependency: transitive
-    description:
-      name: lists
-      sha256: "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   local_auth:
     dependency: "direct main"
     description:
@@ -1334,10 +1334,10 @@ packages:
     dependency: transitive
     description:
       name: mgrs_dart
-      sha256: fb89ae62f05fa0bb90f70c31fc870bcbcfd516c843fb554452ab3396f78586f7
+      sha256: "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   mime:
     dependency: transitive
     description:
@@ -1406,10 +1406,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.5.0"
   octo_image:
     dependency: transitive
     description:
@@ -1574,34 +1574,34 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      sha256: f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.10"
+    version: "9.6.1"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+5"
+    version: "0.1.4+1"
   permission_handler_platform_interface:
     dependency: "direct dev"
     description:
       name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   petitparser:
     dependency: transitive
     description:
@@ -1614,10 +1614,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: fb3bc8ea653370f88742b3baa304700107c83d12748aa58b2b9f2ed3ef15e6c2
+      sha256: "2d00a785b501bf1e5f6180bbef772846e767be11d45d11112b63092ef54a419e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.12.0"
   photo_view:
     dependency: "direct main"
     description:
@@ -1626,6 +1626,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.0"
+  pigeon:
+    dependency: transitive
+    description:
+      name: pigeon
+      sha256: "2a4bfd279fac52b115818e93f5409d07955f7b3718d303fd5f100981be4de386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "26.3.2"
   platform:
     dependency: transitive
     description:
@@ -1662,10 +1670,10 @@ packages:
     dependency: "direct main"
     description:
       name: printing
-      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      sha256: f6cd14c768c1352dd37a958a3ee351aa9ce305b398218d3acd86389d5f7ecad1
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.3"
+    version: "5.15.0"
   process:
     dependency: transitive
     description:
@@ -1678,10 +1686,10 @@ packages:
     dependency: transitive
     description:
       name: proj4dart
-      sha256: c8a659ac9b6864aa47c171e78d41bbe6f5e1d7bd790a5814249e6b68bc44324e
+      sha256: ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.0"
   provider:
     dependency: transitive
     description:
@@ -1734,10 +1742,10 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      sha256: "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "1.1.0"
   riverpod:
     dependency: "direct main"
     description:
@@ -1806,10 +1814,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.23"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1882,6 +1890,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1891,18 +1907,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.13"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1931,42 +1947,42 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   sqlcipher_flutter_libs:
     dependency: "direct main"
     description:
@@ -2064,10 +2080,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0+1"
+    version: "3.4.1+1"
   term_glyph:
     dependency: transitive
     description:
@@ -2104,10 +2120,10 @@ packages:
     dependency: "direct main"
     description:
       name: timezone
-      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -2120,10 +2136,10 @@ packages:
     dependency: transitive
     description:
       name: unicode
-      sha256: "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1"
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "1.1.9"
   universal_platform:
     dependency: transitive
     description:
@@ -2144,10 +2160,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.30"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -2200,10 +2216,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -2216,34 +2232,34 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      sha256: "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.14.0"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      sha256: e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.5"
+    version: "2.12.0"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
+      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.7"
+    version: "2.11.0"
   video_player_platform_interface:
     dependency: "direct dev"
     description:
       name: video_player_platform_interface
-      sha256: "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0"
+      sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.9.0"
   video_player_web:
     dependency: transitive
     description:
@@ -2344,34 +2360,50 @@ packages:
     dependency: "direct main"
     description:
       name: workmanager
-      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0+3"
+    version: "0.10.7"
   workmanager_android:
     dependency: transitive
     description:
       name: workmanager_android
-      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0+2"
+    version: "0.10.6"
   workmanager_apple:
     dependency: transitive
     description:
       name: workmanager_apple
-      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      sha256: "15558fb54415a010910c3529eaf8f61f94d23903dac620331895c472602d6f6e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1+2"
+    version: "0.9.10"
+  workmanager_linux:
+    dependency: transitive
+    description:
+      name: workmanager_linux
+      sha256: "7d8520e1103b910a43d8bafe37ec2415f4c7c148afcb1eee0ec73ae67b4cdd22"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
   workmanager_platform_interface:
     dependency: transitive
     description:
       name: workmanager_platform_interface
-      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      sha256: "378b392db15ee88cd878ab983d3a0b4b1e460cfbb0f096ff74fda2614b1ba172"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.1+1"
+    version: "0.10.4"
+  workmanager_web:
+    dependency: transitive
+    description:
+      name: workmanager_web
+      sha256: "2ac481ade599bdd957ee2891be09a0c34be87923a2c3ca4dfe36add6fc735ffd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   http: ^1.2.2
   # Network-type detection for media store transfer policies (Wi-Fi vs
   # cellular vs offline).
-  connectivity_plus: ^6.1.0
+  connectivity_plus: ^7.3.1
   # FFI for reading the Windows certificate store (TLS trust on Windows).
   ffi: ^2.1.0
 
@@ -89,7 +89,7 @@ dependencies:
   url_launcher: ^6.3.1
   flutter_contacts: ^2.0.2
   geolocator: ^14.0.2
-  geocoding: ^4.0.0
+  geocoding: ^5.0.0
   photo_manager: ^3.6.0
   native_exif: ^0.8.0
   # Pure-Dart decode/resize/JPEG-encode for media store thumbnails.
@@ -125,7 +125,7 @@ dependencies:
 
   # Notifications
   flutter_local_notifications: ^22.0.1
-  workmanager: ^0.9.0+3
+  workmanager: ^0.10.7
   timezone: ^0.11.0
   google_fonts: ^8.0.2
   linked_scroll_controller: ^0.2.0
@@ -153,6 +153,7 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.8
   path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests
   permission_handler_platform_interface: ^4.3.0  # mock BLE scan permission grants
+  geocoding_platform_interface: ^5.0.0  # fake geocoder in location service tests
   flutter_web_auth_2_platform_interface: ^5.0.0  # mock auth in redirect-capture test
   share_plus_platform_interface: ^6.1.0  # fake share sheet in media share tests
   video_player_platform_interface: ^6.7.0  # fake player in media viewer tests

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,23 +21,19 @@ dependencies:
   riverpod: ^3.1.0
 
   # Database
-  drift: ^2.30.0
-  sqlite3: ^2.9.4
-  # SQLCipher-enabled replacement for sqlite3_flutter_libs (same maintainer,
-  # same sqlite3 Dart API). One native lib serves both plaintext and encrypted
-  # databases; the codec only engages when PRAGMA key is set.
-  # Pinned to 0.6.x on purpose: 0.7.0+eol is an empty tombstone release that
-  # removes the native SQLCipher bundling entirely (same pattern as the old
-  # sqlite3_flutter_libs 0.6.0+eol, issue #433). It is only safe once we
-  # migrate to sqlite3 3.x (UPGRADING_TO_V3.md). Build-time note: Windows and
-  # Linux builds compile SQLCipher and need OpenSSL installed on the build
-  # machine (choco install openssl / apt install libssl-dev).
-  sqlcipher_flutter_libs: ">=0.6.8 <0.7.0"
+  drift: ^2.34.3
+  sqlite3: ^3.5.1
+  # SQLCipher now arrives through the sqlite3 build hook rather than a
+  # separate `sqlcipher_flutter_libs` dependency -- see the `hooks:` section
+  # at the bottom of this file. sqlite3 3.x dropped the DynamicLibrary loader
+  # (`package:sqlite3/open.dart`) that the old override needed, and both
+  # `sqlite3_flutter_libs` and `sqlcipher_flutter_libs` are tombstoned as a
+  # result (issue #433). One native lib still serves both plaintext and
+  # encrypted databases; the codec only engages when PRAGMA key is set.
   path_provider: ^2.1.5
   path: ^1.9.0
 
   # Serialization
-  freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
 
   # Navigation
@@ -145,8 +141,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_launcher_icons: ^0.14.4
   build_runner: ^2.10.4
-  drift_dev: ^2.30.0
-  freezed: ^3.2.3
+  drift_dev: ^2.34.0
   json_serializable: ^6.11.2
   riverpod_generator: ^4.0.0+1
   mockito: ^5.6.1
@@ -158,7 +153,7 @@ dev_dependencies:
   share_plus_platform_interface: ^6.1.0  # fake share sheet in media share tests
   video_player_platform_interface: ^6.7.0  # fake player in media viewer tests
   fake_async: ^1.3.3  # synthetic clock + Timer driving for unit tests
-  analyzer: ^9.0.0  # AST parsing for the provider change-tick architecture test
+  analyzer: ^12.0.0  # AST parsing for the provider change-tick architecture test
 
 dependency_overrides:
   # fit_tool (3 years unmaintained) has stale deps; overrides are safe because:
@@ -171,6 +166,19 @@ dependency_overrides:
   # platform channel threading requirement.
   auto_updater_windows:
     path: packages/auto_updater_windows
+
+# Selects the SQLCipher build of SQLite for `package:sqlite3`, replacing the
+# retired `sqlcipher_flutter_libs`. sqlite3 downloads prebuilt SQLCipher
+# libraries (verified against sha256 references baked into the package) for
+# every target, so no local OpenSSL toolchain is needed to build any more --
+# the SQLCipher binaries link OpenSSL on Windows, Linux and Android.
+#
+# Note: upstream warns the SQLCipher build may track a slightly older SQLite
+# version than the default `sqlite3` build.
+hooks:
+  user_defines:
+    sqlite3:
+      source: sqlcipher
 
 flutter:
   generate: true

--- a/test/core/database/background_database_connection_test.dart
+++ b/test/core/database/background_database_connection_test.dart
@@ -227,7 +227,7 @@ void main() {
     try {
       expect(reopened.select('SELECT id FROM t').single['id'], 1);
     } finally {
-      reopened.dispose();
+      reopened.close();
     }
 
     subscription.resume();
@@ -266,7 +266,7 @@ void main() {
     try {
       expect(reopened.select('SELECT id FROM t').single['id'], 7);
     } finally {
-      reopened.dispose();
+      reopened.close();
     }
   }, timeout: const Timeout(Duration(seconds: 60)));
 }

--- a/test/core/database/dive_dive_types_migration_test.dart
+++ b/test/core/database/dive_dive_types_migration_test.dart
@@ -31,7 +31,7 @@ void main() {
       // ids are unique and non-empty
       final ids = db.select('SELECT id FROM dive_dive_types');
       expect(ids.map((r) => r['id']).toSet().length, 3);
-      db.dispose();
+      db.close();
     },
   );
 

--- a/test/core/database/migration_v124_equipment_attributes_test.dart
+++ b/test/core/database/migration_v124_equipment_attributes_test.dart
@@ -124,7 +124,7 @@ void main() {
         "INSERT INTO equipment (id, name, type, size, created_at, updated_at) "
         "VALUES ('eq1', 'Suit', 'wetsuit', 'L', 1000, 2000)",
       );
-      raw.dispose();
+      raw.close();
 
       // First open runs the v124 migration and copies size -> attribute row.
       final db1 = AppDatabase(NativeDatabase(File(path)));

--- a/test/core/database/migration_v93_dive_types_seed_test.dart
+++ b/test/core/database/migration_v93_dive_types_seed_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(custom.length, 1);
     expect(custom.first['name'], 'Reef Cleanup');
 
-    db.dispose();
+    db.close();
   });
 
   test('v93 is in the migration ladder', () {

--- a/test/core/database/pre_migration_backup_integration_test.dart
+++ b/test/core/database/pre_migration_backup_integration_test.dart
@@ -24,7 +24,7 @@ void main() {
       seed.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
       seed.execute('INSERT INTO sentinel VALUES (42)');
     } finally {
-      seed.dispose();
+      seed.close();
     }
 
     SharedPreferences.setMockInitialValues({});
@@ -61,7 +61,7 @@ void main() {
       expect(verify.select('PRAGMA user_version').first.values.first, 63);
       expect(verify.select('SELECT id FROM sentinel').first.values.first, 42);
     } finally {
-      verify.dispose();
+      verify.close();
     }
 
     // Assert the BackupRecord is in the registry with the right shape.

--- a/test/core/database/sqlcipher_defaults_test.dart
+++ b/test/core/database/sqlcipher_defaults_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+import 'package:submersion/core/database/sqlcipher_setup.dart';
+
+void main() {
+  // Databases in the field were encrypted by sqlcipher_flutter_libs 0.6.8,
+  // which bundled SQLCipher 4.10.0; the sqlite3 build hook now supplies
+  // 4.17.0. A file only opens under a different SQLCipher build when the
+  // on-disk parameters match, so pin the ones that define the format.
+  //
+  // The app keys connections with a RAW key (`PRAGMA key = "x'<64 hex>'"`,
+  // see cipherKeyPragma), which bypasses the KDF, so kdf_iter is not part of
+  // the on-disk compatibility surface -- page size, HMAC and cipher are.
+  test('SQLCipher 4 on-disk defaults are unchanged', () {
+    final db = sqlite3.openInMemory();
+    addTearDown(db.close);
+
+    // SQLCipher reports its cipher settings only on a keyed connection, so key
+    // this one exactly the way the app does -- with a raw 32-byte key.
+    db.execute(cipherKeyPragma('ab' * 32));
+
+    String pragma(String name) =>
+        db.select('PRAGMA $name').first.values.first.toString();
+
+    expect(pragma('cipher_page_size'), '4096');
+    expect(pragma('cipher_hmac_algorithm'), 'HMAC_SHA512');
+    expect(pragma('cipher_kdf_algorithm'), 'PBKDF2_HMAC_SHA512');
+    expect(
+      pragma('cipher_version'),
+      startsWith('4.'),
+      reason: 'a SQLCipher 3.x build could not read 4.x databases at all',
+    );
+  });
+}

--- a/test/core/database/sqlcipher_setup_test.dart
+++ b/test/core/database/sqlcipher_setup_test.dart
@@ -1,13 +1,28 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 import 'package:submersion/core/database/sqlcipher_setup.dart';
 
 void main() {
-  test('setupSqlcipher is callable and idempotent on the host', () {
-    // On the host (not Android) this must be a no-op that never throws,
-    // and calling it twice must be safe (per-isolate re-entry happens on
-    // every background open).
-    expect(setupSqlcipher, returnsNormally);
-    expect(setupSqlcipher, returnsNormally);
+  test('the linked sqlite3 is a SQLCipher build', () {
+    // SQLCipher selection moved from a runtime, per-isolate loader override
+    // to the sqlite3 build hook (`hooks: user_defines: sqlite3: source:
+    // sqlcipher`). That makes it a build-time property with no Dart call site
+    // to assert on, so assert the observable consequence instead: only a
+    // SQLCipher build answers `PRAGMA cipher_version`.
+    //
+    // Guards the failure mode the hook config introduces -- silently building
+    // against vanilla SQLite, where every encrypted database would fail to
+    // open at runtime.
+    final db = sqlite3.openInMemory();
+    addTearDown(db.close);
+
+    expect(db.select('PRAGMA cipher_version'), isNotEmpty);
+  });
+
+  test('cipherKeyPragma formats a raw 32-byte key as SQLCipher hex', () {
+    final keyHex = 'ab' * 32;
+
+    expect(cipherKeyPragma(keyHex), 'PRAGMA key = "x\'$keyHex\'"');
   });
 }

--- a/test/core/presentation/pages/startup_page_test.dart
+++ b/test/core/presentation/pages/startup_page_test.dart
@@ -1341,8 +1341,8 @@ void main() {
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
               throw sqlite3.SqliteException(
-                776,
-                'attempt to write a readonly database',
+                extendedResultCode: 776,
+                message: 'attempt to write a readonly database',
               );
             },
           ),
@@ -1378,7 +1378,10 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
-              throw sqlite3.SqliteException(776, 'readonly');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 776,
+                message: 'readonly',
+              );
             },
           ),
         );
@@ -1402,7 +1405,10 @@ void main() {
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
               // SQLITE_BUSY — primary code 5; not in the READONLY family.
-              throw sqlite3.SqliteException(5, 'database is locked');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 5,
+                message: 'database is locked',
+              );
             },
           ),
         );
@@ -1428,7 +1434,10 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
-              throw sqlite3.SqliteException(776, 'readonly');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 776,
+                message: 'readonly',
+              );
             },
             closeAppOverride: () => closeCalled++,
           ),
@@ -1467,7 +1476,10 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
-              throw sqlite3.SqliteException(776, 'readonly');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 776,
+                message: 'readonly',
+              );
             },
           ),
         );
@@ -1511,7 +1523,10 @@ void main() {
             schemaVersionProbeOverride: (_) =>
                 (needsMigration: false, totalSteps: 0),
             initializerOverride: (_) async {
-              throw sqlite3.SqliteException(776, 'readonly');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 776,
+                message: 'readonly',
+              );
             },
           ),
         );
@@ -1558,7 +1573,10 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
           initializerOverride: (_) async {
-            throw sqlite3.SqliteException(776, 'readonly');
+            throw sqlite3.SqliteException(
+              extendedResultCode: 776,
+              message: 'readonly',
+            );
           },
         ),
       );
@@ -1602,7 +1620,10 @@ void main() {
           schemaVersionProbeOverride: (_) =>
               (needsMigration: false, totalSteps: 0),
           initializerOverride: (_) async {
-            throw sqlite3.SqliteException(776, 'readonly');
+            throw sqlite3.SqliteException(
+              extendedResultCode: 776,
+              message: 'readonly',
+            );
           },
           closeAppOverride: () => closeCalled++,
         ),
@@ -1640,7 +1661,10 @@ void main() {
           initializerOverride: (_) async {
             calls++;
             if (calls == 1) {
-              throw sqlite3.SqliteException(776, 'readonly');
+              throw sqlite3.SqliteException(
+                extendedResultCode: 776,
+                message: 'readonly',
+              );
             }
             await Completer<void>().future;
           },

--- a/test/core/providers/ref_invalidate_on_change_test.dart
+++ b/test/core/providers/ref_invalidate_on_change_test.dart
@@ -4,19 +4,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/ref_invalidate_on_change.dart';
 
-/// Reproduction + regression for the Riverpod 3 auto-pause assertion:
+/// Regression cover for the Riverpod 3 auto-pause assertion:
 ///
 ///   Expected pausedActiveSubscriptionCount to be 3, but was 4.
 ///
 /// A `FutureProvider` that self-invalidates from a raw change-stream
-/// (`stream.listen((_) => ref.invalidateSelf())`) keeps firing while the
-/// provider is paused (its widgets are off-screen via `TickerMode`). The
-/// deferred invalidation flushes during the next TickerMode *resume*, cascading
-/// a re-entrant pause/invalidate through the provider's `ref.watch` dependents
+/// (`stream.listen((_) => ref.invalidateSelf())`) kept firing while the
+/// provider was paused (its widgets off-screen via `TickerMode`). The deferred
+/// invalidation flushed during the next TickerMode *resume*, cascading a
+/// re-entrant pause/invalidate through the provider's `ref.watch` dependents
 /// and tripping Riverpod's internal pause-state accounting.
 ///
-/// The raw pattern reproduces the crash; [Ref.invalidateSelfWhen] (which defers
-/// the catch-up invalidation past the pause) must not.
+/// Riverpod 3.3.2 fixed that accounting, so the raw pattern is clean again and
+/// the first test now asserts the absence of the error rather than its
+/// presence. [Ref.invalidateSelfWhen] stays the app-wide pattern regardless:
+/// it is broadcast-safe (it defers instead of pausing, so a tick arriving
+/// while off-screen is never dropped), which is a separate guarantee from the
+/// assertion this file started out documenting.
 void main() {
   /// Drives [body] in its own error-capturing zone so the assertion that
   /// Riverpod reports through `runBinaryGuarded` -> `Zone.handleUncaughtError`
@@ -94,19 +98,20 @@ void main() {
   }
 
   test(
-    'raw stream.listen((_) => ref.invalidateSelf()) trips the pause assertion '
-    'on resume (reproduction)',
+    'raw stream.listen((_) => ref.invalidateSelf()) no longer trips the pause '
+    'assertion (fixed upstream in riverpod 3.3.2)',
     () async {
       final errors = await runPauseResume((ref, changes) {
         final sub = changes.listen((_) => ref.invalidateSelf());
         ref.onDispose(sub.cancel);
       });
-      // Documents the bug: the raw pattern reports the pause-state assertion.
-      expect(errors, isNotEmpty);
-      expect(
-        errors.first.toString(),
-        contains('pausedActiveSubscriptionCount'),
-      );
+      // Was a reproduction: under riverpod 3.2.1 this reported
+      // "Expected pausedActiveSubscriptionCount to be N, but was N+1".
+      // Riverpod 3.3.2 fixed the pause-state accounting, so the raw pattern
+      // is clean again. Kept as a guard: if a future riverpod regresses this,
+      // the ~40 invalidateSelfWhen call sites are what stands between the app
+      // and the crash, and this test says so out loud.
+      expect(errors, isEmpty);
     },
   );
 

--- a/test/core/services/background_service_backup_test.dart
+++ b/test/core/services/background_service_backup_test.dart
@@ -62,7 +62,21 @@ class _UploadFailingCloud extends FakeCloudStorageProvider {
 /// One recorded call to the notification seam.
 typedef _Notification = ({bool success, String? error, bool cloudCopyMissing});
 
+/// Per-file temp root, so the backup service's fixed `Submersion/Backups`
+/// subtree does not collide with the other suites that mock path_provider the
+/// same way. `flutter test` runs files in parallel isolates against one real
+/// $TMPDIR, so sharing it let one suite truncate or encrypt another's artifact
+/// mid-assert.
+final _isolatedTempDir = Directory.systemTemp.createTempSync(
+  'bg_svc_backup_test_',
+);
+
 void main() {
+  tearDownAll(() {
+    if (_isolatedTempDir.existsSync()) {
+      _isolatedTempDir.deleteSync(recursive: true);
+    }
+  });
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
@@ -72,7 +86,7 @@ void main() {
           (MethodCall methodCall) async {
             if (methodCall.method == 'getTemporaryDirectory' ||
                 methodCall.method == 'getApplicationDocumentsDirectory') {
-              return Directory.systemTemp.path;
+              return _isolatedTempDir.path;
             }
             return null;
           },

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -101,7 +101,7 @@ void main() {
     raw.execute(
       'PRAGMA user_version = ${AppDatabase.currentSchemaVersion - 1}',
     );
-    raw.dispose();
+    raw.close();
 
     await DatabaseService.instance.initialize(
       locationService: _FakeLocation(dbPath),
@@ -132,7 +132,7 @@ void main() {
       raw.execute(
         'PRAGMA user_version = ${AppDatabase.currentSchemaVersion + 1}',
       );
-      raw.dispose();
+      raw.close();
 
       await expectLater(
         DatabaseService.instance.initialize(
@@ -215,7 +215,7 @@ void main() {
     await seed.close();
     final raw = sqlite3.sqlite3.open(dbPath);
     raw.execute('PRAGMA user_version = 58');
-    raw.dispose();
+    raw.close();
 
     await expectLater(
       DatabaseService.instance.initialize(

--- a/test/core/services/database_service_key_test.dart
+++ b/test/core/services/database_service_key_test.dart
@@ -21,7 +21,7 @@ void main() {
       final path = '${tmp.path}/plain.db';
       final db = DatabaseService.openRaw(path, mode: OpenMode.readWriteCreate);
       db.execute('PRAGMA user_version = 42');
-      db.dispose();
+      db.close();
       expect(DatabaseService.getStoredSchemaVersion(path), 42);
     },
   );

--- a/test/core/services/database_service_schema_version_test.dart
+++ b/test/core/services/database_service_schema_version_test.dart
@@ -28,7 +28,7 @@ void main() {
       final path = p.join(tempDir.path, 'fresh.db');
       final db = sqlite3.sqlite3.open(path);
       db.execute('CREATE TABLE dummy (id INTEGER)');
-      db.dispose();
+      db.close();
 
       final version = DatabaseService.getStoredSchemaVersion(path);
       expect(version, 0);
@@ -38,7 +38,7 @@ void main() {
       final path = p.join(tempDir.path, 'versioned.db');
       final db = sqlite3.sqlite3.open(path);
       db.execute('PRAGMA user_version = 42');
-      db.dispose();
+      db.close();
 
       final version = DatabaseService.getStoredSchemaVersion(path);
       expect(version, 42);
@@ -67,7 +67,7 @@ void main() {
       db.execute('PRAGMA user_version = 69');
       db.execute('CREATE TABLE t (id INTEGER)');
       db.execute('INSERT INTO t VALUES (1), (2), (3)');
-      db.dispose();
+      db.close();
 
       expect(DatabaseService.recoverHotJournal(path), isTrue);
     });
@@ -76,7 +76,7 @@ void main() {
       final path = p.join(tempDir.path, 'readable.db');
       final db = sqlite3.sqlite3.open(path);
       db.execute('PRAGMA user_version = 42');
-      db.dispose();
+      db.close();
 
       DatabaseService.recoverHotJournal(path);
 
@@ -86,22 +86,34 @@ void main() {
 
   group('DatabaseService.isRecoverableReadonlyError', () {
     test('true for SQLITE_READONLY primary code', () {
-      final e = sqlite3.SqliteException(8, 'attempt to write a readonly db');
+      final e = sqlite3.SqliteException(
+        extendedResultCode: 8,
+        message: 'attempt to write a readonly db',
+      );
       expect(DatabaseService.isRecoverableReadonlyError(e), isTrue);
     });
 
     test('true for SQLITE_READONLY_ROLLBACK extended code 776', () {
-      final e = sqlite3.SqliteException(776, 'attempt to write a readonly db');
+      final e = sqlite3.SqliteException(
+        extendedResultCode: 776,
+        message: 'attempt to write a readonly db',
+      );
       expect(DatabaseService.isRecoverableReadonlyError(e), isTrue);
     });
 
     test('true for SQLITE_READONLY_DIRECTORY extended code 1544', () {
-      final e = sqlite3.SqliteException(1544, 'readonly directory');
+      final e = sqlite3.SqliteException(
+        extendedResultCode: 1544,
+        message: 'readonly directory',
+      );
       expect(DatabaseService.isRecoverableReadonlyError(e), isTrue);
     });
 
     test('false for unrelated SQLite errors (e.g. SQLITE_BUSY)', () {
-      final e = sqlite3.SqliteException(5, 'database is locked');
+      final e = sqlite3.SqliteException(
+        extendedResultCode: 5,
+        message: 'database is locked',
+      );
       expect(DatabaseService.isRecoverableReadonlyError(e), isFalse);
     });
 

--- a/test/core/services/location_service_test.dart
+++ b/test/core/services/location_service_test.dart
@@ -1,10 +1,14 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:ui' show Locale;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geocoding/geocoding.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+// `geocoding` declares its own app-facing `Geocoding`, which shadows the
+// platform-interface class of the same name that fakes must extend.
+import 'package:geocoding_platform_interface/geocoding_platform_interface.dart'
+    as gpi;
 import 'package:submersion/core/services/location_service.dart';
 
 /// One canned HTTP exchange plus a record of what the service actually sent.
@@ -458,19 +462,17 @@ void main() {
     );
   });
 
-  group('native geocoder locale pin (#214)', () {
+  group('native geocoder locale (#214)', () {
     setUp(() {
       LocationService.debugForceNativeGeocoder = true;
-      LocationService.debugResetGeocoderLocalePin();
     });
 
     tearDown(() {
       LocationService.debugForceNativeGeocoder = false;
-      LocationService.debugResetGeocoderLocalePin();
     });
 
-    test('pins the geocoder to English before the first lookup', () async {
-      final platform = _FakeGeocodingPlatform(
+    test('asks the geocoder for English results', () async {
+      final geocoding = _FakeGeocoding(
         placemarks: const [
           Placemark(
             country: 'Spain',
@@ -479,22 +481,21 @@ void main() {
           ),
         ],
       );
-      GeocodingPlatform.instance = platform;
+      GeocodingPlatformFactory.instance = _FakeGeocodingFactory(geocoding);
 
       final result = await service.reverseGeocode(36.0143, -5.6044);
 
-      expect(platform.localeIdentifiers, ['en']);
+      expect(geocoding.locales, [const Locale('en')]);
       expect(result.country, 'Spain');
       expect(result.region, 'Andalusia');
       expect(result.locality, 'Tarifa');
     });
 
-    test('concurrent lookups share a single pin call', () async {
-      final platform = _FakeGeocodingPlatform(
+    test('every lookup carries the English locale', () async {
+      final geocoding = _FakeGeocoding(
         placemarks: const [Placemark(country: 'Spain')],
-        localeDelay: const Duration(milliseconds: 20),
       );
-      GeocodingPlatform.instance = platform;
+      GeocodingPlatformFactory.instance = _FakeGeocodingFactory(geocoding);
 
       await Future.wait([
         service.reverseGeocode(36.0, -5.6),
@@ -503,20 +504,20 @@ void main() {
       ]);
 
       expect(
-        platform.localeIdentifiers,
-        ['en'],
+        geocoding.locales,
+        [const Locale('en'), const Locale('en'), const Locale('en')],
         reason:
-            'the memo holds the in-flight future, so callers that arrive '
-            'before it completes must not each issue their own pin',
+            'geocoding 5 resolves the locale per call, so unlike the old '
+            'pin-once memo no later caller can inherit an unpinned geocoder',
       );
     });
 
-    test('a failed pin is retried by the next lookup', () async {
-      final platform = _FakeGeocodingPlatform(
+    test('a failing native lookup falls back to the web geocoder', () async {
+      final geocoding = _FakeGeocoding(
         placemarks: const [Placemark(country: 'Spain')],
-        failLocaleOnce: true,
+        failOnce: true,
       );
-      GeocodingPlatform.instance = platform;
+      GeocodingPlatformFactory.instance = _FakeGeocodingFactory(geocoding);
 
       // The first attempt throws inside the native branch; the service falls
       // through to the web fallback rather than surfacing the failure.
@@ -524,48 +525,55 @@ void main() {
         body: '{"address": {"country": "Fallback"}}',
       );
       final first = await server.run(() => service.reverseGeocode(36.0, -5.6));
-      expect(first.country, 'Fallback', reason: 'a failed pin is non-fatal');
+      expect(
+        first.country,
+        'Fallback',
+        reason: 'a native geocoder failure is non-fatal',
+      );
 
       final second = await service.reverseGeocode(36.0, -5.6);
 
-      expect(platform.localeIdentifiers, [
-        'en',
-        'en',
-      ], reason: 'clearing the memo on failure lets a later call retry');
-      expect(second.country, 'Spain');
+      expect(
+        second.country,
+        'Spain',
+        reason: 'a later lookup retries the native geocoder',
+      );
+      expect(geocoding.locales, [const Locale('en'), const Locale('en')]);
     });
   });
 }
 
-/// Minimal [GeocodingPlatform] that records the locales it was pinned to.
-class _FakeGeocodingPlatform extends GeocodingPlatform
-    with MockPlatformInterfaceMixin {
-  _FakeGeocodingPlatform({
-    required this.placemarks,
-    this.localeDelay = Duration.zero,
-    this.failLocaleOnce = false,
-  });
+/// Minimal [GeocodingPlatformFactory] handing out one fake [gpi.Geocoding].
+class _FakeGeocodingFactory extends GeocodingPlatformFactory {
+  _FakeGeocodingFactory(this.geocoding);
 
-  final List<Placemark> placemarks;
-  final Duration localeDelay;
-  bool failLocaleOnce;
-
-  final List<String> localeIdentifiers = <String>[];
+  final _FakeGeocoding geocoding;
 
   @override
-  Future<void> setLocaleIdentifier(String localeIdentifier) async {
-    localeIdentifiers.add(localeIdentifier);
-    if (localeDelay > Duration.zero) await Future<void>.delayed(localeDelay);
-    if (failLocaleOnce) {
-      failLocaleOnce = false;
-      throw StateError('geocoder unavailable');
-    }
-  }
+  gpi.Geocoding createGeocoding(GeocodingCreationParams params) => geocoding;
+}
+
+/// Minimal geocoder that records the locale each lookup asked for.
+class _FakeGeocoding extends gpi.Geocoding {
+  _FakeGeocoding({required this.placemarks, this.failOnce = false})
+    : super.implementation(const GeocodingCreationParams());
+
+  final List<Placemark> placemarks;
+  bool failOnce;
+
+  final List<Locale?> locales = <Locale?>[];
 
   @override
   Future<List<Placemark>> placemarkFromCoordinates(
     double latitude,
     double longitude, {
-    String? localeIdentifier,
-  }) async => placemarks;
+    Locale? locale,
+  }) async {
+    locales.add(locale);
+    if (failOnce) {
+      failOnce = false;
+      throw StateError('geocoder unavailable');
+    }
+    return placemarks;
+  }
 }

--- a/test/core/services/media_store/network_status_service_test.dart
+++ b/test/core/services/media_store/network_status_service_test.dart
@@ -29,4 +29,22 @@ void main() {
     );
     expect(NetworkStatusService.kindFrom(const []), NetworkKind.offline);
   });
+
+  test('kindFrom treats satellite as metered, not offline', () {
+    // connectivity_plus 7 added ConnectivityResult.satellite. The old
+    // "anything unrecognised is offline" fallback would have reported a
+    // working satellite link as no link at all, blocking transfers outright.
+    expect(
+      NetworkStatusService.kindFrom([ConnectivityResult.satellite]),
+      NetworkKind.cellular,
+    );
+    expect(
+      NetworkStatusService.kindFrom([
+        ConnectivityResult.satellite,
+        ConnectivityResult.wifi,
+      ]),
+      NetworkKind.unmetered,
+      reason: 'an unmetered transport still wins when both are present',
+    );
+  });
 }

--- a/test/features/backup/data/services/backup_encryption_backup_test.dart
+++ b/test/features/backup/data/services/backup_encryption_backup_test.dart
@@ -44,7 +44,21 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
       throw UnimplementedError('Fake database does not support queries');
 }
 
+/// Per-file temp root, so the backup service's fixed `Submersion/Backups`
+/// subtree does not collide with the other suites that mock path_provider the
+/// same way. `flutter test` runs files in parallel isolates against one real
+/// $TMPDIR, so sharing it let one suite truncate or encrypt another's artifact
+/// mid-assert.
+final _isolatedTempDir = Directory.systemTemp.createTempSync(
+  'backup_enc_bkup_test_',
+);
+
 void main() {
+  tearDownAll(() {
+    if (_isolatedTempDir.existsSync()) {
+      _isolatedTempDir.deleteSync(recursive: true);
+    }
+  });
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
@@ -53,10 +67,10 @@ void main() {
           const MethodChannel('plugins.flutter.io/path_provider'),
           (MethodCall methodCall) async {
             if (methodCall.method == 'getTemporaryDirectory') {
-              return Directory.systemTemp.path;
+              return _isolatedTempDir.path;
             }
             if (methodCall.method == 'getApplicationDocumentsDirectory') {
-              return Directory.systemTemp.path;
+              return _isolatedTempDir.path;
             }
             return null;
           },

--- a/test/features/backup/data/services/backup_service_encryption_test.dart
+++ b/test/features/backup/data/services/backup_service_encryption_test.dart
@@ -43,7 +43,21 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
       throw UnimplementedError('Fake database does not support queries');
 }
 
+/// Per-file temp root, so the backup service's fixed `Submersion/Backups`
+/// subtree does not collide with the other suites that mock path_provider the
+/// same way. `flutter test` runs files in parallel isolates against one real
+/// $TMPDIR, so sharing it let one suite truncate or encrypt another's artifact
+/// mid-assert.
+final _isolatedTempDir = Directory.systemTemp.createTempSync(
+  'backup_enc_test_',
+);
+
 void main() {
+  tearDownAll(() {
+    if (_isolatedTempDir.existsSync()) {
+      _isolatedTempDir.deleteSync(recursive: true);
+    }
+  });
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
@@ -52,10 +66,10 @@ void main() {
           const MethodChannel('plugins.flutter.io/path_provider'),
           (MethodCall methodCall) async {
             if (methodCall.method == 'getTemporaryDirectory') {
-              return Directory.systemTemp.path;
+              return _isolatedTempDir.path;
             }
             if (methodCall.method == 'getApplicationDocumentsDirectory') {
-              return Directory.systemTemp.path;
+              return _isolatedTempDir.path;
             }
             return null;
           },

--- a/test/features/backup/data/services/backup_service_replace_test.dart
+++ b/test/features/backup/data/services/backup_service_replace_test.dart
@@ -216,7 +216,7 @@ void main() {
       final db = sqlite3.sqlite3.open(dbFile.path);
       db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
       db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
-      db.dispose();
+      db.close();
       final record = BackupRecord(
         id: 'r3',
         filename: 'valid_replace.db',
@@ -259,7 +259,7 @@ void main() {
       final db = sqlite3.sqlite3.open(dbFile.path);
       db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
       db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
-      db.dispose();
+      db.close();
       final record = BackupRecord(
         id: 'r2',
         filename: 'valid.db',
@@ -291,7 +291,7 @@ void main() {
       final db = sqlite3.sqlite3.open(dbFile.path);
       db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
       db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
-      db.dispose();
+      db.close();
 
       final cloud = FakeCloudStorageProvider();
       final upload = await cloud.uploadFile(

--- a/test/features/backup/data/services/backup_service_saf_io_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_io_test.dart
@@ -96,7 +96,7 @@ String _validDb(String dir, String name) {
   final db = sqlite3.sqlite3.open(path);
   db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
   db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
-  db.dispose();
+  db.close();
   return path;
 }
 

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -702,7 +702,7 @@ void main() {
         final db = sqlite3.sqlite3.open(dbFile.path);
         db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
         db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
-        db.dispose();
+        db.close();
 
         final service = BackupService(
           dbAdapter: fakeDb,
@@ -734,7 +734,7 @@ void main() {
             'CREATE TABLE dive_sites (id TEXT PRIMARY KEY, name TEXT)',
           );
           db.execute('PRAGMA user_version = 20');
-          db.dispose();
+          db.close();
 
           final service = BackupService(
             dbAdapter: fakeDb,
@@ -758,7 +758,7 @@ void main() {
                   .toList();
               expect(columnNames, isNot(contains('wearable_source')));
             } finally {
-              verifyDb.dispose();
+              verifyDb.close();
             }
           } finally {
             await tempDir.delete(recursive: true);
@@ -793,7 +793,7 @@ void main() {
 
           final db = sqlite3.sqlite3.open(dbFile.path);
           db.execute('CREATE TABLE some_other_table (id TEXT PRIMARY KEY)');
-          db.dispose();
+          db.close();
 
           final service = BackupService(
             dbAdapter: fakeDb,

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -222,7 +222,21 @@ class FakeCloudStorageProvider implements CloudStorageProvider {
 // Tests
 // =============================================================================
 
+/// Per-file temp root, so the backup service's fixed `Submersion/Backups`
+/// subtree does not collide with the other suites that mock path_provider the
+/// same way. `flutter test` runs files in parallel isolates against one real
+/// $TMPDIR, so sharing it let one suite truncate or encrypt another's artifact
+/// mid-assert.
+final _isolatedTempDir = Directory.systemTemp.createTempSync(
+  'backup_svc_test_',
+);
+
 void main() {
+  tearDownAll(() {
+    if (_isolatedTempDir.existsSync()) {
+      _isolatedTempDir.deleteSync(recursive: true);
+    }
+  });
   group('BackupService', () {
     late BackupPreferences preferences;
     late FakeCloudStorageProvider fakeCloud;
@@ -235,10 +249,10 @@ void main() {
             const MethodChannel('plugins.flutter.io/path_provider'),
             (MethodCall methodCall) async {
               if (methodCall.method == 'getTemporaryDirectory') {
-                return Directory.systemTemp.path;
+                return _isolatedTempDir.path;
               }
               if (methodCall.method == 'getApplicationDocumentsDirectory') {
-                return Directory.systemTemp.path;
+                return _isolatedTempDir.path;
               }
               return null;
             },

--- a/test/features/backup/data/services/pre_migration_dead_location_test.dart
+++ b/test/features/backup/data/services/pre_migration_dead_location_test.dart
@@ -67,7 +67,7 @@ void main() {
         seed.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
         seed.execute('INSERT INTO sentinel VALUES (42)');
       } finally {
-        seed.dispose();
+        seed.close();
       }
 
       // Stand-in for the fabricated Drive path: nesting under a regular file

--- a/test/features/universal_import/data/parsers/macdive_sqlite_parser_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_sqlite_parser_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       final db = sqlite3.sqlite3.open(tmp.path);
       db.execute('CREATE TABLE foo (id INTEGER PRIMARY KEY);');
-      db.dispose();
+      db.close();
 
       final otherBytes = Uint8List.fromList(await tmp.readAsBytes());
       final payload = await const MacDiveSqliteParser().parse(otherBytes);

--- a/test/features/universal_import/data/services/macdive_db_reader_test.dart
+++ b/test/features/universal_import/data/services/macdive_db_reader_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       final db = sqlite3.sqlite3.open(tmp.path);
       db.execute('CREATE TABLE foo (id INTEGER PRIMARY KEY);');
-      db.dispose();
+      db.close();
 
       final otherBytes = Uint8List.fromList(await tmp.readAsBytes());
       expect(await MacDiveDbReader.isMacDiveDb(otherBytes), isFalse);

--- a/test/features/universal_import/data/services/shearwater_test_helpers.dart
+++ b/test/features/universal_import/data/services/shearwater_test_helpers.dart
@@ -143,7 +143,7 @@ Uint8List createShearwaterTestDb({
       }
     }
   } finally {
-    db.dispose();
+    db.close();
   }
 
   final bytes = File(tempPath).readAsBytesSync();

--- a/test/features/universal_import/presentation/providers/universal_import_notifier_test.dart
+++ b/test/features/universal_import/presentation/providers/universal_import_notifier_test.dart
@@ -1158,7 +1158,7 @@ void main() {
           try {
             db.execute('CREATE TABLE dive_details (DiveId INTEGER)');
             db.execute('CREATE TABLE log_data (DiveId INTEGER)');
-            db.dispose();
+            db.close();
 
             final bytes = await File(dbPath).readAsBytes();
             final result = await notifier.loadFileFromBytes(

--- a/test/fixtures/macdive_sqlite/build_synthetic_db.dart
+++ b/test/fixtures/macdive_sqlite/build_synthetic_db.dart
@@ -35,7 +35,7 @@ File buildSyntheticMacDiveDb(String path) {
     _createSchema(db);
     _insertFixtureRows(db);
   } finally {
-    db.dispose();
+    db.close();
   }
   return f;
 }

--- a/tools/db_bench.dart
+++ b/tools/db_bench.dart
@@ -51,7 +51,7 @@ void main(List<String> args) {
         exit(64);
     }
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -20,7 +20,6 @@
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
-#include <sqlcipher_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <submersion_ocr/submersion_ocr_plugin_c_api.h>
 #include <submersion_transcoder/submersion_transcoder_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -55,8 +54,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PrintingPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   SubmersionOcrPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SubmersionOcrPluginCApi"));
   SubmersionTranscoderPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -17,7 +17,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   permission_handler_windows
   printing
   share_plus
-  sqlcipher_flutter_libs
   submersion_ocr
   submersion_transcoder
   url_launcher_windows


### PR DESCRIPTION
Three commits, meant to be reviewed separately: the first is routine, the second is not, the third is unrelated test hygiene that the second one flushed out.

## 1. `chore(deps)`: 63 packages, geocoding 5.x

60 packages refreshed lockfile-only, plus three contained majors: `workmanager` 0.9 to 0.10, `geocoding` 4 to 5, `connectivity_plus` 6 to 7.

Two behaviour bugs were found and fixed rather than shipped:

- **geocoding 5.0.0's `Geocoding({locale})` constructor accepts a locale and never forwards it to the field.** Pinning through the constructor, which is what its own migration guide documents, is a silent no-op that would have brought back #214 (country names in the device locale: "Spanien" on German phones, "Espana" on Spanish ones, for the same place). The per-call `locale:` parameter is used instead. The tests assert the locale the geocoder actually received, so a dropped argument fails loudly; verified by mutation (removing the argument fails all three with `Actual: [null]`).
- **`connectivity_plus` 7 adds `ConnectivityResult.satellite`,** and `NetworkStatusService` classified anything unrecognised as `offline`. A working satellite link would have read as no link at all and blocked media transfers outright, which is a plausible situation on a liveaboard. Satellite is metered, so it now maps to `cellular`; an unmetered transport still wins when both are present.

`connectivity_plus` documents an AGP 8.12.1 requirement. That governs building its own repo, not consumers (Flutter's plugin loader applies the root project's AGP to plugin modules), so the deliberate AGP 8.11.1 pin in `settings.gradle.kts` is untouched. Confirmed with a real Android build.

## 2. `feat(db)`: sqlite3 3.x, SQLCipher via build hook

| | from | to |
| --- | --- | --- |
| `sqlite3` | 2.9.4 | 3.5.1 |
| `drift` / `drift_dev` | 2.31.0 | 2.34.3 / 2.34.0 |
| `analyzer` | 9.0.0 | 12.1.0 |
| `riverpod` | 3.2.1 | 3.3.2 |
| `json_serializable` | 6.13.2 | 6.14.1 |
| `sqlcipher_flutter_libs`, `freezed`, `freezed_annotation` | | removed |

### What was actually blocking this

`freezed` and `freezed_annotation` were declared but used by nothing: no `@freezed`, no import, no `*.freezed.dart` anywhere. Stable `freezed` caps `analyzer` below 11, and `riverpod_generator` has no release accepting analyzer 10 or 11, so analyzer was stuck at 9. `drift_dev` below 2.32 pins `sqlite3 ^2.4.6`, which made sqlite3 3.x unreachable, which in turn kept `sqlcipher_flutter_libs` pinned.

Deleting two unused pubspec lines let `analyzer ^12` in and the rest followed, with no new prereleases. (`analyzer ^13` is still blocked, by `pigeon`, via geocoding 5's `geocoding_darwin`.)

### How SQLCipher arrives now

sqlite3 3.x drops `package:sqlite3/open.dart`, the runtime `DynamicLibrary` loader, in favour of Dart build hooks. Both `sqlite3_flutter_libs` and `sqlcipher_flutter_libs` are tombstoned as a result (#433). Selection now lives in `pubspec.yaml`:

```yaml
hooks:
  user_defines:
    sqlite3:
      source: sqlcipher
```

That deletes `setupSqlcipher()` and its four call sites (main isolate, drift worker isolate, Workmanager headless isolate, integration test), because library selection is a build-time property with no per-isolate state to re-apply. `cipherKeyPragma` stays. sqlite3 fetches prebuilt, sha256-verified SQLCipher binaries per platform, so the old "Windows and Linux need OpenSSL installed to build" caveat is gone.

### Existing encrypted databases still open

Field databases were written by SQLCipher 4.10.0; the hook supplies 4.17.0. The app keys with a **raw** key, which bypasses the KDF, so only page size, HMAC and cipher define the on-disk format. `sqlcipher_defaults_test` pins all three (4096, `HMAC_SHA512`, `PBKDF2_HMAC_SHA512`). Those PRAGMAs return no rows on an unkeyed connection, so the test keys the database first.

A side benefit: host `flutter test` now links real SQLCipher, which it did not before, so encrypted-database behaviour is testable outside the on-device integration test. `sqlcipher_setup_test` asserts `PRAGMA cipher_version` is non-empty, which guards against silently building against vanilla SQLite.

### riverpod 3.3.2

The auto-pause accounting bug is fixed upstream, so the raw `stream.listen((_) => ref.invalidateSelf())` reproduction no longer reproduces and now asserts the absence of the error. `invalidateSelfWhen` stays the app-wide pattern regardless: its broadcast safety is a separate guarantee.

The upgrade also surfaced two latent bugs, neither a riverpod regression:

- `MediaItemView._resolve()` initialised a provider during the build phase. An `async` body runs synchronously up to its first `await`, and both callers are `initState`/`didUpdateWidget`, so the read landed mid-build. It now yields before touching `ref`.
- `DiveRoleListNotifier` is `autoDispose` and its mutations run from a dialog whose route drops the last listener, so an in-flight write reached a disposed `Ref`. `_loadDiveRoles` had no `mounted` guard while its sibling `_silentReloadDiveRoles` did. Both the state writes and the `_ref` use are now guarded; skipping the invalidate when disposed is safe because `allDiveRolesProvider` self-invalidates from `watchDiveRolesChanges()`.

### Mechanical

45 `dispose()` calls became `close()` (deprecated in sqlite3 3.x), rewritten at analyzer-reported positions so no unrelated `dispose` was touched, and 13 `SqliteException` constructions moved to named parameters.

## 3. `test(backup)`: give the backup suites their own temp root

Four test files mocked `path_provider` to return `Directory.systemTemp.path` itself rather than a directory of their own, so all four drove the backup service into the same fixed `$TMPDIR/Submersion/Backups` subtree while `flutter test` ran them in parallel isolates. Two symptoms, both interference rather than defects in the code under test:

```
FileSystemException: Failed to decode data using encoding 'utf-8' ... submersion_backup_<ts>.db
   (a suite with encryption ON wrote where a suite asserting "local stays plaintext" then read)

Expected: 'fake backup data'   Actual: ''
   (one suite read the file while another was rewriting it)
```

The sharing is in the test setup and predates this branch. It surfaced now because the dependency changes shift suite timing, and the collision depends on which files happen to run concurrently. Each file now gets its own temp root and removes it in `tearDownAll`. Measured over repeated runs of those four files together: **1 failure in 3 before, 0 in 6 after**, and the full suite is green again.

## Verification

- `flutter analyze` clean; full suite green (18,215 passed, 17 skipped, exit 0)
- Android APK carries `libsqlcipher.so` for arm64-v8a, armeabi-v7a and x86_64
- Both `Podfile.lock`s regenerate (the SQLCipher pod and `sqlcipher_flutter_libs` drop out)
- **macOS and iOS were launched and ran correctly**, which matters because the bundled-app native-asset layout differs from the test host's

## Known gaps

- **Windows.** CI's Build Linux job passes, which covers the Linux half. Windows is the remaining desktop target, and Windows and Linux are where the prebuilt SQLCipher links OpenSSL, so a runtime OpenSSL dependency is worth confirming there before a desktop release. It does not affect mobile or macOS.
- **The iOS native-asset risk is cleared but latent.** This puts SQLCipher on the same pipeline as `objective_c`, whose iOS dlopen failure (flutter#178915) is sporadic and build-to-build nondeterministic. A clean run does not prove the next build is clean. If a flat launch-screen hang ever appears after this, suspect the native asset before the database code and try `flutter clean` first.
- ~~Pre-push hook flakiness~~: diagnosed and fixed in commit 3. The shared `$TMPDIR` collision described above accounts for every flake observed while preparing this branch.

## Deliberately not included

- `flutter_secure_storage` 11 removes the legacy ciphers, and v9-written data is unreadable without a v10 migration. v10 landed here on 2026-06-21, so anyone updating from before then would skip it, and that store holds the database key and the backup/sync encryption keys. Needs its own change with an explicit upgrade path.
- `permission_handler` 13 pulls `permission_handler_android` 14, which hardcodes `compileSdk = 37` and AGP 9.0.1, forcing the Kotlin 2.4 migration that `settings.gradle.kts` defers on purpose. One call site, no API change: bad trade.
- `file_picker` 12 / `share_plus` 13 / `package_info_plus` 10 are unblocked by the analyzer bump and are a natural follow-up. `file_picker` 12 needs real work: four sites rely on the flipped `allowMultiple` default, and `backup_settings_page.dart` uses `saveFile` as a path picker, which cannot supply the now-mandatory `bytes` without loading the whole database into memory.
