### PR TITLE
fix(data-quality): repair scalar water temperature, explain when no fix exists

### DIFF
--- a/lib/features/data_quality/data/services/profile_repair_service.dart
+++ b/lib/features/data_quality/data/services/profile_repair_service.dart
@@ -207,9 +207,10 @@ class ProfileRepairService {
       p.temperature == null
           ? p
           : p.copyWith(
-              temperature: kelvinScale
-                  ? p.temperature! - 273.15
-                  : (p.temperature! - 32) * 5 / 9,
+              temperature: RepairPredicates.convertToCelsius(
+                p.temperature!,
+                kelvinScale: kelvinScale,
+              ),
             ),
   ];
 

--- a/lib/features/data_quality/data/services/quality_repair_executor.dart
+++ b/lib/features/data_quality/data/services/quality_repair_executor.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/data_quality/data/repositories/quality_findi
 import 'package:submersion/features/data_quality/data/services/profile_repair_service.dart';
 import 'package:submersion/features/data_quality/data/services/quality_scan_service.dart';
 import 'package:submersion/features/data_quality/domain/entities/quality_finding.dart';
+import 'package:submersion/features/data_quality/domain/repairs/repair_predicates.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
@@ -149,6 +150,41 @@ class QualityRepairExecutor {
         ),
       );
       SyncEventBus.notifyLocalChange();
+      scheduleQualityScan([diveId]);
+    });
+  }
+
+  /// Reinterpret the dive's recorded water temperature on the scale it was
+  /// really logged on. The sample-channel equivalent goes through
+  /// [applyProfileRepair] with ProfileRepairService.convertTemperature; this
+  /// one rewrites the single scalar column and nothing else.
+  Future<RepairResult> convertWaterTemp({
+    required String diveId,
+    required bool kelvinScale,
+    required String findingId,
+  }) async {
+    final dive = await _diveRepo.getDiveById(diveId);
+    final prior = dive?.waterTemp;
+    if (prior == null) return const RepairResult.noChange();
+    final converted = RepairPredicates.convertToCelsius(
+      prior,
+      kelvinScale: kelvinScale,
+    );
+    if (converted == prior) return const RepairResult.noChange();
+
+    Future<void> write(double value) async {
+      await _db.transaction(
+        () => _diveRepo.bulkUpdateFields([
+          diveId,
+        ], DivesCompanion(waterTemp: Value(value))),
+      );
+      SyncEventBus.notifyLocalChange();
+    }
+
+    await write(converted);
+    await _finish(findingId, [diveId]);
+    return RepairResult.applied(() async {
+      await write(prior);
       scheduleQualityScan([diveId]);
     });
   }

--- a/lib/features/data_quality/data/services/quality_repair_executor.dart
+++ b/lib/features/data_quality/data/services/quality_repair_executor.dart
@@ -166,11 +166,20 @@ class QualityRepairExecutor {
     final dive = await _diveRepo.getDiveById(diveId);
     final prior = dive?.waterTemp;
     if (prior == null) return const RepairResult.noChange();
+    // Re-test convergence against the CURRENT value rather than trusting the
+    // finding's params. The dive may have been corrected by hand since the
+    // scan, and converting an already-plausible reading would corrupt it.
+    // Refusing also subsumes the degenerate -40 case, where Celsius and
+    // Fahrenheit coincide and the conversion could never change anything.
+    if (!RepairPredicates.convertedChannelIsPlausible([
+      prior,
+    ], kelvinScale: kelvinScale)) {
+      return const RepairResult.noChange();
+    }
     final converted = RepairPredicates.convertToCelsius(
       prior,
       kelvinScale: kelvinScale,
     );
-    if (converted == prior) return const RepairResult.noChange();
 
     Future<void> write(double value) async {
       await _db.transaction(

--- a/lib/features/data_quality/domain/detectors/temp_anomaly_detector.dart
+++ b/lib/features/data_quality/domain/detectors/temp_anomaly_detector.dart
@@ -12,7 +12,7 @@ class TempAnomalyDetector extends QualityDetector {
   @override
   String get id => 'temp_anomaly';
   @override
-  int get version => 2;
+  int get version => 3;
   @override
   QualityCategory get category => QualityCategory.temperature;
 
@@ -99,12 +99,27 @@ class TempAnomalyDetector extends QualityDetector {
     if (scalar != null &&
         (scalar < QualityThresholds.waterTempMinC ||
             scalar > QualityThresholds.waterTempMaxC)) {
+      // The recorded water temperature is a single reading, so the same
+      // whole-channel plausibility test decides whether the wrong scale
+      // explains it -- and, because it is the exact condition re-tested
+      // above, guarantees the conversion clears this finding.
       out.add(
         make(
           ctx,
           discriminator: 'scalar',
           severity: QualitySeverity.warning,
-          params: {'waterTempC': scalar},
+          params: {
+            'waterTempC': scalar,
+            'fahrenheitAsKelvinSuspected':
+                scalar > 250 &&
+                RepairPredicates.convertedChannelIsPlausible([
+                  scalar,
+                ], kelvinScale: true),
+            'fahrenheitSuspected': RepairPredicates.convertedChannelIsPlausible(
+              [scalar],
+              kelvinScale: false,
+            ),
+          },
         ),
       );
     }

--- a/lib/features/data_quality/domain/repairs/quality_repair_action.dart
+++ b/lib/features/data_quality/domain/repairs/quality_repair_action.dart
@@ -75,6 +75,18 @@ class ConvertTemperatureRepair extends QualityRepairAction {
   final bool kelvinScale;
 }
 
+/// Reinterpret the dive's recorded water temperature on another scale. The
+/// sibling of [ConvertTemperatureRepair], which converts the sample channel;
+/// this one rewrites the single `dives.water_temp` value.
+class ConvertWaterTempRepair extends QualityRepairAction {
+  const ConvertWaterTempRepair({
+    required this.diveId,
+    required this.kelvinScale,
+  });
+  final String diveId;
+  final bool kelvinScale;
+}
+
 class RecomputeMetricsRepair extends QualityRepairAction {
   const RecomputeMetricsRepair(this.diveId);
   final String diveId;
@@ -221,6 +233,31 @@ List<QualityRepairAction> repairOptionsFor(QualityFinding f) {
       return [GoToDiveRepair(diveId)];
 
     case 'temp_anomaly':
+      // The scalar and range findings carry the same conversion flags, so
+      // dispatch on the shape first: `waterTempC` is the dive's recorded
+      // temperature, `minTempC`/`maxTempC` the sample channel.
+      if (p.containsKey('waterTempC')) {
+        if (p['fahrenheitAsKelvinSuspected'] == true) {
+          return [
+            ConvertWaterTempRepair(diveId: diveId, kelvinScale: true),
+            GoToDiveRepair(diveId),
+          ];
+        }
+        if (p['fahrenheitSuspected'] == true) {
+          return [
+            ConvertWaterTempRepair(diveId: diveId, kelvinScale: false),
+            GoToDiveRepair(diveId),
+          ];
+        }
+        return [GoToDiveRepair(diveId)];
+      }
+      if (p.containsKey('deltaC')) {
+        // A one-sided step survives smoothing, so it navigates instead.
+        if (p['spikeShaped'] == true) {
+          return [SmoothTemperatureRepair(diveId), GoToDiveRepair(diveId)];
+        }
+        return [GoToDiveRepair(diveId)];
+      }
       if (p['fahrenheitAsKelvinSuspected'] == true) {
         return [
           ConvertTemperatureRepair(diveId: diveId, kelvinScale: true),
@@ -232,13 +269,6 @@ List<QualityRepairAction> repairOptionsFor(QualityFinding f) {
           ConvertTemperatureRepair(diveId: diveId, kelvinScale: false),
           GoToDiveRepair(diveId),
         ];
-      }
-      if (p.containsKey('deltaC')) {
-        // A one-sided step survives smoothing, so it navigates instead.
-        if (p['spikeShaped'] == true) {
-          return [SmoothTemperatureRepair(diveId), GoToDiveRepair(diveId)];
-        }
-        return [GoToDiveRepair(diveId)];
       }
       return [GoToDiveRepair(diveId)];
 

--- a/lib/features/data_quality/domain/repairs/repair_predicates.dart
+++ b/lib/features/data_quality/domain/repairs/repair_predicates.dart
@@ -45,6 +45,12 @@ abstract final class RepairPredicates {
     return (c - a).abs() / 2 <= QualityThresholds.tempJumpPerSampleC;
   }
 
+  /// Reinterpret a reading stored as Celsius on the scale it was really
+  /// recorded on. The single definition behind both the plausibility test
+  /// and the conversion repairs, so what is checked is what is applied.
+  static double convertToCelsius(double t, {required bool kelvinScale}) =>
+      kelvinScale ? t - 273.15 : (t - 32) * 5 / 9;
+
   /// Whether reinterpreting a whole temperature channel on another scale
   /// lands every reading inside the plausible water-temperature range. Only
   /// then is a unit conversion the explanation for an out-of-range channel --
@@ -55,7 +61,7 @@ abstract final class RepairPredicates {
   }) {
     if (temps.isEmpty) return false;
     for (final t in temps) {
-      final c = kelvinScale ? t - 273.15 : (t - 32) * 5 / 9;
+      final c = convertToCelsius(t, kelvinScale: kelvinScale);
       if (c < QualityThresholds.waterTempMinC ||
           c > QualityThresholds.waterTempMaxC) {
         return false;

--- a/lib/features/data_quality/presentation/pages/data_quality_inbox_page.dart
+++ b/lib/features/data_quality/presentation/pages/data_quality_inbox_page.dart
@@ -229,6 +229,14 @@ class _DataQualityInboxPageState extends ConsumerState<DataQualityInboxPage> {
             ),
           ),
         );
+      case ConvertWaterTempRepair(:final diveId, :final kelvinScale):
+        await withUndo(
+          () => executor.convertWaterTemp(
+            diveId: diveId,
+            kelvinScale: kelvinScale,
+            findingId: f.id,
+          ),
+        );
       case RecomputeMetricsRepair(:final diveId):
         await withUndo(
           () => executor.recomputeMetrics(diveId: diveId, findingId: f.id),

--- a/lib/features/data_quality/presentation/widgets/quality_finding_card.dart
+++ b/lib/features/data_quality/presentation/widgets/quality_finding_card.dart
@@ -65,6 +65,7 @@ class _QualityFindingCardState extends State<QualityFindingCard> {
       FillGapsRepair() => l10n.dataQuality_repairLabel_fillGaps,
       SmoothTemperatureRepair() => l10n.dataQuality_repairLabel_smoothTemp,
       ConvertTemperatureRepair() => l10n.dataQuality_repairLabel_convertTemp,
+      ConvertWaterTempRepair() => l10n.dataQuality_repairLabel_convertTemp,
       RecomputeMetricsRepair() => l10n.dataQuality_repairLabel_recompute,
       SwapTankRecordPressuresRepair() =>
         l10n.dataQuality_repairLabel_swapPressures,
@@ -114,6 +115,33 @@ class _QualityFindingCardState extends State<QualityFindingCard> {
                   ),
             onTap: () => setState(() => _expanded = !_expanded),
           ),
+          // Some findings are a judgment call the app must not make for the
+          // diver, so no repair converges and the trailing button is absent.
+          // Say that plainly: an unexplained bare row reads as a broken
+          // button (issue #1035).
+          if (primary == null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.build_circle_outlined,
+                    size: 16,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      context.l10n.dataQuality_repair_needsReview,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           if (_expanded) ...[
             if (widget.evidence != null)
               Padding(

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "تراجع",
   "dataQuality_repair_applied": "تم تطبيق الإصلاح",
   "dataQuality_repair_noChange": "لا يوجد ما يمكن إصلاحه هنا",
+  "dataQuality_repair_needsReview": "لا يوجد إصلاح تلقائي. افتح الغطسة لتصحيح ذلك.",
   "dataQuality_repair_failed": "فشل الإصلاح",
   "dataQuality_chip_all": "الكل",
   "dataQuality_chip_time": "الوقت",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Rückgängig",
   "dataQuality_repair_applied": "Korrektur angewendet",
   "dataQuality_repair_noChange": "Hier gibt es nichts zu korrigieren",
+  "dataQuality_repair_needsReview": "Keine automatische Korrektur. Öffne den Tauchgang, um das zu beheben.",
   "dataQuality_repair_failed": "Korrektur fehlgeschlagen",
   "dataQuality_chip_all": "Alle",
   "dataQuality_chip_time": "Zeit",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15206,6 +15206,7 @@
   "dataQuality_action_undo": "Undo",
   "dataQuality_repair_applied": "Repair applied",
   "dataQuality_repair_noChange": "Nothing to repair here",
+  "dataQuality_repair_needsReview": "No automatic fix. Open the dive to correct this.",
   "dataQuality_repair_failed": "Repair failed",
   "dataQuality_chip_all": "All",
   "dataQuality_chip_time": "Time",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Deshacer",
   "dataQuality_repair_applied": "Corrección aplicada",
   "dataQuality_repair_noChange": "Aquí no hay nada que corregir",
+  "dataQuality_repair_needsReview": "Sin corrección automática. Abre la inmersión para corregirlo.",
   "dataQuality_repair_failed": "La corrección falló",
   "dataQuality_chip_all": "Todos",
   "dataQuality_chip_time": "Tiempo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Annuler",
   "dataQuality_repair_applied": "Correction appliquée",
   "dataQuality_repair_noChange": "Rien à corriger ici",
+  "dataQuality_repair_needsReview": "Pas de correction automatique. Ouvrez la plongée pour la corriger.",
   "dataQuality_repair_failed": "Échec de la correction",
   "dataQuality_chip_all": "Tous",
   "dataQuality_chip_time": "Heure",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "בטל",
   "dataQuality_repair_applied": "התיקון הוחל",
   "dataQuality_repair_noChange": "אין כאן מה לתקן",
+  "dataQuality_repair_needsReview": "אין תיקון אוטומטי. פתח את הצלילה כדי לתקן זאת.",
   "dataQuality_repair_failed": "התיקון נכשל",
   "dataQuality_chip_all": "הכול",
   "dataQuality_chip_time": "זמן",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Visszavonás",
   "dataQuality_repair_applied": "Javítás alkalmazva",
   "dataQuality_repair_noChange": "Itt nincs mit javítani",
+  "dataQuality_repair_needsReview": "Nincs automatikus javítás. Nyisd meg a merülést a javításhoz.",
   "dataQuality_repair_failed": "A javítás sikertelen",
   "dataQuality_chip_all": "Mind",
   "dataQuality_chip_time": "Idő",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Annulla",
   "dataQuality_repair_applied": "Correzione applicata",
   "dataQuality_repair_noChange": "Non c'è nulla da correggere",
+  "dataQuality_repair_needsReview": "Nessuna correzione automatica. Apri l'immersione per correggerla.",
   "dataQuality_repair_failed": "Correzione non riuscita",
   "dataQuality_chip_all": "Tutti",
   "dataQuality_chip_time": "Ora",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39811,6 +39811,12 @@ abstract class AppLocalizations {
   /// **'Nothing to repair here'**
   String get dataQuality_repair_noChange;
 
+  /// No description provided for @dataQuality_repair_needsReview.
+  ///
+  /// In en, this message translates to:
+  /// **'No automatic fix. Open the dive to correct this.'**
+  String get dataQuality_repair_needsReview;
+
   /// No description provided for @dataQuality_repair_failed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23429,6 +23429,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dataQuality_repair_noChange => 'لا يوجد ما يمكن إصلاحه هنا';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'لا يوجد إصلاح تلقائي. افتح الغطسة لتصحيح ذلك.';
+
+  @override
   String get dataQuality_repair_failed => 'فشل الإصلاح';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23809,6 +23809,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Hier gibt es nichts zu korrigieren';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Keine automatische Korrektur. Öffne den Tauchgang, um das zu beheben.';
+
+  @override
   String get dataQuality_repair_failed => 'Korrektur fehlgeschlagen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23449,6 +23449,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Nothing to repair here';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'No automatic fix. Open the dive to correct this.';
+
+  @override
   String get dataQuality_repair_failed => 'Repair failed';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23862,6 +23862,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Aquí no hay nada que corregir';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Sin corrección automática. Abre la inmersión para corregirlo.';
+
+  @override
   String get dataQuality_repair_failed => 'La corrección falló';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23921,6 +23921,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Rien à corriger ici';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Pas de correction automatique. Ouvrez la plongée pour la corriger.';
+
+  @override
   String get dataQuality_repair_failed => 'Échec de la correction';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23264,6 +23264,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get dataQuality_repair_noChange => 'אין כאן מה לתקן';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'אין תיקון אוטומטי. פתח את הצלילה כדי לתקן זאת.';
+
+  @override
   String get dataQuality_repair_failed => 'התיקון נכשל';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23767,6 +23767,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Itt nincs mit javítani';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Nincs automatikus javítás. Nyisd meg a merülést a javításhoz.';
+
+  @override
   String get dataQuality_repair_failed => 'A javítás sikertelen';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23846,6 +23846,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Non c\'è nulla da correggere';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Nessuna correzione automatica. Apri l\'immersione per correggerla.';
+
+  @override
   String get dataQuality_repair_failed => 'Correzione non riuscita';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23667,6 +23667,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Hier valt niets te herstellen';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Geen automatische correctie. Open de duik om dit te corrigeren.';
+
+  @override
   String get dataQuality_repair_failed => 'Herstel mislukt';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23847,6 +23847,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dataQuality_repair_noChange => 'Não há nada a corrigir aqui';
 
   @override
+  String get dataQuality_repair_needsReview =>
+      'Sem correção automática. Abra o mergulho para corrigir.';
+
+  @override
   String get dataQuality_repair_failed => 'Falha na correção';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22658,6 +22658,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dataQuality_repair_noChange => '这里没有需要修正的内容';
 
   @override
+  String get dataQuality_repair_needsReview => '无法自动修复。打开该次潜水进行更正。';
+
+  @override
   String get dataQuality_repair_failed => '修复失败';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Ongedaan maken",
   "dataQuality_repair_applied": "Herstel toegepast",
   "dataQuality_repair_noChange": "Hier valt niets te herstellen",
+  "dataQuality_repair_needsReview": "Geen automatische correctie. Open de duik om dit te corrigeren.",
   "dataQuality_repair_failed": "Herstel mislukt",
   "dataQuality_chip_all": "Alle",
   "dataQuality_chip_time": "Tijd",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "Desfazer",
   "dataQuality_repair_applied": "Correção aplicada",
   "dataQuality_repair_noChange": "Não há nada a corrigir aqui",
+  "dataQuality_repair_needsReview": "Sem correção automática. Abra o mergulho para corrigir.",
   "dataQuality_repair_failed": "Falha na correção",
   "dataQuality_chip_all": "Todos",
   "dataQuality_chip_time": "Hora",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -7171,6 +7171,7 @@
   "dataQuality_action_undo": "撤消",
   "dataQuality_repair_applied": "已应用修复",
   "dataQuality_repair_noChange": "这里没有需要修正的内容",
+  "dataQuality_repair_needsReview": "无法自动修复。打开该次潜水进行更正。",
   "dataQuality_repair_failed": "修复失败",
   "dataQuality_chip_all": "全部",
   "dataQuality_chip_time": "时间",

--- a/test/features/data_quality/domain/detectors/temp_pressure_detectors_test.dart
+++ b/test/features/data_quality/domain/detectors/temp_pressure_detectors_test.dart
@@ -66,6 +66,33 @@ void main() {
       expect(out, hasLength(1));
       expect(out.single.params['waterTempC'], 99);
     });
+
+    // The scalar finding carries the same conversion facts the sample-channel
+    // finding does, so `repairOptionsFor` can offer a one-tap fix for a
+    // water temperature that was recorded on the wrong scale.
+    test('scalar waterTemp of 78 reads as Fahrenheit', () {
+      // 78 F is 25.6 C -- plausible water, so the scale is the explanation.
+      final ctx = makeContext(dive: makeTestDive(waterTemp: 78));
+      final params = det.detect(ctx).single.params;
+      expect(params['fahrenheitSuspected'], true);
+      expect(params['fahrenheitAsKelvinSuspected'], false);
+    });
+
+    test('scalar waterTemp of 297 reads as Fahrenheit-as-Kelvin', () {
+      // 297 K is 23.9 C; read as Fahrenheit it would be 147 C.
+      final ctx = makeContext(dive: makeTestDive(waterTemp: 297));
+      final params = det.detect(ctx).single.params;
+      expect(params['fahrenheitAsKelvinSuspected'], true);
+      expect(params['fahrenheitSuspected'], false);
+    });
+
+    test('scalar waterTemp of -50 suspects no scale', () {
+      // No reinterpretation lands in range, so no automatic repair is offered.
+      final ctx = makeContext(dive: makeTestDive(waterTemp: -50));
+      final params = det.detect(ctx).single.params;
+      expect(params['fahrenheitSuspected'], false);
+      expect(params['fahrenheitAsKelvinSuspected'], false);
+    });
   });
 
   group('PressureAnomalyDetector', () {

--- a/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
+++ b/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
@@ -726,6 +726,43 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 6));
   });
 
+  testWidgets('scalar water-temp repair converts the dive and can undo', (
+    tester,
+  ) async {
+    // 78 recorded as Celsius is 25.6 C read as Fahrenheit.
+    await DiveRepository().createDive(
+      domain.Dive(id: 'd1', dateTime: DateTime.utc(2026, 7, 1), waterTemp: 78),
+    );
+    final prefs = await _prefs();
+    await tester.pumpWidget(
+      _scope(
+        prefs,
+        findings: [
+          _f(
+            id: 'r-temp-scalar',
+            detectorId: 'temp_anomaly',
+            category: QualityCategory.temperature,
+            params: const {'waterTempC': 78.0, 'fahrenheitSuspected': true},
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FilledButton).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Repair applied'), findsOneWidget);
+    expect(
+      (await DiveRepository().getDiveById('d1'))!.waterTemp,
+      closeTo(25.5556, 1e-3),
+    );
+
+    await tester.tap(find.text('Undo'));
+    await tester.pumpAndSettle(const Duration(seconds: 6));
+    expect((await DiveRepository().getDiveById('d1'))!.waterTemp, 78);
+  });
+
   testWidgets('consolidate-duplicate repair reports through a SnackBar', (
     tester,
   ) async {

--- a/test/features/data_quality/presentation/quality_finding_card_test.dart
+++ b/test/features/data_quality/presentation/quality_finding_card_test.dart
@@ -203,6 +203,64 @@ void main() {
     });
   });
 
+  group('no-automatic-fix note', () {
+    // A card with no repair button used to render as a bare row, which reads
+    // as a broken button rather than a deliberate judgment call (issue #1035).
+    testWidgets('explains itself when the only option is go-to-dive', (
+      tester,
+    ) async {
+      await pumpCard(
+        tester,
+        finding: _finding(
+          detectorId: 'gas_mod',
+          params: const {'o2Percent': 10},
+        ),
+      );
+      expect(find.byIcon(Icons.build_circle_outlined), findsOneWidget);
+    });
+
+    testWidgets('absent when a repair is offered', (tester) async {
+      await pumpCard(tester, finding: _finding());
+      expect(find.byIcon(Icons.build_circle_outlined), findsNothing);
+    });
+
+    testWidgets('shown for a temperature step that cannot be smoothed', (
+      tester,
+    ) async {
+      await pumpCard(
+        tester,
+        finding: _finding(
+          detectorId: 'temp_anomaly',
+          params: const {'deltaC': 9.0, 'spikeShaped': false},
+        ),
+      );
+      expect(find.byIcon(Icons.build_circle_outlined), findsOneWidget);
+    });
+  });
+
+  group('scalar water temperature repair', () {
+    testWidgets('a Fahrenheit reading offers a one-tap conversion', (
+      tester,
+    ) async {
+      final repaired = <QualityRepairAction>[];
+      await pumpCard(
+        tester,
+        finding: _finding(
+          detectorId: 'temp_anomaly',
+          params: const {'waterTempC': 78.0, 'fahrenheitSuspected': true},
+        ),
+        onRepair: repaired.add,
+      );
+
+      expect(find.byIcon(Icons.build_circle_outlined), findsNothing);
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+      final action = repaired.single as ConvertWaterTempRepair;
+      expect(action.diveId, 'd1');
+      expect(action.kelvinScale, isFalse);
+    });
+  });
+
   group('footer actions when expanded', () {
     testWidgets('go-to-dive button invokes callback with dive id', (
       tester,

--- a/test/features/data_quality/presentation/quality_finding_card_test.dart
+++ b/test/features/data_quality/presentation/quality_finding_card_test.dart
@@ -224,6 +224,30 @@ void main() {
       expect(find.byIcon(Icons.build_circle_outlined), findsNothing);
     });
 
+    testWidgets('announces the message and nothing for the icon', (
+      tester,
+    ) async {
+      // Icon wraps its glyph in ExcludeSemantics and only contributes a label
+      // when semanticLabel is set, so the decorative icon stays silent and the
+      // text carries the meaning.
+      final handle = tester.ensureSemantics();
+      await pumpCard(
+        tester,
+        finding: _finding(
+          detectorId: 'gas_mod',
+          params: const {'o2Percent': 10},
+        ),
+      );
+
+      // The tappable ListTile merges the card into one node, so assert on the
+      // merged label rather than looking for a node of the note's own.
+      final label = tester.getSemantics(find.byType(QualityFindingCard)).label;
+      expect(label, contains('No automatic fix.'));
+      expect(label, isNot(contains('build_circle')));
+      expect(label, isNot(contains('info_outline')));
+      handle.dispose();
+    });
+
     testWidgets('shown for a temperature step that cannot be smoothed', (
       tester,
     ) async {

--- a/test/features/data_quality/repairs/quality_repair_executor_test.dart
+++ b/test/features/data_quality/repairs/quality_repair_executor_test.dart
@@ -318,6 +318,52 @@ void main() {
       expect((await diveRepo.getDiveById('d1'))!.waterTemp, 78);
     });
 
+    test('refuses a scale that does not land the reading in range', () async {
+      // -50 read as Fahrenheit is -45.6 C: still implausible, so converting
+      // would resolve a finding the next scan reopens.
+      await diveRepo.createDive(
+        domain.Dive(
+          id: 'd1',
+          dateTime: DateTime.utc(2026, 7, 1),
+          waterTemp: -50,
+        ),
+      );
+      final finding = await seedFindingForDive('d1');
+
+      final result = await executor.convertWaterTemp(
+        diveId: 'd1',
+        kelvinScale: false,
+        findingId: finding.id,
+      );
+
+      expect(result.changed, isFalse);
+      expect((await diveRepo.getDiveById('d1'))!.waterTemp, -50);
+      expect(await statusOf('d1'), QualityStatus.open);
+    });
+
+    test('refuses when the dive was corrected between scan and tap', () async {
+      // The finding was raised against a bad value, but the diver fixed it by
+      // hand first. Converting a plausible 25 C would turn it into -3.9 C.
+      await diveRepo.createDive(
+        domain.Dive(
+          id: 'd1',
+          dateTime: DateTime.utc(2026, 7, 1),
+          waterTemp: 25,
+        ),
+      );
+      final finding = await seedFindingForDive('d1');
+
+      final result = await executor.convertWaterTemp(
+        diveId: 'd1',
+        kelvinScale: false,
+        findingId: finding.id,
+      );
+
+      expect(result.changed, isFalse);
+      expect((await diveRepo.getDiveById('d1'))!.waterTemp, 25);
+      expect(await statusOf('d1'), QualityStatus.open);
+    });
+
     test('converts a Fahrenheit-as-Kelvin reading', () async {
       await diveRepo.createDive(
         domain.Dive(

--- a/test/features/data_quality/repairs/quality_repair_executor_test.dart
+++ b/test/features/data_quality/repairs/quality_repair_executor_test.dart
@@ -265,6 +265,82 @@ void main() {
     });
   });
 
+  group('convertWaterTemp', () {
+    test('reports no change when the dive is missing', () async {
+      final result = await executor.convertWaterTemp(
+        diveId: 'ghost',
+        kelvinScale: false,
+        findingId: 'irrelevant',
+      );
+      expect(result.changed, isFalse);
+    });
+
+    test('reports no change when the dive has no water temperature', () async {
+      await diveRepo.createDive(
+        domain.Dive(id: 'd1', dateTime: DateTime.utc(2026, 7, 1)),
+      );
+      final finding = await seedFindingForDive('d1');
+
+      final result = await executor.convertWaterTemp(
+        diveId: 'd1',
+        kelvinScale: false,
+        findingId: finding.id,
+      );
+
+      expect(result.changed, isFalse);
+      expect(await statusOf('d1'), QualityStatus.open);
+    });
+
+    test('converts Fahrenheit to Celsius and undo restores prior', () async {
+      await diveRepo.createDive(
+        domain.Dive(
+          id: 'd1',
+          dateTime: DateTime.utc(2026, 7, 1),
+          waterTemp: 78,
+        ),
+      );
+      final finding = await seedFindingForDive('d1');
+
+      final result = await executor.convertWaterTemp(
+        diveId: 'd1',
+        kelvinScale: false,
+        findingId: finding.id,
+      );
+
+      expect(result.changed, isTrue);
+      expect(
+        (await diveRepo.getDiveById('d1'))!.waterTemp,
+        closeTo(25.5556, 1e-3),
+      );
+      expect(await statusOf('d1'), QualityStatus.resolved);
+
+      await result.undo!();
+      expect((await diveRepo.getDiveById('d1'))!.waterTemp, 78);
+    });
+
+    test('converts a Fahrenheit-as-Kelvin reading', () async {
+      await diveRepo.createDive(
+        domain.Dive(
+          id: 'd1',
+          dateTime: DateTime.utc(2026, 7, 1),
+          waterTemp: 297,
+        ),
+      );
+      final finding = await seedFindingForDive('d1');
+
+      await executor.convertWaterTemp(
+        diveId: 'd1',
+        kelvinScale: true,
+        findingId: finding.id,
+      );
+
+      expect(
+        (await diveRepo.getDiveById('d1'))!.waterTemp,
+        closeTo(23.85, 1e-3),
+      );
+    });
+  });
+
   test(
     'swapTankRecordPressures writes swapped values, undo restores',
     () async {

--- a/test/features/data_quality/repairs/repair_convergence_test.dart
+++ b/test/features/data_quality/repairs/repair_convergence_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/data_quality/domain/detectors/temp_anomaly_d
 import 'package:submersion/features/data_quality/domain/entities/dive_quality_context.dart';
 import 'package:submersion/features/data_quality/domain/entities/quality_finding.dart';
 import 'package:submersion/features/data_quality/domain/repairs/quality_repair_action.dart';
+import 'package:submersion/features/data_quality/domain/repairs/repair_predicates.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
 
@@ -211,6 +212,45 @@ void main() {
       expect(findings.single.params['fahrenheitSuspected'], isFalse);
       expect(findings.single.params['fahrenheitAsKelvinSuspected'], isFalse);
       expect(offeredRepair(findings.single), isNull);
+    });
+
+    /// The scalar repair rewrites `dives.water_temp` rather than the sample
+    /// channel, so it converges through the dive instead of `repairAndRedetect`.
+    List<QualityFinding>? repairScalarAndRedetect(double waterTemp) {
+      List<QualityFinding> run(double t) => const TempAnomalyDetector()
+          .detect(makeContext(dive: makeTestDive(waterTemp: t)))
+          .where((f) => f.params.containsKey('waterTempC'))
+          .toList();
+
+      final before = run(waterTemp);
+      expect(before, isNotEmpty, reason: 'test vector must trip the detector');
+      final action = repairOptionsFor(
+        before.single,
+      ).whereType<ConvertWaterTempRepair>().firstOrNull;
+      if (action == null) return null;
+      return run(
+        RepairPredicates.convertToCelsius(
+          waterTemp,
+          kelvinScale: action.kelvinScale,
+        ),
+      );
+    }
+
+    test('the offered repair clears a Fahrenheit water temperature', () {
+      final after = repairScalarAndRedetect(78);
+      expect(after, isNotNull, reason: 'a unit error must be repairable');
+      expect(after, isEmpty);
+    });
+
+    test('the offered repair clears a Fahrenheit-as-Kelvin temperature', () {
+      final after = repairScalarAndRedetect(297);
+      expect(after, isNotNull, reason: 'a unit error must be repairable');
+      expect(after, isEmpty);
+    });
+
+    test('an unexplainable water temperature is offered no repair', () {
+      // No reinterpretation lands -50 in range, so nothing is offered.
+      expect(repairScalarAndRedetect(-50), isNull);
     });
   });
 

--- a/test/features/data_quality/repairs/repair_mapping_test.dart
+++ b/test/features/data_quality/repairs/repair_mapping_test.dart
@@ -225,11 +225,76 @@ void main() {
       expect(actions.single, isA<GoToDiveRepair>());
     });
 
-    test('scalar water temp gets navigation only', () {
+    test('a scalar water temp stored before the rescan navigates', () {
+      // Written by detector v2, which reported no conversion facts; the
+      // finding stays navigation-only until a rescan fills them in.
       final actions = repairOptionsFor(
         f(detectorId: 'temp_anomaly', params: {'waterTempC': 60.0}),
       );
       expect(actions.single, isA<GoToDiveRepair>());
+    });
+
+    test('a Fahrenheit scalar water temp offers a scalar conversion', () {
+      final actions = repairOptionsFor(
+        f(
+          detectorId: 'temp_anomaly',
+          params: {'waterTempC': 78.0, 'fahrenheitSuspected': true},
+        ),
+      );
+      final c = actions.whereType<ConvertWaterTempRepair>().single;
+      expect(c.kelvinScale, isFalse);
+      expect(c.diveId, 'd1');
+      // The dive's recorded temperature is not a sample channel.
+      expect(actions.whereType<ConvertTemperatureRepair>(), isEmpty);
+    });
+
+    test(
+      'a Fahrenheit-as-Kelvin scalar water temp offers a kelvin conversion',
+      () {
+        final actions = repairOptionsFor(
+          f(
+            detectorId: 'temp_anomaly',
+            params: {
+              'waterTempC': 297.0,
+              'fahrenheitAsKelvinSuspected': true,
+              'fahrenheitSuspected': false,
+            },
+          ),
+        );
+        final c = actions.whereType<ConvertWaterTempRepair>().single;
+        expect(c.kelvinScale, isTrue);
+      },
+    );
+
+    test('an unexplainable scalar water temp navigates', () {
+      final actions = repairOptionsFor(
+        f(
+          detectorId: 'temp_anomaly',
+          params: {
+            'waterTempC': -50.0,
+            'fahrenheitSuspected': false,
+            'fahrenheitAsKelvinSuspected': false,
+          },
+        ),
+      );
+      expect(actions.single, isA<GoToDiveRepair>());
+    });
+
+    test('a range finding still routes to the sample-channel conversion', () {
+      // The scalar and range findings now carry the same conversion flags,
+      // so the mapping must dispatch on the shape, not on the flags.
+      final actions = repairOptionsFor(
+        f(
+          detectorId: 'temp_anomaly',
+          params: {
+            'minTempC': 60.0,
+            'maxTempC': 80.0,
+            'fahrenheitSuspected': true,
+          },
+        ),
+      );
+      expect(actions.whereType<ConvertTemperatureRepair>(), hasLength(1));
+      expect(actions.whereType<ConvertWaterTempRepair>(), isEmpty);
     });
 
     test('a Fahrenheit channel offers a non-kelvin conversion', () {


### PR DESCRIPTION
Fixes #1035.

## The report

> Under data quality, the button to clean up the data record is missing. I have currently only found this behavior at temperature.

## Root cause

Not a regression. The convergence contract from #1001 says a repair is only offered when applying it provably clears the finding; offering nothing is the deliberate escape hatch. That escape hatch had **no UI**: `QualityFindingCard` filters `GoToDiveRepair` out of the action list and renders the trailing button only if something remains, so "no automatic fix by design" and "the button is broken" looked identical.

Temperature hits it hardest, because two of its three finding shapes can land there and the third never had a repair at all:

| Shape | Before | After |
| --- | --- | --- |
| `range` (sample channel out of range) | convert only if a whole-channel F to C or K to C lands in range | unchanged, now explained when it does not |
| `jump:` (step over 5 C) | smooth only if the outlier is spike-shaped | unchanged, now explained when it does not |
| `scalar` (`dives.water_temp`) | **never any repair** | one-tap conversion when a scale explains it |

The scalar gap was real. `ConvertTemperatureRepair` only ever rewrote the profile sample series, so a dive whose recorded water temperature was Fahrenheit could not be corrected from the inbox at all.

## Changes

1. **New converging scalar repair.** `TempAnomalyDetector` emits `fahrenheitSuspected` / `fahrenheitAsKelvinSuspected` on the scalar finding by running `convertedChannelIsPlausible` over a one-element channel. Convergence is guaranteed by construction: the predicate asserts exactly the range the detector re-tests. `ConvertWaterTempRepair` routes to `QualityRepairExecutor.convertWaterTemp`, writing the column through `bulkUpdateFields` (the sync-visible scalar path already used by `recomputeMetrics`' undo) and undoing through the same helper, so an undone repair cannot keep winning on other devices. Returns `RepairResult.noChange()` when the dive or its temperature is absent, or when the value would not move.
2. **Shape-first dispatch** in `repairOptionsFor`. The scalar and range findings now carry identical conversion flags, so the previous flag-first order would have routed a scalar finding into a profile repair.
3. **"No automatic fix" note** on every button-less card, rendered below the tile rather than in `trailing` so it does not starve the title. Also covers `gas_mod` and the one-sided temperature step. One new ARB key across all 11 locales.
4. **`temp_anomaly` version 2 to 3**, so existing installs get the "new checks available" banner and its Rescan backfills the scalar params. The version vector is derived from `kQualityDetectors`, so the bump is the whole migration. Findings stored at v2 stay navigation-only until that rescan, the same convention `sample_gap` uses for `fillableGapCount`.
5. **Refactor:** `RepairPredicates.convertToCelsius` is now the single definition of the Fahrenheit and Kelvin conversion, shared by the plausibility predicate, `ProfileRepairService.convertTemperature`, and the executor, so what is checked is what is applied.

No schema change.

## Tests

Written test-first; each was watched failing for the expected reason before implementing.

- `temp_pressure_detectors_test` - scalar params for a Fahrenheit reading, a Fahrenheit-as-Kelvin reading, and one no scale explains
- `repair_mapping_test` - scalar routes to `ConvertWaterTempRepair` and never to the profile repair; an unexplainable scalar navigates; a pre-rescan scalar navigates; a range finding still routes to the sample-channel conversion
- `repair_convergence_test` - applying the offered scalar repair clears the finding, on both scales, and nothing is offered when no scale explains the value
- `quality_repair_executor_test` - apply, undo, and the two no-change paths
- `quality_finding_card_test` - the note appears when no repair is offered and is absent when one is, plus the scalar repair button dispatching the right action

## Verification

`flutter analyze` clean, `dart format` clean.

- `data_quality` 295, `l10n` 74, `dive_log` + `l10n` 2709, `planner` 269 - all pass
- Full suite: 18,315 pass, 17 skipped, 3 fail

The three failures are unrelated to this diff and all pass in isolation (33/33 together):

- `security_settings_page_test` "requires the password, then shows a code that unlocks" is a known pre-existing full-suite flake, where Argon2id verification outruns `settle()` under CPU contention.
- `saved_plans_sheet_test` (2 cases) throw `showSnackBar ... no descendant Scaffolds` after the test has completed, alongside drift "created AppDatabase multiple times" warnings, which is a leaked async continuation from a neighbouring test file. `lib/features/planner/` has no `data_quality` imports, so there is no code path from this diff. Noting for transparency that no main baseline run was done, so this is strong evidence rather than proof.
