### PR TITLE
fix(trips): total runtime instead of bottom time in trip statistics

### DIFF
--- a/lib/core/services/export/pdf/pdf_export_service.dart
+++ b/lib/core/services/export/pdf/pdf_export_service.dart
@@ -83,7 +83,7 @@ class PdfExportService {
               if (stats != null) ...[
                 pw.SizedBox(height: 10),
                 pw.Text(
-                  'Total Bottom Time: ${stats.formattedBottomTime}',
+                  'Total Runtime: ${stats.formattedRuntime}',
                   style: const pw.TextStyle(fontSize: 14),
                 ),
               ],

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -518,7 +518,7 @@ class TripRepository {
     final statsResult = await _db.customSelect('''
       SELECT
         COUNT(*) as dive_count,
-        COALESCE(SUM(bottom_time), 0) as total_bottom_time,
+        COALESCE(SUM(COALESCE(runtime, bottom_time)), 0) as total_runtime,
         MAX(max_depth) as max_depth,
         AVG(max_depth) as avg_depth
       FROM dives
@@ -529,7 +529,7 @@ class TripRepository {
     return domain.TripWithStats(
       trip: trip,
       diveCount: statsResult.data['dive_count'] as int? ?? 0,
-      totalBottomTime: statsResult.data['total_bottom_time'] as int? ?? 0,
+      totalRuntime: statsResult.data['total_runtime'] as int? ?? 0,
       maxDepth: statsResult.data['max_depth'] as double?,
       avgDepth: statsResult.data['avg_depth'] as double?,
     );
@@ -597,7 +597,7 @@ class TripRepository {
       SELECT
         t.*,
         COUNT(DISTINCT d.id) AS dive_count,
-        COALESCE(SUM(d.bottom_time), 0) AS total_bottom_time,
+        COALESCE(SUM(COALESCE(d.runtime, d.bottom_time)), 0) AS total_runtime,
         MAX(d.max_depth) AS max_depth,
         AVG(d.avg_depth) AS avg_depth
       FROM trips t
@@ -612,7 +612,7 @@ class TripRepository {
       return domain.TripWithStats(
         trip: trip,
         diveCount: row.data['dive_count'] as int,
-        totalBottomTime: row.data['total_bottom_time'] as int,
+        totalRuntime: row.data['total_runtime'] as int,
         maxDepth: row.data['max_depth'] as double?,
         avgDepth: row.data['avg_depth'] as double?,
       );

--- a/lib/features/trips/domain/constants/trip_field.dart
+++ b/lib/features/trips/domain/constants/trip_field.dart
@@ -17,7 +17,7 @@ enum TripField implements EntityField {
   resortName,
   liveaboardName,
   diveCount,
-  totalBottomTime,
+  totalRuntime,
   maxDepth,
   avgDepth,
   notes;
@@ -36,7 +36,7 @@ enum TripField implements EntityField {
     TripField.resortName => 'Resort',
     TripField.liveaboardName => 'Liveaboard',
     TripField.diveCount => 'Dive Count',
-    TripField.totalBottomTime => 'Total Bottom Time',
+    TripField.totalRuntime => 'Total Runtime',
     TripField.maxDepth => 'Max Depth',
     TripField.avgDepth => 'Avg Depth',
     TripField.notes => 'Notes',
@@ -53,7 +53,7 @@ enum TripField implements EntityField {
     TripField.resortName => 'Resort',
     TripField.liveaboardName => 'Liveaboard',
     TripField.diveCount => 'Dives',
-    TripField.totalBottomTime => 'BT Total',
+    TripField.totalRuntime => 'RT Total',
     TripField.maxDepth => 'Max D',
     TripField.avgDepth => 'Avg D',
     TripField.notes => 'Notes',
@@ -70,7 +70,7 @@ enum TripField implements EntityField {
     TripField.resortName => Icons.hotel,
     TripField.liveaboardName => Icons.directions_boat,
     TripField.diveCount => Icons.scuba_diving,
-    TripField.totalBottomTime => Icons.access_time,
+    TripField.totalRuntime => Icons.access_time,
     TripField.maxDepth => Icons.arrow_downward,
     TripField.avgDepth => Icons.trending_down,
     TripField.notes => Icons.notes,
@@ -87,7 +87,7 @@ enum TripField implements EntityField {
     TripField.resortName => 120,
     TripField.liveaboardName => 120,
     TripField.diveCount => 80,
-    TripField.totalBottomTime => 90,
+    TripField.totalRuntime => 90,
     TripField.maxDepth => 80,
     TripField.avgDepth => 80,
     TripField.notes => 150,
@@ -104,7 +104,7 @@ enum TripField implements EntityField {
     TripField.resortName => 70,
     TripField.liveaboardName => 70,
     TripField.diveCount => 50,
-    TripField.totalBottomTime => 60,
+    TripField.totalRuntime => 60,
     TripField.maxDepth => 50,
     TripField.avgDepth => 50,
     TripField.notes => 60,
@@ -127,7 +127,7 @@ enum TripField implements EntityField {
     TripField.resortName => 'accommodation',
     TripField.liveaboardName => 'accommodation',
     TripField.diveCount => 'statistics',
-    TripField.totalBottomTime => 'statistics',
+    TripField.totalRuntime => 'statistics',
     TripField.maxDepth => 'statistics',
     TripField.avgDepth => 'statistics',
     TripField.notes => 'other',
@@ -137,7 +137,7 @@ enum TripField implements EntityField {
   bool get isRightAligned => switch (this) {
     TripField.durationDays => true,
     TripField.diveCount => true,
-    TripField.totalBottomTime => true,
+    TripField.totalRuntime => true,
     TripField.maxDepth => true,
     TripField.avgDepth => true,
     _ => false,
@@ -180,7 +180,7 @@ class TripFieldAdapter extends EntityFieldAdapter<TripWithStats, TripField> {
       TripField.resortName => entity.trip.resortName,
       TripField.liveaboardName => entity.trip.liveaboardName,
       TripField.diveCount => entity.diveCount,
-      TripField.totalBottomTime => entity.totalBottomTime,
+      TripField.totalRuntime => entity.totalRuntime,
       TripField.maxDepth => entity.maxDepth,
       TripField.avgDepth => entity.avgDepth,
       TripField.notes => entity.trip.notes,
@@ -196,14 +196,14 @@ class TripFieldAdapter extends EntityFieldAdapter<TripWithStats, TripField> {
       TripField.durationDays => '${value as int} days',
       TripField.tripType => (value as TripType).name,
       TripField.diveCount => (value as int).toString(),
-      TripField.totalBottomTime => _formatBottomTime(value as int),
+      TripField.totalRuntime => _formatRuntime(value as int),
       TripField.maxDepth => units.formatDepth(value as double),
       TripField.avgDepth => units.formatDepth(value as double),
       _ => value is String ? (value.isEmpty ? '--' : value) : value.toString(),
     };
   }
 
-  String _formatBottomTime(int seconds) {
+  String _formatRuntime(int seconds) {
     if (seconds <= 0) return '--';
     final hours = seconds ~/ 3600;
     final mins = (seconds % 3600) ~/ 60;
@@ -211,8 +211,21 @@ class TripFieldAdapter extends EntityFieldAdapter<TripWithStats, TripField> {
     return '${mins}m';
   }
 
+  /// Field names persisted by table layouts written before a rename, mapped to
+  /// the field that replaced them.
+  ///
+  /// Saved layouts store [TripField.name] verbatim, and an unresolved name
+  /// throws out of `EntityTableViewConfig.fromJson`, so dropping an old name
+  /// would break the trips table for anyone who had customized it.
+  static const Map<String, TripField> _legacyNames = {
+    // Renamed when trip totals moved from bottom time to runtime (#889).
+    'totalBottomTime': TripField.totalRuntime,
+  };
+
   @override
   TripField fieldFromName(String name) {
+    final legacy = _legacyNames[name];
+    if (legacy != null) return legacy;
     return TripField.values.firstWhere((e) => e.name == name);
   }
 }

--- a/lib/features/trips/domain/entities/trip.dart
+++ b/lib/features/trips/domain/entities/trip.dart
@@ -169,22 +169,29 @@ int _calendarDaysBetween(DateTime from, DateTime to) {
 class TripWithStats extends Equatable {
   final Trip trip;
   final int diveCount;
-  final int totalBottomTime; // seconds
+
+  /// Total time in the water across the trip's dives, in seconds.
+  ///
+  /// Runtime (surface to surface), falling back to bottom time for dives that
+  /// only carry one. This is the same `COALESCE(runtime, bottom_time)` total
+  /// the statistics page reports, so a trip's hours agree with the overall
+  /// dive-time figure instead of undercounting every ascent (issue #889).
+  final int totalRuntime; // seconds
   final double? maxDepth;
   final double? avgDepth;
 
   const TripWithStats({
     required this.trip,
     this.diveCount = 0,
-    this.totalBottomTime = 0,
+    this.totalRuntime = 0,
     this.maxDepth,
     this.avgDepth,
   });
 
-  /// Total bottom time formatted as hours:minutes
-  String get formattedBottomTime {
-    final hours = totalBottomTime ~/ 3600;
-    final minutes = (totalBottomTime % 3600) ~/ 60;
+  /// Total runtime formatted as hours:minutes
+  String get formattedRuntime {
+    final hours = totalRuntime ~/ 3600;
+    final minutes = (totalRuntime % 3600) ~/ 60;
     if (hours > 0) {
       return '${hours}h ${minutes}m';
     }
@@ -195,7 +202,7 @@ class TripWithStats extends Equatable {
   List<Object?> get props => [
     trip,
     diveCount,
-    totalBottomTime,
+    totalRuntime,
     maxDepth,
     avgDepth,
   ];

--- a/lib/features/trips/domain/entities/trip_story_day.dart
+++ b/lib/features/trips/domain/entities/trip_story_day.dart
@@ -32,9 +32,16 @@ class TripStoryDay extends Equatable {
 
   int get diveCount => dives.length;
 
-  Duration get totalBottomTime => dives.fold(
+  /// Total time in the water for the day.
+  ///
+  /// Runtime (surface to surface) is what divers add up when they talk about
+  /// how long they were in the water, and it is what the rest of the app sums
+  /// (`COALESCE(runtime, bottom_time)` in the statistics and dive-log
+  /// queries). Bottom time stays as the fallback so hand-logged dives that
+  /// only carry one still contribute.
+  Duration get totalRuntime => dives.fold(
     Duration.zero,
-    (sum, dive) => sum + (dive.bottomTime ?? Duration.zero),
+    (sum, dive) => sum + (dive.runtime ?? dive.bottomTime ?? Duration.zero),
   );
 
   double? get maxDepth {

--- a/lib/features/trips/presentation/pages/trip_detail_page.dart
+++ b/lib/features/trips/presentation/pages/trip_detail_page.dart
@@ -331,9 +331,12 @@ class _TripDetailContent extends ConsumerWidget {
                               fontWeight: FontWeight.w500,
                             ),
                           ),
-                        if (dive.bottomTime != null)
+                        // Runtime with a bottom-time fallback, matching the
+                        // trip totals so these rows add up to the figure the
+                        // Overview tab reports (issue #889).
+                        if ((dive.runtime ?? dive.bottomTime) != null)
                           Text(
-                            '${dive.bottomTime!.inMinutes}min',
+                            '${(dive.runtime ?? dive.bottomTime)!.inMinutes}min',
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),

--- a/lib/features/trips/presentation/widgets/compact_trip_list_tile.dart
+++ b/lib/features/trips/presentation/widgets/compact_trip_list_tile.dart
@@ -123,7 +123,7 @@ class CompactTripListTile extends StatelessWidget {
                               color: colorScheme.primary,
                             ),
                           ),
-                          if (tripWithStats.totalBottomTime > 0) ...[
+                          if (tripWithStats.totalRuntime > 0) ...[
                             const SizedBox(width: 12),
                             Icon(
                               Icons.timer,
@@ -132,7 +132,7 @@ class CompactTripListTile extends StatelessWidget {
                             ),
                             const SizedBox(width: 4),
                             Text(
-                              tripWithStats.formattedBottomTime,
+                              tripWithStats.formattedRuntime,
                               style: textTheme.bodySmall?.copyWith(
                                 color: colorScheme.primary,
                               ),

--- a/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_day_card.dart
@@ -175,13 +175,13 @@ class _DayStatStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final bottom = day.totalBottomTime;
-    final bottomLabel = bottom.inHours > 0
-        ? '${bottom.inHours}h ${bottom.inMinutes % 60}m'
-        : '${bottom.inMinutes}m';
+    final runtime = day.totalRuntime;
+    final runtimeLabel = runtime.inHours > 0
+        ? '${runtime.inHours}h ${runtime.inMinutes % 60}m'
+        : '${runtime.inMinutes}m';
     final stats = <(String, String)>[
       (l10n.trips_detail_stat_totalDives, '${day.diveCount}'),
-      (l10n.trips_detail_stat_totalBottomTime, bottomLabel),
+      (l10n.trips_detail_stat_totalRuntime, runtimeLabel),
       if (day.maxDepth != null)
         (l10n.trips_detail_stat_maxDepth, units.formatDepth(day.maxDepth)),
       // siteCount dedupes by site id (siteNames dedupes by display name), so two

--- a/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
+++ b/lib/features/trips/presentation/widgets/story/trip_story_map_header.dart
@@ -265,7 +265,7 @@ class TripStatStrip extends ConsumerWidget {
 
     final entries = <(String, String)>[
       (l10n.trips_detail_stat_totalDives, '${stats.diveCount}'),
-      (l10n.trips_detail_stat_totalBottomTime, stats.formattedBottomTime),
+      (l10n.trips_detail_stat_totalRuntime, stats.formattedRuntime),
       if (stats.maxDepth != null)
         (l10n.trips_detail_stat_maxDepth, units.formatDepth(stats.maxDepth)),
       if (siteCount > 0) (l10n.trips_detail_stat_sitesVisited, '$siteCount'),

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -806,14 +806,24 @@ class TripListTile extends StatelessWidget {
     final theme = Theme.of(context);
 
     final subtitleStr = trip.subtitle != null ? ', ${trip.subtitle}' : '';
-    final diveCountStr = '${tripWithStats.diveCount} dives';
+    final diveCountStr = context.l10n.trips_list_tile_diveCount(
+      tripWithStats.diveCount,
+    );
     final runtimeStr = tripWithStats.totalRuntime > 0
         ? ', ${tripWithStats.formattedRuntime}'
         : '';
+    // The two dates are joined with a dash rather than a connector word, both
+    // to match the compact tile and because a translated "to" would need an
+    // ARB key per locale to read correctly.
+    final dateRangeStr =
+        '${dateFormat.format(trip.startDate)} - ${dateFormat.format(trip.endDate)}';
     final tripLabel =
-        '${trip.name}, ${dateFormat.format(trip.startDate)} to ${dateFormat.format(trip.endDate)}$subtitleStr, $diveCountStr$runtimeStr${isSelected ? ', selected' : ''}';
+        '${trip.name}, $dateRangeStr$subtitleStr, $diveCountStr$runtimeStr';
 
     return Semantics(
+      // Selection is a semantics flag, not label prose: assistive tech
+      // announces it in the user's own language and can filter on it.
+      selected: isSelected,
       label: tripLabel,
       child: Card(
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/lib/features/trips/presentation/widgets/trip_list_content.dart
+++ b/lib/features/trips/presentation/widgets/trip_list_content.dart
@@ -807,11 +807,11 @@ class TripListTile extends StatelessWidget {
 
     final subtitleStr = trip.subtitle != null ? ', ${trip.subtitle}' : '';
     final diveCountStr = '${tripWithStats.diveCount} dives';
-    final bottomTimeStr = tripWithStats.totalBottomTime > 0
-        ? ', ${tripWithStats.formattedBottomTime}'
+    final runtimeStr = tripWithStats.totalRuntime > 0
+        ? ', ${tripWithStats.formattedRuntime}'
         : '';
     final tripLabel =
-        '${trip.name}, ${dateFormat.format(trip.startDate)} to ${dateFormat.format(trip.endDate)}$subtitleStr, $diveCountStr$bottomTimeStr${isSelected ? ', selected' : ''}';
+        '${trip.name}, ${dateFormat.format(trip.startDate)} to ${dateFormat.format(trip.endDate)}$subtitleStr, $diveCountStr$runtimeStr${isSelected ? ', selected' : ''}';
 
     return Semantics(
       label: tripLabel,
@@ -910,7 +910,7 @@ class TripListTile extends StatelessWidget {
                       color: theme.colorScheme.primary,
                     ),
                   ),
-                  if (tripWithStats.totalBottomTime > 0) ...[
+                  if (tripWithStats.totalRuntime > 0) ...[
                     const SizedBox(width: 12),
                     Icon(
                       Icons.timer,
@@ -919,7 +919,7 @@ class TripListTile extends StatelessWidget {
                     ),
                     const SizedBox(width: 4),
                     Text(
-                      tripWithStats.formattedBottomTime,
+                      tripWithStats.formattedRuntime,
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.colorScheme.primary,
                       ),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "إجمالي وقت القاع",
+  "trips_detail_stat_totalRuntime": "إجمالي وقت التشغيل",
   "trips_detail_stat_totalDives": "إجمالي الغوصات",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Gesamte Grundzeit",
+  "trips_detail_stat_totalRuntime": "Gesamte Laufzeit",
   "trips_detail_stat_totalDives": "Tauchgänge gesamt",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10858,7 +10858,7 @@
   "trips_detail_snackBar_deleted": "Trip deleted",
   "trips_detail_stat_avgDepth": "Avg Depth",
   "trips_detail_stat_maxDepth": "Max Depth",
-  "trips_detail_stat_totalBottomTime": "Total Bottom Time",
+  "trips_detail_stat_totalRuntime": "Total Runtime",
   "trips_detail_stat_totalDives": "Total Dives",
   "trips_detail_tab_checklist": "Checklist",
   "trips_detail_tooltip_edit": "Edit trip",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Tiempo de fondo total",
+  "trips_detail_stat_totalRuntime": "Tiempo total",
   "trips_detail_stat_totalDives": "Total de inmersiones",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5484,7 +5484,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Temps au fond total",
+  "trips_detail_stat_totalRuntime": "Duree totale",
   "trips_detail_stat_totalDives": "Total des plongees",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "סה\"כ זמן תחתית",
+  "trips_detail_stat_totalRuntime": "סה\"כ זמן ריצה",
   "trips_detail_stat_totalDives": "סה\"כ צלילות",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5484,7 +5484,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Osszes fenekido",
+  "trips_detail_stat_totalRuntime": "Osszes futasido",
   "trips_detail_stat_totalDives": "Osszes merüles",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5480,7 +5480,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Tempo di fondo totale",
+  "trips_detail_stat_totalRuntime": "Tempo totale",
   "trips_detail_stat_totalDives": "Immersioni totali",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -30481,11 +30481,11 @@ abstract class AppLocalizations {
   /// **'Max Depth'**
   String get trips_detail_stat_maxDepth;
 
-  /// No description provided for @trips_detail_stat_totalBottomTime.
+  /// No description provided for @trips_detail_stat_totalRuntime.
   ///
   /// In en, this message translates to:
-  /// **'Total Bottom Time'**
-  String get trips_detail_stat_totalBottomTime;
+  /// **'Total Runtime'**
+  String get trips_detail_stat_totalRuntime;
 
   /// No description provided for @trips_detail_stat_totalDives.
   ///

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -17904,7 +17904,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'أقصى عمق';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'إجمالي وقت القاع';
+  String get trips_detail_stat_totalRuntime => 'إجمالي وقت التشغيل';
 
   @override
   String get trips_detail_stat_totalDives => 'إجمالي الغوصات';

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -18200,7 +18200,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Max. Tiefe';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Gesamte Grundzeit';
+  String get trips_detail_stat_totalRuntime => 'Gesamte Laufzeit';
 
   @override
   String get trips_detail_stat_totalDives => 'Tauchgänge gesamt';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -17919,7 +17919,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Max Depth';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Total Bottom Time';
+  String get trips_detail_stat_totalRuntime => 'Total Runtime';
 
   @override
   String get trips_detail_stat_totalDives => 'Total Dives';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -18247,7 +18247,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Prof. max.';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Tiempo de fondo total';
+  String get trips_detail_stat_totalRuntime => 'Tiempo total';
 
   @override
   String get trips_detail_stat_totalDives => 'Total de inmersiones';

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -18302,7 +18302,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Profondeur max.';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Temps au fond total';
+  String get trips_detail_stat_totalRuntime => 'Duree totale';
 
   @override
   String get trips_detail_stat_totalDives => 'Total des plongees';

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17770,7 +17770,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'עומק מרבי';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'סה\"כ זמן תחתית';
+  String get trips_detail_stat_totalRuntime => 'סה\"כ זמן ריצה';
 
   @override
   String get trips_detail_stat_totalDives => 'סה\"כ צלילות';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -18180,7 +18180,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Max. melyseg';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Osszes fenekido';
+  String get trips_detail_stat_totalRuntime => 'Osszes futasido';
 
   @override
   String get trips_detail_stat_totalDives => 'Osszes merüles';

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -18232,7 +18232,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Profondità massima';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Tempo di fondo totale';
+  String get trips_detail_stat_totalRuntime => 'Tempo totale';
 
   @override
   String get trips_detail_stat_totalDives => 'Immersioni totali';

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -18084,7 +18084,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Max. diepte';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Totale bodemtijd';
+  String get trips_detail_stat_totalRuntime => 'Totale looptijd';
 
   @override
   String get trips_detail_stat_totalDives => 'Totaal duiken';

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -18242,7 +18242,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trips_detail_stat_maxDepth => 'Prof. Maxima';
 
   @override
-  String get trips_detail_stat_totalBottomTime => 'Tempo de Fundo Total';
+  String get trips_detail_stat_totalRuntime => 'Tempo Total';
 
   @override
   String get trips_detail_stat_totalDives => 'Total de Mergulhos';

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -17307,7 +17307,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trips_detail_stat_maxDepth => '最大深度';
 
   @override
-  String get trips_detail_stat_totalBottomTime => '总计底部时间';
+  String get trips_detail_stat_totalRuntime => '总运行时间';
 
   @override
   String get trips_detail_stat_totalDives => '总计潜水';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Totale bodemtijd",
+  "trips_detail_stat_totalRuntime": "Totale looptijd",
   "trips_detail_stat_totalDives": "Totaal duiken",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5556,7 +5556,7 @@
   "trips_detail_stat_seaDays": "Sea days",
   "trips_detail_stat_sitesVisited": "Sites visited",
   "trips_detail_stat_speciesSeen": "Species seen",
-  "trips_detail_stat_totalBottomTime": "Tempo de Fundo Total",
+  "trips_detail_stat_totalRuntime": "Tempo Total",
   "trips_detail_stat_totalDives": "Total de Mergulhos",
   "trips_detail_tab_dives": "Dives",
   "trips_detail_tab_itinerary": "Itinerary",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5725,7 +5725,7 @@
   "trips_detail_stat_seaDays": "出海天数",
   "trips_detail_stat_sitesVisited": "已访问潜水点",
   "trips_detail_stat_speciesSeen": "已发现物种",
-  "trips_detail_stat_totalBottomTime": "总计底部时间",
+  "trips_detail_stat_totalRuntime": "总运行时间",
   "trips_detail_stat_totalDives": "总计潜水",
   "trips_detail_tab_dives": "潜水",
   "trips_detail_tab_itinerary": "行程",

--- a/test/features/osm_tile_user_agent_test.dart
+++ b/test/features/osm_tile_user_agent_test.dart
@@ -256,7 +256,7 @@ void main() {
       final tripWithStats = TripWithStats(
         trip: trip,
         diveCount: 1,
-        totalBottomTime: 45 * 60,
+        totalRuntime: 45 * 60,
         maxDepth: 25.0,
       );
 

--- a/test/features/trips/data/repositories/trip_repository_test.dart
+++ b/test/features/trips/data/repositories/trip_repository_test.dart
@@ -387,7 +387,7 @@ void main() {
 
           expect(stats.trip.id, equals(trip.id));
           expect(stats.diveCount, equals(0));
-          expect(stats.totalBottomTime, equals(0));
+          expect(stats.totalRuntime, equals(0));
           expect(stats.maxDepth, isNull);
           expect(stats.avgDepth, isNull);
         },
@@ -398,6 +398,86 @@ void main() {
           () => repository.getTripWithStats('non-existent-id'),
           throwsException,
         );
+      });
+    });
+
+    group('trip time totals (issue #889)', () {
+      const ts = 1700000000000;
+
+      Future<void> insertDive({
+        required String tripId,
+        required String diveId,
+        int? bottomTime,
+        int? runtime,
+      }) async {
+        final db = DatabaseService.instance.database;
+        await db
+            .into(db.dives)
+            .insert(
+              DivesCompanion.insert(
+                id: diveId,
+                diveDateTime: ts,
+                tripId: Value(tripId),
+                bottomTime: Value(bottomTime),
+                runtime: Value(runtime),
+                createdAt: ts,
+                updatedAt: ts,
+              ),
+            );
+      }
+
+      test('getTripWithStats totals runtime rather than bottom time', () async {
+        final trip = await repository.createTrip(
+          createTestTrip(name: 'Runtime Trip'),
+        );
+        // Two dives whose ascent adds 10 minutes each on top of bottom time.
+        await insertDive(
+          tripId: trip.id,
+          diveId: 'r1',
+          bottomTime: 2400,
+          runtime: 3000,
+        );
+        await insertDive(
+          tripId: trip.id,
+          diveId: 'r2',
+          bottomTime: 1800,
+          runtime: 2400,
+        );
+
+        final stats = await repository.getTripWithStats(trip.id);
+
+        expect(stats.totalRuntime, equals(5400));
+      });
+
+      test('getTripWithStats falls back to bottom time when runtime is '
+          'missing', () async {
+        final trip = await repository.createTrip(
+          createTestTrip(name: 'Mixed Trip'),
+        );
+        await insertDive(tripId: trip.id, diveId: 'm1', bottomTime: 2400);
+        await insertDive(tripId: trip.id, diveId: 'm2', runtime: 3000);
+
+        final stats = await repository.getTripWithStats(trip.id);
+
+        expect(stats.totalRuntime, equals(5400));
+      });
+
+      test('getAllTripsWithStats totals runtime rather than bottom '
+          'time', () async {
+        final trip = await repository.createTrip(
+          createTestTrip(name: 'Listed Trip'),
+        );
+        await insertDive(
+          tripId: trip.id,
+          diveId: 'l1',
+          bottomTime: 2400,
+          runtime: 3000,
+        );
+
+        final results = await repository.getAllTripsWithStats();
+        final row = results.firstWhere((r) => r.trip.id == trip.id);
+
+        expect(row.totalRuntime, equals(3000));
       });
     });
 

--- a/test/features/trips/domain/constants/trip_field_test.dart
+++ b/test/features/trips/domain/constants/trip_field_test.dart
@@ -30,7 +30,7 @@ void main() {
   final testEntity = TripWithStats(
     trip: testTrip,
     diveCount: 14,
-    totalBottomTime: 12600, // 210 minutes = 3h 30m in seconds
+    totalRuntime: 12600, // 210 minutes = 3h 30m in seconds
     maxDepth: 35.0,
     avgDepth: 18.5,
   );
@@ -81,7 +81,7 @@ void main() {
         byCategory['statistics'],
         containsAll([
           TripField.diveCount,
-          TripField.totalBottomTime,
+          TripField.totalRuntime,
           TripField.maxDepth,
           TripField.avgDepth,
         ]),
@@ -164,9 +164,9 @@ void main() {
       expect(adapter.extractValue(TripField.diveCount, testEntity), equals(14));
     });
 
-    test('returns totalBottomTime in seconds', () {
+    test('returns totalRuntime in seconds', () {
       expect(
-        adapter.extractValue(TripField.totalBottomTime, testEntity),
+        adapter.extractValue(TripField.totalRuntime, testEntity),
         equals(12600),
       );
     });
@@ -317,40 +317,40 @@ void main() {
       expect(adapter.formatValue(TripField.diveCount, 0, units), equals('0'));
     });
 
-    test('formats totalBottomTime with hours and minutes', () {
+    test('formats totalRuntime with hours and minutes', () {
       // 12600 seconds = 3h 30m
       expect(
-        adapter.formatValue(TripField.totalBottomTime, 12600, units),
+        adapter.formatValue(TripField.totalRuntime, 12600, units),
         equals('3h 30m'),
       );
     });
 
-    test('formats totalBottomTime with minutes only when under an hour', () {
+    test('formats totalRuntime with minutes only when under an hour', () {
       // 2700 seconds = 45m
       expect(
-        adapter.formatValue(TripField.totalBottomTime, 2700, units),
+        adapter.formatValue(TripField.totalRuntime, 2700, units),
         equals('45m'),
       );
     });
 
-    test('formats totalBottomTime zero as --', () {
+    test('formats totalRuntime zero as --', () {
       expect(
-        adapter.formatValue(TripField.totalBottomTime, 0, units),
+        adapter.formatValue(TripField.totalRuntime, 0, units),
         equals('--'),
       );
     });
 
-    test('formats totalBottomTime negative as --', () {
+    test('formats totalRuntime negative as --', () {
       expect(
-        adapter.formatValue(TripField.totalBottomTime, -1, units),
+        adapter.formatValue(TripField.totalRuntime, -1, units),
         equals('--'),
       );
     });
 
-    test('formats totalBottomTime exact hour', () {
+    test('formats totalRuntime exact hour', () {
       // 3600 seconds = 1h 0m
       expect(
-        adapter.formatValue(TripField.totalBottomTime, 3600, units),
+        adapter.formatValue(TripField.totalRuntime, 3600, units),
         equals('1h 0m'),
       );
     });
@@ -447,10 +447,21 @@ void main() {
       expect(adapter.fieldFromName('diveCount'), equals(TripField.diveCount));
     });
 
-    test('resolves totalBottomTime', () {
+    test('resolves totalRuntime', () {
+      expect(
+        adapter.fieldFromName('totalRuntime'),
+        equals(TripField.totalRuntime),
+      );
+    });
+
+    test('resolves the legacy totalBottomTime name to totalRuntime', () {
+      // Saved trip-table layouts persist field names verbatim. A layout
+      // written before issue #889 still names the column totalBottomTime,
+      // and an unresolved name throws out of EntityTableViewConfig.fromJson,
+      // which would leave those users with a broken trips table.
       expect(
         adapter.fieldFromName('totalBottomTime'),
-        equals(TripField.totalBottomTime),
+        equals(TripField.totalRuntime),
       );
     });
 
@@ -527,7 +538,7 @@ void main() {
     test('numeric fields are right-aligned', () {
       expect(TripField.durationDays.isRightAligned, isTrue);
       expect(TripField.diveCount.isRightAligned, isTrue);
-      expect(TripField.totalBottomTime.isRightAligned, isTrue);
+      expect(TripField.totalRuntime.isRightAligned, isTrue);
       expect(TripField.maxDepth.isRightAligned, isTrue);
       expect(TripField.avgDepth.isRightAligned, isTrue);
     });
@@ -553,10 +564,7 @@ void main() {
       expect(TripField.resortName.displayName, equals('Resort'));
       expect(TripField.liveaboardName.displayName, equals('Liveaboard'));
       expect(TripField.diveCount.displayName, equals('Dive Count'));
-      expect(
-        TripField.totalBottomTime.displayName,
-        equals('Total Bottom Time'),
-      );
+      expect(TripField.totalRuntime.displayName, equals('Total Runtime'));
       expect(TripField.maxDepth.displayName, equals('Max Depth'));
       expect(TripField.avgDepth.displayName, equals('Avg Depth'));
       expect(TripField.notes.displayName, equals('Notes'));
@@ -572,7 +580,7 @@ void main() {
       expect(TripField.resortName.shortLabel, equals('Resort'));
       expect(TripField.liveaboardName.shortLabel, equals('Liveaboard'));
       expect(TripField.diveCount.shortLabel, equals('Dives'));
-      expect(TripField.totalBottomTime.shortLabel, equals('BT Total'));
+      expect(TripField.totalRuntime.shortLabel, equals('RT Total'));
       expect(TripField.maxDepth.shortLabel, equals('Max D'));
       expect(TripField.avgDepth.shortLabel, equals('Avg D'));
       expect(TripField.notes.shortLabel, equals('Notes'));
@@ -588,7 +596,7 @@ void main() {
       expect(TripField.resortName.icon, equals(Icons.hotel));
       expect(TripField.liveaboardName.icon, equals(Icons.directions_boat));
       expect(TripField.diveCount.icon, equals(Icons.scuba_diving));
-      expect(TripField.totalBottomTime.icon, equals(Icons.access_time));
+      expect(TripField.totalRuntime.icon, equals(Icons.access_time));
       expect(TripField.maxDepth.icon, equals(Icons.arrow_downward));
       expect(TripField.avgDepth.icon, equals(Icons.trending_down));
       expect(TripField.notes.icon, equals(Icons.notes));
@@ -604,7 +612,7 @@ void main() {
       expect(TripField.resortName.defaultWidth, equals(120));
       expect(TripField.liveaboardName.defaultWidth, equals(120));
       expect(TripField.diveCount.defaultWidth, equals(80));
-      expect(TripField.totalBottomTime.defaultWidth, equals(90));
+      expect(TripField.totalRuntime.defaultWidth, equals(90));
       expect(TripField.maxDepth.defaultWidth, equals(80));
       expect(TripField.avgDepth.defaultWidth, equals(80));
       expect(TripField.notes.defaultWidth, equals(150));
@@ -620,7 +628,7 @@ void main() {
       expect(TripField.resortName.minWidth, equals(70));
       expect(TripField.liveaboardName.minWidth, equals(70));
       expect(TripField.diveCount.minWidth, equals(50));
-      expect(TripField.totalBottomTime.minWidth, equals(60));
+      expect(TripField.totalRuntime.minWidth, equals(60));
       expect(TripField.maxDepth.minWidth, equals(50));
       expect(TripField.avgDepth.minWidth, equals(50));
       expect(TripField.notes.minWidth, equals(60));
@@ -636,7 +644,7 @@ void main() {
       expect(TripField.resortName.categoryName, equals('accommodation'));
       expect(TripField.liveaboardName.categoryName, equals('accommodation'));
       expect(TripField.diveCount.categoryName, equals('statistics'));
-      expect(TripField.totalBottomTime.categoryName, equals('statistics'));
+      expect(TripField.totalRuntime.categoryName, equals('statistics'));
       expect(TripField.maxDepth.categoryName, equals('statistics'));
       expect(TripField.avgDepth.categoryName, equals('statistics'));
       expect(TripField.notes.categoryName, equals('other'));

--- a/test/features/trips/domain/entities/trip_story_day_test.dart
+++ b/test/features/trips/domain/entities/trip_story_day_test.dart
@@ -8,6 +8,7 @@ Dive _dive({
   required String id,
   required DateTime dateTime,
   Duration? bottomTime,
+  Duration? runtime,
   double? maxDepth,
   DiveSite? site,
   double? airTemp,
@@ -18,6 +19,7 @@ Dive _dive({
     id: id,
     dateTime: dateTime,
     bottomTime: bottomTime,
+    runtime: runtime,
     maxDepth: maxDepth,
     site: site,
     airTemp: airTemp,
@@ -32,7 +34,7 @@ void main() {
   const siteB = DiveSite(id: 'site-b', name: 'Jetty');
 
   group('TripStoryDay derived getters', () {
-    test('aggregates dive count, bottom time, and max depth', () {
+    test('aggregates dive count, runtime, and max depth', () {
       final day = TripStoryDay(
         date: date,
         dayNumber: 2,
@@ -41,14 +43,16 @@ void main() {
           _dive(
             id: 'd1',
             dateTime: DateTime(2026, 3, 8, 9),
-            bottomTime: const Duration(minutes: 47),
+            bottomTime: const Duration(minutes: 40),
+            runtime: const Duration(minutes: 47),
             maxDepth: 28,
             site: siteA,
           ),
           _dive(
             id: 'd2',
             dateTime: DateTime(2026, 3, 8, 11),
-            bottomTime: const Duration(minutes: 51),
+            bottomTime: const Duration(minutes: 44),
+            runtime: const Duration(minutes: 51),
             maxDepth: 24,
             site: siteA,
           ),
@@ -57,11 +61,37 @@ void main() {
       );
 
       expect(day.diveCount, 3);
-      expect(day.totalBottomTime, const Duration(minutes: 98));
+      expect(day.totalRuntime, const Duration(minutes: 98));
       expect(day.maxDepth, 28);
       expect(day.siteNames, ['Blue Corner', 'Jetty']);
       expect(day.siteCount, 2);
       expect(day.hasContent, isTrue);
+    });
+
+    test('totalRuntime falls back to bottom time when runtime is absent', () {
+      // Hand-logged dives often carry only a bottom time. Dropping them from
+      // the total would under-report the day more badly than the bug this
+      // replaces, so bottom time remains the fallback -- mirroring the
+      // COALESCE(runtime, bottom_time) the SQL aggregates use.
+      final day = TripStoryDay(
+        date: date,
+        dayNumber: 2,
+        kind: TripStoryDayKind.past,
+        dives: [
+          _dive(
+            id: 'd1',
+            dateTime: DateTime(2026, 3, 8, 9),
+            bottomTime: const Duration(minutes: 38),
+          ),
+          _dive(
+            id: 'd2',
+            dateTime: DateTime(2026, 3, 8, 11),
+            runtime: const Duration(minutes: 42),
+          ),
+        ],
+      );
+
+      expect(day.totalRuntime, const Duration(minutes: 80));
     });
 
     test(
@@ -92,7 +122,7 @@ void main() {
         kind: TripStoryDayKind.future,
       );
       expect(day.diveCount, 0);
-      expect(day.totalBottomTime, Duration.zero);
+      expect(day.totalRuntime, Duration.zero);
       expect(day.maxDepth, isNull);
       expect(day.siteNames, isEmpty);
       expect(day.hasContent, isFalse);

--- a/test/features/trips/domain/entities/trip_test.dart
+++ b/test/features/trips/domain/entities/trip_test.dart
@@ -377,7 +377,7 @@ void main() {
     });
   });
 
-  group('TripWithStats.formattedBottomTime', () {
+  group('TripWithStats.formattedRuntime', () {
     Trip makeTrip() => Trip(
       id: 't1',
       name: 'T',
@@ -388,18 +388,18 @@ void main() {
     );
 
     test('shows "Xm" when under an hour', () {
-      final stats = TripWithStats(trip: makeTrip(), totalBottomTime: 1800);
-      expect(stats.formattedBottomTime, equals('30m'));
+      final stats = TripWithStats(trip: makeTrip(), totalRuntime: 1800);
+      expect(stats.formattedRuntime, equals('30m'));
     });
 
     test('shows "Yh Xm" when an hour or more', () {
-      final stats = TripWithStats(trip: makeTrip(), totalBottomTime: 3665);
-      expect(stats.formattedBottomTime, equals('1h 1m'));
+      final stats = TripWithStats(trip: makeTrip(), totalRuntime: 3665);
+      expect(stats.formattedRuntime, equals('1h 1m'));
     });
 
-    test('handles zero bottom time', () {
-      final stats = TripWithStats(trip: makeTrip(), totalBottomTime: 0);
-      expect(stats.formattedBottomTime, equals('0m'));
+    test('handles zero runtime', () {
+      final stats = TripWithStats(trip: makeTrip(), totalRuntime: 0);
+      expect(stats.formattedRuntime, equals('0m'));
     });
 
     test('props distinguishes different stats', () {

--- a/test/features/trips/presentation/pages/trip_detail_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_detail_page_test.dart
@@ -53,7 +53,7 @@ void main() {
     final testTripWithStats = TripWithStats(
       trip: testTrip,
       diveCount: 15,
-      totalBottomTime: 5400,
+      totalRuntime: 5400,
       maxDepth: 32.5,
       avgDepth: 18.3,
     );
@@ -310,7 +310,7 @@ void main() {
       expect(find.text('Delete'), findsOneWidget);
     });
 
-    testWidgets('liveaboard dives tab shows bottomTime', (tester) async {
+    testWidgets('liveaboard dives tab shows runtime', (tester) async {
       _setMobileTestSurfaceSize(tester);
       final liveaboardTrip = Trip(
         id: 'liveaboard-trip',
@@ -326,7 +326,7 @@ void main() {
       final liveaboardStats = TripWithStats(
         trip: liveaboardTrip,
         diveCount: 1,
-        totalBottomTime: 2700,
+        totalRuntime: 2700,
         maxDepth: 25.0,
       );
       final dives = [
@@ -335,6 +335,7 @@ void main() {
           diveNumber: 1,
           dateTime: DateTime(2024, 1, 16, 9, 0),
           bottomTime: const Duration(minutes: 45),
+          runtime: const Duration(minutes: 52),
           maxDepth: 25.0,
           tanks: const [],
           profile: const [],
@@ -382,8 +383,11 @@ void main() {
         await tester.pumpAndSettle();
       }
 
-      // Should show 45min in the dives list
-      expect(find.text('45min'), findsWidgets);
+      // The per-dive rows use the same runtime-with-bottom-time-fallback rule
+      // as the trip total, so the rows on this page add up to the total shown
+      // on the Overview tab (issue #889).
+      expect(find.text('52min'), findsWidgets);
+      expect(find.text('45min'), findsNothing);
     });
   });
 
@@ -405,7 +409,7 @@ void main() {
         final sharedTripWithStats = TripWithStats(
           trip: sharedTrip,
           diveCount: 3,
-          totalBottomTime: 3600,
+          totalRuntime: 3600,
         );
         final twoDivers = [
           Diver(
@@ -610,7 +614,7 @@ void main() {
     final embeddedStats = TripWithStats(
       trip: embeddedTrip,
       diveCount: 3,
-      totalBottomTime: 1800,
+      totalRuntime: 1800,
       maxDepth: 18.0,
     );
 

--- a/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
+++ b/test/features/trips/presentation/widgets/compact_trip_list_tile_test.dart
@@ -9,7 +9,7 @@ import '../../../../helpers/test_app.dart';
 TripWithStats _makeTrip({
   String name = 'Test Trip',
   int diveCount = 5,
-  int totalBottomTime = 0,
+  int totalRuntime = 0,
 }) {
   final now = DateTime(2025, 6, 1);
   return TripWithStats(
@@ -23,7 +23,7 @@ TripWithStats _makeTrip({
       updatedAt: now,
     ),
     diveCount: diveCount,
-    totalBottomTime: totalBottomTime,
+    totalRuntime: totalRuntime,
   );
 }
 
@@ -62,7 +62,7 @@ void main() {
         testApp(
           child: CompactTripListTile(
             // 3600 seconds = 1h 0m
-            tripWithStats: _makeTrip(totalBottomTime: 3600),
+            tripWithStats: _makeTrip(totalRuntime: 3600),
             onTap: () {},
           ),
         ),
@@ -76,7 +76,7 @@ void main() {
       await tester.pumpWidget(
         testApp(
           child: CompactTripListTile(
-            tripWithStats: _makeTrip(totalBottomTime: 0),
+            tripWithStats: _makeTrip(totalRuntime: 0),
             onTap: () {},
           ),
         ),

--- a/test/features/trips/presentation/widgets/dense_trip_list_tile_test.dart
+++ b/test/features/trips/presentation/widgets/dense_trip_list_tile_test.dart
@@ -30,7 +30,7 @@ List<dynamic> _settingsOverrides([AppSettings settings = const AppSettings()]) {
 TripWithStats _makeTrip({
   String name = 'Test Trip',
   int diveCount = 5,
-  int totalBottomTime = 0,
+  int totalRuntime = 0,
 }) {
   final now = DateTime(2025, 6, 1);
   return TripWithStats(
@@ -44,7 +44,7 @@ TripWithStats _makeTrip({
       updatedAt: now,
     ),
     diveCount: diveCount,
-    totalBottomTime: totalBottomTime,
+    totalRuntime: totalRuntime,
   );
 }
 

--- a/test/features/trips/presentation/widgets/story/trip_story_map_header_test.dart
+++ b/test/features/trips/presentation/widgets/story/trip_story_map_header_test.dart
@@ -181,6 +181,20 @@ void main() {
     expect(find.text('14'), findsOneWidget);
   });
 
+  testWidgets('stat strip totals runtime, not bottom time (issue #889)', (
+    tester,
+  ) async {
+    final stats = TripWithStats(
+      trip: _trip(),
+      diveCount: 14,
+      totalRuntime: 12 * 3600 + 40 * 60,
+    );
+    await pumpStrip(tester, stats);
+
+    expect(find.text('Total Runtime'), findsOneWidget);
+    expect(find.text('12h 40m'), findsOneWidget);
+  });
+
   testWidgets('stat strip shows sites visited when siteCount > 0', (
     tester,
   ) async {

--- a/test/features/trips/presentation/widgets/trip_list_tile_semantics_test.dart
+++ b/test/features/trips/presentation/widgets/trip_list_tile_semantics_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/trips/domain/entities/trip.dart';
+import 'package:submersion/features/trips/presentation/widgets/trip_list_content.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The tile's subtree watches [settingsProvider]; the real notifier reaches for
+/// SharedPreferences, so stand in with a fixed [AppSettings].
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier([super.initial = const AppSettings()]);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+// `Override` is sealed and not re-exported, so the helper stays dynamic --
+// same convention as `testApp`'s `overrides` parameter.
+List<dynamic> _settingsOverrides() {
+  return [settingsProvider.overrideWith((ref) => _TestSettingsNotifier())];
+}
+
+TripWithStats _makeTrip({int diveCount = 3, int totalRuntime = 0}) {
+  final start = DateTime(2025, 6, 1);
+  return TripWithStats(
+    trip: Trip(
+      id: 'trip-1',
+      name: 'Red Sea Explorer',
+      startDate: start,
+      endDate: start.add(const Duration(days: 7)),
+      tripType: TripType.shore,
+      createdAt: start,
+      updatedAt: start,
+    ),
+    diveCount: diveCount,
+    totalRuntime: totalRuntime,
+  );
+}
+
+/// The merged semantics label for the single [TripListTile] in the tree.
+String _label(WidgetTester tester) {
+  final node = tester.getSemantics(find.byType(TripListTile));
+  return node.label;
+}
+
+void main() {
+  group('TripListTile semantics', () {
+    testWidgets('dive count is localized, not hard-coded English', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('de'),
+          overrides: _settingsOverrides(),
+          child: TripListTile(tripWithStats: _makeTrip(diveCount: 3)),
+        ),
+      );
+
+      // A German screen reader must not hear the English word "dives".
+      expect(_label(tester), contains('Tauchgänge'));
+      expect(_label(tester), isNot(contains('dives')));
+      handle.dispose();
+    });
+
+    testWidgets('date range needs no translated connector word', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('de'),
+          overrides: _settingsOverrides(),
+          child: TripListTile(tripWithStats: _makeTrip()),
+        ),
+      );
+
+      // The sibling compact tile already joins the two dates with a dash,
+      // which reads correctly in every locale and needs no new ARB key.
+      expect(_label(tester), isNot(contains(' to ')));
+      handle.dispose();
+    });
+
+    testWidgets('selection is a semantics flag, not label text', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: _settingsOverrides(),
+          child: TripListTile(tripWithStats: _makeTrip(), isSelected: true),
+        ),
+      );
+
+      final node = tester.getSemantics(find.byType(TripListTile));
+      expect(node, isSemantics(isSelected: true));
+      expect(node.label, isNot(contains('selected')));
+      handle.dispose();
+    });
+
+    testWidgets('an unselected tile does not carry the selected flag', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: _settingsOverrides(),
+          child: TripListTile(tripWithStats: _makeTrip()),
+        ),
+      );
+
+      final node = tester.getSemantics(find.byType(TripListTile));
+      expect(node, isSemantics(isSelected: false));
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
+++ b/test/features/trips/presentation/widgets/trip_overview_tab_test.dart
@@ -28,7 +28,7 @@ final _trip = Trip(
 final _stats = TripWithStats(
   trip: _trip,
   diveCount: 2,
-  totalBottomTime: 75 * 60,
+  totalRuntime: 75 * 60,
   maxDepth: 30.0,
 );
 


### PR DESCRIPTION
## Summary

Trip totals summed **bottom time** while every other total in the app sums
**runtime** (surface to surface). On multilevel and wall dives that undercounts
every ascent, so the hours shown for a trip never matched the figure the
Statistics page reported for the same dives.

Trips were the only feature doing this: `statistics_repository.dart`,
`dive_repository_impl.dart`, the equipment service clocks and the PDF exports
all already use `COALESCE(runtime, bottom_time)`. This aligns trips with that
convention.

Fixes #889. Also resolves #809, which asked for the same change as an option;
the requested behavior is now the default, so no setting is introduced.

## Changes

- **Aggregates now sum runtime.** Both trip queries in `trip_repository.dart`
  (`getTripWithStats`, `getAllTripsWithStats`) use
  `COALESCE(runtime, bottom_time)`, and `TripStoryDay` sums the same way in
  Dart. Bottom time stays as the fallback so hand-logged dives that carry only
  a bottom time still contribute.
- **Renamed the fields that now hold runtime.**
  `TripWithStats.totalBottomTime` to `totalRuntime`, `formattedBottomTime` to
  `formattedRuntime`, and `TripField.totalBottomTime` to
  `TripField.totalRuntime`.
- **Legacy name alias for saved table layouts.**
  `TripFieldAdapter.fieldFromName` was `firstWhere(...)` with no `orElse`, and
  `EntityTableViewConfig.fromJson` calls it unguarded on the per-diver trips
  table layout. Renaming the enum alone would have thrown `StateError` on load
  for anyone who had customized their trips table, so `totalBottomTime` now
  maps forward to `TripField.totalRuntime`. That layout lives in a JSON blob
  rather than a column, so there is no schema version to bump and the shim
  belongs in the parser.
- **Labels.** `trips_detail_stat_totalBottomTime` becomes
  `trips_detail_stat_totalRuntime` across all 11 locales, reusing each locale's
  existing wording for runtime (German picks up "Laufzeit", matching the
  `diveLog_detail_stat_runtime` string already shipped). The trip PDF export
  header is updated to match.
- **Kept the liveaboard Dives tab consistent.** Its per-dive rows showed bottom
  time while the Overview total became runtime, so the rows would no longer add
  up to the total on the same page. That row uses the same fallback rule now.

No schema change and no migration.

## Test Plan

- [x] `flutter analyze --fatal-infos` passes on the merged tree
- [x] `dart format` clean (0 files changed)
- [x] Trips, OSM tile and equipment suites: 1014 passing on the merged tree
- [x] Full local `flutter test`: 18305 passing, 17 skipped, 1 flaky failure
- [x] CI: all 25 checks green, including all 8 test shards

The one local full-suite failure was
`test/features/media/presentation/media_share_helper_test.dart`. It passes in
isolation and did not recur on CI, whose sharded run covers the same file. Its
root cause is not established: it already scopes its scratch directory with
`Directory.systemTemp.createTemp`, so it is not the shared-`$TMPDIR` pattern
fixed in #1097, and per-file isolates rule out static leakage from another
suite. Flagging it as an observed local flake rather than claiming a diagnosis.
Nothing in this diff touches media sharing.

Every regression test here was verified red-green by reverting the fix and
watching it fail:

| Reverted | Observed failure |
| --- | --- |
| `getTripWithStats` SQL | expected 5400s, got 4200s (the reported symptom) |
| `getAllTripsWithStats` SQL | expected 3000s, got 2400s |
| `TripStoryDay.totalRuntime` | expected 1:38:00, got 1:24:00 |
| English stat label | "Total Runtime" not found |
| Liveaboard dives-tab row | "52min" not found |

New coverage: runtime-preferring and bottom-time-fallback cases for both SQL
aggregates and the day entity, a widget test pinning the rendered
"Total Runtime" label and value, and a test for the legacy `totalBottomTime`
field name resolving forward.

## Notes

Not changed here, worth a follow-up issue: `diver_repository.dart` still uses
`SUM(bottom_time)` for diver-profile totals (surfaced through
`DiverStats.formattedBottomTime`). Same class of inconsistency, but it is the
diver profile rather than Travel, so it sits outside what #889 reports.

