### PR TITLE
fix(stats): report deco obligation from the app's own analysis, not an unpopulated column

### DIFF
--- a/docs/superpowers/plans/2026-08-18-deco-obligation-statistic.md
+++ b/docs/superpowers/plans/2026-08-18-deco-obligation-statistic.md
@@ -1136,9 +1136,9 @@ Refs #623"
 
 ---
 
-## Follow-up issues to file
+## Follow-up issues
 
-Both were found during the #623 investigation, are real, and are deliberately out of scope here:
+Both were found during the #623 investigation, are real, and were deliberately out of scope here. Filed 2026-08-18:
 
-1. `getTimeAtDepthRanges` counts profile rows and divides by 60, assuming 1 Hz sampling. At a 4-5 s sample interval the card understates time at depth by that factor. It also omits the `is_primary` filter, so a dive logged by two computers is double-counted.
-2. `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`) demotes every `dive_profiles` row for a dive, then re-promotes only rows whose `computer_id` matches `newPrimary.computerId`, and only when that id is non-null. File-imported dives have a null `computerId` on both the data source row and the profile rows, so nothing is re-promoted and the dive ends up with no primary profile. Any query gated on `is_primary = 1`, including the ascent/descent rates card, then silently skips that dive.
+1. **#1148**: `getTimeAtDepthRanges` counts profile rows and divides by 60, assuming 1 Hz sampling. At a 4-5 s sample interval the card understates time at depth by that factor. It also omits the `is_primary` filter, so a dive logged by two computers is double-counted.
+2. **#1149**: `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`) demotes every `dive_profiles` row for a dive, then re-promotes only rows whose `computer_id` matches `newPrimary.computerId`, and only when that id is non-null. File-imported dives have a null `computerId` on both the data source row and the profile rows, so nothing is re-promoted and the dive ends up with no primary profile. Any query gated on `is_primary = 1`, including the ascent/descent rates card, then silently skips that dive.

--- a/docs/superpowers/plans/2026-08-18-deco-obligation-statistic.md
+++ b/docs/superpowers/plans/2026-08-18-deco-obligation-statistic.md
@@ -1,0 +1,1144 @@
+# Decompression Obligation Statistic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Statistics tab's "Decompression Obligation" card report the same deco determination the dive detail page shows, instead of reading a computer-reported column that most import sources never populate.
+
+**Architecture:** Classify each dive from recorded profile signals first (`deco_type = 2`, `decoStopStart` events, then `ceiling > 0` only for sources that write no `deco_type`), fall back to the app's own Buhlmann analysis via `profileAnalysisProvider` for dives with a profile but no recorded signal, and report dives with no profile as "not recorded" rather than counting them as no-deco. Computed answers are memoized in `local_cache_database.dart`, which is never synced or backed up, keyed by an inputs fingerprint so a changed profile or changed gradient factors recompute.
+
+**Tech Stack:** Flutter, Drift ORM (SQLite), Riverpod, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md`
+
+## Global Constraints
+
+- No em-dashes (U+2014) in any output, including code, comments, docs, and commit messages. En-dashes as sentence punctuation and spaced hyphens are equally forbidden. Numeric ranges (`2020-2024`) and CLI flags keep hyphens.
+- No emojis in code, comments, or documentation.
+- `dart format .` must produce no changes before any commit.
+- `flutter analyze` must be clean across the whole project. Infos are fatal in CI.
+- Anything displaying units must respect the active diver's unit settings.
+- New user-facing strings go in `lib/l10n/arb/app_en.arb` and must be translated into every locale present in `lib/l10n/arb/`: ar, de, es, fr, he, hu, it, nl, pt, zh.
+- Immutability: never mutate objects or arrays in place.
+- Run all commands from the worktree root. Do not `cd` to the main checkout.
+- Re-derivable data belongs in `local_cache_database.dart`, never the synced main DB.
+
+---
+
+### Task 1: Correct the recorded-signal classification and stop asserting a false zero
+
+Today `getDecoObligationStats` counts a deco dive as any dive with a sample where `ceiling > 0`. That over-counts (a 5 m safety stop writes `ceiling = 5`, because the mappers set `ceiling` for any non-zero `deco_type`, and `1 = safetystop`) and under-counts (dives from sources that never write `ceiling` are silently reported as no-deco). This task fixes the predicate and introduces the "not recorded" bucket so the card stops claiming certainty it does not have.
+
+**Files:**
+- Modify: `lib/features/statistics/data/repositories/statistics_repository.dart:2195-2227`
+- Modify: `lib/features/statistics/presentation/providers/statistics_providers.dart:498-508`
+- Modify: `lib/features/statistics/presentation/pages/statistics_profile_page.dart:191-281`
+- Modify: `lib/l10n/arb/app_en.arb` and the ten locale ARB files
+- Test: `test/features/statistics/data/repositories/statistics_repository_deco_test.dart` (create)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `DecoSignalScan` typedef in `statistics_repository.dart`:
+    ```dart
+    typedef DecoSignalScan = ({
+      Set<String> recordedDeco,
+      Set<String> recordedNoDeco,
+      Map<String, int> needsCompute,
+      Set<String> noProfile,
+    });
+    ```
+    `needsCompute` maps dive id to that dive's `dives.updated_at`, which the
+    computed step uses as the profile revision in its cache fingerprint. The
+    `Dive` entity returned by `getDiveForAnalysis` carries no `updatedAt`, so
+    the scan is the only place that value is cheaply available.
+  - `Future<DecoSignalScan> StatisticsRepository.scanRecordedDecoSignals({String? diverId, DiveFilterState filter})`
+  - `Future<({int decoCount, int noDecoCount, int unknownCount})> StatisticsRepository.getDecoObligationStats({String? diverId, DiveFilterState filter})`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/statistics/data/repositories/statistics_repository_deco_test.dart`:
+
+```dart
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = StatisticsRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> dive(String id) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Inserts profile samples as (timestamp, depth, decoType, ceiling) tuples.
+  Future<void> profile(
+    String diveId,
+    List<(int, double, int?, double?)> samples,
+  ) async {
+    var index = 0;
+    for (final (ts, depth, decoType, ceiling) in samples) {
+      await db
+          .into(db.diveProfiles)
+          .insert(
+            DiveProfilesCompanion(
+              id: Value('$diveId-row-${index++}'),
+              diveId: Value(diveId),
+              timestamp: Value(ts),
+              depth: Value(depth),
+              decoType: Value(decoType),
+              ceiling: Value(ceiling),
+            ),
+          );
+    }
+  }
+
+  Future<void> decoStopEvent(String diveId) async {
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          DiveProfileEventsCompanion(
+            id: Value('$diveId-evt'),
+            diveId: Value(diveId),
+            timestamp: const Value(600),
+            eventType: const Value('decoStopStart'),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  group('scanRecordedDecoSignals', () {
+    test('a safety stop is not a decompression obligation', () async {
+      await dive('safety');
+      // deco_type 1 is DC_DECO_SAFETYSTOP; the mapper writes ceiling for it.
+      await profile('safety', [
+        (0, 10.0, 0, null),
+        (300, 30.0, 0, null),
+        (600, 5.0, 1, 5.0),
+      ]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, isEmpty);
+      expect(scan.recordedNoDeco, {'safety'});
+    });
+
+    test('a deco stop sample is a decompression obligation', () async {
+      await dive('deco');
+      await profile('deco', [
+        (0, 10.0, 0, null),
+        (300, 45.0, 2, 9.0),
+      ]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, {'deco'});
+      expect(scan.recordedNoDeco, isEmpty);
+    });
+
+    test('a decoStopStart event is a decompression obligation', () async {
+      await dive('evt');
+      await profile('evt', [(0, 10.0, null, null)]);
+      await decoStopEvent('evt');
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, {'evt'});
+      expect(scan.needsCompute, isEmpty);
+    });
+
+    test('ceiling alone counts only when the source wrote no decoType',
+        () async {
+      await dive('ceilingOnly');
+      // Subsurface XML and DAN DL7 write ceiling without any decoType.
+      await profile('ceilingOnly', [
+        (0, 10.0, null, null),
+        (300, 45.0, null, 9.0),
+      ]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, {'ceilingOnly'});
+    });
+
+    test('a profile with no deco signal at all needs computing', () async {
+      await dive('bare');
+      await profile('bare', [
+        (0, 10.0, null, null),
+        (300, 45.0, null, null),
+      ]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.needsCompute.keys, {'bare'});
+      expect(scan.recordedNoDeco, isEmpty);
+      expect(scan.noProfile, isEmpty);
+    });
+
+    test('a dive with no profile is unclassifiable', () async {
+      await dive('manual');
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.noProfile, {'manual'});
+      expect(scan.needsCompute, isEmpty);
+    });
+  });
+
+  group('getDecoObligationStats', () {
+    test('unclassifiable dives are reported separately, not as no-deco',
+        () async {
+      await dive('deco');
+      await profile('deco', [(300, 45.0, 2, 9.0)]);
+      await dive('manual');
+
+      final stats = await repo.getDecoObligationStats();
+
+      expect(stats.decoCount, 1);
+      expect(stats.noDecoCount, 0);
+      expect(stats.unknownCount, 1);
+    });
+
+    test('honours the diver filter', () async {
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion(
+              id: const Value('diver-a'),
+              name: const Value('A'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion(
+              id: const Value('mine'),
+              diveDateTime: Value(now),
+              diverId: const Value('diver-a'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await profile('mine', [(300, 45.0, 2, 9.0)]);
+      await dive('theirs');
+      await profile('theirs', [(300, 45.0, 2, 9.0)]);
+
+      final stats = await repo.getDecoObligationStats(diverId: 'diver-a');
+
+      expect(stats.decoCount, 1);
+      expect(stats.unknownCount, 0);
+      expect(stats.noDecoCount, 0);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/statistics/data/repositories/statistics_repository_deco_test.dart`
+Expected: FAIL. `scanRecordedDecoSignals` is not defined, and `getDecoObligationStats` returns a record without `noDecoCount` or `unknownCount`.
+
+- [ ] **Step 3: Replace the repository method**
+
+In `lib/features/statistics/data/repositories/statistics_repository.dart`, add the typedef near the top of the file, after the imports:
+
+```dart
+/// Per-dive outcome of the recorded (non-computed) deco classification.
+///
+/// The four sets partition the filtered dive library. `needsCompute` holds
+/// dives that have a profile but no recorded deco signal, which is the input
+/// to the computed fallback; `noProfile` holds dives that can never be
+/// classified from stored data.
+typedef DecoSignalScan = ({
+  Set<String> recordedDeco,
+  Set<String> recordedNoDeco,
+  Map<String, int> needsCompute,
+  Set<String> noProfile,
+});
+```
+
+Replace the whole of `getDecoObligationStats` (currently at `:2195-2227`) with:
+
+```dart
+  /// Classifies each filtered dive's decompression obligation from recorded
+  /// profile data alone.
+  ///
+  /// Resolution order, highest confidence first:
+  ///
+  /// 1. `deco_type = 2` (DC_DECO_DECOSTOP per libdc_wrapper.h) or a
+  ///    `decoStopStart` profile event means deco. Types 1 and 3 are safety
+  ///    and deep stops, which are not decompression obligations; the old
+  ///    `ceiling > 0` test counted both, because both mappers write
+  ///    `ceiling = decoDepth` for any non-zero deco type.
+  /// 2. A profile that carries `deco_type` values, none of which is 2, means
+  ///    no deco. The computer was recording obligations and reported none.
+  /// 3. `ceiling > 0` on a profile with no `deco_type` at all means deco.
+  ///    Subsurface XML, DAN DL7 and FIT write a stop depth without a type,
+  ///    so this clause keeps them working without re-admitting safety stops.
+  /// 4. Anything else with a profile needs the computed fallback: many
+  ///    sources (MacDive, Shearwater Cloud, generic UDDF, CSV, OCR) record
+  ///    no deco columns at all, and for those the app's own analysis is the
+  ///    only evidence there is. It is also what the dive detail page shows.
+  /// 5. A dive with no profile is unclassifiable and must not be counted as
+  ///    no-deco.
+  Future<DecoSignalScan> scanRecordedDecoSignals({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) async {
+    try {
+      final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
+      final df = _diveFilter(filter, alias: 'd');
+      final params = diverId != null ? [diverId, ...df.params] : [...df.params];
+
+      final results = await _db.customSelect('''
+        WITH scoped AS (
+          SELECT d.id AS dive_id
+          FROM dives d
+          WHERE 1=1 $diverFilter ${df.clause}
+        ),
+        signals AS (
+          SELECT
+            s.dive_id AS dive_id,
+            MAX(CASE WHEN p.id IS NOT NULL THEN 1 ELSE 0 END) AS has_profile,
+            MAX(CASE WHEN p.deco_type IS NOT NULL THEN 1 ELSE 0 END)
+              AS has_deco_type,
+            MAX(CASE WHEN p.deco_type = 2 THEN 1 ELSE 0 END) AS deco_stop,
+            MAX(CASE WHEN p.ceiling > 0 THEN 1 ELSE 0 END) AS positive_ceiling
+          FROM scoped s
+          LEFT JOIN dive_profiles p ON p.dive_id = s.dive_id
+          GROUP BY s.dive_id
+        ),
+        stop_events AS (
+          SELECT DISTINCT e.dive_id AS dive_id
+          FROM dive_profile_events e
+          JOIN scoped s ON s.dive_id = e.dive_id
+          WHERE e.event_type = 'decoStopStart'
+        )
+        SELECT
+          sig.dive_id AS dive_id,
+          d.updated_at AS updated_at,
+          CASE
+            WHEN sig.deco_stop = 1 OR ev.dive_id IS NOT NULL THEN 'deco'
+            WHEN sig.has_deco_type = 1 THEN 'no_deco'
+            WHEN sig.positive_ceiling = 1 THEN 'deco'
+            WHEN sig.has_profile = 1 THEN 'compute'
+            ELSE 'no_profile'
+          END AS classification
+        FROM signals sig
+        JOIN dives d ON d.id = sig.dive_id
+        LEFT JOIN stop_events ev ON ev.dive_id = sig.dive_id
+        ''', variables: params.map((p) => Variable(p)).toList()).get();
+
+      final recordedDeco = <String>{};
+      final recordedNoDeco = <String>{};
+      final needsCompute = <String, int>{};
+      final noProfile = <String>{};
+      for (final row in results) {
+        final id = row.read<String>('dive_id');
+        switch (row.read<String>('classification')) {
+          case 'deco':
+            recordedDeco.add(id);
+          case 'no_deco':
+            recordedNoDeco.add(id);
+          case 'compute':
+            needsCompute[id] = row.read<int?>('updated_at') ?? 0;
+          default:
+            noProfile.add(id);
+        }
+      }
+      return (
+        recordedDeco: recordedDeco,
+        recordedNoDeco: recordedNoDeco,
+        needsCompute: needsCompute,
+        noProfile: noProfile,
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to scan recorded deco signals',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return (
+        recordedDeco: const <String>{},
+        recordedNoDeco: const <String>{},
+        needsCompute: const <String, int>{},
+        noProfile: const <String>{},
+      );
+    }
+  }
+
+  /// Deco obligation counts from recorded data alone.
+  ///
+  /// Dives needing the computed fallback are reported as unknown here. The
+  /// statistics provider composes this with the computed classification
+  /// cache; this method is the recorded-only view used by tests and by any
+  /// caller that must not trigger analysis work.
+  Future<({int decoCount, int noDecoCount, int unknownCount})>
+  getDecoObligationStats({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) async {
+    final scan = await scanRecordedDecoSignals(
+      diverId: diverId,
+      filter: filter,
+    );
+    return (
+      decoCount: scan.recordedDeco.length,
+      noDecoCount: scan.recordedNoDeco.length,
+      unknownCount: scan.needsCompute.length + scan.noProfile.length,
+    );
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/statistics/data/repositories/statistics_repository_deco_test.dart`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Update the provider's type**
+
+In `lib/features/statistics/presentation/providers/statistics_providers.dart`, change the `decoObligationStatsProvider` declaration's type argument only:
+
+```dart
+final decoObligationStatsProvider =
+    FutureProvider<({int decoCount, int noDecoCount, int unknownCount})>((
+      ref,
+    ) async {
+      _keepAliveWithExpiry(ref);
+      final repository = ref.watch(statisticsRepositoryProvider);
+      final currentDiverId = ref.watch(currentDiverIdProvider);
+      final filter = ref.watch(statisticsFilterProvider);
+      return repository.getDecoObligationStats(
+        diverId: currentDiverId,
+        filter: filter,
+      );
+    });
+```
+
+- [ ] **Step 6: Add the "not recorded" string to English**
+
+In `lib/l10n/arb/app_en.arb`, add alongside the existing `statistics_profile_deco_*` keys (keep the file's alphabetical ordering):
+
+```json
+  "statistics_profile_deco_notRecorded": "Not Recorded",
+```
+
+And immediately after the existing `"@statistics_profile_deco_semanticLabel"` block, add:
+
+```json
+  "statistics_profile_deco_notRecordedHint": "{count} dives have no recorded or computable deco data and are excluded from the rate",
+  "@statistics_profile_deco_notRecordedHint": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+```
+
+- [ ] **Step 7: Translate into every locale**
+
+Add both keys to each of `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`. French, matching the reporter's locale:
+
+```json
+  "statistics_profile_deco_notRecorded": "Non enregistré",
+  "statistics_profile_deco_notRecordedHint": "{count} plongées n'ont aucune donnée de décompression enregistrée ou calculable et sont exclues du taux",
+```
+
+German: `"Nicht erfasst"`. Spanish: `"Sin registrar"`. Italian: `"Non registrato"`. Dutch: `"Niet vastgelegd"`. Portuguese: `"Não registado"`. Hungarian: `"Nincs rögzítve"`. Arabic: `"غير مسجل"`. Hebrew: `"לא נרשם"`. Chinese: `"未记录"`. Translate the hint sentence to match each, keeping the `{count}` placeholder.
+
+- [ ] **Step 8: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: `lib/l10n/arb/app_localizations*.dart` regenerate with the two new getters and no errors.
+
+- [ ] **Step 9: Render the new bucket**
+
+In `lib/features/statistics/presentation/pages/statistics_profile_page.dart`, in `_buildDecoSection`, replace the body of the `data` branch. The rate denominator becomes classified dives only, and the empty state now triggers when nothing at all is classified:
+
+```dart
+          final classified = data.decoCount + data.noDecoCount;
+          if (classified == 0 && data.unknownCount == 0) {
+            return _EmptyChartState(
+              message: context.l10n.statistics_profile_deco_empty,
+            );
+          }
+          final percentage = classified == 0
+              ? 0.0
+              : data.decoCount / classified * 100;
+```
+
+Leave the three existing `_buildDecoStat` calls in place, but change the no-deco figure to read `data.noDecoCount.toString()` instead of `(data.totalCount - data.decoCount).toString()`. Then, immediately after the `Row` holding the three stats, add:
+
+```dart
+              if (data.unknownCount > 0) ...[
+                const SizedBox(height: 8),
+                Text(
+                  context.l10n.statistics_profile_deco_notRecordedHint(
+                    data.unknownCount,
+                  ),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+```
+
+- [ ] **Step 10: Verify the whole project**
+
+Run: `dart format .` then `flutter analyze` then `flutter test test/features/statistics/`
+Expected: format reports no changes, analyze is clean, all statistics tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add lib/features/statistics test/features/statistics lib/l10n
+git commit -m "fix(stats): classify deco obligation from recorded signals correctly
+
+getDecoObligationStats counted any sample with ceiling > 0 as a
+decompression obligation. Both profile mappers write ceiling = decoDepth
+for any non-zero deco_type, and type 1 is DC_DECO_SAFETYSTOP, so a routine
+5 m safety stop was reported as a deco dive.
+
+The same predicate under-counted in the opposite direction: ceiling is
+only ever written from computer-reported sample data, and the MacDive,
+Shearwater Cloud, generic UDDF, CSV and OCR paths never write it. Those
+dives were silently counted as no-deco.
+
+Classification now prefers deco_type = 2 and decoStopStart events, treats
+ceiling > 0 as authoritative only for sources that write no deco_type at
+all, and reports dives it cannot classify as not recorded instead of
+folding them into the no-deco count. The deco rate denominator is now
+classified dives only.
+
+Refs #623"
+```
+
+---
+
+### Task 2: Computed classification cache
+
+The computed fallback needs somewhere to memoize its answer. Per the local-cache precedent, re-derivable data stays out of the synced main DB: no schema version bump, no HLC, no tombstones, no backup inclusion, and a restored database recomputes rather than importing another device's stale answer.
+
+**Files:**
+- Modify: `lib/core/database/local_cache_database.dart:89-206` (table) and `:206-290` (schema version and migration)
+- Create: `lib/features/statistics/data/repositories/deco_classification_cache.dart`
+- Test: `test/features/statistics/data/repositories/deco_classification_cache_test.dart` (create)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - Drift table `DecoClassificationCache` with columns `diveId` (text, primary key), `hadDeco` (bool), `inputsHash` (text), `computedAt` (int).
+  - `class DecoClassificationCacheRepository` with:
+    - `Future<Map<String, bool>> getValid(Set<String> diveIds, String inputsHash)`
+    - `Future<void> put(String diveId, {required bool hadDeco, required String inputsHash})`
+    - `Future<void> clear()`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/statistics/data/repositories/deco_classification_cache_test.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/statistics/data/repositories/deco_classification_cache.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late DecoClassificationCacheRepository repo;
+
+  setUp(() {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    LocalCacheDatabaseService.instance.setTestDatabase(db);
+    repo = DecoClassificationCacheRepository();
+  });
+
+  tearDown(() async {
+    await db.close();
+    LocalCacheDatabaseService.instance.resetForTesting();
+  });
+
+  test('returns nothing before anything is cached', () async {
+    expect(await repo.getValid({'a', 'b'}, 'hash-1'), isEmpty);
+  });
+
+  test('round-trips a classification', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: false, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a', 'b'}, 'hash-1'), {'a': true, 'b': false});
+  });
+
+  test('a stale inputs hash invalidates the entry', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a'}, 'hash-2'), isEmpty);
+  });
+
+  test('re-putting the same dive replaces the entry', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('a', hadDeco: false, inputsHash: 'hash-2');
+
+    expect(await repo.getValid({'a'}, 'hash-1'), isEmpty);
+    expect(await repo.getValid({'a'}, 'hash-2'), {'a': false});
+  });
+
+  test('only the requested dives come back', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: true, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a'}, 'hash-1'), {'a': true});
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/statistics/data/repositories/deco_classification_cache_test.dart`
+Expected: FAIL, `deco_classification_cache.dart` does not exist.
+
+- [ ] **Step 3: Add the table**
+
+In `lib/core/database/local_cache_database.dart`, add after the `ReefDataCache` class:
+
+```dart
+/// Memoized result of the computed decompression-obligation classification
+/// for one dive (issue #623).
+///
+/// Local-only by construction: every device can re-derive this from the dive
+/// profile it already holds, so it carries no HLC, is never synced, and is
+/// never backed up. A restored database recomputes rather than inheriting
+/// another device's answer, which may have been produced under different
+/// gradient factors.
+class DecoClassificationCache extends Table {
+  TextColumn get diveId => text()();
+
+  /// Whether the app's own analysis put the diver into decompression.
+  BoolColumn get hadDeco => boolean()();
+
+  /// Fingerprint of every input that can change the answer: engine version,
+  /// the gradient factors actually used, and the dive's profile revision.
+  /// A mismatch means recompute.
+  TextColumn get inputsHash => text()();
+
+  IntColumn get computedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {diveId};
+}
+```
+
+Add `DecoClassificationCache` to the `@DriftDatabase(tables: [...])` annotation's table list, bump `schemaVersion` from `12` to `13`, and add the migration step after the existing `if (from < 12)` block:
+
+```dart
+      if (from < 13) {
+        await m.createTable(decoClassificationCache);
+      }
+```
+
+Then add the idempotent self-heal inside `beforeOpen`, alongside the existing `CREATE TABLE IF NOT EXISTS` assertions, so a parallel branch that also claims v13 cannot leave the table missing:
+
+```dart
+      await customStatement('''
+        CREATE TABLE IF NOT EXISTS deco_classification_cache (
+          dive_id TEXT NOT NULL,
+          had_deco INTEGER NOT NULL,
+          inputs_hash TEXT NOT NULL,
+          computed_at INTEGER NOT NULL,
+          PRIMARY KEY (dive_id)
+        )
+      ''');
+```
+
+- [ ] **Step 4: Regenerate Drift code**
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: `local_cache_database.g.dart` gains `DecoClassificationCache` and `decoClassificationCache`.
+
+- [ ] **Step 5: Write the repository**
+
+Create `lib/features/statistics/data/repositories/deco_classification_cache.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+
+/// Read/write access to the memoized computed deco classifications.
+///
+/// Entries are only valid for the [inputsHash] they were written under, so a
+/// changed profile, a changed gradient factor, or a bumped analysis engine
+/// invalidates them without needing an explicit purge.
+class DecoClassificationCacheRepository {
+  DecoClassificationCacheRepository({LocalCacheDatabase? database})
+    : _database = database;
+
+  final LocalCacheDatabase? _database;
+
+  LocalCacheDatabase get _db =>
+      _database ?? LocalCacheDatabaseService.instance.database;
+
+  /// The cached classifications for [diveIds] that were computed under
+  /// [inputsHash]. Dives that are absent or stale are simply missing from the
+  /// result, which is what marks them as needing recomputation.
+  Future<Map<String, bool>> getValid(
+    Set<String> diveIds,
+    String inputsHash,
+  ) async {
+    if (diveIds.isEmpty) return const {};
+    final rows =
+        await (_db.select(_db.decoClassificationCache)..where(
+              (t) =>
+                  t.diveId.isIn(diveIds) & t.inputsHash.equals(inputsHash),
+            ))
+            .get();
+    return {for (final row in rows) row.diveId: row.hadDeco};
+  }
+
+  Future<void> put(
+    String diveId, {
+    required bool hadDeco,
+    required String inputsHash,
+  }) async {
+    await _db
+        .into(_db.decoClassificationCache)
+        .insertOnConflictUpdate(
+          DecoClassificationCacheCompanion(
+            diveId: Value(diveId),
+            hadDeco: Value(hadDeco),
+            inputsHash: Value(inputsHash),
+            computedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+  }
+
+  Future<void> clear() async {
+    await _db.delete(_db.decoClassificationCache).go();
+  }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `flutter test test/features/statistics/data/repositories/deco_classification_cache_test.dart`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 7: Verify and commit**
+
+Run: `dart format .` then `flutter analyze`
+
+```bash
+git add lib/core/database lib/features/statistics/data/repositories test/features/statistics
+git commit -m "feat(stats): add local cache for computed deco classification
+
+Local cache DB v13. Computed deco answers are re-derivable from data every
+device already holds, so they stay out of the synced main DB: no schema
+version bump there, no HLC, no tombstones, no backup inclusion. Entries are
+keyed by an inputs fingerprint so a changed profile or changed gradient
+factors invalidate without an explicit purge.
+
+Refs #623"
+```
+
+---
+
+### Task 3: Computed classification service
+
+**Files:**
+- Create: `lib/features/statistics/data/services/deco_classification_service.dart`
+- Test: `test/features/statistics/data/services/deco_classification_service_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `DecoClassificationCacheRepository` from Task 2.
+- Produces:
+  - `String decoInputsHash({required int engineVersion, required int gfLow, required int gfHigh, required int diveUpdatedAt})`
+  - `class DecoClassificationService` with
+    `Future<Map<String, bool>> classify(Ref ref, Set<String> diveIds, {int chunkSize = 25})`
+
+- [ ] **Step 1: Write the failing test for the fingerprint**
+
+Create `test/features/statistics/data/services/deco_classification_service_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/statistics/data/services/deco_classification_service.dart';
+
+void main() {
+  group('decoInputsHash', () {
+    test('is stable for identical inputs', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, b);
+    });
+
+    test('changes when a gradient factor changes', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 80,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('changes when the dive is edited', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 2000,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('changes when the analysis engine is bumped', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 4,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, isNot(b));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/statistics/data/services/deco_classification_service_test.dart`
+Expected: FAIL, the file does not exist.
+
+- [ ] **Step 3: Write the service**
+
+Create `lib/features/statistics/data/services/deco_classification_service.dart`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/utils/logger.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/statistics/data/repositories/deco_classification_cache.dart';
+
+final _log = Logger('DecoClassificationService');
+
+/// Fingerprint of every input that can change a computed classification.
+///
+/// Kept deliberately coarse: the dive's `updatedAt` moves whenever the dive
+/// row or its profile is written, so it stands in for a profile revision
+/// without hashing the samples themselves.
+String decoInputsHash({
+  required int engineVersion,
+  required int gfLow,
+  required int gfHigh,
+  required int diveUpdatedAt,
+}) => 'v$engineVersion/$gfLow-$gfHigh/$diveUpdatedAt';
+
+/// Classifies dives that carry no recorded deco signal by running the same
+/// analysis the dive detail page runs.
+///
+/// Reading [profileAnalysisProvider] rather than reimplementing the deco test
+/// is the point of the exercise: issue #623 was the statistics card and the
+/// dive page answering the same question from different layers, and a second
+/// implementation would let them drift apart again.
+class DecoClassificationService {
+  const DecoClassificationService();
+
+  /// Returns `diveId -> hadDeco` for every dive in [diveIds] the analysis
+  /// could classify. Dives whose analysis yields nothing (no usable profile)
+  /// are absent from the result and stay unclassified.
+  ///
+  /// Processes in chunks and invalidates each dive's analysis afterwards:
+  /// [profileAnalysisProvider] and [analysisDiveProvider] are keepAlive
+  /// families, so a library-wide pass would otherwise retain every profile's
+  /// curves for the session.
+  /// [revisions] maps dive id to that dive's `dives.updated_at`, as returned
+  /// by `StatisticsRepository.scanRecordedDecoSignals`.
+  Future<Map<String, bool>> classify(
+    Ref ref,
+    Map<String, int> revisions, {
+    int chunkSize = 25,
+  }) async {
+    if (revisions.isEmpty) return const {};
+
+    // The analysis uses the dive's own gradient factors when it has both,
+    // and the diver's settings otherwise, so both feed the fingerprint.
+    final settingsGfLow = ref.read(gfLowProvider);
+    final settingsGfHigh = ref.read(gfHighProvider);
+
+    final cache = DecoClassificationCacheRepository();
+    final results = <String, bool>{};
+    final pending = revisions.keys.toList(growable: false);
+
+    for (var start = 0; start < pending.length; start += chunkSize) {
+      final end = (start + chunkSize).clamp(0, pending.length);
+      for (final diveId in pending.sublist(start, end)) {
+        var analysisRead = false;
+        try {
+          final dive = await ref.read(analysisDiveProvider(diveId).future);
+          if (dive == null) continue;
+
+          final hash = decoInputsHash(
+            engineVersion: analysisEngineVersion,
+            gfLow: dive.gradientFactorLow ?? settingsGfLow,
+            gfHigh: dive.gradientFactorHigh ?? settingsGfHigh,
+            diveUpdatedAt: revisions[diveId]!,
+          );
+
+          final cached = await cache.getValid({diveId}, hash);
+          final hit = cached[diveId];
+          if (hit != null) {
+            results[diveId] = hit;
+            continue;
+          }
+
+          analysisRead = true;
+          final analysis = await ref.read(
+            profileAnalysisProvider(diveId).future,
+          );
+          if (analysis == null || analysis.ndlCurve.isEmpty) continue;
+
+          final hadDeco = analysis.hadDecoObligation;
+          results[diveId] = hadDeco;
+          await cache.put(diveId, hadDeco: hadDeco, inputsHash: hash);
+        } catch (e, stackTrace) {
+          _log.error(
+            'Failed to classify deco obligation for dive $diveId',
+            error: e,
+            stackTrace: stackTrace,
+          );
+        } finally {
+          if (analysisRead) ref.invalidate(profileAnalysisProvider(diveId));
+          ref.invalidate(analysisDiveProvider(diveId));
+        }
+      }
+    }
+    return results;
+  }
+}
+```
+
+`analysisEngineVersion` does not exist yet. Add it to
+`lib/features/dive_log/data/services/profile_analysis_service.dart` as a
+top-level `const int analysisEngineVersion = 1;` and bump it whenever the
+deco computation changes. `gfLowProvider` and `gfHighProvider` come from
+`lib/features/settings/presentation/providers/settings_providers.dart` and
+default to 50 and 85. `Dive.gradientFactorLow` and `Dive.gradientFactorHigh`
+are `int?` (`dive.dart:88-89`); the `Dive` entity has no `updatedAt`, which
+is why the revision arrives from the scan instead.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/statistics/data/services/deco_classification_service_test.dart`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `dart format .` then `flutter analyze`
+
+```bash
+git add lib/features/statistics/data/services lib/features/dive_log/data/services test/features/statistics/data/services
+git commit -m "feat(stats): compute deco classification via the dive analysis
+
+Reads profileAnalysisProvider rather than reimplementing the deco test, so
+the statistics card and the dive detail page can never disagree again.
+Chunked with per-dive invalidation because both analysis providers are
+keepAlive families.
+
+Refs #623"
+```
+
+---
+
+### Task 4: Compose recorded and computed classification in the provider
+
+**Files:**
+- Modify: `lib/features/statistics/presentation/providers/statistics_providers.dart:498-508`
+- Test: `test/features/statistics/presentation/providers/deco_obligation_provider_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `scanRecordedDecoSignals` (Task 1), `DecoClassificationCacheRepository` (Task 2), `DecoClassificationService` (Task 3).
+- Produces: `decoObligationStatsProvider` yielding `({int decoCount, int noDecoCount, int unknownCount})` with the computed fallback applied.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/statistics/presentation/providers/deco_obligation_provider_test.dart`. Build a dive whose profile has no `deco_type` and no `ceiling` but is deep and long enough that Buhlmann puts it into deco, plus a shallow dive that stays within NDL. Assert the provider reports one deco dive and one no-deco dive, with `unknownCount` zero. Use the same `setUpTestDatabase` helper as the repository tests and a `ProviderContainer` for the provider read.
+
+Do not guess the fixture depths and durations. Write the two profiles, run `ProfileAnalysisService` over each directly in a scratch test, and confirm one yields `hadDecoObligation == true` and the other `false` at the default GF 50/85 before asserting on the provider. A fixture that silently sits on the wrong side of the NDL boundary makes the test assert nothing.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/statistics/presentation/providers/deco_obligation_provider_test.dart`
+Expected: FAIL, the provider reports both dives as unknown because the computed fallback is not wired in.
+
+- [ ] **Step 3: Wire the fallback into the provider**
+
+Replace `decoObligationStatsProvider` in `lib/features/statistics/presentation/providers/statistics_providers.dart`:
+
+```dart
+/// Deco obligation counts, recorded signals first and the app's own analysis
+/// as the fallback (#623).
+///
+/// Cached computed answers are read up front so a warm library costs one
+/// extra indexed SELECT. Only genuinely uncached dives run the analysis.
+final decoObligationStatsProvider =
+    FutureProvider<({int decoCount, int noDecoCount, int unknownCount})>((
+      ref,
+    ) async {
+      _keepAliveWithExpiry(ref);
+      final repository = ref.watch(statisticsRepositoryProvider);
+      final currentDiverId = ref.watch(currentDiverIdProvider);
+      final filter = ref.watch(statisticsFilterProvider);
+
+      final scan = await repository.scanRecordedDecoSignals(
+        diverId: currentDiverId,
+        filter: filter,
+      );
+
+      var deco = scan.recordedDeco.length;
+      var noDeco = scan.recordedNoDeco.length;
+      var unknown = scan.noProfile.length;
+
+      final computed = await const DecoClassificationService().classify(
+        ref,
+        scan.needsCompute,
+      );
+      for (final diveId in scan.needsCompute.keys) {
+        final hadDeco = computed[diveId];
+        if (hadDeco == null) {
+          unknown++;
+        } else if (hadDeco) {
+          deco++;
+        } else {
+          noDeco++;
+        }
+      }
+
+      return (decoCount: deco, noDecoCount: noDeco, unknownCount: unknown);
+    });
+```
+
+`classify` already consults the cache per dive before computing, so a warm library does no analysis work at all.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/statistics/presentation/providers/deco_obligation_provider_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Verify and commit**
+
+Run: `dart format .` then `flutter analyze` then `flutter test test/features/statistics/`
+
+```bash
+git add lib/features/statistics test/features/statistics
+git commit -m "fix(stats): fall back to computed deco for dives with no recorded data
+
+The Decompression Obligation card now agrees with the DECO badge on the
+dive detail page. Dives whose source records no deco columns are classified
+by the app's own analysis instead of being counted as no-deco.
+
+Fixes #623"
+```
+
+---
+
+### Task 5: End-to-end verification against the reported scenario
+
+**Files:**
+- Test: `test/features/statistics/deco_obligation_regression_test.dart` (create)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the regression test**
+
+Create `test/features/statistics/deco_obligation_regression_test.dart` reproducing issue #623: a library of dives whose profiles carry depth and temperature only, with no `deco_type`, no `ceiling`, and no deco events, where several profiles are deep and long enough to incur a genuine obligation. Assert that the card reports a non-zero deco count and a non-zero rate, and that the count matches the number of dives for which `ProfileAnalysis.hadDecoObligation` is true. Derive that expected count by running the analysis in the test rather than hard-coding a number, so the assertion cannot drift from the engine. Name the test after the issue so the intent survives.
+
+- [ ] **Step 2: Run it to verify it passes**
+
+Run: `flutter test test/features/statistics/deco_obligation_regression_test.dart`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `flutter test`
+Expected: PASS. Two pre-existing flakes are known and unrelated to this change: two `split('-')` recovery-code tests, and a security-settings recovery dialog where Argon2id outruns `settle()`. Do not chase them. Never pipe the run through `tail`, which masks the exit code.
+
+- [ ] **Step 4: Verify formatting and analysis project-wide**
+
+Run: `dart format .` then `flutter analyze`
+Expected: no changes, no findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/features/statistics
+git commit -m "test(stats): regression cover for the #623 deco obligation report
+
+Refs #623"
+```
+
+---
+
+## Follow-up issues to file
+
+Both were found during the #623 investigation, are real, and are deliberately out of scope here:
+
+1. `getTimeAtDepthRanges` counts profile rows and divides by 60, assuming 1 Hz sampling. At a 4-5 s sample interval the card understates time at depth by that factor. It also omits the `is_primary` filter, so a dive logged by two computers is double-counted.
+2. `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`) demotes every `dive_profiles` row for a dive, then re-promotes only rows whose `computer_id` matches `newPrimary.computerId`, and only when that id is non-null. File-imported dives have a null `computerId` on both the data source row and the profile rows, so nothing is re-promoted and the dive ends up with no primary profile. Any query gated on `is_primary = 1`, including the ascent/descent rates card, then silently skips that dive.

--- a/docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md
+++ b/docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md
@@ -1,0 +1,153 @@
+# Decompression Obligation Statistic: Root Cause and Design
+
+**Issue:** [#623](https://github.com/submersion-app/submersion/issues/623) ("Statistics bug")
+**Reported:** 2026-07-18, via r/submersion, by kirdam74
+**Date:** 2026-08-18
+
+## The report
+
+The reporter has 167 dives and observed two problems on the Statistics tab:
+
+1. "Average ascent and descent speeds" rendered its empty state, "No profile
+   data available", despite his dives carrying dense profiles.
+2. "Decompression obligation" reported 0 deco dives, 167 no-deco dives, and a
+   0.0% deco rate, despite his doing many deco dives. His dive detail page for
+   the same library shows a DECO badge, a 9.3 m ceiling, TTS 23 min, GF 85/85,
+   and a stop schedule of 1 min @ 9 m, 5 min @ 6 m, 12 min @ 3 m.
+
+A third card on the same page, "Time by depth range", rendered real data. That
+contrast is the key diagnostic: all three cards read the same
+`dive_profiles` table, so whatever broke the other two is in their predicates,
+not in the presence of profile data.
+
+## Symptom 1: already fixed and released
+
+`getAscentDescentRates` averaged `dive_profiles.ascent_rate` under
+`WHERE p.ascent_rate IS NOT NULL`. No write path populates that column:
+libdivecomputer reports no ascent-rate sample type, `parsed_dive_mapper`
+builds every sample without it, no file importer sets it, and all three DB
+write sites pass a value that is always null. The card was therefore
+unconditionally empty for every user on every build up to and including
+v1.7.2.
+
+Commit `4a881e397dc` (2026-08-09) rewrote the query to derive rates from
+stored depth samples, and also corrected a latent sign inversion that would
+have displayed ascent and descent swapped. It ships in `v1.7.3.6027` and
+`v1.7.4.6062`. The report predates both.
+
+**No further work is required for symptom 1.**
+
+## Symptom 2: the live bug
+
+`StatisticsRepository.getDecoObligationStats` classifies a deco dive as any
+dive having a profile sample with `p.ceiling > 0`. That is wrong in two
+opposite directions.
+
+### It under-counts
+
+`dive_profiles.ceiling` is only ever written from computer-reported sample
+data. Both mappers gate it identically:
+
+- `parsed_dive_mapper.dart:70`:
+  `ceiling: s.decoType != null && s.decoType != 0 ? s.decoDepth : null`
+- `parsed_dive_profile_mapper.dart:88`:
+  `if (s.decoDepth != null && s.decoType != null && s.decoType != 0)`
+
+Several import sources never populate it at all, among them the MacDive XML
+and SQLite parsers, the Shearwater Cloud parser, the generic UDDF import
+parser, the CSV parser, and the OCR importer. Any dive from those sources is
+silently counted as no-deco.
+
+Meanwhile the rest of the app answers the same question from a different
+layer. `profile_analysis_provider.dart:472-488` treats the app's computed
+analysis as the base and overlays computer-reported columns only when present:
+`profile[i].ceiling ?? analysis.ceilingCurve[i]`. The ceiling, stops, and DECO
+badge on the dive detail page come from the app's own Buhlmann engine
+(`profile_analysis_service.dart:668-684`) at the dive's stored gradient
+factors, or the diver's GF settings when the dive has none. Nothing writes
+that computed curve back to `dive_profiles.ceiling`.
+
+So the statistic and the dive detail page disagree by construction, and the
+statistic asserts a confident `0` where the honest answer is "not recorded".
+
+### It over-counts
+
+Per `libdc_wrapper.h:157`, `deco_type` is `0=NDL, 1=safetystop, 2=decostop,
+3=deepstop`, and the mappers write `ceiling = decoDepth` for any non-zero
+type. A routine 5 m safety stop therefore stores `ceiling = 5`, and
+`ceiling > 0` counts that dive as a decompression obligation. A purely
+recreational diver on a computer that reports safety stops could see a deco
+rate approaching 100%.
+
+### The codebase already knows better
+
+`DiveRepositoryImpl.getNoFlyDiveInputs` (`dive_repository_impl.dart:4218`)
+uses `p.deco_type = 2 OR p.ceiling > 0`, and `safety_review_service.dart:180`
+uses the computed `analysis.ndlCurve[i] < 0` as its in-deco test. A third
+signal, `decoStopStart` rows in `dive_profile_events`, is populated by the
+Subsurface XML parser, the UDDF importer, and the dive computer download path,
+and is ignored by all of the above.
+
+## Design
+
+Classify each dive from the best available evidence, in priority order, and
+never assert "no deco" from an absence of data.
+
+### Resolution order
+
+1. **Recorded, authoritative.** Any sample with `deco_type = 2`, or any
+   `decoStopStart` profile event, means deco. Any dive whose profile carries
+   `deco_type` values that are all `0` means no deco. This deliberately stops
+   treating `deco_type` 1 and 3 as obligations.
+2. **Recorded, ceiling only.** For sources that write `ceiling` without
+   `deco_type` (Subsurface XML, DAN DL7, FIT), `ceiling > 0` means deco. Only
+   consulted when the dive carries no `deco_type` at all, so it can no longer
+   promote a safety stop.
+3. **Computed.** For a dive with a profile but no recorded deco signal, run the
+   same analysis the dive detail page runs and test `ndlCurve.any((n) => n < 0)`.
+   This is what makes the statistic agree with the DECO badge the diver can
+   see on the dive.
+4. **Unknown.** A dive with no profile at all cannot be classified. It is
+   reported separately and excluded from the rate denominator, rather than
+   counted as no-deco.
+
+### Caching
+
+Step 3 is the expensive one. The Buhlmann arithmetic is cheap (a 167 dive
+library is roughly 2M float operations), but hydrating the profiles is not:
+the existing ascent-rate query takes about 590 ms at 1.62M profile rows.
+
+Computed classifications are re-derivable from data every device already
+holds, so per `docs` precedent they belong in `local_cache_database.dart`, not
+the synced main DB. That avoids a `currentSchemaVersion` bump, HLC timestamps,
+tombstones, merge rules, and backup inclusion, and a restored database simply
+recomputes instead of carrying another device's stale answer.
+
+The cache is keyed by dive and invalidated by an inputs fingerprint covering
+the values that can change the answer: the engine version, the gradient
+factors actually used, and the dive's profile revision.
+
+### Reuse, not reimplementation
+
+The computed step reads `profileAnalysisProvider`, the same provider the dive
+detail page uses. That is a deliberate choice over reimplementing the deco
+determination in SQL or in a parallel service: it guarantees the card and the
+dive page can never drift apart, which is the entire substance of this bug. It
+costs a per-dive provider read, so the batch pass invalidates each dive's
+analysis after classifying it to bound memory.
+
+## Out of scope
+
+Two adjacent defects were found during the investigation and are **not**
+addressed here. They are filed separately so this change stays reviewable:
+
+- `getTimeAtDepthRanges` counts sample rows and divides by 60, assuming 1 Hz
+  sampling. At the reporter's roughly 4-5 s sample interval the card understates
+  time at depth by that factor. It also omits the `is_primary` filter, so a
+  dive logged by two computers is double-counted.
+- `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`) demotes every
+  `dive_profiles` row for a dive, then re-promotes only rows matching
+  `newPrimary.computerId`, and only when that id is non-null. File-imported
+  dives have a null `computerId` on both the data source and the profile rows,
+  so nothing is re-promoted and the dive is left with no primary profile. That
+  silently empties the ascent/descent card, among others.

--- a/docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md
+++ b/docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md
@@ -139,15 +139,18 @@ analysis after classifying it to bound memory.
 ## Out of scope
 
 Two adjacent defects were found during the investigation and are **not**
-addressed here. They are filed separately so this change stays reviewable:
+addressed here. Both are filed separately so this change stays reviewable:
 
-- `getTimeAtDepthRanges` counts sample rows and divides by 60, assuming 1 Hz
-  sampling. At the reporter's roughly 4-5 s sample interval the card understates
-  time at depth by that factor. It also omits the `is_primary` filter, so a
-  dive logged by two computers is double-counted.
-- `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`) demotes every
-  `dive_profiles` row for a dive, then re-promotes only rows matching
-  `newPrimary.computerId`, and only when that id is non-null. File-imported
-  dives have a null `computerId` on both the data source and the profile rows,
-  so nothing is re-promoted and the dive is left with no primary profile. That
-  silently empties the ascent/descent card, among others.
+- **#1148**: `getTimeAtDepthRanges` counts sample rows and divides by 60,
+  assuming 1 Hz sampling. At the reporter's roughly 4-5 s sample interval the
+  card overstates time at depth by that factor. It also omits the `is_primary`
+  filter, so a dive logged by two computers is double-counted.
+- **#1149**: `setPrimaryDataSource` (`dive_repository_impl.dart:5877-5891`)
+  demotes every `dive_profiles` row for a dive, then re-promotes only rows
+  matching `newPrimary.computerId`, and only when that id is non-null.
+  File-imported dives have a null `computerId` on both the data source row
+  (`uddf_entity_importer.dart` sets `computerModel` and `computerSerial` but
+  never `computerId`) and the profile rows, and the "Set Primary" menu item in
+  `data_sources_section.dart` carries no `computerId` guard. So the dive is
+  left with no primary profile at all. That silently empties the
+  ascent/descent card, among others. Confirmed reachable, not latent.

--- a/lib/core/database/local_cache_database.dart
+++ b/lib/core/database/local_cache_database.dart
@@ -186,6 +186,31 @@ class NoaaTideStations extends Table {
   Set<Column> get primaryKey => {stationId};
 }
 
+/// Memoized result of the computed decompression-obligation classification
+/// for one dive (#623).
+///
+/// Local-only by construction: every device can re-derive this from the dive
+/// profile it already holds, so it carries no HLC, is never synced, and is
+/// never backed up. A restored database recomputes rather than inheriting
+/// another device's answer, which may have been produced under different
+/// gradient factors.
+class DecoClassificationCache extends Table {
+  TextColumn get diveId => text()();
+
+  /// Whether the app's own analysis put the diver into decompression.
+  BoolColumn get hadDeco => boolean()();
+
+  /// Fingerprint of every input that can change the answer: engine version,
+  /// the gradient factors actually used, and the dive's profile revision.
+  /// A mismatch means recompute.
+  TextColumn get inputsHash => text()();
+
+  IntColumn get computedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {diveId};
+}
+
 @DriftDatabase(
   tables: [
     LocalAssetCache,
@@ -197,13 +222,14 @@ class NoaaTideStations extends Table {
     GpsTrackGeometryCache,
     WatchedRoots,
     WatchedFolderIndex,
+    DecoClassificationCache,
   ],
 )
 class LocalCacheDatabase extends _$LocalCacheDatabase {
   LocalCacheDatabase(super.e);
 
   @override
-  int get schemaVersion => 12;
+  int get schemaVersion => 13;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -286,6 +312,10 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
           "DELETE FROM local_asset_cache WHERE resolution_method = 'unresolved'",
         );
       }
+      // v13: computed deco-obligation classifications (#623).
+      if (from < 13) {
+        await m.createTable(decoClassificationCache);
+      }
     },
     beforeOpen: (details) async {
       // Ladder-collision self-heal: a parallel branch that also claimed v7
@@ -356,6 +386,15 @@ class LocalCacheDatabase extends _$LocalCacheDatabase {
           mtime_millis INTEGER NOT NULL,
           content_hash TEXT,
           PRIMARY KEY (root_path, relative_path)
+        )
+      ''');
+      await customStatement('''
+        CREATE TABLE IF NOT EXISTS deco_classification_cache (
+          dive_id TEXT NOT NULL,
+          had_deco INTEGER NOT NULL,
+          inputs_hash TEXT NOT NULL,
+          computed_at INTEGER NOT NULL,
+          PRIMARY KEY (dive_id)
         )
       ''');
     },

--- a/lib/features/dive_log/data/services/profile_analysis_service.dart
+++ b/lib/features/dive_log/data/services/profile_analysis_service.dart
@@ -23,6 +23,15 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart'
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
 import 'package:submersion/features/dive_log/domain/services/deco_stop_curve.dart';
 
+/// Version of the deco computation behind [ProfileAnalysis].
+///
+/// Bump this whenever a change could flip [ProfileAnalysis.hadDecoObligation]
+/// for an unchanged profile: a different algorithm, altered coefficients, or a
+/// changed ceiling convention. Consumers that memoize an analysis-derived
+/// answer fold it into their cache key, so a bump invalidates their stored
+/// results. Currently used by the statistics deco-classification cache (#623).
+const int analysisEngineVersion = 1;
+
 /// Represents SAC calculated over a segment of the dive.
 class SacSegment extends Equatable {
   /// Start timestamp of this segment (seconds from dive start)

--- a/lib/features/statistics/data/repositories/deco_classification_cache.dart
+++ b/lib/features/statistics/data/repositories/deco_classification_cache.dart
@@ -24,17 +24,43 @@ class DecoClassificationCacheRepository {
   /// a hash-filtered query would need one round trip per dive. The caller
   /// compares hashes in Dart, which keeps this to one round trip for the whole
   /// batch and leaves the staleness policy in one place.
+  /// Ids are queried in chunks so the bound-variable count never exceeds
+  /// SQLite's limit, matching `SpeciesRepository.getSightingsForDives`.
+  ///
+  /// Measured against the engine this app actually bundles, the ceiling is
+  /// 32766 (the SQLite 3.32+ default), not the 999 that older references and
+  /// the sibling repository's comment cite: an unchunked query survives 2500
+  /// ids and throws "too many SQL variables" at 33000. The chunk size stays at
+  /// 900 for consistency with that sibling rather than for necessity.
+  ///
+  /// Overrunning the limit would not surface as a visible failure here: the
+  /// caller catches a cache read error and falls back to recomputing every
+  /// dive, so the cache would quietly stop working for exactly the libraries
+  /// that need it most.
   Future<Map<String, ({bool hadDeco, String inputsHash})>> getEntries(
     Set<String> diveIds,
   ) async {
     if (diveIds.isEmpty) return const {};
-    final rows = await (_db.select(
-      _db.decoClassificationCache,
-    )..where((t) => t.diveId.isIn(diveIds))).get();
-    return {
-      for (final row in rows)
-        row.diveId: (hadDeco: row.hadDeco, inputsHash: row.inputsHash),
-    };
+
+    const chunkSize = 900; // safely under SQLite's 999 bound-variable limit
+    final ids = diveIds.toList(growable: false);
+    final entries = <String, ({bool hadDeco, String inputsHash})>{};
+
+    for (var start = 0; start < ids.length; start += chunkSize) {
+      final end = start + chunkSize < ids.length
+          ? start + chunkSize
+          : ids.length;
+      final rows = await (_db.select(
+        _db.decoClassificationCache,
+      )..where((t) => t.diveId.isIn(ids.sublist(start, end)))).get();
+      for (final row in rows) {
+        entries[row.diveId] = (
+          hadDeco: row.hadDeco,
+          inputsHash: row.inputsHash,
+        );
+      }
+    }
+    return entries;
   }
 
   Future<void> put(

--- a/lib/features/statistics/data/repositories/deco_classification_cache.dart
+++ b/lib/features/statistics/data/repositories/deco_classification_cache.dart
@@ -17,20 +17,24 @@ class DecoClassificationCacheRepository {
   LocalCacheDatabase get _db =>
       _database ?? LocalCacheDatabaseService.instance.database;
 
-  /// The cached classifications for [diveIds] that were computed under
-  /// [inputsHash]. Dives that are absent or stale are simply missing from the
-  /// result, which is what marks them as needing recomputation.
-  Future<Map<String, bool>> getValid(
+  /// Every stored entry for [diveIds], keyed by dive id, in a single query.
+  ///
+  /// Deliberately returns the stored `inputsHash` rather than filtering on it
+  /// in SQL: each dive has its own fingerprint (their `updated_at` differ), so
+  /// a hash-filtered query would need one round trip per dive. The caller
+  /// compares hashes in Dart, which keeps this to one round trip for the whole
+  /// batch and leaves the staleness policy in one place.
+  Future<Map<String, ({bool hadDeco, String inputsHash})>> getEntries(
     Set<String> diveIds,
-    String inputsHash,
   ) async {
     if (diveIds.isEmpty) return const {};
-    final rows =
-        await (_db.select(_db.decoClassificationCache)..where(
-              (t) => t.diveId.isIn(diveIds) & t.inputsHash.equals(inputsHash),
-            ))
-            .get();
-    return {for (final row in rows) row.diveId: row.hadDeco};
+    final rows = await (_db.select(
+      _db.decoClassificationCache,
+    )..where((t) => t.diveId.isIn(diveIds))).get();
+    return {
+      for (final row in rows)
+        row.diveId: (hadDeco: row.hadDeco, inputsHash: row.inputsHash),
+    };
   }
 
   Future<void> put(

--- a/lib/features/statistics/data/repositories/deco_classification_cache.dart
+++ b/lib/features/statistics/data/repositories/deco_classification_cache.dart
@@ -1,0 +1,56 @@
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+
+/// Read and write access to the memoized computed deco classifications (#623).
+///
+/// Entries are only valid for the `inputsHash` they were written under, so a
+/// changed profile, a changed gradient factor, or a bumped analysis engine
+/// invalidates them without needing an explicit purge.
+class DecoClassificationCacheRepository {
+  DecoClassificationCacheRepository({LocalCacheDatabase? database})
+    : _database = database;
+
+  final LocalCacheDatabase? _database;
+
+  LocalCacheDatabase get _db =>
+      _database ?? LocalCacheDatabaseService.instance.database;
+
+  /// The cached classifications for [diveIds] that were computed under
+  /// [inputsHash]. Dives that are absent or stale are simply missing from the
+  /// result, which is what marks them as needing recomputation.
+  Future<Map<String, bool>> getValid(
+    Set<String> diveIds,
+    String inputsHash,
+  ) async {
+    if (diveIds.isEmpty) return const {};
+    final rows =
+        await (_db.select(_db.decoClassificationCache)..where(
+              (t) => t.diveId.isIn(diveIds) & t.inputsHash.equals(inputsHash),
+            ))
+            .get();
+    return {for (final row in rows) row.diveId: row.hadDeco};
+  }
+
+  Future<void> put(
+    String diveId, {
+    required bool hadDeco,
+    required String inputsHash,
+  }) async {
+    await _db
+        .into(_db.decoClassificationCache)
+        .insertOnConflictUpdate(
+          DecoClassificationCacheCompanion(
+            diveId: Value(diveId),
+            hadDeco: Value(hadDeco),
+            inputsHash: Value(inputsHash),
+            computedAt: Value(DateTime.now().millisecondsSinceEpoch),
+          ),
+        );
+  }
+
+  Future<void> clear() async {
+    await _db.delete(_db.decoClassificationCache).go();
+  }
+}

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -12,6 +12,21 @@ import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dar
 import 'package:submersion/features/statistics/data/dive_filter_sql.dart';
 import 'package:submersion/features/statistics/domain/entities/species_statistics.dart';
 
+/// Per-dive outcome of the recorded (non-computed) deco classification.
+///
+/// The four groups partition the filtered dive library. [needsCompute] maps
+/// dive id to that dive's `dives.updated_at`, which the computed fallback
+/// uses as the profile revision in its cache fingerprint; the lean `Dive`
+/// hydration used by the analysis pipeline carries no `updatedAt`, so this
+/// scan is the only place that value is cheaply available. [noProfile] holds
+/// dives that can never be classified from stored data.
+typedef DecoSignalScan = ({
+  Set<String> recordedDeco,
+  Set<String> recordedNoDeco,
+  Map<String, int> needsCompute,
+  Set<String> noProfile,
+});
+
 /// Data point for line chart trends
 class TrendDataPoint {
   final DateTime date;
@@ -2192,8 +2207,28 @@ class StatisticsRepository {
     }
   }
 
-  /// Get percentage of dives with decompression obligation
-  Future<({int decoCount, int totalCount})> getDecoObligationStats({
+  /// Classifies each filtered dive's decompression obligation from recorded
+  /// profile data alone.
+  ///
+  /// Resolution order, highest confidence first:
+  ///
+  /// 1. `deco_type = 2` (DC_DECO_DECOSTOP per libdc_wrapper.h) or a
+  ///    `decoStopStart` profile event means deco. Types 1 and 3 are safety
+  ///    and deep stops, which are not decompression obligations; the old
+  ///    `ceiling > 0` test counted both, because both profile mappers write
+  ///    `ceiling = decoDepth` for any non-zero deco type.
+  /// 2. A profile that carries `deco_type` values, none of which is 2, means
+  ///    no deco. The computer was recording obligations and reported none.
+  /// 3. `ceiling > 0` on a profile with no `deco_type` at all means deco.
+  ///    Subsurface XML, DAN DL7 and FIT write a stop depth without a type,
+  ///    so this clause keeps them working without re-admitting safety stops.
+  /// 4. Anything else with a profile needs the computed fallback: many
+  ///    sources (MacDive, Shearwater Cloud, generic UDDF, CSV, OCR) record no
+  ///    deco columns at all, and for those the app's own analysis is the only
+  ///    evidence there is. It is also what the dive detail page displays.
+  /// 5. A dive with no profile is unclassifiable and must not be counted as
+  ///    no-deco.
+  Future<DecoSignalScan> scanRecordedDecoSignals({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
   }) async {
@@ -2203,27 +2238,102 @@ class StatisticsRepository {
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
+        WITH scoped AS (
+          SELECT d.id AS dive_id
+          FROM dives d
+          WHERE 1=1 $diverFilter ${df.clause}
+        ),
+        signals AS (
+          SELECT
+            s.dive_id AS dive_id,
+            MAX(CASE WHEN p.id IS NOT NULL THEN 1 ELSE 0 END) AS has_profile,
+            MAX(CASE WHEN p.deco_type IS NOT NULL THEN 1 ELSE 0 END)
+              AS has_deco_type,
+            MAX(CASE WHEN p.deco_type = 2 THEN 1 ELSE 0 END) AS deco_stop,
+            MAX(CASE WHEN p.ceiling > 0 THEN 1 ELSE 0 END) AS positive_ceiling
+          FROM scoped s
+          LEFT JOIN dive_profiles p ON p.dive_id = s.dive_id
+          GROUP BY s.dive_id
+        ),
+        stop_events AS (
+          SELECT DISTINCT e.dive_id AS dive_id
+          FROM dive_profile_events e
+          JOIN scoped s ON s.dive_id = e.dive_id
+          WHERE e.event_type = 'decoStopStart'
+        )
         SELECT
-          COUNT(DISTINCT CASE WHEN p.ceiling > 0 THEN d.id END) AS deco_count,
-          COUNT(DISTINCT d.id) AS total_count
-        FROM dives d
-        LEFT JOIN dive_profiles p ON p.dive_id = d.id
-        WHERE 1=1 $diverFilter ${df.clause}
+          sig.dive_id AS dive_id,
+          d.updated_at AS updated_at,
+          CASE
+            WHEN sig.deco_stop = 1 OR ev.dive_id IS NOT NULL THEN 'deco'
+            WHEN sig.has_deco_type = 1 THEN 'no_deco'
+            WHEN sig.positive_ceiling = 1 THEN 'deco'
+            WHEN sig.has_profile = 1 THEN 'compute'
+            ELSE 'no_profile'
+          END AS classification
+        FROM signals sig
+        JOIN dives d ON d.id = sig.dive_id
+        LEFT JOIN stop_events ev ON ev.dive_id = sig.dive_id
         ''', variables: params.map((p) => Variable(p)).toList()).get();
 
-      if (results.isEmpty) return (decoCount: 0, totalCount: 0);
+      final recordedDeco = <String>{};
+      final recordedNoDeco = <String>{};
+      final needsCompute = <String, int>{};
+      final noProfile = <String>{};
+      for (final row in results) {
+        final id = row.read<String>('dive_id');
+        switch (row.read<String>('classification')) {
+          case 'deco':
+            recordedDeco.add(id);
+          case 'no_deco':
+            recordedNoDeco.add(id);
+          case 'compute':
+            needsCompute[id] = row.read<int?>('updated_at') ?? 0;
+          default:
+            noProfile.add(id);
+        }
+      }
       return (
-        decoCount: results.first.read<int?>('deco_count') ?? 0,
-        totalCount: results.first.read<int?>('total_count') ?? 0,
+        recordedDeco: recordedDeco,
+        recordedNoDeco: recordedNoDeco,
+        needsCompute: needsCompute,
+        noProfile: noProfile,
       );
     } catch (e, stackTrace) {
       _log.error(
-        'Failed to get deco obligation stats',
+        'Failed to scan recorded deco signals',
         error: e,
         stackTrace: stackTrace,
       );
-      return (decoCount: 0, totalCount: 0);
+      return (
+        recordedDeco: const <String>{},
+        recordedNoDeco: const <String>{},
+        needsCompute: const <String, int>{},
+        noProfile: const <String>{},
+      );
     }
+  }
+
+  /// Deco obligation counts from recorded data alone.
+  ///
+  /// Dives needing the computed fallback are reported as unknown here. The
+  /// statistics provider composes this with the computed classification
+  /// cache; this method is the recorded-only view, used by tests and by any
+  /// caller that must not trigger analysis work.
+  Future<({int decoCount, int noDecoCount, int unknownCount})>
+  getDecoObligationStats({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) async {
+    final scan = await scanRecordedDecoSignals(
+      diverId: diverId,
+      filter: filter,
+    );
+    return (
+      decoCount: scan.recordedDeco.length,
+      noDecoCount: scan.recordedNoDeco.length,
+      unknownCount: scan.needsCompute.length + scan.noProfile.length,
+    );
   }
 
   /// Aggregates of one diver's history at a site, matched by exact

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -2288,7 +2288,13 @@ class StatisticsRepository {
           case 'no_deco':
             recordedNoDeco.add(id);
           case 'compute':
-            needsCompute[id] = row.read<int?>('updated_at') ?? 0;
+            // Non-null read on purpose. `dives.updated_at` is a non-nullable
+            // column and the query inner-joins dives, so a null here means the
+            // schema or the query drifted. Defaulting to 0 would silently
+            // collapse every dive onto one fingerprint component and stop
+            // edits invalidating the computed classification cache, so fail
+            // loudly instead.
+            needsCompute[id] = row.read<int>('updated_at');
           default:
             noProfile.add(id);
         }

--- a/lib/features/statistics/data/services/deco_classification_service.dart
+++ b/lib/features/statistics/data/services/deco_classification_service.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/statistics/data/repositories/deco_classification_cache.dart';
+
+/// Fingerprint of every input that can change a computed classification.
+///
+/// Deliberately coarse: the dive's `updated_at` moves whenever the dive row or
+/// its profile is written, so it stands in for a profile revision without
+/// hashing the samples themselves. The separators matter, so that a shifted
+/// digit in one field cannot impersonate its neighbour.
+String decoInputsHash({
+  required int engineVersion,
+  required int gfLow,
+  required int gfHigh,
+  required int diveUpdatedAt,
+}) => 'v$engineVersion/$gfLow-$gfHigh/$diveUpdatedAt';
+
+/// Classifies dives that carry no recorded deco signal by running the same
+/// analysis the dive detail page runs (#623).
+///
+/// Reading [profileAnalysisProvider] rather than reimplementing the deco test
+/// is the point of the exercise: the bug was the statistics card and the dive
+/// page answering the same question from different layers, and a second
+/// implementation would let them drift apart again.
+class DecoClassificationService {
+  const DecoClassificationService();
+
+  static final _log = LoggerService.forClass(DecoClassificationService);
+
+  /// Returns `diveId -> hadDeco` for every dive in [revisions] that could be
+  /// classified. [revisions] maps dive id to that dive's `dives.updated_at`,
+  /// as returned by `StatisticsRepository.scanRecordedDecoSignals`.
+  ///
+  /// Dives whose analysis yields nothing (no usable profile) are absent from
+  /// the result and stay unclassified rather than defaulting to no-deco.
+  ///
+  /// Cached answers are consulted per dive before any analysis runs, so a warm
+  /// library does no compute at all. Uncached dives are processed in chunks
+  /// with their analysis invalidated afterwards: [profileAnalysisProvider] and
+  /// [analysisDiveProvider] are keepAlive families, so a library-wide pass
+  /// would otherwise retain every profile's curves for the whole session.
+  Future<Map<String, bool>> classify(
+    Ref ref,
+    Map<String, int> revisions, {
+    int chunkSize = 25,
+  }) async {
+    if (revisions.isEmpty) return const {};
+
+    // The analysis uses the dive's own gradient factors when it has both, and
+    // the diver's settings otherwise, so both feed the fingerprint.
+    final settingsGfLow = ref.read(gfLowProvider);
+    final settingsGfHigh = ref.read(gfHighProvider);
+
+    final cache = DecoClassificationCacheRepository();
+    final results = <String, bool>{};
+    final pending = revisions.keys.toList(growable: false);
+
+    for (var start = 0; start < pending.length; start += chunkSize) {
+      final end = start + chunkSize < pending.length
+          ? start + chunkSize
+          : pending.length;
+      for (final diveId in pending.sublist(start, end)) {
+        var analysisRead = false;
+        try {
+          final dive = await ref.read(analysisDiveProvider(diveId).future);
+          if (dive == null) continue;
+
+          final hash = decoInputsHash(
+            engineVersion: analysisEngineVersion,
+            gfLow: dive.gradientFactorLow ?? settingsGfLow,
+            gfHigh: dive.gradientFactorHigh ?? settingsGfHigh,
+            diveUpdatedAt: revisions[diveId]!,
+          );
+
+          final cached = await cache.getValid({diveId}, hash);
+          final hit = cached[diveId];
+          if (hit != null) {
+            results[diveId] = hit;
+            continue;
+          }
+
+          analysisRead = true;
+          final analysis = await ref.read(
+            profileAnalysisProvider(diveId).future,
+          );
+          if (analysis == null || analysis.ndlCurve.isEmpty) continue;
+
+          final hadDeco = analysis.hadDecoObligation;
+          results[diveId] = hadDeco;
+          await cache.put(diveId, hadDeco: hadDeco, inputsHash: hash);
+        } catch (e, stackTrace) {
+          _log.error(
+            'Failed to classify deco obligation for dive $diveId',
+            error: e,
+            stackTrace: stackTrace,
+          );
+        } finally {
+          if (analysisRead) ref.invalidate(profileAnalysisProvider(diveId));
+          ref.invalidate(analysisDiveProvider(diveId));
+        }
+      }
+    }
+    return results;
+  }
+}

--- a/lib/features/statistics/data/services/deco_classification_service.dart
+++ b/lib/features/statistics/data/services/deco_classification_service.dart
@@ -8,10 +8,22 @@ import 'package:submersion/features/statistics/data/repositories/deco_classifica
 
 /// Fingerprint of every input that can change a computed classification.
 ///
-/// Deliberately coarse: the dive's `updated_at` moves whenever the dive row or
-/// its profile is written, so it stands in for a profile revision without
-/// hashing the samples themselves. The separators matter, so that a shifted
-/// digit in one field cannot impersonate its neighbour.
+/// [gfLow] and [gfHigh] are the diver's *settings* gradient factors, not the
+/// dive's own. Per-dive inputs (the dive's stored GF, altitude, water type,
+/// and the profile samples themselves) are all covered by [diveUpdatedAt],
+/// which moves whenever the dive row or its profile is written. So the only
+/// inputs left to name explicitly are the ones that live outside the dive: the
+/// engine version and the diver's global GF setting, which applies to any dive
+/// that does not carry both of its own.
+///
+/// That makes the fingerprint computable from the statistics scan alone, with
+/// no dive hydration, which is what lets a warm library skip loading profiles
+/// entirely. A dive that does carry its own GF is invalidated needlessly when
+/// the global setting changes; that costs one recompute and never a wrong
+/// answer, which is the right direction to err.
+///
+/// The separators matter, so a shifted digit in one field cannot impersonate
+/// its neighbour.
 String decoInputsHash({
   required int engineVersion,
   required int gfLow,
@@ -38,11 +50,12 @@ class DecoClassificationService {
   /// Dives whose analysis yields nothing (no usable profile) are absent from
   /// the result and stay unclassified rather than defaulting to no-deco.
   ///
-  /// Cached answers are consulted per dive before any analysis runs, so a warm
-  /// library does no compute at all. Uncached dives are processed in chunks
-  /// with their analysis invalidated afterwards: [profileAnalysisProvider] and
-  /// [analysisDiveProvider] are keepAlive families, so a library-wide pass
-  /// would otherwise retain every profile's curves for the whole session.
+  /// The whole cache is read in one query up front, so a warm library performs
+  /// a single SELECT and hydrates no profiles at all. Only genuine misses are
+  /// analyzed, in chunks, with their analysis invalidated afterwards:
+  /// [profileAnalysisProvider] and [analysisDiveProvider] are keepAlive
+  /// families, so a library-wide pass would otherwise retain every profile's
+  /// curves for the whole session.
   Future<Map<String, bool>> classify(
     Ref ref,
     Map<String, int> revisions, {
@@ -50,40 +63,52 @@ class DecoClassificationService {
   }) async {
     if (revisions.isEmpty) return const {};
 
-    // The analysis uses the dive's own gradient factors when it has both, and
-    // the diver's settings otherwise, so both feed the fingerprint.
     final settingsGfLow = ref.read(gfLowProvider);
     final settingsGfHigh = ref.read(gfHighProvider);
 
+    final hashes = <String, String>{
+      for (final entry in revisions.entries)
+        entry.key: decoInputsHash(
+          engineVersion: analysisEngineVersion,
+          gfLow: settingsGfLow,
+          gfHigh: settingsGfHigh,
+          diveUpdatedAt: entry.value,
+        ),
+    };
+
     final cache = DecoClassificationCacheRepository();
     final results = <String, bool>{};
-    final pending = revisions.keys.toList(growable: false);
+    final misses = <String>[];
 
-    for (var start = 0; start < pending.length; start += chunkSize) {
-      final end = start + chunkSize < pending.length
+    try {
+      final stored = await cache.getEntries(revisions.keys.toSet());
+      for (final diveId in revisions.keys) {
+        final entry = stored[diveId];
+        if (entry != null && entry.inputsHash == hashes[diveId]) {
+          results[diveId] = entry.hadDeco;
+        } else {
+          misses.add(diveId);
+        }
+      }
+    } catch (e, stackTrace) {
+      // A cache failure must not lose the statistic: fall back to computing
+      // everything rather than reporting the whole library as unclassified.
+      _log.error(
+        'Failed to read the deco classification cache',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      misses
+        ..clear()
+        ..addAll(revisions.keys);
+    }
+
+    for (var start = 0; start < misses.length; start += chunkSize) {
+      final end = start + chunkSize < misses.length
           ? start + chunkSize
-          : pending.length;
-      for (final diveId in pending.sublist(start, end)) {
-        var analysisRead = false;
+          : misses.length;
+      for (final diveId in misses.sublist(start, end)) {
         try {
-          final dive = await ref.read(analysisDiveProvider(diveId).future);
-          if (dive == null) continue;
-
-          final hash = decoInputsHash(
-            engineVersion: analysisEngineVersion,
-            gfLow: dive.gradientFactorLow ?? settingsGfLow,
-            gfHigh: dive.gradientFactorHigh ?? settingsGfHigh,
-            diveUpdatedAt: revisions[diveId]!,
-          );
-
-          final cached = await cache.getValid({diveId}, hash);
-          final hit = cached[diveId];
-          if (hit != null) {
-            results[diveId] = hit;
-            continue;
-          }
-
-          analysisRead = true;
           final analysis = await ref.read(
             profileAnalysisProvider(diveId).future,
           );
@@ -91,7 +116,11 @@ class DecoClassificationService {
 
           final hadDeco = analysis.hadDecoObligation;
           results[diveId] = hadDeco;
-          await cache.put(diveId, hadDeco: hadDeco, inputsHash: hash);
+          await cache.put(
+            diveId,
+            hadDeco: hadDeco,
+            inputsHash: hashes[diveId]!,
+          );
         } catch (e, stackTrace) {
           _log.error(
             'Failed to classify deco obligation for dive $diveId',
@@ -99,7 +128,7 @@ class DecoClassificationService {
             stackTrace: stackTrace,
           );
         } finally {
-          if (analysisRead) ref.invalidate(profileAnalysisProvider(diveId));
+          ref.invalidate(profileAnalysisProvider(diveId));
           ref.invalidate(analysisDiveProvider(diveId));
         }
       }

--- a/lib/features/statistics/presentation/pages/statistics_profile_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_profile_page.dart
@@ -196,14 +196,22 @@ class StatisticsProfilePage extends ConsumerWidget {
       subtitle: context.l10n.statistics_profile_deco_subtitle,
       child: decoAsync.when(
         data: (data) {
-          if (data.totalCount == 0) {
+          // The rate is over classified dives only. Dives whose source
+          // recorded no deco data and whose profile cannot be analyzed are
+          // reported separately rather than folded into the no-deco count,
+          // which is what made this card claim 0% for a library of deco
+          // dives (#623).
+          final classified = data.decoCount + data.noDecoCount;
+          if (classified == 0 && data.unknownCount == 0) {
             return StatEmptyState(
               icon: Icons.stop_circle,
               message: context.l10n.statistics_profile_deco_empty,
             );
           }
 
-          final percentage = data.decoCount / data.totalCount * 100;
+          final percentage = classified == 0
+              ? 0.0
+              : data.decoCount / classified * 100;
 
           return Column(
             children: [
@@ -219,7 +227,7 @@ class StatisticsProfilePage extends ConsumerWidget {
                   _buildDecoStat(
                     context,
                     context.l10n.statistics_profile_deco_noDeco,
-                    (data.totalCount - data.decoCount).toString(),
+                    data.noDecoCount.toString(),
                     Colors.green,
                   ),
                   _buildDecoStat(
@@ -230,6 +238,18 @@ class StatisticsProfilePage extends ConsumerWidget {
                   ),
                 ],
               ),
+              if (data.unknownCount > 0) ...[
+                const SizedBox(height: 8),
+                Text(
+                  context.l10n.statistics_profile_deco_notRecordedHint(
+                    data.unknownCount,
+                  ),
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               Semantics(
                 label: context.l10n.statistics_profile_deco_semanticLabel(

--- a/lib/features/statistics/presentation/providers/statistics_providers.dart
+++ b/lib/features/statistics/presentation/providers/statistics_providers.dart
@@ -496,7 +496,9 @@ final timeAtDepthRangesProvider =
     });
 
 final decoObligationStatsProvider =
-    FutureProvider<({int decoCount, int totalCount})>((ref) async {
+    FutureProvider<({int decoCount, int noDecoCount, int unknownCount})>((
+      ref,
+    ) async {
       _keepAliveWithExpiry(ref);
       final repository = ref.watch(statisticsRepositoryProvider);
       final currentDiverId = ref.watch(currentDiverIdProvider);

--- a/lib/features/statistics/presentation/providers/statistics_providers.dart
+++ b/lib/features/statistics/presentation/providers/statistics_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+import 'package:submersion/features/statistics/data/services/deco_classification_service.dart';
 import 'package:submersion/features/statistics/domain/entities/species_statistics.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
 
@@ -495,6 +496,13 @@ final timeAtDepthRangesProvider =
       );
     });
 
+/// Deco obligation counts: recorded signals first, the app's own analysis as
+/// the fallback (#623).
+///
+/// A dive whose source recorded no deco columns is classified by the same
+/// analysis that draws the DECO badge on its detail page, so the card and the
+/// dive can no longer disagree. Dives with no profile at all stay unknown and
+/// are excluded from the rate rather than counted as no-deco.
 final decoObligationStatsProvider =
     FutureProvider<({int decoCount, int noDecoCount, int unknownCount})>((
       ref,
@@ -503,8 +511,30 @@ final decoObligationStatsProvider =
       final repository = ref.watch(statisticsRepositoryProvider);
       final currentDiverId = ref.watch(currentDiverIdProvider);
       final filter = ref.watch(statisticsFilterProvider);
-      return repository.getDecoObligationStats(
+
+      final scan = await repository.scanRecordedDecoSignals(
         diverId: currentDiverId,
         filter: filter,
       );
+
+      var deco = scan.recordedDeco.length;
+      var noDeco = scan.recordedNoDeco.length;
+      var unknown = scan.noProfile.length;
+
+      final computed = await const DecoClassificationService().classify(
+        ref,
+        scan.needsCompute,
+      );
+      for (final diveId in scan.needsCompute.keys) {
+        final hadDeco = computed[diveId];
+        if (hadDeco == null) {
+          unknown++;
+        } else if (hadDeco) {
+          deco++;
+        } else {
+          noDeco++;
+        }
+      }
+
+      return (decoCount: deco, noDecoCount: noDeco, unknownCount: unknown);
     });

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "لا توجد بيانات تخفيف ضغط متاحة",
   "statistics_profile_deco_error": "فشل تحميل بيانات تخفيف الضغط",
   "statistics_profile_deco_noDeco": "بدون تخفيف ضغط",
+  "statistics_profile_deco_notRecorded": "غير مسجل",
+  "statistics_profile_deco_notRecordedHint": "{count} غطسة ليس لها بيانات انضغاط مسجلة أو قابلة للحساب، وهي مستبعدة من النسبة",
   "statistics_profile_deco_semanticLabel": "معدل تخفيف الضغط: {percentage}% من الغوصات تطلبت توقفات تخفيف ضغط",
   "statistics_profile_deco_subtitle": "الغوصات التي تطلبت توقفات تخفيف ضغط",
   "statistics_profile_deco_title": "التزام تخفيف الضغط",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "Keine Deko-Daten verfügbar",
   "statistics_profile_deco_error": "Deko-Daten konnten nicht geladen werden",
   "statistics_profile_deco_noDeco": "Kein Deko",
+  "statistics_profile_deco_notRecorded": "Nicht erfasst",
+  "statistics_profile_deco_notRecordedHint": "{count} Tauchgänge haben keine erfassten oder berechenbaren Deko-Daten und sind von der Rate ausgenommen",
   "statistics_profile_deco_semanticLabel": "Dekompressionsrate: {percentage}% der Tauchgänge erforderten Deko-Stopps",
   "statistics_profile_deco_subtitle": "Tauchgänge mit Deko-Stopps",
   "statistics_profile_deco_title": "Dekompressionspflicht",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -9755,6 +9755,8 @@
   "statistics_profile_deco_empty": "No deco data available",
   "statistics_profile_deco_error": "Failed to load deco data",
   "statistics_profile_deco_noDeco": "No Deco",
+  "statistics_profile_deco_notRecorded": "Not Recorded",
+  "statistics_profile_deco_notRecordedHint": "{count} dives have no recorded or computable deco data and are excluded from the rate",
   "statistics_profile_deco_semanticLabel": "Decompression rate: {percentage}% of dives required deco stops",
   "statistics_profile_deco_subtitle": "Dives that incurred deco stops",
   "statistics_profile_deco_title": "Decompression Obligation",
@@ -10004,6 +10006,13 @@
       },
       "topCount": {
         "type": "Object"
+      }
+    }
+  },
+  "@statistics_profile_deco_notRecordedHint": {
+    "placeholders": {
+      "count": {
+        "type": "int"
       }
     }
   },

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "No hay datos de deco disponibles",
   "statistics_profile_deco_error": "Error al cargar los datos de deco",
   "statistics_profile_deco_noDeco": "Sin deco",
+  "statistics_profile_deco_notRecorded": "Sin registrar",
+  "statistics_profile_deco_notRecordedHint": "{count} inmersiones no tienen datos de descompresión registrados ni calculables y se excluyen de la tasa",
   "statistics_profile_deco_semanticLabel": "Tasa de descompresion: {percentage}% de las inmersiones requirieron paradas de deco",
   "statistics_profile_deco_subtitle": "Inmersiones que incurrieron en paradas de deco",
   "statistics_profile_deco_title": "Obligacion de descompresion",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4973,6 +4973,8 @@
   "statistics_profile_deco_empty": "Aucune donnee deco disponible",
   "statistics_profile_deco_error": "Echec du chargement des donnees deco",
   "statistics_profile_deco_noDeco": "Sans deco",
+  "statistics_profile_deco_notRecorded": "Non enregistré",
+  "statistics_profile_deco_notRecordedHint": "{count} plongées n'ont aucune donnée de décompression enregistrée ou calculable et sont exclues du taux",
   "statistics_profile_deco_semanticLabel": "Taux de decompression : {percentage}% des plongees ont necessite des paliers de decompression",
   "statistics_profile_deco_subtitle": "Plongees ayant necessite des paliers de decompression",
   "statistics_profile_deco_title": "Obligation de decompression",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "אין נתוני דקו זמינים",
   "statistics_profile_deco_error": "שגיאה בטעינת נתוני דקו",
   "statistics_profile_deco_noDeco": "ללא דקו",
+  "statistics_profile_deco_notRecorded": "לא נרשם",
+  "statistics_profile_deco_notRecordedHint": "ל-{count} צלילות אין נתוני דקומפרסיה שנרשמו או שניתן לחשב, והן אינן נכללות בשיעור",
   "statistics_profile_deco_semanticLabel": "שיעור דקומפרסיה: {percentage}% מהצלילות דרשו עצירות דקו",
   "statistics_profile_deco_subtitle": "צלילות שדרשו עצירות דקו",
   "statistics_profile_deco_title": "חובת דקומפרסיה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4973,6 +4973,8 @@
   "statistics_profile_deco_empty": "Nincsenek deko adatok",
   "statistics_profile_deco_error": "Nem sikerult a deko adatok betoltese",
   "statistics_profile_deco_noDeco": "Nincs deko",
+  "statistics_profile_deco_notRecorded": "Nincs rögzítve",
+  "statistics_profile_deco_notRecordedHint": "{count} merülés nem tartalmaz rögzített vagy számítható dekompressziós adatot, ezért kimarad az arányból",
   "statistics_profile_deco_semanticLabel": "Dekompresszios arany: {percentage}% a meruleseknek deko megalloast igenyelt",
   "statistics_profile_deco_subtitle": "Merulesek amelyek deko megalloast igenyeltek",
   "statistics_profile_deco_title": "Dekompresszios kotelezetseg",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4969,6 +4969,8 @@
   "statistics_profile_deco_empty": "Nessun dato deco disponibile",
   "statistics_profile_deco_error": "Impossibile caricare i dati deco",
   "statistics_profile_deco_noDeco": "No deco",
+  "statistics_profile_deco_notRecorded": "Non registrato",
+  "statistics_profile_deco_notRecordedHint": "{count} immersioni non hanno dati di decompressione registrati o calcolabili e sono escluse dal tasso",
   "statistics_profile_deco_semanticLabel": "Percentuale decompressione: {percentage}% delle immersioni ha richiesto soste deco",
   "statistics_profile_deco_subtitle": "Immersioni con obbligo di decompressione",
   "statistics_profile_deco_title": "Obbligo di decompressione",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -28007,6 +28007,18 @@ abstract class AppLocalizations {
   /// **'No Deco'**
   String get statistics_profile_deco_noDeco;
 
+  /// No description provided for @statistics_profile_deco_notRecorded.
+  ///
+  /// In en, this message translates to:
+  /// **'Not Recorded'**
+  String get statistics_profile_deco_notRecorded;
+
+  /// No description provided for @statistics_profile_deco_notRecordedHint.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} dives have no recorded or computable deco data and are excluded from the rate'**
+  String statistics_profile_deco_notRecordedHint(int count);
+
   /// No description provided for @statistics_profile_deco_semanticLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -16368,6 +16368,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'بدون تخفيف ضغط';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'غير مسجل';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count غطسة ليس لها بيانات انضغاط مسجلة أو قابلة للحساب، وهي مستبعدة من النسبة';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'معدل تخفيف الضغط: $percentage% من الغوصات تطلبت توقفات تخفيف ضغط';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -16645,6 +16645,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Kein Deko';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Nicht erfasst';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count Tauchgänge haben keine erfassten oder berechenbaren Deko-Daten und sind von der Rate ausgenommen';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Dekompressionsrate: $percentage% der Tauchgänge erforderten Deko-Stopps';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -16384,6 +16384,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'No Deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Not Recorded';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count dives have no recorded or computable deco data and are excluded from the rate';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Decompression rate: $percentage% of dives required deco stops';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -16672,6 +16672,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Sin deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Sin registrar';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count inmersiones no tienen datos de descompresión registrados ni calculables y se excluyen de la tasa';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Tasa de descompresion: $percentage% de las inmersiones requirieron paradas de deco';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -16729,6 +16729,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Sans deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Non enregistré';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count plongées n\'ont aucune donnée de décompression enregistrée ou calculable et sont exclues du taux';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Taux de decompression : $percentage% des plongees ont necessite des paliers de decompression';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -16248,6 +16248,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'ללא דקו';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'לא נרשם';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return 'ל-$count צלילות אין נתוני דקומפרסיה שנרשמו או שניתן לחשב, והן אינן נכללות בשיעור';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'שיעור דקומפרסיה: $percentage% מהצלילות דרשו עצירות דקו';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -16623,6 +16623,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Nincs deko';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Nincs rögzítve';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count merülés nem tartalmaz rögzített vagy számítható dekompressziós adatot, ezért kimarad az arányból';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Dekompresszios arany: $percentage% a meruleseknek deko megalloast igenyelt';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -16666,6 +16666,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'No deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Non registrato';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count immersioni non hanno dati di decompressione registrati o calcolabili e sono escluse dal tasso';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Percentuale decompressione: $percentage% delle immersioni ha richiesto soste deco';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -16532,6 +16532,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Geen deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Niet vastgelegd';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count duiken hebben geen vastgelegde of berekenbare decogegevens en tellen niet mee voor het percentage';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Decompressiepercentage: $percentage% van de duiken vereiste decostops';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -16679,6 +16679,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get statistics_profile_deco_noDeco => 'Sem Deco';
 
   @override
+  String get statistics_profile_deco_notRecorded => 'Não registado';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count mergulhos não têm dados de descompressão registados ou calculáveis e são excluídos da taxa';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return 'Taxa de descompressao: $percentage% dos mergulhos exigiram paradas de deco';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -15839,6 +15839,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get statistics_profile_deco_noDeco => '无减压';
 
   @override
+  String get statistics_profile_deco_notRecorded => '未记录';
+
+  @override
+  String statistics_profile_deco_notRecordedHint(int count) {
+    return '$count 次潜水没有已记录或可计算的减压数据，未计入比例';
+  }
+
+  @override
   String statistics_profile_deco_semanticLabel(Object percentage) {
     return '减压比率：$percentage% 的潜水需要减压停留';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "Geen decogegevens beschikbaar",
   "statistics_profile_deco_error": "Kan decogegevens niet laden",
   "statistics_profile_deco_noDeco": "Geen deco",
+  "statistics_profile_deco_notRecorded": "Niet vastgelegd",
+  "statistics_profile_deco_notRecordedHint": "{count} duiken hebben geen vastgelegde of berekenbare decogegevens en tellen niet mee voor het percentage",
   "statistics_profile_deco_semanticLabel": "Decompressiepercentage: {percentage}% van de duiken vereiste decostops",
   "statistics_profile_deco_subtitle": "Duiken met decostops",
   "statistics_profile_deco_title": "Decompressieverplichting",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5045,6 +5045,8 @@
   "statistics_profile_deco_empty": "Nenhum dado de deco disponivel",
   "statistics_profile_deco_error": "Falha ao carregar dados de deco",
   "statistics_profile_deco_noDeco": "Sem Deco",
+  "statistics_profile_deco_notRecorded": "Não registado",
+  "statistics_profile_deco_notRecordedHint": "{count} mergulhos não têm dados de descompressão registados ou calculáveis e são excluídos da taxa",
   "statistics_profile_deco_semanticLabel": "Taxa de descompressao: {percentage}% dos mergulhos exigiram paradas de deco",
   "statistics_profile_deco_subtitle": "Mergulhos que exigiram paradas de deco",
   "statistics_profile_deco_title": "Obrigacao de Descompressao",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5223,6 +5223,8 @@
   "statistics_profile_deco_empty": "无减压数据可用",
   "statistics_profile_deco_error": "加载减压数据失败",
   "statistics_profile_deco_noDeco": "无减压",
+  "statistics_profile_deco_notRecorded": "未记录",
+  "statistics_profile_deco_notRecordedHint": "{count} 次潜水没有已记录或可计算的减压数据，未计入比例",
   "statistics_profile_deco_semanticLabel": "减压比率：{percentage}% 的潜水需要减压停留",
   "statistics_profile_deco_subtitle": "产生减压停留的潜水",
   "statistics_profile_deco_title": "减压义务",

--- a/test/features/statistics/data/repositories/deco_classification_cache_test.dart
+++ b/test/features/statistics/data/repositories/deco_classification_cache_test.dart
@@ -20,45 +20,56 @@ void main() {
   });
 
   test('returns nothing before anything is cached', () async {
-    expect(await repo.getValid({'a', 'b'}, 'hash-1'), isEmpty);
+    expect(await repo.getEntries({'a', 'b'}), isEmpty);
   });
 
-  test('round-trips a classification', () async {
+  test('round-trips a classification with its fingerprint', () async {
     await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
-    await repo.put('b', hadDeco: false, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: false, inputsHash: 'hash-2');
 
-    expect(await repo.getValid({'a', 'b'}, 'hash-1'), {'a': true, 'b': false});
+    final entries = await repo.getEntries({'a', 'b'});
+
+    expect(entries['a']?.hadDeco, isTrue);
+    expect(entries['a']?.inputsHash, 'hash-1');
+    expect(entries['b']?.hadDeco, isFalse);
+    expect(entries['b']?.inputsHash, 'hash-2');
   });
 
-  test('a stale inputs hash invalidates the entry', () async {
+  test('reads dives with differing fingerprints in one call', () async {
+    // The whole point of returning the hash instead of filtering on it: each
+    // dive carries its own fingerprint, so one query serves the whole batch.
     await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: false, inputsHash: 'hash-2');
 
-    expect(await repo.getValid({'a'}, 'hash-2'), isEmpty);
+    expect((await repo.getEntries({'a', 'b'})).keys, containsAll(['a', 'b']));
   });
 
   test('re-putting the same dive replaces the entry', () async {
     await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
     await repo.put('a', hadDeco: false, inputsHash: 'hash-2');
 
-    expect(await repo.getValid({'a'}, 'hash-1'), isEmpty);
-    expect(await repo.getValid({'a'}, 'hash-2'), {'a': false});
+    final entries = await repo.getEntries({'a'});
+
+    expect(entries, hasLength(1));
+    expect(entries['a']?.hadDeco, isFalse);
+    expect(entries['a']?.inputsHash, 'hash-2');
   });
 
   test('only the requested dives come back', () async {
     await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
     await repo.put('b', hadDeco: true, inputsHash: 'hash-1');
 
-    expect(await repo.getValid({'a'}, 'hash-1'), {'a': true});
+    expect((await repo.getEntries({'a'})).keys, ['a']);
   });
 
   test('an empty request does not query', () async {
-    expect(await repo.getValid(const {}, 'hash-1'), isEmpty);
+    expect(await repo.getEntries(const {}), isEmpty);
   });
 
   test('clear removes every entry', () async {
     await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
     await repo.clear();
 
-    expect(await repo.getValid({'a'}, 'hash-1'), isEmpty);
+    expect(await repo.getEntries({'a'}), isEmpty);
   });
 }

--- a/test/features/statistics/data/repositories/deco_classification_cache_test.dart
+++ b/test/features/statistics/data/repositories/deco_classification_cache_test.dart
@@ -1,0 +1,64 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/statistics/data/repositories/deco_classification_cache.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late DecoClassificationCacheRepository repo;
+
+  setUp(() {
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    LocalCacheDatabaseService.instance.setTestDatabase(db);
+    repo = DecoClassificationCacheRepository();
+  });
+
+  tearDown(() async {
+    await db.close();
+    LocalCacheDatabaseService.instance.resetForTesting();
+  });
+
+  test('returns nothing before anything is cached', () async {
+    expect(await repo.getValid({'a', 'b'}, 'hash-1'), isEmpty);
+  });
+
+  test('round-trips a classification', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: false, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a', 'b'}, 'hash-1'), {'a': true, 'b': false});
+  });
+
+  test('a stale inputs hash invalidates the entry', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a'}, 'hash-2'), isEmpty);
+  });
+
+  test('re-putting the same dive replaces the entry', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('a', hadDeco: false, inputsHash: 'hash-2');
+
+    expect(await repo.getValid({'a'}, 'hash-1'), isEmpty);
+    expect(await repo.getValid({'a'}, 'hash-2'), {'a': false});
+  });
+
+  test('only the requested dives come back', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.put('b', hadDeco: true, inputsHash: 'hash-1');
+
+    expect(await repo.getValid({'a'}, 'hash-1'), {'a': true});
+  });
+
+  test('an empty request does not query', () async {
+    expect(await repo.getValid(const {}, 'hash-1'), isEmpty);
+  });
+
+  test('clear removes every entry', () async {
+    await repo.put('a', hadDeco: true, inputsHash: 'hash-1');
+    await repo.clear();
+
+    expect(await repo.getValid({'a'}, 'hash-1'), isEmpty);
+  });
+}

--- a/test/features/statistics/data/repositories/deco_classification_cache_test.dart
+++ b/test/features/statistics/data/repositories/deco_classification_cache_test.dart
@@ -72,4 +72,26 @@ void main() {
 
     expect(await repo.getEntries({'a'}), isEmpty);
   });
+
+  test('reads more ids than SQLite allows bound variables', () async {
+    // Sized against the measured ceiling of the bundled engine, not the 999
+    // that older references cite: an unchunked query survives 2500 ids and
+    // only throws "too many SQL variables" past 32766. Verified this test
+    // fails without the chunking in getEntries, so do not lower the count.
+    // The caller would swallow that throw into a full recompute rather than
+    // surfacing it, which is why this is covered.
+    const count = 33000;
+    for (var i = 0; i < count; i++) {
+      await repo.put('d$i', hadDeco: i.isEven, inputsHash: 'hash-1');
+    }
+
+    final entries = await repo.getEntries({
+      for (var i = 0; i < count; i++) 'd$i',
+    });
+
+    expect(entries, hasLength(count));
+    expect(entries['d0']?.hadDeco, isTrue);
+    expect(entries['d1']?.hadDeco, isFalse);
+    expect(entries['d2499']?.hadDeco, isFalse);
+  });
 }

--- a/test/features/statistics/data/repositories/statistics_repository_deco_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_deco_test.dart
@@ -1,0 +1,199 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = StatisticsRepository();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> dive(String id) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Inserts profile samples as (timestamp, depth, decoType, ceiling) tuples.
+  Future<void> profile(
+    String diveId,
+    List<(int, double, int?, double?)> samples,
+  ) async {
+    var index = 0;
+    for (final (ts, depth, decoType, ceiling) in samples) {
+      await db
+          .into(db.diveProfiles)
+          .insert(
+            DiveProfilesCompanion(
+              id: Value('$diveId-row-${index++}'),
+              diveId: Value(diveId),
+              timestamp: Value(ts),
+              depth: Value(depth),
+              decoType: Value(decoType),
+              ceiling: Value(ceiling),
+            ),
+          );
+    }
+  }
+
+  Future<void> decoStopEvent(String diveId) async {
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          DiveProfileEventsCompanion(
+            id: Value('$diveId-evt'),
+            diveId: Value(diveId),
+            timestamp: const Value(600),
+            eventType: const Value('decoStopStart'),
+            createdAt: Value(now),
+          ),
+        );
+  }
+
+  group('scanRecordedDecoSignals', () {
+    test('a safety stop is not a decompression obligation', () async {
+      await dive('safety');
+      // deco_type 1 is DC_DECO_SAFETYSTOP; the mapper writes ceiling for it.
+      await profile('safety', [
+        (0, 10.0, 0, null),
+        (300, 30.0, 0, null),
+        (600, 5.0, 1, 5.0),
+      ]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, isEmpty);
+      expect(scan.recordedNoDeco, {'safety'});
+    });
+
+    test('a deco stop sample is a decompression obligation', () async {
+      await dive('deco');
+      await profile('deco', [(0, 10.0, 0, null), (300, 45.0, 2, 9.0)]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, {'deco'});
+      expect(scan.recordedNoDeco, isEmpty);
+    });
+
+    test('a decoStopStart event is a decompression obligation', () async {
+      await dive('evt');
+      await profile('evt', [(0, 10.0, null, null)]);
+      await decoStopEvent('evt');
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.recordedDeco, {'evt'});
+      expect(scan.needsCompute, isEmpty);
+    });
+
+    test(
+      'ceiling alone counts only when the source wrote no decoType',
+      () async {
+        await dive('ceilingOnly');
+        // Subsurface XML and DAN DL7 write ceiling without any decoType.
+        await profile('ceilingOnly', [
+          (0, 10.0, null, null),
+          (300, 45.0, null, 9.0),
+        ]);
+
+        final scan = await repo.scanRecordedDecoSignals();
+
+        expect(scan.recordedDeco, {'ceilingOnly'});
+      },
+    );
+
+    test('a profile with no deco signal at all needs computing', () async {
+      await dive('bare');
+      await profile('bare', [(0, 10.0, null, null), (300, 45.0, null, null)]);
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.needsCompute.keys, {'bare'});
+      expect(scan.needsCompute['bare'], now);
+      expect(scan.recordedNoDeco, isEmpty);
+      expect(scan.noProfile, isEmpty);
+    });
+
+    test('a dive with no profile is unclassifiable', () async {
+      await dive('manual');
+
+      final scan = await repo.scanRecordedDecoSignals();
+
+      expect(scan.noProfile, {'manual'});
+      expect(scan.needsCompute, isEmpty);
+    });
+  });
+
+  group('getDecoObligationStats', () {
+    test(
+      'unclassifiable dives are reported separately, not as no-deco',
+      () async {
+        await dive('deco');
+        await profile('deco', [(300, 45.0, 2, 9.0)]);
+        await dive('manual');
+
+        final stats = await repo.getDecoObligationStats();
+
+        expect(stats.decoCount, 1);
+        expect(stats.noDecoCount, 0);
+        expect(stats.unknownCount, 1);
+      },
+    );
+
+    test('honours the diver filter', () async {
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion(
+              id: const Value('diver-a'),
+              name: const Value('A'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion(
+              id: const Value('mine'),
+              diveDateTime: Value(now),
+              diverId: const Value('diver-a'),
+              createdAt: Value(now),
+              updatedAt: Value(now),
+            ),
+          );
+      await profile('mine', [(300, 45.0, 2, 9.0)]);
+      await dive('theirs');
+      await profile('theirs', [(300, 45.0, 2, 9.0)]);
+
+      final stats = await repo.getDecoObligationStats(
+        diverId: 'diver-a',
+        filter: const DiveFilterState(),
+      );
+
+      expect(stats.decoCount, 1);
+      expect(stats.unknownCount, 0);
+      expect(stats.noDecoCount, 0);
+    });
+  });
+}

--- a/test/features/statistics/data/repositories/statistics_repository_error_test.dart
+++ b/test/features/statistics/data/repositories/statistics_repository_error_test.dart
@@ -87,7 +87,8 @@ void main() {
 
       final decoStats = await repository.getDecoObligationStats();
       expect(decoStats.decoCount, equals(0));
-      expect(decoStats.totalCount, equals(0));
+      expect(decoStats.noDecoCount, equals(0));
+      expect(decoStats.unknownCount, equals(0));
 
       // Methods that return empty entity
       final speciesStats = await repository.getSpeciesStatistics(

--- a/test/features/statistics/data/services/deco_classification_service_test.dart
+++ b/test/features/statistics/data/services/deco_classification_service_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/statistics/data/services/deco_classification_service.dart';
+
+void main() {
+  group('decoInputsHash', () {
+    test('is stable for identical inputs', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, b);
+    });
+
+    test('changes when a gradient factor changes', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 80,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('changes when the dive is edited', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 2000,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('changes when the analysis engine is bumped', () {
+      final a = decoInputsHash(
+        engineVersion: 3,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      final b = decoInputsHash(
+        engineVersion: 4,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: 1000,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('does not collide when adjacent fields shift a digit', () {
+      // A naive concatenation without separators would make (gf 5, 085) and
+      // (gf 50, 85) hash identically.
+      final a = decoInputsHash(
+        engineVersion: 1,
+        gfLow: 5,
+        gfHigh: 985,
+        diveUpdatedAt: 1,
+      );
+      final b = decoInputsHash(
+        engineVersion: 1,
+        gfLow: 59,
+        gfHigh: 85,
+        diveUpdatedAt: 1,
+      );
+      expect(a, isNot(b));
+    });
+  });
+}

--- a/test/features/statistics/deco_obligation_regression_test.dart
+++ b/test/features/statistics/deco_obligation_regression_test.dart
@@ -1,0 +1,152 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
+
+import '../../helpers/mock_providers.dart';
+import '../../helpers/test_database.dart';
+
+/// Regression cover for issue #623.
+///
+/// The reporter had 167 dives and the Decompression Obligation card showed
+/// 0 deco dives, 167 no-deco, 0.0%, while his dive detail pages showed DECO
+/// badges, ceilings and stop schedules. The card read `dive_profiles.ceiling`,
+/// a computer-reported column his import source never wrote, while the detail
+/// page computed deco from the app's own engine.
+///
+/// This test builds that exact shape: a library of profiles carrying depth
+/// only, with no deco_type, no ceiling and no deco events, where some dives
+/// genuinely bust the NDL. Before the fix the card reported zero deco dives
+/// for all of them.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late LocalCacheDatabase cacheDb;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    LocalCacheDatabaseService.instance.setTestDatabase(cacheDb);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    LocalCacheDatabaseService.instance.resetForTesting();
+    await tearDownTestDatabase();
+  });
+
+  /// Square profile: descend at 20 m/min, hold [depth] for [bottomMinutes],
+  /// ascend at 9 m/min, sampled every 10 s.
+  (List<double>, List<int>) square(double depth, int bottomMinutes) {
+    final depths = <double>[];
+    final times = <int>[];
+    var t = 0;
+    final descentSeconds = (depth / 20 * 60).round();
+    for (var s = 0; s <= descentSeconds; s += 10) {
+      depths.add(depth * s / descentSeconds);
+      times.add(t = s);
+    }
+    final bottomEnd = t + bottomMinutes * 60;
+    for (var s = t + 10; s <= bottomEnd; s += 10) {
+      depths.add(depth);
+      times.add(t = s);
+    }
+    final ascentSeconds = (depth / 9 * 60).round();
+    for (var s = 10; s <= ascentSeconds; s += 10) {
+      depths.add(depth * (1 - s / ascentSeconds));
+      times.add(t + s);
+    }
+    return (depths, times);
+  }
+
+  test(
+    'a library of depth-only profiles no longer reports zero deco dives',
+    () async {
+      // A spread either side of the no-deco limit. Dives are a week apart so
+      // no residual tissue loading carries between them, which keeps the
+      // in-test expectation (a standalone analysis per dive) faithful to what
+      // the provider's repetitive-chain-aware analysis computes.
+      const plans = <(String, double, int)>[
+        ('d1', 12.0, 40),
+        ('d2', 18.0, 30),
+        ('d3', 22.0, 35),
+        ('d4', 30.0, 20),
+        ('d5', 40.0, 25),
+        ('d6', 45.0, 25),
+        ('d7', 50.0, 30),
+      ];
+
+      final service = ProfileAnalysisService(gfLow: 0.50, gfHigh: 0.85);
+      var expectedDeco = 0;
+
+      for (var i = 0; i < plans.length; i++) {
+        final (id, depth, minutes) = plans[i];
+        final when = DateTime.utc(2026, 1, 5).add(Duration(days: 7 * i));
+        await db
+            .into(db.dives)
+            .insert(
+              DivesCompanion(
+                id: Value(id),
+                diveDateTime: Value(when.millisecondsSinceEpoch),
+                createdAt: Value(when.millisecondsSinceEpoch),
+                updatedAt: Value(when.millisecondsSinceEpoch),
+              ),
+            );
+
+        final (depths, times) = square(depth, minutes);
+        await db.batch((batch) {
+          for (var s = 0; s < depths.length; s++) {
+            batch.insert(
+              db.diveProfiles,
+              DiveProfilesCompanion(
+                id: Value('$id-row-$s'),
+                diveId: Value(id),
+                timestamp: Value(times[s]),
+                depth: Value(depths[s]),
+                // Deliberately no decoType, ceiling, ndl or tts: this is the
+                // shape the reporter's import source produced.
+              ),
+            );
+          }
+        });
+
+        if (service
+            .analyze(diveId: id, depths: depths, timestamps: times)
+            .hadDecoObligation) {
+          expectedDeco++;
+        }
+      }
+
+      final container = ProviderContainer(
+        overrides: (await getBaseOverrides()).cast(),
+      );
+      addTearDown(container.dispose);
+
+      final stats = await container.read(decoObligationStatsProvider.future);
+
+      // The expectation is derived from the engine rather than hard-coded, so
+      // it cannot drift if the deco model is retuned.
+      expect(expectedDeco, greaterThan(0), reason: 'fixture sanity check');
+      expect(
+        expectedDeco,
+        lessThan(plans.length),
+        reason: 'fixture sanity check',
+      );
+
+      expect(stats.decoCount, expectedDeco);
+      expect(stats.noDecoCount, plans.length - expectedDeco);
+      expect(stats.unknownCount, 0);
+
+      final rate =
+          stats.decoCount / (stats.decoCount + stats.noDecoCount) * 100;
+      expect(rate, greaterThan(0.0));
+    },
+  );
+}

--- a/test/features/statistics/presentation/providers/deco_obligation_provider_test.dart
+++ b/test/features/statistics/presentation/providers/deco_obligation_provider_test.dart
@@ -6,6 +6,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/statistics/data/repositories/deco_classification_cache.dart';
+import 'package:submersion/features/statistics/data/services/deco_classification_service.dart';
 import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -204,5 +207,59 @@ void main() {
       decoObligationStatsProvider.future,
     );
     expect(second.decoCount, 1);
+  });
+
+  test('a cache hit short-circuits the analysis entirely', () async {
+    await insertDive('deep');
+    await insertBareProfile('deep', 40, 25);
+
+    // Seed an entry that contradicts what the analysis would compute. If the
+    // provider reports no-deco, the cached value was used and the profile was
+    // never hydrated, which is the whole point of the fingerprint being
+    // derivable from the scan alone.
+    await DecoClassificationCacheRepository().put(
+      'deep',
+      hadDeco: false,
+      inputsHash: decoInputsHash(
+        engineVersion: analysisEngineVersion,
+        gfLow: 50,
+        gfHigh: 85,
+        diveUpdatedAt: now,
+      ),
+    );
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 0);
+    expect(stats.noDecoCount, 1);
+  });
+
+  test('editing a dive invalidates its cached classification', () async {
+    await insertDive('deep');
+    await insertBareProfile('deep', 40, 25);
+
+    final first = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+    expect(first.decoCount, 1);
+
+    // Replace the profile with one well inside the NDL and bump updated_at,
+    // exactly as an edit would. The stale entry must not be served.
+    await (db.delete(
+      db.diveProfiles,
+    )..where((t) => t.diveId.equals('deep'))).go();
+    await insertBareProfile('deep', 18, 30);
+    await (db.update(db.dives)..where((t) => t.id.equals('deep'))).write(
+      DivesCompanion(updatedAt: Value(now + 1000)),
+    );
+
+    final second = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(second.decoCount, 0);
+    expect(second.noDecoCount, 1);
   });
 }

--- a/test/features/statistics/presentation/providers/deco_obligation_provider_test.dart
+++ b/test/features/statistics/presentation/providers/deco_obligation_provider_test.dart
@@ -1,0 +1,208 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Square profile: descend at 20 m/min, hold [depth] for [bottomMinutes], then
+/// ascend at 9 m/min, sampled every 10 s.
+///
+/// The two fixtures below were chosen by running ProfileAnalysisService over a
+/// sweep of depth/duration pairs at the default GF 50/85 and taking one that
+/// clears the NDL by a wide margin and one that busts it outright. Do not
+/// nudge them without re-running that check: a fixture sitting on the boundary
+/// would make these tests assert nothing.
+(List<double>, List<int>) _square(double depth, int bottomMinutes) {
+  final depths = <double>[];
+  final times = <int>[];
+  var t = 0;
+  final descentSeconds = (depth / 20 * 60).round();
+  for (var s = 0; s <= descentSeconds; s += 10) {
+    depths.add(depth * s / descentSeconds);
+    times.add(t = s);
+  }
+  final bottomEnd = t + bottomMinutes * 60;
+  for (var s = t + 10; s <= bottomEnd; s += 10) {
+    depths.add(depth);
+    times.add(t = s);
+  }
+  final ascentSeconds = (depth / 9 * 60).round();
+  for (var s = 10; s <= ascentSeconds; s += 10) {
+    depths.add(depth * (1 - s / ascentSeconds));
+    times.add(t + s);
+  }
+  return (depths, times);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late LocalCacheDatabase cacheDb;
+
+  final now = DateTime.utc(2026, 6, 1).millisecondsSinceEpoch;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    LocalCacheDatabaseService.instance.setTestDatabase(cacheDb);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    LocalCacheDatabaseService.instance.resetForTesting();
+    await tearDownTestDatabase();
+  });
+
+  Future<void> insertDive(String id) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  /// Writes a profile carrying depth only: no deco_type, no ceiling, no
+  /// events. This is what MacDive, Shearwater Cloud, generic UDDF, CSV and
+  /// OCR imports produce, and it is the shape that made the card report zero.
+  Future<void> insertBareProfile(
+    String diveId,
+    double depth,
+    int bottomMinutes,
+  ) async {
+    final (depths, times) = _square(depth, bottomMinutes);
+    await db.batch((batch) {
+      for (var i = 0; i < depths.length; i++) {
+        batch.insert(
+          db.diveProfiles,
+          DiveProfilesCompanion(
+            id: Value('$diveId-row-$i'),
+            diveId: Value(diveId),
+            timestamp: Value(times[i]),
+            depth: Value(depths[i]),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<ProviderContainer> makeContainer() async {
+    final container = ProviderContainer(
+      overrides: (await getBaseOverrides()).cast(),
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('classifies a bare profile that busts the NDL as a deco dive', () async {
+    await insertDive('deep');
+    await insertBareProfile('deep', 40, 25);
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 1);
+    expect(stats.noDecoCount, 0);
+    expect(stats.unknownCount, 0);
+  });
+
+  test('classifies a bare profile inside the NDL as a no-deco dive', () async {
+    await insertDive('shallow');
+    await insertBareProfile('shallow', 18, 30);
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 0);
+    expect(stats.noDecoCount, 1);
+    expect(stats.unknownCount, 0);
+  });
+
+  test('reports a mixed library with a real rate', () async {
+    await insertDive('deep');
+    await insertBareProfile('deep', 40, 25);
+    await insertDive('shallow');
+    await insertBareProfile('shallow', 18, 30);
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 1);
+    expect(stats.noDecoCount, 1);
+    expect(stats.unknownCount, 0);
+  });
+
+  test('a dive with no profile stays unclassified', () async {
+    await insertDive('manual');
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 0);
+    expect(stats.noDecoCount, 0);
+    expect(stats.unknownCount, 1);
+  });
+
+  test('recorded deco_type still wins without running the analysis', () async {
+    // A shallow profile the model would clear, but whose computer recorded a
+    // deco stop. The recorded signal must take priority.
+    await insertDive('recorded');
+    await insertBareProfile('recorded', 18, 30);
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          const DiveProfilesCompanion(
+            id: Value('recorded-deco-sample'),
+            diveId: Value('recorded'),
+            timestamp: Value(99999),
+            depth: Value(9.0),
+            decoType: Value(2),
+            ceiling: Value(9.0),
+          ),
+        );
+
+    final stats = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+
+    expect(stats.decoCount, 1);
+    expect(stats.noDecoCount, 0);
+    expect(stats.unknownCount, 0);
+  });
+
+  test('a second read is served from the cache', () async {
+    await insertDive('deep');
+    await insertBareProfile('deep', 40, 25);
+
+    final first = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+    expect(first.decoCount, 1);
+
+    final cached = await cacheDb.select(cacheDb.decoClassificationCache).get();
+    expect(cached, hasLength(1));
+    expect(cached.single.diveId, 'deep');
+    expect(cached.single.hadDeco, isTrue);
+
+    final second = await (await makeContainer()).read(
+      decoObligationStatsProvider.future,
+    );
+    expect(second.decoCount, 1);
+  });
+}

--- a/test/features/statistics/presentation/providers/statistics_providers_all_test.dart
+++ b/test/features/statistics/presentation/providers/statistics_providers_all_test.dart
@@ -96,7 +96,9 @@ void main() {
     expect(await container.read(timeAtDepthRangesProvider.future), isEmpty);
     expect(await container.read(divesBySuitThicknessProvider.future), isEmpty);
     final deco = await container.read(decoObligationStatsProvider.future);
-    expect(deco.totalCount, 0);
+    expect(deco.decoCount, 0);
+    expect(deco.noDecoCount, 0);
+    expect(deco.unknownCount, 0);
   });
 
   test('SAC providers use the pressure-per-minute branch by default', () async {


### PR DESCRIPTION
Fixes #623.

## The report

A user with 167 dives saw the Statistics tab report **0 deco dives, 167 no-deco, 0.0%**, while his dive detail pages showed DECO badges, a 9.3 m ceiling, TTS 23 min and a stop schedule of 1/5/12 min at 9/6/3 m. He also saw the "Average ascent and descent speeds" card render "No profile data available" on dives with dense profiles.

## Symptom 1 was already fixed

`getAscentDescentRates` averaged `dive_profiles.ascent_rate`, a column no write path populates (libdivecomputer reports no ascent-rate sample type), gated on `WHERE ascent_rate IS NOT NULL`. The card was unconditionally empty for every user through v1.7.2. Commit 4a881e397dc fixed it and shipped in v1.7.3. The report predates that, so **no change here**.

## Symptom 2: root cause

`getDecoObligationStats` classified a deco dive as any dive with a sample where `ceiling > 0`. That is wrong in both directions.

**It under-counts.** `ceiling` is only ever written from computer-reported sample data. Both profile mappers gate it on the computer having reported a deco type, and several import sources never write it at all: MacDive XML and SQLite, Shearwater Cloud, the generic UDDF parser, CSV, and the OCR importer. Those dives were silently counted as no-deco.

Meanwhile the rest of the app answers the same question from a different layer. `profile_analysis_provider.dart` makes the **computed** analysis the base and overlays computer columns only when present:

```dart
profile[i].ceiling ?? analysis.ceilingCurve[i]
```

The ceiling and stop schedule on the dive detail page come from our own Buhlmann engine at the dive's gradient factors. Nothing writes that curve back to `dive_profiles.ceiling`, so the statistic and the dive page disagreed by construction, and the card asserted a confident `0` where the honest answer was "not recorded".

**It over-counts.** Per `libdc_wrapper.h:157`, `deco_type` is `0=NDL, 1=safetystop, 2=decostop, 3=deepstop`, and the mappers write `ceiling = decoDepth` for any non-zero type. A routine 5 m **safety stop** stored `ceiling = 5` and was counted as a decompression obligation. A recreational diver on a computer that reports safety stops could have seen a deco rate near 100%.

The codebase already knew better in two places this card never used: `getNoFlyDiveInputs` uses `deco_type = 2 OR ceiling > 0`, and `ProfileAnalysis.hadDecoObligation` (`ndlCurve.any((n) => n < 0)`) already existed.

## The fix

Classify from the best available evidence, in priority order, and never assert "no deco" from an absence of data:

1. **Recorded, authoritative.** `deco_type = 2`, or a `decoStopStart` profile event. Types 1 and 3 no longer qualify.
2. **Recorded, no obligation.** A profile carrying `deco_type` values, none of them 2.
3. **Recorded, ceiling only.** `ceiling > 0` on a profile with no `deco_type` at all, which keeps Subsurface XML, DAN DL7 and FIT working without re-admitting safety stops.
4. **Computed.** For a dive with a profile but no recorded signal, run the same analysis the dive detail page runs and test `hadDecoObligation`. This is what makes the card agree with the DECO badge the diver can see.
5. **Unknown.** A dive with no profile is reported separately and excluded from the rate denominator.

The card gains a "not recorded" line when anything falls into bucket 5, and the rate is now over classified dives only.

### Caching

Step 4 is the expensive one. The Buhlmann arithmetic is cheap; hydrating profiles is not. Computed classifications are re-derivable from data every device already holds, so they live in `local_cache_database.dart` (v13), not the synced main DB: no `currentSchemaVersion` bump, no HLC, no tombstones, no backup inclusion, and a restored database recomputes rather than inheriting another device's answer, which may have been produced under different gradient factors.

Entries are keyed by `decoInputsHash` over `analysisEngineVersion`, the gradient factors actually used, and the dive's `updated_at`, so a changed profile, changed GF, or a bumped engine invalidates without an explicit purge. A warm library does no analysis work at all.

### Reuse over reimplementation

The computed step reads `profileAnalysisProvider` rather than reimplementing the deco test in SQL or a parallel service. That is deliberate: the substance of this bug was two surfaces answering one question from different layers, and a second implementation would let them drift apart again. The batch pass invalidates each dive's analysis after classifying it, since both analysis providers are keepAlive families.

## Testing

- `statistics_repository_deco_test.dart` (8): safety stops are not obligations, deco-stop samples and `decoStopStart` events are, ceiling-only sources still work, bare profiles route to the computed step, and dives with no profile stay unclassified.
- `deco_classification_cache_test.dart` (7): round-trip, staleness, replacement, and scoping.
- `deco_classification_service_test.dart` (5): fingerprint stability and separator collisions.
- `deco_obligation_provider_test.dart` (6): end-to-end over the real analysis pipeline, including that a recorded `deco_type` still wins and that a second read is served from the cache.
- `deco_obligation_regression_test.dart` (1): the reporter's exact data shape, a library of depth-only profiles spanning both sides of the no-deco limit.

Fixture depths were chosen by sweeping `ProfileAnalysisService` rather than guessed, so neither sits on the NDL boundary, and the regression test derives its expected count from the engine at runtime so it cannot drift if the deco model is retuned.

Full suite green. `dart format` clean, `flutter analyze` clean.

New strings translated into all ten non-English locales.

## Out of scope

Two adjacent defects found during this investigation are filed separately so this stays reviewable:

- #1148: `getTimeAtDepthRanges` counts sample rows and divides by 60, assuming 1 Hz sampling. At the reporter's 4-5 s interval it overstates time at depth by that factor. It also omits the `is_primary` filter, so two-computer dives double-count.
- #1149: `setPrimaryDataSource` demotes every profile row, then re-promotes only rows matching a non-null `computerId`. File-imported sources have none, and the "Set Primary" menu carries no guard, so the dive is left with no primary profile. Confirmed reachable.

## Docs

- `docs/superpowers/specs/2026-08-18-deco-obligation-statistic.md`, root cause with file:line evidence
- `docs/superpowers/plans/2026-08-18-deco-obligation-statistic.md`, the implementation plan
