### PR TITLE
fix(backup): make pre-migration backups restorable and WAL-complete

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -670,6 +670,10 @@ class _StartupWrapperState extends State<StartupWrapper>
         fallbackBackupsDirProvider:
             BackupService.resolveDefaultBackupsDirectory,
         preferences: prefs,
+        // The security gate has already run, so this is the live key when
+        // protection is on. Needed only to open the database for the
+        // pre-copy WAL checkpoint.
+        databaseKeyHexProvider: () => DatabaseService.instance.databaseKeyHex,
       );
     }
 

--- a/lib/features/backup/data/services/backup_database_adapter.dart
+++ b/lib/features/backup/data/services/backup_database_adapter.dart
@@ -21,6 +21,16 @@ abstract class BackupDatabaseAdapter {
   });
   Future<String> get databasePath;
   AppDatabase get database;
+
+  /// The live database's SQLCipher key, or null when database password
+  /// protection is off (the overwhelmingly common case).
+  ///
+  /// Needed only to deep-check a `BackupType.preMigration` artifact, which is
+  /// a raw byte copy of the live file and is therefore SQLCipher ciphertext
+  /// exactly when the live database is. Every other backup kind is a portable
+  /// plaintext export and must keep failing validation loudly if it looks
+  /// encrypted.
+  String? get databaseKeyHex;
 }
 
 /// Default adapter that delegates to [DatabaseService.instance].
@@ -50,6 +60,9 @@ class DefaultBackupDatabaseAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => _dbAdapter.database;
+
+  @override
+  String? get databaseKeyHex => _dbAdapter.databaseKeyHex;
 }
 
 // coverage:ignore-end

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -12,6 +12,8 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/security/database_security_sidecar.dart'
+    show isEncryptedDatabaseFile;
 import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/sync/crypto/encryption_key_store.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
@@ -554,7 +556,19 @@ class BackupService {
   ///
   /// Checks: file exists, has correct extension, is a valid SQLite database,
   /// and contains expected Submersion tables.
-  Future<BackupValidationResult> validateBackupFile(String filePath) async {
+  ///
+  /// [allowLiveDatabaseEncryption] opts into the one artifact kind that may
+  /// legitimately be SQLCipher ciphertext: a [BackupType.preMigration] copy,
+  /// which is a raw byte copy of the live database and so carries the live
+  /// database's encryption. Such a file is deep-checked with the live key
+  /// instead of being rejected. Portable backups keep the strict plaintext
+  /// rule: they are decrypted on export precisely so they restore on a
+  /// device where the database password is unknown, and an encrypted-looking
+  /// one is a real problem that must fail loudly.
+  Future<BackupValidationResult> validateBackupFile(
+    String filePath, {
+    bool allowLiveDatabaseEncryption = false,
+  }) async {
     final file = File(filePath);
 
     // Check file exists
@@ -589,15 +603,32 @@ class BackupService {
       return const BackupValidationResult.invalid('File is empty');
     }
 
+    // A pre-migration copy of a protected database is SQLCipher ciphertext,
+    // so the deep check below needs the live key. Without one there is
+    // nothing to open the file with, and nothing a restore could do with it
+    // either, since the key is the only way back to the data.
+    String? deepCheckKeyHex;
+    if (allowLiveDatabaseEncryption && isEncryptedDatabaseFile(filePath)) {
+      deepCheckKeyHex = _dbAdapter.databaseKeyHex;
+      if (deepCheckKeyHex == null) {
+        return const BackupValidationResult.invalid(
+          'This safety copy was taken from a protected database, but this '
+          'install has no database key to open it with',
+        );
+      }
+    }
+
     // Use sqlite3 directly in read-only mode to avoid Drift's migration
     // system triggering ALTER TABLE on older-schema backups. The backup file
     // may also be in a read-only sandboxed directory (iOS/macOS file picker).
-    // Deliberately keyless: backup artifacts are portable plaintext by
-    // design, and an encrypted-looking file should fail validation loudly.
+    // Keyless unless the caller opted in above: backup artifacts are portable
+    // plaintext by design, and an encrypted-looking file should fail
+    // validation loudly.
     try {
       final testDb = DatabaseService.openRaw(
         filePath,
         mode: sqlite3.OpenMode.readOnly,
+        keyHex: deepCheckKeyHex,
       );
       try {
         // Verify it's a valid SQLite database
@@ -676,7 +707,17 @@ class BackupService {
     try {
       // Parity with the file-picker path: the file on disk (or the fresh
       // download) may have been corrupted since the record was written.
-      final validation = await validateBackupFile(materialized.path);
+      //
+      // A pre-migration copy is the one kind that may legitimately be
+      // SQLCipher ciphertext (it is a raw copy of the live file, taken before
+      // the migration with the database closed), so it is deep-checked with
+      // the live key rather than rejected. DatabaseService.restore already
+      // handles such a source: it detects the encrypted header and skips the
+      // re-encryption it would otherwise apply.
+      final validation = await validateBackupFile(
+        materialized.path,
+        allowLiveDatabaseEncryption: record.type == BackupType.preMigration,
+      );
       if (!validation.isValid) {
         throw BackupException(
           validation.error ?? 'Backup file failed validation',

--- a/lib/features/backup/data/services/backup_service.dart
+++ b/lib/features/backup/data/services/backup_service.dart
@@ -604,16 +604,28 @@ class BackupService {
     }
 
     // A pre-migration copy of a protected database is SQLCipher ciphertext,
-    // so the deep check below needs the live key. Without one there is
-    // nothing to open the file with, and nothing a restore could do with it
-    // either, since the key is the only way back to the data.
+    // so the deep check below needs the live key. With one, a keyed open
+    // settles the question: it succeeds on a real encrypted copy and fails
+    // on anything else, which lands in the generic invalid-database result.
+    //
+    // Without one there is nothing to open the file with, and nothing a
+    // restore could do with it either, since the key is the only way back to
+    // the data. The report must stay honest about WHY, though: a corrupt
+    // plaintext database and an encrypted one are indistinguishable at the
+    // header, so isEncryptedDatabaseFile alone must never conclude
+    // "encrypted" (see DatabaseSecuritySidecar.existsFor, which is the
+    // corroborating signal the startup gate and schema probe use). That
+    // signal is unavailable here: the sidecar lives next to the live
+    // database and is never copied into the backups directory. So name both
+    // possibilities rather than asserting one the file cannot prove.
     String? deepCheckKeyHex;
     if (allowLiveDatabaseEncryption && isEncryptedDatabaseFile(filePath)) {
       deepCheckKeyHex = _dbAdapter.databaseKeyHex;
       if (deepCheckKeyHex == null) {
         return const BackupValidationResult.invalid(
-          'This safety copy was taken from a protected database, but this '
-          'install has no database key to open it with',
+          'This safety copy cannot be opened. It was either taken from a '
+          'protected database whose key this install no longer has, or the '
+          'file is corrupt.',
         );
       }
     }

--- a/lib/features/backup/data/services/pre_migration_backup_service.dart
+++ b/lib/features/backup/data/services/pre_migration_backup_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
+import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -22,6 +23,10 @@ class PreMigrationBackupService {
   final AsyncPathResolver _backupsDirProvider;
   final AsyncPathResolver? _fallbackBackupsDirProvider;
   final BackupPreferences _preferences;
+
+  /// The live database's SQLCipher key when protection is on, else null.
+  /// Only used to open the database for the pre-copy WAL checkpoint.
+  final String? Function()? _databaseKeyHexProvider;
   final DateTime Function() _clock;
   final String Function() _idGenerator;
   final _log = LoggerService.forClass(PreMigrationBackupService);
@@ -31,12 +36,14 @@ class PreMigrationBackupService {
     required AsyncPathResolver backupsDirProvider,
     AsyncPathResolver? fallbackBackupsDirProvider,
     required BackupPreferences preferences,
+    String? Function()? databaseKeyHexProvider,
     DateTime Function()? clock,
     String Function()? idGenerator,
   }) : _livePathProvider = livePathProvider,
        _backupsDirProvider = backupsDirProvider,
        _fallbackBackupsDirProvider = fallbackBackupsDirProvider,
        _preferences = preferences,
+       _databaseKeyHexProvider = databaseKeyHexProvider,
        _clock = clock ?? DateTime.now,
        _idGenerator = idGenerator ?? (() => const Uuid().v4());
 
@@ -54,6 +61,8 @@ class PreMigrationBackupService {
     } catch (e, stack) {
       throw BackupFailedException.fromError(e, stack);
     }
+
+    await _checkpointHotWal(livePath);
 
     final now = _clock().toUtc();
     final filename = '${_formatTimestamp(now)}-v$stored-v$target.db';
@@ -118,6 +127,68 @@ class PreMigrationBackupService {
     } catch (e, stack) {
       _log.warning(
         'Pre-migration prune failed (backup kept)',
+        error: e,
+        stackTrace: stack,
+      );
+    }
+  }
+
+  /// Folds a hot `-wal` back into the main database file so the byte copy
+  /// below is a complete snapshot of what the migration is about to touch.
+  ///
+  /// A SQLite database is not one file. A crash or force-kill leaves
+  /// committed transactions in `<db>-wal`, uncheckpointed; the migration
+  /// replays them when it opens the database, so a copy of `<db>` alone is
+  /// missing the tail of the user's data: precisely the data a safety copy
+  /// exists to protect. Copying the sidecar alongside would not help:
+  /// `DatabaseService.restore` stages only the single backup file and deletes
+  /// the destination's sidecars before the swap, so a `-wal` next to the
+  /// backup would never travel. Checkpointing yields a self-contained file
+  /// the existing restore path already handles.
+  ///
+  /// Best-effort by contract. A database that cannot be opened read-write
+  /// (ejected volume, read-only mount, missing or wrong key) still gets its
+  /// plain copy: an incomplete safety net beats a bricked startup, and the
+  /// migration that follows will surface the real problem itself.
+  ///
+  /// Opens only when a non-empty `-wal` is actually present, so the common
+  /// case (a cleanly closed database) never touches the file at all.
+  Future<void> _checkpointHotWal(String livePath) async {
+    try {
+      final wal = File('$livePath-wal');
+      if (!await wal.exists() || await wal.length() == 0) return;
+    } catch (e, stack) {
+      _log.warning(
+        'Could not inspect the WAL sidecar for $livePath; copying as-is',
+        error: e,
+        stackTrace: stack,
+      );
+      return;
+    }
+
+    try {
+      final db = DatabaseService.openRaw(
+        livePath,
+        keyHex: _databaseKeyHexProvider?.call(),
+      );
+      try {
+        // Returns one row (busy, log, checkpointed); busy != 0 means frames
+        // were left behind, so say so rather than implying a clean snapshot.
+        final result = db.select('PRAGMA wal_checkpoint(TRUNCATE)');
+        final busy = result.isEmpty ? null : result.first.values.first;
+        if (busy != 0) {
+          _log.warning(
+            'WAL checkpoint before the pre-migration backup did not complete '
+            '(busy=$busy); the copy may omit WAL-resident rows',
+          );
+        }
+      } finally {
+        db.close();
+      }
+    } catch (e, stack) {
+      _log.warning(
+        'WAL checkpoint before the pre-migration backup failed; copying the '
+        'database file as-is',
         error: e,
         stackTrace: stack,
       );

--- a/test/core/database/pre_migration_backup_integration_test.dart
+++ b/test/core/database/pre_migration_backup_integration_test.dart
@@ -4,9 +4,62 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/security/database_encryption_migrator.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/pre_migration_backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+/// The live-database key an install with password protection would hold.
+const _liveKeyHex =
+    '4a5f1c9d3e8b0726114d90ab63fe2d58c7093a41bb5e6f28d0c1a7935e4b8206';
+
+/// Leaves [dbPath] in the state a crash or force-kill produces: one row
+/// durably in the main file, a second committed row living only in a hot
+/// `-wal` that was never checkpointed.
+///
+/// SQLite checkpoints and deletes the `-wal` when the last connection closes,
+/// so the sidecars are snapshotted while the connection is still open and
+/// written back afterwards, the only way to manufacture a hot WAL from a
+/// single-process test.
+void seedHotWal(String dbPath, {String? keyHex}) {
+  final db = DatabaseService.openRaw(
+    dbPath,
+    mode: sqlite3.OpenMode.readWriteCreate,
+    keyHex: keyHex,
+  );
+  db.select('PRAGMA journal_mode = WAL');
+  db.execute('CREATE TABLE sentinel (id INTEGER PRIMARY KEY)');
+  db.execute('INSERT INTO sentinel VALUES (42)');
+  db.execute('PRAGMA user_version = 63');
+  db.select('PRAGMA wal_checkpoint(TRUNCATE)');
+
+  // Committed, but small enough that no auto-checkpoint folds it in.
+  db.execute('INSERT INTO sentinel VALUES (99)');
+  final mainBytes = File(dbPath).readAsBytesSync();
+  final walBytes = File('$dbPath-wal').readAsBytesSync();
+  db.close();
+
+  File(dbPath).writeAsBytesSync(mainBytes);
+  File('$dbPath-wal').writeAsBytesSync(walBytes);
+}
+
+/// The `sentinel` ids readable from [dbPath], opened standalone (no sidecars).
+List<Object?> sentinelIds(String dbPath, {String? keyHex}) {
+  final db = DatabaseService.openRaw(
+    dbPath,
+    mode: sqlite3.OpenMode.readOnly,
+    keyHex: keyHex,
+  );
+  try {
+    return db
+        .select('SELECT id FROM sentinel ORDER BY id')
+        .map((row) => row.values.first)
+        .toList();
+  } finally {
+    db.close();
+  }
+}
 
 void main() {
   test('end-to-end: seeds v63 DB, backs up, verifies bytes + record', () async {
@@ -70,5 +123,123 @@ void main() {
     expect(records.single.type, BackupType.preMigration);
     expect(records.single.fromSchemaVersion, 63);
     expect(records.single.toSchemaVersion, 64);
+  });
+
+  test(
+    'a hot WAL is folded in, so the copy carries every committed row',
+    () async {
+      final tmp = await Directory.systemTemp.createTemp('pmbs_wal_');
+      addTearDown(() => tmp.delete(recursive: true));
+
+      final livePath = p.join(tmp.path, 'submersion.db');
+      final backupsDir = p.join(tmp.path, 'backups');
+      await Directory(backupsDir).create(recursive: true);
+
+      seedHotWal(livePath);
+      // Precondition: row 99 really is WAL-resident, not in the main file.
+      expect(File('$livePath-wal').lengthSync(), greaterThan(0));
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+      final service = PreMigrationBackupService(
+        livePathProvider: () async => livePath,
+        backupsDirProvider: () async => backupsDir,
+        preferences: prefs,
+        clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+        idGenerator: () => 'wal-id',
+      );
+
+      await service.backupIfMigrationPending(
+        stored: 63,
+        target: 64,
+        appVersion: '1.6.0.1241',
+      );
+
+      final backupPath = p.join(backupsDir, '20260412-081201000-v63-v64.db');
+      expect(sentinelIds(backupPath), [42, 99]);
+      // The checkpoint is lossless for the live database too.
+      expect(sentinelIds(livePath), [42, 99]);
+    },
+  );
+
+  test('a hot WAL on an ENCRYPTED live database is folded in too', () async {
+    final tmp = await Directory.systemTemp.createTemp('pmbs_wal_enc_');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final livePath = p.join(tmp.path, 'submersion.db');
+    final backupsDir = p.join(tmp.path, 'backups');
+    await Directory(backupsDir).create(recursive: true);
+
+    // Create the database, encrypt it in place (as enabling protection does),
+    // then leave a hot WAL on the encrypted file.
+    final seed = sqlite3.sqlite3.open(livePath);
+    seed.execute('PRAGMA user_version = 63');
+    seed.close();
+    await DatabaseEncryptionMigrator().encryptInPlace(
+      dbPath: livePath,
+      keyHex: _liveKeyHex,
+    );
+    seedHotWal(livePath, keyHex: _liveKeyHex);
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => livePath,
+      backupsDirProvider: () async => backupsDir,
+      preferences: prefs,
+      databaseKeyHexProvider: () => _liveKeyHex,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'wal-enc-id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final backupPath = p.join(backupsDir, '20260412-081201000-v63-v64.db');
+    expect(sentinelIds(backupPath, keyHex: _liveKeyHex), [42, 99]);
+  });
+
+  test('an unopenable live database still produces a backup', () async {
+    final tmp = await Directory.systemTemp.createTemp('pmbs_wal_fail_');
+    addTearDown(() => tmp.delete(recursive: true));
+
+    final livePath = p.join(tmp.path, 'submersion.db');
+    final backupsDir = p.join(tmp.path, 'backups');
+    await Directory(backupsDir).create(recursive: true);
+
+    seedHotWal(livePath);
+    // No key supplied for what the checkpoint will read as an unopenable
+    // file: the safety copy must still be taken rather than failing startup.
+    await DatabaseEncryptionMigrator().encryptInPlace(
+      dbPath: livePath,
+      keyHex: _liveKeyHex,
+    );
+    File('$livePath-wal').writeAsBytesSync(List<int>.filled(64, 7));
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = BackupPreferences(await SharedPreferences.getInstance());
+
+    final service = PreMigrationBackupService(
+      livePathProvider: () async => livePath,
+      backupsDirProvider: () async => backupsDir,
+      preferences: prefs,
+      clock: () => DateTime.utc(2026, 4, 12, 8, 12, 1),
+      idGenerator: () => 'wal-fail-id',
+    );
+
+    await service.backupIfMigrationPending(
+      stored: 63,
+      target: 64,
+      appVersion: '1.6.0.1241',
+    );
+
+    final backupPath = p.join(backupsDir, '20260412-081201000-v63-v64.db');
+    expect(File(backupPath).existsSync(), isTrue);
+    expect(prefs.getHistory(), hasLength(1));
   });
 }

--- a/test/core/services/background_service_backup_test.dart
+++ b/test/core/services/background_service_backup_test.dart
@@ -36,6 +36,9 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// An adapter whose backup always fails, modelling a full disk or an

--- a/test/features/backup/data/services/backup_encryption_backup_test.dart
+++ b/test/features/backup/data/services/backup_encryption_backup_test.dart
@@ -42,6 +42,9 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Per-file temp root, so the backup service's fixed `Submersion/Backups`

--- a/test/features/backup/data/services/backup_service_encryption_test.dart
+++ b/test/features/backup/data/services/backup_service_encryption_test.dart
@@ -41,6 +41,9 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Per-file temp root, so the backup service's fixed `Submersion/Backups`

--- a/test/features/backup/data/services/backup_service_premigration_restore_test.dart
+++ b/test/features/backup/data/services/backup_service_premigration_restore_test.dart
@@ -1,0 +1,251 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/security/database_encryption_migrator.dart';
+import 'package:submersion/core/services/security/database_security_sidecar.dart';
+import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
+import 'package:submersion/features/backup/data/services/backup_service.dart';
+import 'package:submersion/features/backup/domain/entities/backup_record.dart';
+import 'package:submersion/features/backup/domain/entities/backup_type.dart';
+
+/// The live-database key an encrypted install would hold in memory.
+const _liveKeyHex =
+    '4a5f1c9d3e8b0726114d90ab63fe2d58c7093a41bb5e6f28d0c1a7935e4b8206';
+
+/// Fake adapter that reports a live SQLCipher key, mirroring an install with
+/// database password protection enabled.
+class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
+  _FakeBackupDatabaseAdapter({this.databaseKeyHex});
+
+  @override
+  final String? databaseKeyHex;
+
+  String? lastRestorePath;
+  int restoreCallCount = 0;
+
+  @override
+  Future<void> backup(String destinationPath) async {
+    final file = File(destinationPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsString('fake backup data');
+  }
+
+  @override
+  Future<void> restore(
+    String backupPath, {
+    void Function(int, int)? onMigrationProgress,
+  }) async {
+    restoreCallCount++;
+    lastRestorePath = backupPath;
+  }
+
+  @override
+  Future<String> get databasePath async => '/fake/db/path';
+
+  @override
+  AppDatabase get database =>
+      throw UnimplementedError('Fake database does not support direct queries');
+}
+
+class _SpySyncRepository extends SyncRepository {
+  @override
+  Future<String> getDeviceId() async => 'live-device-id';
+
+  @override
+  Future<String?> getLastAcceptedEpochId() async => null;
+
+  @override
+  Future<void> rebaselineAfterRestore({
+    String? preserveDeviceId,
+    String? preserveEpochId,
+  }) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late BackupPreferences preferences;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async => Directory.systemTemp.path,
+        );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = BackupPreferences(await SharedPreferences.getInstance());
+    tempDir = await Directory.systemTemp.createTemp('premigration_restore_');
+  });
+
+  tearDown(() => tempDir.delete(recursive: true));
+
+  /// Writes a Submersion-shaped database at [name] and encrypts it in place
+  /// with [_liveKeyHex]: byte-for-byte what `PreMigrationBackupService`
+  /// copies on an install with database protection enabled.
+  Future<String> writeEncryptedPreMigrationCopy(String name) async {
+    final path = '${tempDir.path}/$name';
+    final db = sqlite3.sqlite3.open(path);
+    db.execute('CREATE TABLE dives (id TEXT PRIMARY KEY)');
+    db.execute('CREATE TABLE dive_sites (id TEXT PRIMARY KEY)');
+    db.execute("INSERT INTO dives VALUES ('dive-1')");
+    db.execute('PRAGMA user_version = 63');
+    db.close();
+
+    await DatabaseEncryptionMigrator().encryptInPlace(
+      dbPath: path,
+      keyHex: _liveKeyHex,
+    );
+    return path;
+  }
+
+  BackupRecord recordFor(String path, BackupType type) => BackupRecord(
+    id: 'record-1',
+    filename: path.split(Platform.pathSeparator).last,
+    timestamp: DateTime.utc(2026, 4, 12),
+    sizeBytes: File(path).lengthSync(),
+    location: BackupLocation.local,
+    localPath: path,
+    isAutomatic: true,
+    type: type,
+    fromSchemaVersion: 63,
+    toSchemaVersion: 64,
+  );
+
+  test('the fixture really is SQLCipher ciphertext', () async {
+    final path = await writeEncryptedPreMigrationCopy('enc.db');
+    expect(isEncryptedDatabaseFile(path), isTrue);
+  });
+
+  group('validateBackupFile', () {
+    test('rejects a SQLCipher-encrypted .db by default', () async {
+      final path = await writeEncryptedPreMigrationCopy('enc.db');
+      final service = BackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(databaseKeyHex: _liveKeyHex),
+        preferences: preferences,
+      );
+
+      final result = await service.validateBackupFile(path);
+
+      expect(result.isValid, isFalse);
+    });
+
+    test('accepts a SQLCipher-encrypted .db when live encryption is '
+        'allowed and the live key opens it', () async {
+      final path = await writeEncryptedPreMigrationCopy('enc.db');
+      final service = BackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(databaseKeyHex: _liveKeyHex),
+        preferences: preferences,
+      );
+
+      final result = await service.validateBackupFile(
+        path,
+        allowLiveDatabaseEncryption: true,
+      );
+
+      expect(result.isValid, isTrue, reason: result.error);
+      expect(result.sizeBytes, greaterThan(0));
+    });
+
+    test(
+      'rejects an encrypted copy when the install holds no live key',
+      () async {
+        final path = await writeEncryptedPreMigrationCopy('enc.db');
+        final service = BackupService(
+          dbAdapter: _FakeBackupDatabaseAdapter(),
+          preferences: preferences,
+        );
+
+        final result = await service.validateBackupFile(
+          path,
+          allowLiveDatabaseEncryption: true,
+        );
+
+        expect(result.isValid, isFalse);
+        expect(result.error, contains('protected'));
+      },
+    );
+
+    test(
+      'rejects an encrypted copy when the live key is the wrong one',
+      () async {
+        final path = await writeEncryptedPreMigrationCopy('enc.db');
+        final service = BackupService(
+          dbAdapter: _FakeBackupDatabaseAdapter(databaseKeyHex: 'ff' * 32),
+          preferences: preferences,
+        );
+
+        final result = await service.validateBackupFile(
+          path,
+          allowLiveDatabaseEncryption: true,
+        );
+
+        expect(result.isValid, isFalse);
+      },
+    );
+
+    test(
+      'still rejects a corrupt plaintext .db when live encryption is allowed',
+      () async {
+        final path = '${tempDir.path}/corrupt.db';
+        await File(path).writeAsString('this is not a sqlite database');
+        final service = BackupService(
+          dbAdapter: _FakeBackupDatabaseAdapter(databaseKeyHex: _liveKeyHex),
+          preferences: preferences,
+        );
+
+        final result = await service.validateBackupFile(
+          path,
+          allowLiveDatabaseEncryption: true,
+        );
+
+        expect(result.isValid, isFalse);
+      },
+    );
+  });
+
+  group('restoreFromBackup', () {
+    test('restores an encrypted pre-migration backup', () async {
+      final path = await writeEncryptedPreMigrationCopy('enc.db');
+      final adapter = _FakeBackupDatabaseAdapter(databaseKeyHex: _liveKeyHex);
+      final service = BackupService(
+        dbAdapter: adapter,
+        preferences: preferences,
+        syncRepository: _SpySyncRepository(),
+      );
+
+      await service.restoreFromBackup(recordFor(path, BackupType.preMigration));
+
+      expect(adapter.restoreCallCount, 1);
+      expect(adapter.lastRestorePath, path);
+    });
+
+    test(
+      'still rejects an encrypted artifact offered as a manual backup',
+      () async {
+        final path = await writeEncryptedPreMigrationCopy('enc.db');
+        final adapter = _FakeBackupDatabaseAdapter(databaseKeyHex: _liveKeyHex);
+        final service = BackupService(
+          dbAdapter: adapter,
+          preferences: preferences,
+          syncRepository: _SpySyncRepository(),
+        );
+
+        await expectLater(
+          service.restoreFromBackup(recordFor(path, BackupType.manual)),
+          throwsA(isA<BackupException>()),
+        );
+        expect(adapter.restoreCallCount, 0);
+      },
+    );
+  });
+}

--- a/test/features/backup/data/services/backup_service_premigration_restore_test.dart
+++ b/test/features/backup/data/services/backup_service_premigration_restore_test.dart
@@ -175,6 +175,29 @@ void main() {
       },
     );
 
+    test('names corruption as well as encryption when there is no key to tell '
+        'them apart', () async {
+      // A corrupt plaintext copy and a SQLCipher one are identical at the
+      // header, and the keyslot sidecar that would corroborate "encrypted"
+      // lives next to the LIVE database, never in the backups directory.
+      // With no key to settle it, the report must not assert either story.
+      final path = '${tempDir.path}/corrupt.db';
+      await File(path).writeAsString('this is not a sqlite database');
+      final service = BackupService(
+        dbAdapter: _FakeBackupDatabaseAdapter(),
+        preferences: preferences,
+      );
+
+      final result = await service.validateBackupFile(
+        path,
+        allowLiveDatabaseEncryption: true,
+      );
+
+      expect(result.isValid, isFalse);
+      expect(result.error, contains('corrupt'));
+      expect(result.error, contains('protected'));
+    });
+
     test(
       'rejects an encrypted copy when the live key is the wrong one',
       () async {

--- a/test/features/backup/data/services/backup_service_replace_test.dart
+++ b/test/features/backup/data/services/backup_service_replace_test.dart
@@ -36,6 +36,9 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support direct queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Spy repository with a live epoch, isolating restore wiring from the DB.

--- a/test/features/backup/data/services/backup_service_saf_io_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_io_test.dart
@@ -37,6 +37,9 @@ class _FileWritingAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 class _FakeSafPort implements BackupSafPort {

--- a/test/features/backup/data/services/backup_service_saf_refs_test.dart
+++ b/test/features/backup/data/services/backup_service_saf_refs_test.dart
@@ -25,6 +25,9 @@ class _NoopAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 class _RecordingSafPort implements BackupSafPort {

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -57,6 +57,9 @@ class FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake database does not support direct queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Spy sync repository: records the post-restore re-baseline without touching a

--- a/test/features/backup/data/services/backup_target_test.dart
+++ b/test/features/backup/data/services/backup_target_test.dart
@@ -30,6 +30,9 @@ class _FakeAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 class _FakeSafPort implements BackupSafPort {

--- a/test/features/backup/presentation/pages/backup_settings_page_test.dart
+++ b/test/features/backup/presentation/pages/backup_settings_page_test.dart
@@ -672,6 +672,9 @@ class _FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   @override
   AppDatabase get database =>
       throw UnimplementedError('Fake does not support direct queries');
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// BackupService override recording restore calls so page-level wiring can be
@@ -686,8 +689,10 @@ class _RecordingRestoreService extends BackupService {
   });
 
   @override
-  Future<BackupValidationResult> validateBackupFile(String filePath) async =>
-      const BackupValidationResult.valid(sizeBytes: 1);
+  Future<BackupValidationResult> validateBackupFile(
+    String filePath, {
+    bool allowLiveDatabaseEncryption = false,
+  }) async => const BackupValidationResult.valid(sizeBytes: 1);
 
   @override
   Future<void> restoreFromBackup(

--- a/test/features/backup/presentation/providers/backup_export_saf_test.dart
+++ b/test/features/backup/presentation/providers/backup_export_saf_test.dart
@@ -31,6 +31,9 @@ class _NoopAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Hands back a real temp artifact so the test can prove it is streamed and

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -37,6 +37,9 @@ class _NoopAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Records restore invocations so the notifier's threading of [RestoreMode]
@@ -76,8 +79,10 @@ class _RecordingBackupService extends BackupService {
   }
 
   @override
-  Future<BackupValidationResult> validateBackupFile(String filePath) async =>
-      const BackupValidationResult.valid(sizeBytes: 1);
+  Future<BackupValidationResult> validateBackupFile(
+    String filePath, {
+    bool allowLiveDatabaseEncryption = false,
+  }) async => const BackupValidationResult.valid(sizeBytes: 1);
 
   @override
   Future<void> restoreFromBackup(

--- a/test/features/backup/presentation/widgets/backup_encryption_section_test.dart
+++ b/test/features/backup/presentation/widgets/backup_encryption_section_test.dart
@@ -67,6 +67,9 @@ class _FakeDbAdapter implements BackupDatabaseAdapter {
   Future<String> get databasePath async => '/fake/db';
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// A [BackupService] whose only overridden method is the re-encrypt migration,

--- a/test/features/settings/presentation/pages/cloud_sync_page_test.dart
+++ b/test/features/settings/presentation/pages/cloud_sync_page_test.dart
@@ -121,6 +121,9 @@ class _NoopBackupAdapter implements BackupDatabaseAdapter {
 
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 /// Fake [BackupService] recording safety-backup calls from the adopt flow.

--- a/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
+++ b/test/features/settings/presentation/widgets/encryption_settings_section_flows_test.dart
@@ -152,6 +152,9 @@ class _NoopBackupAdapter implements BackupDatabaseAdapter {
   Future<String> get databasePath async => '/noop';
   @override
   AppDatabase get database => throw UnimplementedError();
+
+  @override
+  String? get databaseKeyHex => null;
 }
 
 class _RecordingBackupService extends BackupService {


### PR DESCRIPTION
Closes #1137.

`PreMigrationBackupService` takes a raw byte copy of the closed live database before a schema migration. That copy is a second, non-portable backup kind, and it inherited two assumptions that only hold for portable backups.

## Bug 1: encrypted installs produced unrestorable safety copies

When database password protection is on, the live file is SQLCipher ciphertext, so the copy is too. `validateBackupFile` admits an encrypted artifact only when it carries the app's own SBE envelope magic, then falls through to a deliberately keyless read-only open, which fails with `SQLITE_NOTADB`. The restore was rejected as "not a valid database".

The layer below was already correct: `DatabaseService.restore` detects the encrypted header and skips the re-encryption it would otherwise apply, and the keyslot sidecar `submersion.keys` sits next to the database, untouched by a migration. Only the validation gate said no.

`validateBackupFile` now takes `allowLiveDatabaseEncryption`, which `restoreFromBackup` sets for a `BackupType.preMigration` record. Such a file is deep-checked with the live key, reached through a new `BackupDatabaseAdapter.databaseKeyHex`, instead of being rejected; it fails with a clear message when this install has no key to open it with. Portable backups keep the strict plaintext rule, so an encrypted-looking manual backup still fails loudly.

## Bug 2: the copy omitted WAL-resident rows

A crash or force-kill leaves committed transactions in `<db>-wal`. Those transactions **are** replayed into the live file when the migration opens it, so a copy of `<db>` alone is not a snapshot of what actually got migrated; it is missing the tail of the user's data. The service now checkpoints a non-empty hot WAL before copying.

### Why checkpoint rather than copy the sidecars

The issue offered both options as equivalent. They are not, and the reason is downstream: `DatabaseService.restore` copies **only** the single backup file into staging, and explicitly deletes `<dest>-wal` / `<dest>-shm` before the swap. A `<backup>.db-wal` sitting next to the backup would never travel, so the sidecar approach would still lose the data at restore time. Checkpointing produces a self-contained single file that the existing restore path already handles.

The checkpoint is best-effort by contract: a database that cannot be opened read-write (ejected volume, read-only mount, missing or wrong key) still gets its plain copy. An incomplete safety net beats a bricked startup, and the migration that follows surfaces the real problem itself. It also opens the file only when a non-empty `-wal` is actually present, so the common case of a cleanly closed database never touches it.

## Interface change

`BackupDatabaseAdapter` gains `String? get databaseKeyHex`. Dart's `implements` requires every member regardless of a default body, so this is a breaking change for the 13 existing test fakes; each gained a one-line `=> null` override, which is also the honest value for a fake modelling an unprotected install.

## Tests

- Encrypted round trip through `restoreFromBackup`, plus the no-key and wrong-key rejections and the unchanged manual-backup rejection (`backup_service_premigration_restore_test.dart`).
- Hot-WAL fixtures in `pre_migration_backup_integration_test.dart`: plaintext, encrypted, and an unopenable database that must still produce a backup. The first two fail with `[42]` instead of `[42, 99]` when the checkpoint is removed, which was verified.
- `flutter analyze` clean; full suite green (18791 passed, 19 skipped).

## Out of scope

Automatic rollback on migration failure and the terminal error screen's lack of a recovery route, per the issue's stated scope (see #1134).
