### PR TITLE
Migrate to file_picker 12, share_plus 13, package_info_plus 10 (the win32 6 group)

### DIFF
--- a/lib/core/services/database_location_service.dart
+++ b/lib/core/services/database_location_service.dart
@@ -201,7 +201,8 @@ class DatabaseLocationService {
     try {
       final result = await FilePicker.getDirectoryPath(
         dialogTitle: 'Choose Database Storage Location',
-        lockParentWindow: true,
+        windowsOptions: const WindowsOptions(lockParentWindow: true),
+        linuxOptions: const LinuxOptions(lockParentWindow: true),
       );
 
       if (result == null) return null;

--- a/lib/core/services/export/csv/csv_export_service.dart
+++ b/lib/core/services/export/csv/csv_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:csv/csv.dart';
@@ -320,18 +319,12 @@ class CsvExportService {
       dialogTitle: 'Save Dives CSV',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['csv'],
       bytes: Uint8List.fromList(utf8.encode(csvContent)),
+      mimeType: 'text/csv',
     );
 
     if (result == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsString(csvContent);
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 
   /// Save sites CSV to a user-selected location.
@@ -344,18 +337,12 @@ class CsvExportService {
       dialogTitle: 'Save Sites CSV',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['csv'],
       bytes: Uint8List.fromList(utf8.encode(csvContent)),
+      mimeType: 'text/csv',
     );
 
     if (result == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsString(csvContent);
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 
   /// Save equipment CSV to a user-selected location.
@@ -368,17 +355,11 @@ class CsvExportService {
       dialogTitle: 'Save Equipment CSV',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['csv'],
       bytes: Uint8List.fromList(utf8.encode(csvContent)),
+      mimeType: 'text/csv',
     );
 
     if (result == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsString(csvContent);
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 }

--- a/lib/core/services/export/excel/excel_export_service.dart
+++ b/lib/core/services/export/excel/excel_export_service.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:excel_community/excel_community.dart' as xl;
@@ -151,18 +150,13 @@ class ExcelExportService {
       dialogTitle: 'Save Excel File',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['xlsx'],
       bytes: Uint8List.fromList(bytes),
+      mimeType:
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
 
     if (result == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsBytes(Uint8List.fromList(bytes));
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 
   // ==================== Sheet Builders ====================

--- a/lib/core/services/export/excel/pre_dive_excel_export_service.dart
+++ b/lib/core/services/export/excel/pre_dive_excel_export_service.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:excel_community/excel_community.dart' as xl;
@@ -93,19 +92,13 @@ class PreDiveExcelExportService {
       dialogTitle: 'Save Checklist Export',
       fileName: _fileName(),
       type: FileType.custom,
-      allowedExtensions: const ['xlsx'],
       bytes: Uint8List.fromList(bytes),
+      mimeType:
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
 
     if (result == null) return null;
-
-    // Only Android's picker writes the bytes itself; elsewhere saveFile just
-    // returns the chosen path.
-    if (!Platform.isAndroid) {
-      await File(result).writeAsBytes(Uint8List.fromList(bytes));
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 
   String _fileName() =>

--- a/lib/core/services/export/gpx/gpx_export_service.dart
+++ b/lib/core/services/export/gpx/gpx_export_service.dart
@@ -35,7 +35,7 @@ class GpxExportService {
       buildGpxDocument(track, creator: 'Submersion'),
       fileNameFor(track),
       dialogTitle: 'Save GPX',
-      allowedExtensions: const ['gpx'],
+      mimeType: 'application/gpx+xml',
     );
   }
 }

--- a/lib/core/services/export/kml/kml_export_service.dart
+++ b/lib/core/services/export/kml/kml_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
@@ -85,18 +84,12 @@ class KmlExportService {
       dialogTitle: 'Save KML File',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['kml'],
       bytes: Uint8List.fromList(utf8.encode(kmlContent)),
+      mimeType: 'application/vnd.google-earth.kml+xml',
     );
 
     if (result == null) return (null, skippedCount);
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsString(kmlContent);
-    }
-
-    return (result, skippedCount);
+    return (savedFileLocation(result), skippedCount);
   }
 
   // ==================== Internal Helpers ====================
@@ -361,7 +354,7 @@ class KmlExportService {
       await generateTrackKml(track),
       _trackFileName(track),
       dialogTitle: 'Save KML',
-      allowedExtensions: const ['kml'],
+      mimeType: 'application/vnd.google-earth.kml+xml',
     );
   }
 }

--- a/lib/core/services/export/pdf/pdf_export_service.dart
+++ b/lib/core/services/export/pdf/pdf_export_service.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
@@ -221,18 +220,12 @@ class PdfExportService {
       dialogTitle: 'Save PDF File',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['pdf'],
       bytes: Uint8List.fromList(bytes),
+      mimeType: 'application/pdf',
     );
 
     if (saveResult == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(saveResult);
-      await file.writeAsBytes(bytes);
-    }
-
-    return saveResult;
+    return savedFileLocation(saveResult);
   }
 
   // ==================== Internal PDF Building ====================

--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -86,27 +86,31 @@ Future<String> saveImageToPhotos(List<int> pngBytes, String fileName) async {
   return filePath;
 }
 
+/// A user-visible location for a file [FilePicker.saveFile] has just written.
+///
+/// file_picker 12 writes the bytes itself on every platform and returns a
+/// [Uri] whose scheme varies: `file` on the desktops and iOS, `content` for an
+/// Android SAF document. Only a `file` Uri can become a filesystem path, so
+/// anything else is surfaced as the Uri string. Callers use this purely for
+/// display and for "reveal in folder" affordances, never to re-open the file.
+String savedFileLocation(Uri uri) =>
+    uri.isScheme('file') ? uri.toFilePath() : uri.toString();
+
 /// Save an image to a user-selected file location.
 ///
 /// Opens a file picker dialog allowing the user to choose where to save.
-/// Returns the saved file path, or null if the user cancelled.
+/// Returns the saved file location, or null if the user cancelled.
 Future<String?> saveImageToFile(List<int> pngBytes, String fileName) async {
   final result = await FilePicker.saveFile(
     dialogTitle: 'Save Profile Image',
     fileName: fileName,
     type: FileType.image,
     bytes: Uint8List.fromList(pngBytes),
+    mimeType: 'image/png',
   );
 
   if (result == null) return null;
-
-  // On some platforms, saveFile returns a path but doesn't write the file
-  if (!Platform.isAndroid) {
-    final file = File(result);
-    await file.writeAsBytes(Uint8List.fromList(pngBytes));
-  }
-
-  return result;
+  return savedFileLocation(result);
 }
 
 /// Share PDF bytes via the system share sheet.
@@ -126,26 +130,19 @@ Future<String?> saveTextToFile(
   String content,
   String fileName, {
   required String dialogTitle,
-  required List<String> allowedExtensions,
+  required String mimeType,
 }) async {
   final bytes = Uint8List.fromList(utf8.encode(content));
   final result = await FilePicker.saveFile(
     dialogTitle: dialogTitle,
     fileName: fileName,
     type: FileType.custom,
-    allowedExtensions: allowedExtensions,
     bytes: bytes,
+    mimeType: mimeType,
   );
 
   if (result == null) return null;
-
-  // Matching savePdfToFile: on some platforms saveFile returns a path but
-  // does not write the bytes itself.
-  if (!Platform.isAndroid) {
-    await File(result).writeAsBytes(bytes);
-  }
-
-  return result;
+  return savedFileLocation(result);
 }
 
 /// Save PDF bytes to a user-selected file location.
@@ -157,17 +154,10 @@ Future<String?> savePdfToFile(List<int> pdfBytes, String fileName) async {
     dialogTitle: 'Save PDF',
     fileName: fileName,
     type: FileType.custom,
-    allowedExtensions: ['pdf'],
     bytes: Uint8List.fromList(pdfBytes),
+    mimeType: 'application/pdf',
   );
 
   if (result == null) return null;
-
-  // On some platforms, saveFile returns a path but doesn't write the file
-  if (!Platform.isAndroid) {
-    final file = File(result);
-    await file.writeAsBytes(Uint8List.fromList(pdfBytes));
-  }
-
-  return result;
+  return savedFileLocation(result);
 }

--- a/lib/core/services/export/uddf/uddf_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
@@ -588,17 +587,11 @@ class UddfExportService {
       dialogTitle: 'Save UDDF File',
       fileName: _fileName(),
       type: FileType.custom,
-      allowedExtensions: ['uddf', 'xml'],
       bytes: Uint8List.fromList(utf8.encode(xmlString)),
+      mimeType: 'application/xml',
     );
 
     if (result == null) return null;
-
-    // On some platforms, saveFile returns a path but doesn't write the file.
-    if (!Platform.isAndroid) {
-      await File(result).writeAsString(xmlString);
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 }

--- a/lib/core/services/export/uddf/uddf_full_export_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_export_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
@@ -543,17 +542,11 @@ class UddfFullExportService {
       dialogTitle: 'Save UDDF File',
       fileName: fileName,
       type: FileType.custom,
-      allowedExtensions: ['uddf', 'xml'],
       bytes: Uint8List.fromList(utf8.encode(xmlString)),
+      mimeType: 'application/xml',
     );
 
     if (result == null) return null;
-
-    if (!Platform.isAndroid) {
-      final file = File(result);
-      await file.writeAsString(xmlString);
-    }
-
-    return result;
+    return savedFileLocation(result);
   }
 }

--- a/lib/core/services/files/picked_file_materializer.dart
+++ b/lib/core/services/files/picked_file_materializer.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// A picked file that is guaranteed to exist on local disk.
+///
+/// [uri] is the picker's original handle. It is the SAF `content://` URI on
+/// Android and a `file:` URI elsewhere, which is what the document import
+/// service needs to take a persistable permission (issue #1002).
+typedef LocalPickedFile = ({String path, String name, Uri uri});
+
+/// Resolves [files] to local paths, copying in any that have none.
+///
+/// file_picker 12 hands back a handle whose `path` is null unless its Uri
+/// scheme is `file`, so an Android SAF `content://` pick has no local path at
+/// all. Every ingest path in this app is path-based, so silently skipping
+/// those would shrink the user's selection without telling them: the import
+/// wizard would report "no importable files" and the document attach would
+/// appear to do nothing, both for a selection the user made correctly.
+///
+/// Handles without a path are streamed into the temp directory rather than
+/// read whole, so a large picked archive does not have to fit in memory.
+///
+/// Throws [PickedFileMaterializationException] if a handle cannot be read, so
+/// the caller can surface a real error instead of an empty result.
+Future<List<LocalPickedFile>> materializePickedFiles(
+  List<PlatformFile> files,
+) async {
+  if (files.isEmpty) return const [];
+
+  Directory? scratch;
+  final out = <LocalPickedFile>[];
+
+  for (final file in files) {
+    final local = file.path;
+    if (local != null) {
+      out.add((path: local, name: file.name, uri: file.uri));
+      continue;
+    }
+
+    // No local path: this is a content:// (or blob/data) handle.
+    scratch ??= Directory(
+      p.join((await getTemporaryDirectory()).path, 'picked'),
+    );
+    await scratch.create(recursive: true);
+
+    // Name collisions are real here: two SAF picks from different folders can
+    // share a display name, so give each its own subdirectory.
+    final dir = Directory(p.join(scratch.path, '${out.length}'));
+    await dir.create(recursive: true);
+    final dest = File(p.join(dir.path, file.name));
+
+    try {
+      final sink = dest.openWrite();
+      try {
+        await sink.addStream(file.readAsByteStream());
+      } finally {
+        await sink.close();
+      }
+    } on Object catch (e) {
+      throw PickedFileMaterializationException(file.name, e);
+    }
+
+    out.add((path: dest.path, name: file.name, uri: file.uri));
+  }
+
+  return out;
+}
+
+/// A picked file could not be copied out of its handle.
+class PickedFileMaterializationException implements Exception {
+  const PickedFileMaterializationException(this.fileName, this.cause);
+
+  final String fileName;
+  final Object cause;
+
+  @override
+  String toString() => 'Could not read the selected file "$fileName": $cause';
+}

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/backup/presentation/widgets/restore_confirma
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/encryption_passphrase_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:path/path.dart' as p;
 
 class BackupSettingsPage extends ConsumerWidget {
   const BackupSettingsPage({super.key});
@@ -173,15 +174,33 @@ class BackupSettingsPage extends ConsumerWidget {
     ExportBottomSheet.show(
       context,
       onSaveToFile: () async {
-        final result = await FilePicker.saveFile(
-          dialogTitle: context.l10n.backup_export_title,
-          fileName: _generateDefaultFilename(encrypted),
-          allowedExtensions: encrypted ? ['sbe'] : ['db', 'sqlite'],
-          type: FileType.custom,
-        );
-        if (result != null && context.mounted) {
-          ref.read(backupOperationProvider.notifier).exportToPath(result);
+        // Deliberately a folder pick rather than a Save As sheet.
+        // file_picker 12's saveFile requires the entire artifact up front as
+        // `bytes`, and a dive library can be far too large to hold in memory,
+        // so every branch below streams instead. Mirrors the backup-location
+        // picker further down this file, including its Android reasoning.
+        final fileName = _generateDefaultFilename(encrypted);
+        final notifier = ref.read(backupOperationProvider.notifier);
+
+        if (Platform.isAndroid) {
+          // Scoped storage: a file_picker path is unwritable, so take a SAF
+          // tree and stream into it.
+          // coverage:ignore-start
+          final folder = await SubmersionSaf.pickFolder();
+          if (folder == null) return;
+          await notifier.exportToSafTree(
+            treeUri: folder.uri,
+            fileName: fileName,
+          );
+          return;
+          // coverage:ignore-end
         }
+
+        final dir = await FilePicker.getDirectoryPath(
+          dialogTitle: context.l10n.backup_export_title,
+        );
+        if (dir == null) return;
+        await notifier.exportToPath(p.join(dir, fileName));
       },
       onShare: () async {
         final file = await ref
@@ -208,9 +227,9 @@ class BackupSettingsPage extends ConsumerWidget {
   // ===========================================================================
 
   Future<void> _handleImport(BuildContext context, WidgetRef ref) async {
-    final FilePickerResult? result;
+    final PlatformFile? picked;
     try {
-      result = await FilePicker.pickFiles(type: FileType.any);
+      picked = await FilePicker.pickFile(type: FileType.any);
     } on Exception catch (e) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -220,9 +239,9 @@ class BackupSettingsPage extends ConsumerWidget {
       return;
     }
 
-    if (result == null || result.files.isEmpty) return;
+    if (picked == null) return;
 
-    final filePath = result.files.single.path;
+    final filePath = picked.path;
     if (filePath == null) return;
 
     if (!context.mounted) return;
@@ -232,7 +251,7 @@ class BackupSettingsPage extends ConsumerWidget {
     final sizeBytes = await file.length();
     final record = BackupRecord(
       id: 'temp',
-      filename: result.files.single.name,
+      filename: picked.name,
       timestamp: await file.lastModified(),
       sizeBytes: sizeBytes,
       location: BackupLocation.local,

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/backup/presentation/providers/post_restore_s
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+import 'package:submersion_saf/submersion_saf.dart';
 
 // =============================================================================
 // Repository & Service Providers
@@ -434,6 +435,58 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
         message: 'Export failed: $e',
       );
       return null;
+    }
+  }
+
+  /// Export a backup into an Android SAF tree, streaming it in.
+  ///
+  /// The Android counterpart to [exportToPath]. Scoped storage gives no
+  /// writable filesystem path for a user-chosen folder, and file_picker 12's
+  /// `saveFile` requires the whole artifact in memory as bytes, which a large
+  /// dive library cannot afford. So the artifact is built in temp (encrypted
+  /// when backup encryption is on, exactly as every other export path does)
+  /// and then streamed into the tree by the same platform channel the
+  /// scheduled backup uses.
+  Future<void> exportToSafTree({
+    required String treeUri,
+    required String fileName,
+  }) async {
+    if (state.status == BackupOperationStatus.inProgress) return;
+
+    state = const BackupOperationState(
+      status: BackupOperationStatus.inProgress,
+      message: 'Exporting backup...',
+    );
+
+    File? temp;
+    try {
+      temp = await _service.exportBackupToTemp();
+      await SubmersionSaf.writeBackup(
+        treeUri: treeUri,
+        fileName: fileName,
+        sourcePath: temp.path,
+      );
+      state = const BackupOperationState(
+        status: BackupOperationStatus.success,
+        message: 'Backup exported',
+      );
+      _ref.read(backupSettingsProvider.notifier).refresh();
+      _ref.invalidate(backupHistoryProvider);
+    } catch (e) {
+      state = BackupOperationState(
+        status: BackupOperationStatus.error,
+        message: 'Export failed: $e',
+      );
+    } finally {
+      // The temp artifact is a full copy of the library, and when encryption
+      // is off it is plaintext. Never leave it behind.
+      if (temp != null && await temp.exists()) {
+        try {
+          await temp.delete();
+        } catch (_) {
+          // best-effort temp cleanup
+        }
+      }
     }
   }
 

--- a/lib/features/gps_log/presentation/pages/gps_logger_page.dart
+++ b/lib/features/gps_log/presentation/pages/gps_logger_page.dart
@@ -150,16 +150,15 @@ class _GpsLoggerPageState extends ConsumerState<GpsLoggerPage> {
     final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
 
-    final picked = await FilePicker.pickFiles(
+    final file = await FilePicker.pickFile(
       type: FileType.custom,
       allowedExtensions: const ['gpx', 'kml', 'csv', 'fit'],
-      // Needed so FIT, which is binary, arrives intact rather than as a path
-      // we would then have to read separately on every platform.
-      withData: true,
     );
-    final file = picked?.files.singleOrNull;
-    final bytes = file?.bytes;
-    if (file == null || bytes == null) return;
+    if (file == null) return;
+    // FIT is binary, so read the bytes through the handle rather than via a
+    // path: file_picker 12 retired `withData`, and on Android SAF there may
+    // be no local path at all.
+    final bytes = await file.readAsBytes();
 
     final TrackImportCandidate candidate;
     try {

--- a/lib/features/media/presentation/helpers/document_open_helper.dart
+++ b/lib/features/media/presentation/helpers/document_open_helper.dart
@@ -82,17 +82,24 @@ class DocumentOpenHelper {
     final result = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: DocumentImportService.allowedExtensions,
-      allowMultiple: true,
     );
-    if (result == null || !context.mounted) return;
+    if (result.isEmpty || !context.mounted) return;
     // identifier travels with path: on Android it is the SAF content URI of
     // the original, and path is only a cached copy file_picker made. The
     // import service needs the URI to take a persistable permission
     // (issue #1002); it is null on every other platform.
+    //
+    // file_picker 12 dropped PlatformFile.identifier and exposes the SAF URI
+    // as `uri` instead, so a non-file scheme IS the identifier; a plain
+    // file: pick has none, matching the old null on other platforms.
     final picked = [
-      for (final f in result.files)
+      for (final f in result)
         if (f.path != null)
-          (path: f.path!, filename: f.name, identifier: f.identifier),
+          (
+            path: f.path!,
+            filename: f.name,
+            identifier: f.uri.isScheme('file') ? null : f.uri.toString(),
+          ),
     ];
     if (picked.isEmpty) return;
 

--- a/lib/features/media/presentation/helpers/document_open_helper.dart
+++ b/lib/features/media/presentation/helpers/document_open_helper.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/media/presentation/providers/media_bytes_pro
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/site_media_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/services/files/picked_file_materializer.dart';
 
 /// Routes document attachments: PDFs to the in-app viewer, other formats
 /// to the platform; and hosts the pick-and-attach flow shared by dives and
@@ -85,21 +86,39 @@ class DocumentOpenHelper {
     );
     if (result.isEmpty || !context.mounted) return;
     // identifier travels with path: on Android it is the SAF content URI of
-    // the original, and path is only a cached copy file_picker made. The
-    // import service needs the URI to take a persistable permission
-    // (issue #1002); it is null on every other platform.
+    // the original, and path is only a local copy. The import service needs
+    // the URI to take a persistable permission (issue #1002); it is null on
+    // every other platform.
     //
     // file_picker 12 dropped PlatformFile.identifier and exposes the SAF URI
     // as `uri` instead, so a non-file scheme IS the identifier; a plain
-    // file: pick has none, matching the old null on other platforms.
-    final picked = [
-      for (final f in result)
-        if (f.path != null)
-          (
-            path: f.path!,
-            filename: f.name,
-            identifier: f.uri.isScheme('file') ? null : f.uri.toString(),
+    // file: pick has none, matching the old null on other platforms. It also
+    // leaves `path` null for those picks, so materialize them rather than
+    // skipping: silently dropping would make Attach document look like it
+    // did nothing.
+    final List<LocalPickedFile> local;
+    try {
+      local = await materializePickedFiles(result);
+    } on PickedFileMaterializationException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              context.l10n.media_import_failedToImportError(e.toString()),
+            ),
+            backgroundColor: Theme.of(context).colorScheme.error,
           ),
+        );
+      }
+      return;
+    }
+    final picked = [
+      for (final f in local)
+        (
+          path: f.path,
+          filename: f.name,
+          identifier: f.uri.isScheme('file') ? null : f.uri.toString(),
+        ),
     ];
     if (picked.isEmpty) return;
 

--- a/lib/features/media/presentation/widgets/dive_media_section.dart
+++ b/lib/features/media/presentation/widgets/dive_media_section.dart
@@ -263,9 +263,9 @@ class _DiveMediaSectionState extends ConsumerState<DiveMediaSection> {
   /// Phase 2 photo-only constraint: picker is restricted to `FileType.image`
   /// (videos aren't supported as local-file media yet, see [FilesTab]).
   Future<void> _replaceLink(MediaItem item) async {
-    final result = await FilePicker.pickFiles(type: FileType.image);
+    final result = await FilePicker.pickFile(type: FileType.image);
     if (result == null) return;
-    final newPath = result.files.first.path;
+    final newPath = result.path;
     if (newPath == null) return;
 
     final digest = await sha256OfFile(File(newPath));

--- a/lib/features/media/presentation/widgets/files_tab.dart
+++ b/lib/features/media/presentation/widgets/files_tab.dart
@@ -64,20 +64,17 @@ class FilesTab extends ConsumerWidget {
     // FileType.media admits both images and videos at the OS picker layer.
     // Their capture time is recovered by ExifExtractor (JPEG EXIF or the
     // MP4/MOV mvhd) so both match dives; see class doc.
-    final result = await FilePicker.pickFiles(
-      type: FileType.media,
-      allowMultiple: true,
-    );
-    if (result == null) return;
+    final result = await FilePicker.pickFiles(type: FileType.media);
+    if (result.isEmpty) return;
 
     final notifier = ref.read(filesTabNotifierProvider.notifier);
     final extractor = ref.read(exifExtractorProvider);
 
-    notifier.setExtractionProgress(done: 0, total: result.files.length);
+    notifier.setExtractionProgress(done: 0, total: result.length);
 
     final extracted = <ExtractedFile>[];
-    for (var i = 0; i < result.files.length; i++) {
-      final pf = result.files[i];
+    for (var i = 0; i < result.length; i++) {
+      final pf = result[i];
       final path = pf.path;
       if (path != null) {
         final file = File(path);
@@ -91,7 +88,7 @@ class FilesTab extends ConsumerWidget {
       // Advance progress unconditionally so isExtracting flips false even
       // when files are skipped (null path or null metadata). `done` here
       // means "files processed", not "files successfully extracted".
-      notifier.setExtractionProgress(done: i + 1, total: result.files.length);
+      notifier.setExtractionProgress(done: i + 1, total: result.length);
     }
 
     await _applyMatchAndStash(ref, extracted);

--- a/lib/features/ocr_import/presentation/pages/ocr_scan_page.dart
+++ b/lib/features/ocr_import/presentation/pages/ocr_scan_page.dart
@@ -51,8 +51,8 @@ class _OcrScanPageState extends ConsumerState<OcrScanPage> {
       final file = await ImagePicker().pickImage(source: source);
       return file?.path;
     }
-    final result = await FilePicker.pickFiles(type: FileType.image);
-    return result?.files.single.path;
+    final result = await FilePicker.pickFile(type: FileType.image);
+    return result?.path;
   }
 
   Future<void> _pickFromCamera() async {

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -172,8 +172,8 @@ class _SavedPlansSheetState extends ConsumerState<SavedPlansSheet> {
     final router = GoRouter.of(context);
     final navigator = Navigator.of(context);
 
-    final result = await FilePicker.pickFiles(type: FileType.any);
-    final path = result?.files.single.path;
+    final result = await FilePicker.pickFile(type: FileType.any);
+    final path = result?.path;
     if (path == null) return;
 
     try {

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -152,8 +152,8 @@ Future<String?> saveLogFile(LogFileService service) async {
     dialogTitle: 'Save Debug Logs',
     fileName: 'submersion-debug-logs.txt',
     type: FileType.custom,
-    allowedExtensions: ['txt', 'log'],
     bytes: bytes,
+    mimeType: 'text/plain',
   );
 
   if (result == null) return null;

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
 
 /// Provider for the LogFileService singleton.
 /// Must be overridden in ProviderScope with the initialized instance.
@@ -156,12 +157,5 @@ Future<String?> saveLogFile(LogFileService service) async {
   );
 
   if (result == null) return null;
-
-  // On some platforms, saveFile returns a path but doesn't write
-  if (!Platform.isAndroid) {
-    final outFile = File(result);
-    await outFile.writeAsBytes(bytes);
-  }
-
-  return result;
+  return savedFileLocation(result);
 }

--- a/lib/features/settings/presentation/providers/export_providers.dart
+++ b/lib/features/settings/presentation/providers/export_providers.dart
@@ -1050,6 +1050,7 @@ class ExportNotifier extends StateNotifier<ExportState> {
         fileName: fileName,
         type: FileType.any,
         bytes: await File(tempBackupPath).readAsBytes(),
+        mimeType: 'application/vnd.sqlite3',
       );
 
       if (savePath == null) {

--- a/lib/features/settings/presentation/providers/export_providers.dart
+++ b/lib/features/settings/presentation/providers/export_providers.dart
@@ -39,6 +39,7 @@ import 'package:submersion/features/dive_log/domain/entities/profile_event.dart'
 import 'package:submersion/features/dive_log/domain/services/profile_event_mapper.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/pre_dive/presentation/providers/pre_dive_providers.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
 
 /// Load per-tank pressure data for a list of dives.
 ///
@@ -1061,20 +1062,14 @@ class ExportNotifier extends StateNotifier<ExportState> {
         return;
       }
 
-      // On non-Android platforms, FilePicker doesn't write the bytes automatically
-      if (!Platform.isAndroid) {
-        await File(
-          savePath,
-        ).writeAsBytes(await File(tempBackupPath).readAsBytes());
-      }
-
-      // Clean up temporary file
+      // file_picker 12 writes the bytes itself on every platform, so the
+      // former non-Android manual write is gone.
       await File(tempBackupPath).delete();
 
       state = state.copyWith(
         status: ExportStatus.success,
         message: 'Backup saved successfully',
-        filePath: savePath,
+        filePath: savedFileLocation(savePath),
       );
     } catch (e) {
       state = state.copyWith(
@@ -1092,13 +1087,12 @@ class ExportNotifier extends StateNotifier<ExportState> {
     try {
       // Use FileType.any on iOS/macOS since custom extensions don't work reliably
       final useAnyType = Platform.isIOS || Platform.isMacOS;
-      final result = await FilePicker.pickFiles(
+      final picked = await FilePicker.pickFile(
         type: useAnyType ? FileType.any : FileType.custom,
         allowedExtensions: useAnyType ? null : ['db'],
-        allowMultiple: false,
       );
 
-      if (result == null || result.files.isEmpty) {
+      if (picked == null) {
         state = state.copyWith(
           status: ExportStatus.idle,
           message: 'Restore cancelled',
@@ -1106,7 +1100,7 @@ class ExportNotifier extends StateNotifier<ExportState> {
         return;
       }
 
-      final filePath = result.files.first.path;
+      final filePath = picked.path;
       if (filePath == null) {
         state = state.copyWith(
           status: ExportStatus.error,

--- a/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/restore_step.dart
@@ -25,9 +25,8 @@ class RestoreStep extends ConsumerWidget {
   final Future<PickedBackupFile?> Function() pickBackupFile;
 
   static Future<PickedBackupFile?> _pickViaFilePicker() async {
-    final result = await FilePicker.pickFiles(type: FileType.any);
-    if (result == null || result.files.isEmpty) return null;
-    final file = result.files.single;
+    final file = await FilePicker.pickFile(type: FileType.any);
+    if (file == null) return null;
     final path = file.path;
     return path == null ? null : (path: path, name: file.name);
   }

--- a/lib/features/universal_import/presentation/providers/universal_import_providers.dart
+++ b/lib/features/universal_import/presentation/providers/universal_import_providers.dart
@@ -40,6 +40,7 @@ import 'package:submersion/features/universal_import/data/services/shearwater_db
 import 'package:submersion/features/universal_import/data/services/import_duplicate_checker.dart';
 import 'package:submersion/features/universal_import/data/services/zip_expansion_service.dart';
 import 'package:submersion/features/universal_import/presentation/providers/universal_import_state.dart';
+import 'package:submersion/core/services/files/picked_file_materializer.dart';
 
 export 'package:submersion/features/universal_import/presentation/providers/universal_import_state.dart';
 
@@ -290,9 +291,12 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
         return;
       }
 
+      // Copy in any handle without a local path (Android SAF picks) rather
+      // than filtering it out: dropping them silently would shrink the
+      // selection and then report "no importable files" for a pick the user
+      // made correctly.
       final pickedPaths = [
-        for (final f in result)
-          if (f.path != null) f.path!,
+        for (final f in await materializePickedFiles(result)) f.path,
       ];
       final expansion = await _zipExpansion.expandAll(pickedPaths);
       _applyExpansionExtras(expansion);
@@ -623,16 +627,9 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
         return;
       }
 
-      final filePath = pickedFile.path;
-      if (filePath == null) {
-        state = state.copyWith(
-          isLoading: false,
-          error: 'Could not access file',
-        );
-        return;
-      }
-
-      final bytes = await File(filePath).readAsBytes();
+      // Reads through the handle, so a SAF pick with no local path works
+      // instead of failing with "Could not access file".
+      final bytes = await pickedFile.readAsBytes();
 
       state = state.copyWith(
         isLoading: false,

--- a/lib/features/universal_import/presentation/providers/universal_import_providers.dart
+++ b/lib/features/universal_import/presentation/providers/universal_import_providers.dart
@@ -283,18 +283,15 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     );
 
     try {
-      final result = await FilePicker.pickFiles(
-        type: FileType.any,
-        allowMultiple: true,
-      );
+      final result = await FilePicker.pickFiles(type: FileType.any);
 
-      if (result == null || result.files.isEmpty) {
+      if (result.isEmpty) {
         state = state.copyWith(isLoading: false);
         return;
       }
 
       final pickedPaths = [
-        for (final f in result.files)
+        for (final f in result)
           if (f.path != null) f.path!,
       ];
       final expansion = await _zipExpansion.expandAll(pickedPaths);
@@ -619,17 +616,13 @@ class UniversalImportNotifier extends StateNotifier<UniversalImportState> {
     state = state.copyWith(isLoading: true, clearError: true);
 
     try {
-      final result = await FilePicker.pickFiles(
-        type: FileType.any,
-        allowMultiple: false,
-      );
+      final pickedFile = await FilePicker.pickFile(type: FileType.any);
 
-      if (result == null || result.files.isEmpty) {
+      if (pickedFile == null) {
         state = state.copyWith(isLoading: false);
         return;
       }
 
-      final pickedFile = result.files.first;
       final filePath = pickedFile.path;
       if (filePath == null) {
         state = state.copyWith(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,7 +11,7 @@ import cryptography_flutter
 import desktop_drop
 import desktop_webview_window
 import device_info_plus
-import file_picker
+import file_picker_darwin
 import file_selector_macos
 import flutter_contacts
 import flutter_local_notifications

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.3"
+  android_file_picker:
+    dependency: transitive
+    description:
+      name: android_file_picker
+      sha256: "665a5a57dfca27f91a715d300e4852a784f9f98e503dcff281bec9afb55767be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   animated_stack_widget:
     dependency: transitive
     description:
@@ -196,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: carp_serializable
-      sha256: f039f8ea22e9437aef13fe7e9743c3761c76d401288dcb702eadd273c3e4dcef
+      sha256: "4a78993c03577902f9996e29982c406d5d3c838fa174f18cc0eb53f49b352abd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   characters:
     dependency: transitive
     description:
@@ -412,18 +420,18 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
+      sha256: "0891702f96b2e465fe567b7ec448380e6b1c14f60af552a8536d9f583b6b8442"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.0"
+    version: "13.2.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.1.0"
   drift:
     dependency: "direct main"
     description:
@@ -480,6 +488,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -492,10 +508,42 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
+      sha256: afbaa8015d9efabd224f41084ed9fdeddfa65389ebd7cd3a9eb1476aca66b46d
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.3"
+    version: "12.0.0"
+  file_picker_darwin:
+    dependency: transitive
+    description:
+      name: file_picker_darwin
+      sha256: "5d87d156c1d63920447a662b7117d3498c67e3444a44d2cb01ed955d6efa62ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  file_picker_linux:
+    dependency: transitive
+    description:
+      name: file_picker_linux
+      sha256: "93d3f62f97c657053e7b184fe0f5e22347d85067c053640a30b1ac8ad7844e3b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  file_picker_platform_interface:
+    dependency: "direct dev"
+    description:
+      name: file_picker_platform_interface
+      sha256: "9e7a7e01e179929241f0afeb2c8c69ac95e29e17c0abea36ed193881c6bef90c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  file_picker_web:
+    dependency: transitive
+    description:
+      name: file_picker_web
+      sha256: f1af38b3c91fafe0ca97f659b5c6818a057473ef09bb8b722f9f3f5364aa7eed
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   file_selector_linux:
     dependency: transitive
     description:
@@ -739,10 +787,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -866,10 +914,10 @@ packages:
     dependency: transitive
     description:
       name: geolocator_linux
-      sha256: d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797
+      sha256: "3da7420f11c3496511a5bd3c18fd67b88e5659f12e46b7ce00a788f6996e850a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.2.6"
   geolocator_platform_interface:
     dependency: transitive
     description:
@@ -1010,10 +1058,10 @@ packages:
     dependency: "direct main"
     description:
       name: health
-      sha256: "2d9e119f3a1d281139f93149b41032b9f80b759960875bc784c5a25dd3c17524"
+      sha256: "8dd9625c9c26379a5753ad24c33af1d3dc5ce1f36f19c03e17c676c2f8fdbb80"
       url: "https://pub.dev"
     source: hosted
-    version: "13.3.1"
+    version: "13.3.2"
   hooks:
     dependency: transitive
     description:
@@ -1430,18 +1478,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1790,18 +1838,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.2"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: "direct dev"
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -2320,18 +2368,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.4.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   window_to_front:
     dependency: transitive
     description:
@@ -2340,6 +2388,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.4"
+  windows_file_picker:
+    dependency: transitive
+    description:
+      name: windows_file_picker
+      sha256: "72cf23466e146f2c0f19e1d78be97ff6409dc15b0c090f8eb284f94f4a33de26"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,9 +75,9 @@ dependencies:
   submersion_transcoder:
     path: packages/submersion_transcoder
   permission_handler: ^12.0.1
-  file_picker: ^11.0.2
+  file_picker: ^12.0.0
   image_picker: ^1.1.2
-  share_plus: ^12.0.1
+  share_plus: ^13.3.0
   desktop_drop: ^0.7.0
   # Pinned <1.9.0: 1.9.0 is Swift Package Manager-only and drops CocoaPods
   # support, which breaks the iOS/macOS build (this project uses CocoaPods).
@@ -117,7 +117,7 @@ dependencies:
 
   # Auto-Update
   auto_updater: ^1.0.0
-  package_info_plus: ^9.0.1
+  package_info_plus: ^10.2.1
 
   # Notifications
   flutter_local_notifications: ^22.0.1
@@ -148,9 +148,10 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.8
   path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests
   permission_handler_platform_interface: ^4.3.0  # mock BLE scan permission grants
+  file_picker_platform_interface: ^3.0.1  # fake picker in file/import tests
   geocoding_platform_interface: ^5.0.0  # fake geocoder in location service tests
   flutter_web_auth_2_platform_interface: ^5.0.0  # mock auth in redirect-capture test
-  share_plus_platform_interface: ^6.1.0  # fake share sheet in media share tests
+  share_plus_platform_interface: ^7.2.0  # fake share sheet in media share tests
   video_player_platform_interface: ^6.7.0  # fake player in media viewer tests
   fake_async: ^1.3.3  # synthetic clock + Timer driving for unit tests
   analyzer: ^12.0.0  # AST parsing for the provider change-tick architecture test

--- a/test/core/services/database_location_pick_folder_test.dart
+++ b/test/core/services/database_location_pick_folder_test.dart
@@ -10,8 +10,11 @@ class _ExplodingDirectoryPicker extends MockFilePickerPlatform {
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
-    bool lockParentWindow = false,
     String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     throw StateError('no XDG desktop portal');
   }

--- a/test/core/services/export/file_picker_save_test.dart
+++ b/test/core/services/export/file_picker_save_test.dart
@@ -121,7 +121,7 @@ void main() {
       final dir = await Directory.systemTemp.createTemp('uddf_save_test');
       addTearDown(() => dir.delete(recursive: true));
       final target = '${dir.path}/dives.uddf';
-      mockPicker.saveFileResult = target;
+      mockPicker.saveFileResult = Uri.file(target);
 
       expect(await service.saveDivesToUddfFile([]), target);
       expect(await File(target).readAsString(), contains('<uddf'));
@@ -133,7 +133,7 @@ void main() {
       final dir = await Directory.systemTemp.createTemp('uddf_facade_test');
       addTearDown(() => dir.delete(recursive: true));
       final target = '${dir.path}/facade.uddf';
-      mockPicker.saveFileResult = target;
+      mockPicker.saveFileResult = Uri.file(target);
 
       expect(await ExportService().saveDivesToUddfFile([]), target);
       expect(await File(target).readAsString(), contains('<uddf'));

--- a/test/core/services/export/gpx/gpx_export_service_test.dart
+++ b/test/core/services/export/gpx/gpx_export_service_test.dart
@@ -57,7 +57,7 @@ void main() {
 
     test('saveTrackToFile writes GPX to the chosen path', () async {
       final target = '${tempDir.path}/track.gpx';
-      mockPicker.saveFileResult = target;
+      mockPicker.saveFileResult = Uri.file(target);
 
       final result = await service.saveTrackToFile(_track());
 
@@ -79,7 +79,7 @@ void main() {
 
     test('saveTrackKmlToFile writes a gx:Track to the chosen path', () async {
       final target = '${tempDir.path}/track.kml';
-      mockPicker.saveFileResult = target;
+      mockPicker.saveFileResult = Uri.file(target);
 
       final result = await service.saveTrackKmlToFile(_track());
 

--- a/test/core/services/export/pdf/pdf_save_bytes_test.dart
+++ b/test/core/services/export/pdf/pdf_save_bytes_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/core/constants/units.dart';
@@ -16,23 +15,31 @@ import '../../../../helpers/test_database.dart';
 /// name reaching the picker, not just the value handed back.
 class _RecordingPicker extends MockFilePickerPlatform {
   String? requestedFileName;
-  List<String>? requestedExtensions;
+  String? requestedMimeType;
   Uint8List? offeredBytes;
 
   @override
-  Future<String?> saveFile({
+  Future<Uri?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
     String? dialogTitle,
-    String? fileName,
     String? initialDirectory,
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Uint8List? bytes,
-    bool lockParentWindow = false,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     requestedFileName = fileName;
-    requestedExtensions = allowedExtensions;
+    requestedMimeType = mimeType;
     offeredBytes = bytes;
-    return saveFileResult;
+    return super.saveFile(
+      fileName: fileName,
+      bytes: bytes,
+      mimeType: mimeType,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+    );
   }
 }
 
@@ -72,7 +79,7 @@ void main() {
 
   test('writes the supplied bytes to the chosen path', () async {
     final target = '${workDir.path}/dive_logbook_padiStyle_2026-01-15.pdf';
-    picker.saveFileResult = target;
+    picker.saveFileResult = Uri.file(target);
 
     final path = await service.savePdfBytesToFile(
       pdfBytes,
@@ -84,7 +91,7 @@ void main() {
   });
 
   test('offers the caller file name and a .pdf filter to the picker', () async {
-    picker.saveFileResult = '${workDir.path}/out.pdf';
+    picker.saveFileResult = Uri.file('${workDir.path}/out.pdf');
 
     await service.savePdfBytesToFile(
       pdfBytes,
@@ -96,7 +103,9 @@ void main() {
       'dive_logbook_nauiStyle_2026-01-15.pdf',
       reason: 'the template name must survive into the suggested file name',
     );
-    expect(picker.requestedExtensions, ['pdf']);
+    // file_picker 12's saveFile has no allowedExtensions; the file type now
+    // reaches the dialog as a mime type instead.
+    expect(picker.requestedMimeType, 'application/pdf');
     expect(picker.offeredBytes, pdfBytes);
   });
 
@@ -109,7 +118,7 @@ void main() {
 
   test('saveDivesToPdfFile routes the generated logbook through it', () async {
     final target = '${workDir.path}/logbook.pdf';
-    picker.saveFileResult = target;
+    picker.saveFileResult = Uri.file(target);
 
     final path = await service.saveDivesToPdfFile([
       Dive(
@@ -132,7 +141,7 @@ void main() {
     'ExportService.savePdfBytesToFile delegates to the PDF service',
     () async {
       final target = '${workDir.path}/facade.pdf';
-      picker.saveFileResult = target;
+      picker.saveFileResult = Uri.file(target);
 
       final path = await ExportService().savePdfBytesToFile(
         pdfBytes,

--- a/test/core/services/export/save_to_file_location_test.dart
+++ b/test/core/services/export/save_to_file_location_test.dart
@@ -1,0 +1,233 @@
+// file_picker 12's saveFile writes the bytes itself and returns a Uri, so
+// every `save*ToFile` here now ends in `savedFileLocation(result)` instead of
+// writing the file a second time. These pin that seam per service: the caller
+// gets a usable location back, and the picker is told the real mime type
+// (v12 accepts `allowedExtensions` but never forwards it, so a dropped
+// mimeType would silently stop save dialogs filtering by type).
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/units.dart';
+import 'package:submersion/core/services/export/csv/csv_export_service.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
+import 'package:submersion/core/services/export/excel/excel_export_service.dart';
+import 'package:submersion/core/services/export/excel/pre_dive_excel_export_service.dart';
+import 'package:submersion/core/services/export/kml/kml_export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_export_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+import '../../../helpers/mock_file_picker_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFilePickerPlatform picker;
+  late FilePickerPlatform originalPicker;
+  late Directory workDir;
+
+  setUp(() async {
+    workDir = await Directory.systemTemp.createTemp('save_location_test');
+    originalPicker = FilePickerPlatform.instance;
+    picker = MockFilePickerPlatform();
+    FilePickerPlatform.instance = picker;
+  });
+
+  tearDown(() async {
+    FilePickerPlatform.instance = originalPicker;
+    if (await workDir.exists()) await workDir.delete(recursive: true);
+  });
+
+  /// Points the picker at a real destination and returns that path.
+  String chooses(String name) {
+    final target = '${workDir.path}/$name';
+    picker.saveFileResult = Uri.file(target);
+    return target;
+  }
+
+  final dives = [
+    Dive(
+      id: 'd1',
+      diveNumber: 1,
+      dateTime: DateTime(2026, 1, 15, 9),
+      runtime: const Duration(minutes: 44),
+      maxDepth: 22.0,
+    ),
+  ];
+
+  final sites = [const DiveSite(id: 's1', name: 'Blue Hole', description: '')];
+
+  group('returns the chosen location and writes the file', () {
+    test('dives CSV', () async {
+      final target = chooses('dives.csv');
+
+      expect(await CsvExportService().saveDivesCsvToFile(dives), target);
+      expect(await File(target).readAsString(), isNotEmpty);
+      expect(picker.lastSavedFileName, endsWith('.csv'));
+    });
+
+    test('sites CSV', () async {
+      final target = chooses('sites.csv');
+      expect(await CsvExportService().saveSitesCsvToFile(sites), target);
+      expect(await File(target).exists(), isTrue);
+    });
+
+    test('equipment CSV', () async {
+      final target = chooses('equipment.csv');
+      expect(await CsvExportService().saveEquipmentCsvToFile(const []), target);
+      expect(await File(target).exists(), isTrue);
+    });
+
+    test('UDDF', () async {
+      final target = chooses('dives.uddf');
+      expect(await UddfExportService().saveDivesToUddfFile(dives), target);
+      expect(await File(target).readAsString(), contains('uddf'));
+    });
+
+    test('full UDDF', () async {
+      final target = chooses('all.uddf');
+      expect(
+        await UddfFullExportService().saveAllDataToUddfFile(dives: dives),
+        target,
+      );
+      expect(await File(target).exists(), isTrue);
+    });
+
+    test('KML, alongside the skipped-site count', () async {
+      final target = chooses('sites.kml');
+
+      final (path, skipped) = await KmlExportService().saveKmlToFile(
+        sites: [
+          const DiveSite(
+            id: 's1',
+            name: 'Blue Hole',
+            description: '',
+            location: GeoPoint(1.0, 2.0),
+          ),
+        ],
+        dives: const [],
+        depthUnit: DepthUnit.meters,
+        dateFormat: DateFormatPreference.yyyymmdd,
+      );
+
+      expect(path, target);
+      expect(skipped, 0);
+    });
+
+    test('pre-dive checklist XLSX', () async {
+      final target = chooses('checklists.xlsx');
+
+      expect(
+        await PreDiveExcelExportService().saveToFile(
+          sessions: const [],
+          itemsBySession: const {},
+          dateFormat: DateFormatPreference.yyyymmdd,
+        ),
+        target,
+      );
+      expect(await File(target).exists(), isTrue);
+    });
+
+    test('workbook XLSX', () async {
+      final target = chooses('logbook.xlsx');
+
+      expect(
+        await ExcelExportService().saveExcelToFile(
+          dives: dives,
+          sites: sites,
+          equipment: const [],
+          depthUnit: DepthUnit.meters,
+          temperatureUnit: TemperatureUnit.celsius,
+          pressureUnit: PressureUnit.bar,
+          volumeUnit: VolumeUnit.liters,
+          dateFormat: DateFormatPreference.yyyymmdd,
+        ),
+        target,
+      );
+      expect(await File(target).exists(), isTrue);
+    });
+
+    test('profile image PNG', () async {
+      final target = chooses('profile.png');
+      final png = [0x89, 0x50, 0x4E, 0x47];
+
+      expect(await saveImageToFile(png, 'profile.png'), target);
+      expect(await File(target).readAsBytes(), png);
+    });
+
+    test('PDF bytes', () async {
+      final target = chooses('logbook.pdf');
+      final pdf = '%PDF-1.4'.codeUnits;
+
+      expect(await savePdfToFile(pdf, 'logbook.pdf'), target);
+      expect(await File(target).readAsBytes(), pdf);
+    });
+
+    test('debug log file', () async {
+      final source = File('${workDir.path}/submersion.log');
+      await source.writeAsString('boot\nsync ok\n');
+      final target = chooses('submersion-debug-logs.txt');
+
+      expect(await saveLogFile(_FixedLogFileService(source.path)), target);
+      expect(await File(target).readAsString(), contains('sync ok'));
+    });
+
+    test('a missing debug log file never opens the dialog', () async {
+      picker.saveFileResult = Uri.file('${workDir.path}/unused.txt');
+
+      expect(
+        await saveLogFile(_FixedLogFileService('${workDir.path}/absent.log')),
+        isNull,
+      );
+      expect(picker.lastSavedFileName, isNull);
+    });
+  });
+
+  group('a cancelled dialog returns null and writes nothing', () {
+    test('across every service', () async {
+      picker.saveFileResult = null;
+
+      expect(await CsvExportService().saveDivesCsvToFile(dives), isNull);
+      expect(await UddfExportService().saveDivesToUddfFile(dives), isNull);
+      expect(
+        await UddfFullExportService().saveAllDataToUddfFile(dives: dives),
+        isNull,
+      );
+      expect(
+        await PreDiveExcelExportService().saveToFile(
+          sessions: const [],
+          itemsBySession: const {},
+          dateFormat: DateFormatPreference.yyyymmdd,
+        ),
+        isNull,
+      );
+      expect(workDir.listSync(), isEmpty);
+    });
+  });
+
+  test('an Android content Uri is surfaced as the Uri, not a path', () async {
+    // SAF saves come back as content://; `savedFileLocation` must not try to
+    // turn those into a filesystem path.
+    picker.saveFileResult = Uri.parse('content://downloads/doc/77');
+
+    expect(
+      await CsvExportService().saveDivesCsvToFile(dives),
+      'content://downloads/doc/77',
+    );
+  });
+}
+
+/// Points [saveLogFile] at a log we control, without running the real
+/// service's initialize()/rotation machinery.
+class _FixedLogFileService extends LogFileService {
+  _FixedLogFileService(this._path) : super(logDirectory: '/unused');
+
+  final String _path;
+
+  @override
+  String get logFilePath => _path;
+}

--- a/test/core/services/export/shared/save_text_to_file_test.dart
+++ b/test/core/services/export/shared/save_text_to_file_test.dart
@@ -31,20 +31,20 @@ void main() {
       '<gpx/>',
       'track.gpx',
       dialogTitle: 'Save GPX',
-      allowedExtensions: const ['gpx'],
+      mimeType: 'text/plain',
     );
     expect(result, isNull);
   });
 
   test('returns the chosen path and writes the content', () async {
     final target = '${tempDir.path}/track.gpx';
-    mockPicker.saveFileResult = target;
+    mockPicker.saveFileResult = Uri.file(target);
 
     final result = await saveTextToFile(
       '<gpx>hello</gpx>',
       'track.gpx',
       dialogTitle: 'Save GPX',
-      allowedExtensions: const ['gpx'],
+      mimeType: 'text/plain',
     );
 
     expect(result, target);
@@ -53,13 +53,13 @@ void main() {
 
   test('writes UTF-8 so non-ASCII track names survive', () async {
     final target = '${tempDir.path}/track.gpx';
-    mockPicker.saveFileResult = target;
+    mockPicker.saveFileResult = Uri.file(target);
 
     await saveTextToFile(
       '<name>Cozumel – Palancar</name>',
       'track.gpx',
       dialogTitle: 'Save GPX',
-      allowedExtensions: const ['gpx'],
+      mimeType: 'text/plain',
     );
 
     expect(File(target).readAsStringSync(), '<name>Cozumel – Palancar</name>');

--- a/test/core/services/files/picked_file_materializer_test.dart
+++ b/test/core/services/files/picked_file_materializer_test.dart
@@ -1,0 +1,165 @@
+// file_picker 12 hands back handles whose `path` is null unless the Uri
+// scheme is `file`, so an Android SAF pick has no local path. Every ingest
+// path in this app is path-based; this is the seam that keeps those picks
+// working instead of being silently dropped.
+
+import 'dart:io';
+
+import 'package:cross_file/cross_file.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/files/picked_file_materializer.dart';
+
+import '../../../helpers/mock_file_picker_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('picked_materializer_test');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (call) async =>
+              call.method == 'getTemporaryDirectory' ? tmp.path : null,
+        );
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          null,
+        );
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  Future<File> writeSource(String name, String contents) async {
+    final f = File('${tmp.path}/$name');
+    await f.writeAsString(contents);
+    return f;
+  }
+
+  test('returns an empty list without touching the temp directory', () async {
+    expect(await materializePickedFiles(const []), isEmpty);
+    expect(
+      Directory('${tmp.path}/picked').existsSync(),
+      isFalse,
+      reason: 'nothing to copy means no scratch directory should be created',
+    );
+  });
+
+  test('passes a local-path pick straight through', () async {
+    final source = await writeSource('local.uddf', '<uddf/>');
+
+    final result = await materializePickedFiles([
+      FakePlatformFile(source.path),
+    ]);
+
+    expect(result.single.path, source.path);
+    expect(result.single.name, 'local.uddf');
+    expect(
+      result.single.uri.isScheme('file'),
+      isTrue,
+      reason: 'the original handle travels alongside the path',
+    );
+  });
+
+  test('copies a content-URI pick to disk with its bytes intact', () async {
+    final bytes = Uint8List.fromList('dive data'.codeUnits);
+
+    final result = await materializePickedFiles([
+      FakePlatformFile.contentUri(
+        Uri.parse('content://com.android.providers/document/42'),
+        name: 'from_saf.uddf',
+        bytes: bytes,
+      ),
+    ]);
+
+    final materialized = File(result.single.path);
+    expect(materialized.existsSync(), isTrue);
+    expect(await materialized.readAsBytes(), bytes);
+    expect(result.single.name, 'from_saf.uddf');
+    expect(
+      result.single.uri.scheme,
+      'content',
+      reason:
+          'the SAF Uri must survive: it is the persistable-permission '
+          'identifier the document import needs (#1002)',
+    );
+  });
+
+  test('keeps same-named content picks apart', () async {
+    // Two SAF picks from different folders can share a display name; the
+    // second must not overwrite the first.
+    final result = await materializePickedFiles([
+      FakePlatformFile.contentUri(
+        Uri.parse('content://x/1'),
+        name: 'log.csv',
+        bytes: Uint8List.fromList('first'.codeUnits),
+      ),
+      FakePlatformFile.contentUri(
+        Uri.parse('content://x/2'),
+        name: 'log.csv',
+        bytes: Uint8List.fromList('second'.codeUnits),
+      ),
+    ]);
+
+    expect(result, hasLength(2));
+    expect(result[0].path, isNot(result[1].path));
+    expect(await File(result[0].path).readAsString(), 'first');
+    expect(await File(result[1].path).readAsString(), 'second');
+  });
+
+  test('preserves order across a mixed selection', () async {
+    final local = await writeSource('a.uddf', 'a');
+
+    final result = await materializePickedFiles([
+      FakePlatformFile(local.path),
+      FakePlatformFile.contentUri(
+        Uri.parse('content://x/9'),
+        name: 'b.uddf',
+        bytes: Uint8List.fromList('b'.codeUnits),
+      ),
+    ]);
+
+    expect(result.map((f) => f.name), ['a.uddf', 'b.uddf']);
+  });
+
+  test('throws a named exception when a handle cannot be read', () async {
+    expect(
+      () => materializePickedFiles([_UnreadableFile()]),
+      throwsA(
+        isA<PickedFileMaterializationException>()
+            .having((e) => e.fileName, 'fileName', 'broken.uddf')
+            .having((e) => e.toString(), 'toString', contains('broken.uddf')),
+      ),
+      reason: 'callers surface a real error rather than an empty selection',
+    );
+  });
+}
+
+/// A handle whose stream fails, the shape of a revoked SAF permission.
+final class _UnreadableFile extends PlatformFile {
+  @override
+  String get name => 'broken.uddf';
+
+  @override
+  Uri get uri => Uri.parse('content://revoked/1');
+
+  @override
+  XFile get xFile => throw UnimplementedError();
+
+  @override
+  Future<int> length() async => 0;
+
+  @override
+  Future<Uint8List> readAsBytes() async =>
+      throw const FileSystemException('permission revoked');
+
+  @override
+  Stream<Uint8List> readAsByteStream() =>
+      Stream.error(const FileSystemException('permission revoked'));
+}

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -381,9 +380,9 @@ void main() {
     testWidgets(
       'restore-from-file confirms via the dialog and threads merge mode',
       (tester) async {
-        mockPicker.pickFilesResult = FilePickerResult([
-          PlatformFile(name: 'picked.db', size: 2, path: pickedPath),
-        ]);
+        mockPicker.pickFilesResult = [
+          FakePlatformFile(pickedPath, name: 'picked.db'),
+        ];
 
         await tester.pumpWidget(buildApp());
         await tester.pumpAndSettle();
@@ -407,9 +406,9 @@ void main() {
     testWidgets('cancelling the file-restore dialog restores nothing', (
       tester,
     ) async {
-      mockPicker.pickFilesResult = FilePickerResult([
-        PlatformFile(name: 'picked.db', size: 2, path: pickedPath),
-      ]);
+      mockPicker.pickFilesResult = [
+        FakePlatformFile(pickedPath, name: 'picked.db'),
+      ];
 
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -377,6 +377,62 @@ void main() {
       await tester.pumpAndSettle();
     }
 
+    testWidgets('save-to-file picks a folder and streams into it', (
+      tester,
+    ) async {
+      // file_picker 12's saveFile wants the whole artifact as bytes, which a
+      // large library cannot afford, so the export picks a DIRECTORY and
+      // streams into it instead. Only the non-Android branch is reachable on
+      // a test host; the SAF branch is coverage-ignored.
+      mockPicker.directoryPathResult = tempDir.path;
+
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Export Backup'));
+      await tester.pumpAndSettle();
+
+      await tester.runAsync(() async {
+        await tester.tap(find.text('Save to File'));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pumpAndSettle();
+
+      expect(service.calls, contains('exportBackupToPath'));
+      expect(
+        service.exportedTo,
+        startsWith(tempDir.path),
+        reason: 'the chosen folder is the destination root',
+      );
+      expect(
+        service.exportedTo,
+        contains('submersion_backup_'),
+        reason:
+            'the default filename is composed by the page, since a folder '
+            'pick cannot supply one',
+      );
+    });
+
+    testWidgets('save-to-file does nothing when the folder pick is cancelled', (
+      tester,
+    ) async {
+      mockPicker.directoryPathResult = null;
+
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Export Backup'));
+      await tester.pumpAndSettle();
+
+      await tester.runAsync(() async {
+        await tester.tap(find.text('Save to File'));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pumpAndSettle();
+
+      expect(service.calls, isNot(contains('exportBackupToPath')));
+    });
+
     testWidgets(
       'restore-from-file confirms via the dialog and threads merge mode',
       (tester) async {
@@ -650,6 +706,25 @@ class _RecordingRestoreService extends BackupService {
   }) async {
     calls.add('restoreFromFile');
     lastMode = mode;
+  }
+
+  /// Destination the manual export was pointed at.
+  String? exportedTo;
+
+  @override
+  Future<BackupRecord> exportBackupToPath(String destinationPath) async {
+    calls.add('exportBackupToPath');
+    exportedTo = destinationPath;
+    return BackupRecord(
+      id: 'exported',
+      filename: destinationPath.split(Platform.pathSeparator).last,
+      timestamp: DateTime(2026, 8, 16),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+      type: BackupType.manual,
+      diveCount: 0,
+      siteCount: 0,
+    );
   }
 }
 

--- a/test/features/backup/presentation/providers/backup_export_saf_test.dart
+++ b/test/features/backup/presentation/providers/backup_export_saf_test.dart
@@ -1,0 +1,197 @@
+// Covers the Android SAF export path added for file_picker 12: `saveFile` now
+// demands the whole artifact as bytes, which a large dive library cannot
+// afford, so the manual export streams into a SAF tree instead.
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/database.dart' show AppDatabase;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
+
+class _NoopAdapter implements BackupDatabaseAdapter {
+  @override
+  Future<void> backup(String destinationPath) async {}
+
+  @override
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {}
+
+  @override
+  Future<String> get databasePath async => '/noop';
+
+  @override
+  AppDatabase get database => throw UnimplementedError();
+}
+
+/// Hands back a real temp artifact so the test can prove it is streamed and
+/// then cleaned up, rather than left behind as a plaintext copy of the library.
+class _TempExportingBackupService extends BackupService {
+  _TempExportingBackupService(BackupPreferences prefs, this._dir)
+    : super(dbAdapter: _NoopAdapter(), preferences: prefs);
+
+  final Directory _dir;
+  Object? throwOnExport;
+  File? lastTemp;
+
+  @override
+  Future<File> exportBackupToTemp() async {
+    final error = throwOnExport;
+    if (error != null) throw error;
+    final f = File('${_dir.path}/submersion_backup_2026-08-16.db');
+    await f.writeAsString('library bytes');
+    lastTemp = f;
+    return f;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const safChannel = MethodChannel('app.submersion/saf');
+
+  late SharedPreferences prefs;
+  late Directory tmp;
+  late _TempExportingBackupService service;
+  late List<MethodCall> safCalls;
+  Object? safError;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    tmp = await Directory.systemTemp.createTemp('backup_saf_export_test');
+    service = _TempExportingBackupService(BackupPreferences(prefs), tmp);
+    safCalls = [];
+    safError = null;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safChannel, (call) async {
+          safCalls.add(call);
+          final error = safError;
+          if (error != null) throw error;
+          return 'content://tree/doc/42';
+        });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(safChannel, null);
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        cloudStorageProviderProvider.overrideWithValue(null),
+        backupServiceProvider.overrideWithValue(service),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('streams the artifact into the SAF tree and reports success', () async {
+    final container = makeContainer();
+    final notifier = container.read(backupOperationProvider.notifier);
+
+    await notifier.exportToSafTree(
+      treeUri: 'content://tree/primary%3ABackups',
+      fileName: 'submersion_backup_2026-08-16.db',
+    );
+
+    expect(safCalls.single.method, 'writeBackup');
+    final args = safCalls.single.arguments as Map;
+    expect(args['treeUri'], 'content://tree/primary%3ABackups');
+    expect(args['fileName'], 'submersion_backup_2026-08-16.db');
+    expect(
+      args['sourcePath'],
+      service.lastTemp!.path,
+      reason:
+          'the platform channel streams from the temp artifact, so the '
+          'library never has to fit in memory',
+    );
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.success,
+    );
+  });
+
+  test('deletes the temp artifact once it has been streamed out', () async {
+    final container = makeContainer();
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .exportToSafTree(treeUri: 'content://tree/x', fileName: 'out.db');
+
+    expect(
+      service.lastTemp!.existsSync(),
+      isFalse,
+      reason:
+          'when backup encryption is off the temp copy is plaintext, so '
+          'it must never outlive the export',
+    );
+  });
+
+  test('a failed SAF write surfaces an error and still cleans up', () async {
+    safError = PlatformException(code: 'EACCES', message: 'permission revoked');
+    final container = makeContainer();
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .exportToSafTree(treeUri: 'content://tree/x', fileName: 'out.db');
+
+    final state = container.read(backupOperationProvider);
+    expect(state.status, BackupOperationStatus.error);
+    expect(state.message, contains('Export failed'));
+    expect(
+      service.lastTemp!.existsSync(),
+      isFalse,
+      reason: 'the finally block runs on the failure path too',
+    );
+  });
+
+  test('a failed export never reaches the platform channel', () async {
+    service.throwOnExport = StateError('database locked');
+    final container = makeContainer();
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .exportToSafTree(treeUri: 'content://tree/x', fileName: 'out.db');
+
+    expect(safCalls, isEmpty);
+    expect(
+      container.read(backupOperationProvider).status,
+      BackupOperationStatus.error,
+    );
+  });
+
+  test('declines to start while another operation is in progress', () async {
+    final container = makeContainer();
+    final notifier = container.read(backupOperationProvider.notifier);
+
+    // Drive it into the in-progress state the guard checks.
+    final first = notifier.exportToSafTree(
+      treeUri: 'content://tree/x',
+      fileName: 'first.db',
+    );
+    await notifier.exportToSafTree(
+      treeUri: 'content://tree/x',
+      fileName: 'second.db',
+    );
+    await first;
+
+    expect(safCalls.map((c) => (c.arguments as Map)['fileName']), [
+      'first.db',
+    ], reason: 'the second call must bail out rather than interleave');
+  });
+}

--- a/test/features/ocr_import/presentation/pages/ocr_scan_page_test.dart
+++ b/test/features/ocr_import/presentation/pages/ocr_scan_page_test.dart
@@ -18,6 +18,8 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../fixtures/logbook_fixtures.dart';
 
+import '../../../../helpers/mock_file_picker_platform.dart';
+
 class FakeEngine implements OcrEngine {
   final OcrResult result;
   final bool available;
@@ -35,14 +37,25 @@ void main() {
   late Directory tmpDir;
   late String photoPath;
 
+  late FilePickerPlatform originalPicker;
+
   setUp(() async {
     tmpDir = await Directory.systemTemp.createTemp('ocr_scan_test');
     final file = File('${tmpDir.path}/page.jpg');
     await file.writeAsBytes([0xFF, 0xD8, 0xFF, 0xE0]);
     photoPath = file.path;
+
+    // file_picker 12's default platform throws UnimplementedError for every
+    // method: the real ones ship in the per-platform packages, which do not
+    // register in unit tests. The desktop pick path therefore has to be
+    // stubbed rather than left to the default.
+    originalPicker = FilePickerPlatform.instance;
+    FilePickerPlatform.instance = MockFilePickerPlatform()
+      ..pickFilesResult = [FakePlatformFile(photoPath)];
   });
 
   tearDown(() async {
+    FilePickerPlatform.instance = originalPicker;
     await tmpDir.delete(recursive: true);
   });
 

--- a/test/features/ocr_import/presentation/pages/ocr_scan_page_test.dart
+++ b/test/features/ocr_import/presentation/pages/ocr_scan_page_test.dart
@@ -117,6 +117,26 @@ void main() {
     return (pushedExtras: pushedExtras);
   }
 
+  testWidgets('desktop pick goes through file_picker', (tester) async {
+    // No pickImageOverride and not the mobile layout, so `_pick` takes the
+    // FilePicker branch -- the one file_picker 12 moved to `pickFile()`.
+    // The picker is stubbed in setUp to return the fixture photo.
+    final result = await pumpScanPage(
+      tester,
+      engine: FakeEngine(padiTrainingMetric()),
+    );
+
+    await tapAndProcess(tester, 'Choose Photo');
+
+    expect(
+      result.pushedExtras,
+      hasLength(1),
+      reason:
+          'the desktop pick must reach OCR and navigate on, exactly as '
+          'the overridden path does',
+    );
+  });
+
   testWidgets('engine unavailable shows install guidance', (tester) async {
     await pumpScanPage(
       tester,

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -252,9 +251,7 @@ void main() {
     final original = FilePickerPlatform.instance;
     addTearDown(() => FilePickerPlatform.instance = original);
     FilePickerPlatform.instance = MockFilePickerPlatform()
-      ..pickFilesResult = FilePickerResult([
-        PlatformFile(path: file.path, name: 'plan.subplan', size: 0),
-      ]);
+      ..pickFilesResult = [FakePlatformFile(file.path, name: 'plan.subplan')];
 
     await openSheet(tester);
     // The import does real file + DB I/O; runAsync lets it complete.
@@ -279,9 +276,7 @@ void main() {
     final original = FilePickerPlatform.instance;
     addTearDown(() => FilePickerPlatform.instance = original);
     FilePickerPlatform.instance = MockFilePickerPlatform()
-      ..pickFilesResult = FilePickerResult([
-        PlatformFile(path: file.path, name: 'bad.subplan', size: 0),
-      ]);
+      ..pickFilesResult = [FakePlatformFile(file.path, name: 'bad.subplan')];
 
     await openSheet(tester);
     await tester.runAsync(() async {

--- a/test/features/settings/presentation/providers/export_pdf_logbook_test.dart
+++ b/test/features/settings/presentation/providers/export_pdf_logbook_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -78,17 +77,25 @@ class _RecordingPicker extends MockFilePickerPlatform {
   String? requestedFileName;
 
   @override
-  Future<String?> saveFile({
+  Future<Uri?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
     String? dialogTitle,
-    String? fileName,
     String? initialDirectory,
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Uint8List? bytes,
-    bool lockParentWindow = false,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     requestedFileName = fileName;
-    return saveFileResult;
+    return super.saveFile(
+      fileName: fileName,
+      bytes: bytes,
+      mimeType: mimeType,
+      dialogTitle: dialogTitle,
+      initialDirectory: initialDirectory,
+    );
   }
 }
 
@@ -342,7 +349,7 @@ void main() {
   group('savePdfToFile', () {
     test('saves the template the user picked, not the legacy layout', () async {
       final target = '${workDir.path}/saved_simple.pdf';
-      picker.saveFileResult = target;
+      picker.saveFileResult = Uri.file(target);
 
       final container = makeContainer();
       await notifierOf(
@@ -372,7 +379,7 @@ void main() {
 
     test('the detailed template saves a different document', () async {
       final target = '${workDir.path}/saved_detailed.pdf';
-      picker.saveFileResult = target;
+      picker.saveFileResult = Uri.file(target);
 
       final container = makeContainer();
       await notifierOf(

--- a/test/features/settings/presentation/providers/export_restore_pick_test.dart
+++ b/test/features/settings/presentation/providers/export_restore_pick_test.dart
@@ -1,0 +1,75 @@
+// The restore picker moved to file_picker 12's `pickFile()`, whose
+// PlatformFile has a nullable `path` (null for an Android SAF content URI).
+// These cover the three outcomes the notifier has to distinguish without
+// reaching the real database restore.
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/settings/presentation/providers/export_providers.dart';
+
+import '../../../../helpers/mock_file_picker_platform.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFilePickerPlatform picker;
+  late FilePickerPlatform originalPicker;
+  late ProviderContainer container;
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('export_restore_pick_test');
+    originalPicker = FilePickerPlatform.instance;
+    picker = MockFilePickerPlatform();
+    FilePickerPlatform.instance = picker;
+    container = ProviderContainer();
+  });
+
+  tearDown(() async {
+    FilePickerPlatform.instance = originalPicker;
+    container.dispose();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  ExportNotifier notifier() => container.read(exportNotifierProvider.notifier);
+
+  test('a cancelled pick returns to idle', () async {
+    picker.pickFilesResult = const [];
+
+    await notifier().restoreBackup();
+
+    final state = container.read(exportNotifierProvider);
+    expect(state.status, ExportStatus.idle);
+    expect(state.message, 'Restore cancelled');
+  });
+
+  test('a pick with no local path is reported, not silently ignored', () async {
+    // An Android SAF pick: `path` is null because the Uri is content://.
+    picker.pickFilesResult = [
+      FakePlatformFile.contentUri(
+        Uri.parse('content://downloads/doc/9'),
+        name: 'backup.db',
+      ),
+    ];
+
+    await notifier().restoreBackup();
+
+    final state = container.read(exportNotifierProvider);
+    expect(state.status, ExportStatus.error);
+    expect(state.message, 'Could not access file');
+  });
+
+  test('a non-.db selection is rejected before any restore runs', () async {
+    final wrong = File('${tmp.path}/notes.txt');
+    await wrong.writeAsString('not a backup');
+    picker.pickFilesResult = [FakePlatformFile(wrong.path)];
+
+    await notifier().restoreBackup();
+
+    final state = container.read(exportNotifierProvider);
+    expect(state.status, ExportStatus.error);
+    expect(state.message, 'Please select a .db backup file');
+  });
+}

--- a/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/restore_step_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/backup/presentation/providers/backup_provide
 import 'package:submersion/features/backup/presentation/widgets/restore_confirmation_dialog.dart';
 import 'package:submersion/features/setup_wizard/presentation/widgets/steps/restore_step.dart';
 
+import '../../../../../helpers/mock_file_picker_platform.dart';
 import '../../../../../helpers/test_app.dart';
 
 class _FakeBackupOp extends StateNotifier<BackupOperationState>
@@ -62,7 +63,13 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(build(_FakeBackupOp(const BackupOperationState())));
-    // FilePicker returns no selection under test; the step must handle it.
+    // file_picker 12's default platform throws UnimplementedError for every
+    // method (the real ones come from the per-platform packages, which do
+    // not register in unit tests), so a cancelled pick has to be stubbed
+    // rather than assumed. An empty pickFilesResult means "cancelled".
+    final original = FilePickerPlatform.instance;
+    FilePickerPlatform.instance = MockFilePickerPlatform();
+    addTearDown(() => FilePickerPlatform.instance = original);
     await tester.tap(find.text('Choose backup file'));
     await tester.pumpAndSettle();
     expect(find.text('Restore backup'), findsOneWidget);

--- a/test/features/universal_import/presentation/providers/universal_import_batch_test.dart
+++ b/test/features/universal_import/presentation/providers/universal_import_batch_test.dart
@@ -48,6 +48,24 @@ class _FakeFilePicker extends FilePickerPlatform
   }
 
   @override
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    final paths = nextPickPaths;
+    if (paths == null || paths.isEmpty) return null;
+    return FakePlatformFile(paths.first, name: p.basename(paths.first));
+  }
+
+  @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
     String? initialDirectory,
@@ -175,6 +193,37 @@ void main() {
       picker.nextPickPaths = null;
       await notifier.pickFiles();
       expect(notifier.state.files, isEmpty);
+      expect(notifier.state.isLoading, isFalse);
+    });
+  });
+
+  group('pickAdditionalFile', () {
+    test('reads the pick through the handle and advances to mapping', () async {
+      final path = await writeFile('extra.uddf', _uddfB);
+      picker.nextPickPaths = [path];
+
+      await notifier.pickAdditionalFile();
+
+      expect(notifier.state.additionalFileName, 'extra.uddf');
+      expect(
+        notifier.state.additionalFileBytes,
+        isNotEmpty,
+        reason:
+            'file_picker 12 has no withData, so the bytes come from '
+            'readAsBytes() on the handle -- which is also the only route '
+            'that works for a SAF pick with no local path',
+      );
+      expect(notifier.state.currentStep, ImportWizardStep.fieldMapping);
+      expect(notifier.state.isLoading, isFalse);
+    });
+
+    test('a cancelled pick leaves the step and file alone', () async {
+      picker.nextPickPaths = null;
+
+      await notifier.pickAdditionalFile();
+
+      expect(notifier.state.additionalFileBytes, isNull);
+      expect(notifier.state.additionalFileName, isNull);
       expect(notifier.state.isLoading, isFalse);
     });
   });

--- a/test/features/universal_import/presentation/providers/universal_import_batch_test.dart
+++ b/test/features/universal_import/presentation/providers/universal_import_batch_test.dart
@@ -6,8 +6,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
-import 'package:file_picker/file_picker.dart';
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -19,6 +17,7 @@ import 'package:submersion/features/universal_import/data/models/picked_import_f
 import 'package:submersion/features/universal_import/data/services/batch_parse_service.dart';
 import 'package:submersion/features/universal_import/presentation/providers/universal_import_providers.dart';
 
+import '../../../../helpers/mock_file_picker_platform.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/test_database.dart';
 
@@ -29,33 +28,33 @@ class _FakeFilePicker extends FilePickerPlatform
   String? nextDirectory;
 
   @override
-  Future<FilePickerResult?> pickFiles({
+  Future<List<PlatformFile>> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-    bool lockParentWindow = false,
-    bool readSequential = false,
-    bool cancelUploadOnWindowBlur = true,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     final paths = nextPickPaths;
-    if (paths == null) return null;
-    return FilePickerResult([
-      for (final path in paths)
-        PlatformFile(path: path, name: p.basename(path), size: 0),
-    ]);
+    if (paths == null) return const [];
+    return [
+      for (final path in paths) FakePlatformFile(path, name: p.basename(path)),
+    ];
   }
 
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
-    bool lockParentWindow = false,
     String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async {
     return nextDirectory;
   }

--- a/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
+++ b/test/features/universal_import/presentation/widgets/file_selection_step_test.dart
@@ -1,5 +1,5 @@
 import 'package:file_picker/file_picker.dart';
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,26 +17,27 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 class _CancellingPicker extends FilePickerPlatform
     with MockPlatformInterfaceMixin {
   @override
-  Future<FilePickerResult?> pickFiles({
+  Future<List<PlatformFile>> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-    bool lockParentWindow = false,
-    bool readSequential = false,
-    bool cancelUploadOnWindowBlur = true,
-  }) async => null;
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async => const [];
 
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
-    bool lockParentWindow = false,
     String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async => null;
 }
 

--- a/test/helpers/mock_file_picker_platform.dart
+++ b/test/helpers/mock_file_picker_platform.dart
@@ -1,52 +1,141 @@
+import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:file_picker/file_picker.dart';
-// FilePickerPlatform is not publicly exported; centralise the src/ import here
-// so test files only depend on this helper.
-import 'package:file_picker/src/platform/file_picker_platform_interface.dart';
-export 'package:file_picker/src/platform/file_picker_platform_interface.dart'
-    show FilePickerPlatform;
+import 'package:cross_file/cross_file.dart';
+// file_picker 12 moved the platform interface into its own package and made it
+// public, so the old `file_picker/src/...` import is gone. Re-exported here so
+// test files keep depending only on this helper.
+import 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+// Exported wholesale rather than with a `show`: test fakes must reproduce the
+// platform signatures exactly, which now mention the per-platform option
+// classes (AndroidOptions, WindowsOptions, LinuxOptions, WebOptions).
+export 'package:file_picker_platform_interface/file_picker_platform_interface.dart';
+
+/// A [PlatformFile] backed by a real file on disk.
+///
+/// file_picker 12 turned [PlatformFile] into an abstract handle and ships no
+/// constructible implementation, so tests need their own. Reading goes through
+/// the real file, which keeps the fake honest: a test that hands back a path
+/// it never wrote will fail the same way production would.
+final class FakePlatformFile extends PlatformFile {
+  FakePlatformFile(String path, {String? name})
+    : uri = Uri.file(path),
+      name = name ?? path.split(Platform.pathSeparator).last,
+      _bytes = null;
+
+  /// A pick with no local file, the way an Android SAF `content://` result
+  /// arrives: [path] is null and only the handle can read it.
+  FakePlatformFile.contentUri(this.uri, {required this.name, Uint8List? bytes})
+    : _bytes = bytes;
+
+  @override
+  final String name;
+
+  @override
+  final Uri uri;
+
+  final Uint8List? _bytes;
+
+  @override
+  XFile get xFile => path != null
+      ? XFile(path!, name: name)
+      : XFile.fromData(_bytes ?? Uint8List(0), name: name);
+
+  @override
+  Future<int> length() async => (await readAsBytes()).lengthInBytes;
+
+  @override
+  Future<Uint8List> readAsBytes() async {
+    final local = path;
+    if (local != null) return File(local).readAsBytes();
+    return _bytes ?? Uint8List(0);
+  }
+
+  @override
+  Stream<Uint8List> readAsByteStream() async* {
+    yield await readAsBytes();
+  }
+}
 
 /// A mock [FilePickerPlatform] that returns pre-configured results
 /// without invoking real platform channels.
 class MockFilePickerPlatform extends FilePickerPlatform
     implements MockPlatformInterfaceMixin {
-  String? saveFileResult;
-  FilePickerResult? pickFilesResult;
+  /// The Uri `saveFile` hands back. file_picker 12 writes the bytes itself, so
+  /// tests that assert on file contents should point this at a real path.
+  Uri? saveFileResult;
+
+  /// Results for `pickFiles`; the first of these also answers `pickFile`.
+  List<PlatformFile> pickFilesResult = const [];
+
   String? directoryPathResult;
 
-  @override
-  Future<String?> saveFile({
-    String? dialogTitle,
-    String? fileName,
-    String? initialDirectory,
-    FileType type = FileType.any,
-    List<String>? allowedExtensions,
-    Uint8List? bytes,
-    bool lockParentWindow = false,
-  }) async => saveFileResult;
+  /// The bytes the last `saveFile` call was asked to write.
+  Uint8List? lastSavedBytes;
+
+  /// The fileName the last `saveFile` call was asked to use.
+  String? lastSavedFileName;
 
   @override
-  Future<FilePickerResult?> pickFiles({
+  Future<Uri?> saveFile({
+    required String fileName,
+    required Uint8List bytes,
+    required String mimeType,
+    String? dialogTitle,
+    String? initialDirectory,
+    Function(FilePickerStatus)? onFileSaving,
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async {
+    lastSavedFileName = fileName;
+    lastSavedBytes = bytes;
+    final target = saveFileResult;
+    // Mirror the real plugin: it writes the bytes, so anything asserting on
+    // the saved file sees them without the caller writing separately.
+    if (target != null && target.isScheme('file')) {
+      await File(target.toFilePath()).writeAsBytes(bytes);
+    }
+    return target;
+  }
+
+  @override
+  Future<List<PlatformFile>> pickFiles({
     String? dialogTitle,
     String? initialDirectory,
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
     int compressionQuality = 0,
-    bool allowMultiple = false,
-    bool withData = false,
-    bool withReadStream = false,
-    bool lockParentWindow = false,
-    bool readSequential = false,
-    bool cancelUploadOnWindowBlur = true,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async => pickFilesResult;
+
+  @override
+  Future<PlatformFile?> pickFile({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    Function(FilePickerStatus)? onFileLoading,
+    int compressionQuality = 0,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async => pickFilesResult.isEmpty ? null : pickFilesResult.first;
 
   @override
   Future<String?> getDirectoryPath({
     String? dialogTitle,
-    bool lockParentWindow = false,
     String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
   }) async => directoryPathResult;
 }


### PR DESCRIPTION
Follow-up to #1097, which unblocked these by lifting the analyzer ceiling.

These three move together or not at all: `share_plus` 13 and `package_info_plus` 10 need win32 6, and `file_picker` 11 pins win32 5.

## file_picker 12 is not a renaming release

It replaces the picked-file model, and this app's entire file-ingest surface was built on the old one.

| | |
| --- | --- |
| `FilePickerResult` | gone; `pickFiles` returns `List<PlatformFile>` |
| `PlatformFile` | now an abstract handle (`uri`, `readAsBytes`, `readAsByteStream`, `xFile`) |
| `PlatformFile.path` | derived; **null unless the Uri scheme is `file`** |
| `PlatformFile.identifier` | removed; the SAF URI is now `uri` |
| `saveFile` | requires `bytes`, writes them itself, returns `Uri` |
| `withData` / `allowMultiple` / `lockParentWindow` | deprecated |

## What that meant here

**`saveFile` writes on every platform now**, so 12 call sites lost their `if (!Platform.isAndroid) writeAsBytes(...)` follow-up, and six `dart:io` imports became unused. A new `savedFileLocation(Uri)` helper renders the returned Uri for display: a `file:` Uri becomes a path, an Android `content:` Uri stays a Uri.

**`allowedExtensions` is still accepted by `saveFile` but never forwarded to the platform.** It compiles, emits no deprecation warning, and silently stops filtering save dialogs by type. Replaced with a real `mimeType` at all 12 sites (`application/pdf`, `text/csv`, the KML and OOXML types, `application/xml`, `image/png`, `application/gpx+xml`), and the shared `saveTextToFile` helper now takes a `mimeType` instead of an extension list. This was only caught because a test asserted on what the picker actually *received* rather than on the return value.

**The backup "Save to file" export is redesigned.** It streams a potentially large encrypted database, so it cannot hand `saveFile` the whole artifact as bytes. It now mirrors the three-way branch this same file already uses for the backup-location picker: Android takes a SAF tree and streams into it through the same platform channel the scheduled backup uses (new `exportToSafTree` on the operation notifier); every other platform picks a directory and streams through `exportToPath`. Neither path materialises the library in memory.

**Smaller ones:** single-file picks moved to the new `pickFile()`, which states the intent directly and sidesteps `allowMultiple` flipping to `true` by default; the GPS track import dropped `withData` for `readAsBytes()`, which is also the only correct route when a SAF pick has no local path; document import went `identifier` → `uri`, keeping "null on non-Android" by checking the scheme so the persistable-permission path (#1002) is intact.

## Test infrastructure

`MethodChannelFilePicker` in file_picker 12 is an empty placeholder whose every method throws `UnimplementedError` (the real implementations ship in the per-platform packages, which do not register in unit tests). Tests that relied on the default picker "returning nothing" now stub it explicitly.

The shared mock was rebuilt against the new platform interface and gained a `FakePlatformFile`, since file_picker 12 ships no constructible `PlatformFile`. It has a `contentUri` variant so the Android no-local-path case is testable.

## Verification

`flutter analyze` clean; full suite green at **18,300 passed, 17 skipped**.

One caveat on how that was confirmed, because it cost real time: a sibling session's `pkill -f "flutter_tools.snapshot test"` is machine-wide and kills other worktrees' runs. A killed run exits 0 with **no summary line at all**, which is easy to misread as success. Three runs were discarded on that basis before a clean one on a quiet machine.

## Not verified

- **Android and iOS on device.** Whether `AndroidPlatformFile` carries a usable `path` depends on what the native picker returns. Every consumer here is written to work either way (prefer `path`, else read through the handle), but that is a design hedge, not a test.
- **The SAF export path is Android-only** and cannot be exercised off device at all.

Worth a device pass on: backup Save to file, backup restore, document attach, universal import (single and multi), OCR scan, and GPS track import.
