### PR TITLE
fix(seascape): stop rough terrain from burying contour lines

### DIFF
--- a/lib/features/dive_3d/domain/entities/mesh_data.dart
+++ b/lib/features/dive_3d/domain/entities/mesh_data.dart
@@ -14,12 +14,25 @@ class MeshData {
   /// null for untextured meshes.
   final Float32List? textureCoordinates;
 
+  /// Per-vertex scene Y to DEPTH-SORT at, when that differs from the Y the
+  /// vertex is drawn at; null sorts at the drawn height.
+  ///
+  /// The renderer has no depth buffer: it orders triangles by their view-
+  /// space centroid, which cannot resolve a small polygon lying on a large
+  /// one. A contour ribbon riding a terrain cell that falls 100 m across
+  /// its own width loses that comparison and gets painted over. Sorting
+  /// such a mesh at the ceiling of the terrain cell it rides settles the
+  /// tie in favor of the thing that is genuinely on top, while still
+  /// drawing it where it belongs.
+  final Float32List? sortHeights;
+
   const MeshData({
     required this.positions,
     required this.indices,
     required this.colors,
     this.opacity = 1.0,
     this.textureCoordinates,
+    this.sortHeights,
   });
 
   int get vertexCount => positions.length ~/ 3;

--- a/lib/features/dive_3d/domain/entities/mesh_data.dart
+++ b/lib/features/dive_3d/domain/entities/mesh_data.dart
@@ -33,7 +33,11 @@ class MeshData {
     this.opacity = 1.0,
     this.textureCoordinates,
     this.sortHeights,
-  });
+  }) : assert(
+         sortHeights == null || sortHeights.length * 3 == positions.length,
+         'sortHeights needs exactly one entry per vertex: the renderer '
+         'indexes it by vertex while building the depth key',
+       );
 
   int get vertexCount => positions.length ~/ 3;
   int get triangleCount => indices.length ~/ 3;

--- a/lib/features/dive_3d/domain/scene_3d.dart
+++ b/lib/features/dive_3d/domain/scene_3d.dart
@@ -14,6 +14,10 @@ import 'package:submersion/features/dive_3d/presentation/scene_overlay.dart';
 /// TOGETHER with the terrain mesh so far-side geometry hides behind
 /// hills. Plain layer order cannot do that: each mesh painted whole would
 /// put every draped triangle on top of the terrain.
+///
+/// Sharing the sort has a catch, though: a drape that is much smaller than
+/// the terrain triangle it rides loses the centroid comparison on rough
+/// ground. Thin drapes fix that by declaring [MeshData.sortHeights].
 class SceneLayer {
   final MeshData mesh;
   final SceneOverlay? overlay;

--- a/lib/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart
@@ -27,6 +27,21 @@ class BathymetryTerrainBuilder {
 
   static const double metersPerDegLat = 110540.0;
 
+  /// The scene Y of grid node [r],[c] on the rendered surface, applying the
+  /// same nodata-to-shoreline and land-height-cap rules [build] bakes into
+  /// the mesh. Anything draped on the terrain asks through here so it never
+  /// drifts from where the surface is actually drawn.
+  static double surfaceY(
+    BathymetryGrid grid,
+    SpatialProjection projection,
+    int r,
+    int c,
+  ) {
+    final landCap = _landHeightCapFraction * math.max(projection.maxDepth, 1.0);
+    final raw = grid.depthAt(r, c);
+    return projection.yOf(raw == null ? 0.0 : math.max(raw, -landCap));
+  }
+
   /// The ramp color at normalized depth [t] (0 = shallow, 1 = ramp max).
   /// Banded mode quantizes into 10 equal segments sampled at their centers
   /// so the seascape reads like a stepped nautical chart tint.
@@ -88,7 +103,7 @@ class BathymetryTerrainBuilder {
         final depth = raw == null ? 0.0 : math.max(raw, -landCap);
         final vi = (r * cols + c) * 3;
         positions[vi] = projection.xOf(east);
-        positions[vi + 1] = projection.yOf(depth);
+        positions[vi + 1] = surfaceY(grid, projection, r, c);
         positions[vi + 2] = projection.zOf(north);
         if (uvs != null) {
           final f = imageryFrame!;

--- a/lib/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart
@@ -27,20 +27,16 @@ class BathymetryTerrainBuilder {
 
   static const double metersPerDegLat = 110540.0;
 
-  /// The scene Y of grid node [r],[c] on the rendered surface, applying the
-  /// same nodata-to-shoreline and land-height-cap rules [build] bakes into
-  /// the mesh. Anything draped on the terrain asks through here so it never
-  /// drifts from where the surface is actually drawn.
-  static double surfaceY(
-    BathymetryGrid grid,
-    SpatialProjection projection,
-    int r,
-    int c,
-  ) {
-    final landCap = _landHeightCapFraction * math.max(projection.maxDepth, 1.0);
-    final raw = grid.depthAt(r, c);
-    return projection.yOf(raw == null ? 0.0 : math.max(raw, -landCap));
-  }
+  /// How far above the waterline land is allowed to rise, so shorelines
+  /// read without dominating the scene. Hoist it out of per-node loops.
+  static double landHeightCap(SpatialProjection projection) =>
+      _landHeightCapFraction * math.max(projection.maxDepth, 1.0);
+
+  /// The depth one raw grid sample renders at: nodata fills as shoreline,
+  /// land elevation is capped. THE definition of the rendered surface, so
+  /// the mesh and anything draped on it cannot drift apart.
+  static double surfaceDepth(double? raw, double landCap) =>
+      raw == null ? 0.0 : math.max(raw, -landCap);
 
   /// The ramp color at normalized depth [t] (0 = shallow, 1 = ramp max).
   /// Banded mode quantizes into 10 equal segments sampled at their centers
@@ -87,7 +83,7 @@ class BathymetryTerrainBuilder {
     final rows = grid.rows, cols = grid.cols;
     final mLon = metersPerDegreeLongitude(center.latitude);
     final maxDepth = math.max(projection.maxDepth, 1.0);
-    final landCap = _landHeightCapFraction * maxDepth;
+    final landCap = landHeightCap(projection);
 
     final positions = Float32List(rows * cols * 3);
     final colors = Float32List(rows * cols * 3);
@@ -99,11 +95,10 @@ class BathymetryTerrainBuilder {
         final lon = grid.originLon + grid.cellSizeLonDeg * c;
         final east = (lon - center.longitude) * mLon;
         final raw = grid.depthAt(r, c);
-        // nodata -> shoreline; land elevation capped so peaks stay modest.
-        final depth = raw == null ? 0.0 : math.max(raw, -landCap);
+        final depth = surfaceDepth(raw, landCap);
         final vi = (r * cols + c) * 3;
         positions[vi] = projection.xOf(east);
-        positions[vi + 1] = surfaceY(grid, projection, r, c);
+        positions[vi + 1] = projection.yOf(depth);
         positions[vi + 2] = projection.zOf(north);
         if (uvs != null) {
           final f = imageryFrame!;

--- a/lib/features/dive_3d/domain/spatial/contour_builder.dart
+++ b/lib/features/dive_3d/domain/spatial/contour_builder.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_3d/domain/spatial/bathymetry_terrain_bu
 import 'package:submersion/features/dive_3d/domain/spatial/seascape_appearance.dart';
 import 'package:submersion/features/dive_3d/domain/spatial/seascape_axes.dart';
 import 'package:submersion/features/dive_3d/domain/spatial/spatial_projection.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/terrain_ceiling.dart';
 import 'package:submersion/features/dive_3d/presentation/scene_overlay.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 
@@ -226,6 +227,11 @@ ContourBuildResult buildContourLayers({
       (grid.originLat + grid.cellSizeLatDeg * r - center.latitude) *
       BathymetryTerrainBuilder.metersPerDegLat;
 
+  final ceiling = TerrainCeiling(
+    grid: grid,
+    center: center,
+    projection: projection,
+  );
   final layers = <SceneLayer>[];
   final labels = <ContourLabelSpec>[];
   for (final level in levels) {
@@ -252,7 +258,12 @@ ContourBuildResult buildContourLayers({
       sceneLines.add(xyz);
       layers.add(
         SceneLayer(
-          _ribbonMesh(xyz, isMajor: level.isMajor, colorArgb: level.colorArgb),
+          _ribbonMesh(
+            xyz,
+            isMajor: level.isMajor,
+            colorArgb: level.colorArgb,
+            ceiling: ceiling,
+          ),
           overlay: SceneOverlay.contours,
           drapedOnTerrain: true,
         ),
@@ -282,10 +293,16 @@ ContourBuildResult buildContourLayers({
 
 /// A thin horizontal ribbon along a scene-space polyline (constant y), the
 /// same perpendicular-extrusion pattern as SpatialPathBuilder.buildRibbon.
+///
+/// Every vertex also carries a sort height: the ribbon is DRAWN on the
+/// isobath but SORTED at the ceiling of the terrain cell it crosses, so the
+/// rough cells that used to paint over it now lose the comparison. See
+/// [TerrainCeiling].
 MeshData _ribbonMesh(
   List<double> xyz, {
   required bool isMajor,
   required int? colorArgb,
+  required TerrainCeiling ceiling,
 }) {
   final n = xyz.length ~/ 3;
   if (n < 2) {
@@ -303,6 +320,7 @@ MeshData _ribbonMesh(
 
   final positions = Float32List(n * 6);
   final colors = Float32List(n * 6);
+  final sortHeights = Float32List(n * 2);
   for (var i = 0; i < n; i++) {
     final j = i < n - 1 ? i : i - 1;
     var tx = xyz[(j + 1) * 3] - xyz[j * 3];
@@ -324,6 +342,15 @@ MeshData _ribbonMesh(
       colors[vi + s * 3] = color.r;
       colors[vi + s * 3 + 1] = color.g;
       colors[vi + s * 3 + 2] = color.b;
+      // Each edge of the ribbon can straddle a different cell on rough
+      // ground, so each asks for its own ceiling. The same lift that keeps
+      // the ribbon off the mesh keeps its sort height off the ceiling.
+      final si = vi + s * 3;
+      sortHeights[i * 2 + s] = math.max(
+        positions[si + 1],
+        ceiling.atScene(positions[si], positions[si + 2]) +
+            contourLiftSceneUnits,
+      );
     }
   }
   final indices = Uint32List((n - 1) * 6);
@@ -342,6 +369,7 @@ MeshData _ribbonMesh(
     indices: indices,
     colors: colors,
     opacity: opacity,
+    sortHeights: sortHeights,
   );
 }
 

--- a/lib/features/dive_3d/domain/spatial/spatial_projection.dart
+++ b/lib/features/dive_3d/domain/spatial/spatial_projection.dart
@@ -35,6 +35,14 @@ class SpatialProjection {
 
   double zOf(double north) => (north - centerNorth) * horizScale;
 
+  /// Inverses of [xOf] and [zOf], for lookups that start from a scene
+  /// position and need the ground coordinate under it. [horizScale] is
+  /// always positive (its divisor is floored at 1), so no guard is needed.
+  double eastAt(double x) =>
+      (x - SceneBounds.xSpan / 2) / horizScale + centerEast;
+
+  double northAt(double z) => z / horizScale + centerNorth;
+
   double yOf(double depth) =>
       maxDepth <= 0 ? 0 : -(depth / maxDepth) * SceneBounds.ySpan;
 

--- a/lib/features/dive_3d/domain/spatial/terrain_ceiling.dart
+++ b/lib/features/dive_3d/domain/spatial/terrain_ceiling.dart
@@ -21,6 +21,10 @@ class TerrainCeiling {
   final GeoPoint _center;
   final double _metersPerDegLon;
 
+  /// Hoisted out of [atScene]: this runs per draped vertex, four corners
+  /// each, and the cap is fixed for the whole scene.
+  final double _landCap;
+
   TerrainCeiling({
     required BathymetryGrid grid,
     required GeoPoint center,
@@ -28,7 +32,8 @@ class TerrainCeiling {
   }) : _grid = grid,
        _center = center,
        _projection = projection,
-       _metersPerDegLon = metersPerDegreeLongitude(center.latitude);
+       _metersPerDegLon = metersPerDegreeLongitude(center.latitude),
+       _landCap = BathymetryTerrainBuilder.landHeightCap(projection);
 
   /// The shallowest surface height of the cell containing scene [x], [z].
   /// Points outside the grid clamp to the nearest edge cell.
@@ -46,19 +51,22 @@ class TerrainCeiling {
       _grid.rows,
     );
 
-    var ceiling = double.negativeInfinity;
+    // Shallowest corner = greatest scene Y, and yOf is monotonic, so take
+    // the minimum DEPTH and convert once.
+    var shallowest = double.infinity;
     for (var dr = 0; dr <= 1; dr++) {
       for (var dc = 0; dc <= 1; dc++) {
-        final y = BathymetryTerrainBuilder.surfaceY(
-          _grid,
-          _projection,
-          (r + dr).clamp(0, _grid.rows - 1),
-          (c + dc).clamp(0, _grid.cols - 1),
+        final depth = BathymetryTerrainBuilder.surfaceDepth(
+          _grid.depthAt(
+            (r + dr).clamp(0, _grid.rows - 1),
+            (c + dc).clamp(0, _grid.cols - 1),
+          ),
+          _landCap,
         );
-        if (y > ceiling) ceiling = y;
+        if (depth < shallowest) shallowest = depth;
       }
     }
-    return ceiling;
+    return _projection.yOf(shallowest);
   }
 
   /// The lower corner of the cell holding fractional index [t], clamped so

--- a/lib/features/dive_3d/domain/spatial/terrain_ceiling.dart
+++ b/lib/features/dive_3d/domain/spatial/terrain_ceiling.dart
@@ -1,0 +1,70 @@
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/spatial_projection.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// How high the rendered seafloor reaches within one grid cell, in scene Y.
+///
+/// The renderer has no depth buffer; it paints triangles ordered by their
+/// view-space centroid. That ordering breaks down for a thin drape lying on
+/// a large terrain triangle, because one ~115 m cell of real bathymetry can
+/// fall a hundred metres across its own width, putting its centroid nearer
+/// the camera than the contour riding it. Draped geometry therefore sorts
+/// at the CEILING of the cell it sits in -- the shallowest of the cell's
+/// four corners -- which clears every triangle of that cell while staying
+/// bounded by local relief, so a distant hill can still hide it in the
+/// orbit views.
+class TerrainCeiling {
+  final BathymetryGrid _grid;
+  final SpatialProjection _projection;
+  final GeoPoint _center;
+  final double _metersPerDegLon;
+
+  TerrainCeiling({
+    required BathymetryGrid grid,
+    required GeoPoint center,
+    required SpatialProjection projection,
+  }) : _grid = grid,
+       _center = center,
+       _projection = projection,
+       _metersPerDegLon = metersPerDegreeLongitude(center.latitude);
+
+  /// The shallowest surface height of the cell containing scene [x], [z].
+  /// Points outside the grid clamp to the nearest edge cell.
+  double atScene(double x, double z) {
+    final lon = _center.longitude + _projection.eastAt(x) / _metersPerDegLon;
+    final lat =
+        _center.latitude +
+        _projection.northAt(z) / BathymetryTerrainBuilder.metersPerDegLat;
+    final c = _cellIndex(
+      (lon - _grid.originLon) / _grid.cellSizeLonDeg,
+      _grid.cols,
+    );
+    final r = _cellIndex(
+      (lat - _grid.originLat) / _grid.cellSizeLatDeg,
+      _grid.rows,
+    );
+
+    var ceiling = double.negativeInfinity;
+    for (var dr = 0; dr <= 1; dr++) {
+      for (var dc = 0; dc <= 1; dc++) {
+        final y = BathymetryTerrainBuilder.surfaceY(
+          _grid,
+          _projection,
+          (r + dr).clamp(0, _grid.rows - 1),
+          (c + dc).clamp(0, _grid.cols - 1),
+        );
+        if (y > ceiling) ceiling = y;
+      }
+    }
+    return ceiling;
+  }
+
+  /// The lower corner of the cell holding fractional index [t], clamped so
+  /// the cell's far corner stays inside a grid of [count] nodes.
+  static int _cellIndex(double t, int count) {
+    if (count < 2 || !t.isFinite) return 0;
+    return t.floor().clamp(0, count - 2);
+  }
+}

--- a/lib/features/dive_3d/presentation/renderer/preview_painter.dart
+++ b/lib/features/dive_3d/presentation/renderer/preview_painter.dart
@@ -195,6 +195,8 @@ class Dive3dScenePainter extends CustomPainter {
     final vx = Float32List(vn);
     final vy = Float32List(vn);
     final vz = Float32List(vn);
+    // Depth the sort uses: vz, except where a mesh declares sort heights.
+    final vzSort = Float32List(vn);
     final sx = Float32List(vn);
     final sy = Float32List(vn);
     final vColors = Float32List(vn * 3);
@@ -204,6 +206,7 @@ class Dive3dScenePainter extends CustomPainter {
     var tOff = 0;
     for (final mesh in meshes) {
       final alpha = (mesh.opacity * 255).round() << 24;
+      final sortHeights = mesh.sortHeights;
       for (var i = 0; i < mesh.vertexCount; i++) {
         final gi = vOff + i;
         final v = projector.viewOf(
@@ -214,6 +217,11 @@ class Dive3dScenePainter extends CustomPainter {
         vx[gi] = v.$1;
         vy[gi] = v.$2;
         vz[gi] = v.$3;
+        vzSort[gi] = sortHeights == null
+            ? v.$3
+            : v.$3 +
+                  (sortHeights[i] - mesh.positions[i * 3 + 1]) *
+                      projector.depthPerUnitY;
         final o = projector.projectView(v);
         sx[gi] = o.dx;
         sy[gi] = o.dy;
@@ -232,14 +240,15 @@ class Dive3dScenePainter extends CustomPainter {
       tOff += mesh.triangleCount;
     }
 
-    // Depth-sort triangles back-to-front by mean view depth.
+    // Depth-sort triangles back-to-front by mean view depth, taken at each
+    // mesh's sort heights where it declares them.
     final order = List<int>.generate(triCount, (i) => i);
     final depths = Float32List(triCount);
     for (var t = 0; t < triCount; t++) {
       final i0 = triIndices[t * 3];
       final i1 = triIndices[t * 3 + 1];
       final i2 = triIndices[t * 3 + 2];
-      depths[t] = (vz[i0] + vz[i1] + vz[i2]) / 3;
+      depths[t] = (vzSort[i0] + vzSort[i1] + vzSort[i2]) / 3;
     }
     order.sort((a, b) => depths[a].compareTo(depths[b]));
 

--- a/lib/features/dive_3d/presentation/renderer/scene_projector.dart
+++ b/lib/features/dive_3d/presentation/renderer/scene_projector.dart
@@ -88,4 +88,12 @@ class SceneProjector {
 
   /// Larger = nearer to camera. Used for back-to-front triangle sorting.
   double viewDepth(double x, double y, double z) => _view(x, y, z).$3;
+
+  /// How much view depth one scene-Y unit buys at this pitch, exactly (view
+  /// depth is affine in y). Lets the renderer re-sort a vertex at a
+  /// different height without projecting it twice, and makes the shift
+  /// self-scaling: straight down it is the whole depth axis, edge-on it is
+  /// nothing -- which is also where the ordering it corrects stops
+  /// mattering. See [MeshData.sortHeights].
+  double get depthPerUnitY => _sp;
 }

--- a/test/features/dive_3d/domain/spatial/contour_occlusion_test.dart
+++ b/test/features/dive_3d/domain/spatial/contour_occlusion_test.dart
@@ -1,0 +1,176 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+import 'package:submersion/features/dive_3d/domain/entities/mesh_data.dart';
+import 'package:submersion/features/dive_3d/domain/scene_3d.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/site_seascape_geometry_service.dart';
+import 'package:submersion/features/dive_3d/presentation/renderer/preview_painter.dart';
+import 'package:submersion/features/dive_3d/presentation/scene_overlay.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// A Bonaire-shaped shelf: land to the east, a narrow reef top, then a drop
+/// to ~700 m westward. [noise] roughens each cell the way a real ~115 m
+/// EMODnet grid is rough, which is the condition that used to bury contours.
+BathymetryGrid _shelfGrid({int n = 40, double noise = 0.18}) {
+  final rnd = math.Random(7);
+  final depths = <double?>[];
+  for (var r = 0; r < n; r++) {
+    for (var c = 0; c < n; c++) {
+      final t = c / (n - 1);
+      final shore = 0.72 + 0.04 * math.sin(r / n * 6.28);
+      double d;
+      if (t >= shore) {
+        d = -20.0 * (t - shore) / (1 - shore);
+      } else {
+        final u = (shore - t) / shore;
+        d = 700 * math.pow(u, 1.6).toDouble();
+      }
+      if (d > 0) d *= 1 + noise * (rnd.nextDouble() * 2 - 1);
+      depths.add(d);
+    }
+  }
+  return BathymetryGrid(
+    originLat: 12.05,
+    originLon: -68.32,
+    cellSizeLatDeg: 8000 / 110540.0 / (n - 1),
+    cellSizeLonDeg: 8000 / 108800.0 / (n - 1),
+    rows: n,
+    cols: n,
+    depthsMeters: depths,
+    sourceId: 'emodnet',
+    resolutionMeters: 115,
+    fetchedAt: DateTime.utc(2026, 1, 1),
+  );
+}
+
+Scene3d _sceneFor(BathymetryGrid grid) =>
+    const SiteSeascapeGeometryService().build(
+      SiteSeascapeInput(
+        grid: grid,
+        center: const GeoPoint(12.09, -68.27),
+        siteName: 'Alice in Wonderland',
+        divePaths: [],
+        nearbySites: [],
+        displayUnitInMeters: 0.3048,
+        depthSymbol: 'ft',
+      ),
+    );
+
+/// The scene Y the painter sorts a vertex at: [MeshData.sortHeights] when
+/// the mesh carries them, the drawn height otherwise.
+double _sortY(MeshData m, int vertex) =>
+    m.sortHeights?[vertex] ?? m.positions[vertex * 3 + 1];
+
+double _meanSortY(MeshData m, int tri) =>
+    (_sortY(m, m.indices[tri * 3]) +
+        _sortY(m, m.indices[tri * 3 + 1]) +
+        _sortY(m, m.indices[tri * 3 + 2])) /
+    3;
+
+double _meanDrawnY(MeshData m, int tri) =>
+    (m.positions[m.indices[tri * 3] * 3 + 1] +
+        m.positions[m.indices[tri * 3 + 1] * 3 + 1] +
+        m.positions[m.indices[tri * 3 + 2] * 3 + 1]) /
+    3;
+
+({double x, double z}) _centroidXz(MeshData m, int tri) {
+  final i0 = m.indices[tri * 3], i1 = m.indices[tri * 3 + 1];
+  final i2 = m.indices[tri * 3 + 2];
+  return (
+    x: (m.positions[i0 * 3] + m.positions[i1 * 3] + m.positions[i2 * 3]) / 3,
+    z:
+        (m.positions[i0 * 3 + 2] +
+            m.positions[i1 * 3 + 2] +
+            m.positions[i2 * 3 + 2]) /
+        3,
+  );
+}
+
+bool _containsXz(MeshData m, int tri, double px, double pz) {
+  final i0 = m.indices[tri * 3], i1 = m.indices[tri * 3 + 1];
+  final i2 = m.indices[tri * 3 + 2];
+  final ax = m.positions[i0 * 3], az = m.positions[i0 * 3 + 2];
+  final bx = m.positions[i1 * 3], bz = m.positions[i1 * 3 + 2];
+  final cx = m.positions[i2 * 3], cz = m.positions[i2 * 3 + 2];
+  double cross(double x1, double z1, double x2, double z2) => x1 * z2 - z1 * x2;
+  final d1 = cross(bx - ax, bz - az, px - ax, pz - az);
+  final d2 = cross(cx - bx, cz - bz, px - bx, pz - bz);
+  final d3 = cross(ax - cx, az - cz, px - cx, pz - cz);
+  return !((d1 < 0 || d2 < 0 || d3 < 0) && (d1 > 0 || d2 > 0 || d3 > 0));
+}
+
+void main() {
+  // In the chart pose (pitch 90) the painter's view-space depth key IS the
+  // scene Y and screen position depends only on scene X/Z, so paint order
+  // can be checked exactly here with 2D containment -- no projection needed.
+  test('no draped triangle sorts behind the terrain it rides', () {
+    final scene = _sceneFor(_shelfGrid());
+    final merged = Dive3dScenePainter.partitionLayers(scene, {
+      SceneOverlay.contours,
+      SceneOverlay.steepWalls,
+    }).merged;
+    final terrain = merged.first;
+    final contours = merged.skip(1).toList();
+    expect(contours, isNotEmpty);
+
+    var checked = 0;
+    final buried = <String>[];
+    for (final m in contours) {
+      for (var tri = 0; tri < m.triangleCount; tri++) {
+        final p = _centroidXz(m, tri);
+        final key = _meanSortY(m, tri);
+        checked++;
+        for (var tt = 0; tt < terrain.triangleCount; tt++) {
+          if (!_containsXz(terrain, tt, p.x, p.z)) continue;
+          if (_meanSortY(terrain, tt) > key) {
+            buried.add(
+              'contour at y=${_meanDrawnY(m, tri).toStringAsFixed(3)} '
+              'sorts ${(_meanSortY(terrain, tt) - key).toStringAsFixed(3)} '
+              'behind terrain',
+            );
+          }
+        }
+      }
+    }
+    expect(checked, greaterThan(500), reason: 'the fixture must be rough');
+    expect(buried, isEmpty, reason: '${buried.length}/$checked buried');
+  });
+
+  test('sort heights lift contours no higher than the local cell ceiling', () {
+    final scene = _sceneFor(_shelfGrid());
+    final merged = Dive3dScenePainter.partitionLayers(scene, {
+      SceneOverlay.contours,
+    }).merged;
+    final terrain = merged.first;
+    var terrainCeiling = double.negativeInfinity;
+    for (var i = 0; i < terrain.vertexCount; i++) {
+      terrainCeiling = math.max(terrainCeiling, terrain.positions[i * 3 + 1]);
+    }
+
+    for (final m in merged.skip(1)) {
+      expect(m.sortHeights, isNotNull);
+      for (var i = 0; i < m.vertexCount; i++) {
+        // Never sorts below where it is drawn, and never floats above the
+        // whole terrain: the lift is bounded by local relief, so a contour
+        // can still hide behind a distant hill in the orbit views.
+        expect(_sortY(m, i), greaterThanOrEqualTo(m.positions[i * 3 + 1]));
+        expect(_sortY(m, i), lessThanOrEqualTo(terrainCeiling + 0.1));
+      }
+    }
+  });
+
+  test('a smooth grid needs no meaningful lift', () {
+    final scene = _sceneFor(_shelfGrid(noise: 0));
+    final merged = Dive3dScenePainter.partitionLayers(scene, {
+      SceneOverlay.contours,
+    }).merged;
+    var maxLift = 0.0;
+    for (final m in merged.skip(1)) {
+      for (var i = 0; i < m.vertexCount; i++) {
+        maxLift = math.max(maxLift, _sortY(m, i) - m.positions[i * 3 + 1]);
+      }
+    }
+    expect(maxLift, lessThan(0.35));
+  });
+}

--- a/test/features/dive_3d/domain/spatial/terrain_ceiling_test.dart
+++ b/test/features/dive_3d/domain/spatial/terrain_ceiling_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/bathymetry/domain/bathymetry_grid.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/bathymetry_terrain_builder.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/spatial_projection.dart';
+import 'package:submersion/features/dive_3d/domain/spatial/terrain_ceiling.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+const _center = GeoPoint(12.0, -68.0);
+
+BathymetryGrid _grid(List<double?> depths, {int rows = 3, int cols = 3}) =>
+    BathymetryGrid(
+      originLat: 11.99,
+      originLon: -68.01,
+      cellSizeLatDeg: 0.01,
+      cellSizeLonDeg: 0.01,
+      rows: rows,
+      cols: cols,
+      depthsMeters: depths,
+      sourceId: 'test',
+      resolutionMeters: 100,
+      fetchedAt: DateTime.utc(2026, 1, 1),
+    );
+
+SpatialProjection _projectionFor(BathymetryGrid grid) {
+  final box = BathymetryTerrainBuilder.enuBounds(grid, _center);
+  return SpatialProjection(
+    minEast: box.minEast,
+    maxEast: box.maxEast,
+    minNorth: box.minNorth,
+    maxNorth: box.maxNorth,
+    maxDepth: grid.maxDepthMeters,
+  );
+}
+
+void main() {
+  test('a cell reports the height of its shallowest corner', () {
+    // Row-major, south -> north. The south-west cell spans depths
+    // 10 / 20 / 30 / 40; its ceiling is the 10 m corner.
+    final grid = _grid([10, 20, 25, 30, 40, 45, 50, 55, 60]);
+    final proj = _projectionFor(grid);
+    final ceiling = TerrainCeiling(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    );
+
+    // A point a quarter into the south-west cell, from its origin corner.
+    final x = proj.xOf(
+      (grid.originLon + grid.cellSizeLonDeg * 0.25 - _center.longitude) *
+          108800,
+    );
+    final z = proj.zOf(
+      (grid.originLat + grid.cellSizeLatDeg * 0.25 - _center.latitude) *
+          BathymetryTerrainBuilder.metersPerDegLat,
+    );
+    expect(ceiling.atScene(x, z), closeTo(proj.yOf(10), 0.02));
+  });
+
+  test('the ceiling is never below the surface at any mesh vertex', () {
+    final grid = _grid([
+      5, 90, 12, //
+      140, 8, 200,
+      30, 400, 60,
+    ]);
+    final proj = _projectionFor(grid);
+    final ceiling = TerrainCeiling(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    );
+    final mesh = BathymetryTerrainBuilder.build(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    ).terrain;
+
+    for (var i = 0; i < mesh.vertexCount; i++) {
+      final x = mesh.positions[i * 3];
+      final y = mesh.positions[i * 3 + 1];
+      final z = mesh.positions[i * 3 + 2];
+      expect(
+        ceiling.atScene(x, z),
+        greaterThanOrEqualTo(y - 1e-6),
+        reason: 'vertex $i sits above its own cell ceiling',
+      );
+    }
+  });
+
+  test('points outside the grid clamp to the nearest edge cell', () {
+    final grid = _grid([10, 20, 25, 30, 40, 45, 50, 55, 60]);
+    final proj = _projectionFor(grid);
+    final ceiling = TerrainCeiling(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    );
+    expect(ceiling.atScene(-1000, -1000), isA<double>());
+    expect(ceiling.atScene(1000, 1000), isA<double>());
+    expect(ceiling.atScene(-1000, -1000).isFinite, isTrue);
+  });
+
+  test('land and nodata report the surface the mesh actually draws', () {
+    // nodata renders at the waterline; land is capped, not raw elevation.
+    final grid = _grid([null, -5000, 20, 30, 40, 45, 50, 55, 60]);
+    final proj = _projectionFor(grid);
+    final ceiling = TerrainCeiling(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    );
+    final capped = BathymetryTerrainBuilder.surfaceY(grid, proj, 0, 1);
+    expect(capped, greaterThan(0), reason: 'land sits above the waterline');
+    expect(ceiling.atScene(proj.xOf(0), proj.zOf(0)), greaterThan(0));
+  });
+}

--- a/test/features/dive_3d/domain/spatial/terrain_ceiling_test.dart
+++ b/test/features/dive_3d/domain/spatial/terrain_ceiling_test.dart
@@ -100,7 +100,8 @@ void main() {
   });
 
   test('land and nodata report the surface the mesh actually draws', () {
-    // nodata renders at the waterline; land is capped, not raw elevation.
+    // A -5000 m sample is land far above any real cap: the mesh clamps it,
+    // and the ceiling has to report the clamped height, not the raw one.
     final grid = _grid([null, -5000, 20, 30, 40, 45, 50, 55, 60]);
     final proj = _projectionFor(grid);
     final ceiling = TerrainCeiling(
@@ -108,8 +109,22 @@ void main() {
       center: _center,
       projection: proj,
     );
-    final capped = BathymetryTerrainBuilder.surfaceY(grid, proj, 0, 1);
-    expect(capped, greaterThan(0), reason: 'land sits above the waterline');
-    expect(ceiling.atScene(proj.xOf(0), proj.zOf(0)), greaterThan(0));
+    final mesh = BathymetryTerrainBuilder.build(
+      grid: grid,
+      center: _center,
+      projection: proj,
+    ).terrain;
+    final drawnLandY = mesh.positions[1 * 3 + 1]; // node (row 0, col 1)
+    expect(drawnLandY, greaterThan(0), reason: 'land sits above the waterline');
+    expect(
+      drawnLandY,
+      lessThan(5000),
+      reason: 'and is capped, not raw elevation',
+    );
+    // The south-west cell holds that land node, so its ceiling is that height.
+    expect(
+      ceiling.atScene(mesh.positions[0], mesh.positions[2]),
+      closeTo(drawnLandY, 1e-6),
+    );
   });
 }

--- a/test/features/dive_3d/presentation/renderer/preview_painter_sort_heights_test.dart
+++ b/test/features/dive_3d/presentation/renderer/preview_painter_sort_heights_test.dart
@@ -1,0 +1,100 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_3d/domain/entities/mesh_data.dart';
+import 'package:submersion/features/dive_3d/domain/geometry/scene_bounds.dart';
+import 'package:submersion/features/dive_3d/domain/scene_3d.dart';
+import 'package:submersion/features/dive_3d/presentation/renderer/preview_painter.dart';
+import 'package:submersion/features/dive_3d/presentation/renderer/scene_projector.dart';
+import 'package:submersion/features/dive_3d/presentation/scene_overlay.dart';
+
+const _size = ui.Size(200, 150);
+const _bounds = SceneBounds(
+  durationSeconds: 1,
+  maxDepthMeters: 10,
+  sceneMinY: -SceneBounds.ySpan,
+  sceneMaxY: 0,
+);
+
+/// One big terrain triangle that falls steeply across its own width, the
+/// way a rough bathymetry cell does. Its CENTROID sits at y = -2, nearer
+/// the camera than the drape at y = -2.5 that rides its far half.
+final _terrain = MeshData(
+  positions: Float32List.fromList([2, -3, -0.8, 8, -3, -0.8, 5, 0, 0.8]),
+  indices: Uint32List.fromList([0, 1, 2]),
+  colors: Float32List.fromList([1, 0, 0, 1, 0, 0, 1, 0, 0]),
+);
+
+MeshData _drape({bool withSortHeights = true}) => MeshData(
+  positions: Float32List.fromList([
+    4.8, -2.5, -0.4, //
+    5.2, -2.5, -0.4,
+    5.0, -2.5, -0.1,
+  ]),
+  indices: Uint32List.fromList([0, 1, 2]),
+  colors: Float32List.fromList([0, 1, 0, 0, 1, 0, 0, 1, 0]),
+  // The ceiling of the terrain it rides.
+  sortHeights: withSortHeights ? Float32List.fromList([0, 0, 0]) : null,
+);
+
+Future<ui.Image> _render(MeshData drape) async {
+  final recorder = ui.PictureRecorder();
+  Dive3dScenePainter(
+    scene: Scene3d(
+      layers: [
+        SceneLayer(_terrain),
+        SceneLayer(
+          drape,
+          overlay: SceneOverlay.contours,
+          drapedOnTerrain: true,
+        ),
+      ],
+      markers: const [],
+      bounds: _bounds,
+    ),
+    yawDegrees: chartYawDegrees,
+    pitchDegrees: chartPitchDegrees,
+    mirrorX: true,
+  ).paint(ui.Canvas(recorder), _size);
+  return recorder.endRecording().toImage(
+    _size.width.round(),
+    _size.height.round(),
+  );
+}
+
+/// The rgb at the drape's projected centroid. Flat shading darkens the
+/// vertex colors, so tests compare channels rather than exact values.
+Future<({int r, int g})> _pixelAtDrape(ui.Image image) async {
+  final projector = SceneProjector(
+    size: _size,
+    bounds: _bounds,
+    yawDegrees: chartYawDegrees,
+    pitchDegrees: chartPitchDegrees,
+    mirrorX: true,
+  );
+  final p = projector.project(5.0, -2.5, -0.3);
+  final bytes = (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!;
+  final offset = (p.dy.round() * image.width + p.dx.round()) * 4;
+  return (r: bytes.getUint8(offset), g: bytes.getUint8(offset + 1));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('a drape sorted at the cell ceiling paints over the terrain', () async {
+    final image = await _render(_drape());
+    addTearDown(image.dispose);
+    final px = await _pixelAtDrape(image);
+    expect(px.g, greaterThan(px.r), reason: 'the drape should be visible');
+  });
+
+  test('without sort heights the same drape is buried', () async {
+    final image = await _render(_drape(withSortHeights: false));
+    addTearDown(image.dispose);
+    final px = await _pixelAtDrape(image);
+    // Documents the bug this mechanism exists to fix: centroid ordering
+    // alone hands the pixel to the terrain triangle underneath.
+    expect(px.r, greaterThan(px.g));
+  });
+}

--- a/test/features/dive_3d/presentation/renderer/preview_painter_sort_heights_test.dart
+++ b/test/features/dive_3d/presentation/renderer/preview_painter_sort_heights_test.dart
@@ -82,6 +82,20 @@ Future<({int r, int g})> _pixelAtDrape(ui.Image image) async {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('sort heights must carry one entry per vertex', () {
+    // The renderer indexes sortHeights by vertex; a short list would throw a
+    // RangeError deep in the paint loop instead of at the mistake.
+    expect(
+      () => MeshData(
+        positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        indices: Uint32List.fromList([0, 1, 2]),
+        colors: Float32List.fromList([1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        sortHeights: Float32List.fromList([0, 0]),
+      ),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
   test('a drape sorted at the cell ceiling paints over the terrain', () async {
     final image = await _render(_drape());
     addTearDown(image.dispose);


### PR DESCRIPTION
## Summary

Seascape contour lines broke up over rough bathymetry. They were not being
occluded by the terrain, they were being **mis-sorted** by it.

`Dive3dScenePainter` is the app's only 3D rasterizer and it is a painter's
algorithm over `Canvas.drawVertices`: **no depth buffer**. It orders triangles
back-to-front by their mean view-space z (the centroid), which is only a valid
visibility test between triangles of comparable size. A contour ribbon is a few
hundredths of a scene unit wide; the terrain triangle it rides spans a whole
grid half-cell, and one ~115 m EMODnet cell on a drop-off can fall over 100 m.
That puts the terrain triangle's centroid nearer the camera than the contour
crossing it, so the seafloor paints last and the line vanishes.

`contourLiftSceneUnits = 0.03` only ever settled exact coplanar ties. Measured
worst-case ordering gap on a rough grid: **1.043 scene-y, 35x the lift**. That
is why the artifact tracks roughness: 41% of ribbon triangles buried on a rough
grid against 14% on a smooth one.

The fix separates where a mesh is *drawn* from where it is *sorted*. Contour
ribbons now sort at the ceiling of the terrain cell under them, which clears
every triangle of that cell by construction. Bounding the lift by LOCAL relief
is what keeps it honest: a contour still cannot rise above a distant hill, so
the far-side hiding that the shared depth sort exists for (88870d5) keeps
working.

## Changes

- `MeshData.sortHeights`: optional per-vertex scene Y used only for the depth
  key. Positions still drive the projection, so nothing shifts on screen.
- `SceneProjector.depthPerUnitY` (= `sin(pitch)`, exact because view depth is
  affine in y). This makes the correction self-scaling: full strength looking
  straight down, where the mis-ordering is worst, and nothing edge-on, where it
  does not apply. No mode flags and no angle thresholds.
- `TerrainCeiling`: the shallowest of the four corners of the grid cell under a
  scene point, resolved through the terrain builder's own surface rule so a
  drape can never drift from where the mesh is actually drawn.
- `BathymetryTerrainBuilder.surfaceY` extracted so the mesh and the ceiling
  lookup share one definition of the rendered surface (nodata to shoreline,
  land height capped).
- `SpatialProjection.eastAt` / `northAt`: the inverses of `xOf` / `zOf`.

## Measurements

Sampling random screen points and comparing the triangle the paint order puts on
top against the one that is truly nearest (barycentric view z), on a synthetic
Bonaire-shaped shelf:

| Pose | contour pixels buried | terrain self-inversions |
| --- | --- | --- |
| chart (pitch 90) | 146 -> **0** | 0 -> 0 |
| orbit (pitch 22) | 3 -> **1** | 6 -> 6 |
| orbit (pitch 45) | 4 -> **0** | 25 -> 22 |
| low (pitch 8) | 0 -> 0 | 1 -> 1 |

Terrain self-ordering is untouched, which was the point of choosing this
approach. The obvious alternative, sorting terrain by its farthest vertex, also
drives every bury to zero but raises terrain self-inversions from 1 to 142 at
grazing pitch, so it was rejected on measurement rather than taste.

Steep-wall highlights never had the problem: their quads are coextensive with
the terrain cell, so centroid ordering already resolves them. The regression
test covers that overlay anyway.

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: macOS (site seascape, chart mode, Bonaire sites)

New tests:

- `contour_occlusion_test.dart`: at the chart pose the painter's depth key IS
  scene Y and screen position depends only on scene X/Z, so paint order is
  checked exactly with 2D containment. Went from 1091/2478 draped triangles
  buried to 0. Also pins that the lift stays bounded by local relief.
- `preview_painter_sort_heights_test.dart`: renders to an image and reads the
  pixel. The second case removes `sortHeights` and asserts the drape IS buried,
  so the mechanism cannot be quietly deleted.
- `terrain_ceiling_test.dart`: cell lookup, clamping outside the grid, and land
  and nodata reporting the surface the mesh actually draws.
