### PR TITLE
fix(wizard): give the real reason iCloud is unavailable

### DIFF
--- a/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
+++ b/lib/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart
@@ -226,8 +226,10 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
                     ? null
                     : () => _connect(CloudProviderType.icloud),
               )
-            // Apple platform where iCloud can't be used (signed out or a
-            // build without the entitlement): explain rather than hide.
+            // Apple platform running a build without the iCloud entitlement
+            // (Developer ID signing cannot carry it): explain rather than
+            // hide. Shares the Cloud Sync settings string so both surfaces
+            // give the same reason and cannot drift apart.
             else if (isApple &&
                 iCloudAvailability == ICloudAvailability.unsupported)
               Card(
@@ -239,7 +241,9 @@ class _BackupSyncStepState extends ConsumerState<BackupSyncStep> {
                   enabled: false,
                   leading: const Icon(Icons.cloud_off),
                   title: const Text('iCloud'),
-                  subtitle: Text(l10n.setup_sync_icloudUnavailable),
+                  subtitle: Text(
+                    l10n.settings_cloudSync_provider_icloud_unsupportedSubtitle,
+                  ),
                 ),
               ),
             if (dropboxConfigured)

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "متصل بـ {provider}",
   "setup_sync_error": "تعذّر الاتصال: {error}",
   "setup_sync_header": "مزامنة السحابة",
-  "setup_sync_icloudUnavailable": "iCloud غير متاح على هذا الجهاز",
   "setup_sync_libraryFound_adopt": "اعتماد المكتبة الحالية",
   "setup_sync_libraryFound_keepFresh": "البدء من جديد",
   "setup_sync_libraryFound_message": "يحتوي هذا الحساب بالفعل على مكتبة Submersion. هل تريد اعتمادها بدلًا من البدء من جديد؟",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Verbunden mit {provider}",
   "setup_sync_error": "Verbindung fehlgeschlagen: {error}",
   "setup_sync_header": "Cloud-Synchronisierung",
-  "setup_sync_icloudUnavailable": "iCloud ist auf diesem Gerät nicht verfügbar",
   "setup_sync_libraryFound_adopt": "Vorhandene Bibliothek übernehmen",
   "setup_sync_libraryFound_keepFresh": "Neu beginnen",
   "setup_sync_libraryFound_message": "Dieses Konto enthält bereits eine Submersion-Bibliothek. Diese übernehmen, statt neu zu beginnen?",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -3516,7 +3516,6 @@
     }
   },
   "setup_sync_header": "Cloud sync",
-  "setup_sync_icloudUnavailable": "iCloud is not available on this device",
   "setup_sync_libraryFound_adopt": "Adopt existing library",
   "setup_sync_libraryFound_keepFresh": "Start fresh",
   "setup_sync_libraryFound_message": "This account already contains a Submersion library. Adopt it instead of starting fresh?",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Conectado a {provider}",
   "setup_sync_error": "No se pudo conectar: {error}",
   "setup_sync_header": "Sincronización en la nube",
-  "setup_sync_icloudUnavailable": "iCloud no está disponible en este dispositivo",
   "setup_sync_libraryFound_adopt": "Adoptar biblioteca existente",
   "setup_sync_libraryFound_keepFresh": "Empezar de cero",
   "setup_sync_libraryFound_message": "Esta cuenta ya contiene una biblioteca de Submersion. ¿Adoptarla en lugar de empezar de cero?",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Connecté à {provider}",
   "setup_sync_error": "Connexion impossible : {error}",
   "setup_sync_header": "Synchronisation cloud",
-  "setup_sync_icloudUnavailable": "iCloud n'est pas disponible sur cet appareil",
   "setup_sync_libraryFound_adopt": "Adopter la bibliothèque existante",
   "setup_sync_libraryFound_keepFresh": "Repartir de zéro",
   "setup_sync_libraryFound_message": "Ce compte contient déjà une bibliothèque Submersion. L'adopter plutôt que de repartir de zéro ?",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "מחובר אל {provider}",
   "setup_sync_error": "החיבור נכשל: {error}",
   "setup_sync_header": "סנכרון ענן",
-  "setup_sync_icloudUnavailable": "iCloud אינו זמין במכשיר זה",
   "setup_sync_libraryFound_adopt": "אימוץ הספרייה הקיימת",
   "setup_sync_libraryFound_keepFresh": "התחלה חדשה",
   "setup_sync_libraryFound_message": "חשבון זה כבר מכיל ספריית Submersion. לאמץ אותה במקום להתחיל מחדש?",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Csatlakoztatva: {provider}",
   "setup_sync_error": "Nem sikerült csatlakozni: {error}",
   "setup_sync_header": "Felhőszinkronizálás",
-  "setup_sync_icloudUnavailable": "Az iCloud nem érhető el ezen az eszközön",
   "setup_sync_libraryFound_adopt": "Meglévő könyvtár átvétele",
   "setup_sync_libraryFound_keepFresh": "Új kezdés",
   "setup_sync_libraryFound_message": "Ez a fiók már tartalmaz Submersion-könyvtárat. Átveszi ahelyett, hogy újat kezdene?",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Connesso a {provider}",
   "setup_sync_error": "Impossibile connettersi: {error}",
   "setup_sync_header": "Sincronizzazione cloud",
-  "setup_sync_icloudUnavailable": "iCloud non è disponibile su questo dispositivo",
   "setup_sync_libraryFound_adopt": "Adotta la libreria esistente",
   "setup_sync_libraryFound_keepFresh": "Inizia da zero",
   "setup_sync_libraryFound_message": "Questo account contiene già una libreria Submersion. Adottarla invece di iniziare da zero?",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -10687,12 +10687,6 @@ abstract class AppLocalizations {
   /// **'Cloud sync'**
   String get setup_sync_header;
 
-  /// No description provided for @setup_sync_icloudUnavailable.
-  ///
-  /// In en, this message translates to:
-  /// **'iCloud is not available on this device'**
-  String get setup_sync_icloudUnavailable;
-
   /// No description provided for @setup_sync_libraryFound_adopt.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -6239,9 +6239,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get setup_sync_header => 'مزامنة السحابة';
 
   @override
-  String get setup_sync_icloudUnavailable => 'iCloud غير متاح على هذا الجهاز';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'اعتماد المكتبة الحالية';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -6368,10 +6368,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get setup_sync_header => 'Cloud-Synchronisierung';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud ist auf diesem Gerät nicht verfügbar';
-
-  @override
   String get setup_sync_libraryFound_adopt =>
       'Vorhandene Bibliothek übernehmen';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -6252,10 +6252,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get setup_sync_header => 'Cloud sync';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud is not available on this device';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Adopt existing library';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -6374,10 +6374,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get setup_sync_header => 'Sincronización en la nube';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud no está disponible en este dispositivo';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Adoptar biblioteca existente';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -6395,10 +6395,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get setup_sync_header => 'Synchronisation cloud';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud n\'est pas disponible sur cet appareil';
-
-  @override
   String get setup_sync_libraryFound_adopt =>
       'Adopter la bibliothèque existante';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -6208,9 +6208,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get setup_sync_header => 'סנכרון ענן';
 
   @override
-  String get setup_sync_icloudUnavailable => 'iCloud אינו זמין במכשיר זה';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'אימוץ הספרייה הקיימת';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -6352,10 +6352,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get setup_sync_header => 'Felhőszinkronizálás';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'Az iCloud nem érhető el ezen az eszközön';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Meglévő könyvtár átvétele';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -6371,10 +6371,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get setup_sync_header => 'Sincronizzazione cloud';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud non è disponibile su questo dispositivo';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Adotta la libreria esistente';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -6321,10 +6321,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get setup_sync_header => 'Cloudsynchronisatie';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'iCloud is niet beschikbaar op dit apparaat';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Bestaande bibliotheek overnemen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -6375,10 +6375,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get setup_sync_header => 'Sincronização na nuvem';
 
   @override
-  String get setup_sync_icloudUnavailable =>
-      'O iCloud não está disponível neste dispositivo';
-
-  @override
   String get setup_sync_libraryFound_adopt => 'Adotar biblioteca existente';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -6048,9 +6048,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get setup_sync_header => '云同步';
 
   @override
-  String get setup_sync_icloudUnavailable => '此设备不支持 iCloud';
-
-  @override
   String get setup_sync_libraryFound_adopt => '采用现有资料库';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Verbonden met {provider}",
   "setup_sync_error": "Kon geen verbinding maken: {error}",
   "setup_sync_header": "Cloudsynchronisatie",
-  "setup_sync_icloudUnavailable": "iCloud is niet beschikbaar op dit apparaat",
   "setup_sync_libraryFound_adopt": "Bestaande bibliotheek overnemen",
   "setup_sync_libraryFound_keepFresh": "Opnieuw beginnen",
   "setup_sync_libraryFound_message": "Dit account bevat al een Submersion-bibliotheek. Deze overnemen in plaats van opnieuw te beginnen?",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -308,7 +308,6 @@
   "setup_sync_connectedTo": "Conectado a {provider}",
   "setup_sync_error": "Não foi possível conectar: {error}",
   "setup_sync_header": "Sincronização na nuvem",
-  "setup_sync_icloudUnavailable": "O iCloud não está disponível neste dispositivo",
   "setup_sync_libraryFound_adopt": "Adotar biblioteca existente",
   "setup_sync_libraryFound_keepFresh": "Começar do zero",
   "setup_sync_libraryFound_message": "Esta conta já contém uma biblioteca do Submersion. Adotá-la em vez de começar do zero?",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -346,7 +346,6 @@
   "setup_sync_connectedTo": "已连接到 {provider}",
   "setup_sync_error": "无法连接：{error}",
   "setup_sync_header": "云同步",
-  "setup_sync_icloudUnavailable": "此设备不支持 iCloud",
   "setup_sync_libraryFound_adopt": "采用现有资料库",
   "setup_sync_libraryFound_keepFresh": "重新开始",
   "setup_sync_libraryFound_message": "此账户已包含 Submersion 资料库。要采用它而不是重新开始吗？",

--- a/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
+++ b/test/features/setup_wizard/presentation/widgets/steps/backup_sync_step_test.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/settings/presentation/providers/sync_provide
 import 'package:submersion/features/setup_wizard/domain/setup_wizard_models.dart';
 import 'package:submersion/features/setup_wizard/presentation/providers/setup_wizard_providers.dart';
 import 'package:submersion/features/setup_wizard/presentation/widgets/steps/backup_sync_step.dart';
+import 'package:submersion/l10n/arb/app_localizations_en.dart';
 
 import '../../../../../helpers/mock_providers.dart';
 import '../../../../../helpers/test_app.dart';
@@ -251,7 +252,19 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('iCloud'), findsOneWidget);
-    expect(find.text('iCloud is not available on this device'), findsOneWidget);
+    // Issue #1088: "iCloud is not available on this device" read as a fault
+    // with the user's Mac or iCloud account. The real cause is the build
+    // (Developer ID signing cannot carry the iCloud entitlement), which is
+    // what the Cloud Sync settings page already says. Asserting against the
+    // settings string rather than a literal keeps the two surfaces from
+    // drifting apart again.
+    expect(
+      find.text(
+        AppLocalizationsEn()
+            .settings_cloudSync_provider_icloud_unsupportedSubtitle,
+      ),
+      findsOneWidget,
+    );
     // The disabled tile is not tappable.
     final tile = tester.widget<ListTile>(
       find.ancestor(of: find.text('iCloud'), matching: find.byType(ListTile)),


### PR DESCRIPTION
Fixes #1088.

## The report

On macOS 1.7.4 (6062) the iCloud option in the setup wizard is disabled, with
the subtitle "iCloud is not available on this device".

## What is actually going on

The disabled state is correct. Apple honors the iCloud entitlement
(`com.apple.developer.ubiquity-container-identifiers`) only for Mac App Store
builds, which are sandboxed, and for development-signed builds. The macOS
build published on GitHub Releases is Developer ID signed and unsandboxed, so
`FileManager.url(forUbiquityContainerIdentifier:)` returns nil and the app
correctly refuses to offer a provider it cannot fulfill.

The wording is the bug. "Not available on this device" points the user at
their Mac or their iCloud account, and no amount of signing in or checking
System Settings will change anything. The Cloud Sync settings page already
words this correctly, because it uses
`settings_cloudSync_provider_icloud_unsupportedSubtitle`. The wizard had its
own `setup_sync_icloudUnavailable` string for the same condition, and the two
drifted.

## The change

- The wizard's disabled iCloud tile now renders the settings string, so both
  surfaces give the same reason.
- `setup_sync_icloudUnavailable` is deleted from all 11 ARB files, along with
  its generated getters. One condition, one string, nothing left to drift.
- The existing widget test asserts against
  `AppLocalizationsEn().settings_cloudSync_provider_icloud_unsupportedSubtitle`
  rather than a literal, which is what structurally pins the two surfaces
  together going forward.

No behavior change beyond the copy: the tile was already disabled for the
`unsupported` availability state, and still is.

## Verification

- Red confirmed before the fix: restoring the old copy in the widget fails
  `unsupported iCloud on Apple shows a disabled explanation` at the
  expectation.
- `flutter test test/features/setup_wizard/ test/features/settings/presentation/pages/cloud_sync_page_test.dart test/l10n/`: 232 passed, 2 skipped.
  `test/l10n/arb_parity_test.dart` covers the key having been removed from
  every locale rather than just English.
- `flutter analyze`: clean. Removing a getter from the generated
  `app_localizations.dart` hub turns any stale reference into a compile
  error, so a clean analyze is what proves the removal is complete.
- `dart format lib/ test/`: clean.

## Deliberately not changed

`settings_cloudSync_launchCheck_unavailable` ("{provider} is not available on
this device", `sync_initializer.dart:271`) has the same misleading shape, but
it is provider-generic and only fires for an already-configured backend.
Rewording it around the iCloud entitlement would make it wrong for S3,
Dropbox, and Google Drive.
