### PR TITLE
ci: scope build-all caches to the release pipeline and record the ref decision

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -53,6 +53,49 @@ permissions:
 env:
   FLUTTER_VERSION_FILE: '.github/flutter-version.txt'
 
+# Cache and ref design (issue #1132, CodeQL actions/cache-poisoning).
+#
+# Every job here runs repo-controlled code before it produces artifacts that
+# ship: build_runner generators, package build hooks (the package:sqlite3 hook
+# downloads and installs SQLCipher), and the scripts/check_*.py guards. Whatever
+# a job restores from a cache is therefore part of the release supply chain, so
+# these two properties are chosen rather than inherited.
+#
+# The ref. The workflow_dispatch path declares no ref input, so checkout falls
+# back to the ref the run was started on, which dispatch already restricts to
+# real refs in this repository. The ref input exists only on workflow_call, and
+# both callers pass one they validated: release.yml passes none, leaving
+# checkout to resolve the tag that triggered it, and beta.yml passes the SHA of
+# a main commit whose CI run concluded successfully. No reachability guard is
+# added here because it would only restate what the callers guarantee.
+#
+# The caches. Two rules, both load-bearing:
+#
+#   1. Cache ~/.pub-cache, never .dart_tool. pubspec.lock records a sha256 for
+#      every hosted package and pub validates cached content against it, so a
+#      tampered pub cache entry is caught. .dart_tool holds build_runner output
+#      and the package config with no integrity check of any kind, and
+#      `dart run build_runner build` consumes it directly. The cost is a cold
+#      codegen pass on release and beta builds; the package downloads, which
+#      dominate the saving, are still cached.
+#   2. Namespace the keys to this workflow. GitHub scopes caches by ref and a
+#      tag run can read the default branch's scope, so a shared key would let a
+#      release build restore an entry written by any job that ran on main.
+#      The build-all prefixes keep that set down to other build-all runs; do not
+#      let them converge with the plain pub-<os> keys ci.yaml uses.
+#
+# Neither rule is carried over to ci.yaml, and that is deliberate. Nothing that
+# workflow produces is distributed, its .dart_tool cache is a real saving across
+# the analyze and test matrix, and narrowing it would buy nothing but slower
+# builds of artifacts that get thrown away.
+#
+# One more thing for whoever revisits this. CodeQL flagged exactly one of the
+# several structurally identical steps in this file. The Android guards use
+# `run: |` with line continuations and the Windows one invokes `python` rather
+# than `python3`, and neither matched the query's pattern for "executes a local
+# script". The discriminator is syntactic, not semantic: the absence of an alert
+# on a step is not evidence that the step is safe.
+
 jobs:
   # ============================================================================
   # macOS Build (signed DMG + Mac App Store)
@@ -99,17 +142,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
-          path: |
-            ~/.pub-cache
-            ${{ github.workspace }}/.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          path: ~/.pub-cache
+          key: pub-build-all-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-build-all-${{ runner.os }}-
 
       # Flutter 3.44 enables Swift Package Manager by default. This project is
       # not migrated to SPM (the Xcode projects carry no package references) and
@@ -387,17 +428,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
-          path: |
-            ~\.pub-cache
-            ${{ github.workspace }}\.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          path: ~\.pub-cache
+          key: pub-build-all-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-build-all-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -531,17 +570,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
-          path: |
-            ~/.pub-cache
-            ${{ github.workspace }}/.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          path: ~/.pub-cache
+          key: pub-build-all-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-build-all-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -616,17 +653,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
-          path: |
-            ~/.pub-cache
-            ${{ github.workspace }}/.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          path: ~/.pub-cache
+          key: pub-build-all-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-build-all-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -792,17 +827,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
-          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+          key: build-all-${{ steps.setup-flutter.outputs.CACHE-KEY }}
 
       - name: Cache pub dependencies
         uses: actions/cache@v6
         with:
-          path: |
-            ~/.pub-cache
-            ${{ github.workspace }}/.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          path: ~/.pub-cache
+          key: pub-build-all-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            pub-${{ runner.os }}-
+            pub-build-all-${{ runner.os }}-
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Closes #1132.

The issue asked for a deliberate decision on `build-all.yml`'s cache and
`workflow_dispatch` ref design rather than an implicit one, after CodeQL alert
#64 (`actions/cache-poisoning/poisonable-step`) surfaced on PR #1131 and was
dismissed as not attributable to the step that triggered it.

## Two corrections to the issue's premise

**The dispatch path has no `ref` input.** `build-all.yml` declares only
`version-tag` and `build-number` for `workflow_dispatch`; `ref` exists solely on
`workflow_call`. On the dispatch path `inputs.ref` is empty and checkout falls
back to the ref the run was started on, which dispatch already restricts to real
refs in this repository. The "dispatch with an attacker-influenced ref" scenario
has no input to influence.

**Both `workflow_call` callers already pass a validated ref.** `release.yml`
passes none, leaving checkout to resolve the tag that triggered it. `beta.yml`
passes `precheck.outputs.sha`, computed after checking out
`github.event.workflow_run.head_sha` from a trigger pinned to `branches: [main]`
with `conclusion == 'success'`.

So no ref validation is added. A reachability guard would need a full-history
fetch to restate what the callers already guarantee.

## What did change

The under-stated risk was in what gets cached, not in the ref:

```yaml
path: |
  ~/.pub-cache
  ${{ github.workspace }}/.dart_tool
key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
restore-keys: |
  pub-${{ runner.os }}-
```

1. **`.dart_tool` is no longer cached; `~/.pub-cache` still is.** `pubspec.lock`
   records a `sha256` for every hosted package (300 entries) and pub validates
   cached content against it, so a tampered pub cache entry is caught.
   `.dart_tool` holds build_runner output and the package config with no
   integrity check of any kind, and `dart run build_runner build` consumes it
   directly. The `restore-keys` prefix made this reachable in practice: it
   restores the newest entry with that prefix regardless of the `pubspec.lock`
   hash, so a `.dart_tool` built against a different dependency set could
   already land in a release build.

2. **Cache keys are namespaced to this workflow** (`pub-build-all-<os>-...` and
   `build-all-<flutter-cache-key>`). GitHub scopes caches by ref and a tag run
   can read the default branch's scope, so the previous shared key let a release
   build restore an entry written by any job that ran on `main`. The Flutter SDK
   key gets the same treatment because it caches the toolchain itself; those
   `actions/cache` steps sit after `subosito/flutter-action`, so their restore
   never beats the SDK download anyway and namespacing them costs nothing.

3. **A decision record above `jobs:`**, in the file's existing rationale style,
   covering the ref analysis, both cache rules, why `ci.yaml` is deliberately
   left alone, and the issue's warning that CodeQL's step-level silence is
   syntactic rather than semantic.

`ci.yaml` is intentionally untouched: nothing it produces is distributed, its
`.dart_tool` cache is a real saving across the analyze and test matrix, and
narrowing it would only slow down artifacts that get thrown away.

## Trade-off

Release and beta builds lose build_runner's incremental cache and do a cold
codegen pass. Package downloads, which dominate the saving, still hit the cache.
The alternative CodeQL recommends, dropping `actions/cache` from release jobs
entirely, would re-download the Flutter SDK and the full dependency set across
five platform jobs on every release and every per-merge beta; that was judged
too expensive for the residual risk, which requires write access to reach.

## Verification

- `actionlint`: 14 shellcheck findings, byte-identical to the `HEAD` baseline;
  zero actionlint findings of its own
- YAML parses with all five jobs intact
- `flutter analyze`: no issues found
- `dart format`: 3832 files, 0 changed

Not measured: the actual CI time cost of the cold codegen pass. That shows up on
the first release or beta run after this merges.
