### PR TITLE
fix(stats): derive time-at-depth from timestamps, not sample counts

### DIFF
--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -2171,8 +2171,17 @@ class StatisticsRepository {
   ///
   /// Each dive's intervals are capped at [_maxSampleGapFactor] times that
   /// profile's own mean interval so a recording pause is not banked as bottom
-  /// time. The last sample of a profile closes no interval and so contributes
-  /// nothing, which costs one sample interval per dive.
+  /// time. A profile's total therefore spans its first sample to its last: the
+  /// last sample opens no interval, and whatever time the diver spent after it
+  /// was never recorded and cannot be recovered here.
+  ///
+  /// Samples are ordered by `(timestamp, id)` rather than timestamp alone.
+  /// Ties cannot lose time whichever way they fall -- every row but the last
+  /// of a tied group yields a zero-length interval, and the last carries the
+  /// whole step to the next timestamp -- but if tied rows sit in different
+  /// buckets, the tie order decides which bucket that step lands in. Ordering
+  /// by row id makes that choice reproducible instead of leaving it to
+  /// SQLite.
   ///
   /// Only primary profile rows are counted, matching [getAscentDescentRates]:
   /// a dive logged by two computers, or one whose original profile was demoted
@@ -2195,6 +2204,7 @@ class StatisticsRepository {
           SELECT
             p.dive_id AS dive_id,
             p.computer_id AS computer_id,
+            p.id AS sample_id,
             p.timestamp AS at,
             p.depth AS depth
           FROM dive_profiles p
@@ -2218,7 +2228,9 @@ class StatisticsRepository {
             depth,
             LEAD(at) OVER w - at AS seconds
           FROM samples
-          WINDOW w AS (PARTITION BY dive_id, computer_id ORDER BY at)
+          WINDOW w AS (
+            PARTITION BY dive_id, computer_id ORDER BY at, sample_id
+          )
         )
         SELECT
           CASE

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -131,6 +131,20 @@ class StatisticsRepository {
   /// actually go up and down".
   static const double _sustainedTransitThreshold = 3.0;
 
+  /// How many times its own mean sample interval a profile may skip before
+  /// [getTimeAtDepthRanges] stops crediting the skip as time at that depth.
+  ///
+  /// Recording gaps are real: a computer paused mid-dive, a surface interval
+  /// swallowed into one dive record, a profile stitched from two downloads.
+  /// Charging the whole pause to whichever bucket the last sample before it
+  /// happened to sit in would invent hours of bottom time. The bound is
+  /// relative to the profile's own cadence rather than an absolute number of
+  /// seconds because recording intervals in a real library run from 1 s to a
+  /// minute or more, and a manually keyed profile is sparser still. Four times
+  /// the mean leaves room for ordinary jitter and the occasional dropped
+  /// sample while cutting anything an order of magnitude larger down to size.
+  static const int _maxSampleGapFactor = 4;
+
   /// Builds the `AND <alias>.id IN (<subquery>)` fragment + raw params for a
   /// stats filter. Empty (no-op) when the filter has no active axes.
   ({String clause, List<Object?> params}) _diveFilter(
@@ -2144,6 +2158,28 @@ class StatisticsRepository {
   /// display layer converts to the user's preferred depth unit so the chart's
   /// axis label and bucket labels match the setting. The top bucket is
   /// open-ended ([upperDepth] is null).
+  ///
+  /// Minutes come from the sample timestamps, not from a row count: the
+  /// interval between one sample and the next is credited to the bucket the
+  /// earlier sample sits in. Counting rows and calling each one a second, as
+  /// this query used to, is only right for a computer sampling at 1 Hz: for
+  /// the many that record every 2, 4, 5, 10 or 20 seconds it divides every
+  /// bucket by that interval. Differencing timestamps needs no
+  /// assumption about the recording rate at all, and it makes duplicate rows
+  /// from a repeated import harmless: the repeat adds a zero-length interval
+  /// rather than a second helping of time.
+  ///
+  /// Each dive's intervals are capped at [_maxSampleGapFactor] times that
+  /// profile's own mean interval so a recording pause is not banked as bottom
+  /// time. The last sample of a profile closes no interval and so contributes
+  /// nothing, which costs one sample interval per dive.
+  ///
+  /// Only primary profile rows are counted, matching [getAscentDescentRates]:
+  /// a dive logged by two computers, or one whose original profile was demoted
+  /// by an edit, otherwise contributes both sample streams and roughly doubles
+  /// every bucket. Note that a dive left with no primary rows at all is
+  /// skipped entirely -- see issue #1149, which tracks the promotion bug that
+  /// can produce that state.
   Future<List<({int lowerDepth, int? upperDepth, int minutes})>>
   getTimeAtDepthRanges({
     String? diverId,
@@ -2155,31 +2191,58 @@ class StatisticsRepository {
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
+        WITH samples AS (
+          SELECT
+            p.dive_id AS dive_id,
+            p.computer_id AS computer_id,
+            p.timestamp AS at,
+            p.depth AS depth
+          FROM dive_profiles p
+          JOIN dives d ON d.id = p.dive_id
+          WHERE p.is_primary = 1 $diverFilter ${df.clause}
+        ),
+        cadence AS (
+          SELECT
+            dive_id,
+            computer_id,
+            (MAX(at) - MIN(at)) * $_maxSampleGapFactor / (COUNT(*) - 1.0)
+              AS max_interval
+          FROM samples
+          GROUP BY dive_id, computer_id
+          HAVING COUNT(*) > 1
+        ),
+        intervals AS (
+          SELECT
+            dive_id,
+            computer_id,
+            depth,
+            LEAD(at) OVER w - at AS seconds
+          FROM samples
+          WINDOW w AS (PARTITION BY dive_id, computer_id ORDER BY at)
+        )
         SELECT
           CASE
-            WHEN p.depth < 10 THEN 0
-            WHEN p.depth < 20 THEN 10
-            WHEN p.depth < 30 THEN 20
-            WHEN p.depth < 40 THEN 30
+            WHEN i.depth < 10 THEN 0
+            WHEN i.depth < 20 THEN 10
+            WHEN i.depth < 30 THEN 20
+            WHEN i.depth < 40 THEN 30
             ELSE 40
           END AS bucket_lo,
-          COUNT(*) AS sample_count
-        FROM dive_profiles p
-        JOIN dives d ON d.id = p.dive_id
-        WHERE 1=1 $diverFilter ${df.clause}
+          SUM(MIN(i.seconds * 1.0, c.max_interval)) AS seconds
+        FROM intervals i
+        JOIN cadence c
+          ON c.dive_id = i.dive_id AND c.computer_id IS i.computer_id
+        WHERE i.seconds > 0
         GROUP BY bucket_lo
         ORDER BY bucket_lo
         ''', variables: params.map((p) => Variable(p)).toList()).get();
 
-      // Sample count approximates minutes (profiles are usually sampled every
-      // second or few seconds) — a rough estimate matching the original
-      // implementation.
       return results.map((row) {
         final lo = row.read<int>('bucket_lo');
         return (
           lowerDepth: lo,
           upperDepth: lo >= 40 ? null : lo + 10,
-          minutes: (row.read<int>('sample_count') / 60).round(),
+          minutes: (row.read<double>('seconds') / 60).round(),
         );
       }).toList();
     } catch (e, stackTrace) {

--- a/test/features/statistics/data/repositories/statistics_repository_time_at_depth_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_time_at_depth_test.dart
@@ -1,0 +1,273 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = StatisticsRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> diver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value(id),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> dive(String id, {String? diverId}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            diverId: Value(diverId),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> computer(String id) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            name: Value(id),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Inserts profile samples as (timestamp seconds, depth meters) pairs.
+  Future<void> profile(
+    String diveId,
+    List<(int, double)> samples, {
+    bool isPrimary = true,
+    String? computerId,
+    String idPrefix = 'row',
+  }) async {
+    await db.batch((batch) {
+      for (final (index, sample) in samples.indexed) {
+        batch.insert(
+          db.diveProfiles,
+          DiveProfilesCompanion(
+            id: Value('$diveId-${computerId ?? 'dc'}-$idPrefix-$index'),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            timestamp: Value(sample.$1),
+            depth: Value(sample.$2),
+          ),
+        );
+      }
+    });
+  }
+
+  /// Holds [depth] from [from] to [to] seconds, sampled every [every] seconds.
+  ///
+  /// The closing sample lands exactly on [to], so the samples span `to - from`
+  /// seconds of elapsed time regardless of the interval.
+  List<(int, double)> level(
+    double depth, {
+    required int from,
+    required int to,
+    required int every,
+  }) => [for (var t = from; t <= to; t += every) (t, depth)];
+
+  int? minutesAt(
+    List<({int lowerDepth, int? upperDepth, int minutes})> ranges,
+    int lowerDepth,
+  ) {
+    for (final range in ranges) {
+      if (range.lowerDepth == lowerDepth) return range.minutes;
+    }
+    return null;
+  }
+
+  test('reports elapsed minutes, not one minute per sixty samples', () async {
+    await dive('a');
+    // 30 minutes held at 5 m, sampled every 4 s: 451 rows. Counting rows and
+    // dividing by 60 reports 8 minutes for the same half hour.
+    await profile('a', level(5.0, from: 0, to: 1800, every: 4));
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    expect(minutesAt(ranges, 0), 30);
+  });
+
+  test('is independent of the recording interval', () async {
+    await dive('fast');
+    await profile('fast', level(5.0, from: 0, to: 1800, every: 1));
+    await dive('slow');
+    await profile('slow', level(25.0, from: 0, to: 1800, every: 20));
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    // The same half hour underwater, recorded twenty times more sparsely.
+    expect(minutesAt(ranges, 0), 30);
+    expect(minutesAt(ranges, 20), 30);
+  });
+
+  test('attributes each interval to the depth it started at', () async {
+    await dive('a');
+    await profile('a', [
+      ...level(5.0, from: 0, to: 300, every: 5),
+      ...level(15.0, from: 305, to: 900, every: 5),
+      ...level(45.0, from: 905, to: 1200, every: 5),
+    ]);
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    // Each leg carries the 5 s step that leaves it into its own bucket, so the
+    // three legs are 305 s, 600 s and 295 s: 5, 10 and 5 minutes.
+    expect(minutesAt(ranges, 0), 5);
+    expect(minutesAt(ranges, 10), 10);
+    expect(minutesAt(ranges, 40), 5);
+    expect(minutesAt(ranges, 20), isNull);
+  });
+
+  test('leaves the deepest bucket open-ended', () async {
+    await dive('a');
+    await profile('a', level(60.0, from: 0, to: 600, every: 10));
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    expect(ranges.single.lowerDepth, 40);
+    expect(ranges.single.upperDepth, isNull);
+  });
+
+  test('counts only the primary profile of a multi-computer dive', () async {
+    await dive('a');
+    await computer('dc-primary');
+    await computer('dc-secondary');
+    await profile(
+      'a',
+      level(5.0, from: 0, to: 1800, every: 4),
+      computerId: 'dc-primary',
+    );
+    // The same dive as logged by a second, demoted computer. Counting both
+    // sample streams doubles every bucket.
+    await profile(
+      'a',
+      level(5.0, from: 0, to: 1800, every: 2),
+      isPrimary: false,
+      computerId: 'dc-secondary',
+    );
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    expect(minutesAt(ranges, 0), 30);
+  });
+
+  test('is unaffected by exact duplicate profile rows', () async {
+    await dive('a');
+    // A repeated import stores every sample twice. Row counts double; the
+    // elapsed time between distinct timestamps does not.
+    await profile('a', level(5.0, from: 0, to: 1800, every: 4));
+    await profile(
+      'a',
+      level(5.0, from: 0, to: 1800, every: 4),
+      idPrefix: 'reimport',
+    );
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    expect(minutesAt(ranges, 0), 30);
+  });
+
+  test('clamps a recording gap instead of crediting it to a bucket', () async {
+    await dive('a');
+    // Fifteen minutes recorded, forty minutes of silence, fifteen more. The
+    // pause must not read as forty minutes spent at 5 m.
+    await profile('a', [
+      ...level(5.0, from: 0, to: 900, every: 2),
+      ...level(5.0, from: 3300, to: 4200, every: 2),
+    ]);
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    expect(minutesAt(ranges, 0), closeTo(30, 1));
+  });
+
+  test('applies the statistics dive filter', () async {
+    await db
+        .into(db.tags)
+        .insert(
+          TagsCompanion(
+            id: const Value('deep'),
+            name: const Value('deep'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    await dive('a');
+    await profile('a', level(25.0, from: 0, to: 1800, every: 4));
+    await dive('b');
+    await profile('b', level(25.0, from: 0, to: 1800, every: 4));
+    await db
+        .into(db.diveTags)
+        .insert(
+          DiveTagsCompanion(
+            id: const Value('a-deep'),
+            diveId: const Value('a'),
+            tagId: const Value('deep'),
+            createdAt: Value(now),
+          ),
+        );
+
+    final unfiltered = await repo.getTimeAtDepthRanges();
+    expect(minutesAt(unfiltered, 20), 60);
+
+    final filtered = await repo.getTimeAtDepthRanges(
+      filter: const DiveFilterState(tagIds: ['deep']),
+    );
+    expect(minutesAt(filtered, 20), 30);
+  });
+
+  test('scopes the totals to the requested diver', () async {
+    await diver('diver-1');
+    await diver('diver-2');
+    await dive('a', diverId: 'diver-1');
+    await profile('a', level(5.0, from: 0, to: 1800, every: 4));
+    await dive('b', diverId: 'diver-2');
+    await profile('b', level(5.0, from: 0, to: 600, every: 4));
+
+    expect(
+      minutesAt(await repo.getTimeAtDepthRanges(diverId: 'diver-1'), 0),
+      30,
+    );
+    expect(
+      minutesAt(await repo.getTimeAtDepthRanges(diverId: 'diver-2'), 0),
+      10,
+    );
+  });
+
+  test('returns nothing for a single-sample profile', () async {
+    await dive('a');
+    await profile('a', [(0, 12.0)]);
+
+    expect(await repo.getTimeAtDepthRanges(), isEmpty);
+  });
+}

--- a/test/features/statistics/data/repositories/statistics_repository_time_at_depth_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_time_at_depth_test.dart
@@ -264,6 +264,27 @@ void main() {
     );
   });
 
+  test('neither loses nor invents time when timestamps tie', () async {
+    await dive('a');
+    // Two samples share t=300 s at depths that fall in different buckets. The
+    // window orders by (timestamp, id), so the tie is broken by row id: the
+    // 11 m row sorts last and carries the interval that leaves the tie.
+    await profile('a', [
+      (0, 5.0),
+      (300, 9.0),
+      (300, 11.0),
+      (600, 5.0),
+      (900, 5.0),
+    ]);
+
+    final ranges = await repo.getTimeAtDepthRanges();
+
+    // 900 s elapsed from the first sample to the last, split 600/300.
+    expect(ranges.fold<int>(0, (sum, r) => sum + r.minutes), 15);
+    expect(minutesAt(ranges, 0), 10);
+    expect(minutesAt(ranges, 10), 5);
+  });
+
   test('returns nothing for a single-sample profile', () async {
     await dive('a');
     await profile('a', [(0, 12.0)]);


### PR DESCRIPTION
## Summary

Fixes #1148. The Statistics > Profile Analysis "time at depth" card counted
profile rows per depth bucket and divided by 60, which is only correct for a
computer sampling at 1 Hz. Plenty record every 2, 4, 5, 10 or 20 seconds, and
for those the card divided every bucket by that interval: 30 real minutes held
at 5 m, sampled every 4 s, reported 8 minutes.

Minutes now come from the sample timestamps. Consecutive samples within a dive
are differenced, and each interval is credited to the bucket of its starting
depth, which needs no assumption about the recording rate at all. The query
also picks up the `is_primary = 1` filter its sibling `getAscentDescentRates`
already carries.

**One correction to the issue:** the sign is backwards there. Row counting
treats each sample as one second, so it *understates* time at depth by the
sample interval; it does not overstate it. Reading the reporter's screenshot
that way, 726 min in the 0-10 m bucket over 167 dives is 4.3 min of shallow
time per dive, which a 3-minute safety stop alone nearly exhausts. The real
figure is closer to 54 hours. The missing `is_primary` filter pushed counts the
other way, which is presumably how the two got conflated. Same fix either way.

## Changes

- `getTimeAtDepthRanges` now sums `LEAD(timestamp) - timestamp` per bucket
  instead of `COUNT(*) / 60`, partitioned by `(dive_id, computer_id)` the same
  way the ascent/descent query is.
- Intervals are capped at `_maxSampleGapFactor` (4) times the profile's own
  mean interval, so a recording pause is not banked as bottom time. The bound
  is relative rather than an absolute number of seconds because real recording
  intervals span 1 s to a minute or more, and a hand-keyed profile is sparser
  still.
- Adds `WHERE p.is_primary = 1`. A dive logged by two computers, or one whose
  original profile was demoted by an edit, previously contributed both sample
  streams and roughly doubled every bucket.
- A repeated import's duplicate rows now add a zero-length interval instead of
  a second helping of time; `COUNT(*)` doubled them.
- New test file, 10 tests, all written before the fix and watched fail.

No UI change: the card consumes the same `minutes` field.

## Known limitation, tracked separately

A dive left with **no** primary profile rows is now skipped by this card
entirely. That state is reachable today through `setPrimaryDataSource`, which
demotes every row then re-promotes only ones matching a non-null `computerId`
(file imports have NULL on both sides). That is filed as #1149 and referenced
from the docstring; fixing it here would mean touching dive-log write paths.
Note `getAscentDescentRates` has had the same exposure since it shipped, so
#1149 fixes both at once.

## Performance

Measured on 720k profile rows (200 dives x 3600 samples): **100 ms to ~950 ms**,
one query behind a keep-alive `FutureProvider`. A covering index on
`dive_profiles(dive_id, computer_id, timestamp)` only got to 880 ms, because
`depth` still forces table lookups, so it was not worth the write amplification
on the largest table in the database. That matches the precedent already
documented in `performance_indexes.dart`, where an index the planner did not
earn its keep with was dropped rather than shipped.

## Test Plan

- [x] `flutter test test/features/statistics` passes (183 tests)
- [x] `flutter analyze` passes (no issues, whole project)
- [x] `dart format` clean
- [x] Pre-push hook's ranked subset passes (84 tests across 13 files)
- [x] Manual testing: not run; the card's inputs are covered by the new
      repository tests and no presentation code changed

### What the new tests pin

| Test | Before | After |
| --- | --- | --- |
| elapsed minutes, not rows/60 | 8 | 30 |
| independent of recording interval (1 s vs 20 s) | 30 / 2 | 30 / 30 |
| interval attributed to its starting depth | wrong split | 5 / 10 / 5 min |
| only the primary profile of a multi-computer dive | 23 | 30 |
| duplicate rows from a repeated import | 15 | 30 |
| recording gap clamped | 15 | 30 (unclamped: 70) |
