### PR TITLE
fix(seascape): contour level editing, sheet spacing, and blend default

### DIFF
--- a/lib/features/dive_3d/domain/spatial/seascape_appearance.dart
+++ b/lib/features/dive_3d/domain/spatial/seascape_appearance.dart
@@ -54,7 +54,10 @@ class SeascapeAppearance extends Equatable {
   /// contours) as a translucent overlay. Synced per-diver like the rest.
   final bool mapDepthOverlay;
 
-  /// The 3D terrain surface: depth ramp, map imagery, or a blend.
+  /// The 3D terrain surface: depth ramp, map imagery, or a blend. Defaults to
+  /// blend, which reads as terrain rather than a colour chart while keeping
+  /// the depth ramp legible; the drape loads non-blocking, so a diver who is
+  /// offline still gets the plain ramp until it lands.
   final SeascapeSurfaceMode surfaceMode;
 
   const SeascapeAppearance({
@@ -64,7 +67,7 @@ class SeascapeAppearance extends Equatable {
     this.customLevels = const [],
     this.wallAngleDeg = 22.0,
     this.mapDepthOverlay = false,
-    this.surfaceMode = SeascapeSurfaceMode.depth,
+    this.surfaceMode = SeascapeSurfaceMode.blend,
   });
 
   SeascapeAppearance copyWith({

--- a/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
+++ b/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
@@ -250,8 +250,14 @@ class _LevelRowState extends State<_LevelRow> {
 
   double get _display => widget.level.depthMeters / widget.unitInMeters;
 
-  SeascapeAppearance get _appearance =>
-      _container.read(settingsProvider).seascapeAppearance;
+  /// Null once the scope is gone. The disposal commit runs during teardown,
+  /// which in tests can land after the container has been torn down, and
+  /// reading a disposed container throws. Disposing a container disposes its
+  /// notifiers too, so the notifier's mounted flag is the public proxy for
+  /// "is this container still readable".
+  SeascapeAppearance? get _appearance => widget.notifier.mounted
+      ? _container.read(settingsProvider).seascapeAppearance
+      : null;
 
   @override
   void initState() {
@@ -309,7 +315,9 @@ class _LevelRowState extends State<_LevelRow> {
     final typed = double.tryParse(_controller.text.trim().replaceAll(',', '.'));
     if (typed == null || !typed.isFinite || typed <= 0) return null;
     final appearance = _appearance;
-    if (widget.index >= appearance.customLevels.length) return null;
+    if (appearance == null || widget.index >= appearance.customLevels.length) {
+      return null;
+    }
     final current = appearance.customLevels[widget.index];
     // Compare in DISPLAY space at the precision the box actually shows. The
     // box renders one decimal, so 30 m reads as "98.4" ft and parsing that
@@ -338,7 +346,9 @@ class _LevelRowState extends State<_LevelRow> {
 
   void _write(SeascapeContourLevel? next) {
     final appearance = _appearance;
-    if (widget.index >= appearance.customLevels.length) return;
+    if (appearance == null || widget.index >= appearance.customLevels.length) {
+      return;
+    }
     widget.notifier.setSeascapeAppearance(
       appearance.copyWith(customLevels: _replace(appearance, next)),
     );

--- a/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
+++ b/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,8 +14,17 @@ void showTerrainAppearanceSheet(BuildContext context) {
     context: context,
     isScrollControlled: true,
     showDragHandle: true,
-    builder: (_) => const SafeArea(
-      child: SingleChildScrollView(child: TerrainAppearanceSheet()),
+    // The custom-level rows open a keypad. Without a viewInsets pad the sheet
+    // keeps its full height, so the lower rows and the add button sit behind
+    // the keyboard with no scroll extent left to bring them up (issue #1094).
+    builder: (sheetContext) => SafeArea(
+      child: Padding(
+        key: const ValueKey('terrainAppearanceSheetInsets'),
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(sheetContext).viewInsets.bottom,
+        ),
+        child: const SingleChildScrollView(child: TerrainAppearanceSheet()),
+      ),
     ),
   );
 }
@@ -53,11 +64,8 @@ class TerrainAppearanceSheet extends ConsumerWidget {
     void update(SeascapeAppearance next) =>
         notifier.setSeascapeAppearance(next);
 
-    String depthText(double meters) {
-      final v = meters / unitInMeters;
-      final text = v % 1 == 0 ? v.toStringAsFixed(0) : v.toStringAsFixed(1);
-      return '$text ${depthUnit.symbol}';
-    }
+    String depthText(double meters) =>
+        '${_formatDisplay(meters / unitInMeters)} ${depthUnit.symbol}';
 
     final rampMax = appearance.rampMaxDepthMeters;
     return Padding(
@@ -151,7 +159,14 @@ class TerrainAppearanceSheet extends ConsumerWidget {
           ),
           if (appearance.contourMode == SeascapeContourMode.custom) ...[
             for (var i = 0; i < appearance.customLevels.length; i++)
-              _levelRow(context, appearance, i, unitInMeters, update),
+              _LevelRow(
+                key: ValueKey('seascapeLevelRow$i'),
+                index: i,
+                level: appearance.customLevels[i],
+                unitInMeters: unitInMeters,
+                unitSymbol: depthUnit.symbol,
+                notifier: notifier,
+              ),
             TextButton.icon(
               key: const ValueKey('seascapeAddLevelButton'),
               icon: const Icon(Icons.add),
@@ -190,76 +205,203 @@ class TerrainAppearanceSheet extends ConsumerWidget {
       ),
     );
   }
+}
 
-  Widget _levelRow(
-    BuildContext context,
+/// Depth in the diver's unit, trimmed to a whole number when it is one.
+String _formatDisplay(double display) =>
+    display % 1 == 0 ? display.toStringAsFixed(0) : display.toStringAsFixed(1);
+
+/// One custom contour level. Stateful because the depth box owns a controller:
+/// a decimal keypad offers no submit key, so the row commits when the field
+/// loses focus and again if the sheet is dismissed with an edit still pending
+/// (issue #1094 — typed levels used to be discarded outright).
+///
+/// Every mutation reads the CURRENT appearance out of the container rather
+/// than a value captured at build time, so a commit that lands after the row
+/// is gone cannot resurrect a level the diver just deleted.
+class _LevelRow extends StatefulWidget {
+  final int index;
+  final SeascapeContourLevel level;
+  final double unitInMeters;
+  final String unitSymbol;
+  final SettingsNotifier notifier;
+
+  const _LevelRow({
+    super.key,
+    required this.index,
+    required this.level,
+    required this.unitInMeters,
+    required this.unitSymbol,
+    required this.notifier,
+  });
+
+  @override
+  State<_LevelRow> createState() => _LevelRowState();
+}
+
+class _LevelRowState extends State<_LevelRow> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+
+  /// Captured once so a commit deferred past disposal still has a live handle
+  /// to read the settings from; `listen: false` because this runs outside
+  /// build. The app-level container outlives the sheet.
+  late final ProviderContainer _container;
+
+  double get _display => widget.level.depthMeters / widget.unitInMeters;
+
+  SeascapeAppearance get _appearance =>
+      _container.read(settingsProvider).seascapeAppearance;
+
+  @override
+  void initState() {
+    super.initState();
+    _container = ProviderScope.containerOf(context, listen: false);
+    _controller = TextEditingController(text: _formatDisplay(_display));
+    _focusNode = FocusNode()..addListener(_onFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant _LevelRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Rows are keyed by index, so a deleted row shifts its neighbours up and a
+    // unit switch restates every level. Re-seed whenever the value this row
+    // represents actually moved; mid-typing it never does, so this cannot
+    // clobber the diver's keystrokes.
+    final wasDisplay = oldWidget.level.depthMeters / oldWidget.unitInMeters;
+    if ((wasDisplay - _display).abs() > 1e-9) {
+      _controller.text = _formatDisplay(_display);
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    final pending = _pendingAppearance();
+    if (pending != null) {
+      // Unmounting runs inside a state-locked finalizeTree, so notifying
+      // Riverpod here directly would trip markNeedsBuild. Land it after.
+      final notifier = widget.notifier;
+      scheduleMicrotask(() {
+        if (notifier.mounted) notifier.setSeascapeAppearance(pending);
+      });
+    }
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (_focusNode.hasFocus || !mounted) return;
+    final pending = _pendingAppearance();
+    if (pending != null) {
+      widget.notifier.setSeascapeAppearance(pending);
+    } else {
+      // Unparseable or non-positive: put the stored level back on screen
+      // rather than leaving a number that will never be adopted.
+      _controller.text = _formatDisplay(_display);
+    }
+  }
+
+  /// The appearance this row's box would produce, or null when the text is
+  /// unusable or already matches what is stored.
+  SeascapeAppearance? _pendingAppearance() {
+    final typed = double.tryParse(_controller.text.trim().replaceAll(',', '.'));
+    if (typed == null || !typed.isFinite || typed <= 0) return null;
+    final appearance = _appearance;
+    if (widget.index >= appearance.customLevels.length) return null;
+    final current = appearance.customLevels[widget.index];
+    // Compare in DISPLAY space at the precision the box actually shows. The
+    // box renders one decimal, so 30 m reads as "98.4" ft and parsing that
+    // back gives 29.99232 m; a metres comparison would call that an edit and
+    // shave the level a little on every blur and every dismissal.
+    if (_formatDisplay(current.depthMeters / widget.unitInMeters) ==
+        _formatDisplay(typed)) {
+      return null;
+    }
+    final meters = typed * widget.unitInMeters;
+    return appearance.copyWith(
+      customLevels: _replace(
+        appearance,
+        SeascapeContourLevel(depthMeters: meters, colorArgb: current.colorArgb),
+      ),
+    );
+  }
+
+  List<SeascapeContourLevel> _replace(
     SeascapeAppearance appearance,
-    int index,
-    double unitInMeters,
-    void Function(SeascapeAppearance) update,
-  ) {
-    final level = appearance.customLevels[index];
-    List<SeascapeContourLevel> withLevel(SeascapeContourLevel? next) => [
-      for (var i = 0; i < appearance.customLevels.length; i++)
-        if (i != index) appearance.customLevels[i] else ?next,
-    ];
-    final display = level.depthMeters / unitInMeters;
+    SeascapeContourLevel? next,
+  ) => [
+    for (var i = 0; i < appearance.customLevels.length; i++)
+      if (i != widget.index) appearance.customLevels[i] else ?next,
+  ];
+
+  void _write(SeascapeContourLevel? next) {
+    final appearance = _appearance;
+    if (widget.index >= appearance.customLevels.length) return;
+    widget.notifier.setSeascapeAppearance(
+      appearance.copyWith(customLevels: _replace(appearance, next)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Row(
       children: [
         SizedBox(
-          width: 96,
-          child: TextFormField(
-            key: ValueKey('seascapeLevelField$index'),
-            initialValue: display % 1 == 0
-                ? display.toStringAsFixed(0)
-                : display.toStringAsFixed(1),
+          width: 120,
+          child: TextField(
+            key: ValueKey('seascapeLevelField${widget.index}'),
+            controller: _controller,
+            focusNode: _focusNode,
             keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            onFieldSubmitted: (text) {
-              final v = double.tryParse(text.replaceAll(',', '.'));
-              if (v == null || v <= 0) return;
-              update(
-                appearance.copyWith(
-                  customLevels: withLevel(
-                    SeascapeContourLevel(
-                      depthMeters: v * unitInMeters,
-                      colorArgb: level.colorArgb,
-                    ),
-                  ),
-                ),
-              );
-            },
+            textInputAction: TextInputAction.done,
+            // The bare number read as ambiguous between metres and feet
+            // (issue #1094); the box now carries the diver's own unit.
+            decoration: InputDecoration(suffixText: widget.unitSymbol),
+            onTapOutside: (_) => _focusNode.unfocus(),
+            onEditingComplete: _focusNode.unfocus,
+            onSubmitted: (_) => _focusNode.unfocus(),
           ),
         ),
         const SizedBox(width: 12),
-        DropdownButton<int?>(
-          key: ValueKey('seascapeLevelColor$index'),
-          value: level.colorArgb,
-          items: [
-            for (final c in _palette)
-              DropdownMenuItem(
-                value: c,
-                child: c == null
-                    ? Text(context.l10n.dive3d_seascape_appearance_defaultColor)
-                    : CircleAvatar(radius: 8, backgroundColor: Color(c)),
-              ),
-          ],
-          onChanged: (c) => update(
-            appearance.copyWith(
-              customLevels: withLevel(
-                SeascapeContourLevel(
-                  depthMeters: level.depthMeters,
-                  colorArgb: c,
+        // Expanded rather than a trailing Spacer: the "default ink" entry is a
+        // translated phrase, and a Spacer cannot give back space once the row
+        // is full, so a long translation used to overflow a phone row.
+        Expanded(
+          child: DropdownButton<int?>(
+            key: ValueKey('seascapeLevelColor${widget.index}'),
+            value: widget.level.colorArgb,
+            isExpanded: true,
+            items: [
+              for (final c in TerrainAppearanceSheet._palette)
+                DropdownMenuItem(
+                  value: c,
+                  child: c == null
+                      ? Text(
+                          context.l10n.dive3d_seascape_appearance_defaultColor,
+                          overflow: TextOverflow.ellipsis,
+                        )
+                      : CircleAvatar(radius: 8, backgroundColor: Color(c)),
                 ),
+            ],
+            onChanged: (c) => _write(
+              SeascapeContourLevel(
+                depthMeters: widget.level.depthMeters,
+                colorArgb: c,
               ),
             ),
           ),
         ),
-        const Spacer(),
         IconButton(
-          key: ValueKey('seascapeLevelRemove$index'),
+          key: ValueKey('seascapeLevelRemove${widget.index}'),
           icon: const Icon(Icons.delete_outline),
-          onPressed: () =>
-              update(appearance.copyWith(customLevels: withLevel(null))),
+          onPressed: () {
+            // Drop focus first so the row being removed cannot commit its old
+            // text back over the shifted list on the way out.
+            _focusNode.unfocus();
+            _write(null);
+          },
         ),
       ],
     );

--- a/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
+++ b/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
@@ -52,6 +52,13 @@ class TerrainAppearanceSheet extends ConsumerWidget {
   /// diver with 32.8 rather than a round number.
   static const double _defaultNewLevelDisplay = 10.0;
 
+  /// Vertical rhythm. The sheet stacks segmented buttons, switches, sliders
+  /// and a row editor, each of which brings its own padding, so the gaps are
+  /// named here to keep one consistent scale instead of ad-hoc spacers.
+  static const _labelGap = SizedBox(height: 8);
+  static const _controlGap = SizedBox(height: 16);
+  static const _sectionRule = Divider(height: 40);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
@@ -78,9 +85,9 @@ class TerrainAppearanceSheet extends ConsumerWidget {
             l10n.dive3d_seascape_appearance,
             style: Theme.of(context).textTheme.titleMedium,
           ),
-          const SizedBox(height: 12),
+          _controlGap,
           Text(l10n.dive3d_seascape_appearance_surface),
-          const SizedBox(height: 8),
+          _labelGap,
           SegmentedButton<SeascapeSurfaceMode>(
             key: const ValueKey('seascapeSurfaceModeSegments'),
             segments: [
@@ -101,6 +108,7 @@ class TerrainAppearanceSheet extends ConsumerWidget {
             onSelectionChanged: (sel) =>
                 update(appearance.copyWith(surfaceMode: sel.single)),
           ),
+          _controlGap,
           SwitchListTile(
             key: const ValueKey('seascapeRampRangeSwitch'),
             contentPadding: EdgeInsets.zero,
@@ -138,9 +146,9 @@ class TerrainAppearanceSheet extends ConsumerWidget {
             value: appearance.rampBanded,
             onChanged: (on) => update(appearance.copyWith(rampBanded: on)),
           ),
-          const Divider(),
+          _sectionRule,
           Text(l10n.dive3d_seascape_appearance_contours),
-          const SizedBox(height: 8),
+          _labelGap,
           SegmentedButton<SeascapeContourMode>(
             key: const ValueKey('seascapeContourModeSegments'),
             segments: [
@@ -158,6 +166,7 @@ class TerrainAppearanceSheet extends ConsumerWidget {
                 update(appearance.copyWith(contourMode: sel.single)),
           ),
           if (appearance.contourMode == SeascapeContourMode.custom) ...[
+            _labelGap,
             for (var i = 0; i < appearance.customLevels.length; i++)
               _LevelRow(
                 key: ValueKey('seascapeLevelRow$i'),
@@ -183,6 +192,7 @@ class TerrainAppearanceSheet extends ConsumerWidget {
               ),
             ),
           ],
+          _sectionRule,
           ListTile(
             contentPadding: EdgeInsets.zero,
             title: Text(l10n.dive3d_seascape_appearance_wallAngle),
@@ -356,64 +366,73 @@ class _LevelRowState extends State<_LevelRow> {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        SizedBox(
-          width: 120,
-          child: TextField(
-            key: ValueKey('seascapeLevelField${widget.index}'),
-            controller: _controller,
-            focusNode: _focusNode,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            textInputAction: TextInputAction.done,
-            // The bare number read as ambiguous between metres and feet
-            // (issue #1094); the box now carries the diver's own unit.
-            decoration: InputDecoration(suffixText: widget.unitSymbol),
-            onTapOutside: (_) => _focusNode.unfocus(),
-            onEditingComplete: _focusNode.unfocus,
-            onSubmitted: (_) => _focusNode.unfocus(),
+    return Padding(
+      // The boxes carry their own border, so without this the rows read as
+      // one dense block rather than a list.
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 120,
+            child: TextField(
+              key: ValueKey('seascapeLevelField${widget.index}'),
+              controller: _controller,
+              focusNode: _focusNode,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              textInputAction: TextInputAction.done,
+              // The bare number read as ambiguous between metres and feet
+              // (issue #1094); the box now carries the diver's own unit.
+              decoration: InputDecoration(suffixText: widget.unitSymbol),
+              onTapOutside: (_) => _focusNode.unfocus(),
+              onEditingComplete: _focusNode.unfocus,
+              onSubmitted: (_) => _focusNode.unfocus(),
+            ),
           ),
-        ),
-        const SizedBox(width: 12),
-        // Expanded rather than a trailing Spacer: the "default ink" entry is a
-        // translated phrase, and a Spacer cannot give back space once the row
-        // is full, so a long translation used to overflow a phone row.
-        Expanded(
-          child: DropdownButton<int?>(
-            key: ValueKey('seascapeLevelColor${widget.index}'),
-            value: widget.level.colorArgb,
-            isExpanded: true,
-            items: [
-              for (final c in TerrainAppearanceSheet._palette)
-                DropdownMenuItem(
-                  value: c,
-                  child: c == null
-                      ? Text(
-                          context.l10n.dive3d_seascape_appearance_defaultColor,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : CircleAvatar(radius: 8, backgroundColor: Color(c)),
+          const SizedBox(width: 12),
+          // Expanded rather than a trailing Spacer: the "default ink" entry is a
+          // translated phrase, and a Spacer cannot give back space once the row
+          // is full, so a long translation used to overflow a phone row.
+          Expanded(
+            child: DropdownButton<int?>(
+              key: ValueKey('seascapeLevelColor${widget.index}'),
+              value: widget.level.colorArgb,
+              isExpanded: true,
+              items: [
+                for (final c in TerrainAppearanceSheet._palette)
+                  DropdownMenuItem(
+                    value: c,
+                    child: c == null
+                        ? Text(
+                            context
+                                .l10n
+                                .dive3d_seascape_appearance_defaultColor,
+                            overflow: TextOverflow.ellipsis,
+                          )
+                        : CircleAvatar(radius: 8, backgroundColor: Color(c)),
+                  ),
+              ],
+              onChanged: (c) => _write(
+                SeascapeContourLevel(
+                  depthMeters: widget.level.depthMeters,
+                  colorArgb: c,
                 ),
-            ],
-            onChanged: (c) => _write(
-              SeascapeContourLevel(
-                depthMeters: widget.level.depthMeters,
-                colorArgb: c,
               ),
             ),
           ),
-        ),
-        IconButton(
-          key: ValueKey('seascapeLevelRemove${widget.index}'),
-          icon: const Icon(Icons.delete_outline),
-          onPressed: () {
-            // Drop focus first so the row being removed cannot commit its old
-            // text back over the shifted list on the way out.
-            _focusNode.unfocus();
-            _write(null);
-          },
-        ),
-      ],
+          IconButton(
+            key: ValueKey('seascapeLevelRemove${widget.index}'),
+            icon: const Icon(Icons.delete_outline),
+            onPressed: () {
+              // Drop focus first so the row being removed cannot commit its old
+              // text back over the shifted list on the way out.
+              _focusNode.unfocus();
+              _write(null);
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/features/dive_3d/domain/spatial/seascape_appearance_test.dart
+++ b/test/features/dive_3d/domain/spatial/seascape_appearance_test.dart
@@ -102,17 +102,32 @@ void main() {
     },
   );
 
-  test('surfaceMode defaults to depth, round-trips, decodes defensively', () {
-    expect(const SeascapeAppearance().surfaceMode, SeascapeSurfaceMode.depth);
-    const blend = SeascapeAppearance(surfaceMode: SeascapeSurfaceMode.blend);
+  test('surfaceMode defaults to blend, round-trips, decodes defensively', () {
+    expect(const SeascapeAppearance().surfaceMode, SeascapeSurfaceMode.blend);
+    const depth = SeascapeAppearance(surfaceMode: SeascapeSurfaceMode.depth);
     expect(
-      SeascapeAppearance.decode(blend.encode()).surfaceMode,
-      SeascapeSurfaceMode.blend,
+      SeascapeAppearance.decode(depth.encode()).surfaceMode,
+      SeascapeSurfaceMode.depth,
     );
     expect(
       SeascapeAppearance.decode('{"surfaceMode":"hologram"}').surfaceMode,
+      SeascapeSurfaceMode.blend,
+    );
+    expect(depth, isNot(const SeascapeAppearance()));
+  });
+
+  test('a stored surface choice survives the change of default', () {
+    // encode() always writes the field, so a diver who already has a saved
+    // appearance keeps whatever they had. The new default only reaches
+    // installs with nothing stored, or a blob written before the field
+    // existed.
+    expect(
+      SeascapeAppearance.decode('{"surfaceMode":"depth"}').surfaceMode,
       SeascapeSurfaceMode.depth,
     );
-    expect(blend, isNot(const SeascapeAppearance()));
+    expect(
+      SeascapeAppearance.decode('{"rampBanded":true}').surfaceMode,
+      SeascapeSurfaceMode.blend,
+    );
   });
 }

--- a/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
+++ b/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+// `show Intl`: intl also exports a TextDirection that shadows dart:ui's enum.
+import 'package:intl/intl.dart' show Intl;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/features/dive_3d/domain/spatial/seascape_appearance.dart';
@@ -11,6 +13,39 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 import '../../../../helpers/mock_providers.dart';
 
 void main() {
+  /// The custom-level rows own their controllers, so the on-screen text is
+  /// read from the controller rather than from a one-shot `initialValue`.
+  String levelFieldText(WidgetTester tester, int index) => tester
+      .widget<TextField>(find.byKey(ValueKey('seascapeLevelField$index')))
+      .controller!
+      .text;
+
+  String? levelFieldSuffix(WidgetTester tester, int index) => tester
+      .widget<TextField>(find.byKey(ValueKey('seascapeLevelField$index')))
+      .decoration
+      ?.suffixText;
+
+  const twoLevels = AppSettings(
+    seascapeAppearance: SeascapeAppearance(
+      contourMode: SeascapeContourMode.custom,
+      customLevels: [
+        SeascapeContourLevel(depthMeters: 20),
+        SeascapeContourLevel(depthMeters: 30),
+      ],
+    ),
+  );
+
+  /// The reporter's list: enough rows that the sheet has to scroll.
+  final manyLevels = AppSettings(
+    seascapeAppearance: SeascapeAppearance(
+      contourMode: SeascapeContourMode.custom,
+      customLevels: [
+        for (var d = 10; d <= 100; d += 10)
+          SeascapeContourLevel(depthMeters: d.toDouble()),
+      ],
+    ),
+  );
+
   Future<ProviderContainer> pumpSheet(
     WidgetTester tester, {
     AppSettings initial = const AppSettings(),
@@ -38,6 +73,44 @@ void main() {
       ),
     );
     await tester.pump();
+    return container;
+  }
+
+  /// Pumps the sheet through its real modal route, which is where the
+  /// keyboard inset and the dismissal commit live.
+  Future<ProviderContainer> pumpSheetRoute(
+    WidgetTester tester, {
+    AppSettings initial = const AppSettings(),
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier(initial)),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => showTerrainAppearanceSheet(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
     return container;
   }
 
@@ -105,14 +178,7 @@ void main() {
         .single;
     expect(level.depthMeters, closeTo(3.048, 1e-9)); // 10 ft
     // The row's field reads the round display value, not 32.8.
-    expect(
-      tester
-          .widget<TextFormField>(
-            find.byKey(const ValueKey('seascapeLevelField0')),
-          )
-          .initialValue,
-      '10',
-    );
+    expect(levelFieldText(tester, 0), '10');
   });
 
   testWidgets('surface mode segmented control writes through', (tester) async {
@@ -143,6 +209,189 @@ void main() {
     expect(
       container.read(settingsProvider).seascapeAppearance.wallAngleDeg,
       greaterThan(22.0),
+    );
+  });
+
+  // Issue #1094: a decimal keypad has no submit key, so requiring
+  // onFieldSubmitted meant every typed level was silently discarded.
+  group('custom level editing (issue #1094)', () {
+    List<SeascapeContourLevel> levelsOf(ProviderContainer c) =>
+        c.read(settingsProvider).seascapeAppearance.customLevels;
+
+    testWidgets('a typed level is adopted when the field loses focus', (
+      tester,
+    ) async {
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '35',
+      );
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      expect(levelsOf(container).first.depthMeters, 35.0);
+    });
+
+    testWidgets('a feet diver has the typed level stored as meters', (
+      tester,
+    ) async {
+      final container = await pumpSheet(
+        tester,
+        initial: twoLevels.copyWith(depthUnit: DepthUnit.feet),
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '100',
+      );
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      expect(levelsOf(container).first.depthMeters, closeTo(30.48, 1e-9));
+    });
+
+    testWidgets('unparseable text reverts to the stored level', (tester) async {
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        'abc',
+      );
+      FocusManager.instance.primaryFocus?.unfocus();
+      await tester.pump();
+      expect(levelsOf(container).first.depthMeters, 20.0);
+      expect(levelFieldText(tester, 0), '20');
+    });
+
+    testWidgets('a pending edit is adopted when the sheet is dismissed', (
+      tester,
+    ) async {
+      // Closing the keyboard with the system back gesture leaves the field
+      // focused, so dismissal is the last chance to keep the diver's number.
+      final container = await pumpSheetRoute(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '45',
+      );
+      await tester.pump();
+      Navigator.of(tester.element(find.byType(TerrainAppearanceSheet))).pop();
+      await tester.pumpAndSettle();
+      expect(levelsOf(container).first.depthMeters, 45.0);
+    });
+
+    testWidgets('deleting a row re-seeds the rows that shift up', (
+      tester,
+    ) async {
+      // The rows are keyed by index, so without a re-seed row 0 would keep
+      // showing the deleted level's number.
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.tap(find.byKey(const ValueKey('seascapeLevelRemove0')));
+      await tester.pump();
+      expect(levelsOf(container).single.depthMeters, 30.0);
+      expect(levelFieldText(tester, 0), '30');
+    });
+
+    testWidgets('switching depth unit re-seeds the row text', (tester) async {
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await container
+          .read(settingsProvider.notifier)
+          .setDepthUnit(DepthUnit.feet);
+      await tester.pump();
+      expect(levelFieldText(tester, 0), '65.6'); // 20 m
+    });
+
+    testWidgets('a de diver dismissing an untouched sheet changes nothing', (
+      tester,
+    ) async {
+      // The reporter is on a comma-decimal locale, and the new commit-on-
+      // dismissal path is where a seed/parse mismatch would silently rescale
+      // an untouched level. Feet display puts a fraction in every box.
+      final previous = Intl.defaultLocale;
+      Intl.defaultLocale = 'de';
+      addTearDown(() => Intl.defaultLocale = previous);
+      final container = await pumpSheetRoute(
+        tester,
+        initial: twoLevels.copyWith(depthUnit: DepthUnit.feet),
+      );
+      expect(levelFieldText(tester, 0), '65.6'); // 20 m in feet
+      Navigator.of(tester.element(find.byType(TerrainAppearanceSheet))).pop();
+      await tester.pumpAndSettle();
+      expect(levelsOf(container).map((l) => l.depthMeters), [
+        closeTo(20.0, 1e-9),
+        closeTo(30.0, 1e-9),
+      ]);
+    });
+
+    testWidgets('a row lays out on a narrow phone without overflowing', (
+      tester,
+    ) async {
+      // The unit suffix widened the depth box, and the colour dropdown shows a
+      // translated "default ink" phrase, so the row has to be able to give.
+      tester.view.physicalSize = const Size(320, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await pumpSheet(tester, initial: twoLevels);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('each row is labelled with the diver depth unit', (
+      tester,
+    ) async {
+      await pumpSheet(tester, initial: twoLevels);
+      expect(levelFieldSuffix(tester, 0), 'm');
+      await pumpSheet(
+        tester,
+        initial: twoLevels.copyWith(depthUnit: DepthUnit.feet),
+      );
+      expect(levelFieldSuffix(tester, 0), 'ft');
+    });
+  });
+
+  testWidgets('the sheet keeps its content clear of the keyboard', (
+    tester,
+  ) async {
+    // Issue #1094: without a viewInsets pad the lower rows and the add
+    // button sit behind the keypad with no scroll extent to reach them.
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 280);
+    addTearDown(tester.view.reset);
+    await pumpSheetRoute(tester, initial: twoLevels);
+    final padding = tester.widget<Padding>(
+      find.byKey(const ValueKey('terrainAppearanceSheetInsets')),
+    );
+    expect(padding.padding.resolve(TextDirection.ltr).bottom, 280);
+  });
+
+  testWidgets('with the keypad open a long level list still scrolls fully', (
+    tester,
+  ) async {
+    // The reporter's actual complaint: with many rows the bottom of the sheet
+    // could not be brought into view while the keypad was up.
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 320);
+    addTearDown(tester.view.reset);
+    await pumpSheetRoute(tester, initial: manyLevels);
+
+    // Every TextField nests its own Scrollable, so take the outermost.
+    final position = tester
+        .state<ScrollableState>(
+          find
+              .descendant(
+                of: find.byType(SingleChildScrollView),
+                matching: find.byType(Scrollable),
+              )
+              .first,
+        )
+        .position;
+    expect(position.maxScrollExtent, greaterThan(0));
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pump();
+
+    // Scrolled to the end, the last control clears the keypad rather than
+    // sitting underneath it.
+    expect(
+      tester
+          .getRect(find.byKey(const ValueKey('seascapeWallAngleSlider')))
+          .bottom,
+      lessThanOrEqualTo(800 - 320),
     );
   });
 }

--- a/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
+++ b/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
@@ -296,6 +296,91 @@ void main() {
       expect(levelFieldText(tester, 0), '65.6'); // 20 m
     });
 
+    testWidgets('moving to the next row commits the one being left', (
+      tester,
+    ) async {
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '25',
+      );
+      await tester.tap(find.byKey(const ValueKey('seascapeLevelField1')));
+      await tester.pump();
+      expect(levelsOf(container).first.depthMeters, 25.0);
+    });
+
+    testWidgets('the tap-outside hook drops focus and commits', (tester) async {
+      // On mobile a TextField does NOT give up focus when the diver taps the
+      // sheet's own chrome, so the row wires onTapOutside itself. TapRegion's
+      // pointer routing is framework behaviour and does not reproduce under
+      // the test harness, so this drives the wired callback directly and
+      // asserts the chain it is responsible for: unfocus, then commit.
+      final container = await pumpSheet(tester, initial: twoLevels);
+      final field = find.byKey(const ValueKey('seascapeLevelField0'));
+      await tester.enterText(field, '27');
+      expect(levelsOf(container).first.depthMeters, 20.0, reason: 'not yet');
+
+      final onTapOutside = tester.widget<TextField>(field).onTapOutside;
+      expect(onTapOutside, isNotNull);
+      onTapOutside!(PointerDownEvent(position: tester.getCenter(field)));
+      await tester.pump();
+
+      expect(levelsOf(container).first.depthMeters, 27.0);
+      expect(tester.widget<TextField>(field).focusNode?.hasFocus, isFalse);
+    });
+
+    testWidgets('the keyboard done action commits the level', (tester) async {
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '28',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(levelsOf(container).first.depthMeters, 28.0);
+    });
+
+    testWidgets('choosing a colour keeps the level depth', (tester) async {
+      const blue = Color(0xFF3B82F6);
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.tap(find.byKey(const ValueKey('seascapeLevelColor0')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find
+            .byWidgetPredicate(
+              (w) => w is CircleAvatar && w.backgroundColor == blue,
+            )
+            .last,
+      );
+      await tester.pumpAndSettle();
+      final level = levelsOf(container).first;
+      expect(level.colorArgb, blue.toARGB32());
+      expect(level.depthMeters, 20.0);
+    });
+
+    testWidgets('an edit pending when the rows unmount is still adopted', (
+      tester,
+    ) async {
+      // Dismissing the sheet unfocuses first, so the focus path handles it.
+      // This is the case that path cannot see: the rows leave the tree with
+      // no focus change at all, which is what the dispose commit is for.
+      final container = await pumpSheet(tester, initial: twoLevels);
+      await tester.enterText(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+        '55',
+      );
+      final notifier = container.read(settingsProvider.notifier);
+      await notifier.setSeascapeAppearance(
+        container
+            .read(settingsProvider)
+            .seascapeAppearance
+            .copyWith(contourMode: SeascapeContourMode.auto),
+      );
+      await tester.pump(); // unmounts the rows
+      await tester.pump(); // lets the deferred commit land
+      expect(levelsOf(container).first.depthMeters, 55.0);
+    });
+
     testWidgets('a de diver dismissing an untouched sheet changes nothing', (
       tester,
     ) async {

--- a/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
+++ b/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
@@ -185,7 +185,7 @@ void main() {
     final container = await pumpSheet(tester);
     expect(
       container.read(settingsProvider).seascapeAppearance.surfaceMode,
-      SeascapeSurfaceMode.depth,
+      SeascapeSurfaceMode.blend,
     );
     await tester.tap(find.text('Map imagery'));
     await tester.pump();
@@ -193,11 +193,11 @@ void main() {
       container.read(settingsProvider).seascapeAppearance.surfaceMode,
       SeascapeSurfaceMode.imagery,
     );
-    await tester.tap(find.text('Blend'));
+    await tester.tap(find.text('Depth colors'));
     await tester.pump();
     expect(
       container.read(settingsProvider).seascapeAppearance.surfaceMode,
-      SeascapeSurfaceMode.blend,
+      SeascapeSurfaceMode.depth,
     );
   });
 
@@ -401,6 +401,19 @@ void main() {
         closeTo(20.0, 1e-9),
         closeTo(30.0, 1e-9),
       ]);
+    });
+
+    testWidgets('rows are separated rather than stacked flush', (tester) async {
+      // The rows read as one dense block when they touch; the boxes already
+      // carry their own border, so they need real air between them.
+      await pumpSheet(tester, initial: twoLevels);
+      final first = tester.getRect(
+        find.byKey(const ValueKey('seascapeLevelField0')),
+      );
+      final second = tester.getRect(
+        find.byKey(const ValueKey('seascapeLevelField1')),
+      );
+      expect(second.top - first.bottom, greaterThanOrEqualTo(12.0));
     });
 
     testWidgets('a row lays out on a narrow phone without overflowing', (


### PR DESCRIPTION
## Summary

Fixes #1094. The custom contour-level editor in the terrain appearance sheet
had three separate defects, all reported together against v1.7.5.6211.

**Typed levels were never adopted.** The depth box committed through
`onFieldSubmitted` only. A decimal keypad has no submit key, so tapping another
row, dismissing the keypad, or closing the sheet discarded the number the diver
had just typed. The reporter's screenshot shows exactly that state: a focused
field holding a value that no code path would ever persist.

**Rows showed stale numbers.** `TextFormField.initialValue` binds its controller
exactly once, and the rows are keyed by list index. Deleting a row therefore
shifted the data up while each field kept its old text, and switching between
metres and feet left the previous unit's numbers on screen.

**The sheet could not be scrolled clear of the keypad.** No
`MediaQuery.viewInsets` padding was applied, so with the keypad up the sheet
kept its full height and the lower rows and the add button had no scroll extent
left to bring them up. That is the "you can't scroll the menu with many
entries" half of the report.

**Units were not shown.** The stored value was already converted correctly
against the diver's depth unit; only the affordance was missing. The box showed
a bare number while the ramp slider directly above it showed `105 m`.

Two follow-ups from reviewing the sheet on desktop are folded in here rather
than split out, since they touch the same widget. **Both go beyond issue
#1094, so they should be judged on their own merits, not waved through as part
of a bugfix:**

- **Spacing.** The custom level rows sat flush, zero pixels between boxes that
  each carry their own border, so the editor read as one dense block. The
  sheet's gaps are now a named scale instead of ad-hoc spacers.
- **Terrain surface now defaults to Blend** rather than Depth colors. This is a
  product default change. `surfaceMode` is unreleased (added after
  `v1.7.4.6062`), so stable installs have nothing stored for it and pick up the
  new default on upgrade; `encode()` always writes the field, so anyone who has
  already chosen keeps their choice. Both halves are pinned by a test. Note
  that means beta users on 1.7.5.62xx keep whatever they have and must flip it
  by hand. No migration, because nothing can distinguish "never chose" from
  "deliberately chose depth".

## Changes

- Level rows own a controller and focus node, and commit on blur (including
  `onTapOutside`, so tapping anywhere else in the sheet counts), on submit, and
  once more on disposal when an edit is still pending. The disposal write is
  deferred through a microtask guarded on the notifier's `mounted` flag,
  because unmounting runs inside a state-locked `finalizeTree`.
- Because a commit can now happen without the diver pressing anything, the
  "is this an edit?" guard compares in DISPLAY space at the precision the box
  shows. The box renders one decimal, so 30 m reads as `98.4` ft and parsing
  that back gives 29.99232 m; comparing in metres would have called that an
  edit and shaved a little off every level on each blur and each dismissal.
- Text that will not parse, or is not positive, restores the stored level
  instead of sitting on screen looking accepted.
- Every mutation reads the current appearance out of the container rather than
  a value captured at build time, so a commit that lands after the row is gone
  cannot resurrect a level the diver just deleted. That read is skipped when
  the notifier is no longer mounted, since teardown can dispose the container
  before the tree unmounts and reading a disposed container throws.
- `didUpdateWidget` re-seeds a row whenever the value it represents actually
  moved. Mid-typing it never moves, so keystrokes are safe.
- `showTerrainAppearanceSheet` pads for the keyboard inset, the same pattern
  the other text-bearing sheets in the app already use.
- Each row carries the diver's own depth unit as a suffix. Because that widened
  the box, the colour dropdown moved into an `Expanded` with `isExpanded: true`;
  the previous trailing `Spacer` could not give space back once a row was full,
  so a long translation of the "default ink" label risked overflowing a phone
  row.

## Test Plan

- [x] `flutter test` passes (17123 tests). The local full run showed four
      failures, all outside this change and all green in isolation:
      `recovery_code_test`, `universal_import_batch_test`,
      `ocr_scan_page_test`, `media_share_helper_test`. The first is a
      pre-existing flake worth filing separately: the EFF wordlist contains
      one hyphenated entry (`yo-yo`) and the test splits the code on `-`, so
      it fails on roughly 0.62% of runs.
- [x] `flutter analyze` passes (project-wide, no issues)
- [x] Manual testing on: **not performed.** The reporter is on Android in a
      German locale; a device pass there would be worth doing before release.

The existing suite pumped the sheet body straight into a `Scaffold`, so it
never built the modal route. That is why all three defects shipped behind six
passing tests. A second harness now pushes the real route, which is where the
keyboard inset and the dismissal commit live. Added coverage:

- a typed level is adopted on blur, in both metres and feet
- a de-locale diver dismissing an untouched sheet changes nothing (this test
  found the rounding drift described above)
- unparseable text reverts to the stored level
- a pending edit is adopted when the sheet is dismissed
- an edit pending when the rows unmount with no focus change is still adopted
- moving to the next row commits the one being left
- the keyboard done action commits the level
- the tap-outside hook drops focus and commits
- choosing a colour keeps the level depth
- deleting a row re-seeds the rows that shift up
- switching depth unit re-seeds the row text
- each row is labelled with the diver's depth unit
- a row lays out on a narrow phone without overflowing
- rows are separated rather than stacked flush (measured exactly 0 before)
- a stored surface choice survives the change of default
- the sheet pads for the keypad, and a long level list still scrolls fully

The scroll test was checked against the unfixed code to confirm it
discriminates: the last control sat at y=696 behind a keypad line of 480.

## Follow-up

The depth box still reads through `double.tryParse` on comma-normalised text,
which is what this field already did. The canonical helpers for that
(`parseUserDecimal` / `formatDecimalForInput` in
`lib/core/utils/number_input.dart`, added for #1091) are not on `main` yet, so
this PR does not depend on them. Once #1091 lands, this field should adopt both
halves; the de-locale guard test above is written so it keeps holding through
that change.
