### PR TITLE
Media provenance PR 1: the provenance channel

### DIFF
--- a/docs/superpowers/plans/2026-08-16-media-provenance-pr1-channel.md
+++ b/docs/superpowers/plans/2026-08-16-media-provenance-pr1-channel.md
@@ -1,0 +1,1637 @@
+# Media Provenance PR 1: The Provenance Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every `MediaSourceData` value report which source produced it and which store tier it is, and record the outcome of real resolutions, so a later PR can tell the user where a media item's bytes are actually coming from.
+
+**Architecture:** Provenance is stamped onto the value object at each production site rather than computed by consumers. Two independent native-then-store fallback paths (`MediaItemView._resolve` and `mediaBytesProvider`) therefore inherit correct provenance without either being rewritten, and cannot disagree. A bounded in-memory recorder captures each completed resolution, including the one fact only the fallback layer knows: that the native source failed and the store covered for it.
+
+**Tech Stack:** Dart / Flutter, Riverpod 3, `flutter_test`, Drift (test fixtures only).
+
+**Spec:** `docs/superpowers/specs/2026-08-16-media-provenance-design.md`
+
+**Branch / worktree:** `worktree-media-provenance` at `.claude/worktrees/media-provenance`. All work happens there. The worktree init trio (submodules, `flutter pub get`, `build_runner`) has already been run.
+
+## Global Constraints
+
+- **No em-dashes.** The `—` (U+2014) character must not appear in any code, comment, doc, test name, or commit message. En-dashes used as prose punctuation and spaced hyphens are equally forbidden. Use commas, colons, semicolons, parentheses, or two sentences.
+- **No emojis** in code, comments, or documentation.
+- **No schema change.** This PR adds no columns, no migration, no schema version bump, and touches no synced entity. If a task appears to need one, stop: something has drifted from the spec.
+- **No behavior change.** Every resolution returns the same bytes, the same `UnavailableKind`, and the same widget rendering as before. Only added metadata. Existing tests must pass unmodified.
+- `dart format .` must produce no changes. Run it before every commit.
+- `flutter analyze` must be clean with zero infos. CI treats infos as fatal.
+- Lints in force (`analysis_options.yaml`): `prefer_const_constructors`, `prefer_const_declarations`, `prefer_final_fields`, `prefer_final_locals`, `avoid_print`, `require_trailing_commas`, `always_use_package_imports`. Never use a relative import in `lib/`; test files use relative imports for test helpers only, matching existing files.
+- Run the targeted test file after each change. Run the full `flutter test` only at the final task.
+
+## Verified Facts (do not re-derive)
+
+These were confirmed against the branch tip before this plan was written.
+
+1. **Super-parameter defaults inherit correctly and stay const.** A subclass declaring `super.servedTier` with no explicit default picks up the base constructor's default, and `const UnavailableData()` still works. This was verified by compiling and running the exact pattern. You do not need to re-test it.
+2. **`PlatformGalleryResolver`'s success paths are not unit-testable on a CI host.** They sit inside `coverage:ignore` blocks because `AssetEntity.fromId` requires a real device gallery. Task 3 stamps them but asserts only on the reachable unavailable paths. Do not invent a fake that pretends otherwise.
+3. **`GalleryThumbnailCache._entries` is private**, so a test cannot pre-seed thumbnail bytes to reach the success branch. Same conclusion as above.
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `lib/features/media/domain/value_objects/media_source_data.dart` | Modify: add `ServedFrom`, `ServedTier`, and the two base-class fields | 1 |
+| `lib/features/media/data/resolvers/local_file_resolver.dart` | Modify: stamp `localDisk` | 2 |
+| `lib/features/media/data/resolvers/platform_gallery_resolver.dart` | Modify: stamp `platformGallery` | 3 |
+| `lib/features/media/data/resolvers/signature_resolver.dart` | Modify: stamp `embedded` | 4 |
+| `lib/features/media/data/resolvers/http_url_media_resolver.dart` | Modify: stamp `networkUrl` | 4 |
+| `lib/features/media/data/resolvers/connector_media_resolver.dart` | Modify: stamp `connectorCache` / `connectorNetwork` | 5 |
+| `lib/features/media/data/resolvers/media_store_resolver.dart` | Modify: stamp cache vs network across three tiers | 6 |
+| `lib/features/media/data/services/media_serving_recorder.dart` | Create: the recorder and its observation value object | 7 |
+| `lib/features/media/presentation/providers/media_serving_providers.dart` | Create: the recorder's Riverpod provider | 7 |
+| `lib/features/media/presentation/providers/media_bytes_providers.dart` | Modify: record the outcome | 8 |
+| `lib/features/media/presentation/widgets/media_item_view.dart` | Modify: carry `storeFallbackUsed`, record the outcome, PDF provenance pass-through | 9 |
+
+---
+
+### Task 1: The provenance fields on MediaSourceData
+
+**Files:**
+- Modify: `lib/features/media/domain/value_objects/media_source_data.dart`
+- Test: `test/features/media/domain/value_objects/media_source_data_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `enum ServedFrom { localDisk, platformGallery, storeCache, storeNetwork, networkUrl, connectorCache, connectorNetwork, embedded }`; `enum ServedTier { original, thumbnail, rendition }`; `MediaSourceData.servedFrom` (`ServedFrom?`) and `MediaSourceData.servedTier` (`ServedTier`, default `ServedTier.original`); all four subclasses accept `servedFrom` and `servedTier` as named optional parameters. Every later task depends on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/domain/value_objects/media_source_data_provenance_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+void main() {
+  test('defaults to no provenance and the original tier', () {
+    final data = BytesData(bytes: Uint8List(0));
+    expect(data.servedFrom, isNull);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('FileData carries the stamp it was constructed with', () {
+    final data = FileData(
+      file: File('/tmp/x'),
+      servedFrom: ServedFrom.storeCache,
+      servedTier: ServedTier.thumbnail,
+    );
+    expect(data.servedFrom, ServedFrom.storeCache);
+    expect(data.servedTier, ServedTier.thumbnail);
+    expect(data.isPoster, isFalse);
+  });
+
+  test('UnavailableData never claims a source', () {
+    const data = UnavailableData(kind: UnavailableKind.notFound);
+    expect(data.servedFrom, isNull);
+    expect(data.kind, UnavailableKind.notFound);
+  });
+
+  test('NetworkData stamps stay const-constructible', () {
+    final data = NetworkData(
+      url: Uri.parse('https://example.test/a.jpg'),
+      servedFrom: ServedFrom.networkUrl,
+    );
+    expect(data.servedFrom, ServedFrom.networkUrl);
+    expect(data.servedTier, ServedTier.original);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/domain/value_objects/media_source_data_provenance_test.dart`
+Expected: FAIL to compile, "The getter 'servedFrom' isn't defined" and "Undefined name 'ServedTier'".
+
+- [ ] **Step 3: Write the implementation**
+
+In `lib/features/media/domain/value_objects/media_source_data.dart`, add the two enums immediately after the existing `UnavailableKind` enum:
+
+```dart
+/// Which concrete source produced a [MediaSourceData]'s bytes.
+///
+/// Distinct from [MediaSourceType], which records where a row was LINKED
+/// from and never changes. This records where the bytes came from on THIS
+/// resolution, which can differ: a gallery-sourced row whose asset has been
+/// deleted from the photo library is served from the cloud store instead.
+enum ServedFrom {
+  /// A file read directly off a mounted volume by [LocalFileResolver].
+  localDisk,
+
+  /// Bytes handed over by photo_manager from the device photo library.
+  platformGallery,
+
+  /// A hit in the local media cache. No network was touched.
+  storeCache,
+
+  /// Downloaded from the cloud media store during this resolution.
+  storeNetwork,
+
+  /// A URL handed to cached_network_image, which owns the transport.
+  networkUrl,
+
+  /// A hit in the service connector's own cache pool.
+  connectorCache,
+
+  /// Fetched from the service connector's API during this resolution.
+  connectorNetwork,
+
+  /// A BLOB stored inline on the media row (signatures).
+  embedded,
+}
+
+/// Which of the three store tiers a [MediaSourceData]'s bytes are.
+///
+/// Orthogonal to [ServedFrom]: the store can serve any tier from either its
+/// cache or the network, so "a cached thumbnail" and "a freshly downloaded
+/// thumbnail" differ in [ServedFrom] while sharing a tier.
+enum ServedTier {
+  /// The item's own full-resolution bytes.
+  original,
+
+  /// A derived small image: a resized photo, a video poster frame, or a
+  /// document page-1 render.
+  thumbnail,
+
+  /// A compressed rendition uploaded in place of the original by a
+  /// non-original upload quality setting.
+  rendition,
+}
+```
+
+Then change the sealed base class and all four subclass constructors. Replace the existing `sealed class MediaSourceData { const MediaSourceData(); }` with:
+
+```dart
+sealed class MediaSourceData {
+  const MediaSourceData({
+    this.servedFrom,
+    this.servedTier = ServedTier.original,
+  });
+
+  /// Which source produced these bytes, or null when nothing did
+  /// ([UnavailableData]) or the producer did not say.
+  final ServedFrom? servedFrom;
+
+  /// Which tier these bytes are. Meaningful mainly for store-served data;
+  /// every other producer leaves it at [ServedTier.original] except when it
+  /// returns a derived image.
+  final ServedTier servedTier;
+}
+```
+
+Add the two super parameters to each subclass constructor, keeping every existing parameter and doc comment untouched:
+
+```dart
+class FileData extends MediaSourceData {
+  final File file;
+  final bool isPoster;
+
+  const FileData({
+    required this.file,
+    this.isPoster = false,
+    super.servedFrom,
+    super.servedTier,
+  });
+}
+```
+
+```dart
+class NetworkData extends MediaSourceData {
+  final Uri url;
+  final Map<String, String> headers;
+  const NetworkData({
+    required this.url,
+    this.headers = const {},
+    super.servedFrom,
+    super.servedTier,
+  });
+}
+```
+
+```dart
+class BytesData extends MediaSourceData {
+  final Uint8List bytes;
+  const BytesData({required this.bytes, super.servedFrom, super.servedTier});
+}
+```
+
+```dart
+class UnavailableData extends MediaSourceData {
+  final UnavailableKind kind;
+  final String? userMessage;
+  final String? originDeviceLabel;
+
+  const UnavailableData({
+    required this.kind,
+    this.userMessage,
+    this.originDeviceLabel,
+  });
+}
+```
+
+`UnavailableData` deliberately does NOT accept the super parameters. Nothing served it, so there is no honest value to pass, and omitting them makes that unrepresentable rather than merely conventional.
+
+Do not touch the existing doc comment on `FileData.isPoster`. Leave it exactly as it is.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/domain/value_objects/media_source_data_provenance_test.dart`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Verify nothing else broke**
+
+Run: `flutter analyze lib/features/media test/features/media`
+Expected: "No issues found." Every existing construction site keeps compiling because both new parameters are optional and defaulted.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/domain/value_objects/media_source_data.dart \
+        test/features/media/domain/value_objects/media_source_data_provenance_test.dart
+git commit -m "Add ServedFrom and ServedTier to MediaSourceData
+
+Provenance rides on the value object so both native-then-store fallback
+paths inherit it without either being rewritten. Both fields are optional
+and defaulted, so every existing construction site is unchanged.
+UnavailableData does not accept them: nothing served it."
+```
+
+---
+
+### Task 2: Stamp LocalFileResolver
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/local_file_resolver.dart`
+- Test: `test/features/media/data/resolvers/local_file_resolver_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom`, `ServedTier` from Task 1.
+- Produces: nothing new. `LocalFileResolver.resolve` returns `FileData`/`BytesData` stamped `ServedFrom.localDisk`; `resolveThumbnail`'s video poster is stamped `ServedFrom.localDisk` with `ServedTier.thumbnail`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/resolvers/local_file_resolver_provenance_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/resolvers/local_file_resolver.dart';
+import 'package:submersion/features/media/data/services/exif_extractor.dart';
+import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
+import 'package:submersion/features/media/data/services/local_media_platform.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('lfr_prov');
+  });
+
+  tearDown(() async {
+    await dir.delete(recursive: true);
+  });
+
+  MediaItem item({String? localPath}) => MediaItem(
+    id: 'm1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.localFile,
+    localPath: localPath,
+    takenAt: DateTime.utc(2026),
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+
+  LocalFileResolver build() => LocalFileResolver(
+    bookmarkStorage: LocalBookmarkStorage(),
+    platform: LocalMediaPlatform(),
+    exifExtractor: ExifExtractor(),
+    usesSecurityScopedBookmarks: () => false,
+  );
+
+  test('a readable local file is stamped localDisk at original tier', () async {
+    final f = File('${dir.path}/reef.jpg');
+    await f.writeAsBytes(const [1, 2, 3], flush: true);
+
+    final data = await build().resolve(item(localPath: f.path));
+
+    expect(data, isA<FileData>());
+    expect(data.servedFrom, ServedFrom.localDisk);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('an unresolvable item claims no source', () async {
+    final data = await build().resolve(item());
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+}
+```
+
+If `LocalBookmarkStorage`, `LocalMediaPlatform`, or `ExifExtractor` cannot be zero-arg constructed, read `test/features/media/data/resolvers/local_file_resolver_test.dart` and copy its exact construction and stubs. Do not invent constructor signatures.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/data/resolvers/local_file_resolver_provenance_test.dart`
+Expected: FAIL on the first test, "Expected: <ServedFrom.localDisk> Actual: <null>".
+
+- [ ] **Step 3: Write the implementation**
+
+Three edits in `local_file_resolver.dart`, all inside `resolve`:
+
+Desktop path, currently `if (blocker == null) return FileData(file: f);`:
+
+```dart
+if (blocker == null) {
+  return FileData(file: f, servedFrom: ServedFrom.localDisk);
+}
+```
+
+Android URI branch, currently `return BytesData(bytes: bytes);`:
+
+```dart
+return BytesData(bytes: bytes, servedFrom: ServedFrom.localDisk);
+```
+
+Security-scoped bookmark branch, currently `return BytesData(bytes: bytes);`:
+
+```dart
+return BytesData(bytes: bytes, servedFrom: ServedFrom.localDisk);
+```
+
+One edit in `resolveThumbnail`, currently `if (poster != null) return BytesData(bytes: poster);`:
+
+```dart
+if (poster != null) {
+  return BytesData(
+    bytes: poster,
+    servedFrom: ServedFrom.localDisk,
+    servedTier: ServedTier.thumbnail,
+  );
+}
+```
+
+Leave every `UnavailableData` return untouched. Leave the `coverage:ignore` markers exactly where they are.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/data/resolvers/local_file_resolver_provenance_test.dart`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Verify the existing suite for this resolver still passes**
+
+Run: `flutter test test/features/media/data/resolvers/local_file_resolver_test.dart test/features/media/data/resolvers/local_file_resolver_video_thumb_test.dart`
+Expected: PASS, unchanged counts. These assert bytes and types, not provenance, so they must be untouched.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/local_file_resolver.dart \
+        test/features/media/data/resolvers/local_file_resolver_provenance_test.dart
+git commit -m "Stamp localDisk provenance in LocalFileResolver
+
+Covers the desktop path read, both bookmark byte paths, and the desktop
+video poster, which is the resolver's only thumbnail-tier product."
+```
+
+---
+
+### Task 3: Stamp PlatformGalleryResolver
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/platform_gallery_resolver.dart`
+- Test: `test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom`, `ServedTier` from Task 1.
+- Produces: nothing new.
+
+**Read this before starting.** The two success returns in this resolver sit inside `coverage:ignore-start` / `coverage:ignore-end` blocks because `AssetEntity.fromId` needs a real device photo library, and `GalleryThumbnailCache` keeps its entries private so a test cannot pre-seed a hit. You will stamp those two returns and you will NOT be able to assert on them from a test host. That is expected and correct. Assert on the unavailable paths, which are reachable, and do not build a fake that simulates a gallery.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart`. Open `test/features/media/data/resolvers/platform_gallery_resolver_test.dart` first and reuse its `_StubPhotoPickerService` and `_FakeAssetResolutionService` verbatim by copying them into the new file (they are private to their file, so they cannot be imported).
+
+```dart
+// Copy _StubPhotoPickerService and _FakeAssetResolutionService from
+// platform_gallery_resolver_test.dart, plus that file's imports.
+
+void main() {
+  MediaItem item({String? assetId}) => MediaItem(
+    id: 'm1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: assetId,
+    takenAt: DateTime.utc(2026),
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+
+  test('a row with no asset id claims no source', () async {
+    final r = PlatformGalleryResolver(
+      resolutionService: _FakeAssetResolutionService(
+        ResolutionResult(status: ResolutionStatus.unavailable),
+      ),
+    );
+
+    final data = await r.resolve(item());
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+
+  test('an unresolvable thumbnail claims no source', () async {
+    final r = PlatformGalleryResolver(
+      resolutionService: _FakeAssetResolutionService(
+        ResolutionResult(status: ResolutionStatus.unavailable),
+      ),
+    );
+
+    final data = await r.resolveThumbnail(item(), target: const Size(128, 128));
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+}
+```
+
+Match `ResolutionResult`'s real constructor to what `_FakeAssetResolutionService` in the existing test expects. Read it; do not guess.
+
+- [ ] **Step 2: Run the test to verify it passes already**
+
+Run: `flutter test test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart`
+Expected: PASS. This is the one task whose test does not fail first, because it pins the null-provenance contract on the unavailable paths, which Task 1 already satisfies. Its value is regression protection: it fails loudly if a later refactor ever stamps an `UnavailableData`.
+
+- [ ] **Step 3: Write the implementation**
+
+Two edits in `platform_gallery_resolver.dart`.
+
+In `resolve`, inside the coverage-ignored block, currently `return BytesData(bytes: bytes);`:
+
+```dart
+return BytesData(bytes: bytes, servedFrom: ServedFrom.platformGallery);
+```
+
+In `resolveThumbnail`, currently `return BytesData(bytes: bytes);`:
+
+```dart
+return BytesData(
+  bytes: bytes,
+  servedFrom: ServedFrom.platformGallery,
+  servedTier: ServedTier.thumbnail,
+);
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `flutter test test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart test/features/media/data/resolvers/platform_gallery_resolver_test.dart test/features/media/data/resolvers/platform_gallery_resolver_extra_test.dart`
+Expected: PASS, all three files.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/platform_gallery_resolver.dart \
+        test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart
+git commit -m "Stamp platformGallery provenance in PlatformGalleryResolver
+
+The two success returns need a real device gallery and stay inside their
+coverage-ignore blocks, so the test pins the reachable contract instead:
+an unavailable resolution never claims a source."
+```
+
+---
+
+### Task 4: Stamp SignatureResolver and HttpUrlMediaResolver
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/signature_resolver.dart`
+- Modify: `lib/features/media/data/resolvers/http_url_media_resolver.dart`
+- Test: `test/features/media/data/resolvers/signature_http_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom` from Task 1.
+- Produces: nothing new.
+
+These two are grouped because each is a two-line change with no shared state, and splitting them would give a reviewer nothing extra to reject.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/resolvers/signature_http_provenance_test.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/resolvers/signature_resolver.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+MediaItem _signature({Uint8List? imageData}) => MediaItem(
+  id: 'sig',
+  mediaType: MediaType.instructorSignature,
+  sourceType: MediaSourceType.signature,
+  imageData: imageData,
+  takenAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+void main() {
+  test('an inline signature blob is stamped embedded', () async {
+    final data = await SignatureResolver().resolve(
+      _signature(imageData: Uint8List.fromList(const [1, 2, 3])),
+    );
+
+    expect(data, isA<BytesData>());
+    expect(data.servedFrom, ServedFrom.embedded);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('a signature with nothing to read claims no source', () async {
+    final data = await SignatureResolver().resolve(_signature());
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+}
+```
+
+Add a third test for the HTTP resolver in the same file. Read `test/features/media/data/resolvers/http_url_media_resolver_test.dart` first and copy its exact construction of `NetworkUrlResolver` and `UrlMetadataExtractor` stubs, since `HttpUrlMediaResolver` requires both:
+
+```dart
+test('a URL row is stamped networkUrl', () async {
+  final resolver = HttpUrlMediaResolver(
+    sourceType: MediaSourceType.networkUrl,
+    networkUrlResolver: <stub from the existing test>,
+    urlMetadataExtractor: <stub from the existing test>,
+  );
+
+  final data = await resolver.resolve(
+    MediaItem(
+      id: 'u1',
+      mediaType: MediaType.photo,
+      sourceType: MediaSourceType.networkUrl,
+      url: 'https://example.test/reef.jpg',
+      takenAt: DateTime.utc(2026),
+      createdAt: DateTime.utc(2026),
+      updatedAt: DateTime.utc(2026),
+    ),
+  );
+
+  expect(data, isA<NetworkData>());
+  expect(data.servedFrom, ServedFrom.networkUrl);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/data/resolvers/signature_http_provenance_test.dart`
+Expected: FAIL on tests 1 and 3, "Expected: <ServedFrom.embedded> Actual: <null>" and the `networkUrl` equivalent.
+
+- [ ] **Step 3: Write the implementation**
+
+In `signature_resolver.dart`, `resolve`:
+
+```dart
+if (item.imageData != null && item.imageData!.isNotEmpty) {
+  return BytesData(bytes: item.imageData!, servedFrom: ServedFrom.embedded);
+}
+final path = item.filePath;
+if (path != null && path.isNotEmpty) {
+  final file = File(path);
+  if (await file.exists()) {
+    return FileData(file: file, servedFrom: ServedFrom.embedded);
+  }
+}
+```
+
+A signature stored as a file is still the app's own signature artifact rather than a user-linked asset, so both branches read `embedded`. That is deliberate.
+
+In `http_url_media_resolver.dart`, `resolve`, currently `return NetworkData(url: uri);`:
+
+```dart
+return NetworkData(url: uri, servedFrom: ServedFrom.networkUrl);
+```
+
+This resolver registers for both `manifestEntry` and `networkUrl`, and both are HTTP transports handed to `cached_network_image`. `ServedFrom` records the transport, not the link provenance, so a single value is correct for both. The link provenance is `MediaItem.sourceType` and is already stored.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/data/resolvers/signature_http_provenance_test.dart`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Verify the existing suites still pass**
+
+Run: `flutter test test/features/media/data/resolvers/signature_resolver_test.dart test/features/media/data/resolvers/signature_resolver_extra_test.dart test/features/media/data/resolvers/http_url_media_resolver_test.dart`
+Expected: PASS, unchanged counts.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/signature_resolver.dart \
+        lib/features/media/data/resolvers/http_url_media_resolver.dart \
+        test/features/media/data/resolvers/signature_http_provenance_test.dart
+git commit -m "Stamp embedded and networkUrl provenance
+
+ServedFrom records the byte transport, so the one HTTP resolver stamps
+networkUrl for both the manifestEntry and networkUrl source types. The
+link provenance those two differ in is already on MediaItem.sourceType."
+```
+
+---
+
+### Task 5: Stamp ConnectorMediaResolver
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/connector_media_resolver.dart`
+- Test: `test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom`, `ServedTier` from Task 1.
+- Produces: nothing new.
+
+This resolver has four success returns inside `_resolveRendition`: one cache hit, two post-fetch cache writes (thumb and hash-verified original), and one uncached `BytesData`. The cache hit is `connectorCache`; the other three are `connectorNetwork`, because the bytes were pulled from the Lightroom API during this call even when they land in the cache on the way out.
+
+Tier follows the `MediaCacheKind` the caller passed: `MediaCacheKind.thumb` maps to `ServedTier.thumbnail`, `MediaCacheKind.original` maps to `ServedTier.original`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart`. Construct the resolver with a `hasLightroomAccount: false` item to reach the `signInRequired` path without any Lightroom stubbing:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/resolvers/connector_media_resolver.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+MediaItem _connectorItem() => MediaItem(
+  id: 'c1',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.serviceConnector,
+  remoteAssetId: 'asset-1',
+  takenAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+void main() {
+  test('a signed-out connector resolution claims no source', () async {
+    final resolver = ConnectorMediaResolver(
+      hasLightroomAccount: false,
+      apiClient: () async => null,
+      catalogId: () async => null,
+      cache: () async => null,
+    );
+
+    final data = await resolver.resolve(_connectorItem());
+
+    expect(data, isA<UnavailableData>());
+    expect((data as UnavailableData).kind, UnavailableKind.signInRequired);
+    expect(data.servedFrom, isNull);
+  });
+}
+```
+
+Then add a cache-hit test. Build a real `MediaCacheStore` over an in-memory `LocalCacheDatabase` exactly as `test/features/media/data/media_store_resolver_test.dart` does in its `setUp`, seed it with `cache.put(hash, MediaCacheKind.original, stagingFile, extension: 'jpg')`, give the item that `contentHash`, and assert:
+
+```dart
+expect(data, isA<FileData>());
+expect(data.servedFrom, ServedFrom.connectorCache);
+expect(data.servedTier, ServedTier.original);
+```
+
+Set `hasLightroomAccount: true` for that test so the cache lookup is reached, and leave `apiClient` returning null so a cache miss would fall to `signInRequired` rather than hitting the network. That asymmetry is what proves the cache branch actually ran.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart`
+Expected: the signed-out test PASSES (null provenance already holds); the cache-hit test FAILS with "Expected: <ServedFrom.connectorCache> Actual: <null>".
+
+- [ ] **Step 3: Write the implementation**
+
+In `connector_media_resolver.dart`, add a tier helper just above `_resolveRendition`:
+
+```dart
+/// The cache pool a rendition request targets also names its tier: the
+/// connector fetches a 'thumbnail2x' rendition into the thumb pool and a
+/// '2048' rendition into the originals pool.
+ServedTier _tierFor(MediaCacheKind kind) =>
+    kind == MediaCacheKind.thumb ? ServedTier.thumbnail : ServedTier.original;
+```
+
+Then stamp the four success returns inside `_resolveRendition`:
+
+Cache hit:
+
+```dart
+if (cached != null) {
+  return FileData(
+    file: cached,
+    isPoster: isPoster,
+    servedFrom: ServedFrom.connectorCache,
+    servedTier: _tierFor(kind),
+  );
+}
+```
+
+Post-fetch thumb write:
+
+```dart
+return FileData(
+  file: file,
+  isPoster: isPoster,
+  servedFrom: ServedFrom.connectorNetwork,
+  servedTier: _tierFor(kind),
+);
+```
+
+Post-fetch hash-verified original write: identical stamp to the thumb write above. Write it out in full rather than sharing a variable; the two sit in different branches.
+
+Uncached fallthrough:
+
+```dart
+return BytesData(
+  bytes: bytes,
+  servedFrom: ServedFrom.connectorNetwork,
+  servedTier: _tierFor(kind),
+);
+```
+
+Leave all three `UnavailableData` returns untouched.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Verify existing connector tests still pass**
+
+Run: `flutter test test/features/media`
+Expected: PASS, unchanged counts. There is no dedicated connector-resolver test file today, so this directory run is the regression net for the Lightroom paths.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/connector_media_resolver.dart \
+        test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart
+git commit -m "Stamp connector cache and network provenance
+
+The three post-fetch returns all read connectorNetwork: bytes pulled from
+the Lightroom API during this call are network-served even when they land
+in the cache on the way out. Only the pre-fetch hit is connectorCache."
+```
+
+---
+
+### Task 6: Stamp MediaStoreResolver
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/media_store_resolver.dart`
+- Test: `test/features/media/data/media_store_resolver_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom`, `ServedTier` from Task 1.
+- Produces: nothing new.
+
+**This is the load-bearing task of the whole PR.** These six returns are the only place in the codebase that knows a cache hit from a network download, and discarding that distinction is the root cause the spec exists to fix. A wrong stamp here makes the entire feature decorative while still looking correct. Test it properly.
+
+Each of the three fetch methods has exactly two success returns, in this order: the cache hit first, the post-download return second.
+
+| Method | Cache hit | Post-download | Tier |
+| --- | --- | --- | --- |
+| `_fetchThumb` | `storeCache` | `storeNetwork` | `thumbnail` |
+| `_fetchCompressed` | `storeCache` | `storeNetwork` | `rendition` |
+| `_fetchOriginal` | `storeCache` | `storeNetwork` | `original` |
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/media_store_resolver_provenance_test.dart`. Copy the `setUp` / `tearDown` / `item` scaffolding from `test/features/media/data/media_store_resolver_test.dart` verbatim, including its relative import of `../../../helpers/in_memory_media_object_store.dart`:
+
+```dart
+test('an original download is storeNetwork, the re-read is storeCache', () async {
+  final bytes = 'submersion'.codeUnits;
+  final tmp = File('${root.path}/seed');
+  await tmp.writeAsBytes(bytes, flush: true);
+  final digest = await sha256OfFile(tmp);
+  store.objects[StoreKeys.objectKey(digest.hash, extension: 'jpg')] = bytes;
+
+  final first = await resolver.tryResolveRemote(
+    item(hash: digest.hash, uploadedAt: DateTime(2026)),
+    thumbnail: false,
+  );
+  expect(first!.servedFrom, ServedFrom.storeNetwork);
+  expect(first.servedTier, ServedTier.original);
+
+  // Emptying the store proves the second read cannot have gone to network.
+  store.objects.clear();
+
+  final second = await resolver.tryResolveRemote(
+    item(hash: digest.hash, uploadedAt: DateTime(2026)),
+    thumbnail: false,
+  );
+  expect(second!.servedFrom, ServedFrom.storeCache);
+  expect(second.servedTier, ServedTier.original);
+});
+```
+
+Write two more tests in the same shape:
+
+- **Thumb tier.** Seed `store.objects[StoreKeys.thumbKey(hash)]` with any bytes, build the item with `remoteThumbUploadedAt: DateTime(2026)` and a `contentHash`, call with `thumbnail: true`. Assert `storeNetwork` then `storeCache`, both at `ServedTier.thumbnail`. Thumbs are not hash-verified, so the bytes can be arbitrary.
+- **Rendition tier.** Seed `store.objects[StoreKeys.renditionKey(hash, ext: 'jpg')]`, build the item with `remoteCompressedUploadedAt: DateTime(2026)` and a `contentHash` but leave `remoteUploadedAt` null, call with `thumbnail: false`. Assert `storeNetwork` then `storeCache`, both at `ServedTier.rendition`. Read `MediaItem`'s constructor for the exact `remoteCompressedUploadedAt` parameter name before writing this; the `item` helper copied from the existing test does not accept it and must be extended.
+
+Emptying `store.objects` between the two reads is the assertion's whole load-bearing mechanism. Without it, a `storeCache` stamp on the second read proves nothing, because a resolver that stamped `storeCache` unconditionally would also pass. Do not skip it.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/data/media_store_resolver_provenance_test.dart`
+Expected: FAIL on all three tests, "Expected: <ServedFrom.storeNetwork> Actual: <null>".
+
+- [ ] **Step 3: Write the implementation**
+
+In `_fetchThumb`:
+
+```dart
+final cached = await _cache.get(hash, MediaCacheKind.thumb);
+if (cached != null) {
+  return FileData(
+    file: cached,
+    isPoster: isPoster,
+    servedFrom: ServedFrom.storeCache,
+    servedTier: ServedTier.thumbnail,
+  );
+}
+```
+
+and the post-download return:
+
+```dart
+return FileData(
+  file: file,
+  isPoster: isPoster,
+  servedFrom: ServedFrom.storeNetwork,
+  servedTier: ServedTier.thumbnail,
+);
+```
+
+In `_fetchCompressed`:
+
+```dart
+if (cached != null) {
+  return FileData(
+    file: cached,
+    servedFrom: ServedFrom.storeCache,
+    servedTier: ServedTier.rendition,
+  );
+}
+```
+
+and:
+
+```dart
+return FileData(
+  file: file,
+  servedFrom: ServedFrom.storeNetwork,
+  servedTier: ServedTier.rendition,
+);
+```
+
+In `_fetchOriginal`:
+
+```dart
+final cached = await _cache.get(hash, MediaCacheKind.original);
+if (cached != null) {
+  return FileData(
+    file: cached,
+    servedFrom: ServedFrom.storeCache,
+    servedTier: ServedTier.original,
+  );
+}
+```
+
+and:
+
+```dart
+return FileData(
+  file: file,
+  servedFrom: ServedFrom.storeNetwork,
+  servedTier: ServedTier.original,
+);
+```
+
+Do not touch `tryResolveRemote`'s tier-selection ladder, the hash verification, the video early-return, or `_discardStaging`. Six return expressions change and nothing else.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/data/media_store_resolver_provenance_test.dart`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Verify the existing store-resolver suites still pass**
+
+Run: `flutter test test/features/media/data/media_store_resolver_test.dart test/features/media/data/media_store_resolver_compressed_test.dart test/features/media/data/media_store_resolver_video_test.dart test/features/media/data/media_store_source_resolver_test.dart`
+Expected: PASS, unchanged counts.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/media_store_resolver.dart \
+        test/features/media/data/media_store_resolver_provenance_test.dart
+git commit -m "Stamp store cache vs network provenance across all three tiers
+
+These six returns were the only place in the app that knew a cache hit
+from a fresh download, and they discarded it. Each test empties the object
+store between the two reads, so a storeCache stamp on the second read can
+only mean the cache actually served it."
+```
+
+---
+
+### Task 7: The serving recorder
+
+**Files:**
+- Create: `lib/features/media/data/services/media_serving_recorder.dart`
+- Create: `lib/features/media/presentation/providers/media_serving_providers.dart`
+- Test: `test/features/media/data/services/media_serving_recorder_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `ServedFrom`, `ServedTier`, `UnavailableKind` from Task 1.
+- Produces, and Tasks 8 and 9 call these exact signatures:
+
+```dart
+class ServingObservation {
+  const ServingObservation({
+    required this.servedFrom,
+    required this.servedTier,
+    required this.failure,
+    required this.storeFallbackUsed,
+    required this.observedAt,
+  });
+  final ServedFrom? servedFrom;
+  final ServedTier servedTier;
+  final UnavailableKind? failure;
+  final bool storeFallbackUsed;
+  final DateTime observedAt;
+}
+
+class MediaServingRecorder extends ChangeNotifier {
+  MediaServingRecorder({DateTime Function()? now, int maxEntries = 200});
+  void record(
+    String mediaId, {
+    required bool thumbnail,
+    ServedFrom? servedFrom,
+    ServedTier servedTier = ServedTier.original,
+    UnavailableKind? failure,
+    bool storeFallbackUsed = false,
+  });
+  ServingObservation? lastFor(String mediaId, {required bool thumbnail});
+  int get entryCount;
+}
+
+final mediaServingRecorderProvider = Provider<MediaServingRecorder>(...);
+```
+
+**Deviation from the spec, and why.** The spec sketched `Listenable listenableFor(String mediaId)`. This plan ships a single `ChangeNotifier` on the recorder instead. A per-id notifier map needs lifecycle management (creation on demand, disposal when the last listener leaves) that buys nothing while exactly one info panel is open at a time, which is the only consumer. The panel in PR 2 listens to the recorder and re-reads `lastFor` for its own id. If a real need for per-id granularity appears, add it then.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/data/services/media_serving_recorder_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+void main() {
+  test('records and reads back a successful resolution', () {
+    final r = MediaServingRecorder(now: () => DateTime.utc(2026, 8, 16));
+
+    r.record(
+      'm1',
+      thumbnail: false,
+      servedFrom: ServedFrom.storeCache,
+      servedTier: ServedTier.original,
+    );
+
+    final obs = r.lastFor('m1', thumbnail: false)!;
+    expect(obs.servedFrom, ServedFrom.storeCache);
+    expect(obs.servedTier, ServedTier.original);
+    expect(obs.failure, isNull);
+    expect(obs.storeFallbackUsed, isFalse);
+    expect(obs.observedAt, DateTime.utc(2026, 8, 16));
+  });
+
+  test('thumbnail and original observations do not overwrite each other', () {
+    final r = MediaServingRecorder();
+
+    r.record('m1', thumbnail: true, servedFrom: ServedFrom.storeCache);
+    r.record('m1', thumbnail: false, servedFrom: ServedFrom.storeNetwork);
+
+    expect(r.lastFor('m1', thumbnail: true)!.servedFrom, ServedFrom.storeCache);
+    expect(
+      r.lastFor('m1', thumbnail: false)!.servedFrom,
+      ServedFrom.storeNetwork,
+    );
+  });
+
+  test('records a failure with no source', () {
+    final r = MediaServingRecorder();
+
+    r.record(
+      'm1',
+      thumbnail: false,
+      failure: UnavailableKind.notFound,
+      storeFallbackUsed: true,
+    );
+
+    final obs = r.lastFor('m1', thumbnail: false)!;
+    expect(obs.servedFrom, isNull);
+    expect(obs.failure, UnavailableKind.notFound);
+    expect(obs.storeFallbackUsed, isTrue);
+  });
+
+  test('returns null for an item never observed', () {
+    expect(MediaServingRecorder().lastFor('nope', thumbnail: false), isNull);
+  });
+
+  test('evicts least recently recorded beyond maxEntries', () {
+    final r = MediaServingRecorder(maxEntries: 2);
+
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('b', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('c', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(r.entryCount, 2);
+    expect(r.lastFor('a', thumbnail: false), isNull);
+    expect(r.lastFor('b', thumbnail: false), isNotNull);
+    expect(r.lastFor('c', thumbnail: false), isNotNull);
+  });
+
+  test('re-recording an id refreshes its recency', () {
+    final r = MediaServingRecorder(maxEntries: 2);
+
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('b', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.storeCache);
+    r.record('c', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(r.lastFor('a', thumbnail: false)!.servedFrom, ServedFrom.storeCache);
+    expect(r.lastFor('b', thumbnail: false), isNull);
+  });
+
+  test('notifies listeners on record', () {
+    final r = MediaServingRecorder();
+    var notifications = 0;
+    r.addListener(() => notifications++);
+
+    r.record('m1', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(notifications, 1);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/data/services/media_serving_recorder_test.dart`
+Expected: FAIL to compile, "Target of URI doesn't exist: media_serving_recorder.dart".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/features/media/data/services/media_serving_recorder.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// What one completed resolution produced.
+///
+/// [storeFallbackUsed] is the fact no resolver can report on its own: it
+/// belongs to the layer that tried the row's native source first, saw it
+/// fail, and asked the media store to cover. It is what turns "the cloud
+/// served this" into "the photo library lookup failed and the cloud served
+/// this", which is the difference between a status readout and a diagnosis.
+@immutable
+class ServingObservation {
+  const ServingObservation({
+    required this.servedFrom,
+    required this.servedTier,
+    required this.failure,
+    required this.storeFallbackUsed,
+    required this.observedAt,
+  });
+
+  final ServedFrom? servedFrom;
+  final ServedTier servedTier;
+
+  /// Set when the resolution produced no bytes at all.
+  final UnavailableKind? failure;
+
+  /// Whether the row's own source failed and the media store was asked.
+  final bool storeFallbackUsed;
+
+  final DateTime observedAt;
+}
+
+/// Remembers how each media item was most recently resolved, so the media
+/// info panel can report what actually painted the pixels rather than
+/// re-resolving and reporting what would happen if it tried again.
+///
+/// Deliberately NOT a StateNotifier or a Riverpod-managed state object.
+/// Every visible tile writes here as it finishes resolving, and routing
+/// that through provider state would rebuild the grid on every scroll.
+/// Listeners are notified so an open info panel can refresh; when nothing
+/// is listening, notification is free.
+class MediaServingRecorder extends ChangeNotifier {
+  MediaServingRecorder({DateTime Function()? now, this.maxEntries = 200})
+    : _now = now ?? DateTime.now;
+
+  final DateTime Function() _now;
+
+  /// Bound on retained observations. A library scroll would otherwise grow
+  /// this map without limit for the lifetime of the process.
+  final int maxEntries;
+
+  /// Insertion-ordered, so the first key is the least recently recorded.
+  /// A re-record removes and re-inserts to move the entry to the end.
+  final Map<String, ServingObservation> _entries =
+      <String, ServingObservation>{};
+
+  @visibleForTesting
+  int get entryCount => _entries.length;
+
+  /// A thumbnail and an original are separate observations of the same row:
+  /// a grid tile resolves the first while the viewer resolves the second,
+  /// and they can legitimately come from different places.
+  String _key(String mediaId, bool thumbnail) =>
+      '$mediaId#${thumbnail ? 't' : 'o'}';
+
+  void record(
+    String mediaId, {
+    required bool thumbnail,
+    ServedFrom? servedFrom,
+    ServedTier servedTier = ServedTier.original,
+    UnavailableKind? failure,
+    bool storeFallbackUsed = false,
+  }) {
+    final key = _key(mediaId, thumbnail);
+    _entries.remove(key);
+    _entries[key] = ServingObservation(
+      servedFrom: servedFrom,
+      servedTier: servedTier,
+      failure: failure,
+      storeFallbackUsed: storeFallbackUsed,
+      observedAt: _now(),
+    );
+    while (_entries.length > maxEntries) {
+      _entries.remove(_entries.keys.first);
+    }
+    notifyListeners();
+  }
+
+  ServingObservation? lastFor(String mediaId, {required bool thumbnail}) =>
+      _entries[_key(mediaId, thumbnail)];
+}
+```
+
+Create `lib/features/media/presentation/providers/media_serving_providers.dart`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+
+/// Process-wide recorder. A plain Provider with a concrete default, so no
+/// consumer test needs an override to construct a widget tree that renders
+/// media.
+final mediaServingRecorderProvider = Provider<MediaServingRecorder>(
+  (ref) => MediaServingRecorder(),
+);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/data/services/media_serving_recorder_test.dart`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/services/media_serving_recorder.dart \
+        lib/features/media/presentation/providers/media_serving_providers.dart \
+        test/features/media/data/services/media_serving_recorder_test.dart
+git commit -m "Add MediaServingRecorder
+
+A bounded LRU of how each item was most recently resolved. Deliberately a
+plain ChangeNotifier rather than Riverpod state: every visible tile writes
+here while scrolling, and routing that through provider state would rebuild
+the grid. Ships one notifier rather than the spec's per-id listenables,
+since a single info panel is the only consumer."
+```
+
+---
+
+### Task 8: Record from mediaBytesProvider
+
+**Files:**
+- Modify: `lib/features/media/presentation/providers/media_bytes_providers.dart`
+- Test: `test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `MediaServingRecorder.record`, `mediaServingRecorderProvider` from Task 7; all resolver stamps from Tasks 2 to 6.
+- Produces: nothing new. `mediaBytesProvider`'s return type is unchanged.
+
+`mediaBytesProvider` always resolves full-resolution bytes, so every call records with `thumbnail: false`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart`. Build a `ProviderContainer` overriding `mediaSourceResolverRegistryProvider` with a registry whose `localFile` resolver returns a stamped `BytesData`, and overriding `mediaServingRecorderProvider` with a recorder you hold a reference to. Read `test/features/media/presentation/providers/` for an existing container-based test to copy the override style and the `mediaStoreRuntimeProvider` handling from; do not guess at how the runtime provider is stubbed.
+
+```dart
+test('a native success is recorded with no store fallback', () async {
+  final recorder = MediaServingRecorder();
+  final container = ProviderContainer(
+    overrides: [
+      mediaServingRecorderProvider.overrideWithValue(recorder),
+      // registry override returning
+      //   BytesData(bytes: ..., servedFrom: ServedFrom.localDisk)
+      // for MediaSourceType.localFile, plus whatever the existing
+      // container tests do for mediaStoreRuntimeProvider.
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await container.read(mediaBytesProvider(item).future);
+
+  final obs = recorder.lastFor(item.id, thumbnail: false)!;
+  expect(obs.servedFrom, ServedFrom.localDisk);
+  expect(obs.storeFallbackUsed, isFalse);
+  expect(obs.failure, isNull);
+});
+
+test('a total failure is recorded with the native failure kind', () async {
+  // Registry resolver returns
+  //   const UnavailableData(kind: UnavailableKind.notFound)
+  // and the store runtime resolves to null.
+  final obs = recorder.lastFor(item.id, thumbnail: false)!;
+  expect(obs.servedFrom, isNull);
+  expect(obs.failure, UnavailableKind.notFound);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart`
+Expected: FAIL, "Null check operator used on a null value" from `lastFor(...)!` because nothing records yet.
+
+- [ ] **Step 3: Write the implementation**
+
+Rewrite the `mediaBytesProvider` body. The three exit points each record once, and the existing doc comment above the provider stays exactly as it is:
+
+```dart
+final mediaBytesProvider =
+    FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      final recorder = ref.read(mediaServingRecorderProvider);
+
+      final native = await _resolveNative(ref, item);
+      final bytes = await _bytesOf(native, item);
+      if (bytes != null) {
+        recorder.record(
+          item.id,
+          thumbnail: false,
+          servedFrom: native.servedFrom,
+          servedTier: native.servedTier,
+        );
+        return ResolvedAssetResult(
+          bytes: bytes,
+          status: ResolutionStatus.resolved,
+        );
+      }
+
+      // The store is the cross-device path for reference-linked media: the
+      // originating device holds the file, everyone else holds the row. Its
+      // resolver self-gates on the upload stamps, so an item that was never
+      // uploaded costs one null return rather than a fetch.
+      final remote = await _resolveRemote(ref, item);
+      final remoteBytes = await _bytesOf(remote, item);
+      if (remoteBytes != null) {
+        recorder.record(
+          item.id,
+          thumbnail: false,
+          servedFrom: remote?.servedFrom,
+          servedTier: remote?.servedTier ?? ServedTier.original,
+          storeFallbackUsed: true,
+        );
+        return ResolvedAssetResult(
+          bytes: remoteBytes,
+          status: ResolutionStatus.resolved,
+        );
+      }
+
+      recorder.record(
+        item.id,
+        thumbnail: false,
+        failure: native is UnavailableData
+            ? native.kind
+            : UnavailableKind.notFound,
+        storeFallbackUsed: true,
+      );
+      return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
+    });
+```
+
+Add the import for `media_serving_providers.dart`. `media_source_data.dart` is already imported.
+
+Note the third branch's `native is UnavailableData ? native.kind : UnavailableKind.notFound`: a native resolution can also produce a `NetworkData`, which this provider deliberately never fetches, and which therefore yields no bytes without being an `UnavailableData`. Collapsing that to `notFound` is the honest reading for a byte consumer, and matches the existing doc comment's reasoning about why `NetworkData` is not fetched here.
+
+`storeFallbackUsed: true` on the failure branch is correct: the store WAS asked and could not help. It records that the fallback ran, not that it succeeded.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Verify existing consumers still pass**
+
+Run: `flutter test test/features/media`
+Expected: PASS, unchanged counts. `mediaServingRecorderProvider` is a plain `Provider` with a concrete default, so no existing test needs an override.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/presentation/providers/media_bytes_providers.dart \
+        test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart
+git commit -m "Record serving provenance from mediaBytesProvider
+
+All three exits record once. The failure branch sets storeFallbackUsed so
+the panel can distinguish an item nothing could serve from one the store
+was never asked about."
+```
+
+---
+
+### Task 9: Record from MediaItemView
+
+**Files:**
+- Modify: `lib/features/media/presentation/widgets/media_item_view.dart`
+- Test: `test/features/media/presentation/widgets/media_item_view_provenance_test.dart` (create)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 and 7.
+- Produces: nothing new. `_Resolution` gains a `storeFallbackUsed` field but stays private to the file.
+
+This widget resolves either a thumbnail or an original depending on `widget.thumbnail`, and records with that same flag. It has seven return sites in `_resolve`; rather than recording at each, add `storeFallbackUsed` to the `_Resolution` record and record once in a wrapper. That keeps the recording logic in one place and makes a missed site a compile error rather than a silent gap.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/media/presentation/widgets/media_item_view_provenance_test.dart`. Read `test/features/media/presentation/widgets/` for the existing `MediaItemView` test harness and copy its `ProviderScope` override set exactly; this widget reads several providers and inventing the overrides will not work.
+
+```dart
+testWidgets('a thumbnail resolution records under the thumbnail key', (
+  tester,
+) async {
+  final recorder = MediaServingRecorder();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        mediaServingRecorderProvider.overrideWithValue(recorder),
+        // registry override whose localFile resolver returns
+        //   BytesData(bytes: <1x1 png>, servedFrom: ServedFrom.localDisk,
+        //             servedTier: ServedTier.thumbnail)
+        // plus the harness's existing overrides.
+      ],
+      child: MaterialApp(home: MediaItemView(item: item, thumbnail: true)),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  final obs = recorder.lastFor(item.id, thumbnail: true)!;
+  expect(obs.servedFrom, ServedFrom.localDisk);
+  expect(obs.servedTier, ServedTier.thumbnail);
+  expect(obs.storeFallbackUsed, isFalse);
+  expect(recorder.lastFor(item.id, thumbnail: false), isNull);
+});
+
+testWidgets('a store fallback is recorded as such', (tester) async {
+  // Registry resolver returns UnavailableData(notFound); the item carries a
+  // contentHash and remoteUploadedAt so storeConfirmed passes; the store
+  // runtime's resolver returns
+  //   FileData(file: ..., servedFrom: ServedFrom.storeNetwork)
+  final obs = recorder.lastFor(item.id, thumbnail: false)!;
+  expect(obs.servedFrom, ServedFrom.storeNetwork);
+  expect(obs.storeFallbackUsed, isTrue);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/media/presentation/widgets/media_item_view_provenance_test.dart`
+Expected: FAIL, "Null check operator used on a null value".
+
+- [ ] **Step 3: Write the implementation**
+
+First extend the `_Resolution` typedef, keeping its existing doc comment and adding a paragraph for the new field:
+
+```dart
+/// [storeFallbackUsed] records that the row's own source could not produce
+/// bytes here and the media store was asked to cover. No resolver can report
+/// this: it is a fact about the sequence of attempts, not about any single
+/// one, and it is what lets the info panel say "the photo library lookup
+/// failed" rather than merely "served from cloud".
+typedef _Resolution = ({
+  MediaSourceData data,
+  bool videoPosterMissing,
+  bool documentRenderable,
+  bool storeFallbackUsed,
+});
+```
+
+Rename the existing `_resolve()` method to `_resolveInner()`, changing nothing inside it except adding `storeFallbackUsed` to each of its seven returned records. Use `false` for the three returns reached before the store is consulted (the PDF branch, the `native is! UnavailableData` return, and the `!storeConfirmed` return) and `true` for the four reached at or after the store attempt (`runtime == null`, the `remote != null` success, the `videoPosterMissing` return, and the `catch (_)` return).
+
+The `runtime == null` case is `true` on purpose: the fallback was attempted and there was no store on this device to answer it. That is a different situation from never having looked, and the panel distinguishes them.
+
+Then add the recording wrapper, and point `initState` and `didUpdateWidget` at it instead of `_resolveInner`:
+
+```dart
+/// Resolves and records the outcome. Recording once here rather than at
+/// each of [_resolveInner]'s seven exits means a new exit added later
+/// cannot silently skip it: the record type makes it a compile error.
+Future<_Resolution> _resolve() async {
+  final resolution = await _resolveInner();
+  final data = resolution.data;
+  ref
+      .read(mediaServingRecorderProvider)
+      .record(
+        widget.item.id,
+        thumbnail: widget.thumbnail,
+        servedFrom: data.servedFrom,
+        servedTier: data.servedTier,
+        failure: data is UnavailableData ? data.kind : null,
+        storeFallbackUsed: resolution.storeFallbackUsed,
+      );
+  return resolution;
+}
+```
+
+Finally, the PDF page-1 branch. It builds a fresh `BytesData` from a render rather than returning the resolver's own value, so it must carry the source resolution's provenance across. Capture it through the closure:
+
+```dart
+if (widget.thumbnail && widget.item.isPdf) {
+  // thumbFor caches its render, so on a cache hit the source closure is
+  // never called and sourceFrom stays null. That is the honest answer:
+  // this render's bytes did not come from anywhere on this pass.
+  ServedFrom? sourceFrom;
+  final page1 = await ref
+      .read(pdfThumbnailServiceProvider)
+      .thumbFor(
+        widget.item,
+        source: () async {
+          final resolved = await resolver.resolve(widget.item);
+          sourceFrom = resolved.servedFrom;
+          return resolved;
+        },
+      );
+  if (page1 != null) {
+    return (
+      data: BytesData(
+        bytes: page1,
+        servedFrom: sourceFrom,
+        servedTier: ServedTier.thumbnail,
+      ),
+      videoPosterMissing: false,
+      documentRenderable: true,
+      storeFallbackUsed: false,
+    );
+  }
+  // No local render (bytes unavailable here, or an unreadable PDF):
+  // fall through, which reaches the store's own page-1 thumb below.
+}
+```
+
+Verify that `PdfThumbnailService.thumbFor`'s `source` parameter accepts an async closure returning `Future<MediaSourceData>`. If its declared type is a synchronous `MediaSourceData Function()`, do not change the service; instead drop the capture and pass `servedFrom: null` with a comment saying the render's source is not observable through this API. Read the signature before writing this step.
+
+Add the import for `media_serving_providers.dart`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/media/presentation/widgets/media_item_view_provenance_test.dart`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Run the full media suite**
+
+Run: `flutter test test/features/media test/features/media_store`
+Expected: PASS, unchanged counts from before this PR.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/presentation/widgets/media_item_view.dart \
+        test/features/media/presentation/widgets/media_item_view_provenance_test.dart
+git commit -m "Record serving provenance from MediaItemView
+
+_Resolution gains storeFallbackUsed and recording happens once in a
+wrapper, so a return site added later cannot skip it: the record type
+makes omission a compile error. The PDF page-1 branch carries its source
+resolution's provenance across the render."
+```
+
+---
+
+### Task 10: Full verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm the tree is clean and formatted**
+
+Run: `dart format --set-exit-if-changed .`
+Expected: exit 0, no files listed.
+
+- [ ] **Step 2: Analyze the whole project**
+
+Run: `flutter analyze`
+Expected: "No issues found." Analyze the whole project, not a subdirectory, and do not pipe the output through `tail` or `grep`: a pipe masks the exit code and CI treats infos as fatal.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `flutter test`
+Expected: zero failures. Compare the pass count against the count on `origin/main` before this branch. This PR adds tests and changes no behavior, so the count should rise by exactly the number of tests added (23 across Tasks 1 to 9) and nothing should have moved from pass to fail.
+
+- [ ] **Step 4: Confirm no schema or sync file was touched**
+
+```bash
+git diff --stat origin/main...HEAD -- lib/core/database lib/features/sync
+```
+Expected: empty output. This PR must not touch the schema or the sync engine. Any output here means something has drifted from the spec; stop and report it rather than proceeding.
+
+- [ ] **Step 5: Confirm no em-dashes entered the diff**
+
+```bash
+git diff origin/main...HEAD | grep -n '^+.*—' || echo "clean"
+```
+Expected: "clean".
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin worktree-media-provenance
+gh pr create --base main --title "Media provenance PR 1: the provenance channel" --body "$(cat <<'BODY'
+First of three PRs implementing docs/superpowers/specs/2026-08-16-media-provenance-design.md.
+
+Adds ServedFrom and ServedTier to MediaSourceData, stamps them at every
+resolver production site, and records the outcome of real resolutions in a
+bounded MediaServingRecorder.
+
+No user-visible change. No schema change. This PR is pure plumbing so that
+PR 2 can build a media info panel that reports where an item was linked
+from, whether it is backed up, and where its bytes are actually coming
+from, and PR 3 can put a combined status badge on the grids.
+
+The load-bearing change is in MediaStoreResolver: its six success returns
+were the only place in the app that knew a media-cache hit from a fresh
+cloud download, and all six discarded that fact. Each new test empties the
+object store between two reads, so a storeCache stamp on the second read
+can only mean the cache actually served it.
+
+Provenance is stamped on the value object at construction rather than
+computed by consumers, so the two independent native-then-store fallback
+paths (MediaItemView._resolve and mediaBytesProvider) inherit it without
+either being rewritten and cannot disagree.
+BODY
+)"
+```
+
+Per project convention the PR body carries no attribution line and no session URL.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Spec section 5.1 (value object) is Task 1. Section 5.2's stamping table is Tasks 2 to 6, one task per resolver file except the two trivial ones grouped in Task 4; every row of that table is claimed. Section 5.3 (recorder) is Task 7, and its PDF pass-through requirement is Task 9 step 3. Sections 6, 7 and 8 belong to PRs 2 and 3 and are correctly absent. Section 9's "load-bearing test" is Task 6. Section 10's PR 1 row is this entire plan. No PR 1 requirement is unclaimed.
+
+**Deviations, both deliberate and both stated at their point of use.** The recorder ships one `ChangeNotifier` instead of the spec's per-id `listenableFor` (Task 7, with reasoning). `UnavailableData` does not accept the provenance parameters, which the spec left implicit (Task 1, with reasoning).
+
+**Type consistency.** `record` is called in Tasks 8 and 9 with exactly the parameter names Task 7 defines: `thumbnail`, `servedFrom`, `servedTier`, `failure`, `storeFallbackUsed`. `lastFor` is called with `thumbnail:` in Tasks 7, 8 and 9. `ServedFrom` and `ServedTier` member names are identical everywhere they appear. `_Resolution`'s four fields in Task 9 match the three existing plus the one added.
+
+**Known-unverifiable steps, flagged rather than faked.** Task 3's gallery success paths (device-only), Task 8's and Task 9's provider override sets (the plan directs the implementer to read the existing harness rather than guessing), and Task 9's `PdfThumbnailService.thumbFor` signature (with an explicit fallback instruction if the closure cannot be async). These are the three places where the plan tells the implementer to look rather than telling them the answer, because the answer was not verifiable from the files read while planning.

--- a/docs/superpowers/specs/2026-08-16-media-provenance-design.md
+++ b/docs/superpowers/specs/2026-08-16-media-provenance-design.md
@@ -1,0 +1,446 @@
+# Media Provenance: Origin, Backup, and Serving Source
+
+Date: 2026-08-16
+Status: Approved (design), not yet planned or implemented
+
+## 1. Problem
+
+A user cannot tell, for any given photo, video, or document in the app:
+
+1. **Where it was linked from.** Was it picked from the device photo library,
+   imported from a folder on disk, fetched from a URL, or pulled from a
+   manifest feed? Was it linked on this device or another one?
+2. **Whether it is safely backed up.** Has the cloud media store received the
+   original, only a thumbnail, or only a compressed rendition? Is it queued,
+   in flight, or failed?
+3. **Why it is broken** when a thumbnail is grey or the original will not
+   open.
+4. **Where the bytes are coming from right now.** Local disk, the local media
+   cache, or a live download from the cloud store (which costs bandwidth).
+
+Today the app answers none of these. `originalFilename`, `contentSizeBytes`,
+`width`/`height`, `sourceType`, `contentHash`, every `remote*UploadedAt`
+stamp, `originDeviceId`, `lastVerifiedAt`, and `retainInLibrary` are stored on
+every row and displayed nowhere. There is no info panel, info sheet, or
+details screen for a media item anywhere in `lib/`.
+
+### 1.1 Root cause for the "serving from" question
+
+Resolution is a pure `MediaItem -> MediaSourceData` function.
+`MediaSourceData` (`lib/features/media/domain/value_objects/media_source_data.dart`)
+is a sealed union of **transport shapes** (`FileData`, `NetworkData`,
+`BytesData`, `UnavailableData`), not of **origins**. A local disk read
+(`local_file_resolver.dart:94`), a media-cache hit
+(`media_store_resolver.dart:130`), and a fresh cloud download
+(`media_store_resolver.dart:149`) all return a structurally identical
+`FileData`, and are therefore indistinguishable to every caller and every
+widget.
+
+The provenance is known at the moment each value is constructed and discarded
+immediately. Six lines in `MediaStoreResolver` (`:75`/`:86`, `:107`/`:117`,
+`:130`/`:149`) are the only place in the codebase that knows cache from
+network.
+
+### 1.2 The two-path complication
+
+The native-then-store fallback is implemented twice, independently:
+
+- `MediaItemView._resolve` (`lib/features/media/presentation/widgets/media_item_view.dart:114-233`)
+- `mediaBytesProvider` (`lib/features/media/presentation/providers/media_bytes_providers.dart:33-58`)
+
+These are **not** duplicates that can simply be merged. `MediaItemView` carries
+PDF page-1 rendering, thumbnail-versus-original branching, a `storeConfirmed`
+stamp gate, and the `videoPosterMissing` / `documentRenderable` view hints.
+`mediaBytesProvider` is a simpler full-resolution-only path. Their divergence
+previously shipped issue #1019.
+
+## 2. Goals
+
+- Every media item can report its origin, its backup state, and its live
+  serving source.
+- The "serving from" readout reflects what actually painted the pixels, not an
+  inference or a re-probe.
+- Diagnosis is possible for a broken item: the user can see that the native
+  source failed and the store served instead.
+- Status is scannable at a glance in grids without opening anything.
+- Where a problem is surfaced, the fix is reachable from the same place,
+  reusing repair machinery that already ships.
+
+## 3. Non-goals
+
+- No new repair, verification, or cache-management logic. Actions are entry
+  points into existing engines only.
+- No cache pinning, forced re-download, or manual cache eviction.
+- No schema change. Every displayed fact is an existing column.
+- No unification of the two fallback paths. That is a worthwhile separate
+  refactor; this design deliberately does not depend on it.
+- No cleanup of the hard-coded English strings in
+  `lib/features/media/presentation/pages/media_sources_page.dart`.
+
+## 4. Approach
+
+Provenance rides on the value object, stamped at each production site, rather
+than being computed by consumers. Both fallback paths then inherit correct
+provenance for free and cannot disagree, without either path being rewritten.
+
+A small recorder captures the outcome of real resolutions so the info panel
+can read what the on-screen image actually used, including the one fact the
+resolvers cannot know: that the native source failed first.
+
+Rejected alternatives:
+
+- **Unify into a resolution service first.** Highest fidelity and would give a
+  full attempt ladder, but the view concerns (PDF render, poster hints,
+  document renderability) either migrate into the service and bloat it or stay
+  outside and leave the unification partial. Large blast radius on the app's
+  most load-bearing media widget.
+- **Side-channel observer only.** Least invasive, but the fallback layer cannot
+  see inside `MediaStoreResolver`, so cache-versus-network is unavailable, and
+  that distinction is the entire bandwidth-awareness goal.
+
+## 5. The provenance channel
+
+### 5.1 Value object changes
+
+In `lib/features/media/domain/value_objects/media_source_data.dart`:
+
+```dart
+enum ServedFrom {
+  localDisk,        // LocalFileResolver, file read off a mounted volume
+  platformGallery,  // photo_manager asset bytes
+  storeCache,       // MediaCacheStore hit, no network touched
+  storeNetwork,     // downloaded from the cloud store just now
+  networkUrl,       // handed to cached_network_image to stream
+  connectorCache,   // ConnectorMediaResolver's own cache
+  connectorNetwork,
+  embedded,         // signature BLOB on the row
+}
+
+/// Which of the three store tiers the bytes are. Distinct from [ServedFrom]:
+/// the store can serve any tier from either cache or network.
+enum ServedTier { original, thumbnail, rendition }
+
+sealed class MediaSourceData {
+  const MediaSourceData({
+    this.servedFrom,
+    this.servedTier = ServedTier.original,
+  });
+  final ServedFrom? servedFrom;
+  final ServedTier servedTier;
+}
+```
+
+Both fields are defaulted so every existing `const` construction site keeps
+compiling. `UnavailableData` leaves `servedFrom` null: nothing served it.
+
+### 5.2 Stamping sites
+
+| File | Lines | Stamp |
+| --- | --- | --- |
+| `local_file_resolver.dart` | `:94`, `:146`, `:174` | `localDisk` |
+| `local_file_resolver.dart` | `:235` (video poster) | `localDisk`, `tier: thumbnail` |
+| `platform_gallery_resolver.dart` | `:62-66` | `platformGallery` |
+| `platform_gallery_resolver.dart` | `:90` | `platformGallery`, `tier: thumbnail` |
+| `signature_resolver.dart` | `:26`, `:32` | `embedded` |
+| `http_url_media_resolver.dart` | `:100` | `networkUrl` |
+| `connector_media_resolver.dart` | `:98`, `:127`, `:137` | `connectorCache` |
+| `connector_media_resolver.dart` | `:145` | `connectorNetwork` |
+| `media_store_resolver.dart` | `:75` / `:86` | `storeCache` / `storeNetwork`, `tier: thumbnail` |
+| `media_store_resolver.dart` | `:107` / `:117` | `storeCache` / `storeNetwork`, `tier: rendition` |
+| `media_store_resolver.dart` | `:130` / `:149` | `storeCache` / `storeNetwork`, `tier: original` |
+
+Line numbers are as of commit `1d0a69c3360` and must be re-derived at
+implementation time.
+
+Neither `MediaItemView._resolve` nor `mediaBytesProvider` computes provenance;
+the value arrives already stamped and passes through.
+
+**One exception.** `MediaItemView`'s PDF page-1 branch
+(`media_item_view.dart:124-137`) constructs a fresh `BytesData` from a render
+rather than returning the resolver's own value. It must carry through the
+provenance of the `resolver.resolve()` call that fed the renderer, with
+`tier: thumbnail`.
+
+### 5.3 The recorder
+
+A plain service, deliberately **not** a `StateNotifier`: the grid must not
+rebuild when a tile finishes resolving.
+
+```dart
+class MediaServingRecorder {
+  void record(
+    String mediaId, {
+    required bool thumbnail,
+    ServedFrom? from,
+    ServedTier tier,
+    UnavailableKind? failure,
+    bool storeFallbackUsed,
+  });
+
+  ServingObservation? lastFor(String mediaId, {required bool thumbnail});
+  Listenable listenableFor(String mediaId);
+}
+```
+
+Observations are keyed by `(mediaId, thumbnail)` because a tile resolves a
+thumbnail while the viewer resolves an original, and both are interesting.
+Storage is a bounded LRU of roughly 200 entries so scrolling a large library
+does not accumulate.
+
+Written at the end of `MediaItemView._resolve` and at the end of
+`mediaBytesProvider`. Read only by the info panel.
+
+`storeFallbackUsed` is the single fact the fallback layer knows and the
+resolvers do not. It is what turns "the cloud served this" into "your photo
+library lookup failed, and the cloud served this", which is the diagnosis the
+user asked for.
+
+## 6. The provenance model
+
+New file `lib/features/media/domain/entities/media_provenance.dart`:
+
+```dart
+class MediaProvenance {
+  final OriginFacts origin;    // where it was linked from
+  final BackupFacts backup;    // whether the cloud store has it
+  final ServingFacts serving;  // what actually painted the pixels
+}
+```
+
+### 6.1 OriginFacts
+
+Pure row reads, no I/O.
+
+- `sourceType`, plus the human-meaningful pointer for that type:
+  `platformAssetId` for gallery, `localPath` or `bookmarkRef` for local files,
+  `url` for network and manifest rows, `contentHash` for `mediaStore` rows,
+  `connectorAccountId` plus `remoteAssetId` for connectors.
+- `originDeviceId`, so the panel can distinguish "linked on this device" from
+  "linked on your iPad".
+- Health, derived from `isOrphaned` and `lastVerifiedAt`, as one of `healthy`,
+  `missing`, or `neverVerified`, carrying the verification date.
+
+**Naming trap.** In this codebase `isOrphaned` means *the file is missing* and
+is orthogonal to *the row has no dive or site link* (which the orphan sweep
+calls unlinked). `OriginFacts.health` maps from `isOrphaned` only.
+`retainInLibrary` is unrelated and must not appear here.
+
+Health is derived from stored state rather than probed, so that opening the
+panel never does source I/O and so that the badge (section 8) can share the
+same provider on every grid tile. An explicit **Check now** action performs the
+probe on demand via the existing `MediaSourceResolver.verify` contract
+(`lib/features/media/domain/services/media_source_resolver.dart:57`).
+
+### 6.2 BackupFacts
+
+- `storeAttached`, plus the store identity hint from
+  `mediaStoreStatusHintProvider`
+  (`lib/features/media_store/presentation/providers/media_store_providers.dart:496-503`),
+  which already yields `"bucket @ host"`.
+- Per-tier upload state from `remoteThumbUploadedAt`, `remoteUploadedAt`, and
+  `remoteCompressedUploadedAt`, so "thumbnail only, original not sent" is
+  expressible. That state exists today and is invisible.
+- Live queue state from the `media_transfer_queue` row for this media id, the
+  same watch `mediaBadgeStateProvider` already performs, including the failure
+  message.
+- `notUploadable` when `sourceType` falls outside `kUploadableSources`
+  (`lib/features/media_store/domain/media_backup_status.dart:7-11`), so a URL
+  row reads as "not eligible for backup" rather than an alarming "not backed
+  up".
+
+### 6.3 ServingFacts
+
+From the recorder: `servedFrom`, `servedTier`, `storeFallbackUsed`, the
+`UnavailableKind` if resolution failed, and the observation timestamp.
+
+Null when the item has not been rendered yet in this session. The panel then
+says "not loaded yet" rather than guessing.
+
+### 6.4 Exposure
+
+`mediaProvenanceProvider = Provider.family<MediaProvenance, MediaItem>`.
+
+Synchronous and cheap: every input is either a row field or an
+already-watched provider. This matters because the badge derives from the same
+object on every tile.
+
+## 7. The info panel
+
+New widget `lib/features/media/presentation/widgets/media_info_panel.dart`,
+plus a `showMediaInfo(context, item)` launcher. Adaptive presentation: a
+draggable bottom sheet on compact widths, a right-hand panel inside the viewer
+on wide ones.
+
+### 7.1 Blocks
+
+**1. File.** `originalFilename`, `width` x `height`, `contentSizeBytes` (and
+`compressedSizeBytes` when a rendition exists), media type, `takenAt`,
+coordinates when present. All units respect the active diver's unit settings
+per project convention. Every one of these is on the row today and none is
+displayed anywhere in the app.
+
+**2. Origin.** Source type label, the pointer for that type, the origin device
+when it is not this one, and health with its verification date.
+
+**3. Backup.** Store identity, per-tier state, queue state or failure text.
+
+**4. Serving now.** `servedFrom` and `servedTier` as one sentence, with the
+fallback note when `storeFallbackUsed` is set, for example: "Photo library
+lookup failed; served from cloud store."
+
+### 7.2 Actions
+
+All reuse existing machinery. No new repair logic.
+
+| Action | Wires to |
+| --- | --- |
+| Check now | `MediaSourceResolver.verify` (`media_source_resolver.dart:57`) |
+| Locate | `MediaRepairService` / repair wizard, scoped to one item |
+| Reveal in Finder, Copy path | platform reveal helper, desktop `localFile` rows only |
+| Back up now, Retry | existing transfer-queue enqueue and retry |
+| Re-upload | existing `MediaReuploadButton` (`media_reupload_button.dart:12-50`) |
+
+**Open question resolved at plan time, not now:** whether
+`MediaRepairWizardPage` accepts a single-item scope or only runs library-wide.
+If it does not, **Locate** opens the wizard pre-filtered rather than growing
+new repair code. Under no circumstance does this feature add repair logic.
+
+### 7.3 Entry points
+
+- An info button in the viewer's `_TopOverlay`
+  (`lib/features/media/presentation/pages/media_viewer_page.dart:1101-1226`),
+  which today has close, page indicator, go-to-dive, write-metadata, Perdix
+  toggle, Lightroom, share, and re-upload, but no info affordance.
+- Tile long-press or context menu in both grids.
+- `MediaMissingView` tiles, whose `onTileTap` is currently a literal no-op
+  (`lib/features/media/presentation/pages/media_missing_view.dart:107`).
+  Wiring it to the panel makes the Missing view answer why an item is missing,
+  in the place a user would look.
+
+### 7.4 Localization
+
+All strings go through the 11 ARB catalogs, which must stay at exact key
+parity. Roughly 35 to 45 new `media_info_*` keys.
+
+## 8. The tile badge
+
+Extends the existing `MediaStoreBadge`
+(`lib/features/media_store/presentation/widgets/media_store_badge.dart:12-42`)
+rather than replacing it. Four of the six states already exist; this is mostly
+a priority ladder plus two new states.
+
+### 8.1 Ladder, first match wins
+
+| Priority | State | Glyph | Condition |
+| --- | --- | --- | --- |
+| 1 | `broken` (new) | `error_outline`, error tint | origin health is `missing` **and** `isBackedUp` is false |
+| 2 | `transferFailed` | `cloud_off`, error tint | queue row failed |
+| 3 | `transferring` / `queued` | `cloud_upload` / `schedule` | live queue row |
+| 4 | `notBackedUp` | `cloud_off` | store attached, source uploadable, no upload stamp |
+| 5 | `cloudOnly` (new) | `cloud` | origin health is `missing` **and** `isBackedUp` is true |
+| n/a | `none` | nothing | healthy and backed up |
+
+`broken` and `cloudOnly` are the same local condition split by whether the
+store can cover for it, and the split is what keeps the badge honest. An item
+whose local file is gone but whose bytes are in the store is not broken: it
+still displays, it just streams. An item whose local file is gone and which
+was never uploaded cannot be displayed at all. `isBackedUp` is the existing
+predicate in `media_backup_status.dart:23-25`, reused rather than restated, so
+the badge and the upload pipeline can never disagree about what "backed up"
+means.
+
+Note that both conditions read `OriginFacts.health`, which is derived from
+`isOrphaned`, and neither reads `ServingFacts`. The badge is therefore
+well-defined for an item that has never been rendered, which is the normal
+case for a tile scrolling into view.
+
+Transfer state deliberately outranks `notBackedUp`. A queued item is by
+definition not yet backed up, so the reverse ordering would mean the transfer
+glyph never appears: every in-flight item would render as `cloud_off`.
+Transfer state is transient, self-resolving, and more informative.
+
+### 8.2 Gating rules
+
+Both are correct in the current badge and are easy to lose.
+
+- Sources outside `kUploadableSources` never reach states 3 through 5. A URL
+  row is not eligible for backup, not failing at it.
+- `broken` renders **even when no store is attached**. Today the whole badge is
+  suppressed by `mediaStoreAttachedProvider`
+  (`media_store_providers.dart:262`), so the attach gate moves from wrapping
+  the badge to guarding states 2 through 5 only.
+
+### 8.3 Mounting
+
+- `MediaThumbnailTile` already has the slot at
+  `lib/features/media/presentation/widgets/media_grid.dart:138` (top-left;
+  top-right is the selection checkmark, bottom-right holds the video, document
+  and depth chips).
+- `MediaLibraryTile`
+  (`lib/features/media/presentation/widgets/media_library_grid.dart:8-52`)
+  gains the same slot. This is the fix for the entire Media console currently
+  rendering badge-less grids.
+
+Each badge carries a `Tooltip`. Tapping it opens the info panel scrolled to
+the block that explains it.
+
+### 8.4 Cost
+
+`mediaBadgeStateProvider` already watches a per-item queue stream on every
+tile, so the per-tile subscription count does not change. The two new states
+derive from `isOrphaned` and the upload stamps, both plain row fields, so no
+tile performs I/O.
+
+## 9. Testing
+
+TDD per project convention. Tests are written before implementation.
+
+- **Per-resolver unit tests** asserting the stamp on every return.
+- **The load-bearing test:** `MediaStoreResolver` against a fake
+  `MediaObjectStore` plus a real `MediaCacheStore`, proving a cache hit stamps
+  `storeCache` and a miss stamps `storeNetwork`, on all three tiers. This
+  single test is the difference between the feature being true and being
+  decorative.
+- **Badge ladder** as a pure function over `MediaProvenance`, table-driven
+  across all six states plus both gating rules.
+- **Recorder tests:** `storeFallbackUsed` is set when the native resolver
+  returns `UnavailableData` and the store then serves; the LRU bound holds
+  under a large scroll.
+- **Widget tests** for each panel block and each action dispatching to a fake.
+- **Regression:** existing media tests stay green unchanged. This design adds
+  information and changes no behavior.
+
+### 9.1 Known repo traps this work walks into
+
+1. **Adding l10n to a shared widget breaks consumer tests.**
+   `MediaLibraryTile` and the badge are rendered by many test-hosted trees;
+   localized tooltips will fail every consumer widget test that does not host
+   localizations. Budget for the fanout.
+2. **New providers must be registered in the tick-subscription contract test.**
+   The repo has a test enumerating media providers that has caught this
+   omission before.
+3. **pdfrx cannot render under `flutter_test`.** The PDF page-1 provenance
+   pass-through can only be unit-tested, never widget-tested. Issue #1019
+   shipped because a bug hid behind exactly that mock.
+
+## 10. Delivery
+
+Three stacked PRs, each in its own worktree per `CLAUDE.md`.
+
+| PR | Contents | Why separable |
+| --- | --- | --- |
+| 1 | `ServedFrom`, `ServedTier`, the stamping sites, `MediaServingRecorder`, recorder writes in both fallback paths | Pure plumbing, no UI, fully unit-testable, zero user-visible change |
+| 2 | `MediaProvenance` and its provider, the info panel, three entry points, actions, ARB keys x11 | The feature proper |
+| 3 | Badge ladder, `MediaLibraryTile` slot, badge-to-panel tap, Missing-view tap | Depends on PR 2 for its tap target |
+
+## 11. Risks
+
+- The stamping edit is wide but shallow: roughly 15 sites across 6 resolver
+  files, one argument each. Low risk individually, easy to miss one. A test
+  per resolver is the guard.
+- ARB parity across 11 catalogs for roughly 40 keys is the most tedious part
+  and the most likely source of CI failure.
+- The badge may read as noisy on first run with a store attached, since
+  nothing is backed up until backfill runs. That is the existing
+  `notBackedUp` behavior rather than something new, but extending it to the
+  console grids makes it far more visible.

--- a/lib/features/media/data/resolvers/connector_media_resolver.dart
+++ b/lib/features/media/data/resolvers/connector_media_resolver.dart
@@ -69,6 +69,12 @@ class ConnectorMediaResolver implements MediaSourceResolver {
     return VerifyResult.available;
   }
 
+  /// The cache pool a rendition request targets also names its tier: the
+  /// connector fetches a 'thumbnail2x' rendition into the thumb pool and a
+  /// '2048' rendition into the originals pool.
+  ServedTier _tierFor(MediaCacheKind kind) =>
+      kind == MediaCacheKind.thumb ? ServedTier.thumbnail : ServedTier.original;
+
   Future<MediaSourceData> _resolveRendition(
     MediaItem item, {
     required String size,
@@ -95,7 +101,14 @@ class ConnectorMediaResolver implements MediaSourceResolver {
 
       if (cache != null && contentHash != null) {
         final cached = await cache.get(contentHash, kind);
-        if (cached != null) return FileData(file: cached, isPoster: isPoster);
+        if (cached != null) {
+          return FileData(
+            file: cached,
+            isPoster: isPoster,
+            servedFrom: ServedFrom.connectorCache,
+            servedTier: _tierFor(kind),
+          );
+        }
       }
 
       final api = await _apiClient();
@@ -124,7 +137,12 @@ class ConnectorMediaResolver implements MediaSourceResolver {
               staging,
               extension: 'jpg',
             );
-            return FileData(file: file, isPoster: isPoster);
+            return FileData(
+              file: file,
+              isPoster: isPoster,
+              servedFrom: ServedFrom.connectorNetwork,
+              servedTier: _tierFor(kind),
+            );
           }
           final digest = await sha256OfFile(staging);
           if (digest.hash == contentHash) {
@@ -134,7 +152,12 @@ class ConnectorMediaResolver implements MediaSourceResolver {
               staging,
               extension: 'jpg',
             );
-            return FileData(file: file, isPoster: isPoster);
+            return FileData(
+              file: file,
+              isPoster: isPoster,
+              servedFrom: ServedFrom.connectorNetwork,
+              servedTier: _tierFor(kind),
+            );
           }
         } finally {
           if (await staging.exists()) {
@@ -142,7 +165,14 @@ class ConnectorMediaResolver implements MediaSourceResolver {
           }
         }
       }
-      return BytesData(bytes: bytes);
+      // Reached only when the bytes could not enter the content-addressed
+      // cache (no hash on the row, or a rendition that failed verification),
+      // so they were still pulled from the API on this call.
+      return BytesData(
+        bytes: bytes,
+        servedFrom: ServedFrom.connectorNetwork,
+        servedTier: _tierFor(kind),
+      );
     } on LightroomApiException catch (e) {
       _log.warning('Lightroom rendition $size failed for ${item.id}: $e');
       return UnavailableData(

--- a/lib/features/media/data/resolvers/http_url_media_resolver.dart
+++ b/lib/features/media/data/resolvers/http_url_media_resolver.dart
@@ -97,7 +97,10 @@ class HttpUrlMediaResolver implements MediaSourceResolver {
     // which already runs through the auth-header injection wired up by
     // Phase 3a's image-cache provider. We do not pre-fetch bytes here —
     // that would defeat the disk cache.
-    return NetworkData(url: uri);
+    // [ServedFrom] records the byte transport, not the link provenance, so
+    // both source types this resolver serves stamp the same value. What
+    // distinguishes them stays on [MediaItem.sourceType].
+    return NetworkData(url: uri, servedFrom: ServedFrom.networkUrl);
   }
 
   @override

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -91,7 +91,9 @@ class LocalFileResolver implements MediaSourceResolver {
         // on macOS — when the direct read is denied.
         if (await f.exists()) {
           final blocker = await _readBlocker(f);
-          if (blocker == null) return FileData(file: f);
+          if (blocker == null) {
+            return FileData(file: f, servedFrom: ServedFrom.localDisk);
+          }
           _log.debug(
             'localPath exists but cannot be opened (sandbox?), falling '
             'back to bookmark: $localPath [item ${item.id}]',
@@ -143,7 +145,7 @@ class LocalFileResolver implements MediaSourceResolver {
       // bookmark-bytes branch below, which is unit-tested.
       try {
         final bytes = await _platform.readUriBytes(ref);
-        return BytesData(bytes: bytes);
+        return BytesData(bytes: bytes, servedFrom: ServedFrom.localDisk);
       } catch (e, st) {
         _log.warning(
           'readUriBytes failed for item ${item.id}',
@@ -171,7 +173,7 @@ class LocalFileResolver implements MediaSourceResolver {
         // FileData from a resolved bookmark handle) avoids leaking the
         // security scope when callers forget to invoke releaseBookmark.
         final bytes = await _platform.readBookmarkBytes(blob);
-        return BytesData(bytes: bytes);
+        return BytesData(bytes: bytes, servedFrom: ServedFrom.localDisk);
       } catch (e, st) {
         _log.warning(
           'readBookmarkBytes failed for item ${item.id}',
@@ -232,7 +234,13 @@ class LocalFileResolver implements MediaSourceResolver {
         item,
         maxDimension: maxDim,
       );
-      if (poster != null) return BytesData(bytes: poster);
+      if (poster != null) {
+        return BytesData(
+          bytes: poster,
+          servedFrom: ServedFrom.localDisk,
+          servedTier: ServedTier.thumbnail,
+        );
+      }
     }
     return resolve(item);
   }

--- a/lib/features/media/data/resolvers/media_store_resolver.dart
+++ b/lib/features/media/data/resolvers/media_store_resolver.dart
@@ -72,7 +72,14 @@ class MediaStoreResolver {
     File? staging;
     try {
       final cached = await _cache.get(hash, MediaCacheKind.thumb);
-      if (cached != null) return FileData(file: cached, isPoster: isPoster);
+      if (cached != null) {
+        return FileData(
+          file: cached,
+          isPoster: isPoster,
+          servedFrom: ServedFrom.storeCache,
+          servedTier: ServedTier.thumbnail,
+        );
+      }
       staging = await _cache.stagingFile();
       await _store.getFile(StoreKeys.thumbKey(hash), staging);
       // No hash verification: thumb bytes are derived; the key carries the
@@ -83,7 +90,12 @@ class MediaStoreResolver {
         staging,
         extension: 'jpg',
       );
-      return FileData(file: file, isPoster: isPoster);
+      return FileData(
+        file: file,
+        isPoster: isPoster,
+        servedFrom: ServedFrom.storeNetwork,
+        servedTier: ServedTier.thumbnail,
+      );
     } on Exception catch (e) {
       _log.warning('Thumb fetch failed for ${item.id}: $e');
       return null;
@@ -104,7 +116,13 @@ class MediaStoreResolver {
         MediaCacheKind.rendition,
         freshAfter: item.remoteCompressedUploadedAt,
       );
-      if (cached != null) return FileData(file: cached);
+      if (cached != null) {
+        return FileData(
+          file: cached,
+          servedFrom: ServedFrom.storeCache,
+          servedTier: ServedTier.rendition,
+        );
+      }
       staging = await _cache.stagingFile();
       await _store.getFile(StoreKeys.renditionKey(hash, ext: ext), staging);
       final file = await _cache.put(
@@ -114,7 +132,11 @@ class MediaStoreResolver {
         sourceVersion: item.remoteCompressedUploadedAt?.millisecondsSinceEpoch,
         extension: ext,
       );
-      return FileData(file: file);
+      return FileData(
+        file: file,
+        servedFrom: ServedFrom.storeNetwork,
+        servedTier: ServedTier.rendition,
+      );
     } on Exception catch (e) {
       _log.warning('Rendition fetch failed for ${item.id}: $e');
       return null;
@@ -127,7 +149,13 @@ class MediaStoreResolver {
     File? staging;
     try {
       final cached = await _cache.get(hash, MediaCacheKind.original);
-      if (cached != null) return FileData(file: cached);
+      if (cached != null) {
+        return FileData(
+          file: cached,
+          servedFrom: ServedFrom.storeCache,
+          servedTier: ServedTier.original,
+        );
+      }
 
       staging = await _cache.stagingFile();
       final extension = StoreKeys.extensionFor(item.originalFilename);
@@ -146,7 +174,11 @@ class MediaStoreResolver {
         staging,
         extension: _cacheExtensionFor(item, extension),
       );
-      return FileData(file: file);
+      return FileData(
+        file: file,
+        servedFrom: ServedFrom.storeNetwork,
+        servedTier: ServedTier.original,
+      );
     } on Exception catch (e) {
       _log.warning('Store fallback failed for ${item.id}: $e');
       return null;

--- a/lib/features/media/data/resolvers/platform_gallery_resolver.dart
+++ b/lib/features/media/data/resolvers/platform_gallery_resolver.dart
@@ -63,7 +63,7 @@ class PlatformGalleryResolver implements MediaSourceResolver {
     if (bytes == null) {
       return const UnavailableData(kind: UnavailableKind.notFound);
     }
-    return BytesData(bytes: bytes);
+    return BytesData(bytes: bytes, servedFrom: ServedFrom.platformGallery);
     // coverage:ignore-end
   }
 
@@ -87,7 +87,11 @@ class PlatformGalleryResolver implements MediaSourceResolver {
     if (bytes == null) {
       return const UnavailableData(kind: UnavailableKind.notFound);
     }
-    return BytesData(bytes: bytes);
+    return BytesData(
+      bytes: bytes,
+      servedFrom: ServedFrom.platformGallery,
+      servedTier: ServedTier.thumbnail,
+    );
   }
 
   /// Runs only on a cache miss.

--- a/lib/features/media/data/resolvers/signature_resolver.dart
+++ b/lib/features/media/data/resolvers/signature_resolver.dart
@@ -22,14 +22,18 @@ class SignatureResolver implements MediaSourceResolver {
 
   @override
   Future<MediaSourceData> resolve(MediaItem item) async {
+    // Both branches read [ServedFrom.embedded]: a signature is the app's own
+    // artifact either way, and whether it happens to live inline or beside
+    // the database is an implementation detail rather than a source the user
+    // linked from.
     if (item.imageData != null && item.imageData!.isNotEmpty) {
-      return BytesData(bytes: item.imageData!);
+      return BytesData(bytes: item.imageData!, servedFrom: ServedFrom.embedded);
     }
     final path = item.filePath;
     if (path != null && path.isNotEmpty) {
       final file = File(path);
       if (await file.exists()) {
-        return FileData(file: file);
+        return FileData(file: file, servedFrom: ServedFrom.embedded);
       }
     }
     return const UnavailableData(kind: UnavailableKind.notFound);

--- a/lib/features/media/data/services/media_serving_recorder.dart
+++ b/lib/features/media/data/services/media_serving_recorder.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// What one completed resolution produced.
+///
+/// [storeFallbackUsed] is the fact no resolver can report on its own: it
+/// belongs to the layer that tried the row's native source first, saw it
+/// fail, and asked the media store to cover. It is what turns "the cloud
+/// served this" into "the photo library lookup failed and the cloud served
+/// this", which is the difference between a status readout and a diagnosis.
+@immutable
+class ServingObservation {
+  const ServingObservation({
+    required this.servedFrom,
+    required this.servedTier,
+    required this.failure,
+    required this.storeFallbackUsed,
+    required this.observedAt,
+  });
+
+  final ServedFrom? servedFrom;
+  final ServedTier servedTier;
+
+  /// Set when the resolution produced no bytes at all.
+  final UnavailableKind? failure;
+
+  /// Whether the row's own source failed and the media store was asked.
+  /// Records that the fallback RAN, not that it succeeded.
+  final bool storeFallbackUsed;
+
+  final DateTime observedAt;
+}
+
+/// Remembers how each media item was most recently resolved, so the media
+/// info panel can report what actually painted the pixels rather than
+/// re-resolving and reporting what would happen if it tried again.
+///
+/// Deliberately NOT a StateNotifier or a Riverpod-managed state object.
+/// Every visible tile writes here as it finishes resolving, and routing
+/// that through provider state would rebuild the grid on every scroll.
+/// Listeners are notified so an open info panel can refresh; when nothing
+/// is listening, notification is free.
+class MediaServingRecorder extends ChangeNotifier {
+  MediaServingRecorder({DateTime Function()? now, this.maxEntries = 200})
+    : _now = now ?? DateTime.now;
+
+  final DateTime Function() _now;
+
+  /// Bound on retained observations. A library scroll would otherwise grow
+  /// this map without limit for the lifetime of the process.
+  final int maxEntries;
+
+  /// Insertion-ordered, so the first key is the least recently recorded.
+  /// A re-record removes and re-inserts to move the entry to the end.
+  final Map<String, ServingObservation> _entries =
+      <String, ServingObservation>{};
+
+  @visibleForTesting
+  int get entryCount => _entries.length;
+
+  /// A thumbnail and an original are separate observations of the same row:
+  /// a grid tile resolves the first while the viewer resolves the second,
+  /// and they can legitimately come from different places.
+  String _key(String mediaId, bool thumbnail) =>
+      '$mediaId#${thumbnail ? 't' : 'o'}';
+
+  void record(
+    String mediaId, {
+    required bool thumbnail,
+    ServedFrom? servedFrom,
+    ServedTier servedTier = ServedTier.original,
+    UnavailableKind? failure,
+    bool storeFallbackUsed = false,
+  }) {
+    final key = _key(mediaId, thumbnail);
+    _entries.remove(key);
+    _entries[key] = ServingObservation(
+      servedFrom: servedFrom,
+      servedTier: servedTier,
+      failure: failure,
+      storeFallbackUsed: storeFallbackUsed,
+      observedAt: _now(),
+    );
+    while (_entries.length > maxEntries) {
+      _entries.remove(_entries.keys.first);
+    }
+    notifyListeners();
+  }
+
+  ServingObservation? lastFor(String mediaId, {required bool thumbnail}) =>
+      _entries[_key(mediaId, thumbnail)];
+}

--- a/lib/features/media/data/services/media_serving_recorder.dart
+++ b/lib/features/media/data/services/media_serving_recorder.dart
@@ -59,6 +59,14 @@ class MediaServingRecorder extends ChangeNotifier {
   @visibleForTesting
   int get entryCount => _entries.length;
 
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
   /// A thumbnail and an original are separate observations of the same row:
   /// a grid tile resolves the first while the viewer resolves the second,
   /// and they can legitimately come from different places.
@@ -73,6 +81,11 @@ class MediaServingRecorder extends ChangeNotifier {
     UnavailableKind? failure,
     bool storeFallbackUsed = false,
   }) {
+    // A resolution can outlive the container that owns this recorder: a
+    // FutureProvider still in flight when a ProviderContainer is disposed
+    // runs its continuation afterwards. notifyListeners asserts once the
+    // notifier is disposed, so a late write is dropped rather than attempted.
+    if (_disposed) return;
     final key = _key(mediaId, thumbnail);
     _entries.remove(key);
     _entries[key] = ServingObservation(

--- a/lib/features/media/domain/value_objects/media_source_data.dart
+++ b/lib/features/media/domain/value_objects/media_source_data.dart
@@ -25,6 +25,56 @@ enum UnavailableKind {
   volumeOffline,
 }
 
+/// Which concrete source produced a [MediaSourceData]'s bytes.
+///
+/// Distinct from `MediaSourceType`, which records where a row was LINKED
+/// from and never changes. This records where the bytes came from on THIS
+/// resolution, which can differ: a gallery-sourced row whose asset has been
+/// deleted from the photo library is served from the cloud store instead.
+enum ServedFrom {
+  /// A file read directly off a mounted volume by `LocalFileResolver`.
+  localDisk,
+
+  /// Bytes handed over by photo_manager from the device photo library.
+  platformGallery,
+
+  /// A hit in the local media cache. No network was touched.
+  storeCache,
+
+  /// Downloaded from the cloud media store during this resolution.
+  storeNetwork,
+
+  /// A URL handed to `cached_network_image`, which owns the transport.
+  networkUrl,
+
+  /// A hit in the service connector's own cache pool.
+  connectorCache,
+
+  /// Fetched from the service connector's API during this resolution.
+  connectorNetwork,
+
+  /// A BLOB stored inline on the media row (signatures).
+  embedded,
+}
+
+/// Which of the three store tiers a [MediaSourceData]'s bytes are.
+///
+/// Orthogonal to [ServedFrom]: the store can serve any tier from either its
+/// cache or the network, so "a cached thumbnail" and "a freshly downloaded
+/// thumbnail" differ in [ServedFrom] while sharing a tier.
+enum ServedTier {
+  /// The item's own full-resolution bytes.
+  original,
+
+  /// A derived small image: a resized photo, a video poster frame, or a
+  /// document page-1 render.
+  thumbnail,
+
+  /// A compressed rendition uploaded in place of the original by a
+  /// non-original upload quality setting.
+  rendition,
+}
+
 /// A handle to displayable media bytes — or, when unavailable, a structured
 /// explanation for the UI placeholder.
 ///
@@ -32,7 +82,24 @@ enum UnavailableKind {
 /// universal `MediaItemView` widget. Each variant maps to the most
 /// efficient Flutter widget for that kind of source.
 sealed class MediaSourceData {
-  const MediaSourceData();
+  const MediaSourceData({
+    this.servedFrom,
+    this.servedTier = ServedTier.original,
+  });
+
+  /// Which source produced these bytes, or null when nothing did
+  /// ([UnavailableData]) or the producer did not say.
+  ///
+  /// Stamped at construction rather than computed by consumers: the two
+  /// independent native-then-store fallback paths (`MediaItemView._resolve`
+  /// and `mediaBytesProvider`) therefore inherit it without either being
+  /// rewritten, and cannot disagree about it.
+  final ServedFrom? servedFrom;
+
+  /// Which tier these bytes are. Meaningful mainly for store-served data;
+  /// every other producer leaves it at [ServedTier.original] except when it
+  /// returns a derived image.
+  final ServedTier servedTier;
 }
 
 /// Bytes live in a local file the OS can read directly.
@@ -52,7 +119,12 @@ class FileData extends MediaSourceData {
   /// photo itself, resized.
   final bool isPoster;
 
-  const FileData({required this.file, this.isPoster = false});
+  const FileData({
+    required this.file,
+    this.isPoster = false,
+    super.servedFrom,
+    super.servedTier,
+  });
 }
 
 /// Bytes live at an HTTP(S) URL that requires the given headers.
@@ -60,18 +132,28 @@ class FileData extends MediaSourceData {
 class NetworkData extends MediaSourceData {
   final Uri url;
   final Map<String, String> headers;
-  const NetworkData({required this.url, this.headers = const {}});
+  const NetworkData({
+    required this.url,
+    this.headers = const {},
+    super.servedFrom,
+    super.servedTier,
+  });
 }
 
 /// Bytes are already in memory (used for signature BLOBs and small assets).
 /// Maps to `Image.memory`.
 class BytesData extends MediaSourceData {
   final Uint8List bytes;
-  const BytesData({required this.bytes});
+  const BytesData({required this.bytes, super.servedFrom, super.servedTier});
 }
 
 /// We cannot resolve the bytes on the current device.
 /// Renders an informational badge via `UnavailableMediaPlaceholder`.
+///
+/// Deliberately does not accept [MediaSourceData.servedFrom] or
+/// [MediaSourceData.servedTier]: nothing served these bytes, so there is no
+/// honest value to pass. Omitting the parameters makes that unrepresentable
+/// rather than merely conventional.
 class UnavailableData extends MediaSourceData {
   final UnavailableKind kind;
   final String? userMessage;

--- a/lib/features/media/presentation/providers/media_bytes_providers.dart
+++ b/lib/features/media/presentation/providers/media_bytes_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/media/data/services/asset_resolution_service
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
@@ -32,9 +33,19 @@ const _log = LoggerService('mediaBytesProvider');
 /// purpose, indistinguishable from an absent one.
 final mediaBytesProvider =
     FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      // Always thumbnail: false. This provider resolves full-resolution
+      // bytes only; grid thumbnails go through MediaItemView.
+      final recorder = ref.read(mediaServingRecorderProvider);
+
       final native = await _resolveNative(ref, item);
       final bytes = await _bytesOf(native, item);
       if (bytes != null) {
+        recorder.record(
+          item.id,
+          thumbnail: false,
+          servedFrom: native.servedFrom,
+          servedTier: native.servedTier,
+        );
         return ResolvedAssetResult(
           bytes: bytes,
           status: ResolutionStatus.resolved,
@@ -48,12 +59,34 @@ final mediaBytesProvider =
       final remote = await _resolveRemote(ref, item);
       final remoteBytes = await _bytesOf(remote, item);
       if (remoteBytes != null) {
+        recorder.record(
+          item.id,
+          thumbnail: false,
+          servedFrom: remote?.servedFrom,
+          servedTier: remote?.servedTier ?? ServedTier.original,
+          storeFallbackUsed: true,
+        );
         return ResolvedAssetResult(
           bytes: remoteBytes,
           status: ResolutionStatus.resolved,
         );
       }
 
+      // A native NetworkData yields no bytes without being an
+      // UnavailableData: this provider deliberately does not fetch URLs (see
+      // [_bytesOf]). For a byte consumer that is indistinguishable from an
+      // absent source, so it collapses to notFound.
+      //
+      // storeFallbackUsed is true because the store WAS asked and could not
+      // help. It records that the fallback ran, not that it succeeded.
+      recorder.record(
+        item.id,
+        thumbnail: false,
+        failure: native is UnavailableData
+            ? native.kind
+            : UnavailableKind.notFound,
+        storeFallbackUsed: true,
+      );
       return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
     });
 

--- a/lib/features/media/presentation/providers/media_serving_providers.dart
+++ b/lib/features/media/presentation/providers/media_serving_providers.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+
+/// Process-wide recorder of how each media item was most recently resolved.
+///
+/// A plain Provider with a concrete default, so no consumer test needs an
+/// override to construct a widget tree that renders media. Tests that want
+/// to assert on what was recorded override it with their own instance.
+final mediaServingRecorderProvider = Provider<MediaServingRecorder>(
+  (ref) => MediaServingRecorder(),
+);

--- a/lib/features/media/presentation/providers/media_serving_providers.dart
+++ b/lib/features/media/presentation/providers/media_serving_providers.dart
@@ -7,6 +7,11 @@ import 'package:submersion/features/media/data/services/media_serving_recorder.d
 /// A plain Provider with a concrete default, so no consumer test needs an
 /// override to construct a widget tree that renders media. Tests that want
 /// to assert on what was recorded override it with their own instance.
-final mediaServingRecorderProvider = Provider<MediaServingRecorder>(
-  (ref) => MediaServingRecorder(),
-);
+final mediaServingRecorderProvider = Provider<MediaServingRecorder>((ref) {
+  final recorder = MediaServingRecorder();
+  // Owned by the container. Disposing is safe because record() drops writes
+  // once disposed: a resolution still in flight when the container goes away
+  // would otherwise assert inside notifyListeners.
+  ref.onDispose(recorder.dispose);
+  return recorder;
+});

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -126,6 +126,16 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
   /// past that method's own opening yield.
   Future<_Resolution> _resolve() async {
     final resolution = await _resolveInner();
+    // A grid tile can scroll out and be disposed while its resolution is
+    // still in flight. Riverpod's WidgetRef.read asserts the element is still
+    // mounted and throws StateError otherwise (flutter_riverpod
+    // consumer.dart, read -> _assertNotDisposed), and because FutureBuilder
+    // keeps an onError callback registered across dispose, that throw is
+    // silently swallowed rather than surfaced. The observable cost is a
+    // thrown-and-discarded exception per tile on every fast scroll, and a
+    // real error here would be just as invisible. Nothing to record anyway:
+    // no one is watching this resolution.
+    if (!mounted) return resolution;
     final data = resolution.data;
     ref
         .read(mediaServingRecorderProvider)

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/unavailable_media_placeholder.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
@@ -73,10 +74,17 @@ class MediaItemView extends ConsumerStatefulWidget {
 /// back as the store's THUMB. Every other document resolution (local
 /// original, store original) is raw document bytes that Image widgets
 /// cannot decode, and draws the placeholder instead.
+///
+/// [storeFallbackUsed] records that the row's own source could not produce
+/// bytes here and the media store was asked to cover. No resolver can report
+/// this: it is a fact about the SEQUENCE of attempts rather than about any
+/// single one, and it is what lets the info panel say "the photo library
+/// lookup failed" instead of merely "served from cloud".
 typedef _Resolution = ({
   MediaSourceData data,
   bool videoPosterMissing,
   bool documentRenderable,
+  bool storeFallbackUsed,
 });
 
 class _MediaItemViewState extends ConsumerState<MediaItemView> {
@@ -106,12 +114,38 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
       old.thumbnail != widget.thumbnail ||
       old.targetSize != widget.targetSize;
 
+  /// Resolves and records the outcome.
+  ///
+  /// Recording once here rather than at each of [_resolveInner]'s seven exits
+  /// means a new exit added later cannot silently skip it: the record type
+  /// forces every return to supply `storeFallbackUsed`, so an omission is a
+  /// compile error rather than a quietly missing observation.
+  ///
+  /// The `ref` read is safe despite both callers running inside the build
+  /// phase: it happens after [_resolveInner] has completed, which is well
+  /// past that method's own opening yield.
+  Future<_Resolution> _resolve() async {
+    final resolution = await _resolveInner();
+    final data = resolution.data;
+    ref
+        .read(mediaServingRecorderProvider)
+        .record(
+          widget.item.id,
+          thumbnail: widget.thumbnail,
+          servedFrom: data.servedFrom,
+          servedTier: data.servedTier,
+          failure: data is UnavailableData ? data.kind : null,
+          storeFallbackUsed: resolution.storeFallbackUsed,
+        );
+    return resolution;
+  }
+
   // Declared `async` (not just returning a Future from a sync body) so any
   // synchronous throw — e.g. `MediaSourceResolverRegistry.resolverFor`
   // throwing UnsupportedError when a row's source_type has no registered
   // resolver — becomes a Future error caught by FutureBuilder's hasError
   // branch in [build] instead of escaping initState/didUpdateWidget.
-  Future<_Resolution> _resolve() async {
+  Future<_Resolution> _resolveInner() async {
     // Yield before the first `ref` touch. Both callers (initState and
     // didUpdateWidget) run inside the build phase, and an `async` body still
     // executes synchronously up to its first await -- so reading a provider
@@ -131,14 +165,31 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
     // back across a platform channel) happens once per document instead of
     // once per tile that scrolls into view.
     if (widget.thumbnail && widget.item.isPdf) {
+      // The render is built from the source's bytes, so it inherits the
+      // source's provenance. thumbFor caches its output, and on a cache hit
+      // the closure is never called, leaving this null: the honest answer,
+      // because on that pass the bytes did not come from anywhere.
+      ServedFrom? sourceFrom;
       final page1 = await ref
           .read(pdfThumbnailServiceProvider)
-          .thumbFor(widget.item, source: () => resolver.resolve(widget.item));
+          .thumbFor(
+            widget.item,
+            source: () async {
+              final resolved = await resolver.resolve(widget.item);
+              sourceFrom = resolved.servedFrom;
+              return resolved;
+            },
+          );
       if (page1 != null) {
         return (
-          data: BytesData(bytes: page1),
+          data: BytesData(
+            bytes: page1,
+            servedFrom: sourceFrom,
+            servedTier: ServedTier.thumbnail,
+          ),
           videoPosterMissing: false,
           documentRenderable: true,
+          storeFallbackUsed: false,
         );
       }
       // No local render (bytes unavailable here, or an unreadable PDF):
@@ -161,6 +212,7 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         data: native,
         videoPosterMissing: false,
         documentRenderable: false,
+        storeFallbackUsed: false,
       );
     }
     // Media store fallback (design spec section 10): only engages when the
@@ -186,6 +238,9 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         data: native,
         videoPosterMissing: false,
         documentRenderable: false,
+        // The store was never consulted: the row carries no stamp saying it
+        // would have anything to offer.
+        storeFallbackUsed: false,
       );
     }
     try {
@@ -198,6 +253,10 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
           data: native,
           videoPosterMissing: false,
           documentRenderable: false,
+          // True on purpose: the fallback was attempted and there was no
+          // store here to answer it, which is a different situation from
+          // never having looked.
+          storeFallbackUsed: true,
         );
       }
       final remote = await runtime.resolver.tryResolveRemote(
@@ -215,6 +274,7 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
           // it handed back, and isPoster is how it says so.
           documentRenderable:
               widget.thumbnail && remote is FileData && remote.isPoster,
+          storeFallbackUsed: true,
         );
       }
       // The movie tile claims something specific -- this video has no poster
@@ -231,12 +291,14 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
             widget.item.isVideo &&
             widget.item.remoteThumbUploadedAt == null,
         documentRenderable: false,
+        storeFallbackUsed: true,
       );
     } catch (_) {
       return (
         data: native,
         videoPosterMissing: false,
         documentRenderable: false,
+        storeFallbackUsed: true,
       );
     }
   }

--- a/test/features/media/data/media_store_resolver_provenance_test.dart
+++ b/test/features/media/data/media_store_resolver_provenance_test.dart
@@ -1,0 +1,139 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+
+import '../../../helpers/in_memory_media_object_store.dart';
+
+/// These six stamps are the reason the provenance feature exists: the two
+/// returns in each fetch method were the only place in the app that knew a
+/// media-cache hit from a fresh cloud download, and all six discarded it.
+///
+/// Every test here EMPTIES the object store between the two reads. That is
+/// the load-bearing step: without it a resolver that stamped storeCache
+/// unconditionally would pass too, and the assertion would prove nothing.
+void main() {
+  late LocalCacheDatabase db;
+  late Directory root;
+  late InMemoryMediaObjectStore store;
+  late MediaCacheStore cache;
+  late MediaStoreResolver resolver;
+
+  setUp(() async {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('msr_prov');
+    store = InMemoryMediaObjectStore();
+    cache = MediaCacheStore(database: db, root: root);
+    resolver = MediaStoreResolver(store: store, cache: cache);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  MediaItem item({
+    String? hash,
+    DateTime? uploadedAt,
+    DateTime? thumbUploadedAt,
+    DateTime? compressedUploadedAt,
+    MediaType mediaType = MediaType.photo,
+  }) => MediaItem(
+    id: 'm1',
+    mediaType: mediaType,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: 'gone-from-this-device',
+    originalFilename: 'reef.jpg',
+    takenAt: DateTime(2026),
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    contentHash: hash,
+    remoteUploadedAt: uploadedAt,
+    remoteThumbUploadedAt: thumbUploadedAt,
+    remoteCompressedUploadedAt: compressedUploadedAt,
+  );
+
+  test(
+    'an original download is storeNetwork, the re-read is storeCache',
+    () async {
+      final bytes = 'submersion'.codeUnits;
+      final tmp = File('${root.path}/seed');
+      await tmp.writeAsBytes(bytes, flush: true);
+      final digest = await sha256OfFile(tmp);
+      store.objects[StoreKeys.objectKey(digest.hash, extension: 'jpg')] = bytes;
+
+      final first = await resolver.tryResolveRemote(
+        item(hash: digest.hash, uploadedAt: DateTime(2026)),
+        thumbnail: false,
+      );
+      expect(first!.servedFrom, ServedFrom.storeNetwork);
+      expect(first.servedTier, ServedTier.original);
+
+      // Emptying the store proves the second read cannot have gone to network.
+      store.objects.clear();
+
+      final second = await resolver.tryResolveRemote(
+        item(hash: digest.hash, uploadedAt: DateTime(2026)),
+        thumbnail: false,
+      );
+      expect(second!.servedFrom, ServedFrom.storeCache);
+      expect(second.servedTier, ServedTier.original);
+    },
+  );
+
+  test('a thumb download is storeNetwork, the re-read is storeCache', () async {
+    final hash = 'a' * 64;
+    // Thumbs are derived bytes and are not hash-verified, so any content
+    // works here.
+    store.objects[StoreKeys.thumbKey(hash)] = 'thumb-bytes'.codeUnits;
+
+    final first = await resolver.tryResolveRemote(
+      item(hash: hash, thumbUploadedAt: DateTime(2026)),
+      thumbnail: true,
+    );
+    expect(first!.servedFrom, ServedFrom.storeNetwork);
+    expect(first.servedTier, ServedTier.thumbnail);
+
+    store.objects.clear();
+
+    final second = await resolver.tryResolveRemote(
+      item(hash: hash, thumbUploadedAt: DateTime(2026)),
+      thumbnail: true,
+    );
+    expect(second!.servedFrom, ServedFrom.storeCache);
+    expect(second.servedTier, ServedTier.thumbnail);
+  });
+
+  test(
+    'a rendition download is storeNetwork, the re-read is storeCache',
+    () async {
+      final hash = 'b' * 64;
+      store.objects[StoreKeys.renditionKey(hash, ext: 'jpg')] =
+          'rendition-bytes'.codeUnits;
+
+      // No remoteUploadedAt: the compressed stamp alone must route here.
+      final first = await resolver.tryResolveRemote(
+        item(hash: hash, compressedUploadedAt: DateTime(2026)),
+        thumbnail: false,
+      );
+      expect(first!.servedFrom, ServedFrom.storeNetwork);
+      expect(first.servedTier, ServedTier.rendition);
+
+      store.objects.clear();
+
+      final second = await resolver.tryResolveRemote(
+        item(hash: hash, compressedUploadedAt: DateTime(2026)),
+        thumbnail: false,
+      );
+      expect(second!.servedFrom, ServedFrom.storeCache);
+      expect(second.servedTier, ServedTier.rendition);
+    },
+  );
+}

--- a/test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart
+++ b/test/features/media/data/resolvers/connector_media_resolver_provenance_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+import 'dart:ui' show Size;
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/resolvers/connector_media_resolver.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late Directory root;
+  late MediaCacheStore cache;
+
+  setUp(() async {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('cmr_prov');
+    cache = MediaCacheStore(database: db, root: root);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  MediaItem item({String? contentHash}) => MediaItem(
+    id: 'c1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.serviceConnector,
+    remoteAssetId: 'asset-1',
+    contentHash: contentHash,
+    takenAt: DateTime.utc(2026),
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+
+  test('a signed-out connector resolution claims no source', () async {
+    final resolver = ConnectorMediaResolver(
+      hasLightroomAccount: false,
+      apiClient: () async => null,
+      catalogId: () async => null,
+      cache: () async => null,
+    );
+
+    final data = await resolver.resolve(item());
+
+    expect(data, isA<UnavailableData>());
+    expect((data as UnavailableData).kind, UnavailableKind.signInRequired);
+    expect(data.servedFrom, isNull);
+  });
+
+  test('a cache hit is stamped connectorCache at the original tier', () async {
+    const hash = 'abc123';
+    final staging = await cache.stagingFile();
+    await staging.writeAsBytes(const [1, 2, 3], flush: true);
+    await cache.put(hash, MediaCacheKind.original, staging, extension: 'jpg');
+
+    // apiClient stays null on purpose: a cache MISS would fall through to
+    // signInRequired, so a FileData here can only mean the cache served it.
+    final resolver = ConnectorMediaResolver(
+      hasLightroomAccount: true,
+      apiClient: () async => null,
+      catalogId: () async => null,
+      cache: () async => cache,
+    );
+
+    final data = await resolver.resolve(item(contentHash: hash));
+
+    expect(data, isA<FileData>());
+    expect(data.servedFrom, ServedFrom.connectorCache);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('a thumb cache hit carries the thumbnail tier', () async {
+    const hash = 'def456';
+    final staging = await cache.stagingFile();
+    await staging.writeAsBytes(const [4, 5, 6], flush: true);
+    await cache.put(hash, MediaCacheKind.thumb, staging, extension: 'jpg');
+
+    final resolver = ConnectorMediaResolver(
+      hasLightroomAccount: true,
+      apiClient: () async => null,
+      catalogId: () async => null,
+      cache: () async => cache,
+    );
+
+    final data = await resolver.resolveThumbnail(
+      item(contentHash: hash),
+      target: const Size(128, 128),
+    );
+
+    expect(data, isA<FileData>());
+    expect(data.servedFrom, ServedFrom.connectorCache);
+    expect(data.servedTier, ServedTier.thumbnail);
+  });
+}

--- a/test/features/media/data/resolvers/local_file_resolver_provenance_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_provenance_test.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' show Size;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/resolvers/local_file_resolver.dart';
+import 'package:submersion/features/media/data/services/exif_extractor.dart';
+import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
+import 'package:submersion/features/media/data/services/local_media_platform.dart';
+import 'package:submersion/features/media/data/services/video_thumbnail_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// Returns a fixed blob for any ref, so the security-scoped bookmark branch
+/// can be reached without keychain I/O.
+class _StubBookmarkStorage extends LocalBookmarkStorage {
+  _StubBookmarkStorage(this._blob);
+  final Uint8List? _blob;
+
+  @override
+  Future<Uint8List?> read(String ref) async => _blob;
+}
+
+class _StubPlatform implements LocalMediaPlatform {
+  _StubPlatform(this._bytes);
+  final Uint8List _bytes;
+
+  @override
+  Future<Uint8List> readBookmarkBytes(Uint8List bookmarkBlob) async => _bytes;
+
+  @override
+  Future<Uint8List> readUriBytes(String uri) async => _bytes;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} should not be called');
+}
+
+class _StubThumbs extends VideoThumbnailService {
+  _StubThumbs(this._bytes)
+    : super(
+        platform: LocalMediaPlatform(),
+        bookmarkStorage: LocalBookmarkStorage(),
+        cacheDir: () async => Directory.systemTemp,
+      );
+  final Uint8List? _bytes;
+
+  @override
+  Future<Uint8List?> posterFor(
+    MediaItem item, {
+    int maxDimension = 512,
+  }) async => _bytes;
+}
+
+void main() {
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('lfr_prov');
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  MediaItem item({
+    String? localPath,
+    String? bookmarkRef,
+    MediaType mediaType = MediaType.photo,
+  }) => MediaItem(
+    id: 'm1',
+    mediaType: mediaType,
+    sourceType: MediaSourceType.localFile,
+    localPath: localPath,
+    bookmarkRef: bookmarkRef,
+    takenAt: DateTime.utc(2026),
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+
+  test('a readable local file is stamped localDisk at original tier', () async {
+    final f = File('${dir.path}/reef.jpg');
+    await f.writeAsBytes(const [1, 2, 3], flush: true);
+    final resolver = LocalFileResolver(
+      bookmarkStorage: LocalBookmarkStorage(),
+      platform: LocalMediaPlatform(),
+      exifExtractor: ExifExtractor(),
+      usesSecurityScopedBookmarks: () => false,
+    );
+
+    final data = await resolver.resolve(item(localPath: f.path));
+
+    expect(data, isA<FileData>());
+    expect(data.servedFrom, ServedFrom.localDisk);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('bookmark-read bytes are stamped localDisk', () async {
+    final resolver = LocalFileResolver(
+      bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList(const [9])),
+      platform: _StubPlatform(Uint8List.fromList(const [4, 5, 6])),
+      exifExtractor: ExifExtractor(),
+      usesSecurityScopedBookmarks: () => true,
+    );
+
+    final data = await resolver.resolve(item(bookmarkRef: 'ref-1'));
+
+    expect(data, isA<BytesData>());
+    expect(data.servedFrom, ServedFrom.localDisk);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('a video poster is stamped localDisk at thumbnail tier', () async {
+    final f = File('${dir.path}/clip.mp4');
+    await f.writeAsBytes(const [1, 2, 3], flush: true);
+    final resolver = LocalFileResolver(
+      bookmarkStorage: LocalBookmarkStorage(),
+      platform: LocalMediaPlatform(),
+      exifExtractor: ExifExtractor(),
+      videoThumbnails: _StubThumbs(Uint8List.fromList(const [8, 8])),
+      usesSecurityScopedBookmarks: () => false,
+    );
+
+    final data = await resolver.resolveThumbnail(
+      item(localPath: f.path, mediaType: MediaType.video),
+      target: const Size(128, 128),
+    );
+
+    expect(data, isA<BytesData>());
+    expect(data.servedFrom, ServedFrom.localDisk);
+    expect(data.servedTier, ServedTier.thumbnail);
+  });
+
+  test('an unresolvable item claims no source', () async {
+    final resolver = LocalFileResolver(
+      bookmarkStorage: LocalBookmarkStorage(),
+      platform: LocalMediaPlatform(),
+      exifExtractor: ExifExtractor(),
+      usesSecurityScopedBookmarks: () => false,
+    );
+
+    final data = await resolver.resolve(item());
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+}

--- a/test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart
+++ b/test/features/media/data/resolvers/platform_gallery_resolver_provenance_test.dart
@@ -1,0 +1,106 @@
+import 'dart:typed_data';
+import 'dart:ui' show Size;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
+import 'package:submersion/features/media/data/resolvers/platform_gallery_resolver.dart';
+import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
+import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
+
+// The resolver's two SUCCESS returns cannot be reached from a test host:
+// they call AssetEntity.fromId, which needs a real device photo library, and
+// GalleryThumbnailCache keeps its entries private so a hit cannot be seeded.
+// Both are stamped in the implementation and sit inside coverage:ignore
+// blocks. What is reachable, and what this file pins, is the contract on the
+// other side: a resolution that produced nothing must never claim a source.
+
+class _StubPhotoPickerService implements PhotoPickerService {
+  @override
+  bool get supportsGalleryBrowsing => false;
+
+  @override
+  Future<List<AssetInfo>> getAssetsInDateRange(
+    DateTime start,
+    DateTime end,
+  ) async => [];
+
+  @override
+  Future<Uint8List?> getThumbnail(String assetId, {int size = 200}) async =>
+      null;
+
+  @override
+  Future<Uint8List?> getFileBytes(String assetId) async => null;
+
+  @override
+  Future<PhotoPermissionStatus> checkPermission() async =>
+      PhotoPermissionStatus.denied;
+
+  @override
+  Future<PhotoPermissionStatus> requestPermission() async =>
+      PhotoPermissionStatus.denied;
+
+  @override
+  Future<String?> getFilePath(String assetId) async => null;
+
+  @override
+  Future<MediaSourceMetadata?> getAssetMetadata(String assetId) async => null;
+}
+
+class _FakeAssetResolutionService extends AssetResolutionService {
+  _FakeAssetResolutionService(this._result)
+    : super(
+        cacheRepository: LocalAssetCacheRepository(),
+        photoPickerService: _StubPhotoPickerService(),
+      );
+
+  final ResolutionResult _result;
+
+  @override
+  Future<ResolutionResult> resolveAssetId(MediaItem item) async => _result;
+}
+
+PlatformGalleryResolver _unresolvable() => PlatformGalleryResolver(
+  resolutionService: _FakeAssetResolutionService(
+    const ResolutionResult(status: ResolutionStatus.unavailable),
+  ),
+);
+
+MediaItem _gallery({String? assetId}) => MediaItem(
+  id: 'm1',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.platformGallery,
+  platformAssetId: assetId,
+  takenAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+void main() {
+  test('a row with no asset id claims no source', () async {
+    final data = await _unresolvable().resolve(_gallery());
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+
+  test('an unresolvable asset id claims no source', () async {
+    final data = await _unresolvable().resolve(_gallery(assetId: 'gone'));
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+
+  test('an unresolvable thumbnail claims no source', () async {
+    final data = await _unresolvable().resolveThumbnail(
+      _gallery(assetId: 'gone'),
+      target: const Size(128, 128),
+    );
+
+    expect(data, isA<UnavailableData>());
+    expect(data.servedFrom, isNull);
+  });
+}

--- a/test/features/media/data/resolvers/signature_http_provenance_test.dart
+++ b/test/features/media/data/resolvers/signature_http_provenance_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/features/media/data/resolvers/http_url_media_resolver.dart';
+import 'package:submersion/features/media/data/resolvers/signature_resolver.dart';
+import 'package:submersion/features/media/data/services/network_credentials_service.dart';
+import 'package:submersion/features/media/data/services/network_url_resolver.dart';
+import 'package:submersion/features/media/data/services/url_metadata_extractor.dart';
+import 'package:submersion/features/media/domain/entities/extracted_metadata.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+class _StubCreds implements NetworkCredentialsService {
+  @override
+  Future<Map<String, String>?> headersFor(Uri uri) async => null;
+  @override
+  noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+HttpUrlMediaResolver _httpResolver(MediaSourceType sourceType) {
+  final resolver = NetworkUrlResolver(
+    client: MockClient((_) async => http.Response.bytes([], 200)),
+    credentials: _StubCreds(),
+  );
+  return HttpUrlMediaResolver(
+    sourceType: sourceType,
+    networkUrlResolver: resolver,
+    urlMetadataExtractor: UrlMetadataExtractor(
+      resolver: resolver,
+      exifExtract: (_) async => const ExtractedMetadata(),
+    ),
+  );
+}
+
+MediaItem _signature({Uint8List? imageData, String? filePath}) => MediaItem(
+  id: 'sig',
+  mediaType: MediaType.instructorSignature,
+  sourceType: MediaSourceType.signature,
+  imageData: imageData,
+  filePath: filePath,
+  takenAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+MediaItem _urlItem(MediaSourceType sourceType) => MediaItem(
+  id: 'u1',
+  mediaType: MediaType.photo,
+  sourceType: sourceType,
+  url: 'https://example.test/reef.jpg',
+  takenAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+  updatedAt: DateTime.utc(2026),
+);
+
+void main() {
+  group('SignatureResolver', () {
+    test('an inline signature blob is stamped embedded', () async {
+      final data = await SignatureResolver().resolve(
+        _signature(imageData: Uint8List.fromList(const [1, 2, 3])),
+      );
+
+      expect(data, isA<BytesData>());
+      expect(data.servedFrom, ServedFrom.embedded);
+      expect(data.servedTier, ServedTier.original);
+    });
+
+    test('a signature file on disk is also stamped embedded', () async {
+      final dir = await Directory.systemTemp.createTemp('sig_prov');
+      addTearDown(() async {
+        if (await dir.exists()) await dir.delete(recursive: true);
+      });
+      final f = File('${dir.path}/sig.png');
+      await f.writeAsBytes(const [1, 2, 3], flush: true);
+
+      final data = await SignatureResolver().resolve(
+        _signature(filePath: f.path),
+      );
+
+      expect(data, isA<FileData>());
+      expect(data.servedFrom, ServedFrom.embedded);
+    });
+
+    test('a signature with nothing to read claims no source', () async {
+      final data = await SignatureResolver().resolve(_signature());
+
+      expect(data, isA<UnavailableData>());
+      expect(data.servedFrom, isNull);
+    });
+  });
+
+  group('HttpUrlMediaResolver', () {
+    test('a networkUrl row is stamped networkUrl', () async {
+      final data = await _httpResolver(
+        MediaSourceType.networkUrl,
+      ).resolve(_urlItem(MediaSourceType.networkUrl));
+
+      expect(data, isA<NetworkData>());
+      expect(data.servedFrom, ServedFrom.networkUrl);
+      expect(data.servedTier, ServedTier.original);
+    });
+
+    test('a manifestEntry row is stamped networkUrl too', () async {
+      // ServedFrom records the byte transport, and both source types hand
+      // the same HTTP transport to cached_network_image. The distinction
+      // between them is link provenance, which lives on MediaItem.sourceType.
+      final data = await _httpResolver(
+        MediaSourceType.manifestEntry,
+      ).resolve(_urlItem(MediaSourceType.manifestEntry));
+
+      expect(data, isA<NetworkData>());
+      expect(data.servedFrom, ServedFrom.networkUrl);
+    });
+
+    test('a row with no url claims no source', () async {
+      final data = await _httpResolver(MediaSourceType.networkUrl).resolve(
+        MediaItem(
+          id: 'u2',
+          mediaType: MediaType.photo,
+          sourceType: MediaSourceType.networkUrl,
+          takenAt: DateTime.utc(2026),
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        ),
+      );
+
+      expect(data, isA<UnavailableData>());
+      expect(data.servedFrom, isNull);
+    });
+  });
+}

--- a/test/features/media/data/services/media_serving_recorder_test.dart
+++ b/test/features/media/data/services/media_serving_recorder_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+void main() {
+  test('records and reads back a successful resolution', () {
+    final r = MediaServingRecorder(now: () => DateTime.utc(2026, 8, 16));
+
+    r.record(
+      'm1',
+      thumbnail: false,
+      servedFrom: ServedFrom.storeCache,
+      servedTier: ServedTier.original,
+    );
+
+    final obs = r.lastFor('m1', thumbnail: false)!;
+    expect(obs.servedFrom, ServedFrom.storeCache);
+    expect(obs.servedTier, ServedTier.original);
+    expect(obs.failure, isNull);
+    expect(obs.storeFallbackUsed, isFalse);
+    expect(obs.observedAt, DateTime.utc(2026, 8, 16));
+  });
+
+  test('thumbnail and original observations do not overwrite each other', () {
+    final r = MediaServingRecorder();
+
+    r.record('m1', thumbnail: true, servedFrom: ServedFrom.storeCache);
+    r.record('m1', thumbnail: false, servedFrom: ServedFrom.storeNetwork);
+
+    expect(r.lastFor('m1', thumbnail: true)!.servedFrom, ServedFrom.storeCache);
+    expect(
+      r.lastFor('m1', thumbnail: false)!.servedFrom,
+      ServedFrom.storeNetwork,
+    );
+  });
+
+  test('records a failure with no source', () {
+    final r = MediaServingRecorder();
+
+    r.record(
+      'm1',
+      thumbnail: false,
+      failure: UnavailableKind.notFound,
+      storeFallbackUsed: true,
+    );
+
+    final obs = r.lastFor('m1', thumbnail: false)!;
+    expect(obs.servedFrom, isNull);
+    expect(obs.failure, UnavailableKind.notFound);
+    expect(obs.storeFallbackUsed, isTrue);
+  });
+
+  test('returns null for an item never observed', () {
+    expect(MediaServingRecorder().lastFor('nope', thumbnail: false), isNull);
+  });
+
+  test('evicts least recently recorded beyond maxEntries', () {
+    final r = MediaServingRecorder(maxEntries: 2);
+
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('b', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('c', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(r.entryCount, 2);
+    expect(r.lastFor('a', thumbnail: false), isNull);
+    expect(r.lastFor('b', thumbnail: false), isNotNull);
+    expect(r.lastFor('c', thumbnail: false), isNotNull);
+  });
+
+  test('re-recording an id refreshes its recency', () {
+    final r = MediaServingRecorder(maxEntries: 2);
+
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('b', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    r.record('a', thumbnail: false, servedFrom: ServedFrom.storeCache);
+    r.record('c', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(r.lastFor('a', thumbnail: false)!.servedFrom, ServedFrom.storeCache);
+    expect(r.lastFor('b', thumbnail: false), isNull);
+  });
+
+  test('notifies listeners on record', () {
+    final r = MediaServingRecorder();
+    var notifications = 0;
+    r.addListener(() => notifications++);
+
+    r.record('m1', thumbnail: false, servedFrom: ServedFrom.localDisk);
+
+    expect(notifications, 1);
+  });
+}

--- a/test/features/media/data/services/media_serving_recorder_test.dart
+++ b/test/features/media/data/services/media_serving_recorder_test.dart
@@ -88,4 +88,19 @@ void main() {
 
     expect(notifications, 1);
   });
+
+  // A resolution can outlive the container that owns the recorder: a
+  // FutureProvider still in flight when a ProviderContainer is disposed runs
+  // its continuation afterwards and records into a notifier that is already
+  // gone. notifyListeners asserts in that state, so the write has to be
+  // dropped rather than attempted.
+  test('recording after dispose is a no-op rather than a throw', () {
+    final r = MediaServingRecorder()..dispose();
+
+    expect(
+      () => r.record('m1', thumbnail: false, servedFrom: ServedFrom.localDisk),
+      returnsNormally,
+    );
+    expect(r.lastFor('m1', thumbnail: false), isNull);
+  });
 }

--- a/test/features/media/domain/value_objects/media_source_data_provenance_test.dart
+++ b/test/features/media/domain/value_objects/media_source_data_provenance_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+void main() {
+  test('defaults to no provenance and the original tier', () {
+    final data = BytesData(bytes: Uint8List(0));
+    expect(data.servedFrom, isNull);
+    expect(data.servedTier, ServedTier.original);
+  });
+
+  test('FileData carries the stamp it was constructed with', () {
+    final data = FileData(
+      file: File('/tmp/x'),
+      servedFrom: ServedFrom.storeCache,
+      servedTier: ServedTier.thumbnail,
+    );
+    expect(data.servedFrom, ServedFrom.storeCache);
+    expect(data.servedTier, ServedTier.thumbnail);
+    expect(data.isPoster, isFalse);
+  });
+
+  test('UnavailableData never claims a source', () {
+    const data = UnavailableData(kind: UnavailableKind.notFound);
+    expect(data.servedFrom, isNull);
+    expect(data.kind, UnavailableKind.notFound);
+  });
+
+  test('NetworkData stamps stay const-constructible', () {
+    final data = NetworkData(
+      url: Uri.parse('https://example.test/a.jpg'),
+      servedFrom: ServedFrom.networkUrl,
+    );
+    expect(data.servedFrom, ServedFrom.networkUrl);
+    expect(data.servedTier, ServedTier.original);
+  });
+}

--- a/test/features/media/presentation/media_item_view_provenance_test.dart
+++ b/test/features/media/presentation/media_item_view_provenance_test.dart
@@ -1,0 +1,218 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/services/media_source_resolver.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
+import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+import '../../../helpers/in_memory_media_object_store.dart';
+
+/// Valid 1x1 transparent PNG.
+const _onePixelPngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpe'
+    'qz8AAAAASUVORK5CYII=';
+
+/// Returns whatever it is handed, so a test can pin the stamp that reaches
+/// the recorder without depending on any real source.
+class _StubResolver implements MediaSourceResolver {
+  const _StubResolver(this._data);
+
+  final MediaSourceData _data;
+
+  @override
+  MediaSourceType get sourceType => MediaSourceType.platformGallery;
+
+  @override
+  bool canResolveOnThisDevice(MediaItem item) => true;
+
+  @override
+  Future<MediaSourceData> resolve(MediaItem item) async => _data;
+
+  @override
+  Future<MediaSourceData> resolveThumbnail(
+    MediaItem item, {
+    required Size target,
+  }) async => _data;
+
+  @override
+  Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async => null;
+
+  @override
+  Future<VerifyResult> verify(MediaItem item) async => VerifyResult.available;
+}
+
+void main() {
+  late LocalCacheDatabase db;
+  late Directory root;
+  late InMemoryMediaObjectStore store;
+  late MediaCacheStore cache;
+  late MediaServingRecorder recorder;
+
+  setUp(() async {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('miv_prov_test');
+    store = InMemoryMediaObjectStore();
+    cache = MediaCacheStore(database: db, root: root);
+    recorder = MediaServingRecorder();
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  Widget app(
+    MediaItem item, {
+    required MediaSourceData nativeData,
+    required bool thumbnail,
+    MediaStoreRuntime? runtime,
+  }) => ProviderScope(
+    overrides: [
+      mediaSourceResolverRegistryProvider.overrideWithValue(
+        MediaSourceResolverRegistry({
+          MediaSourceType.platformGallery: _StubResolver(nativeData),
+        }),
+      ),
+      mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
+      mediaServingRecorderProvider.overrideWithValue(recorder),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 100,
+          height: 100,
+          child: MediaItemView(item: item, thumbnail: thumbnail),
+        ),
+      ),
+    ),
+  );
+
+  MediaItem galleryItem({String? hash}) => MediaItem(
+    id: 'm1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: 'asset-1',
+    originalFilename: 'reef.png',
+    takenAt: DateTime(2026),
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    contentHash: hash,
+    remoteUploadedAt: hash == null ? null : DateTime(2026, 7, 1),
+  );
+
+  testWidgets('a thumbnail resolution records under the thumbnail key', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final bytes = base64Decode(_onePixelPngBase64);
+
+      await tester.pumpWidget(
+        app(
+          galleryItem(),
+          nativeData: BytesData(
+            bytes: bytes,
+            servedFrom: ServedFrom.platformGallery,
+            servedTier: ServedTier.thumbnail,
+          ),
+          thumbnail: true,
+        ),
+      );
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        if (recorder.lastFor('m1', thumbnail: true) != null) break;
+      }
+
+      final obs = recorder.lastFor('m1', thumbnail: true)!;
+      expect(obs.servedFrom, ServedFrom.platformGallery);
+      expect(obs.servedTier, ServedTier.thumbnail);
+      expect(obs.storeFallbackUsed, isFalse);
+      expect(obs.failure, isNull);
+      // The original was never asked for, so it must have no observation.
+      expect(recorder.lastFor('m1', thumbnail: false), isNull);
+    });
+  });
+
+  testWidgets('a store fallback is recorded as such', (tester) async {
+    await tester.runAsync(() async {
+      final bytes = base64Decode(_onePixelPngBase64);
+      final seed = File('${root.path}/seed.png');
+      await seed.writeAsBytes(bytes, flush: true);
+      final digest = await sha256OfFile(seed);
+      store.objects[StoreKeys.objectKey(digest.hash, extension: 'png')] = bytes;
+
+      final runtime = MediaStoreRuntime(
+        storeId: 'store-1',
+        store: store,
+        cache: cache,
+        resolver: MediaStoreResolver(store: store, cache: cache),
+      );
+
+      await tester.pumpWidget(
+        app(
+          galleryItem(hash: digest.hash),
+          nativeData: const UnavailableData(kind: UnavailableKind.notFound),
+          thumbnail: false,
+          runtime: runtime,
+        ),
+      );
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        if (recorder.lastFor('m1', thumbnail: false) != null) break;
+      }
+
+      final obs = recorder.lastFor('m1', thumbnail: false)!;
+      expect(obs.servedFrom, ServedFrom.storeNetwork);
+      expect(obs.servedTier, ServedTier.original);
+      expect(obs.storeFallbackUsed, isTrue);
+      expect(obs.failure, isNull);
+    });
+  });
+
+  testWidgets('an unresolvable item records its failure kind', (tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        app(
+          // No contentHash, so storeConfirmed is false and the store is
+          // never consulted.
+          galleryItem(),
+          nativeData: const UnavailableData(
+            kind: UnavailableKind.volumeOffline,
+          ),
+          thumbnail: false,
+        ),
+      );
+      for (var i = 0; i < 40; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await tester.pump();
+        if (recorder.lastFor('m1', thumbnail: false) != null) break;
+      }
+
+      final obs = recorder.lastFor('m1', thumbnail: false)!;
+      expect(obs.servedFrom, isNull);
+      expect(obs.failure, UnavailableKind.volumeOffline);
+      expect(obs.storeFallbackUsed, isFalse);
+    });
+  });
+}

--- a/test/features/media/presentation/media_item_view_provenance_test.dart
+++ b/test/features/media/presentation/media_item_view_provenance_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -32,10 +33,14 @@ const _onePixelPngBase64 =
 
 /// Returns whatever it is handed, so a test can pin the stamp that reaches
 /// the recorder without depending on any real source.
+///
+/// When [gate] is supplied, resolution parks on it until the test completes
+/// it, which is how the disposal test gets a tile unmounted mid-resolution.
 class _StubResolver implements MediaSourceResolver {
-  const _StubResolver(this._data);
+  const _StubResolver(this._data, {this.gate});
 
   final MediaSourceData _data;
+  final Future<void>? gate;
 
   @override
   MediaSourceType get sourceType => MediaSourceType.platformGallery;
@@ -44,13 +49,19 @@ class _StubResolver implements MediaSourceResolver {
   bool canResolveOnThisDevice(MediaItem item) => true;
 
   @override
-  Future<MediaSourceData> resolve(MediaItem item) async => _data;
+  Future<MediaSourceData> resolve(MediaItem item) async {
+    if (gate != null) await gate;
+    return _data;
+  }
 
   @override
   Future<MediaSourceData> resolveThumbnail(
     MediaItem item, {
     required Size target,
-  }) async => _data;
+  }) async {
+    if (gate != null) await gate;
+    return _data;
+  }
 
   @override
   Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async => null;
@@ -84,11 +95,15 @@ void main() {
     required MediaSourceData nativeData,
     required bool thumbnail,
     MediaStoreRuntime? runtime,
+    Future<void>? gate,
   }) => ProviderScope(
     overrides: [
       mediaSourceResolverRegistryProvider.overrideWithValue(
         MediaSourceResolverRegistry({
-          MediaSourceType.platformGallery: _StubResolver(nativeData),
+          MediaSourceType.platformGallery: _StubResolver(
+            nativeData,
+            gate: gate,
+          ),
         }),
       ),
       mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
@@ -187,6 +202,46 @@ void main() {
       expect(obs.servedTier, ServedTier.original);
       expect(obs.storeFallbackUsed, isTrue);
       expect(obs.failure, isNull);
+    });
+  });
+
+  // Riverpod's WidgetRef.read throws StateError once the element is unmounted
+  // (flutter_riverpod consumer.dart, read -> _assertNotDisposed). Recording
+  // happens after the resolution await, so a tile scrolled out of a grid
+  // mid-resolution reaches that read while disposed. Nothing awaits the
+  // Future at that point either, so the throw would surface as an unhandled
+  // async error rather than anything the FutureBuilder could render.
+  testWidgets('a tile disposed mid-resolution does not record or throw', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      final gate = Completer<void>();
+      final bytes = base64Decode(_onePixelPngBase64);
+
+      await tester.pumpWidget(
+        app(
+          galleryItem(),
+          nativeData: BytesData(
+            bytes: bytes,
+            servedFrom: ServedFrom.platformGallery,
+            servedTier: ServedTier.thumbnail,
+          ),
+          thumbnail: true,
+          gate: gate.future,
+        ),
+      );
+      await tester.pump();
+
+      // Replace the tree, disposing the view while resolution is parked.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      gate.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(recorder.lastFor('m1', thumbnail: true), isNull);
     });
   });
 

--- a/test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart
+++ b/test/features/media/presentation/providers/media_bytes_provider_provenance_test.dart
@@ -1,0 +1,138 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
+import 'package:submersion/features/media/data/services/media_serving_recorder.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+import '../../../../helpers/in_memory_media_object_store.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+
+void main() {
+  late FakeLocalFileResolver resolver;
+  late MediaServingRecorder recorder;
+
+  setUp(() {
+    resolver = FakeLocalFileResolver();
+    recorder = MediaServingRecorder();
+  });
+
+  MediaItem doc({String? contentHash, DateTime? remoteUploadedAt}) => MediaItem(
+    id: 'doc-1',
+    siteId: 'site-1',
+    mediaType: MediaType.document,
+    sourceType: MediaSourceType.localFile,
+    originalFilename: 'reef-map.pdf',
+    takenAt: DateTime(2026, 8, 12),
+    createdAt: DateTime(2026, 8, 12),
+    updatedAt: DateTime(2026, 8, 12),
+    contentHash: contentHash,
+    remoteUploadedAt: remoteUploadedAt,
+  );
+
+  ProviderContainer container({MediaStoreRuntime? runtime}) {
+    final c = ProviderContainer(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWithValue(
+          MediaSourceResolverRegistry({MediaSourceType.localFile: resolver}),
+        ),
+        mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
+        mediaServingRecorderProvider.overrideWithValue(recorder),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('a native success is recorded with no store fallback', () async {
+    resolver.data = BytesData(
+      bytes: Uint8List.fromList([37, 80, 68, 70]),
+      servedFrom: ServedFrom.localDisk,
+    );
+
+    await container().read(mediaBytesProvider(doc()).future);
+
+    final obs = recorder.lastFor('doc-1', thumbnail: false)!;
+    expect(obs.servedFrom, ServedFrom.localDisk);
+    expect(obs.servedTier, ServedTier.original);
+    expect(obs.storeFallbackUsed, isFalse);
+    expect(obs.failure, isNull);
+  });
+
+  test('a store fallback success is recorded as such', () async {
+    final db = LocalCacheDatabase(NativeDatabase.memory());
+    final root = await Directory.systemTemp.createTemp('mbp_prov_store');
+    addTearDown(() async {
+      await db.close();
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+    final store = InMemoryMediaObjectStore();
+    final cache = MediaCacheStore(database: db, root: root);
+
+    final bytes = List<int>.generate(2048, (i) => (i * 7) % 251);
+    final seed = File('${root.path}/seed.pdf')..writeAsBytesSync(bytes);
+    final digest = await sha256OfFile(seed);
+    store.objects[StoreKeys.objectKey(digest.hash, extension: 'pdf')] = bytes;
+
+    resolver.data = const UnavailableData(kind: UnavailableKind.notFound);
+
+    final runtime = MediaStoreRuntime(
+      storeId: 's1',
+      store: store,
+      cache: cache,
+      resolver: MediaStoreResolver(store: store, cache: cache),
+    );
+
+    await container(runtime: runtime).read(
+      mediaBytesProvider(
+        doc(contentHash: digest.hash, remoteUploadedAt: DateTime(2026, 8, 12)),
+      ).future,
+    );
+
+    final obs = recorder.lastFor('doc-1', thumbnail: false)!;
+    expect(obs.servedFrom, ServedFrom.storeNetwork);
+    expect(obs.servedTier, ServedTier.original);
+    expect(obs.storeFallbackUsed, isTrue);
+    expect(obs.failure, isNull);
+  });
+
+  test('a total failure is recorded with the native failure kind', () async {
+    resolver.data = const UnavailableData(kind: UnavailableKind.volumeOffline);
+
+    await container().read(mediaBytesProvider(doc()).future);
+
+    final obs = recorder.lastFor('doc-1', thumbnail: false)!;
+    expect(obs.servedFrom, isNull);
+    expect(obs.failure, UnavailableKind.volumeOffline);
+    // The store WAS asked and could not help. This records that the fallback
+    // ran, not that it succeeded.
+    expect(obs.storeFallbackUsed, isTrue);
+  });
+
+  test('a NetworkData native resolution records as notFound', () async {
+    // This provider deliberately never fetches NetworkData, so such a row
+    // yields no bytes without ever being an UnavailableData. For a byte
+    // consumer that is indistinguishable from an absent source.
+    resolver.data = NetworkData(url: Uri.parse('https://example.com/a.pdf'));
+
+    await container().read(mediaBytesProvider(doc()).future);
+
+    final obs = recorder.lastFor('doc-1', thumbnail: false)!;
+    expect(obs.servedFrom, isNull);
+    expect(obs.failure, UnavailableKind.notFound);
+  });
+}

--- a/test/features/media/presentation/providers/media_serving_providers_test.dart
+++ b/test/features/media/presentation/providers/media_serving_providers_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
+
+void main() {
+  test('the container owns the recorder and disposes it', () {
+    final container = ProviderContainer();
+    final recorder = container.read(mediaServingRecorderProvider);
+    var notifications = 0;
+    recorder.addListener(() => notifications++);
+
+    recorder.record('m1', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    expect(notifications, 1);
+
+    container.dispose();
+
+    // Disposed: a late write from a resolution that outlived the container is
+    // dropped instead of asserting inside notifyListeners.
+    recorder.record('m2', thumbnail: false, servedFrom: ServedFrom.localDisk);
+    expect(notifications, 1);
+    expect(recorder.lastFor('m2', thumbnail: false), isNull);
+  });
+
+  test('each container gets its own recorder', () {
+    final a = ProviderContainer();
+    final b = ProviderContainer();
+    addTearDown(a.dispose);
+    addTearDown(b.dispose);
+
+    expect(
+      identical(
+        a.read(mediaServingRecorderProvider),
+        b.read(mediaServingRecorderProvider),
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
First of three PRs implementing `docs/superpowers/specs/2026-08-16-media-provenance-design.md`.

## What this adds

`ServedFrom` and `ServedTier` on `MediaSourceData`, stamped at every resolver production site, plus a bounded `MediaServingRecorder` that captures the outcome of real resolutions.

**No user-visible change. No schema change.** This PR is pure plumbing so that PR 2 can build a media info panel reporting where an item was linked from, whether it is backed up, and where its bytes are actually coming from, and PR 3 can put a combined status badge on the grids.

## Why it is shaped this way

Resolution was a pure `MediaItem -> MediaSourceData` function, and `MediaSourceData` is a union of *transport shapes* (`FileData` / `NetworkData` / `BytesData` / `UnavailableData`), not of *origins*. A local disk read, a media-cache hit, and a fresh cloud download all returned a structurally identical `FileData` and were indistinguishable to every caller.

Provenance is now stamped on the value object at construction rather than computed by consumers. That matters because the native-then-store fallback is implemented twice, independently, in `MediaItemView._resolve` and `mediaBytesProvider`. Those two are not duplicates that can simply be merged: the first carries PDF page-1 rendering, thumbnail-versus-original branching, a `storeConfirmed` stamp gate, and the `videoPosterMissing` / `documentRenderable` view hints. Stamping at the source means both inherit correct provenance without either being rewritten, and they cannot disagree.

## The load-bearing change

`MediaStoreResolver`'s six success returns were the only place in the app that knew a media-cache hit from a fresh cloud download, and all six discarded that fact.

Each new test **empties the object store between two reads**, so a `storeCache` stamp on the second read can only mean the cache actually served it. Without that step a resolver that stamped `storeCache` unconditionally would also pass, and the assertion would prove nothing.

Asserting the tier alongside the source also pins the thumb path against silent degradation: `tryResolveRemote` falls back to the original when a thumb is missing, and that now surfaces as a tier mismatch.

## Notes on two deliberate deviations from the spec

- `UnavailableData` does not accept the provenance parameters. Nothing served it, so there is no honest value to pass; omitting them makes that unrepresentable rather than merely conventional.
- The recorder ships one `ChangeNotifier` instead of the spec's per-id `listenableFor`. Per-id notifiers need lifecycle management that buys nothing while a single info panel is the only consumer.

`SignatureResolver` stamps `embedded` on both its branches, including the file-on-disk one. A signature is the app's own artifact either way; calling the file branch `localDisk` would have the info panel tell a diver their instructor's signature came from a folder on their disk, which is true of the bytes and false of the meaning.

## Verification

- `flutter test`: **18,337 passed / 17 skipped / 0 failed**
- `flutter analyze` (whole project): no issues
- `dart format --set-exit-if-changed .`: clean
- `git diff --stat origin/main...HEAD -- lib/core/database lib/features/sync`: empty

Every pre-existing media and media_store test passed **unmodified**. This PR adds 23 tests and alters no existing expectation.

## Known limitation

`PlatformGalleryResolver`'s two success returns are stamped but cannot be unit-tested on a CI host: they call `AssetEntity.fromId`, which needs a real device photo library, and `GalleryThumbnailCache` keeps its entries private so a hit cannot be seeded. The test file pins the reachable contract instead (an unavailable resolution never claims a source) and says so explicitly rather than faking coverage.