### PR TITLE
flutter_secure_storage 11 and permission_handler 13, via compileSdk 37

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -629,6 +629,14 @@ jobs:
           perl -pi -e 's/^(version:\s*[0-9]+\.[0-9]+\.[0-9]+)\+[0-9]+/${1}+$ENV{BUILD_NUMBER}/' pubspec.yaml
           grep '^version:' pubspec.yaml
 
+      # flutter_secure_storage 11 hardcodes compileSdk 37 in its own module,
+      # so the app compiles against 37 too (android/app/build.gradle.kts).
+      # Installed explicitly rather than left to Gradle's auto-download: the
+      # runner image only preinstalls a few platforms, and a missing one fails
+      # late with an opaque "failed to find target with hash string" error.
+      - name: Install Android SDK platform 37
+        run: sdkmanager --install "platforms;android-37.0"
+
       - name: Setup Android signing
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -635,7 +635,19 @@ jobs:
       # runner image only preinstalls a few platforms, and a missing one fails
       # late with an opaque "failed to find target with hash string" error.
       - name: Install Android SDK platform 37
-        run: sdkmanager --install "platforms;android-37.0"
+        run: |
+          # sdkmanager is not on PATH on the runner image; it lives under
+          # $ANDROID_HOME/cmdline-tools/<version>/bin. Located rather than
+          # hardcoded so a runner-image reshuffle fails loudly here instead
+          # of surfacing later as a confusing Gradle error.
+          sdkmanager="$(find "${ANDROID_HOME:-$ANDROID_SDK_ROOT}/cmdline-tools" \
+            -name sdkmanager -type f 2>/dev/null | head -1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::error::sdkmanager not found under ANDROID_HOME=$ANDROID_HOME"
+            exit 1
+          fi
+          echo "Using $sdkmanager"
+          "$sdkmanager" --install "platforms;android-37.0" < /dev/null
 
       - name: Setup Android signing
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -779,7 +779,19 @@ jobs:
       # runner image only preinstalls a few platforms, and a missing one fails
       # late with an opaque "failed to find target with hash string" error.
       - name: Install Android SDK platform 37
-        run: sdkmanager --install "platforms;android-37.0"
+        run: |
+          # sdkmanager is not on PATH on the runner image; it lives under
+          # $ANDROID_HOME/cmdline-tools/<version>/bin. Located rather than
+          # hardcoded so a runner-image reshuffle fails loudly here instead
+          # of surfacing later as a confusing Gradle error.
+          sdkmanager="$(find "${ANDROID_HOME:-$ANDROID_SDK_ROOT}/cmdline-tools" \
+            -name sdkmanager -type f 2>/dev/null | head -1)"
+          if [ -z "$sdkmanager" ]; then
+            echo "::error::sdkmanager not found under ANDROID_HOME=$ANDROID_HOME"
+            exit 1
+          fi
+          echo "Using $sdkmanager"
+          "$sdkmanager" --install "platforms;android-37.0" < /dev/null
 
       - name: Disable Swift Package Manager (project uses CocoaPods)
         run: flutter config --no-enable-swift-package-manager

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -773,6 +773,14 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      # flutter_secure_storage 11 hardcodes compileSdk 37 in its own module,
+      # so the app compiles against 37 too (android/app/build.gradle.kts).
+      # Installed explicitly rather than left to Gradle's auto-download: the
+      # runner image only preinstalls a few platforms, and a missing one fails
+      # late with an opaque "failed to find target with hash string" error.
+      - name: Install Android SDK platform 37
+        run: sdkmanager --install "platforms;android-37.0"
+
       - name: Disable Swift Package Manager (project uses CocoaPods)
         run: flutter config --no-enable-swift-package-manager
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,7 +14,12 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "app.submersion"
-    compileSdk = flutter.compileSdkVersion
+    // Pinned above Flutter 3.47's default (36) because flutter_secure_storage
+    // 11 hardcodes `compileSdk = 37` in its own module, and Gradle refuses to
+    // build an app compiled against an older API than a library it consumes.
+    // Bumping here rather than waiting on flutter.compileSdkVersion also
+    // unblocks permission_handler 13, which demands the same.
+    compileSdk = 37
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -15,40 +15,9 @@ PODS:
     - Flutter
   - device_info_plus (0.0.1):
     - Flutter
-  - DKImagePickerController/Core (4.3.9):
-    - DKImagePickerController/ImageDataManager
-    - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.9)
-  - DKImagePickerController/PhotoGallery (4.3.9):
-    - DKImagePickerController/Core
-    - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.9)
-  - DKPhotoGallery (0.0.19):
-    - DKPhotoGallery/Core (= 0.0.19)
-    - DKPhotoGallery/Model (= 0.0.19)
-    - DKPhotoGallery/Preview (= 0.0.19)
-    - DKPhotoGallery/Resource (= 0.0.19)
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Core (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Preview
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Model (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.19):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Resource
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.19):
-    - SDWebImage
-    - SwiftyGif
-  - file_picker (0.0.1):
-    - DKImagePickerController/PhotoGallery
+  - file_picker_darwin (1.0.0):
     - Flutter
+    - FlutterMacOS
   - Flutter (1.0.0)
   - flutter_contacts (0.0.1):
     - Flutter
@@ -95,7 +64,7 @@ PODS:
   - GTMSessionFetcher/Core (3.5.0)
   - GTMSessionFetcher/Full (3.5.0):
     - GTMSessionFetcher/Core
-  - health (13.3.1):
+  - health (13.3.2):
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
@@ -127,9 +96,6 @@ PODS:
   - PromisesObjC (2.4.0)
   - receive_sharing_intent (1.8.1):
     - Flutter
-  - SDWebImage (5.21.7):
-    - SDWebImage/Core (= 5.21.7)
-  - SDWebImage/Core (5.21.7)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -144,7 +110,6 @@ PODS:
   - submersion_transcoder (0.1.0):
     - Flutter
     - FlutterMacOS
-  - SwiftyGif (5.4.5)
   - url_launcher_ios (0.0.1):
     - Flutter
   - video_player_avfoundation (0.0.1):
@@ -157,7 +122,7 @@ DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - cryptography_flutter (from `.symlinks/plugins/cryptography_flutter/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
-  - file_picker (from `.symlinks/plugins/file_picker/ios`)
+  - file_picker_darwin (from `.symlinks/plugins/file_picker_darwin/darwin`)
   - Flutter (from `Flutter`)
   - flutter_contacts (from `.symlinks/plugins/flutter_contacts/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
@@ -193,16 +158,12 @@ SPEC REPOS:
   trunk:
     - AppAuth
     - AppCheckCore
-    - DKImagePickerController
-    - DKPhotoGallery
     - GoogleSignIn
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
     - ObjectBox
     - PromisesObjC
-    - SDWebImage
-    - SwiftyGif
 
 EXTERNAL SOURCES:
   connectivity_plus:
@@ -211,8 +172,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/cryptography_flutter/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/ios"
+  file_picker_darwin:
+    :path: ".symlinks/plugins/file_picker_darwin/darwin"
   Flutter:
     :path: Flutter
   flutter_contacts:
@@ -280,13 +241,11 @@ SPEC CHECKSUMS:
   connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   cryptography_flutter: 4868d92d3e47f91f0bc321e63e6fa0387f365f11
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
-  DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
-  DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker_darwin: 65c8ed1d70cc2ea0b81ae1840db93f8d9c051d19
   Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
   flutter_contacts: 2ec1d6b62ca2869c3bbb3871bd74d4e3ef157135
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_secure_storage_darwin: 46e401699982ee74142909676535e0f6a7321e58
   flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
   gal: baecd024ebfd13c441269ca7404792a7152fde89
   geocoding_darwin: 968545604e6896deeef55517d53a81b3b9801971
@@ -296,7 +255,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
+  health: 72947bca89ee7906256d6f650db061ca4b2f92c7
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   libdivecomputer_plugin: d7dd76c5ddfeb51f879e840f21f9e0eb13176d76
@@ -311,13 +270,11 @@ SPEC CHECKSUMS:
   printing: a8960104e6c1a2b4bd3483a2f79c69be60830d08
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
-  SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   submersion_ocr: c16e8aa86fee22293c92688fcf97c5293b6b159f
   submersion_transcoder: c0bc7bb59ce039c73dcd24cb7797b390cfd2dab6
-  SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
   workmanager_apple: 1fc2a64e6a63ed3540fbb91b65f0c0d501881248

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -22,7 +22,8 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - FlutterMacOS
-  - file_picker (0.0.1):
+  - file_picker_darwin (1.0.0):
+    - Flutter
     - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
@@ -124,7 +125,7 @@ DEPENDENCIES:
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - desktop_webview_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos`)
   - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
+  - file_picker_darwin (from `Flutter/ephemeral/.symlinks/plugins/file_picker_darwin/darwin`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - flutter_contacts (from `Flutter/ephemeral/.symlinks/plugins/flutter_contacts/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
@@ -177,8 +178,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos
   device_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
+  file_picker_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker_darwin/darwin
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   flutter_contacts:
@@ -241,11 +242,11 @@ SPEC CHECKSUMS:
   desktop_drop: 10a3e6a7fa9dbe350541f2574092fecfa345a07b
   desktop_webview_window: 07ec5b575166556b3b9c96c5b7c962b2c044b452
   device_info_plus: 4fb280989f669696856f8b129e4a5e3cd6c48f76
-  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  file_picker_darwin: 65c8ed1d70cc2ea0b81ae1840db93f8d9c051d19
   file_selector_macos: 9e9e068e90ebee155097d00e89ae91edb2374db7
   flutter_contacts: 6f45cdf49f4fb2241793263546f823f7e812668e
   flutter_local_notifications: 1fc7ffb10a83d6a2eeeeddb152d43f1944b0aad0
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_secure_storage_darwin: 46e401699982ee74142909676535e0f6a7321e58
   flutter_web_auth_2: 7fe624ff12ddcb4c19e5dbcd56c9e9ea4899d967
   FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
   gal: baecd024ebfd13c441269ca7404792a7152fde89

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -747,18 +747,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      sha256: "15e8c8fe269fdf7d469b23008ab3df521c8b826ed345820532364c31bdebace6"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "11.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      sha256: ac6d76a752de0cd738334eb4b21743fc4943f449f5b6e308f18838b048c02ac0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -1606,18 +1606,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
+      sha256: e7317eb2eb611d1bf0386b6b974be9c50449f975f19a90a7b8ea013550302b30
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.3"
+    version: "13.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      sha256: d7676c6fcf2f0b92537ec41476a6ead45a00b0d8bbb852395a6f9f33f49d6242
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.1"
+    version: "14.0.0"
   permission_handler_apple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,7 @@ dependencies:
     path: packages/submersion_ocr
   submersion_transcoder:
     path: packages/submersion_transcoder
-  permission_handler: ^12.0.1
+  permission_handler: ^13.0.1
   file_picker: ^12.0.0
   image_picker: ^1.1.2
   share_plus: ^13.3.0
@@ -94,7 +94,21 @@ dependencies:
 
   # Storage
   shared_preferences: ^2.3.2
-  flutter_secure_storage: ^10.0.0
+  # v11 removed the legacy Android ciphers (RSA_ECB_PKCS1Padding,
+  # AES_CBC_PKCS7Padding). v10 rewrites existing entries to the new ciphers on
+  # first access (migrateOnAlgorithmChange defaults to true, and we pass no
+  # AndroidOptions), so anyone who has run a v10 build is already migrated.
+  # A user who skips v10 entirely -- last ran a pre-2026-06-21 build, then
+  # jumps here -- loses the Android entries. That degrades rather than
+  # destroys: every secret in this store is a CACHE or MIRROR whose durable
+  # copy lives elsewhere (the database sidecar, the self-decrypting .sbe, the
+  # cloud keyslot file), so the worst case is the lock screen asking for the
+  # passphrase and cloud accounts needing re-auth. Apple/Windows/Linux are
+  # untouched: everything v11 removed is Android-only.
+  #
+  # Costs compileSdk 37, which the module hardcodes -- see
+  # android/app/build.gradle.kts.
+  flutter_secure_storage: ^11.0.0
 
   # PDF/Printing
   printing: ^5.14.2
@@ -151,7 +165,7 @@ dev_dependencies:
   mockito: ^5.6.1
   plugin_platform_interface: ^2.1.8
   path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests
-  permission_handler_platform_interface: ^4.3.0  # mock BLE scan permission grants
+  permission_handler_platform_interface: ^4.4.0  # mock BLE scan permission grants
   file_picker_platform_interface: ^3.0.1  # fake picker in file/import tests
   geocoding_platform_interface: ^5.0.0  # fake geocoder in location service tests
   flutter_web_auth_2_platform_interface: ^5.0.0  # mock auth in redirect-capture test


### PR DESCRIPTION
Clears the last two parked dependency upgrades. They were parked for what looked like two separate reasons; they turn out to share one blocker, and it is neither of the ones previously recorded.

| | from | to |
| --- | --- | --- |
| `flutter_secure_storage` | 10.3.1 | 11.0.0 |
| `permission_handler` | 12.0.3 | 13.0.1 |

## The whole cost is `compileSdk 37`

Each package hardcodes `compileSdk = 37` in its own Android module, and Gradle refuses to build an app compiled against an older API than a library it consumes. So `android/app/build.gradle.kts` pins compileSdk 37 rather than following `flutter.compileSdkVersion` (36 on Flutter 3.47). `platforms;android-37.0` is on the **stable** sdkmanager channel, not a preview.

Nothing else moved:

- **AGP 8.11.1, Gradle 8.14, Kotlin 2.2.20 untouched.** The deliberate floors documented in `settings.gradle.kts` still stand, and AGP raises nothing whatsoever about compileSdk 37.
- **No Dart changes.** `flutter analyze` is clean, because the app only ever constructs a bare `const FlutterSecureStorage()` and never referenced the `AndroidOptions` v11 removed.

## Two earlier assessments corrected

**permission_handler does not force an AGP 9 / Kotlin 2.4 migration.** `permission_handler_android` 14 really does declare `classpath("com.android.tools.build:gradle:9.0.1")`, which is why it was written off twice. In a Flutter app that buildscript block is vestigial: the plugin loader applies the root project's AGP to every plugin module. Same lesson `connectivity_plus` taught when its docs claimed an AGP 8.12.1 requirement.

**The flutter_secure_storage data risk was overstated.** v11 removes the legacy Android ciphers, and v10 rewrites existing entries to the new ones on first access (`migrateOnAlgorithmChange` defaults true, and we pass no `AndroidOptions`), so anyone who has run a v10 build is already migrated. Someone who skips v10 entirely does lose the Android entries, but every secret in that store is a **cache or mirror** whose durable copy lives elsewhere:

| secret | durable copy |
| --- | --- |
| database key | the sidecar file beside the database |
| backup key | inside each `.sbe`, which is self-decrypting |
| sync key | the cloud keyslot file |
| cloud credentials | re-authenticate |

so the worst case is the existing lock screen asking for a passphrase, not lost data. Apple, Windows and Linux are untouched: everything v11 removed lives in `android_options.dart`. That reasoning is recorded next to the dependency in `pubspec.yaml` so this does not get re-parked on the alarming reading.

## CI

Both Android-building workflows (`ci.yaml`, `build-all.yml`) now install the platform explicitly rather than relying on runner preinstalls or Gradle auto-download, which fails late with an opaque "failed to find target with hash string".

`ios/Podfile.lock` also picks up a correction that belongs to #1116: file_picker 12 split into `file_picker_darwin` and dropped `DKImagePickerController`, `DKPhotoGallery`, `SDWebImage` and `SwiftyGif`. That never reached the committed lock because #1116 ran no local Apple build — CI builds iOS but does not commit the regenerated lock back.

## Verification

- `flutter analyze` clean
- full suite green: **18,559 passed, 19 skipped**
- Android APK, macOS and iOS all build locally

## Worth a device pass

Android specifically, since that is the only platform this touches: confirm secure storage still reads after upgrading over an existing install (permissions prompts, cloud account connections, and — if you have an encrypted database — that it either unlocks from the cache or presents the lock screen rather than erroring).

This also stacks on the file_picker 12 device verification still outstanding from #1116.
