### PR TITLE
fix(ci): stop a newer beta run cancelling one that is already uploading

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -20,10 +20,18 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: beta-pipeline
-  cancel-in-progress: true
-
+# Concurrency is declared per job, not for the whole workflow, because the two
+# phases of this pipeline want opposite policies. Workflow-level concurrency is
+# evaluated when the run is created, long before any job has been scheduled, so
+# it cannot tell a run that is two minutes into compiling from one that is
+# mid-upload to App Store Connect; a newer run cancelled either. That is how a
+# beta lost all three store uploads at 22:56 on 2026-08-17 after a 26 minute
+# build, to a run that then skipped every job because its upstream CI had been
+# cancelled rather than succeeding.
+#
+# Build phase: still preemptible. Finishing a superseded build helps nobody.
+# Publish phase: never cancelled. Once a lane starts talking to a store, a
+# newer run's matching lane queues behind it instead of killing it.
 jobs:
   precheck:
     name: Compute version and gate
@@ -157,6 +165,11 @@ jobs:
     name: Build
     needs: precheck
     if: needs.precheck.outputs.proceed == 'true'
+    # The group name must stay distinct from anything build-all.yml declares
+    # (it declares none), or the caller would cancel itself.
+    concurrency:
+      group: beta-build
+      cancel-in-progress: true
     uses: ./.github/workflows/build-all.yml
     with:
       version-tag: ${{ needs.precheck.outputs.tag }}
@@ -168,6 +181,12 @@ jobs:
     name: Publish to beta-builds
     needs: [precheck, build]
     if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    # One group per lane rather than one shared publish group: a shared group
+    # would serialize this run's own four lanes against each other and stretch
+    # about 90 seconds of parallel uploads into three and a half minutes.
+    concurrency:
+      group: beta-publish-release
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -278,6 +297,9 @@ jobs:
     runs-on: macos-15
     needs: [precheck, build]
     if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    concurrency:
+      group: beta-publish-ios
+      cancel-in-progress: false
     timeout-minutes: 45
     steps:
       - name: Checkout repository
@@ -379,6 +401,9 @@ jobs:
     runs-on: macos-15
     needs: [precheck, build]
     if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    concurrency:
+      group: beta-publish-macos
+      cancel-in-progress: false
     timeout-minutes: 45
     steps:
       - name: Checkout repository
@@ -474,6 +499,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [precheck, build]
     if: needs.precheck.outputs.proceed == 'true' && inputs.skip-publish != true
+    concurrency:
+      group: beta-publish-play
+      cancel-in-progress: false
     timeout-minutes: 15
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The beta pipeline declared `concurrency: beta-pipeline` with `cancel-in-progress: true` at the **workflow** level. GitHub evaluates that group when a run is created, before any job is scheduled, so it cannot distinguish a run two minutes into compiling from one that is mid-upload to App Store Connect. A newer run cancelled either.

## What happened

[Run 32076264869](https://github.com/submersion-app/submersion/actions/runs/32076264869) built a beta of `29d574a` across all five platforms, published it to `beta-builds`, and was 51 seconds into the macOS TestFlight upload when a new Beta run queued and evicted it. All three store lanes died with `Canceling since a higher priority waiting request for beta-pipeline exists`.

The evicting run then skipped every job. It was triggered by `workflow_run` with `types: [completed]`, which fires for **cancelled** upstream runs too, and `precheck` correctly rejected it on `github.event.workflow_run.conclusion == 'success'`. But the run-level concurrency group had already been claimed by then. A no-op destroyed 26 minutes of validated builds during their final step.

## The change

Concurrency moves to the jobs, split by phase:

| Job | Group | `cancel-in-progress` |
| --- | --- | --- |
| `precheck` | none | n/a (32s, nothing to protect) |
| `build` | `beta-build` | `true` |
| `publish-beta` | `beta-publish-release` | `false` |
| `upload-testflight-ios` | `beta-publish-ios` | `false` |
| `upload-testflight-macos` | `beta-publish-macos` | `false` |
| `upload-play` | `beta-publish-play` | `false` |

- **Build stays preemptible.** Finishing a superseded build helps nobody.
- **Publish is never cancelled.** Once a lane starts talking to a store, a newer run's matching lane queues behind it instead of killing it.
- **One group per lane**, not one shared publish group, or a run would serialize its own four lanes and stretch about 90 seconds of parallel uploads into three and a half minutes.

This also fixes the no-op eviction for free: a run whose upstream CI was cancelled skips `precheck`, so `build` skips too, and a skipped job never claims its group. Such a run now cancels nothing at any phase.

## Notes

- `jobs.<job_id>.concurrency` is [one of the twelve keywords permitted](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations) on a job that calls a reusable workflow, so `build` can carry it despite being a `uses:` caller. `build-all.yml` declares no concurrency of its own, so there is no caller/callee group collision. (actionlint's error text for that allowlist is stale and omits `concurrency`; its actual validation accepts it.)
- Upload ordering is safe. If a run has cleared the build phase it can no longer be cancelled, and a later run still needs about 25 minutes of building, so its uploads always queue after rather than racing ahead.
- With `cancel-in-progress: false`, if two runs queue behind an uploading lane, GitHub keeps only the newest pending job. That is the wanted behavior: a superseded build should not reach testers behind a newer one.

## Testing

- `actionlint .github/workflows/beta.yml` passes.
- Negative control: adding `runs-on:` to the `build` job makes actionlint fail with a `syntax-check` error, confirming the clean pass is meaningful.
- YAML parse confirms the workflow-level block is gone and all six jobs carry the intended groups.

This touches only `.github/*`, which both `ci.yaml`'s changes filter and the beta gate treat as inert, so merging it will not itself trigger a beta. The policy takes effect on the next merge that changes shippable code.