### PR TITLE
fix(deps): bump riverpod to 3.4.2 for the setState-during-build crash

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "99.0.0"
+    version: "103.0.0"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.3.0"
   analyzer_buffer:
     dependency: transitive
     description:
@@ -388,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.12"
   dbus:
     dependency: transitive
     description:
@@ -444,10 +444,10 @@ packages:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
+      sha256: "735aad3c34215805c66bd518c8812fa4f83b5534b2c13c4092c970c04a7e9983"
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.5"
   equatable:
     dependency: "direct main"
     description:
@@ -739,10 +739,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
+      sha256: "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -874,10 +874,10 @@ packages:
     dependency: transitive
     description:
       name: geocoding_darwin
-      sha256: ac9c85dc6fbb1afa6fea9be0c174a782132b19c01c0e44c4204d7fe8974ac96b
+      sha256: "97552aa24f1453defc17e4d8e40b13ddf097e669c2edfa17ed86349cacdbc1ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   geocoding_platform_interface:
     dependency: "direct dev"
     description:
@@ -1290,6 +1290,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  listen:
+    dependency: transitive
+    description:
+      name: listen
+      sha256: "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   local_auth:
     dependency: "direct main"
     description:
@@ -1390,10 +1398,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
+      sha256: "6c1970612452260366064d4df80fdb3eece1ec5e52610ae34a0e51f2f3d8e64f"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.4"
+    version: "5.8.1"
   native_exif:
     dependency: "direct main"
     description:
@@ -1674,14 +1682,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.0"
-  pigeon:
-    dependency: transitive
-    description:
-      name: pigeon
-      sha256: "04cfefc8add8b47ddf9ccac8b92bb4edeb67c87f185c623ba0db118ac99334ad"
-      url: "https://pub.dev"
-    source: hosted
-    version: "26.3.4"
   platform:
     dependency: transitive
     description:
@@ -1798,34 +1798,34 @@ packages:
     dependency: "direct main"
     description:
       name: riverpod
-      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
+      sha256: "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
+      sha256: "46a8dd0461080fde8f886f65f87580758dae8495e352f9ea6a09953abc3df7bd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.10"
+    version: "1.0.0-dev.11"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
+      sha256: dd043c75eb3cea2654f5dca51234413ac04bd092ccc73e747fd73cae37ac5360
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.6"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
+      sha256: "2e66b5691cf5d50d6a409904b0477e869e0ecbdd5ada1535d263a95d44439e75"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.8"
   rxdart:
     dependency: transitive
     description:
@@ -2043,10 +2043,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
+      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.44.5"
+    version: "0.45.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,10 @@ dependencies:
   # UncontrolledProviderScope when a Consumer reads a provider that was
   # invalidated while auto-paused. Guard test:
   # test/core/providers/autopause_flush_during_build_test.dart
+  # riverpod_annotation pins an EXACT riverpod version (4.0.6 -> 3.4.2), so
+  # these three move as a set; keep their floors in step.
   flutter_riverpod: ^3.4.2
-  riverpod_annotation: ^4.0.0
+  riverpod_annotation: ^4.0.6
   riverpod: ^3.4.2
 
   # Database
@@ -165,7 +167,9 @@ dev_dependencies:
   build_runner: ^2.10.4
   drift_dev: ^2.34.0
   json_serializable: ^6.11.2
-  riverpod_generator: ^4.0.0+1
+  # 4.0.8 is the generator that matches riverpod_annotation 4.0.6, and the
+  # reason the analyzer floor below is ^13.
+  riverpod_generator: ^4.0.8
   mockito: ^5.6.1
   plugin_platform_interface: ^2.1.8
   path_provider_platform_interface: ^2.1.3  # mock docs dir in db service tests

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,9 +16,13 @@ dependencies:
   cupertino_icons: ^1.0.8
 
   # State Management
-  flutter_riverpod: ^3.1.0
+  # 3.4.2 floor: earlier versions throw "setState() called during build" from
+  # UncontrolledProviderScope when a Consumer reads a provider that was
+  # invalidated while auto-paused. Guard test:
+  # test/core/providers/autopause_flush_during_build_test.dart
+  flutter_riverpod: ^3.4.2
   riverpod_annotation: ^4.0.0
-  riverpod: ^3.1.0
+  riverpod: ^3.4.2
 
   # Database
   drift: ^2.34.3
@@ -172,7 +176,9 @@ dev_dependencies:
   share_plus_platform_interface: ^7.2.0  # fake share sheet in media share tests
   video_player_platform_interface: ^6.7.0  # fake player in media viewer tests
   fake_async: ^1.3.3  # synthetic clock + Timer driving for unit tests
-  analyzer: ^12.0.0  # AST parsing for the provider change-tick architecture test
+  # AST parsing for the provider change-tick architecture test. The ^13 floor
+  # is forced by riverpod_generator 4.0.8, which riverpod 3.4.2 requires.
+  analyzer: ^13.3.0
 
 dependency_overrides:
   # fit_tool (3 years unmaintained) has stale deps; overrides are safe because:

--- a/test/core/providers/autopause_flush_during_build_test.dart
+++ b/test/core/providers/autopause_flush_during_build_test.dart
@@ -1,0 +1,109 @@
+// Guard test for the Riverpod behaviour the whole app depends on: flushing a
+// stale provider from inside a widget build must not schedule a provider
+// refresh, because that refresh calls setState() on UncontrolledProviderScope
+// and Flutter forbids setState() during build.
+//
+// The failure this pins down (seen on the Home page, GaugeStrip watching
+// dashboardGaugesProvider) needs three things to line up:
+//
+//   1. A Consumer goes off-screen, so Riverpod 3 auto-pause pauses its
+//      subscriptions and the providers it watches become inactive.
+//   2. Something invalidates one of those providers while it is inactive.
+//      ProviderScheduler._performRefresh() only flushes elements that are
+//      active, then clears its queue, so the element stays dirty forever.
+//   3. A Consumer mounts (or rebuilds) and reads a descendant of that stale
+//      element. ref.watch flushes it synchronously mid-build, the rebuilt
+//      ancestor notifies the descendant, and the descendant calls
+//      invalidateSelf() -> scheduleProviderRefresh() -> setState() during
+//      build.
+//
+// Riverpod 3.4.0/3.4.2 fixed it by guarding invalidateSelf() with
+// `!_isFlushing && isActive`. Riverpod 3.3.2 and earlier throw here.
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A new identity on every build, so a rebuild always notifies listeners.
+final _upstreamProvider = Provider<Object>((ref) => Object());
+
+final _downstreamProvider = Provider<Object>((ref) {
+  ref.watch(_upstreamProvider);
+  return Object();
+});
+
+class _Harness extends StatefulWidget {
+  const _Harness();
+
+  @override
+  State<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends State<_Harness> {
+  bool tickerEnabled = true;
+  bool showSecondConsumer = false;
+
+  /// Drives the consumer off-screen, pausing its subscriptions.
+  void park() => setState(() => tickerEnabled = false);
+
+  /// Mounts a second, live consumer on the stale provider chain.
+  void addConsumer() => setState(() => showSecondConsumer = true);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Parking this one pauses its subscriptions, which is what makes
+        // both providers inactive.
+        TickerMode(
+          enabled: tickerEnabled,
+          child: Consumer(
+            builder: (context, ref, _) {
+              ref.watch(_downstreamProvider);
+              return const SizedBox(height: 1);
+            },
+          ),
+        ),
+        if (showSecondConsumer)
+          Consumer(
+            builder: (context, ref, _) {
+              ref.watch(_downstreamProvider);
+              return const SizedBox(height: 1);
+            },
+          ),
+      ],
+    );
+  }
+}
+
+void main() {
+  testWidgets('flushing a provider invalidated while paused does not setState '
+      'during build', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: Scaffold(body: _Harness())),
+      ),
+    );
+
+    final state = tester.state<_HarnessState>(find.byType(_Harness));
+
+    // 1. Park the only consumer: both providers go inactive.
+    state.park();
+    await tester.pump();
+
+    // 2. Invalidate the upstream provider while it is inactive. The
+    //    scheduler queues it, skips it because it is not active, then
+    //    drops the queue.
+    container.invalidate(_upstreamProvider);
+    await tester.pump();
+
+    // 3. Mount a live consumer that reads the stale chain during build.
+    state.addConsumer();
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Running the app threw `setState() or markNeedsBuild() called during build` on
`UncontrolledProviderScope` while `GaugeStrip` was building, at
`gauge_strip.dart:36` (`ref.watch(dashboardGaugesProvider)`). The cause is a
riverpod 3.3.2 bug, not app code. Bumping to riverpod 3.4.2 fixes it.

Two riverpod internals collide:

1. `ProviderScheduler._performRefresh()` flushes queued dirty elements only
   `if (element.isActive)`, then calls `stateToRefresh.clear()`. `isActive` is
   `listenerCount - pausedActiveSubscriptionCount > 0`, so it is false whenever
   every listener is auto-paused, which riverpod 3 does to a Consumer's
   subscriptions when it goes off-screen via `TickerMode`. A provider
   invalidated during that window is queued, skipped, then dropped from the
   queue: it stays dirty permanently.

2. `Ref.watch` on that stale element calls `element.flush()` synchronously.
   `flush` walks ancestors, rebuilds the stale one, the rebuild notifies the
   descendant's watch-listener, and the descendant calls `invalidateSelf()`,
   which in 3.3.2 unconditionally reaches `scheduleProviderRefresh()` and then
   `_UncontrolledProviderScopeState.scheduleRefresh()`, which calls
   `setState()`. Inside a widget build that is the assertion.

It needs a three-way coincidence (a Consumer paused, an invalidation landing
during the pause, and a remount that reads the chain), which is why it surfaced
on Home, where tab switching pauses `GaugeStrip` constantly, and why it looked
intermittent.

riverpod 3.4.0 and 3.4.2 fix exactly this, guarding `invalidateSelf` with
`!_isFlushing && isActive`:

> 3.4.0: Fix markNeedsBuild exception when flushing a provider inside Widget
> lifecycle
> 3.4.2: Fix a different source of `markNeedsBuild` error. Those are tricky!

3.4.0 also reworked `addDependentSubscription` pause accounting, the same area
as the `pausedActiveSubscriptionCount` assertion fixed in #431.

## Changes

- `riverpod` / `flutter_riverpod` `^3.1.0` to `^3.4.2`, with a comment recording
  why the floor exists so it does not get relaxed later.
- `analyzer` `^12.0.0` to `^13.3.0`. This is forced, not incidental: riverpod
  3.4.2 requires `riverpod_annotation 4.0.6`, which requires
  `riverpod_generator 4.0.8`, which requires `analyzer ^13`. The analyzer dep is
  real (`test/architecture/provider_tick_scanner.dart` parses provider ASTs), so
  it had to move with it.
- New guard test `test/core/providers/autopause_flush_during_build_test.dart`.
  It reproduces the crash with riverpod primitives only: park a Consumer with
  `TickerMode(enabled: false)`, invalidate the upstream provider while it is
  inactive, then mount a second live Consumer. It fails on 3.3.2 with a stack
  identical to the app crash and passes on 3.4.2, so it pins the behaviour
  against a future regression or downgrade.

Two notes on the lock diff:

- `dart pub upgrade riverpod flutter_riverpod` reports "No dependencies changed"
  and gives no reason. Tightening the constraint first is what makes the solver
  print the real conflict.
- `pigeon` drops out of the root `pubspec.lock`. It was only ever a transitive
  dev dependency of plugin packages; `packages/libdivecomputer_plugin` carries
  its own lock and its own `pigeon: ^22.0.0`, so its codegen is unaffected. The
  lock also picks up `mockito 5.8.1`, `drift_dev 2.34.5`, `sqlparser 0.45.0` and
  `_fe_analyzer_shared 103`.

## Test Plan

- [x] `flutter test` passes: 18866 passed, 19 skipped, 0 failed
- [x] `flutter analyze` passes: no issues
- [x] `dart format .` clean: 3893 files, 0 changed
- [x] `dart run build_runner build --delete-conflicting-outputs` clean under
      analyzer 13 / drift_dev 2.34.5 / mockito 5.8.1 (7583 outputs)
- [x] Guard test fails on riverpod 3.3.2, passes on 3.4.2
- [ ] Manual testing on: not yet run on device. The reproduction is covered by
      the guard test, but exercising Home with tab switching during a sync would
      be a useful belt-and-braces check before merge.
