### PR TITLE
fix(equipment): read DPV speed in m/min and burn time in minutes

### DIFF
--- a/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
+++ b/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
@@ -15,8 +15,11 @@ enum AttributeKind { text, number, thickness, choice, flag, date }
 /// thicknessMm always displays in mm (industry convention in every market).
 ///
 /// Every dimension stores its canonical metric value, which for all of them
-/// except [speedMps] is also what a metric diver reads. Speed is stored in m/s
-/// to match wind speed and GPS track speed, and displays as km/h or knots.
+/// except the two per-time ones is also what a metric diver reads:
+/// - [speedMps] stores m/s (matching wind speed and GPS track speed) and
+///   displays as m/min or ft/min, the way a DPV's rated speed is quoted.
+/// - [durationH] stores hours and displays as minutes, the way a scooter's
+///   rated run time is quoted.
 enum AttributeDimension {
   none,
   thicknessMm,
@@ -26,6 +29,7 @@ enum AttributeDimension {
   lengthM,
   depthM,
   speedMps,
+  durationH,
 }
 
 /// Stable attribute keys referenced from more than one file.
@@ -269,9 +273,15 @@ abstract final class EquipmentAttributeCatalog {
         kind: AttributeKind.choice,
         choiceKeys: ['tow_behind', 'ride_on', 'handheld'],
       ),
-      // Rated run time in hours, dimensionless for the same reason as the
-      // rebreather's scrubber duration.
-      EquipmentAttributeDef(key: 'burn_time_h', kind: AttributeKind.number),
+      // Rated run time. Stored in hours (hence the key), but shown in minutes
+      // because that is how every scooter's burn time is specced -- "90 min",
+      // not "1.5 h" (issue #1096). The rebreather's scrubber duration keeps
+      // hours: those are quoted as "3 h", not "180 min".
+      EquipmentAttributeDef(
+        key: 'burn_time_h',
+        kind: AttributeKind.number,
+        dimension: AttributeDimension.durationH,
+      ),
       EquipmentAttributeDef(
         key: 'battery_type',
         kind: AttributeKind.choice,
@@ -288,6 +298,8 @@ abstract final class EquipmentAttributeCatalog {
         kind: AttributeKind.choice,
         choiceKeys: ['brushless', 'brushed'],
       ),
+      // Stored in m/s, read as m/min or ft/min: a DPV's speed is quoted per
+      // minute on every manufacturer's sheet, never in km/h or knots.
       EquipmentAttributeDef(
         key: 'speed_mps',
         kind: AttributeKind.number,

--- a/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
+++ b/lib/features/equipment/presentation/utils/equipment_attribute_units.dart
@@ -16,9 +16,13 @@ double attributeDisplayFromMetric(
   AttributeDimension.pressureBar => units.convertPressure(metric),
   AttributeDimension.lengthM ||
   AttributeDimension.depthM => units.convertDepth(metric),
-  // Stored in m/s (see AttributeDimension.speedMps); shares the wind-speed
-  // conversion so two speeds never disagree on units.
-  AttributeDimension.speedMps => units.convertWindSpeed(metric),
+  // Stored in m/s (see AttributeDimension.speedMps), read as distance per
+  // minute: m/s -> m/min is x60, then the depth conversion carries it to
+  // ft/min for an imperial diver. Same shape as the ascent-rate axis, which
+  // is the app's other distance-per-minute readout.
+  AttributeDimension.speedMps => units.convertDepth(metric * 60),
+  // Stored in hours, read in minutes; a minute is a minute in every market.
+  AttributeDimension.durationH => metric * 60,
   AttributeDimension.thicknessMm || AttributeDimension.none => metric,
 };
 
@@ -33,7 +37,8 @@ double attributeMetricFromDisplay(
   AttributeDimension.pressureBar => units.pressureToBar(display),
   AttributeDimension.lengthM ||
   AttributeDimension.depthM => units.depthToMeters(display),
-  AttributeDimension.speedMps => units.windSpeedToMs(display),
+  AttributeDimension.speedMps => units.depthToMeters(display) / 60,
+  AttributeDimension.durationH => display / 60,
   AttributeDimension.thicknessMm || AttributeDimension.none => display,
 };
 
@@ -44,7 +49,8 @@ String attributeUnitSymbol(AttributeDimension d, UnitFormatter units) =>
       AttributeDimension.pressureBar => units.pressureSymbol,
       AttributeDimension.lengthM ||
       AttributeDimension.depthM => units.depthSymbol,
-      AttributeDimension.speedMps => units.speedSymbol,
+      AttributeDimension.speedMps => '${units.depthSymbol}/min',
+      AttributeDimension.durationH => 'min',
       AttributeDimension.thicknessMm => 'mm',
       AttributeDimension.none => '',
     };
@@ -59,9 +65,14 @@ String formatAttributeNumberForEditing(
   double metricValue,
 ) {
   final display = attributeDisplayFromMetric(dimension, units, metricValue);
-  return display == display.roundToDouble()
-      ? display.toStringAsFixed(0)
-      : display.toStringAsFixed(1);
+  // Round to the one decimal place actually rendered BEFORE asking whether the
+  // value is whole. A per-time round trip (100 min -> 1.666..h -> 100.000...1)
+  // is binary noise, not a fraction the diver typed, and must still read as
+  // "100" rather than "100.0".
+  final rounded = (display * 10).roundToDouble() / 10;
+  return rounded == rounded.roundToDouble()
+      ? rounded.toStringAsFixed(0)
+      : rounded.toStringAsFixed(1);
 }
 
 /// Display string for a stored attribute value (detail page, CSV).

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "أسطوانة المخفف",
   "attrLabel_o2_cylinder_l": "أسطوانة O2",
   "attrLabel_dpv_style": "النمط",
-  "attrLabel_burn_time_h": "زمن التشغيل (ساعة)",
+  "attrLabel_burn_time_h": "زمن التشغيل",
   "attrLabel_battery_type": "البطارية",
   "attrLabel_battery_capacity_wh": "سعة البطارية (واط·ساعة)",
   "attrLabel_motor_type": "المحرك",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Diluent-Flasche",
   "attrLabel_o2_cylinder_l": "O2-Flasche",
   "attrLabel_dpv_style": "Bauart",
-  "attrLabel_burn_time_h": "Laufzeit (h)",
+  "attrLabel_burn_time_h": "Laufzeit",
   "attrLabel_battery_type": "Akku",
   "attrLabel_battery_capacity_wh": "Akkukapazität (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -14795,7 +14795,7 @@
   "attrLabel_diluent_cylinder_l": "Diluent cylinder",
   "attrLabel_o2_cylinder_l": "O2 cylinder",
   "attrLabel_dpv_style": "Style",
-  "attrLabel_burn_time_h": "Burn time (h)",
+  "attrLabel_burn_time_h": "Burn time",
   "attrLabel_battery_type": "Battery",
   "attrLabel_battery_capacity_wh": "Battery capacity (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Botella de diluyente",
   "attrLabel_o2_cylinder_l": "Botella de O2",
   "attrLabel_dpv_style": "Estilo",
-  "attrLabel_burn_time_h": "Autonomía (h)",
+  "attrLabel_burn_time_h": "Autonomía",
   "attrLabel_battery_type": "Batería",
   "attrLabel_battery_capacity_wh": "Capacidad de batería (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Bouteille de diluant",
   "attrLabel_o2_cylinder_l": "Bouteille d'O2",
   "attrLabel_dpv_style": "Style",
-  "attrLabel_burn_time_h": "Autonomie (h)",
+  "attrLabel_burn_time_h": "Autonomie",
   "attrLabel_battery_type": "Batterie",
   "attrLabel_battery_capacity_wh": "Capacité de la batterie (Wh)",
   "attrLabel_motor_type": "Moteur",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "בלון מדלל",
   "attrLabel_o2_cylinder_l": "בלון O2",
   "attrLabel_dpv_style": "סגנון",
-  "attrLabel_burn_time_h": "זמן פעולה (שעות)",
+  "attrLabel_burn_time_h": "זמן פעולה",
   "attrLabel_battery_type": "סוללה",
   "attrLabel_battery_capacity_wh": "קיבולת סוללה (Wh)",
   "attrLabel_motor_type": "מנוע",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Diluent palack",
   "attrLabel_o2_cylinder_l": "O2 palack",
   "attrLabel_dpv_style": "Fazon",
-  "attrLabel_burn_time_h": "Üzemidő (ó)",
+  "attrLabel_burn_time_h": "Üzemidő",
   "attrLabel_battery_type": "Akkumulátor",
   "attrLabel_battery_capacity_wh": "Akkukapacitás (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Bombola diluente",
   "attrLabel_o2_cylinder_l": "Bombola O2",
   "attrLabel_dpv_style": "Stile",
-  "attrLabel_burn_time_h": "Autonomia (h)",
+  "attrLabel_burn_time_h": "Autonomia",
   "attrLabel_battery_type": "Batteria",
   "attrLabel_battery_capacity_wh": "Capacità batteria (Wh)",
   "attrLabel_motor_type": "Motore",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -38332,7 +38332,7 @@ abstract class AppLocalizations {
   /// No description provided for @attrLabel_burn_time_h.
   ///
   /// In en, this message translates to:
-  /// **'Burn time (h)'**
+  /// **'Burn time'**
   String get attrLabel_burn_time_h;
 
   /// No description provided for @attrLabel_battery_type.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -22584,7 +22584,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get attrLabel_dpv_style => 'النمط';
 
   @override
-  String get attrLabel_burn_time_h => 'زمن التشغيل (ساعة)';
+  String get attrLabel_burn_time_h => 'زمن التشغيل';
 
   @override
   String get attrLabel_battery_type => 'البطارية';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -22951,7 +22951,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get attrLabel_dpv_style => 'Bauart';
 
   @override
-  String get attrLabel_burn_time_h => 'Laufzeit (h)';
+  String get attrLabel_burn_time_h => 'Laufzeit';
 
   @override
   String get attrLabel_battery_type => 'Akku';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -22605,7 +22605,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get attrLabel_dpv_style => 'Style';
 
   @override
-  String get attrLabel_burn_time_h => 'Burn time (h)';
+  String get attrLabel_burn_time_h => 'Burn time';
 
   @override
   String get attrLabel_battery_type => 'Battery';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23006,7 +23006,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get attrLabel_dpv_style => 'Estilo';
 
   @override
-  String get attrLabel_burn_time_h => 'Autonomía (h)';
+  String get attrLabel_burn_time_h => 'Autonomía';
 
   @override
   String get attrLabel_battery_type => 'Batería';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23064,7 +23064,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get attrLabel_dpv_style => 'Style';
 
   @override
-  String get attrLabel_burn_time_h => 'Autonomie (h)';
+  String get attrLabel_burn_time_h => 'Autonomie';
 
   @override
   String get attrLabel_battery_type => 'Batterie';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -22423,7 +22423,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get attrLabel_dpv_style => 'סגנון';
 
   @override
-  String get attrLabel_burn_time_h => 'זמן פעולה (שעות)';
+  String get attrLabel_burn_time_h => 'זמן פעולה';
 
   @override
   String get attrLabel_battery_type => 'סוללה';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -22915,7 +22915,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get attrLabel_dpv_style => 'Fazon';
 
   @override
-  String get attrLabel_burn_time_h => 'Üzemidő (ó)';
+  String get attrLabel_burn_time_h => 'Üzemidő';
 
   @override
   String get attrLabel_battery_type => 'Akkumulátor';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -22990,7 +22990,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get attrLabel_dpv_style => 'Stile';
 
   @override
-  String get attrLabel_burn_time_h => 'Autonomia (h)';
+  String get attrLabel_burn_time_h => 'Autonomia';
 
   @override
   String get attrLabel_battery_type => 'Batteria';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -22817,7 +22817,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get attrLabel_dpv_style => 'Stijl';
 
   @override
-  String get attrLabel_burn_time_h => 'Looptijd (u)';
+  String get attrLabel_burn_time_h => 'Looptijd';
 
   @override
   String get attrLabel_battery_type => 'Accu';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -22992,7 +22992,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get attrLabel_dpv_style => 'Estilo';
 
   @override
-  String get attrLabel_burn_time_h => 'Autonomia (h)';
+  String get attrLabel_burn_time_h => 'Autonomia';
 
   @override
   String get attrLabel_battery_type => 'Bateria';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -21842,7 +21842,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get attrLabel_dpv_style => '款式';
 
   @override
-  String get attrLabel_burn_time_h => '续航时间（小时）';
+  String get attrLabel_burn_time_h => '续航时间';
 
   @override
   String get attrLabel_battery_type => '电池';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Diluentfles",
   "attrLabel_o2_cylinder_l": "O2-fles",
   "attrLabel_dpv_style": "Stijl",
-  "attrLabel_burn_time_h": "Looptijd (u)",
+  "attrLabel_burn_time_h": "Looptijd",
   "attrLabel_battery_type": "Accu",
   "attrLabel_battery_capacity_wh": "Accucapaciteit (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "Cilindro de diluente",
   "attrLabel_o2_cylinder_l": "Cilindro de O2",
   "attrLabel_dpv_style": "Estilo",
-  "attrLabel_burn_time_h": "Autonomia (h)",
+  "attrLabel_burn_time_h": "Autonomia",
   "attrLabel_battery_type": "Bateria",
   "attrLabel_battery_capacity_wh": "Capacidade da bateria (Wh)",
   "attrLabel_motor_type": "Motor",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6716,7 +6716,7 @@
   "attrLabel_diluent_cylinder_l": "稀释气瓶",
   "attrLabel_o2_cylinder_l": "O2 气瓶",
   "attrLabel_dpv_style": "款式",
-  "attrLabel_burn_time_h": "续航时间（小时）",
+  "attrLabel_burn_time_h": "续航时间",
   "attrLabel_battery_type": "电池",
   "attrLabel_battery_capacity_wh": "电池容量（瓦时）",
   "attrLabel_motor_type": "电机",

--- a/test/features/equipment/domain/equipment_attribute_catalog_test.dart
+++ b/test/features/equipment/domain/equipment_attribute_catalog_test.dart
@@ -152,15 +152,22 @@ void main() {
       expect(def.dimension, AttributeDimension.speedMps);
     });
 
-    test('burn time and battery capacity are dimensionless numbers', () {
-      // Hours are hours and watt-hours are watt-hours in every market, the
-      // same call scrubber_duration_h makes.
-      for (final key in ['burn_time_h', 'battery_capacity_wh']) {
-        final def = EquipmentAttributeCatalog.defFor(key);
-        expect(def, isNotNull, reason: key);
-        expect(def!.kind, AttributeKind.number, reason: key);
-        expect(def.dimension, AttributeDimension.none, reason: key);
-      }
+    test('burn time carries the duration dimension so it reads in minutes', () {
+      // A scooter's rated run time is quoted in minutes, not fractions of an
+      // hour (issue #1096); storage stays in hours, the dimension converts.
+      final def = EquipmentAttributeCatalog.defFor('burn_time_h');
+      expect(def, isNotNull);
+      expect(def!.kind, AttributeKind.number);
+      expect(def.dimension, AttributeDimension.durationH);
+    });
+
+    test('battery capacity is a dimensionless number', () {
+      // Watt-hours are watt-hours in every market, the same call
+      // scrubber_duration_h makes.
+      final def = EquipmentAttributeCatalog.defFor('battery_capacity_wh');
+      expect(def, isNotNull);
+      expect(def!.kind, AttributeKind.number);
+      expect(def.dimension, AttributeDimension.none);
     });
 
     test('reuses the shared depth_rating_m definition', () {

--- a/test/features/equipment/presentation/equipment_attribute_units_test.dart
+++ b/test/features/equipment/presentation/equipment_attribute_units_test.dart
@@ -69,10 +69,15 @@ void main() {
   group('attributeDisplayFromMetric', () {
     test('metric formatter is identity for every same-unit dimension', () {
       // Every dimension whose canonical storage unit is also its metric
-      // display unit: kg, L, bar, m, mm. speedMps is the deliberate exception
-      // (stored m/s, shown km/h) and is asserted on its own below.
+      // display unit: kg, L, bar, m, mm. speedMps (stored m/s, shown m/min)
+      // and durationH (stored hours, shown minutes) are the deliberate
+      // per-time exceptions and are asserted on their own below.
+      const perTime = {
+        AttributeDimension.speedMps,
+        AttributeDimension.durationH,
+      };
       for (final d in AttributeDimension.values) {
-        if (d == AttributeDimension.speedMps) continue;
+        if (perTime.contains(d)) continue;
         expect(
           attributeDisplayFromMetric(d, units, 10),
           closeTo(10, 1e-9),
@@ -82,15 +87,27 @@ void main() {
     });
 
     test('speed converts out of canonical m/s in both unit systems', () {
-      // Stored in m/s like wind speed and GPS track speed; a metric diver
-      // reads km/h, an imperial diver reads knots.
+      // Stored in m/s, but a DPV is specced in distance per minute on every
+      // manufacturer's sheet: m/min metric, ft/min imperial (issue #1096).
       expect(
         attributeDisplayFromMetric(AttributeDimension.speedMps, units, 1),
-        closeTo(3.6, 1e-6),
+        closeTo(60, 1e-6),
       );
       expect(
         attributeDisplayFromMetric(AttributeDimension.speedMps, imperial, 1),
-        closeTo(1.94384, 1e-4),
+        closeTo(196.85, 1e-2),
+      );
+    });
+
+    test('duration converts hours to minutes in both unit systems', () {
+      // Minutes are minutes in every market, so both formatters agree.
+      expect(
+        attributeDisplayFromMetric(AttributeDimension.durationH, units, 1.5),
+        closeTo(90, 1e-9),
+      );
+      expect(
+        attributeDisplayFromMetric(AttributeDimension.durationH, imperial, 1.5),
+        closeTo(90, 1e-9),
       );
     });
 
@@ -148,8 +165,13 @@ void main() {
     expect(attributeUnitSymbol(AttributeDimension.lengthM, imperial), 'ft');
     expect(attributeUnitSymbol(AttributeDimension.depthM, imperial), 'ft');
     expect(attributeUnitSymbol(AttributeDimension.thicknessMm, imperial), 'mm');
-    expect(attributeUnitSymbol(AttributeDimension.speedMps, imperial), 'kts');
-    expect(attributeUnitSymbol(AttributeDimension.speedMps, units), 'km/h');
+    expect(
+      attributeUnitSymbol(AttributeDimension.speedMps, imperial),
+      'ft/min',
+    );
+    expect(attributeUnitSymbol(AttributeDimension.speedMps, units), 'm/min');
+    expect(attributeUnitSymbol(AttributeDimension.durationH, imperial), 'min');
+    expect(attributeUnitSymbol(AttributeDimension.durationH, units), 'min');
     expect(attributeUnitSymbol(AttributeDimension.none, imperial), '');
   });
 
@@ -218,6 +240,54 @@ void main() {
       expect(text, matches(r'^\d+(\.\d)?$'));
       // A whole-number display drops the decimal entirely.
       expect(formatAttributeNumberForEditing(def.dimension, units, 3.0), '3');
+    });
+
+    test('a display value whole to one decimal drops the decimal', () {
+      // 100 minutes round-trips through hours as 1.6666...h, which multiplies
+      // back to 100.00000000000001 -- binary noise, not a real fraction. The
+      // edit field must show "100", never "100.0".
+      expect(
+        formatAttributeNumberForEditing(
+          AttributeDimension.durationH,
+          units,
+          100 / 60,
+        ),
+        '100',
+      );
+    });
+
+    group('dpv (issue #1096)', () {
+      test('burn time renders stored hours as minutes', () {
+        final def = EquipmentAttributeCatalog.defFor('burn_time_h');
+        // 1.5 stored hours is what a pre-#1096 diver entered under the
+        // "Burn time (h)" label; it must now read as 90 min, not 1.5.
+        expect(
+          formatAttributeValue(attr(num: 1.5), def, units, l10n),
+          '90 min',
+        );
+        expect(
+          formatAttributeValue(attr(num: 1.5), def, imperial, l10n),
+          '90 min',
+        );
+      });
+
+      test('top speed renders in distance per minute, not km/h', () {
+        final def = EquipmentAttributeCatalog.defFor('speed_mps');
+        // 55 m/min is a typical tow-behind scooter's rated speed.
+        final metricValue = attributeMetricFromDisplay(
+          def!.dimension,
+          units,
+          55,
+        );
+        expect(
+          formatAttributeValue(attr(num: metricValue), def, units, l10n),
+          '55 m/min',
+        );
+        expect(
+          formatAttributeValue(attr(num: metricValue), def, imperial, l10n),
+          '180.4 ft/min',
+        );
+      });
     });
 
     test('choice kind resolves the localized option label', () {


### PR DESCRIPTION
Fixes #1096.

A DPV's top speed was rendered through the wind-speed formatter, so it read as km/h for a metric diver and knots for an imperial one, and burn time was rendered as a raw number of hours. Neither matches how a scooter is actually specced: every manufacturer (Suex, Seacraft, Bonex metric; Dive Xtras imperial) quotes speed per minute and run time in minutes.

| Field | Before | After (metric / imperial) |
| --- | --- | --- |
| Top speed | `3.3 km/h` / `1.8 kts` | `55 m/min` / `180.4 ft/min` |
| Burn time | `Burn time (h)`: `1.5` | `Burn time`: `90 min` (both systems) |

## Changes

- **`AttributeDimension.speedMps`** now displays as distance per minute off the diver's depth unit, `units.convertDepth(metric * 60)` with symbol `<depthSymbol>/min`. That is the same shape as the ascent-rate readout in `unit_axis.dart` and the statistics profile page, so the app's two distance-per-minute values now agree on their dialect.
- **New `AttributeDimension.durationH`** (stores hours, displays minutes) attached to `burn_time_h`. The rebreather's `scrubber_duration_h` deliberately keeps hours: scrubbers are quoted as "3 h", not "180 min".
- **l10n, all 12 locales:** the hard-coded hour suffix comes out of `attrLabel_burn_time_h` ("Burn time (h)" to "Burn time", "Laufzeit (h)" to "Laufzeit", and so on) because the unit now comes from the dimension symbol. The edit-form label renders as `Burn time (min)` and `Top speed (m/min)`.
- **`formatAttributeNumberForEditing`** rounds to the precision it actually renders before testing whether the value is whole. The two new dimensions divide by 60, so a round trip of 100 minutes lands on `100.00000000000001`; that is binary noise, not a fraction the diver typed, and must still read as "100" rather than "100.0".

## Storage is unchanged, deliberately

`speed_mps` stays canonical m/s and `burn_time_h` stays canonical hours, so this is a display-boundary fix with no schema migration. Every existing DPV entry stays semantically correct: a diver who entered `1.5` under the old "(h)" label now reads `90 min`, and a speed entered as `3.3 km/h` now reads `55 m/min`.

The alternative (moving canonical storage to m/min and minutes) would have needed a migration whose value rewrite carries no HLC bump, which is the exact shape of the sync-divergence problems this repo has hit before. The trade-off is that the two attribute keys now name their storage unit rather than their display unit; the catalog comments call that out explicitly.

## Verification

- `flutter analyze` (whole project): `No issues found!`, zero infos
- `flutter test` (whole project): `+18305 ~17: All tests passed!`
- `dart format lib/ test/`: clean
- Pre-push hook ran fully enabled against the worktree: format, analyze, and 42 affected test files all green

Tests updated: the two existing cases that asserted km/h and knots now assert m/min and ft/min, plus new cases covering stored hours rendering as minutes in both unit systems, the m/min and ft/min symbols, and the round-trip precision guard.
