### PR TITLE
fix(healthkit): stop a non-answer on read access zeroing Apple Watch import (#1128)

### DIFF
--- a/lib/features/dive_import/data/services/healthkit_service.dart
+++ b/lib/features/dive_import/data/services/healthkit_service.dart
@@ -44,7 +44,7 @@ class HealthKitService implements HealthImportService {
       return await _pluginChannel.invokeMethod<bool>(
         'checkIfHealthDataAvailable',
       );
-    } catch (e) {
+    } catch (_) {
       return null;
     }
   }
@@ -53,7 +53,7 @@ class HealthKitService implements HealthImportService {
   Future<bool> get _healthKitExists async {
     try {
       return await _healthDataAvailableProbe() ?? true;
-    } catch (e) {
+    } catch (_) {
       return true;
     }
   }
@@ -109,7 +109,7 @@ class HealthKitService implements HealthImportService {
       return granted
           ? HealthPermissionStatus.granted
           : HealthPermissionStatus.denied;
-    } catch (e) {
+    } catch (_) {
       // A failed probe is not a denial. Reporting "unsupported" here would
       // block the read, which is the exact mistake that broke this import.
       return HealthPermissionStatus.undetermined;
@@ -137,7 +137,7 @@ class HealthKitService implements HealthImportService {
       );
 
       return authorized;
-    } catch (e) {
+    } catch (_) {
       return false;
     }
   }
@@ -208,7 +208,7 @@ class HealthKitService implements HealthImportService {
         startTime: startTime,
         endTime: endTime,
       );
-    } catch (e) {
+    } catch (_) {
       return [];
     }
   }

--- a/lib/features/dive_import/data/services/healthkit_service.dart
+++ b/lib/features/dive_import/data/services/healthkit_service.dart
@@ -73,6 +73,11 @@ class HealthKitService implements HealthImportService {
   /// [HealthDataType.UNDERWATER_DEPTH] and [HealthDataType.WATER_TEMPERATURE]
   /// are the dive-specific series an Apple Watch Ultra records; without them
   /// an imported dive has no profile and a max depth of zero.
+  ///
+  /// Safe to request wholesale below iOS 16, where the plugin never registers
+  /// those two. Its `requestAuthorization` logs an unknown type and moves on,
+  /// leaving it out of the read set, then authorises the types it did resolve.
+  /// An older device is granted workouts and heart rate as usual.
   static const List<HealthDataType> _readTypes = [
     HealthDataType.WORKOUT,
     HealthDataType.HEART_RATE,
@@ -82,9 +87,10 @@ class HealthKitService implements HealthImportService {
 
   /// Types used to probe permission state.
   ///
-  /// Deliberately excludes the iOS 16+ dive types: the plugin reports an
-  /// unknown type as an outright denial, which would make every pre-iOS-16
-  /// device look permanently denied.
+  /// Deliberately narrower than [_readTypes]. Where `requestAuthorization`
+  /// shrugs an unknown type off, `hasPermissions` short-circuits the whole
+  /// probe to false on one, so probing with the iOS 16+ dive types would make
+  /// every pre-iOS-16 device look permanently denied.
   static const List<HealthDataType> _probeTypes = [
     HealthDataType.WORKOUT,
     HealthDataType.HEART_RATE,

--- a/lib/features/dive_import/data/services/healthkit_service.dart
+++ b/lib/features/dive_import/data/services/healthkit_service.dart
@@ -1,20 +1,62 @@
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:health/health.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
 import 'package:submersion/features/dive_import/domain/services/health_import_service.dart';
+
+/// Answers "can this device do HealthKit at all", or null when unknowable.
+typedef HealthDataAvailabilityProbe = Future<bool?> Function();
 
 /// HealthKit implementation of HealthImportService for Apple platforms.
 ///
 /// Fetches underwater diving workouts and associated data (depth, temperature,
 /// heart rate) from Apple HealthKit. Only available on iOS.
 class HealthKitService implements HealthImportService {
-  HealthKitService({Health? health, bool? isPlatformSupported})
-    : _health = health ?? Health(),
-      _isPlatformSupported = isPlatformSupported ?? Platform.isIOS;
+  HealthKitService({
+    Health? health,
+    bool? isPlatformSupported,
+    HealthDataAvailabilityProbe? healthDataAvailable,
+  }) : _health = health ?? Health(),
+       _isPlatformSupported = isPlatformSupported ?? Platform.isIOS,
+       _healthDataAvailableProbe = healthDataAvailable ?? _askPlatform;
 
   final Health _health;
   final bool _isPlatformSupported;
+  final HealthDataAvailabilityProbe _healthDataAvailableProbe;
+
+  /// The health plugin's own method channel.
+  static const MethodChannel _pluginChannel = MethodChannel('flutter_health');
+
+  /// Ask the platform whether HealthKit exists on this device.
+  ///
+  /// `Platform.isIOS` is not a capability check: it says yes on hardware with
+  /// no Health app at all (iPadOS before 17). `HKHealthStore
+  /// .isHealthDataAvailable()` is the honest answer, and the plugin's native
+  /// side already serves it under `checkIfHealthDataAvailable` — its Dart API
+  /// simply never calls it, so we go to the channel directly.
+  ///
+  /// Returns null when the answer cannot be obtained (channel missing, no
+  /// binding in a unit test, plugin renamed the handler). Null is "unknown",
+  /// never a refusal.
+  static Future<bool?> _askPlatform() async {
+    try {
+      return await _pluginChannel.invokeMethod<bool>(
+        'checkIfHealthDataAvailable',
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// True unless the platform states outright that HealthKit is unavailable.
+  Future<bool> get _healthKitExists async {
+    try {
+      return await _healthDataAvailableProbe() ?? true;
+    } catch (e) {
+      return true;
+    }
+  }
 
   /// Everything we ask HealthKit for read access to.
   ///
@@ -46,11 +88,12 @@ class HealthKitService implements HealthImportService {
   ImportSource get source => ImportSource.appleWatch;
 
   @override
-  Future<bool> isAvailable() async => _isPlatformSupported;
+  Future<bool> isAvailable() async =>
+      _isPlatformSupported && await _healthKitExists;
 
   @override
   Future<HealthPermissionStatus> permissionStatus() async {
-    if (!_isPlatformSupported) {
+    if (!_isPlatformSupported || !await _healthKitExists) {
       return HealthPermissionStatus.unsupported;
     }
 
@@ -79,7 +122,7 @@ class HealthKitService implements HealthImportService {
 
   @override
   Future<bool> requestPermissions() async {
-    if (!_isPlatformSupported) {
+    if (!_isPlatformSupported || !await _healthKitExists) {
       return false;
     }
 

--- a/lib/features/dive_import/data/services/healthkit_service.dart
+++ b/lib/features/dive_import/data/services/healthkit_service.dart
@@ -50,7 +50,17 @@ class HealthKitService implements HealthImportService {
   }
 
   /// True unless the platform states outright that HealthKit is unavailable.
-  Future<bool> get _healthKitExists async {
+  ///
+  /// Asked once per service. Whether the hardware has HealthKit cannot change
+  /// while the app runs, and every entry point below needs the answer, so the
+  /// in-flight future is shared rather than re-queried four times a wizard.
+  Future<bool> get _healthKitExists =>
+      _healthKitExistsCache ??= _resolveHealthKitExists();
+
+  Future<bool>? _healthKitExistsCache;
+
+  /// Never throws, so the memoised future can never be a poisoned one.
+  Future<bool> _resolveHealthKitExists() async {
     try {
       return await _healthDataAvailableProbe() ?? true;
     } catch (_) {

--- a/lib/features/dive_import/data/services/healthkit_service.dart
+++ b/lib/features/dive_import/data/services/healthkit_service.dart
@@ -7,7 +7,7 @@ import 'package:submersion/features/dive_import/domain/services/health_import_se
 /// HealthKit implementation of HealthImportService for Apple platforms.
 ///
 /// Fetches underwater diving workouts and associated data (depth, temperature,
-/// heart rate, GPS) from Apple HealthKit. Only available on iOS.
+/// heart rate) from Apple HealthKit. Only available on iOS.
 class HealthKitService implements HealthImportService {
   HealthKitService({Health? health, bool? isPlatformSupported})
     : _health = health ?? Health(),
@@ -16,46 +16,66 @@ class HealthKitService implements HealthImportService {
   final Health _health;
   final bool _isPlatformSupported;
 
-  /// HealthKit data types we need to read for dive imports.
+  /// Everything we ask HealthKit for read access to.
+  ///
+  /// [HealthDataType.UNDERWATER_DEPTH] and [HealthDataType.WATER_TEMPERATURE]
+  /// are the dive-specific series an Apple Watch Ultra records; without them
+  /// an imported dive has no profile and a max depth of zero.
   static const List<HealthDataType> _readTypes = [
     HealthDataType.WORKOUT,
     HealthDataType.HEART_RATE,
+    HealthDataType.UNDERWATER_DEPTH,
+    HealthDataType.WATER_TEMPERATURE,
   ];
+
+  /// Types used to probe permission state.
+  ///
+  /// Deliberately excludes the iOS 16+ dive types: the plugin reports an
+  /// unknown type as an outright denial, which would make every pre-iOS-16
+  /// device look permanently denied.
+  static const List<HealthDataType> _probeTypes = [
+    HealthDataType.WORKOUT,
+    HealthDataType.HEART_RATE,
+  ];
+
+  /// Widest gap between a depth sample and an auxiliary (temperature or heart
+  /// rate) sample for the two to be considered contemporaneous.
+  static const Duration _auxiliaryMatchWindow = Duration(seconds: 30);
 
   @override
   ImportSource get source => ImportSource.appleWatch;
 
   @override
-  Future<bool> isAvailable() async {
-    // HealthKit import is only available on iOS
+  Future<bool> isAvailable() async => _isPlatformSupported;
+
+  @override
+  Future<HealthPermissionStatus> permissionStatus() async {
     if (!_isPlatformSupported) {
-      return false;
+      return HealthPermissionStatus.unsupported;
     }
 
     try {
-      return await _health.hasPermissions(_readTypes) ?? false;
+      final granted = await _health.hasPermissions(
+        _probeTypes,
+        permissions: _probeTypes.map((_) => HealthDataAccess.READ).toList(),
+      );
+      if (granted == null) {
+        // iOS never discloses read access. Not an answer, not a denial.
+        return HealthPermissionStatus.undetermined;
+      }
+      return granted
+          ? HealthPermissionStatus.granted
+          : HealthPermissionStatus.denied;
     } catch (e) {
-      // HealthKit not available on this device
-      return false;
+      // A failed probe is not a denial. Reporting "unsupported" here would
+      // block the read, which is the exact mistake that broke this import.
+      return HealthPermissionStatus.undetermined;
     }
   }
 
   @override
-  Future<bool> hasPermissions() async {
-    if (!_isPlatformSupported) {
-      return false;
-    }
-
-    try {
-      final hasPerms = await _health.hasPermissions(
-        _readTypes,
-        permissions: _readTypes.map((_) => HealthDataAccess.READ).toList(),
-      );
-      return hasPerms ?? false;
-    } catch (e) {
-      return false;
-    }
-  }
+  Future<bool> hasPermissions() async =>
+      await permissionStatus() == HealthPermissionStatus.granted;
 
   @override
   Future<bool> requestPermissions() async {
@@ -84,42 +104,42 @@ class HealthKitService implements HealthImportService {
     required DateTime startDate,
     required DateTime endDate,
   }) async {
-    if (!await hasPermissions()) {
+    // Only a definitive "no" stops us. An undetermined status is the normal
+    // answer for a granted read on iOS, so querying is the only way to find
+    // out what is actually there.
+    final status = await permissionStatus();
+    if (!status.canAttemptRead) {
       return [];
     }
 
-    try {
-      // Fetch workouts in the date range
-      final workouts = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.WORKOUT],
-        startTime: startDate,
-        endTime: endDate,
-      );
+    // Fetch workouts in the date range
+    final workouts = await _fetchType(
+      HealthDataType.WORKOUT,
+      startDate,
+      endDate,
+    );
 
-      // Filter for underwater diving workouts only
-      final diveWorkouts = workouts.where((data) {
-        if (data.value is! WorkoutHealthValue) return false;
-        final workout = data.value as WorkoutHealthValue;
-        return workout.workoutActivityType ==
-            HealthWorkoutActivityType.UNDERWATER_DIVING;
-      }).toList();
+    // Filter for underwater diving workouts only
+    final diveWorkouts = workouts.where((data) {
+      if (data.value is! WorkoutHealthValue) return false;
+      final workout = data.value as WorkoutHealthValue;
+      return workout.workoutActivityType ==
+          HealthWorkoutActivityType.UNDERWATER_DIVING;
+    }).toList();
 
-      // Convert each workout to an ImportedDive
-      final dives = <ImportedDive>[];
-      for (final workout in diveWorkouts) {
-        final dive = await _workoutToDive(workout);
-        if (dive != null) {
-          dives.add(dive);
-        }
+    // Convert each workout to an ImportedDive
+    final dives = <ImportedDive>[];
+    for (final workout in diveWorkouts) {
+      final dive = await _workoutToDive(workout);
+      if (dive != null) {
+        dives.add(dive);
       }
-
-      // Sort by start time descending (newest first)
-      dives.sort((a, b) => b.startTime.compareTo(a.startTime));
-
-      return dives;
-    } catch (e) {
-      return [];
     }
+
+    // Sort by start time descending (newest first)
+    dives.sort((a, b) => b.startTime.compareTo(a.startTime));
+
+    return dives;
   }
 
   @override
@@ -129,11 +149,31 @@ class HealthKitService implements HealthImportService {
     return [];
   }
 
+  /// Read one data type, isolating its failures.
+  ///
+  /// The plugin queries types in a loop and rethrows, so batching types means
+  /// one unsupported type (the dive series below iOS 16) or one revoked type
+  /// discards every other type's samples too.
+  Future<List<HealthDataPoint>> _fetchType(
+    HealthDataType type,
+    DateTime startTime,
+    DateTime endTime,
+  ) async {
+    try {
+      return await _health.getHealthDataFromTypes(
+        types: [type],
+        startTime: startTime,
+        endTime: endTime,
+      );
+    } catch (e) {
+      return [];
+    }
+  }
+
   /// Convert a HealthKit workout to an ImportedDive entity.
   Future<ImportedDive?> _workoutToDive(HealthDataPoint workoutPoint) async {
     if (workoutPoint.value is! WorkoutHealthValue) return null;
 
-    final workout = workoutPoint.value as WorkoutHealthValue;
     final startTime = workoutPoint.dateFrom;
     final endTime = workoutPoint.dateTo;
 
@@ -146,9 +186,6 @@ class HealthKitService implements HealthImportService {
     final tempRange = _calculateTemperatureRange(samples);
     final avgHeartRate = _calculateAvgHeartRate(samples);
 
-    // Extract GPS coordinates if available
-    final gps = _extractGpsCoordinates(workout);
-
     return ImportedDive(
       sourceId: workoutPoint.uuid,
       source: ImportSource.appleWatch,
@@ -159,53 +196,134 @@ class HealthKitService implements HealthImportService {
       minTemperature: tempRange.min,
       maxTemperature: tempRange.max,
       avgHeartRate: avgHeartRate,
-      latitude: gps?.latitude,
-      longitude: gps?.longitude,
       profile: samples,
       sourceFileName: null,
       sourceFileFormat: 'healthkit',
     );
   }
 
-  /// Fetch depth, temperature, and heart rate samples for a workout.
+  /// Build the dive profile from the depth, temperature, and heart rate
+  /// series HealthKit recorded across the workout's time range.
+  ///
+  /// Depth drives the timeline — it is the one series that defines a dive
+  /// profile. Temperature and heart rate are sampled far less often, so each
+  /// depth point picks up the nearest reading within
+  /// [_auxiliaryMatchWindow]. When no depth series exists (an older watch, or
+  /// depth access declined) the heart rate series is used on its own so the
+  /// dive still imports.
   Future<List<ImportedProfileSample>> _fetchWorkoutSamples(
     DateTime startTime,
     DateTime endTime,
   ) async {
-    try {
-      // Fetch heart rate samples (depth and temperature may not be available
-      // in the standard health package - depends on device capabilities)
-      final heartRateData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.HEART_RATE],
-        startTime: startTime,
-        endTime: endTime,
-      );
+    final depthPoints = _numericSeries(
+      await _fetchType(HealthDataType.UNDERWATER_DEPTH, startTime, endTime),
+    );
+    final temperaturePoints = _numericSeries(
+      await _fetchType(HealthDataType.WATER_TEMPERATURE, startTime, endTime),
+    );
+    final heartRatePoints = _numericSeries(
+      await _fetchType(HealthDataType.HEART_RATE, startTime, endTime),
+    );
 
-      // Build profile samples from heart rate data
-      // Note: Actual depth/temperature would come from workout samples
-      // which require native platform code beyond the health package
-      final samples = <ImportedProfileSample>[];
-
-      for (final dataPoint in heartRateData) {
-        if (dataPoint.value is! NumericHealthValue) continue;
-
-        final hrValue = dataPoint.value as NumericHealthValue;
-        final timeSeconds = dataPoint.dateFrom.difference(startTime).inSeconds;
-
-        samples.add(
-          ImportedProfileSample(
-            timeSeconds: timeSeconds,
-            depth: 0.0, // Would come from UNDERWATER_DEPTH if available
-            temperature: null, // Would come from WATER_TEMPERATURE if available
-            heartRate: hrValue.numericValue.round(),
-          ),
-        );
-      }
-
-      return samples;
-    } catch (e) {
-      return [];
+    if (depthPoints.isEmpty) {
+      return _heartRateOnlyProfile(startTime, heartRatePoints);
     }
+
+    // Collapse to one entry per second, keeping the deepest reading. HealthKit
+    // can hold several samples for the same instant across sources.
+    final deepestBySecond = <int, double>{};
+    for (final point in depthPoints) {
+      final second = point.time.difference(startTime).inSeconds;
+      if (second < 0) continue;
+      final existing = deepestBySecond[second];
+      if (existing == null || point.value > existing) {
+        deepestBySecond[second] = point.value;
+      }
+    }
+
+    final seconds = deepestBySecond.keys.toList()..sort();
+
+    return [
+      for (final second in seconds)
+        ImportedProfileSample(
+          timeSeconds: second,
+          depth: deepestBySecond[second]!,
+          temperature: _nearestValue(
+            temperaturePoints,
+            startTime.add(Duration(seconds: second)),
+          ),
+          heartRate: _nearestValue(
+            heartRatePoints,
+            startTime.add(Duration(seconds: second)),
+          )?.round(),
+        ),
+    ];
+  }
+
+  /// Fallback profile for dives with no depth series: heart rate at depth 0.
+  List<ImportedProfileSample> _heartRateOnlyProfile(
+    DateTime startTime,
+    List<_TimedValue> heartRatePoints,
+  ) {
+    return [
+      for (final point in heartRatePoints)
+        if (!point.time.isBefore(startTime))
+          ImportedProfileSample(
+            timeSeconds: point.time.difference(startTime).inSeconds,
+            depth: 0.0,
+            heartRate: point.value.round(),
+          ),
+    ];
+  }
+
+  /// Reduce raw data points to a time-sorted numeric series.
+  List<_TimedValue> _numericSeries(List<HealthDataPoint> points) {
+    final series = <_TimedValue>[
+      for (final point in points)
+        if (point.value is NumericHealthValue)
+          _TimedValue(
+            point.dateFrom,
+            (point.value as NumericHealthValue).numericValue.toDouble(),
+          ),
+    ];
+    series.sort((a, b) => a.time.compareTo(b.time));
+    return series;
+  }
+
+  /// Value of the series entry closest to [at], or null when the series is
+  /// empty or its closest entry is further away than [_auxiliaryMatchWindow].
+  ///
+  /// [series] must be sorted by time; a binary search keeps merging a
+  /// thousand-sample depth series against the other series linear rather than
+  /// quadratic.
+  double? _nearestValue(List<_TimedValue> series, DateTime at) {
+    if (series.isEmpty) return null;
+
+    var low = 0;
+    var high = series.length;
+    while (low < high) {
+      final mid = (low + high) ~/ 2;
+      if (series[mid].time.isBefore(at)) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    // `low` is the first entry at or after `at`; its predecessor is the last
+    // entry before it. The nearest entry is one of those two.
+    _TimedValue? best;
+    var bestGap = _auxiliaryMatchWindow + const Duration(microseconds: 1);
+    for (final index in [low - 1, low]) {
+      if (index < 0 || index >= series.length) continue;
+      final gap = series[index].time.difference(at).abs();
+      if (gap < bestGap) {
+        best = series[index];
+        bestGap = gap;
+      }
+    }
+
+    return best?.value;
   }
 
   /// Calculate maximum depth from samples.
@@ -245,17 +363,12 @@ class HealthKitService implements HealthImportService {
     final sum = hrs.reduce((a, b) => a + b);
     return sum / hrs.length;
   }
+}
 
-  /// Extract GPS coordinates from workout metadata.
-  ({double latitude, double longitude})? _extractGpsCoordinates(
-    WorkoutHealthValue workout,
-  ) {
-    // GPS coordinates would be extracted from the workout route
-    // This requires additional platform-specific code to access
-    // HKWorkoutRoute samples, which isn't directly available in the
-    // health package. For now, return null.
-    // In a future enhancement, this could use method channels to
-    // fetch the workout route from native HealthKit.
-    return null;
-  }
+/// A single numeric reading at a point in time.
+class _TimedValue {
+  const _TimedValue(this.time, this.value);
+
+  final DateTime time;
+  final double value;
 }

--- a/lib/features/dive_import/domain/services/health_import_service.dart
+++ b/lib/features/dive_import/domain/services/health_import_service.dart
@@ -36,7 +36,9 @@ extension HealthPermissionStatusX on HealthPermissionStatus {
 /// Abstract interface for importing dives from platform health APIs.
 ///
 /// Implementations handle platform-specific APIs:
-/// - [HealthKitService] for Apple Watch (iOS/macOS)
+/// - `HealthKitService` for Apple Watch, iOS only. The `health` package
+///   declares android and ios platforms and nothing else, so there is no
+///   macOS path to support however capable the Mac is.
 /// - Future: GarminService, SuuntoService
 abstract class HealthImportService {
   /// Check if this health import service is available on the current platform.

--- a/lib/features/dive_import/domain/services/health_import_service.dart
+++ b/lib/features/dive_import/domain/services/health_import_service.dart
@@ -1,5 +1,38 @@
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
 
+/// What the platform health API will tell us about read access.
+///
+/// Apple deliberately refuses to disclose whether *read* access was granted,
+/// so on iOS the answer is almost always [undetermined]. Treating that as
+/// "denied" is what broke Apple Watch import: the only honest reading of
+/// [undetermined] is "try the query and see what comes back".
+enum HealthPermissionStatus {
+  /// No health API on this platform, or it is unusable on this device.
+  unsupported,
+
+  /// The platform confirms we may read the data we asked for.
+  granted,
+
+  /// The platform confirms we may not read the data we asked for.
+  denied,
+
+  /// The platform will not say. Either access has never been requested, or
+  /// (iOS read access) the API refuses to disclose the answer by design.
+  undetermined,
+}
+
+/// Whether it is worth issuing a read query for this status.
+extension HealthPermissionStatusX on HealthPermissionStatus {
+  /// True unless the platform has definitively ruled a read out.
+  ///
+  /// [HealthPermissionStatus.undetermined] counts as readable: on iOS it is
+  /// the normal answer for a granted read, and a query on a genuinely
+  /// unauthorized type simply comes back empty.
+  bool get canAttemptRead =>
+      this != HealthPermissionStatus.unsupported &&
+      this != HealthPermissionStatus.denied;
+}
+
 /// Abstract interface for importing dives from platform health APIs.
 ///
 /// Implementations handle platform-specific APIs:
@@ -8,17 +41,26 @@ import 'package:submersion/features/dive_import/domain/entities/imported_dive.da
 abstract class HealthImportService {
   /// Check if this health import service is available on the current platform.
   ///
-  /// Returns true if the underlying health API is accessible.
+  /// Reports platform capability only — whether a health API exists here at
+  /// all. It says nothing about permissions; use [permissionStatus] for that.
   Future<bool> isAvailable();
 
   /// Request necessary permissions to read dive data.
   ///
-  /// Returns true if all required permissions were granted.
+  /// Returns true if the request completed. On iOS a completed request does
+  /// not imply the user granted anything: Apple will not disclose read access.
+  /// Requesting again once the user has decided is a silent no-op, so callers
+  /// may call this on every visit rather than gating it behind a check.
   Future<bool> requestPermissions();
 
-  /// Check if permissions have already been granted.
+  /// What the platform will tell us about read access.
+  Future<HealthPermissionStatus> permissionStatus();
+
+  /// Whether the platform *confirms* read access has been granted.
   ///
-  /// Returns true if we can read dive data without prompting.
+  /// This is [permissionStatus] narrowed to [HealthPermissionStatus.granted],
+  /// so it is false whenever the platform declines to answer. Never use it to
+  /// gate a read — use [HealthPermissionStatusX.canAttemptRead].
   Future<bool> hasPermissions();
 
   /// Fetch dives within the specified date range.

--- a/lib/features/dive_import/presentation/providers/dive_import_providers.dart
+++ b/lib/features/dive_import/presentation/providers/dive_import_providers.dart
@@ -54,12 +54,16 @@ final healthImportAvailableProvider = FutureProvider<bool>((ref) async {
   return service.isAvailable();
 });
 
-/// Whether we have HealthKit permissions.
-final healthImportHasPermissionsProvider = FutureProvider<bool>((ref) async {
-  final service = ref.watch(healthImportServiceProvider);
-  if (service == null) return false;
-  return service.hasPermissions();
-});
+/// What the platform will tell us about HealthKit read access.
+///
+/// On iOS this is normally [HealthPermissionStatus.undetermined]: Apple does
+/// not disclose read access. Callers must not read that as a refusal.
+final healthImportPermissionStatusProvider =
+    FutureProvider<HealthPermissionStatus>((ref) async {
+      final service = ref.watch(healthImportServiceProvider);
+      if (service == null) return HealthPermissionStatus.unsupported;
+      return service.permissionStatus();
+    });
 
 // ============================================================================
 // Import State Providers

--- a/lib/features/dive_import/presentation/providers/dive_import_providers.dart
+++ b/lib/features/dive_import/presentation/providers/dive_import_providers.dart
@@ -17,9 +17,13 @@ import 'package:submersion/features/dive_import/presentation/widgets/imported_di
 // Service Providers
 // ============================================================================
 
-/// Provider for the HealthKit service (Apple platforms only).
+/// Provider for the HealthKit service (iOS only).
+///
+/// Not macOS: the `health` package registers android and ios platforms and
+/// nothing else, so a service built on a Mac could only ever report itself
+/// unsupported.
 final healthKitServiceProvider = Provider<HealthKitService?>((ref) {
-  if (!Platform.isIOS && !Platform.isMacOS) {
+  if (!Platform.isIOS) {
     return null;
   }
   return HealthKitService();
@@ -27,7 +31,7 @@ final healthKitServiceProvider = Provider<HealthKitService?>((ref) {
 
 /// Provider for the active health import service.
 ///
-/// Currently returns HealthKitService on Apple platforms, null elsewhere.
+/// Currently returns HealthKitService on iOS, null elsewhere.
 /// Future: Could include Garmin, Suunto services based on platform/settings.
 final healthImportServiceProvider = Provider<HealthImportService?>((ref) {
   return ref.watch(healthKitServiceProvider);

--- a/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
@@ -22,21 +22,53 @@ final healthKitDivesFetchedProvider = StateProvider<bool>((ref) => false);
 /// Riverpod [StateProvider] holding the user-selected date range for the
 /// HealthKit fetch. Defaults to the last 30 days.
 final healthKitDateRangeProvider = StateProvider<DateTimeRange>(
-  (ref) => DateTimeRange(
-    start: DateTime.now().subtract(const Duration(days: 30)),
-    end: DateTime.now(),
+  (ref) => healthKitWholeDayRange(
+    DateTime.now().subtract(const Duration(days: 30)),
+    DateTime.now(),
   ),
 );
+
+/// Widen a pair of picked dates to cover both days end to end.
+///
+/// The date pickers hand back midnight, and HealthKit matches samples with a
+/// strict start-date predicate. Without this, picking the day of a dive as the
+/// end date puts every dive that day *after* the range and finds nothing.
+DateTimeRange healthKitWholeDayRange(DateTime start, DateTime end) {
+  return DateTimeRange(
+    start: DateTime(start.year, start.month, start.day),
+    end: DateTime(end.year, end.month, end.day, 23, 59, 59, 999),
+  );
+}
 
 // =============================================================================
 // Step widgets
 // =============================================================================
 
+/// How far the permissions step has got with HealthKit.
+enum HealthKitPermissionUiState {
+  /// Asking the platform what it knows.
+  checking,
+
+  /// The authorization sheet has been handed to the system.
+  requesting,
+
+  /// Access has been requested (or confirmed); the wizard may continue.
+  ready,
+
+  /// The platform confirms access is refused.
+  refused,
+
+  /// No health API on this platform.
+  unavailable,
+}
+
 /// Permissions step for the HealthKit import wizard.
 ///
-/// Checks whether HealthKit permissions have already been granted. If not,
-/// presents a button to request them. Sets [healthKitPermissionsGrantedProvider]
-/// to true when permissions are granted.
+/// Asks the platform what it knows about read access and, when it will not
+/// say, requests authorization outright. Apple never discloses read access and
+/// only shows its sheet once, so requesting is both the only way to make
+/// progress and safe to repeat: on later visits the system answers silently
+/// and the step lands straight on the ready state.
 class HealthKitPermissionsStep extends ConsumerStatefulWidget {
   const HealthKitPermissionsStep({super.key, required this.healthService});
 
@@ -49,138 +81,154 @@ class HealthKitPermissionsStep extends ConsumerStatefulWidget {
 
 class _HealthKitPermissionsStepState
     extends ConsumerState<HealthKitPermissionsStep> {
-  bool _isChecking = true;
-  bool _isRequesting = false;
-  bool _permissionsGranted = false;
+  HealthKitPermissionUiState _state = HealthKitPermissionUiState.checking;
 
   @override
   void initState() {
     super.initState();
-    _checkPermissions();
+    _resolvePermissions();
   }
 
-  Future<void> _checkPermissions() async {
+  Future<void> _resolvePermissions() async {
+    HealthPermissionStatus status;
     try {
-      final granted = await widget.healthService.hasPermissions();
-      if (mounted) {
-        setState(() {
-          _isChecking = false;
-          _permissionsGranted = granted;
-        });
-        if (granted) {
-          ref.read(healthKitPermissionsGrantedProvider.notifier).state = true;
-        }
-      }
+      status = await widget.healthService.permissionStatus();
     } catch (_) {
-      if (mounted) {
-        setState(() => _isChecking = false);
-      }
+      status = HealthPermissionStatus.undetermined;
+    }
+    if (!mounted) return;
+
+    switch (status) {
+      case HealthPermissionStatus.unsupported:
+        _setState(HealthKitPermissionUiState.unavailable);
+      case HealthPermissionStatus.granted:
+        _setState(HealthKitPermissionUiState.ready);
+      case HealthPermissionStatus.denied:
+        _setState(HealthKitPermissionUiState.refused);
+      case HealthPermissionStatus.undetermined:
+        await _requestPermissions();
     }
   }
 
   Future<void> _requestPermissions() async {
-    setState(() => _isRequesting = true);
+    _setState(HealthKitPermissionUiState.requesting);
+    bool requested;
     try {
-      final granted = await widget.healthService.requestPermissions();
-      if (mounted) {
-        setState(() {
-          _isRequesting = false;
-          _permissionsGranted = granted;
-        });
-        ref.read(healthKitPermissionsGrantedProvider.notifier).state = granted;
-      }
+      requested = await widget.healthService.requestPermissions();
     } catch (_) {
-      if (mounted) {
-        setState(() => _isRequesting = false);
-      }
+      requested = false;
     }
+    if (!mounted) return;
+    _setState(
+      requested
+          ? HealthKitPermissionUiState.ready
+          : HealthKitPermissionUiState.refused,
+    );
+  }
+
+  void _setState(HealthKitPermissionUiState state) {
+    setState(() => _state = state);
+    ref.read(healthKitPermissionsGrantedProvider.notifier).state =
+        state == HealthKitPermissionUiState.ready;
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    if (_isChecking) {
-      return const Center(child: CircularProgressIndicator());
+    switch (_state) {
+      case HealthKitPermissionUiState.checking:
+        return const Center(child: CircularProgressIndicator());
+      case HealthKitPermissionUiState.unavailable:
+        return _Message(
+          icon: Icons.info_outline,
+          iconColor: theme.colorScheme.onSurfaceVariant,
+          title: context.l10n.diveImport_healthkit_notAvailable,
+          body: [context.l10n.diveImport_healthkit_notAvailableDescription],
+        );
+      case HealthKitPermissionUiState.ready:
+        return _Message(
+          icon: Icons.check_circle,
+          iconColor: theme.colorScheme.primary,
+          title: context.l10n.diveImport_healthkit_accessGranted,
+          body: [
+            context.l10n.diveImport_healthkit_accessGrantedBody,
+            context.l10n.diveImport_healthkit_accessGrantedHint,
+          ],
+        );
+      case HealthKitPermissionUiState.requesting:
+      case HealthKitPermissionUiState.refused:
+        return _Message(
+          icon: Icons.health_and_safety,
+          iconColor: theme.colorScheme.primary,
+          title: context.l10n.diveImport_healthkit_accessRequired,
+          body: [context.l10n.diveImport_healthkit_accessDescription],
+          action: FilledButton.icon(
+            icon: _state == HealthKitPermissionUiState.requesting
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.health_and_safety),
+            label: Text(
+              _state == HealthKitPermissionUiState.requesting
+                  ? context.l10n.diveImport_healthkit_requesting
+                  : context.l10n.diveImport_healthkit_grantAccessButton,
+            ),
+            onPressed: _state == HealthKitPermissionUiState.requesting
+                ? null
+                : _requestPermissions,
+          ),
+        );
     }
+  }
+}
 
-    if (_permissionsGranted) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ExcludeSemantics(
-                child: Icon(
-                  Icons.check_circle,
-                  size: 64,
-                  color: theme.colorScheme.primary,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                context.l10n.diveImport_healthkit_accessGranted,
-                style: theme.textTheme.titleLarge,
-                textAlign: TextAlign.center,
-              ),
+/// Centred icon, headline, body paragraphs, and an optional action button.
+class _Message extends StatelessWidget {
+  const _Message({
+    required this.icon,
+    required this.iconColor,
+    required this.title,
+    required this.body,
+    this.action,
+  });
+
+  final IconData icon;
+  final Color iconColor;
+  final String title;
+  final List<String> body;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ExcludeSemantics(child: Icon(icon, size: 64, color: iconColor)),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              style: theme.textTheme.titleLarge,
+              textAlign: TextAlign.center,
+            ),
+            for (final paragraph in body) ...[
               const SizedBox(height: 8),
               Text(
-                context.l10n.diveImport_healthkit_accessGrantedBody,
+                paragraph,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
                 textAlign: TextAlign.center,
               ),
             ],
-          ),
-        ),
-      );
-    }
-
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ExcludeSemantics(
-              child: Icon(
-                Icons.health_and_safety,
-                size: 64,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              context.l10n.diveImport_healthkit_accessRequired,
-              style: theme.textTheme.headlineSmall,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              context.l10n.diveImport_healthkit_accessDescription,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            FilledButton.icon(
-              icon: _isRequesting
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.health_and_safety),
-              label: Text(
-                _isRequesting
-                    ? context.l10n.diveImport_healthkit_requesting
-                    : context.l10n.diveImport_healthkit_grantAccessButton,
-              ),
-              onPressed: _isRequesting ? null : _requestPermissions,
-            ),
+            if (action != null) ...[const SizedBox(height: 24), action!],
           ],
         ),
       ),
@@ -217,12 +265,14 @@ class _HealthKitDateRangeStepState
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         ref.read(healthKitDateRangeSelectedProvider.notifier).state = true;
-        ref.read(healthKitDateRangeProvider.notifier).state = DateTimeRange(
-          start: _startDate,
-          end: _endDate,
-        );
+        _publishRange();
       }
     });
+  }
+
+  void _publishRange() {
+    ref.read(healthKitDateRangeProvider.notifier).state =
+        healthKitWholeDayRange(_startDate, _endDate);
   }
 
   Future<void> _selectStartDate() async {
@@ -235,10 +285,7 @@ class _HealthKitDateRangeStepState
     if (selected != null && mounted) {
       setState(() => _startDate = selected);
       ref.read(healthKitDateRangeSelectedProvider.notifier).state = true;
-      ref.read(healthKitDateRangeProvider.notifier).state = DateTimeRange(
-        start: _startDate,
-        end: _endDate,
-      );
+      _publishRange();
     }
   }
 
@@ -252,10 +299,7 @@ class _HealthKitDateRangeStepState
     if (selected != null && mounted) {
       setState(() => _endDate = selected);
       ref.read(healthKitDateRangeSelectedProvider.notifier).state = true;
-      ref.read(healthKitDateRangeProvider.notifier).state = DateTimeRange(
-        start: _startDate,
-        end: _endDate,
-      );
+      _publishRange();
     }
   }
 
@@ -502,7 +546,7 @@ class _HealthKitFetchStepState extends ConsumerState<HealthKitFetchStep> {
 
     if (_hasFetched) {
       return Center(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(32),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -518,13 +562,17 @@ class _HealthKitFetchStepState extends ConsumerState<HealthKitFetchStep> {
               Text(
                 context.l10n.diveImport_healthkit_foundDives(_diveCount),
                 style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
               ),
               const SizedBox(height: 8),
               Text(
-                context.l10n.diveImport_healthkit_proceedingToReview,
+                _diveCount == 0
+                    ? context.l10n.diveImport_healthkit_foundNoDivesHint
+                    : context.l10n.diveImport_healthkit_proceedingToReview,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
+                textAlign: TextAlign.center,
               ),
             ],
           ),

--- a/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/healthkit_adapter_steps.dart
@@ -33,6 +33,12 @@ final healthKitDateRangeProvider = StateProvider<DateTimeRange>(
 /// The date pickers hand back midnight, and HealthKit matches samples with a
 /// strict start-date predicate. Without this, picking the day of a dive as the
 /// end date puts every dive that day *after* the range and finds nothing.
+///
+/// The end is the last instant of the day this API can express, not the last
+/// instant of the day: the health plugin puts both bounds on the method
+/// channel as `millisecondsSinceEpoch`, so anything finer than a millisecond
+/// is truncated before HealthKit ever sees it. Spelling the end as
+/// `23:59:59.999999` would send the very same integer.
 DateTimeRange healthKitWholeDayRange(DateTime start, DateTime end) {
   return DateTimeRange(
     start: DateTime(start.year, start.month, start.day),

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -39,6 +39,7 @@ import 'package:submersion/features/settings/presentation/widgets/settings_list_
 import 'package:submersion/features/settings/presentation/widgets/settings_summary_widget.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/features/dive_import/domain/services/health_import_service.dart';
 import 'package:submersion/features/dive_import/presentation/providers/dive_import_providers.dart';
 import 'package:submersion/features/auto_update/domain/beta_program_links.dart';
 import 'package:submersion/features/auto_update/domain/entities/release_channel.dart';
@@ -2636,7 +2637,7 @@ class _DataSourcesSectionContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final permissionsAsync = ref.watch(healthImportHasPermissionsProvider);
+    final permissionsAsync = ref.watch(healthImportPermissionStatusProvider);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -2699,12 +2700,13 @@ class _DataSourcesSectionContent extends ConsumerWidget {
                   const SizedBox(height: 12),
                   // Permission status
                   permissionsAsync.when(
-                    data: (hasPerms) =>
-                        _buildPermissionStatus(context, hasPerms: hasPerms),
-                    loading: () =>
-                        _buildPermissionStatus(context, isLoading: true),
-                    error: (_, _) =>
-                        _buildPermissionStatus(context, hasPerms: false),
+                    data: (status) =>
+                        _buildPermissionStatus(context, status: status),
+                    loading: () => _buildPermissionStatus(context),
+                    error: (_, _) => _buildPermissionStatus(
+                      context,
+                      status: HealthPermissionStatus.undetermined,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Text(
@@ -2733,6 +2735,22 @@ class _DataSourcesSectionContent extends ConsumerWidget {
                     context
                         .l10n
                         .settings_dataSources_appleHealth_dataTypeWorkouts,
+                  ),
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  leading: const Icon(Icons.vertical_align_bottom),
+                  title: Text(
+                    context.l10n.settings_dataSources_appleHealth_dataTypeDepth,
+                  ),
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  leading: const Icon(Icons.thermostat),
+                  title: Text(
+                    context
+                        .l10n
+                        .settings_dataSources_appleHealth_dataTypeWaterTemp,
                   ),
                 ),
                 const Divider(height: 1),
@@ -2813,15 +2831,19 @@ class _DataSourcesSectionContent extends ConsumerWidget {
     );
   }
 
+  /// Permission row for the Apple Health card.
+  ///
+  /// A null [status] means the check is still running. Apple never discloses
+  /// read access, so [HealthPermissionStatus.undetermined] is the normal
+  /// steady state on iOS and must not be painted as a refusal.
   Widget _buildPermissionStatus(
     BuildContext context, {
-    bool hasPerms = false,
-    bool isLoading = false,
+    HealthPermissionStatus? status,
   }) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    if (isLoading) {
+    if (status == null) {
       return Row(
         children: [
           SizedBox(
@@ -2843,23 +2865,40 @@ class _DataSourcesSectionContent extends ConsumerWidget {
       );
     }
 
+    final (icon, color, label) = switch (status) {
+      HealthPermissionStatus.granted => (
+        Icons.check_circle,
+        Colors.green,
+        context.l10n.settings_dataSources_appleHealth_permissionGranted,
+      ),
+      HealthPermissionStatus.denied => (
+        Icons.cancel,
+        colorScheme.error,
+        context.l10n.settings_dataSources_appleHealth_permissionNotGranted,
+      ),
+      HealthPermissionStatus.unsupported => (
+        Icons.info_outline,
+        colorScheme.onSurfaceVariant,
+        context.l10n.settings_dataSources_appleHealth_permissionUnsupported,
+      ),
+      HealthPermissionStatus.undetermined => (
+        Icons.health_and_safety,
+        colorScheme.onSurfaceVariant,
+        context.l10n.settings_dataSources_appleHealth_permissionManagedInHealth,
+      ),
+    };
+
     return Row(
       children: [
-        Icon(
-          hasPerms ? Icons.check_circle : Icons.cancel,
-          size: 16,
-          color: hasPerms ? Colors.green : colorScheme.error,
-        ),
+        Icon(icon, size: 16, color: color),
         const SizedBox(width: 8),
-        Text(
-          hasPerms
-              ? context.l10n.settings_dataSources_appleHealth_permissionGranted
-              : context
-                    .l10n
-                    .settings_dataSources_appleHealth_permissionNotGranted,
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: hasPerms ? Colors.green : colorScheme.error,
-            fontWeight: FontWeight.w500,
+        Expanded(
+          child: Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w500,
+            ),
           ),
         ),
       ],

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1503,7 +1503,7 @@
   "diveImport_healthkit_noDivesFound": "لم يتم العثور على غطسات",
   "diveImport_healthkit_noDivesFoundDescription": "لم يتم العثور على أنشطة غوص في النطاق الزمني المحدد.",
   "diveImport_healthkit_notAvailable": "غير متاح",
-  "diveImport_healthkit_notAvailableDescription": "استيراد Apple Watch متاح فقط على أجهزة iOS وmacOS.",
+  "diveImport_healthkit_notAvailableDescription": "يتطلب الاستيراد من Apple Watch جهاز iPhone مزوّدًا بتطبيق صحة.",
   "diveImport_healthkit_permissionCheckFailed": "فشل التحقق من الأذونات",
   "diveImport_healthkit_title": "استيراد من Apple Watch",
   "diveImport_healthkit_watchTitle": "استيراد من الساعة",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "في انتظار الرفع",
   "media_status_cloudOnly": "مخزن في السحابة فقط",
   "media_status_notBackedUp": "لا يوجد نسخ احتياطي",
-  "media_tile_infoMenuItem": "معلومات الوسائط"
+  "media_tile_infoMenuItem": "معلومات الوسائط",
+  "diveImport_healthkit_accessGrantedHint": "لا يخبر تطبيق صحة Apple التطبيقات أبدًا بما إذا كان قد تم منح إذن القراءة. إذا لم تظهر أي غطسات، افتح تطبيق صحة ثم المشاركة ثم التطبيقات ثم Submersion، وفعّل التمارين وعمق الغوص ودرجة حرارة الماء ومعدل ضربات القلب.",
+  "diveImport_healthkit_foundNoDivesHint": "لا توجد تمارين غوص في هذا النطاق. تأكد من أن التواريخ تغطي الغطسة، ومن تفعيل التمارين وعمق الغوص في تطبيق صحة ضمن المشاركة ثم التطبيقات ثم Submersion.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "عمق الغوص - عينات العمق المسجلة أثناء الغطسات",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "درجة حرارة الماء - عينات درجة الحرارة المسجلة أثناء الغطسات",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "تتم إدارة وصول HealthKit من تطبيق صحة",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit غير متوفر على هذا الجهاز"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "Warten auf Upload",
   "media_status_cloudOnly": "Nur in der Cloud gespeichert",
   "media_status_notBackedUp": "Nicht gesichert",
-  "media_tile_infoMenuItem": "Medieninfo"
+  "media_tile_infoMenuItem": "Medieninfo",
+  "diveImport_healthkit_accessGrantedHint": "Apple Health teilt Apps nie mit, ob Lesezugriff gewährt wurde. Falls keine Tauchgänge erscheinen, öffne Health, dann Teilen, Apps, Submersion, und aktiviere Workouts, Unterwassertiefe, Wassertemperatur und Herzfrequenz.",
+  "diveImport_healthkit_foundNoDivesHint": "Keine Tauch-Workouts in diesem Zeitraum. Prüfe, ob die Daten den Tauchgang abdecken und ob unter Health, Teilen, Apps, Submersion die Optionen Workouts und Unterwassertiefe aktiviert sind.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Unterwassertiefe - während Tauchgängen aufgezeichnete Tiefenwerte",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Wassertemperatur - während Tauchgängen aufgezeichnete Temperaturwerte",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "Der HealthKit-Zugriff wird in der Health-App verwaltet",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit ist auf diesem Gerät nicht verfügbar"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1503,7 +1503,7 @@
   "diveImport_healthkit_noDivesFound": "Keine Tauchgänge gefunden",
   "diveImport_healthkit_noDivesFoundDescription": "Im ausgewählten Zeitraum wurden keine Tauchaktivitäten gefunden.",
   "diveImport_healthkit_notAvailable": "Nicht verfügbar",
-  "diveImport_healthkit_notAvailableDescription": "Apple Watch-Import ist nur auf iOS- und macOS-Geräten verfügbar.",
+  "diveImport_healthkit_notAvailableDescription": "Der Apple-Watch-Import benötigt ein iPhone mit der Health-App.",
   "diveImport_healthkit_permissionCheckFailed": "Berechtigungsprüfung fehlgeschlagen",
   "diveImport_healthkit_title": "Von Apple Watch importieren",
   "diveImport_healthkit_watchTitle": "Von Watch importieren",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -18199,5 +18199,17 @@
   "media_status_queued": "Waiting to upload",
   "media_status_cloudOnly": "Stored in the cloud only",
   "media_status_notBackedUp": "Not backed up",
-  "media_tile_infoMenuItem": "Media info"
+  "media_tile_infoMenuItem": "Media info",
+  "diveImport_healthkit_accessGrantedHint": "Apple Health never tells apps whether read access was granted. If no dives turn up, open Health, then Sharing, Apps, Submersion, and turn on Workouts, Underwater Depth, Water Temperature, and Heart Rate.",
+  "diveImport_healthkit_foundNoDivesHint": "No underwater diving workouts in this range. Check that the dates cover the dive, and that Health, Sharing, Apps, Submersion has Workouts and Underwater Depth turned on.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Underwater Depth - depth samples recorded during dives",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Water Temperature - water temperature samples recorded during dives",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "HealthKit access is managed in the Health app",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit is not available on this device",
+  "@diveImport_healthkit_accessGrantedHint": {"description": "Hint under the HealthKit access headline explaining that iOS will not confirm read access."},
+  "@diveImport_healthkit_foundNoDivesHint": {"description": "Hint shown when a HealthKit fetch returned zero dives."},
+  "@settings_dataSources_appleHealth_dataTypeDepth": {"description": "HealthKit data type disclosure: underwater depth."},
+  "@settings_dataSources_appleHealth_dataTypeWaterTemp": {"description": "HealthKit data type disclosure: water temperature."},
+  "@settings_dataSources_appleHealth_permissionManagedInHealth": {"description": "Permission row shown when the platform will not disclose read access."},
+  "@settings_dataSources_appleHealth_permissionUnsupported": {"description": "Permission row shown when HealthKit is unavailable on this device."}
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -12952,7 +12952,7 @@
   "diveImport_healthkit_noDivesFound": "No Dives Found",
   "diveImport_healthkit_noDivesFoundDescription": "No underwater diving activities found in the selected date range.",
   "diveImport_healthkit_notAvailable": "Not Available",
-  "diveImport_healthkit_notAvailableDescription": "Apple Watch import is only available on iOS and macOS devices.",
+  "diveImport_healthkit_notAvailableDescription": "Apple Watch import needs an iPhone with the Health app.",
   "diveImport_healthkit_permissionCheckFailed": "Failed to check permissions",
   "diveImport_healthkit_title": "Import from Apple Watch",
   "diveImport_healthkit_watchTitle": "Import from Watch",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1503,7 +1503,7 @@
   "diveImport_healthkit_noDivesFound": "Sin inmersiones encontradas",
   "diveImport_healthkit_noDivesFoundDescription": "No se encontraron actividades de buceo en el rango de fechas seleccionado.",
   "diveImport_healthkit_notAvailable": "No disponible",
-  "diveImport_healthkit_notAvailableDescription": "La importacion de Apple Watch solo esta disponible en dispositivos iOS y macOS.",
+  "diveImport_healthkit_notAvailableDescription": "La importación desde el Apple Watch necesita un iPhone con la app Salud.",
   "diveImport_healthkit_permissionCheckFailed": "Error al verificar permisos",
   "diveImport_healthkit_title": "Importar desde Apple Watch",
   "diveImport_healthkit_watchTitle": "Importar desde Watch",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "Esperando para subir",
   "media_status_cloudOnly": "Solo en la nube",
   "media_status_notBackedUp": "Sin copia de seguridad",
-  "media_tile_infoMenuItem": "Información del medio"
+  "media_tile_infoMenuItem": "Información del medio",
+  "diveImport_healthkit_accessGrantedHint": "Apple Salud nunca indica a las apps si se concedió el acceso de lectura. Si no aparece ninguna inmersión, abre Salud, luego Compartir, Apps, Submersion, y activa Entrenamientos, Profundidad bajo el agua, Temperatura del agua y Frecuencia cardíaca.",
+  "diveImport_healthkit_foundNoDivesHint": "No hay entrenamientos de buceo en este intervalo. Comprueba que las fechas incluyan la inmersión y que en Salud, Compartir, Apps, Submersion estén activados Entrenamientos y Profundidad bajo el agua.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Profundidad bajo el agua - muestras de profundidad registradas durante las inmersiones",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Temperatura del agua - muestras de temperatura registradas durante las inmersiones",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "El acceso a HealthKit se gestiona en la app Salud",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit no está disponible en este dispositivo"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "En attente de téléversement",
   "media_status_cloudOnly": "Stocké uniquement dans le cloud",
   "media_status_notBackedUp": "Non sauvegardé",
-  "media_tile_infoMenuItem": "Infos du média"
+  "media_tile_infoMenuItem": "Infos du média",
+  "diveImport_healthkit_accessGrantedHint": "Apple Santé n'indique jamais aux apps si l'accès en lecture a été accordé. Si aucune plongée n'apparaît, ouvrez Santé, puis Partage, Apps, Submersion, et activez Entraînements, Profondeur sous l'eau, Température de l'eau et Fréquence cardiaque.",
+  "diveImport_healthkit_foundNoDivesHint": "Aucun entraînement de plongée sur cette période. Vérifiez que les dates couvrent la plongée et que Santé, Partage, Apps, Submersion autorise Entraînements et Profondeur sous l'eau.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Profondeur sous l'eau - mesures de profondeur enregistrées pendant les plongées",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Température de l'eau - mesures de température enregistrées pendant les plongées",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "L'accès à HealthKit se gère dans l'app Santé",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit n'est pas disponible sur cet appareil"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1431,7 +1431,7 @@
   "diveImport_healthkit_noDivesFound": "Aucune plongee trouvee",
   "diveImport_healthkit_noDivesFoundDescription": "Aucune activite de plongee sous-marine trouvee dans la periode selectionnee.",
   "diveImport_healthkit_notAvailable": "Non disponible",
-  "diveImport_healthkit_notAvailableDescription": "L'import depuis l'Apple Watch est disponible uniquement sur les appareils iOS et macOS.",
+  "diveImport_healthkit_notAvailableDescription": "L'importation depuis l'Apple Watch nécessite un iPhone avec l'app Santé.",
   "diveImport_healthkit_permissionCheckFailed": "Echec de la verification des autorisations",
   "diveImport_healthkit_title": "Import depuis l'Apple Watch",
   "diveImport_healthkit_watchTitle": "Import depuis la montre",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "ממתין להעלאה",
   "media_status_cloudOnly": "מאוחסן בענן בלבד",
   "media_status_notBackedUp": "לא מגובה",
-  "media_tile_infoMenuItem": "פרטי מדיה"
+  "media_tile_infoMenuItem": "פרטי מדיה",
+  "diveImport_healthkit_accessGrantedHint": "אפליקציית הבריאות של Apple לעולם אינה מגלה ליישומים אם ניתנה הרשאת קריאה. אם לא מופיעות צלילות, פתחו את אפליקציית הבריאות, ואז שיתוף, יישומים, Submersion, והפעילו אימונים, עומק מתחת למים, טמפרטורת מים ודופק.",
+  "diveImport_healthkit_foundNoDivesHint": "אין אימוני צלילה בטווח הזה. ודאו שהתאריכים כוללים את הצלילה ושבאפליקציית הבריאות, בשיתוף, יישומים, Submersion, מופעלים אימונים ועומק מתחת למים.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "עומק מתחת למים - דגימות עומק שנרשמו במהלך צלילות",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "טמפרטורת מים - דגימות טמפרטורה שנרשמו במהלך צלילות",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "הגישה ל-HealthKit מנוהלת באפליקציית הבריאות",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit אינו זמין במכשיר הזה"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1431,7 +1431,7 @@
   "diveImport_healthkit_noDivesFound": "לא נמצאו צלילות",
   "diveImport_healthkit_noDivesFoundDescription": "לא נמצאו פעילויות צלילה תת-ימיות בטווח התאריכים שנבחר.",
   "diveImport_healthkit_notAvailable": "לא זמין",
-  "diveImport_healthkit_notAvailableDescription": "ייבוא מ-Apple Watch זמין רק במכשירי iOS ו-macOS.",
+  "diveImport_healthkit_notAvailableDescription": "ייבוא מ-Apple Watch מחייב אייפון עם אפליקציית הבריאות.",
   "diveImport_healthkit_permissionCheckFailed": "בדיקת הרשאות נכשלה",
   "diveImport_healthkit_title": "ייבוא מ-Apple Watch",
   "diveImport_healthkit_watchTitle": "ייבוא מהשעון",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "Feltöltésre vár",
   "media_status_cloudOnly": "Csak a felhőben tárolva",
   "media_status_notBackedUp": "Nincs mentve",
-  "media_tile_infoMenuItem": "Média infó"
+  "media_tile_infoMenuItem": "Média infó",
+  "diveImport_healthkit_accessGrantedHint": "Az Apple Health soha nem árulja el az alkalmazásoknak, hogy megkapta-e az olvasási hozzáférést. Ha nem jelenik meg merülés, nyisd meg a Health appot, majd a Megosztás, Appok, Submersion menüpontot, és kapcsold be az Edzések, Vízmélység, Vízhőmérséklet és Pulzus tételt.",
+  "diveImport_healthkit_foundNoDivesHint": "Nincs merülés edzés ebben az időszakban. Ellenőrizd, hogy a dátumok lefedik-e a merülést, és hogy a Health, Megosztás, Appok, Submersion menüben be van-e kapcsolva az Edzések és a Vízmélység.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Vízmélység - a merülések során rögzített mélységadatok",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Vízhőmérséklet - a merülések során rögzített hőmérsékleti adatok",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "A HealthKit hozzáférést a Health alkalmazásban kezelheted",
+  "settings_dataSources_appleHealth_permissionUnsupported": "A HealthKit nem érhető el ezen az eszközön"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1431,7 +1431,7 @@
   "diveImport_healthkit_noDivesFound": "Nem talalhato merules",
   "diveImport_healthkit_noDivesFoundDescription": "A kivalasztott idoszakban nem talalhato vizalatti merulesi tevekenyse.",
   "diveImport_healthkit_notAvailable": "Nem elerheto",
-  "diveImport_healthkit_notAvailableDescription": "Az Apple Watch importalas csak iOS es macOS eszkozokon erheto el.",
+  "diveImport_healthkit_notAvailableDescription": "Az Apple Watch importáláshoz iPhone szükséges a Health alkalmazással.",
   "diveImport_healthkit_permissionCheckFailed": "Nem sikerult az engedelyek ellenorzese",
   "diveImport_healthkit_title": "Importalas Apple Watch-rol",
   "diveImport_healthkit_watchTitle": "Importalas orarol",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1431,7 +1431,7 @@
   "diveImport_healthkit_noDivesFound": "Nessuna immersione trovata",
   "diveImport_healthkit_noDivesFoundDescription": "Nessuna attività subacquea trovata nell'intervallo di date selezionato.",
   "diveImport_healthkit_notAvailable": "Non disponibile",
-  "diveImport_healthkit_notAvailableDescription": "L'importazione da Apple Watch è disponibile solo su dispositivi iOS e macOS.",
+  "diveImport_healthkit_notAvailableDescription": "L'importazione da Apple Watch richiede un iPhone con l'app Salute.",
   "diveImport_healthkit_permissionCheckFailed": "Verifica dei permessi fallita",
   "diveImport_healthkit_title": "Importa da Apple Watch",
   "diveImport_healthkit_watchTitle": "Importa da Watch",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "In attesa di caricamento",
   "media_status_cloudOnly": "Salvato solo nel cloud",
   "media_status_notBackedUp": "Nessun backup",
-  "media_tile_infoMenuItem": "Info media"
+  "media_tile_infoMenuItem": "Info media",
+  "diveImport_healthkit_accessGrantedHint": "Apple Salute non comunica mai alle app se l'accesso in lettura è stato concesso. Se non compare nessuna immersione, apri Salute, poi Condivisione, App, Submersion, e attiva Allenamenti, Profondità subacquea, Temperatura dell'acqua e Frequenza cardiaca.",
+  "diveImport_healthkit_foundNoDivesHint": "Nessun allenamento di immersione in questo intervallo. Verifica che le date coprano l'immersione e che in Salute, Condivisione, App, Submersion siano attivi Allenamenti e Profondità subacquea.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Profondità subacquea - campioni di profondità registrati durante le immersioni",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Temperatura dell'acqua - campioni di temperatura registrati durante le immersioni",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "L'accesso a HealthKit si gestisce nell'app Salute",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit non è disponibile su questo dispositivo"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -53375,6 +53375,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Media info'**
   String get media_tile_infoMenuItem;
+
+  /// Hint under the HealthKit access headline explaining that iOS will not confirm read access.
+  ///
+  /// In en, this message translates to:
+  /// **'Apple Health never tells apps whether read access was granted. If no dives turn up, open Health, then Sharing, Apps, Submersion, and turn on Workouts, Underwater Depth, Water Temperature, and Heart Rate.'**
+  String get diveImport_healthkit_accessGrantedHint;
+
+  /// Hint shown when a HealthKit fetch returned zero dives.
+  ///
+  /// In en, this message translates to:
+  /// **'No underwater diving workouts in this range. Check that the dates cover the dive, and that Health, Sharing, Apps, Submersion has Workouts and Underwater Depth turned on.'**
+  String get diveImport_healthkit_foundNoDivesHint;
+
+  /// HealthKit data type disclosure: underwater depth.
+  ///
+  /// In en, this message translates to:
+  /// **'Underwater Depth - depth samples recorded during dives'**
+  String get settings_dataSources_appleHealth_dataTypeDepth;
+
+  /// HealthKit data type disclosure: water temperature.
+  ///
+  /// In en, this message translates to:
+  /// **'Water Temperature - water temperature samples recorded during dives'**
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp;
+
+  /// Permission row shown when the platform will not disclose read access.
+  ///
+  /// In en, this message translates to:
+  /// **'HealthKit access is managed in the Health app'**
+  String get settings_dataSources_appleHealth_permissionManagedInHealth;
+
+  /// Permission row shown when HealthKit is unavailable on this device.
+  ///
+  /// In en, this message translates to:
+  /// **'HealthKit is not available on this device'**
+  String get settings_dataSources_appleHealth_permissionUnsupported;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -33807,7 +33807,7 @@ abstract class AppLocalizations {
   /// No description provided for @diveImport_healthkit_notAvailableDescription.
   ///
   /// In en, this message translates to:
-  /// **'Apple Watch import is only available on iOS and macOS devices.'**
+  /// **'Apple Watch import needs an iPhone with the Health app.'**
   String get diveImport_healthkit_notAvailableDescription;
 
   /// No description provided for @diveImport_healthkit_permissionCheckFailed.

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -19913,7 +19913,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'استيراد Apple Watch متاح فقط على أجهزة iOS وmacOS.';
+      'يتطلب الاستيراد من Apple Watch جهاز iPhone مزوّدًا بتطبيق صحة.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -31926,4 +31926,28 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'معلومات الوسائط';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'لا يخبر تطبيق صحة Apple التطبيقات أبدًا بما إذا كان قد تم منح إذن القراءة. إذا لم تظهر أي غطسات، افتح تطبيق صحة ثم المشاركة ثم التطبيقات ثم Submersion، وفعّل التمارين وعمق الغوص ودرجة حرارة الماء ومعدل ضربات القلب.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'لا توجد تمارين غوص في هذا النطاق. تأكد من أن التواريخ تغطي الغطسة، ومن تفعيل التمارين وعمق الغوص في تطبيق صحة ضمن المشاركة ثم التطبيقات ثم Submersion.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'عمق الغوص - عينات العمق المسجلة أثناء الغطسات';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'درجة حرارة الماء - عينات درجة الحرارة المسجلة أثناء الغطسات';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'تتم إدارة وصول HealthKit من تطبيق صحة';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit غير متوفر على هذا الجهاز';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -32164,4 +32164,28 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Medieninfo';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Health teilt Apps nie mit, ob Lesezugriff gewährt wurde. Falls keine Tauchgänge erscheinen, öffne Health, dann Teilen, Apps, Submersion, und aktiviere Workouts, Unterwassertiefe, Wassertemperatur und Herzfrequenz.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Keine Tauch-Workouts in diesem Zeitraum. Prüfe, ob die Daten den Tauchgang abdecken und ob unter Health, Teilen, Apps, Submersion die Optionen Workouts und Unterwassertiefe aktiviert sind.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Unterwassertiefe - während Tauchgängen aufgezeichnete Tiefenwerte';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Wassertemperatur - während Tauchgängen aufgezeichnete Temperaturwerte';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'Der HealthKit-Zugriff wird in der Health-App verwaltet';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit ist auf diesem Gerät nicht verfügbar';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -20246,7 +20246,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'Apple Watch-Import ist nur auf iOS- und macOS-Geräten verfügbar.';
+      'Der Apple-Watch-Import benötigt ein iPhone mit der Health-App.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -31723,4 +31723,28 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Media info';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Health never tells apps whether read access was granted. If no dives turn up, open Health, then Sharing, Apps, Submersion, and turn on Workouts, Underwater Depth, Water Temperature, and Heart Rate.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'No underwater diving workouts in this range. Check that the dates cover the dive, and that Health, Sharing, Apps, Submersion has Workouts and Underwater Depth turned on.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Underwater Depth - depth samples recorded during dives';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Water Temperature - water temperature samples recorded during dives';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'HealthKit access is managed in the Health app';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit is not available on this device';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -19931,7 +19931,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'Apple Watch import is only available on iOS and macOS devices.';
+      'Apple Watch import needs an iPhone with the Health app.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -20290,7 +20290,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'La importacion de Apple Watch solo esta disponible en dispositivos iOS y macOS.';
+      'La importación desde el Apple Watch necesita un iPhone con la app Salud.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -32266,4 +32266,28 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Información del medio';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Salud nunca indica a las apps si se concedió el acceso de lectura. Si no aparece ninguna inmersión, abre Salud, luego Compartir, Apps, Submersion, y activa Entrenamientos, Profundidad bajo el agua, Temperatura del agua y Frecuencia cardíaca.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'No hay entrenamientos de buceo en este intervalo. Comprueba que las fechas incluyan la inmersión y que en Salud, Compartir, Apps, Submersion estén activados Entrenamientos y Profundidad bajo el agua.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Profundidad bajo el agua - muestras de profundidad registradas durante las inmersiones';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Temperatura del agua - muestras de temperatura registradas durante las inmersiones';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'El acceso a HealthKit se gestiona en la app Salud';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit no está disponible en este dispositivo';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -20346,7 +20346,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'L\'import depuis l\'Apple Watch est disponible uniquement sur les appareils iOS et macOS.';
+      'L\'importation depuis l\'Apple Watch nécessite un iPhone avec l\'app Santé.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -32309,4 +32309,28 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Infos du média';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Santé n\'indique jamais aux apps si l\'accès en lecture a été accordé. Si aucune plongée n\'apparaît, ouvrez Santé, puis Partage, Apps, Submersion, et activez Entraînements, Profondeur sous l\'eau, Température de l\'eau et Fréquence cardiaque.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Aucun entraînement de plongée sur cette période. Vérifiez que les dates couvrent la plongée et que Santé, Partage, Apps, Submersion autorise Entraînements et Profondeur sous l\'eau.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Profondeur sous l\'eau - mesures de profondeur enregistrées pendant les plongées';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Température de l\'eau - mesures de température enregistrées pendant les plongées';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'L\'accès à HealthKit se gère dans l\'app Santé';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit n\'est pas disponible sur cet appareil';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -31589,4 +31589,28 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'פרטי מדיה';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'אפליקציית הבריאות של Apple לעולם אינה מגלה ליישומים אם ניתנה הרשאת קריאה. אם לא מופיעות צלילות, פתחו את אפליקציית הבריאות, ואז שיתוף, יישומים, Submersion, והפעילו אימונים, עומק מתחת למים, טמפרטורת מים ודופק.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'אין אימוני צלילה בטווח הזה. ודאו שהתאריכים כוללים את הצלילה ושבאפליקציית הבריאות, בשיתוף, יישומים, Submersion, מופעלים אימונים ועומק מתחת למים.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'עומק מתחת למים - דגימות עומק שנרשמו במהלך צלילות';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'טמפרטורת מים - דגימות טמפרטורה שנרשמו במהלך צלילות';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'הגישה ל-HealthKit מנוהלת באפליקציית הבריאות';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit אינו זמין במכשיר הזה';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -19772,7 +19772,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'ייבוא מ-Apple Watch זמין רק במכשירי iOS ו-macOS.';
+      'ייבוא מ-Apple Watch מחייב אייפון עם אפליקציית הבריאות.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed => 'בדיקת הרשאות נכשלה';

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -20217,7 +20217,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'Az Apple Watch importalas csak iOS es macOS eszkozokon erheto el.';
+      'Az Apple Watch importáláshoz iPhone szükséges a Health alkalmazással.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -32110,4 +32110,28 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Média infó';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Az Apple Health soha nem árulja el az alkalmazásoknak, hogy megkapta-e az olvasási hozzáférést. Ha nem jelenik meg merülés, nyisd meg a Health appot, majd a Megosztás, Appok, Submersion menüpontot, és kapcsold be az Edzések, Vízmélység, Vízhőmérséklet és Pulzus tételt.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Nincs merülés edzés ebben az időszakban. Ellenőrizd, hogy a dátumok lefedik-e a merülést, és hogy a Health, Megosztás, Appok, Submersion menüben be van-e kapcsolva az Edzések és a Vízmélység.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Vízmélység - a merülések során rögzített mélységadatok';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Vízhőmérséklet - a merülések során rögzített hőmérsékleti adatok';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'A HealthKit hozzáférést a Health alkalmazásban kezelheted';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'A HealthKit nem érhető el ezen az eszközön';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -20272,7 +20272,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'L\'importazione da Apple Watch è disponibile solo su dispositivi iOS e macOS.';
+      'L\'importazione da Apple Watch richiede un iPhone con l\'app Salute.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -32221,4 +32221,28 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Info media';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Salute non comunica mai alle app se l\'accesso in lettura è stato concesso. Se non compare nessuna immersione, apri Salute, poi Condivisione, App, Submersion, e attiva Allenamenti, Profondità subacquea, Temperatura dell\'acqua e Frequenza cardiaca.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Nessun allenamento di immersione in questo intervallo. Verifica che le date coprano l\'immersione e che in Salute, Condivisione, App, Submersion siano attivi Allenamenti e Profondità subacquea.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Profondità subacquea - campioni di profondità registrati durante le immersioni';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Temperatura dell\'acqua - campioni di temperatura registrati durante le immersioni';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'L\'accesso a HealthKit si gestisce nell\'app Salute';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit non è disponibile su questo dispositivo';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -32005,4 +32005,28 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Media-info';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple Gezondheid vertelt apps nooit of leestoegang is verleend. Verschijnen er geen duiken, open dan Gezondheid, vervolgens Delen, Apps, Submersion, en zet Workouts, Waterdiepte, Watertemperatuur en Hartslag aan.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Geen duikworkouts in dit bereik. Controleer of de datums de duik omvatten en of bij Gezondheid, Delen, Apps, Submersion de opties Workouts en Waterdiepte aanstaan.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Waterdiepte - dieptemetingen die tijdens duiken zijn vastgelegd';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Watertemperatuur - temperatuurmetingen die tijdens duiken zijn vastgelegd';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'HealthKit-toegang beheer je in de app Gezondheid';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'HealthKit is niet beschikbaar op dit apparaat';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -20117,7 +20117,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'Apple Watch-import is alleen beschikbaar op iOS- en macOS-apparaten.';
+      'Voor importeren vanaf de Apple Watch is een iPhone met de app Gezondheid nodig.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -32239,4 +32239,28 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => 'Informações da mídia';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'O Apple Saúde nunca informa às apps se o acesso de leitura foi concedido. Se nenhum mergulho aparecer, abra Saúde, depois Partilha, Apps, Submersion, e ative Treinos, Profundidade subaquática, Temperatura da água e Frequência cardíaca.';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      'Sem treinos de mergulho neste intervalo. Confirme que as datas cobrem o mergulho e que em Saúde, Partilha, Apps, Submersion estão ativos Treinos e Profundidade subaquática.';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      'Profundidade subaquática - amostras de profundidade registadas durante os mergulhos';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      'Temperatura da água - amostras de temperatura registadas durante os mergulhos';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'O acesso ao HealthKit é gerido na app Saúde';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      'O HealthKit não está disponível neste dispositivo';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -20280,7 +20280,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'A importacao do Apple Watch esta disponivel apenas em dispositivos iOS e macOS.';
+      'A importação do Apple Watch precisa de um iPhone com a app Saúde.';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed =>

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -30386,4 +30386,28 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get media_tile_infoMenuItem => '媒体信息';
+
+  @override
+  String get diveImport_healthkit_accessGrantedHint =>
+      'Apple 健康从不告知 App 是否已获得读取权限。如果没有出现潜水记录，请打开“健康”，依次进入“共享”“App”“Submersion”，并开启“体能训练”“水下深度”“水温”和“心率”。';
+
+  @override
+  String get diveImport_healthkit_foundNoDivesHint =>
+      '此时间范围内没有潜水体能训练。请确认日期涵盖该次潜水，并在“健康”“共享”“App”“Submersion”中开启“体能训练”和“水下深度”。';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeDepth =>
+      '水下深度 - 潜水过程中记录的深度采样';
+
+  @override
+  String get settings_dataSources_appleHealth_dataTypeWaterTemp =>
+      '水温 - 潜水过程中记录的水温采样';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionManagedInHealth =>
+      'HealthKit 访问权限在“健康”App 中管理';
+
+  @override
+  String get settings_dataSources_appleHealth_permissionUnsupported =>
+      '此设备不支持 HealthKit';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -19251,7 +19251,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get diveImport_healthkit_notAvailableDescription =>
-      'Apple Watch 导入仅在 iOS 和 macOS 设备上可用。';
+      '从 Apple Watch 导入需要装有“健康”App 的 iPhone。';
 
   @override
   String get diveImport_healthkit_permissionCheckFailed => '权限检查失败';

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1503,7 +1503,7 @@
   "diveImport_healthkit_noDivesFound": "Geen duiken gevonden",
   "diveImport_healthkit_noDivesFoundDescription": "Geen onderwaterduikactiviteiten gevonden in het geselecteerde datumbereik.",
   "diveImport_healthkit_notAvailable": "Niet beschikbaar",
-  "diveImport_healthkit_notAvailableDescription": "Apple Watch-import is alleen beschikbaar op iOS- en macOS-apparaten.",
+  "diveImport_healthkit_notAvailableDescription": "Voor importeren vanaf de Apple Watch is een iPhone met de app Gezondheid nodig.",
   "diveImport_healthkit_permissionCheckFailed": "Controle van machtigingen mislukt",
   "diveImport_healthkit_title": "Importeren vanuit Apple Watch",
   "diveImport_healthkit_watchTitle": "Importeren vanuit Watch",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "Wacht op uploaden",
   "media_status_cloudOnly": "Alleen in de cloud opgeslagen",
   "media_status_notBackedUp": "Geen back-up",
-  "media_tile_infoMenuItem": "Media-info"
+  "media_tile_infoMenuItem": "Media-info",
+  "diveImport_healthkit_accessGrantedHint": "Apple Gezondheid vertelt apps nooit of leestoegang is verleend. Verschijnen er geen duiken, open dan Gezondheid, vervolgens Delen, Apps, Submersion, en zet Workouts, Waterdiepte, Watertemperatuur en Hartslag aan.",
+  "diveImport_healthkit_foundNoDivesHint": "Geen duikworkouts in dit bereik. Controleer of de datums de duik omvatten en of bij Gezondheid, Delen, Apps, Submersion de opties Workouts en Waterdiepte aanstaan.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Waterdiepte - dieptemetingen die tijdens duiken zijn vastgelegd",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Watertemperatuur - temperatuurmetingen die tijdens duiken zijn vastgelegd",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "HealthKit-toegang beheer je in de app Gezondheid",
+  "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit is niet beschikbaar op dit apparaat"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "Aguardando envio",
   "media_status_cloudOnly": "Armazenado apenas na nuvem",
   "media_status_notBackedUp": "Sem backup",
-  "media_tile_infoMenuItem": "Informações da mídia"
+  "media_tile_infoMenuItem": "Informações da mídia",
+  "diveImport_healthkit_accessGrantedHint": "O Apple Saúde nunca informa às apps se o acesso de leitura foi concedido. Se nenhum mergulho aparecer, abra Saúde, depois Partilha, Apps, Submersion, e ative Treinos, Profundidade subaquática, Temperatura da água e Frequência cardíaca.",
+  "diveImport_healthkit_foundNoDivesHint": "Sem treinos de mergulho neste intervalo. Confirme que as datas cobrem o mergulho e que em Saúde, Partilha, Apps, Submersion estão ativos Treinos e Profundidade subaquática.",
+  "settings_dataSources_appleHealth_dataTypeDepth": "Profundidade subaquática - amostras de profundidade registadas durante os mergulhos",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "Temperatura da água - amostras de temperatura registadas durante os mergulhos",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "O acesso ao HealthKit é gerido na app Saúde",
+  "settings_dataSources_appleHealth_permissionUnsupported": "O HealthKit não está disponível neste dispositivo"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1503,7 +1503,7 @@
   "diveImport_healthkit_noDivesFound": "Nenhum Mergulho Encontrado",
   "diveImport_healthkit_noDivesFoundDescription": "Nenhuma atividade de mergulho subaquatico encontrada no periodo selecionado.",
   "diveImport_healthkit_notAvailable": "Nao Disponivel",
-  "diveImport_healthkit_notAvailableDescription": "A importacao do Apple Watch esta disponivel apenas em dispositivos iOS e macOS.",
+  "diveImport_healthkit_notAvailableDescription": "A importação do Apple Watch precisa de um iPhone com a app Saúde.",
   "diveImport_healthkit_permissionCheckFailed": "Falha ao verificar permissoes",
   "diveImport_healthkit_title": "Importar do Apple Watch",
   "diveImport_healthkit_watchTitle": "Importar do Relogio",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -9497,5 +9497,11 @@
   "media_status_queued": "等待上传",
   "media_status_cloudOnly": "仅存储在云端",
   "media_status_notBackedUp": "未备份",
-  "media_tile_infoMenuItem": "媒体信息"
+  "media_tile_infoMenuItem": "媒体信息",
+  "diveImport_healthkit_accessGrantedHint": "Apple 健康从不告知 App 是否已获得读取权限。如果没有出现潜水记录，请打开“健康”，依次进入“共享”“App”“Submersion”，并开启“体能训练”“水下深度”“水温”和“心率”。",
+  "diveImport_healthkit_foundNoDivesHint": "此时间范围内没有潜水体能训练。请确认日期涵盖该次潜水，并在“健康”“共享”“App”“Submersion”中开启“体能训练”和“水下深度”。",
+  "settings_dataSources_appleHealth_dataTypeDepth": "水下深度 - 潜水过程中记录的深度采样",
+  "settings_dataSources_appleHealth_dataTypeWaterTemp": "水温 - 潜水过程中记录的水温采样",
+  "settings_dataSources_appleHealth_permissionManagedInHealth": "HealthKit 访问权限在“健康”App 中管理",
+  "settings_dataSources_appleHealth_permissionUnsupported": "此设备不支持 HealthKit"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1597,7 +1597,7 @@
   "diveImport_healthkit_noDivesFound": "未找到潜水记录",
   "diveImport_healthkit_noDivesFoundDescription": "在所选日期范围内未找到水下潜水活动。",
   "diveImport_healthkit_notAvailable": "不可用",
-  "diveImport_healthkit_notAvailableDescription": "Apple Watch 导入仅在 iOS 和 macOS 设备上可用。",
+  "diveImport_healthkit_notAvailableDescription": "从 Apple Watch 导入需要装有“健康”App 的 iPhone。",
   "diveImport_healthkit_permissionCheckFailed": "权限检查失败",
   "diveImport_healthkit_title": "从 Apple Watch 导入",
   "diveImport_healthkit_watchTitle": "从手表导入",

--- a/test/features/dive_import/data/services/healthkit_service_test.dart
+++ b/test/features/dive_import/data/services/healthkit_service_test.dart
@@ -4,6 +4,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:submersion/features/dive_import/data/services/healthkit_service.dart';
 import 'package:submersion/features/dive_import/domain/entities/imported_dive.dart';
+import 'package:submersion/features/dive_import/domain/services/health_import_service.dart';
 
 @GenerateMocks([Health])
 import 'healthkit_service_test.mocks.dart';
@@ -25,30 +26,97 @@ void main() {
     });
 
     group('isAvailable', () {
-      test('returns false when hasPermissions throws', () async {
+      test('reports platform capability, not permission state', () async {
+        expect(await service.isAvailable(), isTrue);
+        expect(
+          await HealthKitService(
+            health: mockHealth,
+            isPlatformSupported: false,
+          ).isAvailable(),
+          isFalse,
+        );
+        verifyNever(mockHealth.hasPermissions(any));
+      });
+    });
+
+    group('permissionStatus', () {
+      test('is undetermined when the platform will not say', () async {
+        // iOS never discloses read access; the plugin returns null.
         when(
-          mockHealth.hasPermissions(any),
-        ).thenThrow(Exception('Not available'));
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => null);
 
-        final result = await service.isAvailable();
-
-        expect(result, isFalse);
+        expect(
+          await service.permissionStatus(),
+          equals(HealthPermissionStatus.undetermined),
+        );
       });
 
-      test('returns false when hasPermissions returns null', () async {
-        when(mockHealth.hasPermissions(any)).thenAnswer((_) async => null);
+      test('is undetermined when the probe throws', () async {
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenThrow(Exception('Error'));
 
-        final result = await service.isAvailable();
-
-        expect(result, isFalse);
+        expect(
+          await service.permissionStatus(),
+          equals(HealthPermissionStatus.undetermined),
+        );
       });
 
-      test('returns true when hasPermissions returns true', () async {
-        when(mockHealth.hasPermissions(any)).thenAnswer((_) async => true);
+      test('is granted when the platform confirms access', () async {
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => true);
 
-        final result = await service.isAvailable();
+        expect(
+          await service.permissionStatus(),
+          equals(HealthPermissionStatus.granted),
+        );
+      });
 
-        expect(result, isTrue);
+      test('is denied when the platform refuses access', () async {
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => false);
+
+        expect(
+          await service.permissionStatus(),
+          equals(HealthPermissionStatus.denied),
+        );
+      });
+
+      test('is unsupported off Apple platforms', () async {
+        final offPlatform = HealthKitService(
+          health: mockHealth,
+          isPlatformSupported: false,
+        );
+
+        expect(
+          await offPlatform.permissionStatus(),
+          equals(HealthPermissionStatus.unsupported),
+        );
+      });
+
+      test('probes only types available on every supported iOS', () async {
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => null);
+
+        await service.permissionStatus();
+
+        // UNDERWATER_DEPTH is iOS 16+, and the plugin reports an unknown type
+        // as an outright denial, so probing with it would make every older
+        // device look permanently denied.
+        final probed =
+            verify(
+                  mockHealth.hasPermissions(
+                    captureAny,
+                    permissions: anyNamed('permissions'),
+                  ),
+                ).captured.single
+                as List<HealthDataType>;
+        expect(probed, isNot(contains(HealthDataType.UNDERWATER_DEPTH)));
+        expect(probed, isNot(contains(HealthDataType.WATER_TEMPERATURE)));
       });
     });
 
@@ -106,6 +174,36 @@ void main() {
         ).called(1);
       });
 
+      test('asks for the dive-specific data types', () async {
+        when(mockHealth.configure()).thenAnswer((_) async {});
+        when(
+          mockHealth.requestAuthorization(
+            any,
+            permissions: anyNamed('permissions'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        await service.requestPermissions();
+
+        final requested =
+            verify(
+                  mockHealth.requestAuthorization(
+                    captureAny,
+                    permissions: anyNamed('permissions'),
+                  ),
+                ).captured.single
+                as List<HealthDataType>;
+        expect(
+          requested,
+          containsAll([
+            HealthDataType.WORKOUT,
+            HealthDataType.HEART_RATE,
+            HealthDataType.UNDERWATER_DEPTH,
+            HealthDataType.WATER_TEMPERATURE,
+          ]),
+        );
+      });
+
       test('returns false when configure throws', () async {
         when(mockHealth.configure()).thenThrow(Exception('Error'));
 
@@ -130,10 +228,73 @@ void main() {
     });
 
     group('fetchDives', () {
-      test('returns empty list when no permissions', () async {
+      /// Stub every per-type query the service issues.
+      void stubReads({
+        List<HealthDataPoint> workouts = const [],
+        List<HealthDataPoint> depth = const [],
+        List<HealthDataPoint> temperature = const [],
+        List<HealthDataPoint> heartRate = const [],
+      }) {
+        final byType = {
+          HealthDataType.WORKOUT: workouts,
+          HealthDataType.UNDERWATER_DEPTH: depth,
+          HealthDataType.WATER_TEMPERATURE: temperature,
+          HealthDataType.HEART_RATE: heartRate,
+        };
+        for (final entry in byType.entries) {
+          when(
+            mockHealth.getHealthDataFromTypes(
+              types: [entry.key],
+              startTime: anyNamed('startTime'),
+              endTime: anyNamed('endTime'),
+            ),
+          ).thenAnswer((_) async => entry.value);
+        }
+      }
+
+      void stubStatus(bool? probeResult) {
         when(
           mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => false);
+        ).thenAnswer((_) async => probeResult);
+      }
+
+      test('fetches dives when the platform will not disclose access', () async {
+        // Regression for #1128: iOS never confirms read access, and gating the
+        // fetch on that non-answer made Apple Watch import always come back
+        // empty.
+        stubStatus(null);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: DateTime(2024, 1, 15, 9, 0),
+              endTime: DateTime(2024, 1, 15, 10, 0),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+        );
+
+        final result = await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first.sourceId, equals('dive-uuid-123'));
+      });
+
+      test('returns empty list when the platform refuses access', () async {
+        stubStatus(false);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: DateTime(2024, 1, 15, 9, 0),
+              endTime: DateTime(2024, 1, 15, 10, 0),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+        );
 
         final result = await service.fetchDives(
           startDate: DateTime(2024, 1, 1),
@@ -141,15 +302,35 @@ void main() {
         );
 
         expect(result, isEmpty);
-      });
-
-      test('returns empty list when getHealthDataFromTypes throws', () async {
-        when(
-          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => true);
-        when(
+        verifyNever(
           mockHealth.getHealthDataFromTypes(
             types: anyNamed('types'),
+            startTime: anyNamed('startTime'),
+            endTime: anyNamed('endTime'),
+          ),
+        );
+      });
+
+      test('returns empty list off Apple platforms', () async {
+        final offPlatform = HealthKitService(
+          health: mockHealth,
+          isPlatformSupported: false,
+        );
+
+        final result = await offPlatform.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when the workout query throws', () async {
+        stubStatus(true);
+        stubReads();
+        when(
+          mockHealth.getHealthDataFromTypes(
+            types: [HealthDataType.WORKOUT],
             startTime: anyNamed('startTime'),
             endTime: anyNamed('endTime'),
           ),
@@ -164,16 +345,8 @@ void main() {
       });
 
       test('returns empty list when no diving workouts found', () async {
-        when(
-          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => true);
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: anyNamed('types'),
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => []);
+        stubStatus(true);
+        stubReads();
 
         final result = await service.fetchDives(
           startDate: DateTime(2024, 1, 1),
@@ -184,23 +357,17 @@ void main() {
       });
 
       test('filters out non-diving workouts', () async {
-        final runningWorkout = _createMockWorkoutDataPoint(
-          uuid: 'running-uuid',
-          startTime: DateTime(2024, 1, 15, 10, 0),
-          endTime: DateTime(2024, 1, 15, 11, 0),
-          activityType: HealthWorkoutActivityType.RUNNING,
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'running-uuid',
+              startTime: DateTime(2024, 1, 15, 10, 0),
+              endTime: DateTime(2024, 1, 15, 11, 0),
+              activityType: HealthWorkoutActivityType.RUNNING,
+            ),
+          ],
         );
-
-        when(
-          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => true);
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: anyNamed('types'),
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => [runningWorkout]);
 
         final result = await service.fetchDives(
           startDate: DateTime(2024, 1, 1),
@@ -211,34 +378,17 @@ void main() {
       });
 
       test('converts diving workouts to ImportedDive entities', () async {
-        final divingWorkout = _createMockWorkoutDataPoint(
-          uuid: 'dive-uuid-123',
-          startTime: DateTime(2024, 1, 15, 9, 0),
-          endTime: DateTime(2024, 1, 15, 10, 0),
-          activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: DateTime(2024, 1, 15, 9, 0),
+              endTime: DateTime(2024, 1, 15, 10, 0),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
         );
-
-        when(
-          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => true);
-
-        // First call for workouts
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: [HealthDataType.WORKOUT],
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => [divingWorkout]);
-
-        // Second call for heart rate samples
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: [HealthDataType.HEART_RATE],
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => []);
 
         final result = await service.fetchDives(
           startDate: DateTime(2024, 1, 1),
@@ -250,43 +400,233 @@ void main() {
         expect(result.first.source, equals(ImportSource.appleWatch));
         expect(result.first.startTime, equals(DateTime(2024, 1, 15, 9, 0)));
         expect(result.first.endTime, equals(DateTime(2024, 1, 15, 10, 0)));
+        expect(result.first.sourceFileFormat, equals('healthkit'));
+      });
+
+      test('builds the profile from the underwater depth series', () async {
+        final start = DateTime(2024, 1, 15, 9, 0);
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: start,
+              endTime: start.add(const Duration(minutes: 40)),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+          depth: [
+            _numericPoint(start, 0.0, HealthDataType.UNDERWATER_DEPTH),
+            _numericPoint(
+              start.add(const Duration(seconds: 30)),
+              18.4,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+            _numericPoint(
+              start.add(const Duration(seconds: 60)),
+              9.2,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+          ],
+        );
+
+        final dive = (await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        )).single;
+
+        expect(
+          dive.profile.map((s) => s.timeSeconds).toList(),
+          equals([0, 30, 60]),
+        );
+        expect(
+          dive.profile.map((s) => s.depth).toList(),
+          equals([0.0, 18.4, 9.2]),
+        );
+        expect(dive.maxDepth, equals(18.4));
+        expect(dive.avgDepth, closeTo(9.2, 0.001));
+      });
+
+      test('merges temperature and heart rate onto depth samples', () async {
+        final start = DateTime(2024, 1, 15, 9, 0);
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: start,
+              endTime: start.add(const Duration(minutes: 40)),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+          depth: [
+            _numericPoint(
+              start.add(const Duration(seconds: 10)),
+              12.0,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+            _numericPoint(
+              start.add(const Duration(seconds: 600)),
+              20.0,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+          ],
+          temperature: [
+            _numericPoint(
+              start.add(const Duration(seconds: 12)),
+              21.5,
+              HealthDataType.WATER_TEMPERATURE,
+            ),
+          ],
+          heartRate: [
+            _numericPoint(
+              start.add(const Duration(seconds: 8)),
+              78.4,
+              HealthDataType.HEART_RATE,
+            ),
+          ],
+        );
+
+        final dive = (await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        )).single;
+
+        expect(dive.profile.first.temperature, equals(21.5));
+        expect(dive.profile.first.heartRate, equals(78));
+        // The second sample sits ten minutes from either reading, well past
+        // the match window, so it must not inherit them.
+        expect(dive.profile.last.temperature, isNull);
+        expect(dive.profile.last.heartRate, isNull);
+        expect(dive.minTemperature, equals(21.5));
+        expect(dive.maxTemperature, equals(21.5));
+        expect(dive.avgHeartRate, equals(78));
+      });
+
+      test('keeps the deepest reading when a second repeats', () async {
+        final start = DateTime(2024, 1, 15, 9, 0);
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: start,
+              endTime: start.add(const Duration(minutes: 40)),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+          depth: [
+            _numericPoint(
+              start.add(const Duration(seconds: 30)),
+              11.0,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+            _numericPoint(
+              start.add(const Duration(seconds: 30, milliseconds: 400)),
+              14.0,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+          ],
+        );
+
+        final dive = (await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        )).single;
+
+        expect(dive.profile, hasLength(1));
+        expect(dive.profile.single.depth, equals(14.0));
+      });
+
+      test('falls back to heart rate alone when no depth series', () async {
+        final start = DateTime(2024, 1, 15, 9, 0);
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: start,
+              endTime: start.add(const Duration(minutes: 40)),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+          heartRate: [
+            _numericPoint(
+              start.add(const Duration(seconds: 15)),
+              82.0,
+              HealthDataType.HEART_RATE,
+            ),
+          ],
+        );
+
+        final dive = (await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        )).single;
+
+        expect(dive.profile, hasLength(1));
+        expect(dive.profile.single.depth, equals(0.0));
+        expect(dive.profile.single.heartRate, equals(82));
+        expect(dive.maxDepth, equals(0.0));
+      });
+
+      test('one failing series does not discard the others', () async {
+        // The plugin queries types in a loop and rethrows, so an unsupported
+        // type (the dive series below iOS 16) must not take the rest with it.
+        final start = DateTime(2024, 1, 15, 9, 0);
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'dive-uuid-123',
+              startTime: start,
+              endTime: start.add(const Duration(minutes: 40)),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
+          depth: [
+            _numericPoint(
+              start.add(const Duration(seconds: 30)),
+              18.0,
+              HealthDataType.UNDERWATER_DEPTH,
+            ),
+          ],
+        );
+        when(
+          mockHealth.getHealthDataFromTypes(
+            types: [HealthDataType.WATER_TEMPERATURE],
+            startTime: anyNamed('startTime'),
+            endTime: anyNamed('endTime'),
+          ),
+        ).thenThrow(Exception('INVALID_TYPE'));
+
+        final dive = (await service.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        )).single;
+
+        expect(dive.maxDepth, equals(18.0));
+        expect(dive.minTemperature, isNull);
       });
 
       test('sorts dives by start time descending', () async {
-        final olderDive = _createMockWorkoutDataPoint(
-          uuid: 'older-dive',
-          startTime: DateTime(2024, 1, 10, 9, 0),
-          endTime: DateTime(2024, 1, 10, 10, 0),
-          activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+        stubStatus(true);
+        stubReads(
+          workouts: [
+            _workoutPoint(
+              uuid: 'older-dive',
+              startTime: DateTime(2024, 1, 10, 9, 0),
+              endTime: DateTime(2024, 1, 10, 10, 0),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+            _workoutPoint(
+              uuid: 'newer-dive',
+              startTime: DateTime(2024, 1, 20, 9, 0),
+              endTime: DateTime(2024, 1, 20, 10, 0),
+              activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
+            ),
+          ],
         );
-
-        final newerDive = _createMockWorkoutDataPoint(
-          uuid: 'newer-dive',
-          startTime: DateTime(2024, 1, 20, 9, 0),
-          endTime: DateTime(2024, 1, 20, 10, 0),
-          activityType: HealthWorkoutActivityType.UNDERWATER_DIVING,
-        );
-
-        when(
-          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
-        ).thenAnswer((_) async => true);
-
-        // Return older dive first
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: [HealthDataType.WORKOUT],
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => [olderDive, newerDive]);
-
-        when(
-          mockHealth.getHealthDataFromTypes(
-            types: [HealthDataType.HEART_RATE],
-            startTime: anyNamed('startTime'),
-            endTime: anyNamed('endTime'),
-          ),
-        ).thenAnswer((_) async => []);
 
         final result = await service.fetchDives(
           startDate: DateTime(2024, 1, 1),
@@ -294,7 +634,6 @@ void main() {
         );
 
         expect(result, hasLength(2));
-        // Newer dive should be first
         expect(result[0].sourceId, equals('newer-dive'));
         expect(result[1].sourceId, equals('older-dive'));
       });
@@ -309,8 +648,8 @@ void main() {
   });
 }
 
-/// Helper to create a mock workout data point for testing.
-HealthDataPoint _createMockWorkoutDataPoint({
+/// Helper to create a workout data point for testing.
+HealthDataPoint _workoutPoint({
   required String uuid,
   required DateTime startTime,
   required DateTime endTime,
@@ -329,6 +668,22 @@ HealthDataPoint _createMockWorkoutDataPoint({
     unit: HealthDataUnit.NO_UNIT,
     dateFrom: startTime,
     dateTo: endTime,
+    sourcePlatform: HealthPlatformType.appleHealth,
+    sourceDeviceId: 'apple-watch',
+    sourceId: 'com.apple.health',
+    sourceName: 'Apple Watch',
+  );
+}
+
+/// Helper to create a numeric sample (depth, temperature, or heart rate).
+HealthDataPoint _numericPoint(DateTime at, double value, HealthDataType type) {
+  return HealthDataPoint(
+    uuid: '${type.name}-${at.microsecondsSinceEpoch}',
+    value: NumericHealthValue(numericValue: value),
+    type: type,
+    unit: dataTypeToUnit[type] ?? HealthDataUnit.NO_UNIT,
+    dateFrom: at,
+    dateTo: at,
     sourcePlatform: HealthPlatformType.appleHealth,
     sourceDeviceId: 'apple-watch',
     sourceId: 'com.apple.health',

--- a/test/features/dive_import/data/services/healthkit_service_test.dart
+++ b/test/features/dive_import/data/services/healthkit_service_test.dart
@@ -92,6 +92,60 @@ void main() {
         );
       });
 
+      test('asks the platform once and reuses the answer', () async {
+        // Whether the hardware has HealthKit cannot change while the app
+        // runs, and every entry point needs the answer.
+        var probes = 0;
+        final counted = HealthKitService(
+          health: mockHealth,
+          isPlatformSupported: true,
+          healthDataAvailable: () async {
+            probes++;
+            return true;
+          },
+        );
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => null);
+        when(
+          mockHealth.getHealthDataFromTypes(
+            types: anyNamed('types'),
+            startTime: anyNamed('startTime'),
+            endTime: anyNamed('endTime'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        await counted.isAvailable();
+        await counted.permissionStatus();
+        await counted.fetchDives(
+          startDate: DateTime(2024, 1, 1),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        expect(probes, equals(1));
+      });
+
+      test('shares one probe across concurrent callers', () async {
+        var probes = 0;
+        final counted = HealthKitService(
+          health: mockHealth,
+          isPlatformSupported: true,
+          healthDataAvailable: () async {
+            probes++;
+            await Future<void>.delayed(Duration.zero);
+            return true;
+          },
+        );
+
+        await Future.wait([
+          counted.isAvailable(),
+          counted.isAvailable(),
+          counted.isAvailable(),
+        ]);
+
+        expect(probes, equals(1));
+      });
+
       test('an unknown probe never blocks the read', () async {
         final unknown = _serviceWithProbe(mockHealth, null);
         when(

--- a/test/features/dive_import/data/services/healthkit_service_test.dart
+++ b/test/features/dive_import/data/services/healthkit_service_test.dart
@@ -26,7 +26,7 @@ void main() {
     });
 
     group('isAvailable', () {
-      test('reports platform capability, not permission state', () async {
+      test('reports device capability, not permission state', () async {
         expect(await service.isAvailable(), isTrue);
         expect(
           await HealthKitService(
@@ -36,6 +36,72 @@ void main() {
           isFalse,
         );
         verifyNever(mockHealth.hasPermissions(any));
+      });
+
+      test('is false when the device has no HealthKit', () async {
+        // Platform.isIOS is not a capability check: iPadOS before 17 has no
+        // Health app at all. HKHealthStore.isHealthDataAvailable() is.
+        expect(
+          await _serviceWithProbe(mockHealth, false).isAvailable(),
+          isFalse,
+        );
+      });
+
+      test('is true when the probe cannot answer', () async {
+        // Unknown is not a refusal.
+        expect(await _serviceWithProbe(mockHealth, null).isAvailable(), isTrue);
+      });
+
+      test('is true when the probe throws', () async {
+        final thrower = HealthKitService(
+          health: mockHealth,
+          isPlatformSupported: true,
+          healthDataAvailable: () async => throw Exception('no channel'),
+        );
+
+        expect(await thrower.isAvailable(), isTrue);
+      });
+    });
+
+    group('device capability gating', () {
+      test('permissionStatus is unsupported without HealthKit', () async {
+        expect(
+          await _serviceWithProbe(mockHealth, false).permissionStatus(),
+          equals(HealthPermissionStatus.unsupported),
+        );
+        verifyNever(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        );
+      });
+
+      test('requestPermissions is refused without HealthKit', () async {
+        expect(
+          await _serviceWithProbe(mockHealth, false).requestPermissions(),
+          isFalse,
+        );
+        verifyNever(mockHealth.configure());
+      });
+
+      test('fetchDives returns nothing without HealthKit', () async {
+        expect(
+          await _serviceWithProbe(mockHealth, false).fetchDives(
+            startDate: DateTime(2024, 1, 1),
+            endDate: DateTime(2024, 1, 31),
+          ),
+          isEmpty,
+        );
+      });
+
+      test('an unknown probe never blocks the read', () async {
+        final unknown = _serviceWithProbe(mockHealth, null);
+        when(
+          mockHealth.hasPermissions(any, permissions: anyNamed('permissions')),
+        ).thenAnswer((_) async => null);
+
+        expect(
+          await unknown.permissionStatus(),
+          equals(HealthPermissionStatus.undetermined),
+        );
       });
     });
 
@@ -646,6 +712,15 @@ void main() {
       });
     });
   });
+}
+
+/// A service whose device-capability probe returns [available].
+HealthKitService _serviceWithProbe(MockHealth health, bool? available) {
+  return HealthKitService(
+    health: health,
+    isPlatformSupported: true,
+    healthDataAvailable: () async => available,
+  );
 }
 
 /// Helper to create a workout data point for testing.

--- a/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
@@ -2635,6 +2635,27 @@ void main() {
       expect(range.end.isAfter(DateTime(2024, 1, 20, 9, 0)), isTrue);
     });
 
+    test('ends on the last instant the method channel can carry', () {
+      // The health plugin sends both bounds as millisecondsSinceEpoch, so
+      // 23:59:59.999999 would truncate to the same integer. Spelling the end
+      // with microseconds buys nothing; this pins that they are equivalent so
+      // the extra precision is not reintroduced as a "fix".
+      final range = healthKitWholeDayRange(
+        DateTime(2024, 1, 15),
+        DateTime(2024, 1, 20),
+      );
+      final lastMicrosecond = DateTime(
+        2024,
+        1,
+        21,
+      ).subtract(const Duration(microseconds: 1));
+
+      expect(
+        range.end.millisecondsSinceEpoch,
+        equals(lastMicrosecond.millisecondsSinceEpoch),
+      );
+    });
+
     test('covers a single day picked for both ends', () {
       final range = healthKitWholeDayRange(
         DateTime(2024, 1, 15),

--- a/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/healthkit_adapter_test.dart
@@ -1773,22 +1773,24 @@ void main() {
       tester,
     ) async {
       final service = MockHealthImportService();
-      final completer = Completer<bool>();
-      when(service.hasPermissions()).thenAnswer((_) => completer.future);
+      final completer = Completer<HealthPermissionStatus>();
+      when(service.permissionStatus()).thenAnswer((_) => completer.future);
 
       await tester.pumpWidget(buildPermissionsStep(service));
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-      completer.complete(false);
+      completer.complete(HealthPermissionStatus.granted);
       await tester.pumpAndSettle();
     });
 
-    testWidgets('shows granted state when permissions already granted', (
+    testWidgets('shows granted state when the platform confirms access', (
       tester,
     ) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => true);
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.granted);
 
       await tester.pumpWidget(buildPermissionsStep(service));
       await tester.pumpAndSettle();
@@ -1796,30 +1798,76 @@ void main() {
       expect(find.text('HealthKit Access Granted'), findsOneWidget);
       expect(find.text('You can proceed to the next step.'), findsOneWidget);
       expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      // Nothing to request: the platform already said yes.
+      verifyNever(service.requestPermissions());
     });
 
-    testWidgets('shows request button when permissions not yet granted', (
+    testWidgets('requests access when the platform will not disclose it', (
+      tester,
+    ) async {
+      // Regression for #1128: iOS never reports read access, so the step used
+      // to sit on "Access Required" and demand a button tap on every visit.
+      final service = MockHealthImportService();
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.undetermined);
+      when(service.requestPermissions()).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(buildPermissionsStep(service));
+      await tester.pumpAndSettle();
+
+      verify(service.requestPermissions()).called(1);
+      expect(find.text('HealthKit Access Granted'), findsOneWidget);
+      expect(find.text('Grant HealthKit Access'), findsNothing);
+    });
+
+    testWidgets('explains where to fix access once it is requested', (
       tester,
     ) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.undetermined);
+      when(service.requestPermissions()).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(buildPermissionsStep(service));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('never tells apps whether read access'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows the unavailable state off Apple platforms', (
+      tester,
+    ) async {
+      final service = MockHealthImportService();
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.unsupported);
+
+      await tester.pumpWidget(buildPermissionsStep(service));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Not Available'), findsOneWidget);
+      verifyNever(service.requestPermissions());
+    });
+
+    testWidgets('offers a retry button when the platform refuses access', (
+      tester,
+    ) async {
+      final service = MockHealthImportService();
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.denied);
 
       await tester.pumpWidget(buildPermissionsStep(service));
       await tester.pumpAndSettle();
 
       expect(find.text('Apple HealthKit Access Required'), findsOneWidget);
       expect(find.text('Grant HealthKit Access'), findsOneWidget);
-    });
-
-    testWidgets('shows description text when permissions not granted', (
-      tester,
-    ) async {
-      final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
-
-      await tester.pumpWidget(buildPermissionsStep(service));
-      await tester.pumpAndSettle();
-
+      expect(find.byIcon(Icons.health_and_safety), findsAtLeast(1));
       expect(
         find.text(
           'Submersion uses Apple HealthKit to read underwater diving workout '
@@ -1828,25 +1876,16 @@ void main() {
         ),
         findsOneWidget,
       );
+      verifyNever(service.requestPermissions());
     });
 
-    testWidgets('shows health_and_safety icon when permissions not granted', (
+    testWidgets('tapping the retry button requests access again', (
       tester,
     ) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
-
-      await tester.pumpWidget(buildPermissionsStep(service));
-      await tester.pumpAndSettle();
-
-      expect(find.byIcon(Icons.health_and_safety), findsAtLeast(1));
-    });
-
-    testWidgets('tapping request button calls requestPermissions', (
-      tester,
-    ) async {
-      final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.denied);
       final requestCompleter = Completer<bool>();
       when(
         service.requestPermissions(),
@@ -1859,99 +1898,58 @@ void main() {
       await tester.pump();
 
       verify(service.requestPermissions()).called(1);
-
-      // Shows requesting state
       expect(find.text('Requesting...'), findsOneWidget);
+
+      // The button disables itself while the request is in flight.
+      await tester.tap(find.byType(FilledButton));
+      await tester.pump();
+      verifyNever(service.requestPermissions());
 
       requestCompleter.complete(true);
       await tester.pumpAndSettle();
-    });
-
-    testWidgets('shows granted state after permissions granted via button', (
-      tester,
-    ) async {
-      final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
-      when(service.requestPermissions()).thenAnswer((_) async => true);
-
-      await tester.pumpWidget(buildPermissionsStep(service));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Grant HealthKit Access'));
-      await tester.pumpAndSettle();
 
       expect(find.text('HealthKit Access Granted'), findsOneWidget);
-      expect(find.byIcon(Icons.check_circle), findsOneWidget);
     });
 
-    testWidgets('stays on request screen when permissions denied via button', (
+    testWidgets('stays on the request screen when the request fails', (
       tester,
     ) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.undetermined);
       when(service.requestPermissions()).thenAnswer((_) async => false);
 
       await tester.pumpWidget(buildPermissionsStep(service));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Grant HealthKit Access'));
-      await tester.pumpAndSettle();
-
       expect(find.text('Apple HealthKit Access Required'), findsOneWidget);
       expect(find.text('Grant HealthKit Access'), findsOneWidget);
     });
 
-    testWidgets('button is disabled while requesting permissions', (
-      tester,
-    ) async {
+    testWidgets('requests access when the status check throws', (tester) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
-      final requestCompleter = Completer<bool>();
-      when(
-        service.requestPermissions(),
-      ).thenAnswer((_) => requestCompleter.future);
+      when(service.permissionStatus()).thenThrow(Exception('platform error'));
+      when(service.requestPermissions()).thenAnswer((_) async => true);
 
       await tester.pumpWidget(buildPermissionsStep(service));
       await tester.pumpAndSettle();
 
-      // Tap the button to start the request.
-      await tester.tap(find.text('Grant HealthKit Access'));
-      await tester.pump();
-
-      // While the request is in flight, tapping again should be a no-op
-      // because the button disables itself (onPressed = null).
-      // Verify by checking that requestPermissions was called exactly once.
+      // A failed check is not a denial, so it must not block the import.
       verify(service.requestPermissions()).called(1);
-
-      requestCompleter.complete(false);
-      await tester.pumpAndSettle();
-    });
-
-    testWidgets('handles exception during hasPermissions check gracefully', (
-      tester,
-    ) async {
-      final service = MockHealthImportService();
-      when(service.hasPermissions()).thenThrow(Exception('platform error'));
-
-      await tester.pumpWidget(buildPermissionsStep(service));
-      await tester.pumpAndSettle();
-
-      // Falls through to the request screen
-      expect(find.text('Apple HealthKit Access Required'), findsOneWidget);
-      expect(find.text('Grant HealthKit Access'), findsOneWidget);
+      expect(find.text('HealthKit Access Granted'), findsOneWidget);
     });
 
     testWidgets('handles exception during requestPermissions gracefully', (
       tester,
     ) async {
       final service = MockHealthImportService();
-      when(service.hasPermissions()).thenAnswer((_) async => false);
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.undetermined);
       when(service.requestPermissions()).thenThrow(Exception('platform error'));
 
       await tester.pumpWidget(buildPermissionsStep(service));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Grant HealthKit Access'));
       await tester.pumpAndSettle();
 
       // Should recover -- still on request screen, not crashed
@@ -1960,10 +1958,12 @@ void main() {
     });
 
     testWidgets(
-      'sets healthKitPermissionsGrantedProvider when permissions granted on check',
+      'sets healthKitPermissionsGrantedProvider once access is ready',
       (tester) async {
         final service = MockHealthImportService();
-        when(service.hasPermissions()).thenAnswer((_) async => true);
+        when(
+          service.permissionStatus(),
+        ).thenAnswer((_) async => HealthPermissionStatus.granted);
 
         late WidgetRef capturedRef;
         await tester.pumpWidget(
@@ -2008,6 +2008,57 @@ void main() {
         expect(capturedRef.read(healthKitPermissionsGrantedProvider), isTrue);
       },
     );
+
+    testWidgets('clears healthKitPermissionsGrantedProvider when refused', (
+      tester,
+    ) async {
+      final service = MockHealthImportService();
+      when(
+        service.permissionStatus(),
+      ).thenAnswer((_) async => HealthPermissionStatus.denied);
+
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: Column(
+                children: [
+                  Consumer(
+                    builder: (context, ref, _) {
+                      capturedRef = ref;
+                      return const SizedBox();
+                    },
+                  ),
+                  Expanded(
+                    child: Builder(
+                      builder: (context) {
+                        final widgetAdapter = HealthKitAdapter(
+                          healthService: service,
+                          diveMatcher: MockDiveMatcher(),
+                          converter: MockImportedDiveConverter(),
+                          diveRepository: MockDiveRepository(),
+                          diverId: 'diver-1',
+                        );
+                        return widgetAdapter.acquisitionSteps[0].builder(
+                          context,
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(capturedRef.read(healthKitPermissionsGrantedProvider), isFalse);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -2143,6 +2194,60 @@ void main() {
       expect(capturedRef.read(healthKitDateRangeSelectedProvider), isTrue);
     });
 
+    testWidgets('publishes a range covering both days end to end', (
+      tester,
+    ) async {
+      // Regression for #1128: the pickers hand back midnight and HealthKit
+      // matches on a strict start date, so a range ending at midnight drops
+      // every dive on its own end day.
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: Column(
+                children: [
+                  Consumer(
+                    builder: (context, ref, _) {
+                      capturedRef = ref;
+                      return const SizedBox();
+                    },
+                  ),
+                  Expanded(
+                    child: Builder(
+                      builder: (context) {
+                        final widgetAdapter = HealthKitAdapter(
+                          healthService: MockHealthImportService(),
+                          diveMatcher: MockDiveMatcher(),
+                          converter: MockImportedDiveConverter(),
+                          diveRepository: MockDiveRepository(),
+                          diverId: 'diver-1',
+                        );
+                        return widgetAdapter.acquisitionSteps[1].builder(
+                          context,
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final range = capturedRef.read(healthKitDateRangeProvider);
+      expect(range.start.hour, equals(0));
+      expect(range.start.minute, equals(0));
+      expect(range.end.hour, equals(23));
+      expect(range.end.minute, equals(59));
+      expect(range.end.second, equals(59));
+    });
+
     testWidgets('both date picker buttons are tappable InkWells', (
       tester,
     ) async {
@@ -2259,7 +2364,12 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Found 0 dives'), findsOneWidget);
-      expect(find.text('Proceeding to review...'), findsOneWidget);
+      // A zero-dive result points at the two things that actually cause it.
+      expect(find.text('Proceeding to review...'), findsNothing);
+      expect(
+        find.textContaining('Check that the dates cover the dive'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows error state when fetch fails', (tester) async {
@@ -2497,6 +2607,42 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(capturedRef.read(healthKitDivesFetchedProvider), isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // healthKitWholeDayRange
+  // -------------------------------------------------------------------------
+
+  group('healthKitWholeDayRange', () {
+    test('starts the range at midnight on the start day', () {
+      final range = healthKitWholeDayRange(
+        DateTime(2024, 1, 15, 14, 30),
+        DateTime(2024, 1, 20, 8, 0),
+      );
+
+      expect(range.start, equals(DateTime(2024, 1, 15)));
+    });
+
+    test('runs the range to the last instant of the end day', () {
+      // A dive at 09:00 on the end day must fall inside the range.
+      final range = healthKitWholeDayRange(
+        DateTime(2024, 1, 15),
+        DateTime(2024, 1, 20),
+      );
+
+      expect(range.end, equals(DateTime(2024, 1, 20, 23, 59, 59, 999)));
+      expect(range.end.isAfter(DateTime(2024, 1, 20, 9, 0)), isTrue);
+    });
+
+    test('covers a single day picked for both ends', () {
+      final range = healthKitWholeDayRange(
+        DateTime(2024, 1, 15),
+        DateTime(2024, 1, 15),
+      );
+
+      expect(range.start.isBefore(DateTime(2024, 1, 15, 9, 0)), isTrue);
+      expect(range.end.isAfter(DateTime(2024, 1, 15, 9, 0)), isTrue);
     });
   });
 }


### PR DESCRIPTION
Fixes #1128.

## Root cause

Apple deliberately refuses to disclose **read** authorization. `HKHealthStore.authorizationStatus(for:)` is only meaningful for share/write access, so the `health` plugin's iOS helper hard-returns `nil` for reads:

```swift
// health-13.3.2 ios/health/Sources/health/HealthDataOperations.swift
private func hasPermission(type: HKObjectType, access: Int) -> Bool? {
    let status = healthStore.authorizationStatus(for: type)
    switch access {
    case 0: // READ
        return nil
```

`HealthKitService.hasPermissions()` collapsed that `nil` with `?? false`, and `fetchDives()` used it as a hard gate:

```dart
if (!await hasPermissions()) return [];
```

So the Apple Watch import could never return a dive on iOS, no matter what the user granted. The same `nil` also explains the reporter's other symptom (the wizard demanding a permission tap on every visit) and a red "HealthKit access not granted" that never cleared in Settings > Data Sources.

"The platform will not say" is not "the platform said no", but a `bool` cannot carry that distinction.

## Fix

Model the answer as a tri-state and gate reads on it:

```dart
enum HealthPermissionStatus { unsupported, granted, denied, undetermined }

extension HealthPermissionStatusX on HealthPermissionStatus {
  bool get canAttemptRead => this != unsupported && this != denied;
}
```

Only a definitive refusal stops the fetch. A failed probe maps to `undetermined` rather than blocking, so a transient error cannot re-break the import.

Status is probed with `WORKOUT` and `HEART_RATE` alone. The native `hasPermissions` returns `false` and short-circuits for any type missing from `dataTypesDict`, so probing with the iOS 16+ dive types would make every older device look permanently denied: the same mistake in a new costume.

## Three more defects on the same path

Each of these also surfaces to the user as "no dives found", which is why one report was four bugs.

| Defect | Effect |
| --- | --- |
| Profile samples hardcoded `depth: 0.0`, built from heart rate alone | Every imported dive would log **0 m max depth** |
| `getHealthDataFromTypes` batches types and rethrows | One unsupported type (the dive series below iOS 16) discarded **every** other type's samples |
| Date pickers return midnight vs the native `.strictStartDate` predicate | Picking the dive's own day as the **end** date excluded it |

On the first: the code comment claiming the package cannot read depth was stale. `health` 13.x registers `UNDERWATER_DEPTH` (metres) and `WATER_TEMPERATURE` (Celsius) in `initializeIOS16Types()`. Depth now drives the profile timeline, and the far sparser temperature and heart rate series are merged onto each depth sample by nearest reading within 30 s, via binary search so a thousand-sample dive stays linear rather than quadratic. Samples sharing a second collapse to the deepest reading. When no depth series exists the old heart-rate-only profile remains as a fallback so the dive still imports.

## UX

The permissions step now requests authorization outright when the platform will not answer. iOS shows its sheet at most once and answers silently thereafter, so requesting is idempotent and repeat visits land straight on the ready state instead of re-asking. The ready screen says plainly that Apple never confirms read access and points at Health > Sharing > Apps > Submersion; a zero-dive fetch result says the same rather than "Proceeding to review...".

Settings > Data Sources reports the tri-state honestly ("HealthKit access is managed in the Health app" for undetermined) and discloses the two newly read data types, per App Store guideline 2.5.1. New strings are translated across all 11 locales.

## Testing

- `healthkit_service_test.dart`: 29 tests, including a regression that stubs the probe to `null` (exactly what iOS returns) and asserts a dive comes back, plus coverage for the depth series, the merge window, per-type query isolation, and the deny/unsupported paths.
- `healthkit_adapter_test.dart`: 114 tests, retargeted at the tri-state, plus whole-day range coverage.
- Full suite: 18881 passed, 19 skipped. `flutter analyze` clean.

**Not verified on hardware.** Reproducing this needs a real Apple Watch Ultra with a logged dive on iOS 17+ (`.underwaterDiving` as a workout type is iOS 17+; the depth and temperature quantity types are iOS 16+). Worth a device check before release.

Note for existing users: the import now requests two additional read types, so iOS will show its permission sheet once more.
