### PR TITLE
fix(windows): bundle the native assets a configure-time guard was dropping

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -416,6 +416,13 @@ jobs:
       - name: Build Windows release
         run: flutter build windows --release --dart-define=UPDATE_CHANNEL=github
 
+      - name: Check bundled native assets
+        # Runs before the installer is compiled: the .iss packages whatever is
+        # in the Release directory, so a native asset missing here ships to
+        # every user and takes the app down at startup (issue #1129). Windows
+        # runners expose the interpreter as `python`, not `python3`.
+        run: python scripts/check_bundled_native_assets.py build\windows\x64\runner\Release
+
       - name: Build Windows installer
         env:
           TAG_NAME: ${{ inputs.version-tag }}
@@ -552,6 +559,12 @@ jobs:
 
       - name: Build Linux release
         run: flutter build linux --release --dart-define=UPDATE_CHANNEL=github
+
+      - name: Check bundled native assets
+        # Runs before the tarball is rolled, for the same reason as the Windows
+        # job: a missing native asset is invisible until a user launches the
+        # app (issue #1129).
+        run: python3 scripts/check_bundled_native_assets.py build/linux/x64/release/bundle
 
       - name: Create tarball
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,11 +369,13 @@ jobs:
       - name: Run Python guard tests with coverage
         run: |
           mkdir -p coverage
-          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
+          guards='scripts/check_proguard_serial_keep.py,scripts/check_native_libs_present.py,scripts/check_bundled_native_assets.py,scripts/check_jni_local_refs.py,scripts/check_dc_process_isolation.py,scripts/fix_macho_symbol_order.py,scripts/release/sanitize_apple_store_notes.py'
           python3 -m coverage run --include="$guards" \
             scripts/check_proguard_serial_keep_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_native_libs_present_test.py
+          python3 -m coverage run --append --include="$guards" \
+            scripts/check_bundled_native_assets_test.py
           python3 -m coverage run --append --include="$guards" \
             scripts/check_jni_local_refs_test.py
           python3 -m coverage run --append --include="$guards" \
@@ -922,6 +924,12 @@ jobs:
       - name: Build Linux
         run: flutter build linux --release "${{ env.DART_DEFINES }}" -v
 
+      - name: Check bundled native assets
+        # Same guard as the Windows job. Linux uses the stock Flutter install
+        # rule and has always bundled its libraries, so this doubles as the
+        # positive control that the check is not vacuously passing.
+        run: python3 scripts/check_bundled_native_assets.py build/linux/x64/release/bundle
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v7
         if: >
@@ -997,6 +1005,14 @@ jobs:
 
       - name: Build Windows
         run: flutter build windows --release "${{ env.DART_DEFINES }}" -v
+
+      - name: Check bundled native assets
+        # A Windows build that never bundles sqlcipher.dll still compiles,
+        # packages and ships; it only fails when a user launches it (issue
+        # #1129). CI builds but never launches, so this is the step that has to
+        # notice. Windows runners expose the interpreter as `python`, not the
+        # `python3` the Linux guard steps use.
+        run: python scripts/check_bundled_native_assets.py build\windows\x64\runner\Release
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7

--- a/scripts/check_bundled_native_assets.py
+++ b/scripts/check_bundled_native_assets.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Verify a desktop app bundle actually contains the native assets it declares.
+
+Dart build hooks (``hook/build.dart``) hand Flutter a set of "code assets":
+prebuilt or freshly compiled dynamic libraries that the packaging step is meant
+to copy next to the executable. Flutter records what it promised in
+``data/flutter_assets/NativeAssetsManifest.json``. Nothing checks that the
+promise was kept: the manifest is written by the Dart side, while the copying is
+done by the platform's own packaging rules, and the two can disagree without any
+build step failing.
+
+This is issue #1129. ``windows/CMakeLists.txt`` wrapped its native-asset install
+rule in ``if(EXISTS "${NATIVE_ASSETS_DIR}")``. CMake evaluates that at
+*configure* time, but the directory is produced later, during the build, by the
+``flutter_assemble`` target. On a clean tree the test was always false, so the
+install rule was never generated and every native asset was silently dropped:
+
+    Invalid argument(s): Couldn't resolve native function 'sqlite3_initialize'
+    in 'package:sqlite3/src/ffi/libsqlite3.g.dart' : Failed to load dynamic
+    library 'sqlcipher.dll': The specified module could not be found.
+    (error code: 126)
+
+Windows builds passed CI throughout, because CI builds the app but never
+launches it. ``pdfium.dll`` was dropped by the same rule and had been missing
+since PDF attachments shipped in v1.7.3, unnoticed only because it fails lazily
+when a PDF is opened rather than at startup.
+
+This guard is the complementary check to ``check_native_libs_present.py`` (which
+covers Android archives): it reads the manifest out of a built bundle and
+asserts that every library the manifest declares is really on disk, and that the
+database engine is declared at all. Dependency-free (pure stdlib) so it runs
+identically on the Windows and Linux runners.
+
+Windows and Linux only for now. macOS packages native assets through Xcode
+rather than CMake, was verified by launching the bundled .app during the
+sqlite3 3.x migration, and nests the same tree inside ``Contents/Frameworks``,
+which ``MANIFEST_RELPATH`` below does not yet account for.
+
+Usage:
+    check_bundled_native_assets.py <bundle-root> [more-bundles ...]
+
+    Windows: build\\windows\\x64\\runner\\Release
+    Linux:   build/linux/x64/release/bundle
+"""
+
+import json
+import os
+import sys
+
+# Relative location of the manifest inside a desktop bundle. Identical on
+# Windows and Linux (see the macOS note in the module docstring).
+MANIFEST_RELPATH = os.path.join("data", "flutter_assets", "NativeAssetsManifest.json")
+
+# Directories, relative to the bundle root, where a bundled library may sit.
+# Windows puts them beside the .exe; Linux puts them in lib/ and finds them
+# through the runner's $ORIGIN/lib rpath.
+SEARCH_DIRS = ("", "lib")
+
+# Link modes that mean "this library is shipped inside the bundle". Anything
+# else ("system", "process", "executable") resolves through the OS loader or
+# the host process and has no file for us to look for.
+BUNDLED_LINK_MODES = ("absolute", "relative")
+
+# The SQLCipher build of SQLite, supplied by package:sqlite3's build hook (see
+# the `hooks:` section of pubspec.yaml). Its absence is fatal at startup: the
+# app cannot open its database and never reaches the first screen. Asserting the
+# id is present stops a bundle that is internally consistent but has quietly
+# lost the engine (a pubspec hook define dropped in a dependency bump, say)
+# from passing on file-presence alone.
+REQUIRED_ASSET_ID = "package:sqlite3/src/ffi/libsqlite3.g.dart"
+
+
+def bundled_libraries(manifest):
+    """Return ``[(asset_id, filename), ...]`` for assets shipped in the bundle.
+
+    Entries are ``[link_mode]`` or ``[link_mode, path]``. A path that is
+    absolute or contains directory separators points outside the bundle (a
+    system library), so only bare filenames are ours to verify.
+    """
+    found = []
+    for assets in manifest.get("native-assets", {}).values():
+        for asset_id, entry in assets.items():
+            if not isinstance(entry, list) or len(entry) < 2:
+                continue
+            link_mode, path = entry[0], entry[1]
+            if link_mode not in BUNDLED_LINK_MODES:
+                continue
+            if os.path.isabs(path) or "/" in path or "\\" in path:
+                continue
+            found.append((asset_id, path))
+    return found
+
+
+def declared_asset_ids(manifest):
+    """Every asset id in the manifest, across all targets."""
+    ids = set()
+    for assets in manifest.get("native-assets", {}).values():
+        ids.update(assets)
+    return ids
+
+
+def locate(root, filename):
+    """Return the bundle-relative path of ``filename``, or None if absent."""
+    for subdir in SEARCH_DIRS:
+        candidate = os.path.join(root, subdir, filename)
+        if os.path.isfile(candidate):
+            return os.path.join(subdir, filename) if subdir else filename
+    return None
+
+
+def check_bundle(root):
+    """Check one bundle. Return ``(ok, lines)`` where ``lines`` is the report."""
+    manifest_path = os.path.join(root, MANIFEST_RELPATH)
+    try:
+        with open(manifest_path) as fh:
+            manifest = json.load(fh)
+    except (OSError, ValueError) as exc:
+        # Fail closed: without the manifest we cannot vouch for the bundle.
+        return False, [f"  FAIL  cannot read {MANIFEST_RELPATH}: {exc}"]
+
+    lines = []
+    ok = True
+
+    if REQUIRED_ASSET_ID not in declared_asset_ids(manifest):
+        ok = False
+        lines.append(
+            f"  FAIL  manifest does not declare {REQUIRED_ASSET_ID} "
+            "(the SQLCipher engine); the app cannot open its database"
+        )
+
+    libraries = bundled_libraries(manifest)
+    if not libraries:
+        ok = False
+        lines.append("  FAIL  manifest declares no bundled native libraries")
+
+    for asset_id, filename in sorted(libraries, key=lambda pair: pair[1]):
+        location = locate(root, filename)
+        if location is None:
+            ok = False
+            lines.append(
+                f"  FAIL  {filename} declared by {asset_id} is missing from the bundle"
+            )
+        else:
+            lines.append(f"  ok    {location} ({asset_id})")
+
+    return ok, lines
+
+
+def main(argv):
+    roots = argv[1:]
+    if not roots:
+        print(__doc__)
+        return 2
+
+    all_ok = True
+    for root in roots:
+        print(f"Checking bundled native assets: {root}")
+        ok, lines = check_bundle(root)
+        for line in lines:
+            print(line)
+        if ok:
+            print("  -> PASS: every declared native asset is bundled")
+        else:
+            print(
+                "  -> FAIL: a declared native asset is missing from the bundle "
+                "(the app will fail to load it at runtime; see issue #1129)"
+            )
+        all_ok = all_ok and ok
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv))

--- a/scripts/check_bundled_native_assets_test.py
+++ b/scripts/check_bundled_native_assets_test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Unit tests for check_bundled_native_assets.py.
+
+Run: python3 scripts/check_bundled_native_assets_test.py
+
+The headline case is the issue #1129 regression: a Windows bundle whose
+NativeAssetsManifest.json declares sqlcipher.dll but whose Release directory
+does not actually contain it, because the CMake install rule that copies
+build/native_assets/windows/ was skipped. That build succeeds, packages, ships,
+and then dies on the user's machine with error 126.
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+
+# Load the sibling script by path so the test runs from any working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_bundled_native_assets",
+    os.path.join(_HERE, "check_bundled_native_assets.py"),
+)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+SQLITE = guard.REQUIRED_ASSET_ID
+PDFIUM = "package:pdfium_dart/libpdfium"
+
+
+def _windows_manifest(assets):
+    return {"format-version": [1, 0, 0], "native-assets": {"windows_x64": assets}}
+
+
+def _linux_manifest(assets):
+    return {"format-version": [1, 0, 0], "native-assets": {"linux_x64": assets}}
+
+
+class BundleBuilder:
+    """Builds a throwaway app bundle on disk for one test case."""
+
+    def __init__(self, test, manifest=None, files=(), manifest_missing=False):
+        self.root = tempfile.mkdtemp()
+        test.addCleanup(self._cleanup)
+        assets_dir = os.path.join(self.root, "data", "flutter_assets")
+        os.makedirs(assets_dir)
+        if not manifest_missing:
+            with open(os.path.join(assets_dir, "NativeAssetsManifest.json"), "w") as fh:
+                json.dump(manifest, fh)
+        for rel in files:
+            path = os.path.join(self.root, rel.replace("/", os.sep))
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "wb") as fh:
+                fh.write(b"")
+
+    def _cleanup(self):
+        for dirpath, _dirnames, filenames in os.walk(self.root, topdown=False):
+            for name in filenames:
+                os.unlink(os.path.join(dirpath, name))
+            os.rmdir(dirpath)
+
+
+class CheckBundleTests(unittest.TestCase):
+    def _check(self, **kwargs):
+        return guard.check_bundle(BundleBuilder(self, **kwargs).root)
+
+    def test_green_windows_bundle_has_every_declared_dll(self):
+        ok, lines = self._check(
+            manifest=_windows_manifest(
+                {
+                    SQLITE: ["absolute", "sqlcipher.dll"],
+                    PDFIUM: ["absolute", "pdfium.dll"],
+                }
+            ),
+            files=("sqlcipher.dll", "pdfium.dll"),
+        )
+        self.assertTrue(ok, lines)
+        self.assertTrue(all("FAIL" not in line for line in lines))
+
+    def test_red_issue_1129_declared_but_not_bundled(self):
+        # The manifest promises sqlcipher.dll; the install step never copied it.
+        ok, lines = self._check(
+            manifest=_windows_manifest({SQLITE: ["absolute", "sqlcipher.dll"]}),
+            files=(),
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("sqlcipher.dll" in line and "FAIL" in line for line in lines))
+
+    def test_red_one_of_several_missing(self):
+        # pdfium.dll dropped the same way; a partial bundle is still a failure.
+        ok, lines = self._check(
+            manifest=_windows_manifest(
+                {
+                    SQLITE: ["absolute", "sqlcipher.dll"],
+                    PDFIUM: ["absolute", "pdfium.dll"],
+                }
+            ),
+            files=("sqlcipher.dll",),
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("pdfium.dll" in line and "FAIL" in line for line in lines))
+
+    def test_green_linux_layout_resolves_lib_subdirectory(self):
+        # The Linux bundle puts native assets in lib/ next to the executable.
+        ok, lines = self._check(
+            manifest=_linux_manifest({SQLITE: ["absolute", "libsqlcipher.so"]}),
+            files=("lib/libsqlcipher.so",),
+        )
+        self.assertTrue(ok, lines)
+
+    def test_system_libraries_are_not_expected_in_the_bundle(self):
+        # A "system" asset resolves through the OS loader, not the bundle.
+        ok, lines = self._check(
+            manifest=_windows_manifest(
+                {
+                    SQLITE: ["absolute", "sqlcipher.dll"],
+                    "package:foo/bar": ["system", "/usr/lib/libz.so"],
+                }
+            ),
+            files=("sqlcipher.dll",),
+        )
+        self.assertTrue(ok, lines)
+
+    def test_process_assets_have_no_file_to_check(self):
+        ok, lines = self._check(
+            manifest=_windows_manifest(
+                {
+                    SQLITE: ["absolute", "sqlcipher.dll"],
+                    "package:foo/bar": ["process"],
+                }
+            ),
+            files=("sqlcipher.dll",),
+        )
+        self.assertTrue(ok, lines)
+
+    def test_missing_manifest_fails_closed(self):
+        ok, lines = self._check(manifest_missing=True)
+        self.assertFalse(ok)
+        self.assertTrue(any("NativeAssetsManifest.json" in line for line in lines))
+
+    def test_manifest_without_the_database_engine_fails_closed(self):
+        # The manifest itself lost SQLCipher (e.g. the pubspec hook define was
+        # dropped): the bundle is self-consistent but the app cannot open its
+        # database, so file-presence alone must not be enough to pass.
+        ok, lines = self._check(
+            manifest=_windows_manifest({PDFIUM: ["absolute", "pdfium.dll"]}),
+            files=("pdfium.dll",),
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any(SQLITE in line for line in lines))
+
+    def test_manifest_with_no_native_assets_fails_closed(self):
+        ok, lines = self._check(manifest=_windows_manifest({}))
+        self.assertFalse(ok)
+
+
+class MainTests(unittest.TestCase):
+    def _main(self, *args):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = guard.main(["check_bundled_native_assets.py", *args])
+        return code, buf.getvalue()
+
+    def test_no_args_prints_usage(self):
+        code, out = self._main()
+        self.assertEqual(code, 2)
+        self.assertIn("Usage:", out)
+
+    def test_missing_bundle_is_a_failure(self):
+        code, out = self._main("/no/such/bundle")
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", out)
+
+    def test_green_bundle_exits_zero(self):
+        root = BundleBuilder(
+            self,
+            manifest=_windows_manifest({SQLITE: ["absolute", "sqlcipher.dll"]}),
+            files=("sqlcipher.dll",),
+        ).root
+        code, out = self._main(root)
+        self.assertEqual(code, 0)
+        self.assertIn("PASS", out)
+
+    def test_red_bundle_exits_one(self):
+        root = BundleBuilder(
+            self,
+            manifest=_windows_manifest({SQLITE: ["absolute", "sqlcipher.dll"]}),
+            files=(),
+        ).root
+        code, out = self._main(root)
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -93,14 +93,21 @@ if(PLUGIN_BUNDLED_LIBRARIES)
 endif()
 
 # Copy the native assets provided by the build.dart from all packages.
-# Some builds (e.g., when no native assets are produced) won't create this
-# directory. Guard the install step to avoid failing the install target.
+#
+# OPTIONAL, not `if(EXISTS ...)`: this directory is produced by the
+# flutter_assemble target during the *build*, long after CMake has finished
+# configuring, so a configure-time existence test is always false on a clean
+# tree and silently drops every native asset from the bundle. That is issue
+# #1129: sqlcipher.dll and pdfium.dll never reached the installer, and the app
+# died at startup with "Failed to load dynamic library 'sqlcipher.dll'",
+# error 126.
+# OPTIONAL defers the check to install time, which keeps the install target
+# from failing when a build genuinely produces no native assets.
 set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
-if(EXISTS "${NATIVE_ASSETS_DIR}")
-  install(DIRECTORY "${NATIVE_ASSETS_DIR}"
-    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-    COMPONENT Runtime)
-endif()
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+  DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime
+  OPTIONAL)
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.


### PR DESCRIPTION
Fixes #1129.

## The bug

Windows beta v1.7.5.6322 could not start at all:

> Invalid argument(s): Couldn't resolve native function 'sqlite3_initialize' in 'package:sqlite3/src/ffi/libsqlite3.g.dart' : Failed to load dynamic library 'sqlcipher.dll': The specified module could not be found. (error code: 126)

`windows/CMakeLists.txt` deviated from the stock Flutter template by wrapping
the native-assets install rule in a **configure-time** existence test:

```cmake
if(EXISTS "${NATIVE_ASSETS_DIR}")     # evaluated when CMake configures
  install(DIRECTORY ...)              # so this rule is never even generated
endif()
```

`build/native_assets/windows/` is created *during the build*, by the
`flutter_assemble` custom target in `windows/flutter/CMakeLists.txt` that shells
out to `tool_backend.bat`. On a clean tree the test is always false, CMake
generates no copy rule, and every Dart code asset is dropped from the bundle.
The Inno Setup script then faithfully packages a `Release\` directory that has
no `sqlcipher.dll` in it.

The guard was added with the initial project scaffold, when no package produced
native assets on Windows. It only became load-bearing when `package:sqlite3`
3.x started supplying SQLCipher through a build hook (#1097).

## Blast radius is wider than the database

The rule drops **all** code assets, not just SQLCipher. `pdfium.dll`
(pdfrx / pdfium_dart) has been missing on Windows since PDF attachments shipped
in **v1.7.3 stable**. It went unnoticed only because it fails lazily when a PDF
is opened, rather than at startup. Worth spot-checking Windows PDF viewing once
a fixed build exists.

## The fix

Use `OPTIONAL` instead of the `if`, which defers the existence check to install
time.

The original guard was not pointless, and deleting it outright would regress a
real case: unguarded `install(DIRECTORY)` on a missing directory genuinely does
fail with `file INSTALL cannot find`. `OPTIONAL` covers that case correctly and
restores stock template behaviour otherwise.

## Regression guard

CI builds the desktop apps but never launches them, so no build job could have
caught this. Added `scripts/check_bundled_native_assets.py`, which reads the
`NativeAssetsManifest.json` that the build itself wrote and asserts that every
library the manifest declares is actually on disk in the bundle, plus that the
SQLCipher engine is declared at all (so a bundle that is internally consistent
but has quietly lost the engine cannot pass on file-presence alone).

Wired into the Windows and Linux jobs of both `ci.yaml` and `build-all.yml`. In
`build-all.yml` it runs **before** the installer is compiled and before the
tarball is rolled, so a bundle missing a native asset can never be packaged.
`beta.yml` and `release.yml` both reuse `build-all.yml`, so every shipped
artifact is covered.

Linux keeps the stock unguarded rule and has always bundled its libraries
correctly, so running the same check there doubles as a positive control that
the guard is not vacuously passing.

## Verification

- **CMake mechanism reproduced locally with real `cmake`.** The guarded form
  installs nothing when the directory appears after configure; the new
  `OPTIONAL` form installs `sqlcipher.dll` and `pdfium.dll`, and still exits 0
  when the directory genuinely does not exist.
- **The guard was validated against a real shipped artifact**, not only
  fixtures: the actual `Submersion-v1.7.5.6322-Linux.tar.gz` passes
  (`lib/libsqlcipher.so` and `lib/libpdfium.so` both found), and deleting those
  two files makes it fail with the exact diagnostic. Linux is the useful control
  because it kept the stock rule, which is what isolates the fault to the
  Windows deviation.
- 13 new unit tests, including the #1129 case (manifest declares the DLL, bundle
  does not contain it). Sibling guard tests still pass, both workflow files
  parse, format and analyze clean.

## Ruled out

Windows error 126 (`ERROR_MOD_NOT_FOUND`) can also mean a *dependency* of the
DLL is missing, which would have pointed at OpenSSL. Dumping the PE import table
of the prebuilt `sqlcipher.x64.windows.dll` shows it imports only `CRYPT32`,
`USER32`, `ADVAPI32`, `WS2_32` and `KERNEL32`. All Windows system DLLs, no
OpenSSL, no MSVC runtime. There is nothing for it to be missing, so 126 here can
only mean the file itself is absent.

## Interim workaround for affected users

Until a fixed build ships, a stuck Windows user can drop the DLL in by hand:
download `sqlcipher.x64.windows.dll` from the
`simolus3/sqlite3.dart` release `sqlite3-3.5.1`, rename it to `sqlcipher.dll`,
and place it next to `submersion.exe` in the install directory. That file hashes
to `6303c226ba65246dcb75bb60550b2578a2dd59ae51d65fc96edeb5d812d4cac8`, which is
byte-identical to the sha256 the sqlite3 build hook pins for that asset. No data
is at risk either way; the database on disk is untouched.
