### PR TITLE
fix(import): stop Subsurface imports duplicating sites and losing coordinates

### DIFF
--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/equipment/data/services/dive_equipment_defau
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/core/services/location_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/utils/geo_math.dart';
 import 'package:submersion/core/utils/number_utils.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
@@ -912,6 +913,37 @@ class UddfEntityImporter {
 
   // -- Site import --
 
+  /// How close a deselected site must be to an existing row to bind to it
+  /// when their names differ. Matches the radius `ImportDuplicateChecker`
+  /// uses to flag the site as a duplicate in the first place.
+  static const double _siteProximityMeters = 100;
+
+  /// Nearest existing site within [_siteProximityMeters] of [item]'s
+  /// coordinates, or null when the item has no coordinates or nothing sits
+  /// close enough.
+  DiveSite? _nearestExistingSite(
+    List<DiveSite> existingSites,
+    Map<String, dynamic> item,
+  ) {
+    final lat = (item['latitude'] as num?)?.toDouble();
+    final lon = (item['longitude'] as num?)?.toDouble();
+    if (lat == null || lon == null) return null;
+    final point = GeoPoint(lat, lon);
+
+    DiveSite? nearest;
+    var nearestMeters = double.infinity;
+    for (final site in existingSites) {
+      final location = site.location;
+      if (location == null) continue;
+      final meters = distanceMeters(location, point);
+      if (meters <= _siteProximityMeters && meters < nearestMeters) {
+        nearest = site;
+        nearestMeters = meters;
+      }
+    }
+    return nearest;
+  }
+
   Future<int> _importSites(
     List<Map<String, dynamic>> items,
     Set<int> selected,
@@ -922,8 +954,14 @@ class UddfEntityImporter {
     ImportProgressCallback? onProgress,
   ) async {
     // For deselected sites (duplicates the user chose not to re-import),
-    // resolve their UDDF IDs to existing database sites by name so that
-    // dives referencing them still get linked correctly.
+    // resolve their UDDF IDs to existing database sites so that dives
+    // referencing them still get linked correctly.
+    //
+    // The name lookup alone is not enough: ImportDuplicateChecker flags a site
+    // as a duplicate on name OR on proximity, so a site suppressed by the
+    // proximity arm carries a name that matches nothing here. Without the
+    // coordinate fallback its dives import with no site and no location at
+    // all, silently.
     final existingSites = await repository.getAllSites(diverId: diverId);
     final existingByName = <String, DiveSite>{};
     final existingById = <String, DiveSite>{};
@@ -935,12 +973,13 @@ class UddfEntityImporter {
       if (selected.contains(i)) continue; // will be imported below
       if (overrides.containsKey(i)) continue; // will be overwritten below
       final uddfId = items[i]['uddfId'] as String?;
+      if (uddfId == null) continue;
       final name = items[i]['name'] as String?;
-      if (uddfId != null && name != null) {
-        final existing = existingByName[name.toLowerCase()];
-        if (existing != null) {
-          idMapping[uddfId] = existing;
-        }
+      final existing =
+          (name == null ? null : existingByName[name.toLowerCase()]) ??
+          _nearestExistingSite(existingSites, items[i]);
+      if (existing != null) {
+        idMapping[uddfId] = existing;
       }
     }
 

--- a/lib/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart
+++ b/lib/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart
@@ -44,7 +44,15 @@ FoldedSites foldSubsurfaceSites(List<Map<String, dynamic>> raw) {
     if (name == null) continue;
     final host = _findSameName(survivors, name, raw[i]);
     if (host == null) {
-      survivors.add(_Survivor(order: i, site: raw[i], normalizedName: name));
+      // Copy: _absorb writes into the survivor, and the caller's maps must
+      // come back out of here exactly as they went in.
+      survivors.add(
+        _Survivor(
+          order: i,
+          site: Map<String, dynamic>.from(raw[i]),
+          normalizedName: name,
+        ),
+      );
     } else {
       _absorb(host, raw[i], aliases);
     }

--- a/lib/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart
+++ b/lib/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart
@@ -1,0 +1,168 @@
+import 'package:submersion/core/utils/geo_math.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// Result of folding a Subsurface `<divesites>` block.
+class FoldedSites {
+  /// Surviving sites, in the order their first entry appeared in the file.
+  final List<Map<String, dynamic>> sites;
+
+  /// Maps each folded-away site uuid to the uuid it folded into, so a dive's
+  /// `divesiteid` can be redirected to the survivor.
+  final Map<String, String> aliases;
+
+  const FoldedSites({required this.sites, required this.aliases});
+}
+
+/// Two entries sharing a name fold together when no further apart than this.
+///
+/// Subsurface starts a new dive site whenever a dive's GPS lands more than
+/// 20 m from every known one, so a single reef accumulates a long tail of
+/// same-named entries a few dozen metres apart. Beyond a kilometre the two
+/// are treated as genuinely different places that happen to share a name.
+const double _sameNameFoldMeters = 1000;
+
+/// An entry Subsurface left unnamed folds into a site this close, whatever
+/// that site is called. Matches the coincidence guard `SiteMatchingService`
+/// applies when it proposes sites for a dive.
+const double _unnamedFoldMeters = 100;
+
+/// Collapses the duplicate dive sites a Subsurface logbook accumulates.
+///
+/// Named entries fold into an earlier entry of the same name; entries
+/// Subsurface left unnamed fold into whichever site sits on top of them, and
+/// otherwise survive under a name built from their coordinates rather than
+/// being discarded. An entry with neither a name nor coordinates carries
+/// nothing worth importing and is dropped.
+FoldedSites foldSubsurfaceSites(List<Map<String, dynamic>> raw) {
+  final aliases = <String, String>{};
+  final survivors = <_Survivor>[];
+
+  // Named entries fold among themselves first so that an unnamed entry can
+  // see every named site regardless of the order Subsurface wrote them in.
+  for (var i = 0; i < raw.length; i++) {
+    final name = _normalizedName(raw[i]['name'] as String?);
+    if (name == null) continue;
+    final host = _findSameName(survivors, name, raw[i]);
+    if (host == null) {
+      survivors.add(_Survivor(order: i, site: raw[i], normalizedName: name));
+    } else {
+      _absorb(host, raw[i], aliases);
+    }
+  }
+
+  for (var i = 0; i < raw.length; i++) {
+    if (_normalizedName(raw[i]['name'] as String?) != null) continue;
+    final point = _pointOf(raw[i]);
+    if (point == null) continue;
+    final host = _findNearest(survivors, point, _unnamedFoldMeters);
+    if (host == null) {
+      final named = Map<String, dynamic>.from(raw[i])
+        ..['name'] = point.toString();
+      survivors.add(_Survivor(order: i, site: named, normalizedName: null));
+    } else {
+      _absorb(host, raw[i], aliases);
+    }
+  }
+
+  survivors.sort((a, b) => a.order.compareTo(b.order));
+  return FoldedSites(
+    sites: [for (final survivor in survivors) survivor.site],
+    aliases: aliases,
+  );
+}
+
+/// A site that survived folding, plus the bookkeeping the fold needs.
+class _Survivor {
+  /// Position of this site's first entry in the file, so the surviving list
+  /// can be restored to document order after the two passes.
+  final int order;
+
+  final Map<String, dynamic> site;
+
+  /// Null for a site Subsurface left unnamed: its coordinate-derived name is
+  /// a label, not an identity, and must never attract a same-name fold.
+  final String? normalizedName;
+
+  _Survivor({
+    required this.order,
+    required this.site,
+    required this.normalizedName,
+  });
+}
+
+/// Folds [folded] into [host], filling gaps rather than overwriting.
+///
+/// The first entry of a name wins every field it actually carries; later
+/// entries only supply what it was missing. This mirrors how `PayloadMerger`
+/// enriches a survivor when it folds entities across files.
+void _absorb(
+  _Survivor host,
+  Map<String, dynamic> folded,
+  Map<String, String> aliases,
+) {
+  final foldedId = folded['uddfId'] as String?;
+  final hostId = host.site['uddfId'] as String?;
+  if (foldedId != null && hostId != null) aliases[foldedId] = hostId;
+
+  folded.forEach((key, value) {
+    if (key == 'uddfId' || key == 'name') return;
+    if (_isBlank(value)) return;
+    if (_isBlank(host.site[key])) host.site[key] = value;
+  });
+}
+
+_Survivor? _findSameName(
+  List<_Survivor> survivors,
+  String name,
+  Map<String, dynamic> candidate,
+) {
+  final point = _pointOf(candidate);
+  for (final survivor in survivors) {
+    if (survivor.normalizedName != name) continue;
+    final hostPoint = _pointOf(survivor.site);
+    // A side without coordinates cannot contradict the other, so the shared
+    // name decides on its own.
+    if (point == null || hostPoint == null) return survivor;
+    if (distanceMeters(hostPoint, point) <= _sameNameFoldMeters) {
+      return survivor;
+    }
+  }
+  return null;
+}
+
+_Survivor? _findNearest(
+  List<_Survivor> survivors,
+  GeoPoint point,
+  double maxMeters,
+) {
+  _Survivor? nearest;
+  var nearestMeters = double.infinity;
+  for (final survivor in survivors) {
+    final hostPoint = _pointOf(survivor.site);
+    if (hostPoint == null) continue;
+    final meters = distanceMeters(hostPoint, point);
+    if (meters <= maxMeters && meters < nearestMeters) {
+      nearest = survivor;
+      nearestMeters = meters;
+    }
+  }
+  return nearest;
+}
+
+/// Case- and whitespace-insensitive identity for a site name, or null when
+/// Subsurface supplied no usable name.
+String? _normalizedName(String? raw) {
+  if (raw == null) return null;
+  final collapsed = raw.trim().replaceAll(RegExp(r'\s+'), ' ').toLowerCase();
+  return collapsed.isEmpty ? null : collapsed;
+}
+
+GeoPoint? _pointOf(Map<String, dynamic> site) {
+  final lat = site['latitude'] as double?;
+  final lon = site['longitude'] as double?;
+  if (lat == null || lon == null) return null;
+  return GeoPoint(lat, lon);
+}
+
+bool _isBlank(Object? value) =>
+    value == null || (value is String && value.trim().isEmpty);

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/universal_import/data/models/import_options.
 import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
 import 'package:submersion/features/universal_import/data/parsers/import_parser.dart';
+import 'package:submersion/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart';
 
 /// Parser for Subsurface XML (.ssrf) dive log files.
 ///
@@ -71,16 +72,17 @@ class SubsurfaceXmlParser implements ImportParser {
       );
     }
 
-    // Parse sites and build lookup map
-    final siteMap = <String, Map<String, dynamic>>{};
+    // Parse sites, folding the duplicates a Subsurface logbook accumulates.
+    // The aliases the fold produces redirect each dive's divesiteid to the
+    // surviving site.
+    var siteAliases = const <String, String>{};
     final divesitesElement = root.findElements('divesites').firstOrNull;
     if (divesitesElement != null) {
-      final sites = _parseSites(divesitesElement);
-      for (final site in sites) {
-        final id = site['uddfId'] as String?;
-        if (id != null) siteMap[id] = site;
+      final folded = foldSubsurfaceSites(_parseSites(divesitesElement));
+      siteAliases = folded.aliases;
+      if (folded.sites.isNotEmpty) {
+        entities[ImportEntityType.sites] = folded.sites;
       }
-      if (sites.isNotEmpty) entities[ImportEntityType.sites] = sites;
     }
 
     // Parse dives (with trip support)
@@ -100,7 +102,7 @@ class SubsurfaceXmlParser implements ImportParser {
         final tripDives = <Map<String, dynamic>>[];
         for (final diveElement in tripElement.findElements('dive')) {
           try {
-            final diveData = _parseDive(diveElement, siteMap: siteMap);
+            final diveData = _parseDive(diveElement, siteAliases: siteAliases);
             if (diveData != null) {
               diveData['tripRef'] = tripId;
               _collectTags(diveElement, diveData, allTags);
@@ -134,7 +136,7 @@ class SubsurfaceXmlParser implements ImportParser {
       // Process standalone dives (not inside a trip)
       for (final diveElement in divesElement.findElements('dive')) {
         try {
-          final diveData = _parseDive(diveElement, siteMap: siteMap);
+          final diveData = _parseDive(diveElement, siteAliases: siteAliases);
           if (diveData != null) {
             _collectTags(diveElement, diveData, allTags);
             _collectBuddies(diveElement, diveData, allBuddies);
@@ -170,7 +172,7 @@ class SubsurfaceXmlParser implements ImportParser {
 
   Map<String, dynamic>? _parseDive(
     XmlElement dive, {
-    Map<String, Map<String, dynamic>> siteMap = const {},
+    Map<String, String> siteAliases = const {},
   }) {
     final dateStr = dive.getAttribute('date');
     final timeStr = dive.getAttribute('time');
@@ -287,10 +289,11 @@ class SubsurfaceXmlParser implements ImportParser {
     }
     if (notesParts.isNotEmpty) result['notes'] = notesParts.join('\n');
 
-    // Site linking via divesiteid attribute
+    // Site linking via divesiteid attribute, redirected to the surviving site
+    // when the referenced entry folded into a duplicate.
     final siteId = dive.getAttribute('divesiteid')?.trim();
     if (siteId != null && siteId.isNotEmpty) {
-      result['site'] = {'uddfId': siteId};
+      result['site'] = {'uddfId': siteAliases[siteId] ?? siteId};
     }
 
     // Profile samples — parsed before cylinders for pressure fallback
@@ -328,23 +331,26 @@ class SubsurfaceXmlParser implements ImportParser {
     return result;
   }
 
+  /// Reads every `<site>` verbatim, including the ones Subsurface left
+  /// unnamed. Deciding which of these are the same place is the folder's job:
+  /// dropping an unnamed site here would strand its dives with no coordinates
+  /// at all, which is how imported dives used to lose their location.
   List<Map<String, dynamic>> _parseSites(XmlElement divesites) {
     final sites = <Map<String, dynamic>>[];
     for (final site in divesites.findElements('site')) {
+      final siteData = <String, dynamic>{};
       final name = site.getAttribute('name');
-      if (name == null || name.isEmpty) continue;
-      final siteData = <String, dynamic>{'name': name};
+      if (name != null && name.trim().isNotEmpty) siteData['name'] = name;
       final uuid = site.getAttribute('uuid')?.trim();
       if (uuid != null) siteData['uddfId'] = uuid;
-      final gps = site.getAttribute('gps');
-      if (gps != null) {
-        final parts = gps.trim().split(RegExp(r'\s+'));
-        if (parts.length == 2) {
-          final lat = double.tryParse(parts[0].trim());
-          final lon = double.tryParse(parts[1].trim());
-          if (lat != null) siteData['latitude'] = lat;
-          if (lon != null) siteData['longitude'] = lon;
-        }
+      final coordinates = _parseGps(site.getAttribute('gps'));
+      if (coordinates != null) {
+        siteData['latitude'] = coordinates.$1;
+        siteData['longitude'] = coordinates.$2;
+      }
+      final description = site.getAttribute('description');
+      if (description != null && description.trim().isNotEmpty) {
+        siteData['description'] = description.trim();
       }
       for (final geo in site.findElements('geo')) {
         final cat = geo.getAttribute('cat');
@@ -360,6 +366,23 @@ class SubsurfaceXmlParser implements ImportParser {
       sites.add(siteData);
     }
     return sites;
+  }
+
+  /// Parses a Subsurface `gps` attribute: two decimal degrees separated by
+  /// whitespace or a comma, the same pair of separators Subsurface's own
+  /// `parse_location()` accepts.
+  ///
+  /// A pair that is short, unparseable, or off the globe yields null rather
+  /// than a half-set or nonsensical coordinate.
+  (double, double)? _parseGps(String? raw) {
+    if (raw == null) return null;
+    final parts = raw.trim().split(RegExp(r'[\s,]+'));
+    if (parts.length != 2) return null;
+    final lat = double.tryParse(parts[0]);
+    final lon = double.tryParse(parts[1]);
+    if (lat == null || lon == null) return null;
+    if (lat.abs() > 90 || lon.abs() > 180) return null;
+    return (lat, lon);
   }
 
   Map<String, dynamic> _parseTrip(XmlElement trip) {

--- a/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/subsurface_xml_parser.dart
@@ -339,10 +339,10 @@ class SubsurfaceXmlParser implements ImportParser {
     final sites = <Map<String, dynamic>>[];
     for (final site in divesites.findElements('site')) {
       final siteData = <String, dynamic>{};
-      final name = site.getAttribute('name');
-      if (name != null && name.trim().isNotEmpty) siteData['name'] = name;
+      final name = site.getAttribute('name')?.trim();
+      if (name != null && name.isNotEmpty) siteData['name'] = name;
       final uuid = site.getAttribute('uuid')?.trim();
-      if (uuid != null) siteData['uddfId'] = uuid;
+      if (uuid != null && uuid.isNotEmpty) siteData['uddfId'] = uuid;
       final coordinates = _parseGps(site.getAttribute('gps'));
       if (coordinates != null) {
         siteData['latitude'] = coordinates.$1;
@@ -374,6 +374,10 @@ class SubsurfaceXmlParser implements ImportParser {
   ///
   /// A pair that is short, unparseable, or off the globe yields null rather
   /// than a half-set or nonsensical coordinate.
+  ///
+  /// The `isFinite` check is not redundant with the range check: `double`
+  /// parses 'NaN', and every comparison against NaN is false, so a range
+  /// check on its own would wave it straight through.
   (double, double)? _parseGps(String? raw) {
     if (raw == null) return null;
     final parts = raw.trim().split(RegExp(r'[\s,]+'));
@@ -381,6 +385,7 @@ class SubsurfaceXmlParser implements ImportParser {
     final lat = double.tryParse(parts[0]);
     final lon = double.tryParse(parts[1]);
     if (lat == null || lon == null) return null;
+    if (!lat.isFinite || !lon.isFinite) return null;
     if (lat.abs() > 90 || lon.abs() > 180) return null;
     return (lat, lon);
   }

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -699,6 +699,133 @@ void main() {
     });
   });
 
+  group('Site linking fallback for a GPS-matched duplicate', () {
+    // The duplicate checker flags an incoming site as a duplicate on name OR
+    // on 100 m proximity, and the wizard then leaves it out of the selection.
+    // A site caught by the proximity arm carries a different name, so binding
+    // its uddfId by name alone strands every dive that referenced it.
+    const existingSite = DiveSite(
+      id: 'existing-maclearie',
+      diverId: diverId,
+      name: 'Maclearie Park',
+      location: GeoPoint(40.179561, -74.037475),
+    );
+
+    setUp(() {
+      when(
+        mockSiteRepo.getAllSites(diverId: anyNamed('diverId')),
+      ).thenAnswer((_) async => [existingSite]);
+      when(mockDiveRepo.createDive(any)).thenAnswer(
+        (invocation) async => invocation.positionalArguments[0] as Dive,
+      );
+    });
+
+    test('links the dive to the existing site the duplicate sits on', () async {
+      final data = UddfImportResult(
+        sites: [
+          {
+            // Spelled differently, so the name lookup cannot rescue this.
+            'name': 'Maclearie Pk',
+            'uddfId': 'site-1',
+            'latitude': 40.179575,
+            'longitude': -74.037466,
+          },
+        ],
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 20.0,
+            'site': {'uddfId': 'site-1'},
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(sites: {}, dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(mockDiveRepo.createDive(captureAny)).captured;
+      final dive = captured[0] as Dive;
+      expect(dive.site, isNotNull);
+      expect(dive.site!.id, 'existing-maclearie');
+    });
+
+    test('leaves the dive unlinked when no existing site is near', () async {
+      final data = UddfImportResult(
+        sites: [
+          {
+            'name': 'Somewhere Else',
+            'uddfId': 'site-1',
+            'latitude': 18.465562,
+            'longitude': -66.084902,
+          },
+        ],
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 20.0,
+            'site': {'uddfId': 'site-1'},
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(sites: {}, dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(mockDiveRepo.createDive(captureAny)).captured;
+      final dive = captured[0] as Dive;
+      expect(dive.site, isNull);
+    });
+
+    test('prefers a name match over a nearer site with another name', () async {
+      const sameNameFarther = DiveSite(
+        id: 'existing-by-name',
+        diverId: diverId,
+        name: 'Maclearie Pk',
+        location: GeoPoint(40.180561, -74.037475),
+      );
+      when(
+        mockSiteRepo.getAllSites(diverId: anyNamed('diverId')),
+      ).thenAnswer((_) async => [existingSite, sameNameFarther]);
+
+      final data = UddfImportResult(
+        sites: [
+          {
+            'name': 'Maclearie Pk',
+            'uddfId': 'site-1',
+            'latitude': 40.179575,
+            'longitude': -74.037466,
+          },
+        ],
+        dives: [
+          {
+            'dateTime': now,
+            'maxDepth': 20.0,
+            'site': {'uddfId': 'site-1'},
+          },
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(sites: {}, dives: {0}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final captured = verify(mockDiveRepo.createDive(captureAny)).captured;
+      final dive = captured[0] as Dive;
+      expect(dive.site!.id, 'existing-by-name');
+    });
+  });
+
   group('Import sites (siteOverrides / replaceSource)', () {
     // A pre-existing site carrying values the import payload will NOT supply,
     // so tests can assert those survive the overwrite.

--- a/test/features/universal_import/data/parsers/subsurface/subsurface_site_folder_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface/subsurface_site_folder_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart';
+
+void main() {
+  group('foldSubsurfaceSites', () {
+    test('leaves the caller\'s site maps untouched', () async {
+      final first = <String, dynamic>{'uddfId': 'aaa', 'name': 'Blue Hole'};
+      final second = <String, dynamic>{
+        'uddfId': 'bbb',
+        'name': 'Blue Hole',
+        'latitude': 18.465562,
+        'longitude': -66.084902,
+        'country': 'Puerto Rico',
+      };
+
+      final folded = foldSubsurfaceSites([first, second]);
+
+      // The survivor picks up what the first entry was missing...
+      expect(folded.sites.length, 1);
+      expect(folded.sites[0]['country'], 'Puerto Rico');
+      expect(folded.aliases, {'bbb': 'aaa'});
+
+      // ...without writing any of it back into the inputs.
+      expect(first, {'uddfId': 'aaa', 'name': 'Blue Hole'});
+      expect(second.containsKey('country'), isTrue);
+      expect(second['uddfId'], 'bbb');
+    });
+
+    test('returns an empty result for no sites', () async {
+      final folded = foldSubsurfaceSites([]);
+      expect(folded.sites, isEmpty);
+      expect(folded.aliases, isEmpty);
+    });
+  });
+}

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -920,6 +920,260 @@ void main() {
     });
   });
 
+  group('site folding and coordinate retention', () {
+    String divelog(String divesites, String dives) =>
+        '''
+<divelog program='subsurface' version='3'>
+<divesites>
+$divesites
+</divesites>
+<dives>
+$dives
+</dives>
+</divelog>
+''';
+
+    String dive(String uuid, {int number = 1}) =>
+        '''
+<dive number='$number' divesiteid='$uuid' date='2025-01-15' time='1$number:00:00' duration='30:00 min'>
+  <divecomputer model='Test'>
+  <depth max='20.0 m' mean='15.0 m' />
+  </divecomputer>
+</dive>
+''';
+
+    String siteRefOf(Map<String, dynamic> diveData) =>
+        (diveData['site'] as Map<String, dynamic>)['uddfId'] as String;
+
+    test(
+      'folds same-named sites logged within a kilometre of each other',
+      () async {
+        // Subsurface splits a site whenever a dive's GPS drifts more than 20 m,
+        // so one real location accumulates many same-named site entries.
+        final result = await parser.parse(
+          xmlBytes(
+            divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' name='Blue Hole' gps='18.470562 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+          ),
+        );
+
+        final sites = result.entitiesOf(ImportEntityType.sites);
+        expect(sites.length, 1);
+        expect(sites[0]['uddfId'], 'aaa');
+
+        final dives = result.entitiesOf(ImportEntityType.dives);
+        expect(dives.map(siteRefOf), ['aaa', 'aaa']);
+      },
+    );
+
+    test('keeps same-named sites that are kilometres apart', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' name='Blue Hole' gps='18.665562 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 2);
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives.map(siteRefOf), ['aaa', 'bbb']);
+    });
+
+    test('folds a same-named site that carries no coordinates', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' name='Blue Hole'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives.map(siteRefOf), ['aaa', 'aaa']);
+    });
+
+    test('folds case- and whitespace-variant names together', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' name='  blue   hole ' gps='18.465562 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      expect(result.entitiesOf(ImportEntityType.sites).length, 1);
+    });
+
+    test('keeps an unnamed site and names it from its coordinates', () async {
+      // Subsurface omits the name attribute entirely for unnamed sites.
+      // Dropping the site strands the dive with no coordinates at all.
+      final result = await parser.parse(
+        xmlBytes(
+          divelog("<site uuid='aaa' gps='18.465562 -66.084902'/>", dive('aaa')),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0]['name'], '18.465562, -66.084902');
+      expect(sites[0]['latitude'], closeTo(18.465562, 0.000001));
+      expect(sites[0]['longitude'], closeTo(-66.084902, 0.000001));
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(siteRefOf(dives.first), 'aaa');
+    });
+
+    test('folds an unnamed site into a named site within 100 metres', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' gps='18.465862 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0]['name'], 'Blue Hole');
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives.map(siteRefOf), ['aaa', 'aaa']);
+    });
+
+    test('folds two unnamed sites that sit on each other', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' gps='18.465562 -66.084902'/>
+<site uuid='bbb' gps='18.465862 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0]['name'], '18.465562, -66.084902');
+
+      final dives = result.entitiesOf(ImportEntityType.dives);
+      expect(dives.map(siteRefOf), ['aaa', 'aaa']);
+    });
+
+    test('keeps an unnamed site that is far from any named site', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' gps='18.475562 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      expect(result.entitiesOf(ImportEntityType.sites).length, 2);
+    });
+
+    test('never folds two named sites on proximity alone', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole' gps='18.465562 -66.084902'/>
+<site uuid='bbb' name='Coral Gardens' gps='18.465562 -66.084902'/>
+''', '${dive('aaa')}${dive('bbb', number: 2)}'),
+        ),
+      );
+
+      expect(result.entitiesOf(ImportEntityType.sites).length, 2);
+    });
+
+    test('survivor inherits fields the first entry was missing', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog('''
+<site uuid='aaa' name='Blue Hole'/>
+<site uuid='bbb' name='Blue Hole' gps='18.465562 -66.084902'>
+  <geo cat='2' origin='2' value='Puerto Rico'/>
+  <geo cat='3' origin='0' value='Isabela'/>
+  <notes>Wall dive on the north side.</notes>
+</site>
+''', dive('aaa')),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0]['uddfId'], 'aaa');
+      expect(sites[0]['latitude'], closeTo(18.465562, 0.000001));
+      expect(sites[0]['country'], 'Puerto Rico');
+      expect(sites[0]['region'], 'Isabela');
+      expect(sites[0]['notes'], 'Wall dive on the north side.');
+    });
+
+    test('parses comma-separated coordinates', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog(
+            "<site uuid='aaa' name='Blue Hole' gps='18.465562,-66.084902'/>",
+            dive('aaa'),
+          ),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites[0]['latitude'], closeTo(18.465562, 0.000001));
+      expect(sites[0]['longitude'], closeTo(-66.084902, 0.000001));
+    });
+
+    test('drops coordinates outside the valid range', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog(
+            "<site uuid='aaa' name='Blue Hole' gps='118.465562 -66.084902'/>",
+            dive('aaa'),
+          ),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0]['name'], 'Blue Hole');
+      expect(sites[0].containsKey('latitude'), isFalse);
+      expect(sites[0].containsKey('longitude'), isFalse);
+    });
+
+    test('skips a site with neither a name nor coordinates', () async {
+      final result = await parser.parse(
+        xmlBytes(divelog("<site uuid='aaa'/>", dive('aaa'))),
+      );
+
+      expect(result.entitiesOf(ImportEntityType.sites), isEmpty);
+    });
+
+    test('reads the site description attribute', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog(
+            "<site uuid='aaa' name='Blue Hole' description='Boat access only'/>",
+            dive('aaa'),
+          ),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites[0]['description'], 'Boat access only');
+    });
+  });
+
   group('trips', () {
     test('parses trip wrapper and links child dives', () async {
       final result = await parser.parse(
@@ -1121,8 +1375,29 @@ $diveXml
       final dives = result.entitiesOf(ImportEntityType.dives);
       expect(dives.length, 16);
 
+      // The export holds six site entries, two of which are 'Maclearie Park'
+      // 1.8 m apart -- Subsurface split them on GPS drift between two entries.
+      // They fold back into one site, and every dive that referenced either
+      // uuid follows the survivor.
       final sites = result.entitiesOf(ImportEntityType.sites);
-      expect(sites.length, 5);
+      expect(sites.length, 4);
+      expect(
+        sites.map((s) => s['name']),
+        containsAll(<String>['Maclearie Park']),
+      );
+      expect(
+        sites.where((s) => s['name'] == 'Maclearie Park').length,
+        1,
+        reason: 'GPS-drift duplicates of one site must not import twice',
+      );
+
+      final maclearieId = sites.firstWhere(
+        (s) => s['name'] == 'Maclearie Park',
+      )['uddfId'];
+      final maclearieDives = dives.where(
+        (d) => (d['site'] as Map<String, dynamic>?)?['uddfId'] == maclearieId,
+      );
+      expect(maclearieDives.length, greaterThan(1));
 
       // Verify a specific dive has expected data
       final dive1 = dives.firstWhere((d) => d['diveNumber'] == 1);

--- a/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/subsurface_xml_parser_test.dart
@@ -1151,6 +1151,45 @@ $dives
       expect(sites[0].containsKey('longitude'), isFalse);
     });
 
+    test('drops non-finite coordinates', () async {
+      // double.tryParse('NaN') succeeds, and every comparison against NaN is
+      // false, so a range check alone lets it through.
+      final result = await parser.parse(
+        xmlBytes(
+          divelog(
+            "<site uuid='aaa' name='Blue Hole' gps='NaN NaN'/>",
+            dive('aaa'),
+          ),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0].containsKey('latitude'), isFalse);
+      expect(sites[0].containsKey('longitude'), isFalse);
+    });
+
+    test('trims whitespace off the stored site name', () async {
+      final result = await parser.parse(
+        xmlBytes(
+          divelog("<site uuid='aaa' name='  Blue Hole  '/>", dive('aaa')),
+        ),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites[0]['name'], 'Blue Hole');
+    });
+
+    test('stores no uddfId when the uuid attribute is blank', () async {
+      final result = await parser.parse(
+        xmlBytes(divelog("<site uuid='  ' name='Blue Hole'/>", dive('aaa'))),
+      );
+
+      final sites = result.entitiesOf(ImportEntityType.sites);
+      expect(sites.length, 1);
+      expect(sites[0].containsKey('uddfId'), isFalse);
+    });
+
     test('skips a site with neither a name nor coordinates', () async {
       final result = await parser.parse(
         xmlBytes(divelog("<site uuid='aaa'/>", dive('aaa'))),


### PR DESCRIPTION
Addresses the coordinate and duplicate-site halves of #153. Media/photo import stays open and is tracked separately.

## The duplicate sites

Subsurface's `gps_in_dive()` starts a **new** dive site whenever a dive's GPS lands more than 20 m from every known one. A real logbook therefore accumulates a long tail of same-named entries a few metres apart, and the importer created a row for every one of them.

This repo's own fixture already contained the bug:

```
<site uuid='be380099' name='Maclearie Park' gps='40.179561 -74.037475'>
<site uuid='be38009a' name='Maclearie Park' gps='40.179575 -74.037466'>
```

Those are **1.8 m apart**. `subsurface_xml_parser_test.dart` asserted `expect(sites.length, 5)`, encoding the duplicate as correct behavior.

Folding now happens in the parser, which owns the uuid map and can redirect each dive's `divesiteid` in the same pass (`_parseSites` runs before the dive loop):

- Named entries fold into an earlier entry of the same name when within **1 km**; beyond that they are different places that happen to share a name.
- Entries Subsurface left unnamed fold into whatever site sits within **100 m**, matching the coincidence guard `SiteMatchingService` already applies.
- Named sites never fold into each other on proximity alone.
- The first entry of a name wins every field it carries; later entries only fill gaps, the same enrichment rule `PayloadMerger` uses across files.

## The lost coordinates

Two separate paths dropped a dive's location silently.

**Unnamed sites were discarded.** `_parseSites` did `if (name == null || name.isEmpty) continue;`. Subsurface omits the `name` attribute entirely for unnamed sites, so the site vanished, the dive's `divesiteid` resolved to nothing, and the dive imported with no site and no coordinates at all. No warning. Such a site is now kept, named from its coordinates.

**The importer resolved a two-predicate match with one predicate.** `ImportDuplicateChecker` flags an incoming site as a duplicate on name **or** on 100 m proximity, and the wizard then leaves it out of the selection. But `UddfEntityImporter._importSites` bound a deselected site's `uddfId` to an existing row **by lowercase name only**. A site caught by the proximity arm carries a different name, so nothing matched and every dive referencing it lost its site link. The fallback now falls through to the nearest existing site within 100 m. This one is format-agnostic and fixes the same hole for UDDF and CSV imports.

## Also

- `gps` accepts the comma separator Subsurface's own `parse_location()` accepts, and rejects a pair that is off the globe instead of storing it.
- The `description` attribute on `<site>`, previously discarded, is now read. `UddfEntityImporter` already mapped that key, so it flows straight through.
- The dead `siteMap` parameter that `parse()` built and threaded into `_parseDive` but never read is replaced by the alias map that is actually used.

## Structure

Folding lives in `lib/features/universal_import/data/parsers/subsurface/subsurface_site_folder.dart` rather than in the parser, which was already at 1060 lines, past the 800-line ceiling in CLAUDE.md. It is a pure function over the raw site maps, so it is testable without XML.

## Testing

18 new tests, written before the implementation and watched fail:

- same-name folding within/beyond the radius, case and whitespace variants, and folding when one side has no GPS
- unnamed site retained with a coordinate name; unnamed folding into a named neighbour, into another unnamed site, and staying separate when far away
- named sites never folding on proximity alone
- survivor field enrichment
- comma-separated and out-of-range coordinates
- a site with neither name nor coordinates dropped
- the importer's proximity link arm, its negative case, and name-match precedence over a nearer differently-named site

The real-export integration test now asserts the folded count and that both dives which referenced either Maclearie uuid follow the survivor.

Full suite: 18863 passed, 19 skipped, 1 failed. The failure is `security_settings_page_test.dart`, which passes in isolation; it is the known Argon2id/`pumpAndSettle` full-suite flake and is unrelated to this diff. `flutter analyze` clean, `dart format` clean.

## Not in this PR

Subsurface writes `<picture filename='...' offset='...' gps='...'/>` per dive and none of it is read: no parser touches media, and `ImportEntityType` has no media member, so a payload structurally cannot carry photos. That needs its own design, mainly because Subsurface stores absolute paths from the exporting machine. Tracked separately; #153 should stay open until it lands.
