### PR TITLE
fix(media): give the site picker a way to accept picked files

### DIFF
--- a/lib/features/media/data/services/network_fetch_pipeline.dart
+++ b/lib/features/media/data/services/network_fetch_pipeline.dart
@@ -133,16 +133,23 @@ class NetworkFetchPipeline {
   /// and Lightroom auto-linking).
   ///
   /// [siteId] attaches every row directly to a dive site, for URLs added
-  /// from that site's attachment picker. Callers passing it should also pass
-  /// `autoMatch: false`: a site has no time window of its own, so the dive
-  /// matcher would route the photo to whichever unrelated dive happened to
-  /// span its timestamp instead of to the site the user was looking at
-  /// (issue #1098).
+  /// from that site's attachment picker (issue #1098).
+  ///
+  /// A site id **overrides** [autoMatch]: a site has no time window of its
+  /// own, so the dive matcher would stamp `diveId` from whichever unrelated
+  /// dive happened to span the photo's timestamp, leaving a row owned by both
+  /// a site and a dive it has nothing to do with. Rather than leave that to
+  /// every caller to remember, the two are mutually exclusive here.
   Future<List<String>> ingest(
     List<Uri> urls, {
     bool autoMatch = true,
     String? siteId,
   }) async {
+    // Site attachment and dive matching are two answers to "who owns this
+    // row", so a caller cannot ask for both. Enforced rather than documented
+    // because the failure is silent: the row lands on a dive the user never
+    // named and simply does not appear on the site.
+    final matchDives = autoMatch && siteId == null;
     final ids = <String>[];
     final specs = <_FillSpec>[];
     final nowMillis = _now().millisecondsSinceEpoch;
@@ -163,7 +170,7 @@ class NetworkFetchPipeline {
             ),
           );
       ids.add(id);
-      specs.add(_FillSpec(id: id, uri: uri, autoMatch: autoMatch));
+      specs.add(_FillSpec(id: id, uri: uri, autoMatch: matchDives));
     }
     _scheduleFill(specs);
     return ids;

--- a/lib/features/media/data/services/network_fetch_pipeline.dart
+++ b/lib/features/media/data/services/network_fetch_pipeline.dart
@@ -131,7 +131,18 @@ class NetworkFetchPipeline {
   /// dive's time window are attached to that dive after the background
   /// fill completes (same DivePhotoMatcher semantics as the gallery scan
   /// and Lightroom auto-linking).
-  Future<List<String>> ingest(List<Uri> urls, {bool autoMatch = true}) async {
+  ///
+  /// [siteId] attaches every row directly to a dive site, for URLs added
+  /// from that site's attachment picker. Callers passing it should also pass
+  /// `autoMatch: false`: a site has no time window of its own, so the dive
+  /// matcher would route the photo to whichever unrelated dive happened to
+  /// span its timestamp instead of to the site the user was looking at
+  /// (issue #1098).
+  Future<List<String>> ingest(
+    List<Uri> urls, {
+    bool autoMatch = true,
+    String? siteId,
+  }) async {
     final ids = <String>[];
     final specs = <_FillSpec>[];
     final nowMillis = _now().millisecondsSinceEpoch;
@@ -145,6 +156,7 @@ class NetworkFetchPipeline {
               filePath: '',
               sourceType: const Value('networkUrl'),
               url: Value(uri.toString()),
+              siteId: Value(siteId),
               isOrphaned: const Value(false),
               createdAt: nowMillis,
               updatedAt: nowMillis,

--- a/lib/features/media/domain/value_objects/media_attach_target.dart
+++ b/lib/features/media/domain/value_objects/media_attach_target.dart
@@ -1,0 +1,50 @@
+import 'package:equatable/equatable.dart';
+
+/// The entity a photo-picker session attaches its media to.
+///
+/// The picker's Gallery tab hands its selection back to the caller, which
+/// decides where the rows go. The Files and URL tabs do not: they write rows
+/// themselves, so they have to be told what to link those rows to. Before
+/// this type existed they were told only a `diveId`, which is why a session
+/// opened from a dive site had no reachable commit path at all (issue #1098)
+/// - the Files tab's button was gated on the dive matcher having produced a
+/// group, and a site can never produce one.
+///
+/// A sealed hierarchy rather than two nullable ids: a session attaches to a
+/// dive or to a site, never both, and `switch` over it is exhaustive so the
+/// analyzer flags any new decision point that forgets one of the two.
+///
+/// A null target (no instance at all) means the session has no owning entity
+/// - the library importer - where date-based dive matching is the only thing
+/// that can assign one.
+sealed class MediaAttachTarget extends Equatable {
+  const MediaAttachTarget();
+
+  @override
+  bool get stringify => true;
+}
+
+/// Media picked in this session belongs to one dive.
+final class DiveAttachTarget extends MediaAttachTarget {
+  const DiveAttachTarget(this.diveId);
+
+  final String diveId;
+
+  @override
+  List<Object?> get props => [diveId];
+}
+
+/// Media picked in this session belongs to one dive site, as a direct
+/// attachment.
+///
+/// Dive matching is meaningless here: a site has no time window, and a photo
+/// that happens to fall inside some unrelated dive's window would land on
+/// that dive rather than on the site the user was looking at.
+final class SiteAttachTarget extends MediaAttachTarget {
+  const SiteAttachTarget(this.siteId);
+
+  final String siteId;
+
+  @override
+  List<Object?> get props => [siteId];
+}

--- a/lib/features/media/presentation/helpers/photo_import_helper.dart
+++ b/lib/features/media/presentation/helpers/photo_import_helper.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/domain/services/dive_photo_matcher.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/pages/photo_picker_page.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
@@ -68,7 +69,7 @@ class PhotoImportHelper {
       buffer: Duration.zero,
       alreadyLinkedIds: alreadyLinkedIds,
       // Lets the Files tab link photos this dive's date window rejected.
-      diveId: dive.id,
+      target: DiveAttachTarget(dive.id),
     );
     // coverage:ignore-end
 

--- a/lib/features/media/presentation/helpers/site_media_import_helper.dart
+++ b/lib/features/media/presentation/helpers/site_media_import_helper.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/pages/photo_picker_page.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
@@ -27,6 +28,14 @@ class SiteMediaImportHelper {
 
     // Sites have no dive window: open the picker over all time. buffer is
     // zeroed so showPhotoPicker does not widen the range further.
+    //
+    // The target is what makes the Files and URL tabs usable here. Those
+    // tabs persist rows themselves instead of returning a selection, and
+    // without it they fall back to matching against dives, which for a site
+    // meant no commit button at all (issue #1098). They also do not pop with
+    // a result, so `linkSelectedAssets` below sees null and no-ops for them;
+    // that is correct, they have already written their rows, and
+    // mediaForSiteProvider picks the change up through watchMediaChanges.
     // coverage:ignore-start
     // showPhotoPicker drives a full-screen page tied to photo_manager + the
     // platform photo library; not unit-testable from flutter_test.
@@ -36,6 +45,7 @@ class SiteMediaImportHelper {
       diveEndTime: DateTime.now().add(const Duration(days: 1)),
       buffer: Duration.zero,
       alreadyLinkedIds: alreadyLinkedIds,
+      target: SiteAttachTarget(siteId),
     );
     // coverage:ignore-end
     if (!context.mounted) return false;

--- a/lib/features/media/presentation/pages/photo_picker_page.dart
+++ b/lib/features/media/presentation/pages/photo_picker_page.dart
@@ -4,6 +4,8 @@ import 'package:photo_manager/photo_manager.dart' as pm;
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
+import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/files_tab.dart';
 import 'package:submersion/features/media/presentation/widgets/url_tab.dart';
@@ -27,12 +29,17 @@ class PhotoPickerPage extends ConsumerStatefulWidget {
   /// Called when user confirms selection with the selected assets.
   final void Function(List<AssetInfo> selectedAssets)? onSelectionConfirmed;
 
-  /// The dive this picker was opened from, when there is one.
+  /// What this picker session attaches media to, when it has an owner.
   ///
-  /// Passed to the Files tab so photos the date matcher rejects can still be
-  /// linked to the dive the user was looking at. Null when the picker is
-  /// opened outside a dive context.
-  final String? diveId;
+  /// Only the Gallery tab hands its selection back to the caller; the Files
+  /// and URL tabs write rows themselves, so they need to be told the target
+  /// or they cannot link anything. Passing only a dive id (as this used to)
+  /// left a session opened from a dive site with no reachable commit path at
+  /// all: issue #1098.
+  ///
+  /// Null when the picker is opened with no owning entity, e.g. the library
+  /// importer.
+  final MediaAttachTarget? target;
 
   const PhotoPickerPage({
     super.key,
@@ -40,7 +47,7 @@ class PhotoPickerPage extends ConsumerStatefulWidget {
     required this.endTime,
     this.alreadyLinkedIds = const {},
     this.onSelectionConfirmed,
-    this.diveId,
+    this.target,
   });
 
   @override
@@ -53,7 +60,21 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
   @override
   void initState() {
     super.initState();
+    Future.microtask(_clearStaleStaging);
     _checkPermissionAndLoad();
+  }
+
+  /// Drops files staged by an earlier session that was abandoned rather than
+  /// committed: `filesTabNotifierProvider` is not autoDispose, and this
+  /// session may well attach to a different dive, or to a site.
+  ///
+  /// Deferred by a microtask because Riverpod forbids mutating a provider
+  /// inside a widget life-cycle. It still lands before the first frame the
+  /// user can interact with, and well before the Files tab is reachable
+  /// (it is not even the initially-selected tab).
+  void _clearStaleStaging() {
+    if (!mounted) return;
+    ref.read(filesTabNotifierProvider.notifier).clearStagedFiles();
   }
 
   Future<void> _checkPermissionAndLoad() async {
@@ -170,8 +191,8 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
             body: TabBarView(
               children: [
                 _galleryTab(context),
-                FilesTab(diveId: widget.diveId),
-                const UrlTab(),
+                FilesTab(target: widget.target),
+                UrlTab(target: widget.target),
               ],
             ),
           );
@@ -698,7 +719,7 @@ Future<List<AssetInfo>?> showPhotoPicker({
   required DateTime diveEndTime,
   Set<String> alreadyLinkedIds = const {},
   Duration buffer = const Duration(minutes: 30),
-  String? diveId,
+  MediaAttachTarget? target,
 }) {
   final startTime = diveStartTime.subtract(buffer);
   final endTime = diveEndTime.add(buffer);
@@ -710,7 +731,7 @@ Future<List<AssetInfo>?> showPhotoPicker({
         startTime: startTime,
         endTime: endTime,
         alreadyLinkedIds: alreadyLinkedIds,
-        diveId: diveId,
+        target: target,
       ),
     ),
   );

--- a/lib/features/media/presentation/providers/files_tab_providers.dart
+++ b/lib/features/media/presentation/providers/files_tab_providers.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
@@ -81,8 +82,9 @@ class FilesTabState extends Equatable {
 /// Phase 2 actions: [toggleAutoMatch], [clear], [setFiles],
 /// [setExtractionProgress], [removeFile], [commit], [undoCommit].
 ///
-/// [commit] iterates the matcher's assignment and persists each
-/// [ExtractedFile] as a [MediaItem] row via [MediaRepository.createMedia].
+/// [commit] persists each staged [ExtractedFile] as a [MediaItem] row via
+/// [MediaRepository.createMedia]: walking the matcher's per-dive assignment
+/// for a dive session, or the flat file list for a site one (see [commit]).
 /// On iOS / macOS it first creates a security-scoped bookmark blob via
 /// [LocalMediaPlatform.createBookmark] and stores it in the keychain via
 /// [LocalBookmarkStorage.write] keyed by a freshly-generated UUID; that
@@ -90,7 +92,9 @@ class FilesTabState extends Equatable {
 /// Android alike — it stores the absolute filesystem path in `localPath`;
 /// see [_persistOne] for why Android has no persistable URI to take.
 ///
-/// Unmatched files are skipped — assignment UI for them is Phase 3.
+/// In a dive session, unmatched files are skipped; the review pane's assign
+/// actions are what move them into a dive group. A site session has no
+/// unmatched bucket to skip; every staged file belongs to the site.
 ///
 /// [undoCommit] takes the list of IDs returned by [commit] and deletes
 /// each row. The keychain bookmark blob (if any) is intentionally left
@@ -130,6 +134,25 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
 
   void clear() {
     state = FilesTabState.initial();
+  }
+
+  /// Drops the staged files and their grouping while keeping the user's
+  /// auto-match preference.
+  ///
+  /// Called when the picker opens. The notifier is not autoDispose, so files
+  /// picked and then abandoned (backing out without committing) outlive the
+  /// session that picked them, and the next session may attach to a
+  /// different dive, or to a site. Offering yesterday's leftovers as
+  /// "attach these to this site" is wrong regardless of what the user then
+  /// taps, so the staged set starts empty every time.
+  void clearStagedFiles() {
+    state = state.copyWith(
+      files: const [],
+      match: MatchedSelection.empty(),
+      isExtracting: false,
+      extractedCount: 0,
+      totalToExtract: 0,
+    );
   }
 
   void setFiles(List<ExtractedFile> files, {required MatchedSelection match}) {
@@ -223,21 +246,40 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
     );
   }
 
-  /// Persists the matcher's per-dive assignment as [MediaItem] rows and
-  /// returns the list of created IDs. Pass the list back to [undoCommit]
-  /// to roll back. State is reset via [clear] before returning.
+  /// Persists the staged files as [MediaItem] rows and returns the list of
+  /// created IDs. Pass the list back to [undoCommit] to roll back. State is
+  /// reset via [clear] before returning.
+  ///
+  /// What gets persisted depends on [target]:
+  ///
+  /// - [SiteAttachTarget]: every file in [FilesTabState.files], each stamped
+  ///   with the site id. The dive matcher's grouping is ignored outright:
+  ///   `matched` is keyed by dive id and a site session has no dives to key
+  ///   on, so honouring it would either persist nothing (the issue #1098
+  ///   symptom) or scatter the user's photos across whatever dives their
+  ///   timestamps happened to fall inside.
+  /// - [DiveAttachTarget], or no target at all: the matcher's per-dive
+  ///   assignment, which the review pane lets the user correct first.
+  ///   Unmatched files are skipped; the pane's assign actions are how they
+  ///   get out of that bucket.
   ///
   /// Both photos and videos are persisted; [_persistOne] tags each row with
   /// the right [MediaType] from its MIME. On desktop a local-file video
   /// resolves by localPath and plays via `VideoPlayerController.file`
   /// (see [FilesTab] class doc for the iOS caveat).
-  Future<List<String>> commit() async {
+  Future<List<String>> commit({MediaAttachTarget? target}) async {
     final created = <String>[];
-    for (final entry in state.match.matched.entries) {
-      for (final file in entry.value) {
-        final id = await _persistOne(file, entry.key);
-        created.add(id);
-      }
+    switch (target) {
+      case SiteAttachTarget(:final siteId):
+        for (final file in state.files) {
+          created.add(await _persistOne(file, siteId: siteId));
+        }
+      case DiveAttachTarget() || null:
+        for (final entry in state.match.matched.entries) {
+          for (final file in entry.value) {
+            created.add(await _persistOne(file, diveId: entry.key));
+          }
+        }
     }
     clear();
     return created;
@@ -256,7 +298,14 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
     }
   }
 
-  Future<String> _persistOne(ExtractedFile file, String diveId) async {
+  /// Writes one row. Exactly one of [diveId] / [siteId] is supplied by
+  /// [commit]; the other stays null so the row belongs to one owner and does
+  /// not surface in both a dive's grid and a site's.
+  Future<String> _persistOne(
+    ExtractedFile file, {
+    String? diveId,
+    String? siteId,
+  }) async {
     String? localPath;
     String? bookmarkRef;
 
@@ -289,6 +338,7 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
       // Empty id triggers UUID generation in MediaRepository.createMedia.
       id: '',
       diveId: diveId,
+      siteId: siteId,
       mediaType: file.metadata.mimeType.startsWith('video/')
           ? MediaType.video
           : MediaType.photo,

--- a/lib/features/media/presentation/providers/files_tab_providers.dart
+++ b/lib/features/media/presentation/providers/files_tab_providers.dart
@@ -306,6 +306,15 @@ class FilesTabNotifier extends StateNotifier<FilesTabState> {
     String? diveId,
     String? siteId,
   }) async {
+    // Asserted, not just documented: neither mistake announces itself. Both
+    // set puts the photo in a dive's grid and a site's; neither set writes an
+    // ownerless row that shows up in no grid at all, which reads to the user
+    // exactly like the import having silently failed.
+    assert(
+      (diveId == null) != (siteId == null),
+      'a Files-tab row belongs to exactly one owner, got '
+      'diveId=$diveId siteId=$siteId',
+    );
     String? localPath;
     String? bookmarkRef;
 

--- a/lib/features/media/presentation/providers/url_tab_providers.dart
+++ b/lib/features/media/presentation/providers/url_tab_providers.dart
@@ -36,6 +36,7 @@ import 'package:submersion/features/media/data/services/url_metadata_extractor.d
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/utils/url_validator.dart';
 import 'package:submersion/features/media/domain/entities/extracted_metadata.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
@@ -162,7 +163,13 @@ class UrlTabNotifier extends StateNotifier<UrlTabState> {
   /// the ingest call — the UI is expected to disable the "Add" button when
   /// any line fails validation, so reaching here with invalid lines is
   /// degenerate (we still skip them defensively rather than throw).
-  Future<List<String>> commit() async {
+  ///
+  /// A [SiteAttachTarget] attaches every row to that site and turns dive
+  /// matching off: a site has no time window, so matching would hand the
+  /// photo to whichever unrelated dive spanned its timestamp rather than to
+  /// the site the picker was opened from (issue #1098). Any other target
+  /// leaves the user's auto-match preference alone.
+  Future<List<String>> commit({MediaAttachTarget? target}) async {
     final uris = <Uri>[];
     for (final raw in state.draftLines) {
       final result = UrlValidator.parse(raw);
@@ -170,7 +177,15 @@ class UrlTabNotifier extends StateNotifier<UrlTabState> {
         uris.add(result.uri);
       }
     }
-    final ids = await _pipeline.ingest(uris, autoMatch: state.autoMatchByDate);
+    final siteId = switch (target) {
+      SiteAttachTarget(:final siteId) => siteId,
+      DiveAttachTarget() || null => null,
+    };
+    final ids = await _pipeline.ingest(
+      uris,
+      autoMatch: siteId == null && state.autoMatchByDate,
+      siteId: siteId,
+    );
     state = state.copyWith(committedIds: ids, draftLines: const []);
     return ids;
   }

--- a/lib/features/media/presentation/widgets/file_review_pane.dart
+++ b/lib/features/media/presentation/widgets/file_review_pane.dart
@@ -121,9 +121,12 @@ class FileReviewPane extends ConsumerWidget {
       children: [
         Padding(
           padding: const EdgeInsets.all(8),
+          // "item", not "photo": the Files tab picks with FileType.media and
+          // the folder scan admits .mp4/.mov/.m4v, so a staged set can be all
+          // video. Matches the commit button's wording.
           // TODO(media): l10n, pluralization
           child: Text(
-            '$count photo${count == 1 ? '' : 's'}',
+            '$count item${count == 1 ? '' : 's'}',
             style: theme.textTheme.titleMedium,
           ),
         ),

--- a/lib/features/media/presentation/widgets/file_review_pane.dart
+++ b/lib/features/media/presentation/widgets/file_review_pane.dart
@@ -26,11 +26,27 @@ class FileReviewPane extends ConsumerWidget {
   /// assign affordance; null hides both.
   final String? assignableDiveId;
 
-  const FileReviewPane({super.key, required this.state, this.assignableDiveId});
+  /// Renders one flat list of every staged file instead of the matched /
+  /// unmatched dive grouping.
+  ///
+  /// Used when the session attaches to a dive site: matched-vs-unmatched is
+  /// a statement about dives, so on a site it is both meaningless and
+  /// alarming: the user sees "0 dives, N unmatched" and reasonably concludes
+  /// the app rejected their photos (issue #1098).
+  final bool flat;
+
+  const FileReviewPane({
+    super.key,
+    required this.state,
+    this.assignableDiveId,
+    this.flat = false,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    if (flat) return _buildFlat(context, theme);
+
     // TODO(media): l10n
     final summary =
         '${state.files.length} photos → '
@@ -89,6 +105,33 @@ class FileReviewPane extends ConsumerWidget {
                       ),
                   ],
                 ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Flat variant: a count and one card per staged file, with no dive
+  /// grouping and no assign affordances (there is no dive to assign to).
+  Widget _buildFlat(BuildContext context, ThemeData theme) {
+    final count = state.files.length;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8),
+          // TODO(media): l10n, pluralization
+          child: Text(
+            '$count photo${count == 1 ? '' : 's'}',
+            style: theme.textTheme.titleMedium,
+          ),
+        ),
+        Expanded(
+          child: ListView(
+            children: [
+              for (final f in state.files)
+                FileReviewCard(file: f, targetDiveId: null),
             ],
           ),
         ),

--- a/lib/features/media/presentation/widgets/files_tab.dart
+++ b/lib/features/media/presentation/widgets/files_tab.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/media/domain/services/dive_photo_matcher.dart';
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/file_review_pane.dart';
@@ -40,18 +41,39 @@ import 'package:submersion/features/media/presentation/widgets/file_review_pane.
 /// then an iOS-imported video matches and stores but shows the viewer's
 /// video-unavailable state rather than playing.
 class FilesTab extends ConsumerWidget {
-  const FilesTab({super.key, this.diveId});
+  const FilesTab({super.key, this.target});
 
-  /// The dive the picker was opened from, when there is one.
+  /// What this picker session attaches its files to, when it has an owner.
   ///
-  /// [FilesTabNotifier.commit] only persists files sitting in
-  /// [MatchedSelection.matched], and the Link button is gated on that map
-  /// being non-empty, so a photo the date matcher rejected had no route into
-  /// the database. When the picker came from a dive, that dive is the obvious
-  /// manual target: it backs the review pane's "add all to this dive" action
-  /// and makes turning auto-match off produce a usable selection instead of
-  /// an inert one. Null when the picker was opened outside a dive context.
-  final String? diveId;
+  /// A [DiveAttachTarget] backs the review pane's "add all to this dive"
+  /// action and makes turning auto-match off produce a usable selection
+  /// instead of an inert one: [FilesTabNotifier.commit] only persists files
+  /// sitting in [MatchedSelection.matched], so without a manual target a
+  /// photo the date matcher rejected had no route into the database.
+  ///
+  /// A [SiteAttachTarget] switches the tab out of dive mode entirely; see
+  /// [_isSiteSession]. Null when the picker was opened with no owning entity
+  /// (the library importer), where the matcher is the only thing that can
+  /// assign one.
+  final MediaAttachTarget? target;
+
+  /// A site session drops every dive affordance: the auto-match checkbox,
+  /// the matcher itself, the dive-grouped review pane, and the per-file
+  /// assign actions.
+  ///
+  /// Dive matching against a site is not merely useless, it is wrong. A site
+  /// has no time window, so the matcher compares the photo against every
+  /// dive in the log and either finds nothing (the issue #1098 symptom: no
+  /// group, therefore no commit button, therefore no way to save) or routes
+  /// the photo to some dive the user never mentioned.
+  bool get _isSiteSession => target is SiteAttachTarget;
+
+  /// The dive files may be manually assigned to, or null when there isn't
+  /// one to offer.
+  String? get _assignableDiveId => switch (target) {
+    DiveAttachTarget(:final diveId) => diveId,
+    SiteAttachTarget() || null => null,
+  };
 
   // coverage:ignore-start
   // FilePicker.pickFiles is a static method on package:file_picker; not
@@ -140,18 +162,26 @@ class FilesTab extends ConsumerWidget {
   ) async {
     final notifier = ref.read(filesTabNotifierProvider.notifier);
     final state = ref.read(filesTabNotifierProvider);
+    if (_isSiteSession) {
+      // The site owns every picked file, so there is nothing to match and
+      // nothing to group. `commit` reads `files` directly for this case; the
+      // empty selection keeps any dive grouping from an earlier session on
+      // this (non-autoDispose) notifier from leaking into the review pane.
+      notifier.setFiles(extracted, match: MatchedSelection.empty());
+      return;
+    }
     if (!state.autoMatchByDate) {
       // Opened from a dive, auto-match declined: the user asked for exactly
       // these files on exactly this dive, so stage them as matched. Parking
       // them in `unmatched` (as this used to) hid the Link button and made
       // the unchecked checkbox a dead end.
-      final target = diveId;
+      final assignable = _assignableDiveId;
       notifier.setFiles(
         extracted,
-        match: target == null
+        match: assignable == null
             ? MatchedSelection(matched: const {}, unmatched: extracted)
             : MatchedSelection(
-                matched: {target: extracted},
+                matched: {assignable: extracted},
                 unmatched: const [],
               ),
       );
@@ -210,19 +240,22 @@ class FilesTab extends ConsumerWidget {
               ),
             ],
           ),
-          Row(
-            children: [
-              Checkbox(
-                value: state.autoMatchByDate,
-                onChanged: (_) => ref
-                    .read(filesTabNotifierProvider.notifier)
-                    .toggleAutoMatch(),
-              ),
-              const Expanded(
-                child: Text('Auto-match photos and videos to dives by date'),
-              ),
-            ],
-          ),
+          // Dives are not this session's business when a site is the target,
+          // so the option is hidden rather than shown-and-ignored.
+          if (!_isSiteSession)
+            Row(
+              children: [
+                Checkbox(
+                  value: state.autoMatchByDate,
+                  onChanged: (_) => ref
+                      .read(filesTabNotifierProvider.notifier)
+                      .toggleAutoMatch(),
+                ),
+                const Expanded(
+                  child: Text('Auto-match photos and videos to dives by date'),
+                ),
+              ],
+            ),
           if (state.isExtracting) ...[
             const SizedBox(height: 16),
             LinearProgressIndicator(
@@ -240,27 +273,51 @@ class FilesTab extends ConsumerWidget {
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
                   )
-                : FileReviewPane(state: state, assignableDiveId: diveId),
+                : FileReviewPane(
+                    state: state,
+                    assignableDiveId: _assignableDiveId,
+                    flat: _isSiteSession,
+                  ),
           ),
-          // TODO(media): l10n, pluralization
-          if (state.match.matched.isNotEmpty)
+          // Rendered for anything staged, disabled when nothing is
+          // committable, rather than hidden. Hiding it (issue #1098) left a
+          // user who had picked files staring at a screen with no way to
+          // accept them and no explanation; the URL tab's always-present
+          // "Add" is the convention being matched here.
+          if (state.files.isNotEmpty)
             Padding(
               padding: const EdgeInsets.only(top: 16),
               child: SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  // coverage:ignore-start
-                  onPressed: () => _commit(context, ref),
+                  onPressed: _committableCount(state) == 0
+                      ? null
+                      // coverage:ignore-start
+                      : () => _commit(context, ref),
                   // coverage:ignore-end
-                  child: Text(
-                    'Link ${state.match.totalFiles - state.match.unmatched.length} items',
-                  ),
+                  child: Text(_commitLabel(state)),
                 ),
               ),
             ),
         ],
       ),
     );
+  }
+
+  /// How many staged files [FilesTabNotifier.commit] would actually persist.
+  int _committableCount(FilesTabState state) => _isSiteSession
+      ? state.files.length
+      : state.match.totalFiles - state.match.unmatched.length;
+
+  // TODO(media): l10n, pluralization. The whole tab is still hardcoded
+  // English behind `TODO(media): l10n` markers; localizing these two strings
+  // alone would not make the tab usable in another language.
+  String _commitLabel(FilesTabState state) {
+    final count = _committableCount(state);
+    if (_isSiteSession) {
+      return 'Attach $count item${count == 1 ? '' : 's'} to this site';
+    }
+    return 'Link $count items';
   }
 
   // coverage:ignore-start
@@ -276,15 +333,23 @@ class FilesTab extends ConsumerWidget {
     // on the dive-detail view we return to.
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
-    final created = await notifier.commit();
+    final created = await notifier.commit(target: target);
     if (!context.mounted) return;
-    // Return to the dive-detail view now that the files are linked; the grid
-    // refreshes reactively via mediaForDiveProvider's watchDiveDetailChanges.
+    // Return to the detail view now that the files are linked; the grid
+    // refreshes reactively via mediaForDiveProvider's watchDiveDetailChanges,
+    // and mediaForSiteProvider's invalidateSelfWhen(watchMediaChanges) does
+    // the same for a site.
     navigator.pop();
-    // TODO(media): l10n, pluralization
+    // TODO(media): l10n
     messenger.showSnackBar(
       SnackBar(
-        content: Text('Linked ${created.length} items'),
+        content: Text(
+          _isSiteSession
+              ? 'Attached ${created.length} '
+                    'item${created.length == 1 ? '' : 's'} to this site'
+              // TODO(media): pluralization
+              : 'Linked ${created.length} items',
+        ),
         action: SnackBarAction(
           label: 'Undo',
           onPressed: () => notifier.undoCommit(created),

--- a/lib/features/media/presentation/widgets/url_tab.dart
+++ b/lib/features/media/presentation/widgets/url_tab.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/media/data/utils/url_validator.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/manifest_mode_panel.dart';
 import 'package:submersion/features/media/presentation/widgets/network_signin_sheet.dart';
@@ -29,7 +30,17 @@ import 'package:submersion/features/media/presentation/widgets/url_review_pane.d
 /// The Manifest mode segment renders [ManifestModePanel] (Phase 3b,
 /// Task 13).
 class UrlTab extends ConsumerStatefulWidget {
-  const UrlTab({super.key});
+  const UrlTab({super.key, this.target});
+
+  /// What this picker session attaches its rows to, when it has an owner.
+  ///
+  /// A [SiteAttachTarget] attaches every added URL to that site and drops the
+  /// dive auto-match option: a site has no time window, so matching would
+  /// route the photo to an unrelated dive rather than to the site the picker
+  /// was opened from (issue #1098). Null, or a [DiveAttachTarget], leaves the
+  /// existing date-matching behavior alone: a dive session's rows are
+  /// assigned by the matcher, not by the dive the picker came from.
+  final MediaAttachTarget? target;
 
   @override
   ConsumerState<UrlTab> createState() => _UrlTabState();
@@ -55,10 +66,12 @@ class _UrlTabState extends ConsumerState<UrlTab> {
     super.dispose();
   }
 
+  bool get _isSiteSession => widget.target is SiteAttachTarget;
+
   Future<void> _commit() async {
     final notifier = ref.read(urlTabNotifierProvider.notifier);
     final messenger = ScaffoldMessenger.of(context);
-    final ids = await notifier.commit();
+    final ids = await notifier.commit(target: widget.target);
     if (!mounted) return;
     if (!context.mounted) return;
     // Sync the multi-line controller with the cleared draft state so
@@ -174,20 +187,23 @@ class _UrlTabState extends ConsumerState<UrlTab> {
         },
       ),
       const SizedBox(height: 12),
-      Row(
-        children: [
-          Checkbox(
-            value: state.autoMatchByDate,
-            onChanged: (value) => ref
-                .read(urlTabNotifierProvider.notifier)
-                .setAutoMatchByDate(value ?? true),
-          ),
-          const Expanded(
-            // TODO(media): l10n
-            child: Text('Auto-match URLs to dives by date'),
-          ),
-        ],
-      ),
+      // Dives are not this session's business when a site is the target, so
+      // the option is hidden rather than shown-and-ignored.
+      if (!_isSiteSession)
+        Row(
+          children: [
+            Checkbox(
+              value: state.autoMatchByDate,
+              onChanged: (value) => ref
+                  .read(urlTabNotifierProvider.notifier)
+                  .setAutoMatchByDate(value ?? true),
+            ),
+            const Expanded(
+              // TODO(media): l10n
+              child: Text('Auto-match URLs to dives by date'),
+            ),
+          ],
+        ),
       const SizedBox(height: 16),
       Expanded(child: UrlReviewPane(state: state)),
       const SizedBox(height: 12),

--- a/test/features/media/data/services/network_fetch_pipeline_test.dart
+++ b/test/features/media/data/services/network_fetch_pipeline_test.dart
@@ -571,6 +571,37 @@ void main() {
       expect(await diveIdOf(ids.single), isNull);
     });
 
+    // A site id and dive matching are two answers to "who owns this row".
+    // A caller that asks for both would otherwise get a row attached to the
+    // site AND stamped with a dive it has nothing to do with, so siteId wins
+    // without the caller having to remember to turn matching off.
+    test('a site id suppresses matching even with autoMatch on', () async {
+      await seedDive('d1');
+      await db
+          .into(db.diveSites)
+          .insert(
+            DiveSitesCompanion.insert(
+              id: 'site-1',
+              name: 'Blue Hole',
+              createdAt: 1700000000000,
+              updatedAt: 1700000000000,
+            ),
+          );
+      final pipeline = pipelineWith([window('d1')]);
+
+      final ids = await pipeline.ingest([
+        Uri.parse('https://example.com/a.jpg'),
+      ], siteId: 'site-1');
+      await pipeline.idle();
+
+      // Without the override this row would have matched d1 confidently.
+      expect(await diveIdOf(ids.single), isNull);
+      final row = await (db.select(
+        db.media,
+      )..where((t) => t.id.equals(ids.single))).getSingle();
+      expect(row.siteId, 'site-1');
+    });
+
     test('a confident match marks the media row pending for sync', () async {
       await seedDive('d1');
       final pipeline = pipelineWith([window('d1')]);

--- a/test/features/media/data/services/network_fetch_pipeline_test.dart
+++ b/test/features/media/data/services/network_fetch_pipeline_test.dart
@@ -104,6 +104,54 @@ void main() {
     },
   );
 
+  // Issue #1098: a URL added from a dive site's attachment picker has to land
+  // on that site. Without siteId on the insert the row was site-less and the
+  // site's grid stayed empty no matter what the user pasted.
+  test('ingest stamps siteId when the session targets a site', () async {
+    const url = 'https://example.com/a.jpg';
+    final extractor = _StubExtractor(results: {url: _ok(url)});
+    final pipeline = NetworkFetchPipeline(db: db, extractor: extractor);
+    // media.site_id carries a real FK, so the row has to point at a real
+    // site. Inserting one also proves the stamp survives that constraint.
+    await db
+        .into(db.diveSites)
+        .insert(
+          DiveSitesCompanion.insert(
+            id: 'site-1',
+            name: 'Blue Hole',
+            createdAt: 1700000000000,
+            updatedAt: 1700000000000,
+          ),
+        );
+
+    final ids = await pipeline.ingest(
+      [Uri.parse(url)],
+      autoMatch: false,
+      siteId: 'site-1',
+    );
+    await pipeline.idle();
+
+    final row = await (db.select(
+      db.media,
+    )..where((t) => t.id.equals(ids.single))).getSingle();
+    expect(row.siteId, 'site-1');
+    expect(row.diveId, isNull);
+  });
+
+  test('ingest leaves siteId null when the session has no site', () async {
+    const url = 'https://example.com/a.jpg';
+    final extractor = _StubExtractor(results: {url: _ok(url)});
+    final pipeline = NetworkFetchPipeline(db: db, extractor: extractor);
+
+    final ids = await pipeline.ingest([Uri.parse(url)], autoMatch: false);
+    await pipeline.idle();
+
+    final row = await (db.select(
+      db.media,
+    )..where((t) => t.id.equals(ids.single))).getSingle();
+    expect(row.siteId, isNull);
+  });
+
   test('background success patches row + sets lastVerifiedAt', () async {
     const url = 'https://example.com/a.jpg';
     final extractor = _StubExtractor(results: {url: _ok(url)});

--- a/test/features/media/presentation/pages/photo_picker_page_tab_shell_test.dart
+++ b/test/features/media/presentation/pages/photo_picker_page_tab_shell_test.dart
@@ -9,17 +9,24 @@
 // `NetworkThumbnail` reads directly) with hand-rolled fakes so the URL tab
 // can paint its empty review pane without touching the database.
 
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
+import 'package:submersion/features/media/data/services/local_media_platform.dart';
 import 'package:submersion/features/media/data/services/network_credentials_service.dart';
 import 'package:submersion/features/media/data/services/network_fetch_pipeline.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
+import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
+import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 import 'package:submersion/features/media/presentation/pages/photo_picker_page.dart';
+import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/files_tab.dart';
@@ -76,13 +83,27 @@ class _FakeMediaRepository implements MediaRepository {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-Widget _wrap() {
+/// Collaborators for the seeded [FilesTabNotifier] used by the stale-staging
+/// test. Nothing is committed there, so neither is ever called.
+class _FakeBookmarkStorage implements LocalBookmarkStorage {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeMediaPlatform implements LocalMediaPlatform {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _wrap({MediaAttachTarget? target, FilesTabNotifier? filesTab}) {
   final pipeline = _FakeNetworkFetchPipeline();
   final credentials = _FakeNetworkCredentialsService();
   final mediaRepo = _FakeMediaRepository();
   return ProviderScope(
     overrides: [
       photoPickerServiceProvider.overrideWithValue(_StubPhotoPickerService()),
+      if (filesTab != null)
+        filesTabNotifierProvider.overrideWith((ref) => filesTab),
       // [UrlTab] watches [urlTabNotifierProvider]. The default factory
       // pulls `DatabaseService.instance.database` (uninitialized in tests),
       // so swap it for a notifier built from the fakes above.
@@ -106,6 +127,7 @@ Widget _wrap() {
       home: PhotoPickerPage(
         startTime: DateTime.utc(2024, 1, 1, 9),
         endTime: DateTime.utc(2024, 1, 1, 11),
+        target: target,
       ),
     ),
   );
@@ -194,6 +216,74 @@ void main() {
       await tester.pump(const Duration(milliseconds: 350));
 
       expect(find.text('Done'), findsOneWidget);
+    });
+  });
+
+  testWidgets('opening the picker drops files staged by an earlier session', (
+    tester,
+  ) async {
+    // filesTabNotifierProvider is not autoDispose. A session abandoned
+    // without committing leaves its files behind, and the next session may
+    // attach somewhere else entirely; here, a site inheriting files picked
+    // while a dive was open.
+    final leftover = ExtractedFile(
+      sourcePath: '/left/over.jpg',
+      file: File('/left/over.jpg'),
+      metadata: const MediaSourceMetadata(mimeType: 'image/jpeg'),
+    );
+    final filesTab = FilesTabNotifier(
+      mediaRepository: _FakeMediaRepository(),
+      bookmarkStorage: _FakeBookmarkStorage(),
+      platform: _FakeMediaPlatform(),
+    );
+    filesTab.setFiles(
+      [leftover],
+      match: MatchedSelection(
+        matched: {
+          'an-old-dive': [leftover],
+        },
+        unmatched: const [],
+      ),
+    );
+
+    await tester.pumpWidget(
+      _wrap(target: const SiteAttachTarget('site-1'), filesTab: filesTab),
+    );
+    await tester.pump();
+
+    expect(filesTab.state.files, isEmpty);
+    expect(filesTab.state.match, MatchedSelection.empty());
+  });
+
+  // Issue #1098: the page used to accept only a dive id, so the Files and URL
+  // tabs had no way to know a site session was even a site session.
+  group('attach target reaches the self-committing tabs', () {
+    testWidgets('Files tab receives the page target', (tester) async {
+      await tester.pumpWidget(_wrap(target: const SiteAttachTarget('site-1')));
+      await tester.pump();
+
+      await tester.tap(find.text('Files'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(
+        tester.widget<FilesTab>(find.byType(FilesTab)).target,
+        const SiteAttachTarget('site-1'),
+      );
+    });
+
+    testWidgets('URL tab receives the page target', (tester) async {
+      await tester.pumpWidget(_wrap(target: const SiteAttachTarget('site-1')));
+      await tester.pump();
+
+      await tester.tap(find.text('URL'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(
+        tester.widget<UrlTab>(find.byType(UrlTab)).target,
+        const SiteAttachTarget('site-1'),
+      );
     });
   });
 }

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -816,6 +816,62 @@ void main() {
     });
   });
 
+  // A row that names both owners shows up in a dive's grid and a site's; one
+  // that names neither shows up in nothing, which is indistinguishable from
+  // the import having silently failed. Neither announces itself, so the
+  // one-owner rule is asserted at the write.
+  group('one-owner invariant', () {
+    test('a site commit never also stamps a dive', () async {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles([a], match: MatchedSelection.empty());
+      when(
+        mockPlatform.createBookmark(any),
+      ).thenAnswer((_) async => Uint8List.fromList([1]));
+      when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
+      final captured = <MediaItem>[];
+      when(mockRepo.createMedia(any)).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as MediaItem);
+        return _saved('saved-1');
+      });
+
+      await notifier.commit(target: const SiteAttachTarget('site-1'));
+
+      // The assert in _persistOne would have thrown before reaching here had
+      // commit passed both; this pins the resulting row shape too.
+      expect(captured.single.siteId, 'site-1');
+      expect(captured.single.diveId, isNull);
+    });
+
+    test('a dive commit never also stamps a site', () async {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles(
+        [a],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: const [],
+        ),
+      );
+      when(
+        mockPlatform.createBookmark(any),
+      ).thenAnswer((_) async => Uint8List.fromList([1]));
+      when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
+      final captured = <MediaItem>[];
+      when(mockRepo.createMedia(any)).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as MediaItem);
+        return _saved('saved-1');
+      });
+
+      await notifier.commit(target: const DiveAttachTarget('d1'));
+
+      expect(captured.single.diveId, 'd1');
+      expect(captured.single.siteId, isNull);
+    });
+  });
+
   // A dive target must keep routing through the matcher's grouping: a file
   // the user assigned to dive B stays on dive B even though the picker was
   // opened from dive A.

--- a/test/features/media/presentation/providers/files_tab_providers_test.dart
+++ b/test/features/media/presentation/providers/files_tab_providers_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
@@ -93,6 +94,36 @@ void main() {
       final state = container.read(filesTabNotifierProvider);
       expect(state.files, isEmpty);
       expect(state.autoMatchByDate, isTrue); // reset to default
+    });
+
+    // The notifier is not autoDispose, so an abandoned session's files
+    // outlive it. The next session may attach to a different dive or to a
+    // site, where they would show up as that entity's staged set.
+    test('clearStagedFiles drops files and match, keeping the toggle', () {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.toggleAutoMatch();
+      notifier.setFiles(
+        [a],
+        match: MatchedSelection(
+          matched: {
+            'd1': [a],
+          },
+          unmatched: const [],
+        ),
+      );
+      notifier.setExtractionProgress(done: 1, total: 2);
+
+      notifier.clearStagedFiles();
+
+      final state = container.read(filesTabNotifierProvider);
+      expect(state.files, isEmpty);
+      expect(state.match, MatchedSelection.empty());
+      expect(state.isExtracting, isFalse);
+      expect(state.extractedCount, 0);
+      expect(state.totalToExtract, 0);
+      // Unlike clear(), the user's preference is not a staging artifact.
+      expect(state.autoMatchByDate, isFalse);
     });
 
     test('setFiles updates files and match', () {
@@ -662,6 +693,164 @@ void main() {
       );
 
       await expectLater(notifier.commit(), completion(['media-2']));
+    });
+  });
+
+  // Issue #1098: the picker opened from a dive site staged files that had no
+  // route into the database. commit() only walked match.matched, which is
+  // keyed by dive id, so a site session committed nothing no matter what the
+  // user did. A site target bypasses the matcher entirely: every staged file
+  // belongs to the site the user was looking at.
+  group('commit with a site target', () {
+    setUp(() {
+      when(
+        mockPlatform.createBookmark(any),
+      ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+      when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
+    });
+
+    test('persists every staged file against the site', () async {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      final b = _ef('/b.jpg');
+      notifier.setFiles([a, b], match: MatchedSelection.empty());
+
+      final captured = <MediaItem>[];
+      var counter = 0;
+      when(mockRepo.createMedia(any)).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as MediaItem);
+        counter += 1;
+        return _saved('saved-$counter');
+      });
+
+      final created = await notifier.commit(
+        target: const SiteAttachTarget('site-1'),
+      );
+
+      expect(created, ['saved-1', 'saved-2']);
+      expect(captured.map((m) => m.siteId), ['site-1', 'site-1']);
+      // A site attachment is not a dive attachment. Setting both would make
+      // the row show up in the dive's grid too.
+      expect(captured.map((m) => m.diveId), [null, null]);
+    });
+
+    test('persists files the dive matcher rejected', () async {
+      // The exact state from the issue: auto-match ran, matched no dive, and
+      // parked everything in `unmatched`. Under the dive-keyed commit this
+      // was the unreachable case.
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles([
+        a,
+      ], match: MatchedSelection(matched: const {}, unmatched: [a]));
+      when(
+        mockRepo.createMedia(any),
+      ).thenAnswer((_) async => _saved('saved-1'));
+
+      final created = await notifier.commit(
+        target: const SiteAttachTarget('site-1'),
+      );
+
+      expect(created, ['saved-1']);
+      verify(mockRepo.createMedia(any)).called(1);
+    });
+
+    test('ignores a stale dive grouping left in match', () async {
+      // `match` can still hold a dive grouping from an earlier session on the
+      // same (non-autoDispose) notifier. `files` is the authority for a site
+      // commit, so nothing may be persisted twice or routed to a dive.
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      notifier.setFiles(
+        [a],
+        match: MatchedSelection(
+          matched: {
+            'stale-dive': [a],
+          },
+          unmatched: const [],
+        ),
+      );
+
+      final captured = <MediaItem>[];
+      when(mockRepo.createMedia(any)).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as MediaItem);
+        return _saved('saved-1');
+      });
+
+      await notifier.commit(target: const SiteAttachTarget('site-1'));
+
+      expect(captured, hasLength(1));
+      expect(captured.single.diveId, isNull);
+      expect(captured.single.siteId, 'site-1');
+    });
+
+    test('clears state on success', () async {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      notifier.setFiles([_ef('/a.jpg')], match: MatchedSelection.empty());
+      when(
+        mockRepo.createMedia(any),
+      ).thenAnswer((_) async => _saved('saved-1'));
+
+      await notifier.commit(target: const SiteAttachTarget('site-1'));
+
+      expect(container.read(filesTabNotifierProvider), FilesTabState.initial());
+    });
+
+    test('enqueues each created row for upload', () async {
+      final enqueued = <String>[];
+      when(
+        mockRepo.createMedia(any),
+      ).thenAnswer((_) async => _saved('media-1'));
+
+      final notifier = FilesTabNotifier(
+        mediaRepository: mockRepo,
+        bookmarkStorage: mockBookmarkStorage,
+        platform: mockPlatform,
+        onMediaCreated: enqueued.add,
+      );
+      notifier.setFiles([_ef('/a.jpg')], match: MatchedSelection.empty());
+
+      await notifier.commit(target: const SiteAttachTarget('site-1'));
+
+      expect(enqueued, ['media-1']);
+    });
+  });
+
+  // A dive target must keep routing through the matcher's grouping: a file
+  // the user assigned to dive B stays on dive B even though the picker was
+  // opened from dive A.
+  group('commit with a dive target', () {
+    test('still persists the matcher grouping, not the opening dive', () async {
+      final notifier = container.read(filesTabNotifierProvider.notifier);
+      final a = _ef('/a.jpg');
+      final b = _ef('/b.jpg');
+      notifier.setFiles(
+        [a, b],
+        match: MatchedSelection(
+          matched: {
+            'dive-a': [a],
+            'dive-b': [b],
+          },
+          unmatched: const [],
+        ),
+      );
+
+      when(
+        mockPlatform.createBookmark(any),
+      ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+      when(mockBookmarkStorage.write(any, any)).thenAnswer((_) async {});
+      final captured = <MediaItem>[];
+      var counter = 0;
+      when(mockRepo.createMedia(any)).thenAnswer((invocation) async {
+        captured.add(invocation.positionalArguments.first as MediaItem);
+        counter += 1;
+        return _saved('saved-$counter');
+      });
+
+      await notifier.commit(target: const DiveAttachTarget('dive-a'));
+
+      expect(captured.map((m) => m.diveId), ['dive-a', 'dive-b']);
+      expect(captured.map((m) => m.siteId), [null, null]);
     });
   });
 }

--- a/test/features/media/presentation/widgets/files_tab_test.dart
+++ b/test/features/media/presentation/widgets/files_tab_test.dart
@@ -441,6 +441,20 @@ void main() {
       expect(find.text('Unmatched'), findsNothing);
     });
 
+    testWidgets('counts staged files as items, not photos', (tester) async {
+      // FileType.media admits video, and the folder scan admits
+      // .mp4/.mov/.m4v, so a staged set can be entirely video.
+      final clip = ExtractedFile(
+        sourcePath: '/clip.mp4',
+        file: File('/clip.mp4'),
+        metadata: const MediaSourceMetadata(mimeType: 'video/mp4'),
+      );
+      await tester.pumpWidget(wrap(staged([clip])));
+
+      expect(find.text('1 item'), findsOneWidget);
+      expect(find.textContaining('photo'), findsNothing);
+    });
+
     testWidgets('lists every staged file flat', (tester) async {
       await tester.pumpWidget(wrap(staged([_ef('/a.jpg'), _ef('/b.jpg')])));
 

--- a/test/features/media/presentation/widgets/files_tab_test.dart
+++ b/test/features/media/presentation/widgets/files_tab_test.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/media/data/services/local_bookmark_storage.d
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
 import 'package:submersion/features/media/domain/value_objects/extracted_file.dart';
 import 'package:submersion/features/media/domain/value_objects/matched_selection.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 import 'package:submersion/features/media/presentation/providers/files_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/file_review_pane.dart';
@@ -202,7 +203,13 @@ void main() {
     expect(find.text('Link 2 items'), findsOneWidget);
   });
 
-  testWidgets('hides Link button when match.matched is empty', (tester) async {
+  // Issue #1098: the button used to disappear entirely when nothing was
+  // assignable, which read as "there is no way to save these". It now stays
+  // put and disables, matching the URL tab, so the affordance is always
+  // discoverable and its disabled state is the honest signal.
+  testWidgets('shows a disabled Link button when match.matched is empty', (
+    tester,
+  ) async {
     final seeded = FilesTabState.initial().copyWith(
       files: [_ef('/a.jpg')],
       match: MatchedSelection(matched: const {}, unmatched: [_ef('/a.jpg')]),
@@ -215,6 +222,21 @@ void main() {
           ),
         ],
         child: const MaterialApp(home: Scaffold(body: FilesTab())),
+      ),
+    );
+    expect(find.text('Link 0 items'), findsOneWidget);
+    final button = tester.widget<FilledButton>(find.byType(FilledButton).last);
+    expect(button.onPressed, isNull);
+  });
+
+  testWidgets('shows no commit button before any file is staged', (
+    tester,
+  ) async {
+    // A permanently-greyed button over an empty canvas is noise; the button
+    // earns its place only once there is something staged to act on.
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: Scaffold(body: FilesTab())),
       ),
     );
     expect(find.textContaining('Link '), findsNothing);
@@ -281,7 +303,11 @@ void main() {
         ),
       ],
       child: MaterialApp(
-        home: Scaffold(body: FilesTab(diveId: diveId)),
+        home: Scaffold(
+          body: FilesTab(
+            target: diveId == null ? null : DiveAttachTarget(diveId),
+          ),
+        ),
       ),
     );
 
@@ -318,7 +344,7 @@ void main() {
         ProviderScope(
           overrides: [filesTabNotifierProvider.overrideWith((ref) => notifier)],
           child: const MaterialApp(
-            home: Scaffold(body: FilesTab(diveId: 'd1')),
+            home: Scaffold(body: FilesTab(target: DiveAttachTarget('d1'))),
           ),
         ),
       );
@@ -346,6 +372,82 @@ void main() {
       // Without an assign affordance the unchecked checkbox made the whole
       // tab a no-op: nothing could ever reach commit().
       expect(find.text('Add all 1 to this dive'), findsOneWidget);
+    });
+  });
+
+  // Issue #1098. Opened from a dive site, the tab offered no way to accept the
+  // picked files: the commit button was gated on the dive matcher having
+  // produced a group, and a site never produces one. The site is now the
+  // target, so dive matching does not apply at all.
+  group('site target', () {
+    Widget wrap(FilesTabState seed) => ProviderScope(
+      overrides: [
+        filesTabNotifierProvider.overrideWith(
+          (ref) => _SeededFilesTabNotifier(seed),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: FilesTab(target: SiteAttachTarget('site-1'))),
+      ),
+    );
+
+    FilesTabState staged(List<ExtractedFile> files) =>
+        FilesTabState.initial().copyWith(
+          files: files,
+          // What auto-match leaves behind when nothing lines up with a dive,
+          // which is the normal outcome for a site.
+          match: MatchedSelection(matched: const {}, unmatched: files),
+        );
+
+    testWidgets('offers an enabled commit button for unmatched files', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(staged([_ef('/a.jpg')])));
+
+      expect(find.text('Attach 1 item to this site'), findsOneWidget);
+      final button = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Attach 1 item to this site'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('pluralises the commit button label', (tester) async {
+      await tester.pumpWidget(wrap(staged([_ef('/a.jpg'), _ef('/b.jpg')])));
+
+      expect(find.text('Attach 2 items to this site'), findsOneWidget);
+    });
+
+    testWidgets('shows no commit button before any file is staged', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(FilesTabState.initial()));
+
+      expect(find.textContaining('Attach '), findsNothing);
+    });
+
+    testWidgets('hides the dive auto-match checkbox', (tester) async {
+      // A site has no time window, so matching photos to dives by date would
+      // silently route them somewhere the user did not ask for.
+      await tester.pumpWidget(wrap(staged([_ef('/a.jpg')])));
+
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.textContaining('Auto-match'), findsNothing);
+    });
+
+    testWidgets('offers no dive assignment affordances', (tester) async {
+      await tester.pumpWidget(wrap(staged([_ef('/a.jpg')])));
+
+      expect(find.textContaining('to this dive'), findsNothing);
+      expect(find.text('Unmatched'), findsNothing);
+    });
+
+    testWidgets('lists every staged file flat', (tester) async {
+      await tester.pumpWidget(wrap(staged([_ef('/a.jpg'), _ef('/b.jpg')])));
+
+      expect(find.text('a.jpg'), findsOneWidget);
+      expect(find.text('b.jpg'), findsOneWidget);
+      // No dive grouping to expand or collapse.
+      expect(find.byType(ExpansionTile), findsNothing);
     });
   });
 }

--- a/test/features/media/presentation/widgets/url_tab_test.dart
+++ b/test/features/media/presentation/widgets/url_tab_test.dart
@@ -44,6 +44,7 @@ import 'package:submersion/features/media/data/repositories/media_repository.dar
 import 'package:submersion/features/media/data/services/manifest_fetch_service.dart';
 import 'package:submersion/features/media/data/services/network_credentials_service.dart';
 import 'package:submersion/features/media/data/services/network_fetch_pipeline.dart';
+import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/network_signin_sheet.dart';
@@ -362,5 +363,50 @@ void main() {
         displayName: anyNamed('displayName'),
       ),
     ).called(1);
+  });
+
+  // Issue #1098. Opened from a dive site, the URL tab's "Add" button ingested
+  // rows that could only ever land on a dive, so the site never gained the
+  // attachment the user asked for.
+  group('site target', () {
+    testWidgets('hides the dive auto-match checkbox', (tester) async {
+      await tester.pumpWidget(
+        wrap(const UrlTab(target: SiteAttachTarget('site-1'))),
+      );
+
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.textContaining('Auto-match'), findsNothing);
+    });
+
+    testWidgets('ingests against the site with dive matching off', (
+      tester,
+    ) async {
+      when(
+        pipeline.ingest(
+          any,
+          autoMatch: anyNamed('autoMatch'),
+          siteId: anyNamed('siteId'),
+        ),
+      ).thenAnswer((_) async => ['id-1']);
+
+      await tester.pumpWidget(
+        wrap(
+          const UrlTab(target: SiteAttachTarget('site-1')),
+          seed: const UrlTabState(draftLines: ['https://example.com/a.jpg']),
+        ),
+      );
+      await tester.tap(find.widgetWithText(FilledButton, 'Add'));
+      await tester.pump();
+
+      verify(
+        pipeline.ingest(
+          argThat(equals([Uri.parse('https://example.com/a.jpg')])),
+          // A site has no time window, so a date match here would attach the
+          // photo to some unrelated dive instead of to the site.
+          autoMatch: false,
+          siteId: 'site-1',
+        ),
+      ).called(1);
+    });
   });
 }


### PR DESCRIPTION
Fixes #1098.

## The bug

Attaching photos to a dive site, the Files tab offered no way to accept the picked files. There was no Done, OK, or Save control anywhere on the tab.

## Root cause

Two defects, not one.

**1. The commit button was dive-gated.** `files_tab.dart` rendered it only `if (state.match.matched.isNotEmpty)`, where `matched` is a `Map<diveId, List<file>>` produced by `DivePhotoMatcher`. The screenshot on the issue reads "1 photos -> 0 dives, 1 unmatched", so `matched` was empty and the button never existed. The sibling URL tab always renders its "Add" button and merely disables it; the picker had three tabs with three different commit conventions, and only one of them could vanish entirely.

**2. Neither self-committing tab knew what a site was.** `showPhotoPicker` / `PhotoPickerPage` accepted only a `diveId`, and `SiteMediaImportHelper.importPhotosForSite` called them without one. The Files and URL tabs write rows themselves rather than returning a selection, so with no target they persisted to dives or to nothing at all. Even the "turn auto-match off" escape hatch was dead, because it needed a non-null `diveId`.

Un-gating the button on its own would have produced a permanently disabled button over a dead path, so this fixes the plumbing underneath it.

## The change

A new sealed `MediaAttachTarget` (`DiveAttachTarget` / `SiteAttachTarget`; null means the library importer, which has no owning entity) is threaded through `showPhotoPicker` -> `PhotoPickerPage` -> both self-committing tabs. Two nullable ids would have made "both set" representable; a sealed type makes `switch` exhaustive, so the analyzer flags every new dive-vs-site decision point.

**Files tab, site session:** dive matching is skipped outright, the auto-match checkbox is hidden, the review pane renders one flat list instead of matched/unmatched dive groups, and an enabled **"Attach N items to this site"** appears as soon as anything is staged. `FilesTabNotifier.commit(target:)` writes `MediaItem(siteId: ..., diveId: null)`.

**Files tab, dive session:** behavior unchanged, except the button now stays visible and disabled ("Link 0 items") rather than disappearing when nothing is committable.

**URL tab:** same target plumbing. `NetworkFetchPipeline.ingest` gained a `siteId`, and a site session forces `autoMatch: false` -- a site has no time window, so matching would hand the photo to whichever unrelated dive spanned its timestamp instead of to the site the user was looking at.

**Stale staging:** `filesTabNotifierProvider` is not `autoDispose`, so files picked and then abandoned without committing outlive their session. That was harmless while they were inert, but once they are committable a site session could inherit files staged from a dive. The picker now clears staged files on open (deferred by a microtask, since Riverpod rejects provider mutation inside a widget life-cycle) while keeping the user's auto-match preference.

The site grid refreshes on its own after either tab commits: `mediaForSiteProvider` uses `invalidateSelfWhen(watchMediaChanges())`, a Drift `tableUpdates` stream on `media`, which both tabs' direct inserts tick.

## Testing

33 new or updated tests, written before the implementation:

- `files_tab_providers_test`: site-target commit stamps `siteId` and leaves `diveId` null, persists files the matcher rejected, ignores a stale dive grouping, clears state, enqueues uploads; dive-target commit still honours the matcher's grouping rather than the opening dive; `clearStagedFiles` drops files while keeping the toggle.
- `files_tab_test`: site target shows an enabled pluralised commit button, hides the auto-match checkbox and every dive-assignment affordance, lists files flat; the dive path shows a disabled button instead of hiding it.
- `url_tab_test`: site target hides the checkbox and ingests with `siteId` set and `autoMatch: false`.
- `photo_picker_page_tab_shell_test`: the target reaches both tabs; opening the picker drops files staged by an earlier session.
- `network_fetch_pipeline_test`: `ingest` stamps `siteId` (against a real `dive_sites` row, so the FK is exercised) and leaves it null otherwise.

`flutter analyze` clean, `dart format` clean, full suite run locally.

## Not in scope

- **l10n.** The Files and URL tabs are wholesale hardcoded English behind pre-existing `TODO(media): l10n` markers. Localizing only the two new strings across the 11 ARB catalogs would not make either tab usable in another language, so this keeps the existing convention and leaves the markers in place. Worth a separate issue.
- **`media_import_view.dart`** (the library importer) passes no target, so its Files tab still shows a disabled button when nothing matches a dive. That is honest -- there is no owning entity to attach to -- but it is the third caller with the same shape if we want to give the library a real import target.
