### PR TITLE
fix(dive-log): pin the filter sheet's header and actions (#989)

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -17,6 +17,10 @@ import 'package:submersion/shared/widgets/app_date_picker.dart';
 
 /// Filter sheet for dive list
 class DiveFilterSheet extends ConsumerStatefulWidget {
+  /// Identifies the resize grip at the top of the sheet, so tests can drive it
+  /// the way a diver does with a pointer.
+  static const gripKey = ValueKey<String>('dive_filter_sheet_grip');
+
   final WidgetRef ref;
   final StateProvider<DiveFilterState> filterProvider;
 
@@ -39,6 +43,13 @@ class DiveFilterSheet extends ConsumerStatefulWidget {
 }
 
 class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
+  // Sheet extents, as a fraction of the available height.
+  static const double _minSheetSize = 0.5;
+  static const double _initialSheetSize = 0.7;
+  static const double _maxSheetSize = 0.95;
+
+  final _sheetController = DraggableScrollableController();
+
   late final FocusNode _buddyFocusNode;
   late DateTime? _startDate;
   late DateTime? _endDate;
@@ -108,6 +119,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
 
   @override
   void dispose() {
+    _sheetController.dispose();
     _buddyFocusNode.dispose();
     _minDepthController.dispose();
     _maxDepthController.dispose();
@@ -136,754 +148,911 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
 
+    // The form is several screens tall, so the chrome -- grip, title, close
+    // and the Clear All / Apply actions -- sits OUTSIDE the scrolling field
+    // list. Kept inside it, the actions were the last children of a lazy
+    // ListView roughly a thousand pixels below the fold: never built, never
+    // reachable, and on desktop indistinguishable from a sheet clipped by the
+    // bottom of the window (#989). This mirrors SiteFilterSheet and
+    // PreDiveSessionFilterSheet, which were already built this way.
     return DraggableScrollableSheet(
-      initialChildSize: 0.7,
-      minChildSize: 0.5,
-      maxChildSize: 0.95,
+      controller: _sheetController,
+      initialChildSize: _initialSheetSize,
+      minChildSize: _minSheetSize,
+      maxChildSize: _maxSheetSize,
       expand: false,
       builder: (context, scrollController) {
         return Padding(
           padding: EdgeInsets.only(
             bottom: MediaQuery.of(context).viewInsets.bottom,
           ),
-          child: ListView(
-            controller: scrollController,
-            padding: const EdgeInsets.all(16),
+          child: Column(
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    context.l10n.diveLog_filter_title,
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  IconButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    icon: const Icon(Icons.close),
-                    tooltip: context.l10n.diveLog_filter_tooltip_close,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              // Link to advanced search
-              Align(
-                alignment: AlignmentDirectional.centerStart,
-                child: TextButton.icon(
-                  onPressed: () {
-                    // push, not go: this sheet also opens from Statistics, and
-                    // `go` into the `/dives` child route would rebuild the
-                    // stack as [dive list, search] and discard the section --
-                    // and its filters -- the user opened the sheet from. It
-                    // would also leave system back with nothing to pop and
-                    // close the app (#647).
-                    //
-                    // The router is captured BEFORE the pop: after it, this
-                    // sheet's context is deactivated and cannot be looked up
-                    // through.
-                    //
-                    // The target filter travels with the push so the advanced
-                    // form edits the same filter this sheet does, instead of
-                    // always hijacking the dive list's (#1079).
-                    final router = GoRouter.of(context);
-                    Navigator.of(context).pop();
-                    router.push('/dives/search', extra: widget.filterProvider);
-                  },
-                  icon: const Icon(Icons.manage_search, size: 18),
-                  label: Text(context.l10n.diveLog_search_appBar),
-                ),
-              ),
-              const SizedBox(height: 16),
-
-              // Date Range Section
-              Text(
-                context.l10n.diveLog_filter_sectionDateRange,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                children: [
-                  _datePresetChip(
-                    context,
-                    context.l10n.diveLog_filter_presetAllTime,
-                    () {
-                      setState(() {
-                        _startDate = null;
-                        _endDate = null;
-                      });
-                    },
-                  ),
-                  _datePresetChip(
-                    context,
-                    context.l10n.diveLog_filter_presetThisYear,
-                    () {
-                      final now = DateTime.now();
-                      setState(() {
-                        _startDate = DateTime(now.year, 1, 1);
-                        _endDate = DateTime(now.year, now.month, now.day);
-                      });
-                    },
-                  ),
-                  _datePresetChip(
-                    context,
-                    context.l10n.diveLog_filter_presetLast12Months,
-                    () {
-                      final now = DateTime.now();
-                      setState(() {
-                        _startDate = DateTime(now.year - 1, now.month, now.day);
-                        _endDate = DateTime(now.year, now.month, now.day);
-                      });
-                    },
-                  ),
-                  _datePresetChip(
-                    context,
-                    context.l10n.diveLog_filter_presetLastYear,
-                    () {
-                      final now = DateTime.now();
-                      setState(() {
-                        _startDate = DateTime(now.year - 1, 1, 1);
-                        _endDate = DateTime(now.year - 1, 12, 31);
-                      });
-                    },
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: () => _selectDate(context, isStart: true),
-                      icon: const Icon(Icons.calendar_today, size: 18),
-                      label: Text(
-                        _startDate != null
-                            ? units.formatDate(_startDate)
-                            : context.l10n.diveLog_filter_startDate,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(context.l10n.diveLog_filter_dateSeparator),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: () => _selectDate(context, isStart: false),
-                      icon: const Icon(Icons.calendar_today, size: 18),
-                      label: Text(
-                        _endDate != null
-                            ? units.formatDate(_endDate)
-                            : context.l10n.diveLog_filter_endDate,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              if (_startDate != null || _endDate != null)
-                Align(
-                  alignment: AlignmentDirectional.centerEnd,
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _startDate = null;
-                        _endDate = null;
-                      });
-                    },
-                    child: Text(context.l10n.diveLog_filter_clearDates),
-                  ),
-                ),
-              const SizedBox(height: 24),
-
-              // Dive Type Section
-              Text(
-                context.l10n.diveLog_filter_sectionDiveType,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Consumer(
-                builder: (context, ref, child) {
-                  final diveTypesAsync = ref.watch(diveTypesProvider);
-                  return diveTypesAsync.when(
-                    loading: () => const LinearProgressIndicator(),
-                    error: (e, st) =>
-                        Text(context.l10n.diveLog_listPage_errorLoading(e)),
-                    data: (diveTypes) => DropdownButtonFormField<String?>(
-                      initialValue: _diveTypeId,
-                      decoration: InputDecoration(
-                        hintText: context.l10n.diveLog_filter_allTypes,
-                        prefixIcon: const Icon(Icons.category),
-                      ),
-                      items: [
-                        DropdownMenuItem(
-                          value: null,
-                          child: Text(context.l10n.diveLog_filter_allTypes),
+              _buildGrip(context),
+              _buildHeader(context),
+              const Divider(height: 1),
+              Expanded(
+                child: Scrollbar(
+                  controller: scrollController,
+                  // Desktop draws no thumb until a scroll gesture starts, so
+                  // nothing told the diver the form continued past the fold.
+                  thumbVisibility: true,
+                  child: ListView(
+                    controller: scrollController,
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      // Link to advanced search
+                      Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: TextButton.icon(
+                          onPressed: () {
+                            // push, not go: this sheet also opens from Statistics, and
+                            // `go` into the `/dives` child route would rebuild the
+                            // stack as [dive list, search] and discard the section --
+                            // and its filters -- the user opened the sheet from. It
+                            // would also leave system back with nothing to pop and
+                            // close the app (#647).
+                            //
+                            // The router is captured BEFORE the pop: after it, this
+                            // sheet's context is deactivated and cannot be looked up
+                            // through.
+                            //
+                            // The target filter travels with the push so the advanced
+                            // form edits the same filter this sheet does, instead of
+                            // always hijacking the dive list's (#1079).
+                            final router = GoRouter.of(context);
+                            Navigator.of(context).pop();
+                            router.push(
+                              '/dives/search',
+                              extra: widget.filterProvider,
+                            );
+                          },
+                          icon: const Icon(Icons.manage_search, size: 18),
+                          label: Text(context.l10n.diveLog_search_appBar),
                         ),
-                        ...diveTypes.map((type) {
-                          return DropdownMenuItem(
-                            value: type.id,
-                            child: Text(type.localizedName(context.l10n)),
-                          );
-                        }),
-                      ],
-                      onChanged: (value) {
-                        setState(() => _diveTypeId = value);
-                      },
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(height: 24),
+                      ),
+                      const SizedBox(height: 16),
 
-              // Site Section
-              Text(
-                context.l10n.diveLog_filter_sectionDiveSite,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              sites.when(
-                data: (siteList) => DropdownButtonFormField<String?>(
-                  initialValue: _siteId,
-                  decoration: InputDecoration(
-                    hintText: context.l10n.diveLog_filter_allSites,
-                    prefixIcon: const Icon(Icons.location_on),
-                  ),
-                  items: [
-                    DropdownMenuItem(
-                      value: null,
-                      child: Text(context.l10n.diveLog_filter_allSites),
-                    ),
-                    ...siteList.map((site) {
-                      return DropdownMenuItem(
-                        value: site.id,
-                        child: Text(site.name),
-                      );
-                    }),
-                  ],
-                  onChanged: (value) {
-                    setState(() => _siteId = value);
-                  },
-                ),
-                loading: () => const LinearProgressIndicator(),
-                error: (_, _) =>
-                    Text(context.l10n.diveLog_filter_errorLoadingSites),
-              ),
-              const SizedBox(height: 24),
-
-              // Dive Computer Section
-              Text(
-                context.l10n.diveLog_filter_sectionDiveComputer,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Consumer(
-                builder: (context, ref, child) {
-                  final computersAsync = ref.watch(allDiveComputersProvider);
-                  return computersAsync.when(
-                    loading: () => const LinearProgressIndicator(),
-                    error: (_, _) =>
-                        Text(context.l10n.transfer_computers_errorLoading),
-                    data: (computers) {
-                      // Every registered computer is offered. The list used to
-                      // be restricted to computers carrying a serial number,
-                      // which hid every device whose firmware never reports one
-                      // (issue #1064); attribution rides the computer id, which
-                      // is always present.
-                      if (computers.isEmpty) {
-                        return Text(
-                          context.l10n.diveLog_filter_noComputersRegistered,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
+                      // Date Range Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDateRange,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        children: [
+                          _datePresetChip(
+                            context,
+                            context.l10n.diveLog_filter_presetAllTime,
+                            () {
+                              setState(() {
+                                _startDate = null;
+                                _endDate = null;
+                              });
+                            },
+                          ),
+                          _datePresetChip(
+                            context,
+                            context.l10n.diveLog_filter_presetThisYear,
+                            () {
+                              final now = DateTime.now();
+                              setState(() {
+                                _startDate = DateTime(now.year, 1, 1);
+                                _endDate = DateTime(
+                                  now.year,
+                                  now.month,
+                                  now.day,
+                                );
+                              });
+                            },
+                          ),
+                          _datePresetChip(
+                            context,
+                            context.l10n.diveLog_filter_presetLast12Months,
+                            () {
+                              final now = DateTime.now();
+                              setState(() {
+                                _startDate = DateTime(
+                                  now.year - 1,
+                                  now.month,
+                                  now.day,
+                                );
+                                _endDate = DateTime(
+                                  now.year,
+                                  now.month,
+                                  now.day,
+                                );
+                              });
+                            },
+                          ),
+                          _datePresetChip(
+                            context,
+                            context.l10n.diveLog_filter_presetLastYear,
+                            () {
+                              final now = DateTime.now();
+                              setState(() {
+                                _startDate = DateTime(now.year - 1, 1, 1);
+                                _endDate = DateTime(now.year - 1, 12, 31);
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: () =>
+                                  _selectDate(context, isStart: true),
+                              icon: const Icon(Icons.calendar_today, size: 18),
+                              label: Text(
+                                _startDate != null
+                                    ? units.formatDate(_startDate)
+                                    : context.l10n.diveLog_filter_startDate,
                               ),
-                        );
-                      }
-                      // Reset to null if the saved computer is no longer known
-                      // (deleted since the filter was set).
-                      final validId = computers.any((c) => c.id == _computerId)
-                          ? _computerId
-                          : null;
-                      if (validId != _computerId) {
-                        _computerId = validId;
-                      }
-                      return DropdownButtonFormField<String?>(
-                        initialValue: validId,
-                        decoration: InputDecoration(
-                          hintText: context.l10n.diveLog_filter_allComputers,
-                          prefixIcon: const Icon(Icons.watch),
-                        ),
-                        items: [
-                          DropdownMenuItem(
-                            value: null,
-                            child: Text(
-                              context.l10n.diveLog_filter_allComputers,
                             ),
                           ),
-                          ...computers.map(
-                            (c) => DropdownMenuItem(
-                              value: c.id,
-                              child: Text(c.displayName),
+                          const SizedBox(width: 8),
+                          Text(context.l10n.diveLog_filter_dateSeparator),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: () =>
+                                  _selectDate(context, isStart: false),
+                              icon: const Icon(Icons.calendar_today, size: 18),
+                              label: Text(
+                                _endDate != null
+                                    ? units.formatDate(_endDate)
+                                    : context.l10n.diveLog_filter_endDate,
+                              ),
                             ),
                           ),
                         ],
-                        onChanged: (value) {
-                          setState(() => _computerId = value);
+                      ),
+                      if (_startDate != null || _endDate != null)
+                        Align(
+                          alignment: AlignmentDirectional.centerEnd,
+                          child: TextButton(
+                            onPressed: () {
+                              setState(() {
+                                _startDate = null;
+                                _endDate = null;
+                              });
+                            },
+                            child: Text(context.l10n.diveLog_filter_clearDates),
+                          ),
+                        ),
+                      const SizedBox(height: 24),
+
+                      // Dive Type Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDiveType,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Consumer(
+                        builder: (context, ref, child) {
+                          final diveTypesAsync = ref.watch(diveTypesProvider);
+                          return diveTypesAsync.when(
+                            loading: () => const LinearProgressIndicator(),
+                            error: (e, st) => Text(
+                              context.l10n.diveLog_listPage_errorLoading(e),
+                            ),
+                            data: (diveTypes) =>
+                                DropdownButtonFormField<String?>(
+                                  initialValue: _diveTypeId,
+                                  decoration: InputDecoration(
+                                    hintText:
+                                        context.l10n.diveLog_filter_allTypes,
+                                    prefixIcon: const Icon(Icons.category),
+                                  ),
+                                  items: [
+                                    DropdownMenuItem(
+                                      value: null,
+                                      child: Text(
+                                        context.l10n.diveLog_filter_allTypes,
+                                      ),
+                                    ),
+                                    ...diveTypes.map((type) {
+                                      return DropdownMenuItem(
+                                        value: type.id,
+                                        child: Text(
+                                          type.localizedName(context.l10n),
+                                        ),
+                                      );
+                                    }),
+                                  ],
+                                  onChanged: (value) {
+                                    setState(() => _diveTypeId = value);
+                                  },
+                                ),
+                          );
                         },
-                      );
-                    },
-                  );
-                },
-              ),
-              const SizedBox(height: 24),
+                      ),
+                      const SizedBox(height: 24),
 
-              // Depth Range Section
-              Text(
-                context.l10n.diveLog_filter_sectionDepthRangeUnit(
-                  units.depthSymbol,
-                ),
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _minDepthController,
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_min,
-                        prefixIcon: const Icon(Icons.arrow_downward),
-                        suffixText: units.depthSymbol,
+                      // Site Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDiveSite,
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
-                      keyboardType: TextInputType.number,
-                      onChanged: (value) {
-                        final entered = parseUserDecimal(value);
-                        _minDepth = entered == null
-                            ? null
-                            : units.depthToMeters(entered);
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: TextField(
-                      controller: _maxDepthController,
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_max,
-                        prefixIcon: const Icon(Icons.arrow_downward),
-                        suffixText: units.depthSymbol,
+                      const SizedBox(height: 8),
+                      sites.when(
+                        data: (siteList) => DropdownButtonFormField<String?>(
+                          initialValue: _siteId,
+                          decoration: InputDecoration(
+                            hintText: context.l10n.diveLog_filter_allSites,
+                            prefixIcon: const Icon(Icons.location_on),
+                          ),
+                          items: [
+                            DropdownMenuItem(
+                              value: null,
+                              child: Text(context.l10n.diveLog_filter_allSites),
+                            ),
+                            ...siteList.map((site) {
+                              return DropdownMenuItem(
+                                value: site.id,
+                                child: Text(site.name),
+                              );
+                            }),
+                          ],
+                          onChanged: (value) {
+                            setState(() => _siteId = value);
+                          },
+                        ),
+                        loading: () => const LinearProgressIndicator(),
+                        error: (_, _) =>
+                            Text(context.l10n.diveLog_filter_errorLoadingSites),
                       ),
-                      keyboardType: TextInputType.number,
-                      onChanged: (value) {
-                        final entered = parseUserDecimal(value);
-                        _maxDepth = entered == null
-                            ? null
-                            : units.depthToMeters(entered);
-                      },
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
+                      const SizedBox(height: 24),
 
-              // Favorites Section
-              SwitchListTile(
-                title: Text(context.l10n.diveLog_filter_favoritesOnly),
-                subtitle: Text(context.l10n.diveLog_filter_showOnlyFavorites),
-                secondary: Icon(
-                  Icons.favorite,
-                  color: _favoritesOnly ? Colors.red : null,
-                ),
-                value: _favoritesOnly,
-                onChanged: (value) {
-                  setState(() => _favoritesOnly = value);
-                },
-              ),
-              const SizedBox(height: 24),
+                      // Dive Computer Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDiveComputer,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Consumer(
+                        builder: (context, ref, child) {
+                          final computersAsync = ref.watch(
+                            allDiveComputersProvider,
+                          );
+                          return computersAsync.when(
+                            loading: () => const LinearProgressIndicator(),
+                            error: (_, _) => Text(
+                              context.l10n.transfer_computers_errorLoading,
+                            ),
+                            data: (computers) {
+                              // Every registered computer is offered. The list used to
+                              // be restricted to computers carrying a serial number,
+                              // which hid every device whose firmware never reports one
+                              // (issue #1064); attribution rides the computer id, which
+                              // is always present.
+                              if (computers.isEmpty) {
+                                return Text(
+                                  context
+                                      .l10n
+                                      .diveLog_filter_noComputersRegistered,
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        color: Theme.of(
+                                          context,
+                                        ).colorScheme.onSurfaceVariant,
+                                      ),
+                                );
+                              }
+                              // Reset to null if the saved computer is no longer known
+                              // (deleted since the filter was set).
+                              final validId =
+                                  computers.any((c) => c.id == _computerId)
+                                  ? _computerId
+                                  : null;
+                              if (validId != _computerId) {
+                                _computerId = validId;
+                              }
+                              return DropdownButtonFormField<String?>(
+                                initialValue: validId,
+                                decoration: InputDecoration(
+                                  hintText:
+                                      context.l10n.diveLog_filter_allComputers,
+                                  prefixIcon: const Icon(Icons.watch),
+                                ),
+                                items: [
+                                  DropdownMenuItem(
+                                    value: null,
+                                    child: Text(
+                                      context.l10n.diveLog_filter_allComputers,
+                                    ),
+                                  ),
+                                  ...computers.map(
+                                    (c) => DropdownMenuItem(
+                                      value: c.id,
+                                      child: Text(c.displayName),
+                                    ),
+                                  ),
+                                ],
+                                onChanged: (value) {
+                                  setState(() => _computerId = value);
+                                },
+                              );
+                            },
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 24),
 
-              // Suit Thickness Section (equipment-attribute axis)
-              Text(
-                context.l10n.diveLog_filter_sectionSuitThickness,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextFormField(
-                      initialValue: _formatThicknessBound(_suitThicknessMin),
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_thicknessMin,
+                      // Depth Range Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDepthRangeUnit(
+                          units.depthSymbol,
+                        ),
+                        style: Theme.of(context).textTheme.titleMedium,
                       ),
-                      keyboardType: const TextInputType.numberWithOptions(
-                        decimal: true,
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextField(
+                              controller: _minDepthController,
+                              decoration: InputDecoration(
+                                labelText: context.l10n.diveLog_filter_min,
+                                prefixIcon: const Icon(Icons.arrow_downward),
+                                suffixText: units.depthSymbol,
+                              ),
+                              keyboardType: TextInputType.number,
+                              onChanged: (value) {
+                                final entered = parseUserDecimal(value);
+                                _minDepth = entered == null
+                                    ? null
+                                    : units.depthToMeters(entered);
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: TextField(
+                              controller: _maxDepthController,
+                              decoration: InputDecoration(
+                                labelText: context.l10n.diveLog_filter_max,
+                                prefixIcon: const Icon(Icons.arrow_downward),
+                                suffixText: units.depthSymbol,
+                              ),
+                              keyboardType: TextInputType.number,
+                              onChanged: (value) {
+                                final entered = parseUserDecimal(value);
+                                _maxDepth = entered == null
+                                    ? null
+                                    : units.depthToMeters(entered);
+                              },
+                            ),
+                          ),
+                        ],
                       ),
-                      onChanged: (value) => setState(
-                        () => _suitThicknessMin = _parseThicknessBound(value),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: TextFormField(
-                      initialValue: _formatThicknessBound(_suitThicknessMax),
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_thicknessMax,
-                      ),
-                      keyboardType: const TextInputType.numberWithOptions(
-                        decimal: true,
-                      ),
-                      onChanged: (value) => setState(
-                        () => _suitThicknessMax = _parseThicknessBound(value),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
+                      const SizedBox(height: 24),
 
-              // Tags Section
-              Text(
-                context.l10n.diveLog_filter_sectionTags,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              ref
-                  .watch(tagListNotifierProvider)
-                  .when(
-                    data: (allTags) {
-                      if (allTags.isEmpty) {
-                        return Text(
-                          context.l10n.diveLog_filter_noTagsYet,
-                          style: const TextStyle(fontStyle: FontStyle.italic),
-                        );
-                      }
-                      return Wrap(
+                      // Favorites Section
+                      SwitchListTile(
+                        title: Text(context.l10n.diveLog_filter_favoritesOnly),
+                        subtitle: Text(
+                          context.l10n.diveLog_filter_showOnlyFavorites,
+                        ),
+                        secondary: Icon(
+                          Icons.favorite,
+                          color: _favoritesOnly ? Colors.red : null,
+                        ),
+                        value: _favoritesOnly,
+                        onChanged: (value) {
+                          setState(() => _favoritesOnly = value);
+                        },
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Suit Thickness Section (equipment-attribute axis)
+                      Text(
+                        context.l10n.diveLog_filter_sectionSuitThickness,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              initialValue: _formatThicknessBound(
+                                _suitThicknessMin,
+                              ),
+                              decoration: InputDecoration(
+                                labelText:
+                                    context.l10n.diveLog_filter_thicknessMin,
+                              ),
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(
+                                    decimal: true,
+                                  ),
+                              onChanged: (value) => setState(
+                                () => _suitThicknessMin = _parseThicknessBound(
+                                  value,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: TextFormField(
+                              initialValue: _formatThicknessBound(
+                                _suitThicknessMax,
+                              ),
+                              decoration: InputDecoration(
+                                labelText:
+                                    context.l10n.diveLog_filter_thicknessMax,
+                              ),
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(
+                                    decimal: true,
+                                  ),
+                              onChanged: (value) => setState(
+                                () => _suitThicknessMax = _parseThicknessBound(
+                                  value,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Tags Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionTags,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      ref
+                          .watch(tagListNotifierProvider)
+                          .when(
+                            data: (allTags) {
+                              if (allTags.isEmpty) {
+                                return Text(
+                                  context.l10n.diveLog_filter_noTagsYet,
+                                  style: const TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                  ),
+                                );
+                              }
+                              return Wrap(
+                                spacing: 8,
+                                runSpacing: 8,
+                                children: allTags.map((tag) {
+                                  final isSelected = _selectedTagIds.contains(
+                                    tag.id,
+                                  );
+                                  return FilterChip(
+                                    label: Text(tag.name),
+                                    selected: isSelected,
+                                    selectedColor: tag.color.withValues(
+                                      alpha: 0.3,
+                                    ),
+                                    checkmarkColor: tag.color,
+                                    side: BorderSide(
+                                      color: isSelected
+                                          ? tag.color
+                                          : Colors.grey.shade300,
+                                    ),
+                                    onSelected: (selected) {
+                                      setState(() {
+                                        if (selected) {
+                                          _selectedTagIds.add(tag.id);
+                                        } else {
+                                          _selectedTagIds.remove(tag.id);
+                                        }
+                                      });
+                                    },
+                                  );
+                                }).toList(),
+                              );
+                            },
+                            loading: () => const CircularProgressIndicator(),
+                            error: (_, _) => Text(
+                              context.l10n.diveLog_filter_errorLoadingTags,
+                            ),
+                          ),
+                      const SizedBox(height: 24),
+
+                      // Buddy Name Filter Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionBuddy,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      LayoutBuilder(
+                        builder: (context, _) {
+                          final buddiesAsync = ref.watch(allBuddiesProvider);
+                          final allBuddyNames =
+                              buddiesAsync.valueOrNull
+                                  ?.map((b) => b.name)
+                                  .toSet()
+                                  .toList() ??
+                              const <String>[];
+
+                          return RawAutocomplete<String>(
+                            textEditingController: _buddyNameController,
+                            focusNode: _buddyFocusNode,
+                            optionsBuilder:
+                                (TextEditingValue textEditingValue) {
+                                  final text = textEditingValue.text;
+                                  final parts = text
+                                      .split(',')
+                                      .map((e) => e.trim())
+                                      .toList();
+                                  final currentBuddies = parts.length > 1
+                                      ? parts
+                                            .sublist(0, parts.length - 1)
+                                            .map((e) => e.toLowerCase())
+                                            .toSet()
+                                      : <String>{};
+
+                                  final buddyNames = allBuddyNames
+                                      .where(
+                                        (name) => !currentBuddies.contains(
+                                          name.toLowerCase(),
+                                        ),
+                                      )
+                                      .toList();
+
+                                  if (text.isEmpty) {
+                                    return [];
+                                  }
+
+                                  final lastPart = text
+                                      .split(',')
+                                      .last
+                                      .trim()
+                                      .toLowerCase();
+
+                                  if (lastPart.isEmpty) {
+                                    return buddyNames;
+                                  }
+
+                                  return buddyNames.where((String option) {
+                                    return option.toLowerCase().contains(
+                                      lastPart,
+                                    );
+                                  }).toList();
+                                },
+                            onSelected: (String selection) {
+                              final text = _buddyNameFilter ?? '';
+                              final parts = text.split(',');
+                              String newText;
+                              if (parts.length > 1 || text.contains(',')) {
+                                parts.removeLast();
+                                final prefix = parts.join(',');
+                                newText = prefix.trim().isEmpty
+                                    ? selection
+                                    : '${prefix.trim()}, $selection';
+                              } else {
+                                newText = selection;
+                              }
+
+                              _buddyNameController.text = newText;
+                              _buddyNameController.selection =
+                                  TextSelection.collapsed(
+                                    offset: newText.length,
+                                  );
+
+                              setState(() {
+                                _buddyNameFilter = newText;
+                              });
+                            },
+                            fieldViewBuilder:
+                                (
+                                  context,
+                                  textEditingController,
+                                  focusNode,
+                                  onFieldSubmitted,
+                                ) {
+                                  return TextField(
+                                    controller: textEditingController,
+                                    focusNode: focusNode,
+                                    decoration: InputDecoration(
+                                      labelText:
+                                          context.l10n.diveLog_filter_buddyName,
+                                      hintText:
+                                          context.l10n.diveLog_filter_buddyHint,
+                                      prefixIcon: const Icon(Icons.person),
+                                    ),
+                                    onChanged: (value) {
+                                      setState(() {
+                                        _buddyNameFilter = value.isEmpty
+                                            ? null
+                                            : value;
+                                      });
+                                    },
+                                    // Commits the highlighted suggestion when the
+                                    // options list is open; a no-op otherwise, so
+                                    // free-text entry still submits normally.
+                                    onSubmitted: (_) => onFieldSubmitted(),
+                                  );
+                                },
+                            optionsViewBuilder: (context, onSelected, options) {
+                              return Align(
+                                alignment: Alignment.topLeft,
+                                child: Material(
+                                  elevation: 4.0,
+                                  child: ConstrainedBox(
+                                    constraints: const BoxConstraints(
+                                      maxHeight: 200,
+                                    ),
+                                    child: ListView.builder(
+                                      padding: EdgeInsets.zero,
+                                      shrinkWrap: true,
+                                      itemCount: options.length,
+                                      itemBuilder:
+                                          (BuildContext context, int index) {
+                                            final String option = options
+                                                .elementAt(index);
+                                            return ListTile(
+                                              title: Text(option),
+                                              onTap: () => onSelected(option),
+                                            );
+                                          },
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Gas Mix (O2%) Filter Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionGasMix,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
                         spacing: 8,
                         runSpacing: 8,
-                        children: allTags.map((tag) {
-                          final isSelected = _selectedTagIds.contains(tag.id);
-                          return FilterChip(
-                            label: Text(tag.name),
-                            selected: isSelected,
-                            selectedColor: tag.color.withValues(alpha: 0.3),
-                            checkmarkColor: tag.color,
-                            side: BorderSide(
-                              color: isSelected
-                                  ? tag.color
-                                  : Colors.grey.shade300,
-                            ),
+                        children: [
+                          ChoiceChip(
+                            label: Text(context.l10n.diveLog_filter_gasAll),
+                            selected:
+                                _minO2Percent == null && _maxO2Percent == null,
                             onSelected: (selected) {
+                              if (selected) {
+                                setState(() {
+                                  _minO2Percent = null;
+                                  _maxO2Percent = null;
+                                });
+                              }
+                            },
+                          ),
+                          ChoiceChip(
+                            label: Text(context.l10n.diveLog_filter_gasAir),
+                            selected:
+                                _minO2Percent == 20 && _maxO2Percent == 22,
+                            onSelected: (selected) {
+                              if (selected) {
+                                setState(() {
+                                  _minO2Percent = 20;
+                                  _maxO2Percent = 22;
+                                });
+                              }
+                            },
+                          ),
+                          ChoiceChip(
+                            label: Text(context.l10n.diveLog_filter_gasNitrox),
+                            selected:
+                                _minO2Percent == 22 && _maxO2Percent == null,
+                            onSelected: (selected) {
+                              if (selected) {
+                                setState(() {
+                                  _minO2Percent = 22;
+                                  _maxO2Percent = null;
+                                });
+                              }
+                            },
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Rating Filter Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionMinRating,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: List.generate(5, (index) {
+                          final rating = index + 1;
+                          final isSelected =
+                              _minRating != null && rating <= _minRating!;
+                          return IconButton(
+                            icon: Icon(
+                              isSelected ? Icons.star : Icons.star_border,
+                              color: isSelected ? Colors.amber : null,
+                              size: 32,
+                            ),
+                            tooltip: context.l10n
+                                .diveSites_edit_rating_starTooltip(rating),
+                            onPressed: () {
                               setState(() {
-                                if (selected) {
-                                  _selectedTagIds.add(tag.id);
+                                if (_minRating == rating) {
+                                  _minRating = null; // Tap same star to clear
                                 } else {
-                                  _selectedTagIds.remove(tag.id);
+                                  _minRating = rating;
                                 }
                               });
                             },
                           );
-                        }).toList(),
-                      );
-                    },
-                    loading: () => const CircularProgressIndicator(),
-                    error: (_, _) =>
-                        Text(context.l10n.diveLog_filter_errorLoadingTags),
-                  ),
-              const SizedBox(height: 24),
-
-              // Buddy Name Filter Section
-              Text(
-                context.l10n.diveLog_filter_sectionBuddy,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              LayoutBuilder(
-                builder: (context, _) {
-                  final buddiesAsync = ref.watch(allBuddiesProvider);
-                  final allBuddyNames =
-                      buddiesAsync.valueOrNull
-                          ?.map((b) => b.name)
-                          .toSet()
-                          .toList() ??
-                      const <String>[];
-
-                  return RawAutocomplete<String>(
-                    textEditingController: _buddyNameController,
-                    focusNode: _buddyFocusNode,
-                    optionsBuilder: (TextEditingValue textEditingValue) {
-                      final text = textEditingValue.text;
-                      final parts = text
-                          .split(',')
-                          .map((e) => e.trim())
-                          .toList();
-                      final currentBuddies = parts.length > 1
-                          ? parts
-                                .sublist(0, parts.length - 1)
-                                .map((e) => e.toLowerCase())
-                                .toSet()
-                          : <String>{};
-
-                      final buddyNames = allBuddyNames
-                          .where(
-                            (name) =>
-                                !currentBuddies.contains(name.toLowerCase()),
-                          )
-                          .toList();
-
-                      if (text.isEmpty) {
-                        return [];
-                      }
-
-                      final lastPart = text
-                          .split(',')
-                          .last
-                          .trim()
-                          .toLowerCase();
-
-                      if (lastPart.isEmpty) {
-                        return buddyNames;
-                      }
-
-                      return buddyNames.where((String option) {
-                        return option.toLowerCase().contains(lastPart);
-                      }).toList();
-                    },
-                    onSelected: (String selection) {
-                      final text = _buddyNameFilter ?? '';
-                      final parts = text.split(',');
-                      String newText;
-                      if (parts.length > 1 || text.contains(',')) {
-                        parts.removeLast();
-                        final prefix = parts.join(',');
-                        newText = prefix.trim().isEmpty
-                            ? selection
-                            : '${prefix.trim()}, $selection';
-                      } else {
-                        newText = selection;
-                      }
-
-                      _buddyNameController.text = newText;
-                      _buddyNameController.selection = TextSelection.collapsed(
-                        offset: newText.length,
-                      );
-
-                      setState(() {
-                        _buddyNameFilter = newText;
-                      });
-                    },
-                    fieldViewBuilder:
-                        (
-                          context,
-                          textEditingController,
-                          focusNode,
-                          onFieldSubmitted,
-                        ) {
-                          return TextField(
-                            controller: textEditingController,
-                            focusNode: focusNode,
-                            decoration: InputDecoration(
-                              labelText: context.l10n.diveLog_filter_buddyName,
-                              hintText: context.l10n.diveLog_filter_buddyHint,
-                              prefixIcon: const Icon(Icons.person),
-                            ),
-                            onChanged: (value) {
-                              setState(() {
-                                _buddyNameFilter = value.isEmpty ? null : value;
-                              });
-                            },
-                            // Commits the highlighted suggestion when the
-                            // options list is open; a no-op otherwise, so
-                            // free-text entry still submits normally.
-                            onSubmitted: (_) => onFieldSubmitted(),
-                          );
-                        },
-                    optionsViewBuilder: (context, onSelected, options) {
-                      return Align(
-                        alignment: Alignment.topLeft,
-                        child: Material(
-                          elevation: 4.0,
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxHeight: 200),
-                            child: ListView.builder(
-                              padding: EdgeInsets.zero,
-                              shrinkWrap: true,
-                              itemCount: options.length,
-                              itemBuilder: (BuildContext context, int index) {
-                                final String option = options.elementAt(index);
-                                return ListTile(
-                                  title: Text(option),
-                                  onTap: () => onSelected(option),
-                                );
-                              },
+                        }),
+                      ),
+                      if (_minRating != null)
+                        Align(
+                          alignment: AlignmentDirectional.centerStart,
+                          child: TextButton(
+                            onPressed: () => setState(() => _minRating = null),
+                            child: Text(
+                              context.l10n.diveLog_filter_clearRating,
                             ),
                           ),
                         ),
-                      );
-                    },
-                  );
-                },
-              ),
-              const SizedBox(height: 24),
+                      const SizedBox(height: 24),
 
-              // Gas Mix (O2%) Filter Section
-              Text(
-                context.l10n.diveLog_filter_sectionGasMix,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  ChoiceChip(
-                    label: Text(context.l10n.diveLog_filter_gasAll),
-                    selected: _minO2Percent == null && _maxO2Percent == null,
-                    onSelected: (selected) {
-                      if (selected) {
-                        setState(() {
-                          _minO2Percent = null;
-                          _maxO2Percent = null;
-                        });
-                      }
-                    },
-                  ),
-                  ChoiceChip(
-                    label: Text(context.l10n.diveLog_filter_gasAir),
-                    selected: _minO2Percent == 20 && _maxO2Percent == 22,
-                    onSelected: (selected) {
-                      if (selected) {
-                        setState(() {
-                          _minO2Percent = 20;
-                          _maxO2Percent = 22;
-                        });
-                      }
-                    },
-                  ),
-                  ChoiceChip(
-                    label: Text(context.l10n.diveLog_filter_gasNitrox),
-                    selected: _minO2Percent == 22 && _maxO2Percent == null,
-                    onSelected: (selected) {
-                      if (selected) {
-                        setState(() {
-                          _minO2Percent = 22;
-                          _maxO2Percent = null;
-                        });
-                      }
-                    },
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
-
-              // Rating Filter Section
-              Text(
-                context.l10n.diveLog_filter_sectionMinRating,
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: List.generate(5, (index) {
-                  final rating = index + 1;
-                  final isSelected =
-                      _minRating != null && rating <= _minRating!;
-                  return IconButton(
-                    icon: Icon(
-                      isSelected ? Icons.star : Icons.star_border,
-                      color: isSelected ? Colors.amber : null,
-                      size: 32,
-                    ),
-                    tooltip: context.l10n.diveSites_edit_rating_starTooltip(
-                      rating,
-                    ),
-                    onPressed: () {
-                      setState(() {
-                        if (_minRating == rating) {
-                          _minRating = null; // Tap same star to clear
-                        } else {
-                          _minRating = rating;
-                        }
-                      });
-                    },
-                  );
-                }),
-              ),
-              if (_minRating != null)
-                Align(
-                  alignment: AlignmentDirectional.centerStart,
-                  child: TextButton(
-                    onPressed: () => setState(() => _minRating = null),
-                    child: Text(context.l10n.diveLog_filter_clearRating),
+                      // Duration Range Filter Section
+                      Text(
+                        context.l10n.diveLog_filter_sectionDuration,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextField(
+                              controller: _minDurationController,
+                              decoration: InputDecoration(
+                                labelText: context.l10n.diveLog_filter_min,
+                                prefixIcon: const Icon(Icons.timer),
+                                suffixText:
+                                    context.l10n.units_profileMetric_min,
+                              ),
+                              keyboardType: TextInputType.number,
+                              onChanged: (value) {
+                                _minDurationMinutes = parseUserInt(value);
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: TextField(
+                              controller: _maxDurationController,
+                              decoration: InputDecoration(
+                                labelText: context.l10n.diveLog_filter_max,
+                                prefixIcon: const Icon(Icons.timer),
+                                suffixText:
+                                    context.l10n.units_profileMetric_min,
+                              ),
+                              keyboardType: TextInputType.number,
+                              onChanged: (value) {
+                                _maxDurationMinutes = parseUserInt(value);
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
-              const SizedBox(height: 24),
-
-              // Duration Range Filter Section
-              Text(
-                context.l10n.diveLog_filter_sectionDuration,
-                style: Theme.of(context).textTheme.titleMedium,
               ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _minDurationController,
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_min,
-                        prefixIcon: const Icon(Icons.timer),
-                        suffixText: context.l10n.units_profileMetric_min,
-                      ),
-                      keyboardType: TextInputType.number,
-                      onChanged: (value) {
-                        _minDurationMinutes = parseUserInt(value);
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: TextField(
-                      controller: _maxDurationController,
-                      decoration: InputDecoration(
-                        labelText: context.l10n.diveLog_filter_max,
-                        prefixIcon: const Icon(Icons.timer),
-                        suffixText: context.l10n.units_profileMetric_min,
-                      ),
-                      keyboardType: TextInputType.number,
-                      onChanged: (value) {
-                        _maxDurationMinutes = parseUserInt(value);
-                      },
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 32),
-
-              // Action Buttons
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: () {
-                        widget.ref.read(widget.filterProvider.notifier).state =
-                            const DiveFilterState();
-                        Navigator.of(context).pop();
-                      },
-                      child: Text(context.l10n.diveLog_filter_clearAll),
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: FilledButton(
-                      onPressed: _applyFilters,
-                      child: Text(context.l10n.diveLog_filter_apply),
-                    ),
-                  ),
-                ],
-              ),
+              const Divider(height: 1),
+              _buildActions(context),
             ],
           ),
         );
       },
+    );
+  }
+
+  /// Resize grip. Vertical drags on it move the sheet extent directly, in
+  /// both directions.
+  ///
+  /// [DraggableScrollableSheet] only converts a drag into a resize when the
+  /// drag reaches its inner scrollable while that list sits at offset zero,
+  /// and Flutter's desktop scroll behaviour leaves the mouse out of
+  /// `dragDevices` entirely. Between them, a macOS diver could shrink the
+  /// sheet but never grow it back (#989).
+  Widget _buildGrip(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeUpDown,
+      child: GestureDetector(
+        key: DiveFilterSheet.gripKey,
+        behavior: HitTestBehavior.opaque,
+        onVerticalDragUpdate: _resizeSheet,
+        child: Semantics(
+          label: context.l10n.diveLog_filter_resizeGrip,
+          child: SizedBox(
+            height: 28,
+            width: double.infinity,
+            child: Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _resizeSheet(DragUpdateDetails details) {
+    if (!_sheetController.isAttached) return;
+    // Dragging up gives a negative dy and has to grow the sheet, so the delta
+    // is subtracted rather than added.
+    final delta = _sheetController.pixelsToSize(details.delta.dy);
+    _sheetController.jumpTo(
+      (_sheetController.size - delta).clamp(_minSheetSize, _maxSheetSize),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 16, end: 4),
+      child: Row(
+        children: [
+          // Expanded, not spaceBetween: a long localized title would otherwise
+          // overflow the row instead of wrapping.
+          Expanded(
+            child: Text(
+              context.l10n.diveLog_filter_title,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+          ),
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: const Icon(Icons.close),
+            tooltip: context.l10n.diveLog_filter_tooltip_close,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActions(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: () {
+                  widget.ref.read(widget.filterProvider.notifier).state =
+                      const DiveFilterState();
+                  Navigator.of(context).pop();
+                },
+                child: Text(context.l10n.diveLog_filter_clearAll),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: FilledButton(
+                onPressed: _applyFilters,
+                child: Text(context.l10n.diveLog_filter_apply),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -2003,6 +2003,7 @@
   "diveLog_filter_showOnlyFavorites": "عرض الغوصات المفضلة فقط",
   "diveLog_filter_startDate": "تاريخ البدء",
   "diveLog_filter_title": "تصفية الغوصات",
+  "diveLog_filter_resizeGrip": "تغيير حجم لوحة التصفية",
   "diveLog_filter_tooltip_close": "إغلاق التصفية",
   "diveLog_fullscreenProfile_close": "إغلاق ملء الشاشة",
   "diveLog_fullscreenProfile_readoutHint": "مرر المؤشر أو اسحب فوق ملف الغوصة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -2003,6 +2003,7 @@
   "diveLog_filter_showOnlyFavorites": "Nur Favoriten anzeigen",
   "diveLog_filter_startDate": "Startdatum",
   "diveLog_filter_title": "Tauchgänge filtern",
+  "diveLog_filter_resizeGrip": "Filterbereich skalieren",
   "diveLog_filter_tooltip_close": "Filter schließen",
   "diveLog_fullscreenProfile_close": "Vollbild schließen",
   "diveLog_fullscreenProfile_readoutHint": "Zeiger über das Profil bewegen oder scrubben",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -3201,6 +3201,7 @@
   "diveLog_filter_showOnlyFavorites": "Show only favorite dives",
   "diveLog_filter_startDate": "Start Date",
   "diveLog_filter_title": "Filter Dives",
+  "diveLog_filter_resizeGrip": "Resize filter panel",
   "diveLog_filter_tooltip_close": "Close filter",
   "diveLog_fullscreenProfile_close": "Close fullscreen",
   "diveLog_fullscreenProfile_readoutHint": "Hover or scrub the profile",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -2003,6 +2003,7 @@
   "diveLog_filter_showOnlyFavorites": "Mostrar solo inmersiones favoritas",
   "diveLog_filter_startDate": "Fecha de inicio",
   "diveLog_filter_title": "Filtrar inmersiones",
+  "diveLog_filter_resizeGrip": "Cambiar el tamaño del panel de filtros",
   "diveLog_filter_tooltip_close": "Cerrar filtro",
   "diveLog_fullscreenProfile_close": "Cerrar pantalla completa",
   "diveLog_fullscreenProfile_readoutHint": "Pasa el cursor o desliza sobre el perfil",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1931,6 +1931,7 @@
   "diveLog_filter_showOnlyFavorites": "Afficher uniquement les plongees favorites",
   "diveLog_filter_startDate": "Date de debut",
   "diveLog_filter_title": "Filtrer les plongees",
+  "diveLog_filter_resizeGrip": "Redimensionner le panneau de filtres",
   "diveLog_filter_tooltip_close": "Fermer le filtre",
   "diveLog_fullscreenProfile_close": "Fermer le plein ecran",
   "diveLog_fullscreenProfile_readoutHint": "Survolez ou faites glisser sur le profil",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1931,6 +1931,7 @@
   "diveLog_filter_showOnlyFavorites": "הצגת צלילות מועדפות בלבד",
   "diveLog_filter_startDate": "תאריך התחלה",
   "diveLog_filter_title": "סינון צלילות",
+  "diveLog_filter_resizeGrip": "שינוי גודל חלונית הסינון",
   "diveLog_filter_tooltip_close": "סגירת מסנן",
   "diveLog_fullscreenProfile_close": "סגירת מסך מלא",
   "diveLog_fullscreenProfile_readoutHint": "רחפו או גררו על הפרופיל",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1931,6 +1931,7 @@
   "diveLog_filter_showOnlyFavorites": "Csak kedvenc merulesek mutatasa",
   "diveLog_filter_startDate": "Kezdes datuma",
   "diveLog_filter_title": "Merulesek szurese",
+  "diveLog_filter_resizeGrip": "Szűrőpanel átméretezése",
   "diveLog_filter_tooltip_close": "Szuro bezarasa",
   "diveLog_fullscreenProfile_close": "Teljes kepernyo bezarasa",
   "diveLog_fullscreenProfile_readoutHint": "Vigye az egermutatot a profil fole, vagy huzza rajta az ujjat",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1931,6 +1931,7 @@
   "diveLog_filter_showOnlyFavorites": "Mostra solo le immersioni preferite",
   "diveLog_filter_startDate": "Data di inizio",
   "diveLog_filter_title": "Filtra immersioni",
+  "diveLog_filter_resizeGrip": "Ridimensiona il pannello dei filtri",
   "diveLog_filter_tooltip_close": "Chiudi filtro",
   "diveLog_fullscreenProfile_close": "Chiudi schermo intero",
   "diveLog_fullscreenProfile_readoutHint": "Passa il cursore o scorri sul profilo",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -9637,6 +9637,12 @@ abstract class AppLocalizations {
   /// **'Filter Dives'**
   String get diveLog_filter_title;
 
+  /// No description provided for @diveLog_filter_resizeGrip.
+  ///
+  /// In en, this message translates to:
+  /// **'Resize filter panel'**
+  String get diveLog_filter_resizeGrip;
+
   /// No description provided for @diveLog_filter_tooltip_close.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -5660,6 +5660,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_filter_title => 'تصفية الغوصات';
 
   @override
+  String get diveLog_filter_resizeGrip => 'تغيير حجم لوحة التصفية';
+
+  @override
   String get diveLog_filter_tooltip_close => 'إغلاق التصفية';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -5778,6 +5778,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_filter_title => 'Tauchgänge filtern';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Filterbereich skalieren';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Filter schließen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -5674,6 +5674,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_filter_title => 'Filter Dives';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Resize filter panel';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Close filter';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -5785,6 +5785,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_filter_title => 'Filtrar inmersiones';
 
   @override
+  String get diveLog_filter_resizeGrip =>
+      'Cambiar el tamaño del panel de filtros';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Cerrar filtro';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -5805,6 +5805,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_filter_title => 'Filtrer les plongees';
 
   @override
+  String get diveLog_filter_resizeGrip =>
+      'Redimensionner le panneau de filtres';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Fermer le filtre';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -5631,6 +5631,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_filter_title => 'סינון צלילות';
 
   @override
+  String get diveLog_filter_resizeGrip => 'שינוי גודל חלונית הסינון';
+
+  @override
   String get diveLog_filter_tooltip_close => 'סגירת מסנן';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -5764,6 +5764,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_filter_title => 'Merulesek szurese';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Szűrőpanel átméretezése';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Szuro bezarasa';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -5782,6 +5782,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_filter_title => 'Filtra immersioni';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Ridimensiona il pannello dei filtri';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Chiudi filtro';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -5737,6 +5737,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_filter_title => 'Duiken filteren';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Formaat van filterpaneel wijzigen';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Filter sluiten';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -5787,6 +5787,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_filter_title => 'Filtrar Mergulhos';
 
   @override
+  String get diveLog_filter_resizeGrip => 'Redimensionar o painel de filtros';
+
+  @override
   String get diveLog_filter_tooltip_close => 'Fechar filtro';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -5490,6 +5490,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_filter_title => '筛选潜水';
 
   @override
+  String get diveLog_filter_resizeGrip => '调整筛选面板大小';
+
+  @override
   String get diveLog_filter_tooltip_close => '关闭筛选';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -2003,6 +2003,7 @@
   "diveLog_filter_showOnlyFavorites": "Toon alleen favoriete duiken",
   "diveLog_filter_startDate": "Startdatum",
   "diveLog_filter_title": "Duiken filteren",
+  "diveLog_filter_resizeGrip": "Formaat van filterpaneel wijzigen",
   "diveLog_filter_tooltip_close": "Filter sluiten",
   "diveLog_fullscreenProfile_close": "Volledig scherm sluiten",
   "diveLog_fullscreenProfile_readoutHint": "Beweeg de muis over het profiel of veeg erover",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -2003,6 +2003,7 @@
   "diveLog_filter_showOnlyFavorites": "Mostrar apenas mergulhos favoritos",
   "diveLog_filter_startDate": "Data Inicial",
   "diveLog_filter_title": "Filtrar Mergulhos",
+  "diveLog_filter_resizeGrip": "Redimensionar o painel de filtros",
   "diveLog_filter_tooltip_close": "Fechar filtro",
   "diveLog_fullscreenProfile_close": "Fechar tela cheia",
   "diveLog_fullscreenProfile_readoutHint": "Passe o cursor ou deslize sobre o perfil",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -2134,6 +2134,7 @@
   "diveLog_filter_showOnlyFavorites": "仅显示收藏的潜水",
   "diveLog_filter_startDate": "开始日期",
   "diveLog_filter_title": "筛选潜水",
+  "diveLog_filter_resizeGrip": "调整筛选面板大小",
   "diveLog_filter_tooltip_close": "关闭筛选",
   "diveLog_fullscreenProfile_close": "关闭全屏",
   "diveLog_fullscreenProfile_readoutHint": "悬停或滑动查看轮廓",

--- a/test/features/dive_log/presentation/pages/dive_filter_sheet_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_filter_sheet_test.dart
@@ -33,6 +33,8 @@ void main() {
             ),
           ].cast(),
           child: MaterialApp(
+            // Pinned: the assertions match English strings.
+            locale: const Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
@@ -101,6 +101,8 @@ void main() {
           allDiveComputersProvider.overrideWith((ref) async => computers),
         ].cast(),
         child: MaterialApp(
+          // Pinned: this suite drives the sheet by English label.
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_interactions_test.dart
@@ -138,6 +138,11 @@ void main() {
     // The sheet's ListView builds children lazily, so a deep target may not be
     // in the tree yet; scroll it in. Targets already present (e.g. the preset
     // chips near the top) are skipped to avoid a needless scroll.
+    //
+    // Pass a PLAIN finder: `evaluate()` on an index-qualified one (`.first`,
+    // `.at(n)`) throws "Bad state: No element" when nothing has been built
+    // yet, both here and inside dragUntilVisible. Disambiguation happens below
+    // instead, once the target exists.
     if (finder.evaluate().isEmpty) {
       await tester.scrollUntilVisible(finder, 60.0, scrollable: scrollable());
     }
@@ -210,7 +215,7 @@ void main() {
     );
 
     Future<void> selectFrom(String hint, String option) async {
-      await scrollTo(tester, find.text(hint).first);
+      await scrollTo(tester, find.text(hint));
       await tester.tap(find.text(hint).first);
       await tester.pumpAndSettle();
       await tester.tap(find.text(option).last);

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_layout_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_layout_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_filter_sheet.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+final _testFilter = StateProvider<DiveFilterState>(
+  (ref) => const DiveFilterState(),
+);
+
+/// Layout contract for the filter sheet (#989).
+///
+/// The sheet is far taller than the 70% viewport it opens into, so its chrome
+/// -- title, close button and the Clear All / Apply actions -- has to live
+/// outside the scrolling field list. Otherwise the primary action sits about a
+/// thousand pixels below the fold with no scrollbar hinting at it, which on
+/// desktop reads as a sheet clipped by the bottom of the window.
+void main() {
+  setUp(() async {
+    await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> openSheet(WidgetTester tester) async {
+    final overrides = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides.cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Consumer(
+              builder: (context, ref, _) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () => showModalBottomSheet<void>(
+                      context: context,
+                      isScrollControlled: true,
+                      builder: (_) => DiveFilterSheet(
+                        ref: ref,
+                        filterProvider: _testFilter,
+                      ),
+                    ),
+                    child: const Text('Open filter'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open filter'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Apply Filters is visible without scrolling the field list', (
+    tester,
+  ) async {
+    await openSheet(tester);
+
+    // No scrollUntilVisible, no ensureVisible: the action row is pinned, so it
+    // is in the tree and hit-testable the moment the sheet opens.
+    expect(find.text('Apply Filters'), findsOneWidget);
+    expect(find.text('Clear All'), findsOneWidget);
+
+    await tester.tap(find.text('Apply Filters'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply Filters'), findsNothing, reason: 'sheet closed');
+  });
+
+  testWidgets('the pinned action row sits inside the window', (tester) async {
+    await openSheet(tester);
+
+    final apply = tester.getRect(find.text('Apply Filters'));
+    final windowHeight =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+
+    expect(apply.bottom, lessThanOrEqualTo(windowHeight));
+  });
+
+  testWidgets('the title stays pinned while the field list scrolls', (
+    tester,
+  ) async {
+    await openSheet(tester);
+
+    // Measured against the grip, not the window: the first drag on a list that
+    // sits at offset zero grows the sheet rather than scrolling it, so the
+    // whole chrome legitimately moves up together.
+    double titleOffsetInSheet() =>
+        tester.getTopLeft(find.text('Filter Dives')).dy -
+        tester.getTopLeft(find.byKey(DiveFilterSheet.gripKey)).dy;
+
+    final offsetBefore = titleOffsetInSheet();
+    expect(find.text('Date Range'), findsOneWidget);
+
+    // Two drags: the first expands the sheet to its maximum, the second
+    // actually scrolls the field list.
+    for (var i = 0; i < 2; i++) {
+      await tester.drag(
+        find.byType(Scrollable).first,
+        const Offset(0, -400),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+    }
+
+    expect(find.text('Date Range'), findsNothing, reason: 'the list scrolled');
+    expect(find.text('Filter Dives'), findsOneWidget);
+    expect(titleOffsetInSheet(), offsetBefore);
+    expect(find.text('Apply Filters'), findsOneWidget);
+  });
+
+  testWidgets('dragging the grip upward grows the sheet', (tester) async {
+    await openSheet(tester);
+
+    final grip = find.byKey(DiveFilterSheet.gripKey);
+    expect(grip, findsOneWidget);
+
+    final topBefore = tester.getTopLeft(grip).dy;
+
+    await tester.drag(grip, const Offset(0, -150));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getTopLeft(grip).dy,
+      lessThan(topBefore),
+      reason: 'the sheet should grow when the grip is dragged upward',
+    );
+  });
+
+  testWidgets('dragging the grip downward shrinks the sheet', (tester) async {
+    await openSheet(tester);
+
+    final grip = find.byKey(DiveFilterSheet.gripKey);
+    final topBefore = tester.getTopLeft(grip).dy;
+
+    await tester.drag(grip, const Offset(0, 100));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(grip).dy, greaterThan(topBefore));
+  });
+}

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_layout_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_layout_test.dart
@@ -36,6 +36,12 @@ void main() {
       ProviderScope(
         overrides: overrides.cast(),
         child: MaterialApp(
+          // Pinned: the assertions below match English strings. flutter_test
+          // forwards the HOST machine's locale list rather than a fixed en_US,
+          // and the app ships 11 locales, so an unpinned MaterialApp renders a
+          // translated sheet on a non-English dev machine and every
+          // find.text() here misses.
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(

--- a/test/features/dive_log/presentation/widgets/dive_filter_sheet_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_filter_sheet_test.dart
@@ -34,6 +34,8 @@ void main() {
         ProviderScope(
           overrides: overrides.cast(),
           child: MaterialApp(
+            // Pinned: the assertions match English strings.
+            locale: const Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(
@@ -101,6 +103,8 @@ void main() {
         ProviderScope(
           overrides: overrides.cast(),
           child: MaterialApp(
+            // Pinned: the assertions match English strings.
+            locale: const Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(


### PR DESCRIPTION
Fixes #989.

## The bug

The dive list's Filter Dives sheet appeared clipped by the bottom of the macOS
window, with no reachable Apply button and a drag that only ever made it
smaller.

## Root cause

Two independent causes, both structural.

**The actions were never built.** `DiveFilterSheet` rendered the entire sheet,
including the `Clear All` / `Apply Filters` row, as children of one `ListView`
inside a `DraggableScrollableSheet` opened at 70% of the window height. The form
is several screens tall, so the action row sat roughly a thousand pixels below
the fold. A lazy `ListView` does not merely hide off-screen children, it never
constructs them, so no amount of window resizing or app zoom could surface the
button. A widget test confirms the old behaviour: `find.text('Apply Filters')`
returned zero widgets, not an off-screen rect. Desktop also draws no scrollbar
thumb until a scroll gesture begins, so nothing signalled that the form
continued past the visible edge.

**The sheet could not be grown.** `DraggableScrollableSheet` converts a drag
into a resize only when the drag reaches its inner scrollable while that list
sits at offset zero, and Flutter's desktop `ScrollBehavior` leaves
`PointerDeviceKind.mouse` out of `dragDevices` entirely. Between them, a macOS
diver using a mouse had no working way to expand the sheet, only to shrink it.

## The fix

Adopt the structure `SiteFilterSheet` and `PreDiveSessionFilterSheet` already
use: chrome outside the scrollable.

| | Before | After |
| --- | --- | --- |
| Title and close | scrolled away with the content | pinned above a divider |
| Fields | the whole sheet | `Expanded(Scrollbar(ListView))`, thumb always visible |
| Clear All / Apply | last children of the list | pinned footer inside a bottom `SafeArea` |
| Resize | shrink only | grip drives the extent in both directions |

The new grip is a `GestureDetector` rather than a `Scrollable`, so it responds
to a mouse. It converts drag pixels through
`DraggableScrollableController.pixelsToSize` and clamps to the sheet's 0.5-0.95
extents, and carries a `resizeUpDown` cursor plus a localized semantics label
(`diveLog_filter_resizeGrip`, translated across all 11 locales).

## Test fallout worth noting

Pinning the footer shrinks the field viewport by roughly 165px, which pushed the
Dive Type dropdown outside the list's cache extent. That exposed a latent bug in
`dive_filter_sheet_interactions_test.dart`: `evaluate()` on an index-qualified
finder (`.first`, `.at(n)`) throws `Bad state: No element` when nothing has been
built yet, so the helper's "scroll it in if absent" guard never ran.
`dragUntilVisible` has the same hazard internally. The call site now passes a
plain finder and disambiguates only once the target exists.

## Verification

- New `dive_filter_sheet_layout_test.dart`: 5 tests covering the pinned actions,
  the pinned title under scroll, and grip resize in both directions. Each was
  watched failing against the old layout first.
- All four pre-existing filter-sheet suites pass (25 tests).
- `test/features/dive_log/presentation`: 1628 pass.
  `test/features/statistics`: 173 pass. `test/l10n` including arb parity: 77
  pass.
- `flutter analyze` clean project-wide; `dart format .` reports no changes.
- Ran the real macOS build and drove the sheet by hand: pinned title, visible
  scrollbar thumb, both action buttons fully inside the window, and mouse drags
  on the grip that grow and shrink the sheet.

## Not addressed

The issue also asks to move the panel freely left and right. A modal bottom
sheet is anchored to the bottom by design, so this makes it reliably resizable
in both directions instead. Reframing the filter as a floating or centered
dialog at desktop widths would be a larger change and deserves its own issue.
