### PR TITLE
fix(sources): promote profile samples by owning source, not computerId

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -773,6 +773,26 @@ class DiveProfiles extends Table {
       text().references(Dives, #id, onDelete: KeyAction.cascade)();
   TextColumn get computerId =>
       text().nullable().references(DiveComputers, #id)();
+
+  /// Owning [DiveDataSources] row (issue #1149).
+  ///
+  /// [computerId] cannot identify the owner on its own: file imports and
+  /// manual entries leave it null on both the source row and the profile
+  /// rows, so two file-imported sources on one dive are indistinguishable.
+  /// This FK names the owner outright, which is what `setPrimaryDataSource`
+  /// promotes on.
+  ///
+  /// Nullable, and consumers must tolerate null: rows written before v158,
+  /// and rows synced from a peer running an older schema, carry none. The
+  /// fallback is the legacy convention (match on [computerId]; null belongs
+  /// to the primary source). `onDelete: setNull` because samples must
+  /// outlive their metadata row -- dropping a source must never destroy the
+  /// profile it describes.
+  TextColumn get sourceId => text().nullable().references(
+    DiveDataSources,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
   BoolColumn get isPrimary => boolean().withDefault(
     const Constant(true),
   )(); // Primary profile for stats
@@ -3096,7 +3116,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 157;
+  static const int currentSchemaVersion = 158;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3356,6 +3376,10 @@ class AppDatabase extends _$AppDatabase {
     // Renumbered from 154 and then 156, which #1104, #828 and #1127 claimed
     // first on main.
     157,
+    // v158 (issue #1149): owning-source FK on dive_profiles. Renumbered
+    // from 154 and then 156, which #1104, #1127 and #829 claimed first
+    // on main.
+    158,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4864,6 +4888,91 @@ class AppDatabase extends _$AppDatabase {
         'INTEGER NOT NULL DEFAULT 0',
       );
     }
+  }
+
+  /// Owning-source FK on dive_profiles (issue #1149). PRAGMA-guarded so a
+  /// healthy database no-ops and a partial schema does not throw.
+  Future<void> _assertProfileSourceIdColumn() async {
+    final cols = await customSelect("PRAGMA table_info('dive_profiles')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (names.contains('source_id')) return;
+    await customStatement(
+      'ALTER TABLE dive_profiles ADD COLUMN source_id TEXT '
+      'REFERENCES dive_data_sources(id) ON DELETE SET NULL',
+    );
+  }
+
+  /// One-time attribution of existing dive_profiles rows to their owning
+  /// dive_data_sources row (issue #1149).
+  ///
+  /// Reproduces the pre-v158 read convention that `getProfilesByDataSource`
+  /// implements, so nothing changes owner as a result of the migration:
+  ///
+  /// 1. A row whose `computer_id` matches a source on the same dive belongs
+  ///    to that source.
+  /// 2. Everything else -- a null `computer_id` (file imports, manual
+  ///    entries, and the rows `saveEditedProfile` writes) or a `computer_id`
+  ///    matching no source -- belongs to the dive's primary source.
+  ///
+  /// Rule 2 is lossy for the one case this FK exists to fix: a dive carrying
+  /// two file-imported sources has two indistinguishable null-`computer_id`
+  /// row sets, and they all land on the primary. That is exactly where the
+  /// old read path already put them, so this is not a regression, and every
+  /// row written from v158 on is attributed at insert time instead.
+  ///
+  /// Runs in the ladder only, never in `beforeOpen`: dive_profiles is the
+  /// largest table in the database and an "is anything unowned?" probe on
+  /// every open would be a full scan once the answer is no.
+  Future<void> _backfillProfileSourceIds() async {
+    // Probe BOTH tables' columns, not just dive_profiles'. PRAGMA table_info
+    // returns empty for a missing table, so this covers "table absent" and
+    // "column absent" in one check -- the same guard _backfillDiveComputerIds
+    // uses. Migration-test fixtures and databases caught mid-upgrade routinely
+    // hold dive_profiles without dive_data_sources, and the correlated
+    // subqueries below would fail with "no such table".
+    final cols = await customSelect("PRAGMA table_info('dive_profiles')").get();
+    if (!cols.map((c) => c.read<String>('name')).contains('source_id')) return;
+
+    final sourceCols = await customSelect(
+      "PRAGMA table_info('dive_data_sources')",
+    ).get();
+    final sourceNames = sourceCols.map((c) => c.read<String>('name')).toSet();
+    if (!sourceNames.containsAll({
+      'id',
+      'dive_id',
+      'computer_id',
+      'is_primary',
+      'created_at',
+    })) {
+      return;
+    }
+
+    // Deterministic pick so a re-run cannot move a row: primary first, then
+    // oldest. Mirrors the ordering getProfilesByDataSource reads sources in.
+    const primaryForDive =
+        'SELECT s.id FROM dive_data_sources s '
+        'WHERE s.dive_id = dive_profiles.dive_id '
+        'ORDER BY s.is_primary DESC, s.created_at ASC LIMIT 1';
+
+    await customStatement(
+      'UPDATE dive_profiles SET source_id = ('
+      'SELECT s.id FROM dive_data_sources s '
+      'WHERE s.dive_id = dive_profiles.dive_id '
+      'AND s.computer_id = dive_profiles.computer_id '
+      'ORDER BY s.is_primary DESC, s.created_at ASC LIMIT 1) '
+      'WHERE source_id IS NULL AND computer_id IS NOT NULL '
+      'AND EXISTS (SELECT 1 FROM dive_data_sources s '
+      'WHERE s.dive_id = dive_profiles.dive_id '
+      'AND s.computer_id = dive_profiles.computer_id)',
+    );
+
+    await customStatement(
+      'UPDATE dive_profiles SET source_id = ($primaryForDive) '
+      'WHERE source_id IS NULL '
+      'AND EXISTS (SELECT 1 FROM dive_data_sources s '
+      'WHERE s.dive_id = dive_profiles.dive_id)',
+    );
   }
 
   /// One-time clear of weather descriptions this app generated itself.
@@ -8250,6 +8359,13 @@ class AppDatabase extends _$AppDatabase {
           await _assertServiceCostColumns();
         }
         if (from < 157) await reportProgress();
+        // v158: owning-source FK on dive_profiles (issue #1149), plus the
+        // one-time attribution of existing rows.
+        if (from < 158) {
+          await _assertProfileSourceIdColumn();
+          await _backfillProfileSourceIds();
+        }
+        if (from < 158) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -8410,6 +8526,11 @@ class AppDatabase extends _$AppDatabase {
         // onUpgrade, and reading settings without this column throws. This
         // also covers a database stranded at 154 by the #1104 collision.
         await _assertGasModelColumn();
+        // v158 backstop: re-assert the dive_profiles owning-source column
+        // (issue #1149; same parallel-branch version-collision self-heal).
+        // Column only -- _backfillProfileSourceIds is a full-table pass and
+        // belongs to the ladder, not to every open.
+        await _assertProfileSourceIdColumn();
 
         // v156 backstop: re-assert the dive_plan_tanks travel-gas column
         // (same parallel-branch version-collision self-heal).

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -2008,6 +2008,7 @@ class SyncService {
     'diveProfiles': [
       (field: 'diveId', parent: 'dives', nullable: false),
       (field: 'computerId', parent: 'diveComputers', nullable: true),
+      (field: 'sourceId', parent: 'diveDataSources', nullable: true),
     ],
     'diveTanks': [
       (field: 'diveId', parent: 'dives', nullable: false),

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -86,6 +86,7 @@ class ReparseService {
         await _replaceDiveProfiles(
           diveId: diveId,
           computerId: computerId,
+          sourceId: sourceRow.id,
           parsed: parsed,
           isPrimary: sourceRow.isPrimary,
         );
@@ -462,6 +463,7 @@ class ReparseService {
   Future<void> _replaceDiveProfiles({
     required String diveId,
     required String? computerId,
+    required String sourceId,
     required pigeon.ParsedDive parsed,
     required bool isPrimary,
   }) async {
@@ -486,6 +488,9 @@ class ReparseService {
             id: Value(_uuid.v4()),
             diveId: Value(diveId),
             computerId: Value(computerId),
+            // Re-parsing rewrites this source's samples in place, so the
+            // replacements belong to the same source row (issue #1149).
+            sourceId: Value(sourceId),
             isPrimary: Value(isPrimary),
             timestamp: Value(s.timeSeconds),
             depth: Value(s.depthMeters),

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -740,6 +740,28 @@ class DiveComputerRepository {
     }
   }
 
+  /// The dive_data_sources row on [diveId] that describes [computerId], or
+  /// null when the dive has no source row for that computer yet.
+  ///
+  /// Used to stamp `dive_profiles.sourceId` at insert time (issue #1149).
+  /// Primary first so a dive that somehow carries two rows for one computer
+  /// resolves to the one the rest of the app treats as canonical.
+  Future<String?> _dataSourceIdFor(String diveId, String computerId) async {
+    final row =
+        await (_db.select(_db.diveDataSources)
+              ..where(
+                (t) =>
+                    t.diveId.equals(diveId) & t.computerId.equals(computerId),
+              )
+              ..orderBy([
+                (t) => OrderingTerm.desc(t.isPrimary),
+                (t) => OrderingTerm.asc(t.createdAt),
+              ])
+              ..limit(1))
+            .getSingleOrNull();
+    return row?.id;
+  }
+
   /// Get the primary profile's computer for a dive
   Future<String?> getPrimaryComputerId(String diveId) async {
     try {
@@ -1277,6 +1299,13 @@ class DiveComputerRepository {
         isPrimary = true;
       }
 
+      // Attribute the samples to the dive_data_sources row that describes
+      // this computer's reading (issue #1149), so a later primary swap
+      // promotes them by identity instead of re-deriving ownership from
+      // computerId. Null when no source row exists yet; consumers fall back
+      // to the pre-v154 computerId convention.
+      final ownerSourceId = await _dataSourceIdFor(diveId, computerId);
+
       // Batch insert profile points for performance (~100x faster than individual)
       // No individual sync records needed - parent dive sync covers child data
       await _db.batch((batch) {
@@ -1287,6 +1316,7 @@ class DiveComputerRepository {
               id: Value(_uuid.v4()),
               diveId: Value(diveId),
               computerId: Value(computerId),
+              sourceId: Value(ownerSourceId),
               timestamp: Value(point.timestamp),
               depth: Value(point.depth),
               pressure: const Value(null),

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -6142,13 +6142,11 @@ class DiveRepository {
         // dive kept rendering, because getDiveById and getMergedProfile do
         // not filter on the flag, while getDiveProfile, getAscentDescentRates
         // and the data-quality prefilters silently skipped it.
-        final promote = await _profileIdsOwnedBySource(diveId, newPrimary);
-        if (promote.isNotEmpty) {
+        if (await _sourceOwnsProfiles(diveId, newPrimary)) {
           await (_db.update(_db.diveProfiles)
                 ..where((t) => t.diveId.equals(diveId)))
               .write(const DiveProfilesCompanion(isPrimary: Value(false)));
-          await (_db.update(_db.diveProfiles)..where((t) => t.id.isIn(promote)))
-              .write(const DiveProfilesCompanion(isPrimary: Value(true)));
+          await _promoteProfilesOwnedBySource(diveId, newPrimary);
         }
       });
       SyncEventBus.notifyLocalChange();
@@ -6162,8 +6160,7 @@ class DiveRepository {
     }
   }
 
-  /// Ids of the [DiveProfiles] rows on [diveId] that [source] owns, reduced
-  /// to a single generation.
+  /// Matches the [DiveProfiles] rows on a dive that [source] owns.
   ///
   /// Ownership prefers the v154 `sourceId` FK and falls back to the pre-v154
   /// convention for rows that carry none -- rows written before the migration
@@ -6172,63 +6169,90 @@ class DiveRepository {
   /// a row belongs to [source] when their `computerId`s match, and a
   /// null-`computerId` row belongs to whichever source is primary.
   ///
-  /// The two are unioned rather than tried in order, because a database can
-  /// legitimately hold both shapes at once after syncing with an older peer.
+  /// `computer_id IS ?` rather than `=` is load-bearing. `=` never matches
+  /// NULL, which is exactly how issue #1149 began: the old promote could not
+  /// address a file-imported source's rows at all. `IS` compares null-safely,
+  /// so one predicate covers both a real computer id and the null every file
+  /// import and manual entry carries.
   ///
-  /// The dedupe by timestamp is what keeps an edited profile from rendering
-  /// twice. [saveEditedProfile] does not replace the rows it supersedes: it
-  /// demotes them and inserts a second, null-`computerId` generation
-  /// alongside. Both generations belong to the same source, so promoting the
-  /// owned set wholesale would resurrect the originals next to the edit.
-  /// Null-`computerId` rows win the tie, which is the same "the edit is the
-  /// live one" rule [restoreOriginalProfile] encodes.
-  Future<List<String>> _profileIdsOwnedBySource(
+  /// `source.isPrimary` is deliberately not consulted: callers load the row
+  /// before swapping the source flags, so it still reads false for the very
+  /// source being promoted. The convention is applied prospectively -- this
+  /// source is about to be primary, so the dive's unattributed
+  /// null-computerId rows are the ones it will own.
+  static const String _ownedBySourceSql =
+      '(p.source_id = ?2 OR (p.source_id IS NULL AND p.computer_id IS ?3))';
+
+  List<Variable<Object>> _ownershipVars(
+    String diveId,
+    DiveDataSourcesData source,
+  ) => [
+    Variable<String>(diveId),
+    Variable<String>(source.id),
+    Variable<String>(source.computerId),
+  ];
+
+  /// Whether [source] owns any of the dive's profile rows.
+  ///
+  /// Read before the demote so a source that owns nothing leaves the existing
+  /// primary set alone rather than stranding the dive (issue #1149).
+  Future<bool> _sourceOwnsProfiles(
     String diveId,
     DiveDataSourcesData source,
   ) async {
-    final rows =
-        await (_db.select(_db.diveProfiles)
-              ..where((t) => t.diveId.equals(diveId))
-              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
-            .get();
-    if (rows.isEmpty) return const [];
+    final row = await _db
+        .customSelect(
+          'SELECT EXISTS(SELECT 1 FROM dive_profiles p '
+          'WHERE p.dive_id = ?1 AND $_ownedBySourceSql) AS owns',
+          variables: _ownershipVars(diveId, source),
+          readsFrom: {_db.diveProfiles},
+        )
+        .getSingle();
+    return row.read<int>('owns') == 1;
+  }
 
-    // `source.isPrimary` is deliberately not consulted: callers load the row
-    // before swapping the source flags, so it still reads false for the very
-    // source being promoted. The convention is applied prospectively -- this
-    // source is about to be primary, so the dive's unattributed
-    // null-computerId rows are the ones it will own.
-    bool ownedByLegacyConvention(DiveProfile row) {
-      if (row.sourceId != null) return false;
-      return source.computerId != null
-          ? row.computerId == source.computerId
-          : row.computerId == null;
-    }
-
-    final owned = rows
-        .where((r) => r.sourceId == source.id || ownedByLegacyConvention(r))
-        .toList();
-
-    // Deterministic on purpose. A null computerId marks the edit, so it wins
-    // the tie; where that cannot separate them (two generations of the same
-    // file-imported source) the greater id does. Ids are shared across
-    // devices, so every peer resolves the same winner and the flag does not
-    // ping-pong through sync.
-    bool supersedes(DiveProfile candidate, DiveProfile held) {
-      if ((candidate.computerId == null) != (held.computerId == null)) {
-        return candidate.computerId == null;
-      }
-      return candidate.id.compareTo(held.id) > 0;
-    }
-
-    final liveByTimestamp = <int, DiveProfile>{};
-    for (final row in owned) {
-      final held = liveByTimestamp[row.timestamp];
-      if (held == null || supersedes(row, held)) {
-        liveByTimestamp[row.timestamp] = row;
-      }
-    }
-    return [for (final row in liveByTimestamp.values) row.id];
+  /// Promotes the rows [source] owns, one per timestamp.
+  ///
+  /// Expressed as a predicate rather than a list of ids on purpose. Binding
+  /// one variable per sample capped the method at SQLite's bound-variable
+  /// limit -- 999 on builds before 3.32, 32766 after -- so a long enough dive
+  /// failed with "too many SQL variables". The limit varies by platform build
+  /// (system SQLite on Android, the bundled SQLCipher elsewhere), so this
+  /// binds a fixed three variables at any dive length instead of chunking to
+  /// whichever ceiling the current build happens to have.
+  ///
+  /// The ranking is what keeps an edited profile from rendering twice.
+  /// [saveEditedProfile] does not replace the rows it supersedes: it demotes
+  /// them and inserts a second, null-computerId generation alongside. Both
+  /// generations belong to the same source and share timestamps, so promoting
+  /// the whole owned set would resurrect the originals next to the edit. Only
+  /// the winner at each timestamp is promoted: the null-computerId row first,
+  /// which is the same "the edit is the live one" rule
+  /// [restoreOriginalProfile] encodes, then the greatest id. Both halves are
+  /// deterministic and derived from synced values, so every device resolves
+  /// the same winner and the flag does not ping-pong through sync.
+  ///
+  /// ROW_NUMBER, not a correlated subquery matching on timestamp. There is no
+  /// index on dive_profiles(timestamp) -- only dive_id -- so a correlated form
+  /// rescans the dive once per row, which measured 45 seconds on a
+  /// 32767-sample dive. The window function sorts the dive's rows once
+  /// instead. The same pattern already appears in the dedupe migrations in
+  /// database.dart.
+  Future<void> _promoteProfilesOwnedBySource(
+    String diveId,
+    DiveDataSourcesData source,
+  ) async {
+    await _db.customStatement(
+      'UPDATE dive_profiles SET is_primary = 1 WHERE id IN ('
+      'SELECT id FROM ('
+      'SELECT p.id AS id, ROW_NUMBER() OVER ('
+      'PARTITION BY p.timestamp '
+      'ORDER BY (p.computer_id IS NULL) DESC, p.id DESC) AS rn '
+      'FROM dive_profiles p '
+      'WHERE p.dive_id = ?1 AND $_ownedBySourceSql'
+      ') WHERE rn = 1)',
+      _ownershipVars(diveId, source).map((v) => v.value).toList(),
+    );
   }
 
   /// Resolves a `{ computerId -> friendly name }` map for the given source

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -590,6 +590,18 @@ class DiveRepository {
       final now = DateTime.now().millisecondsSinceEpoch;
 
       await _db.transaction(() async {
+        // The edit belongs to whichever source is primary right now: it is a
+        // correction of that source's samples, not a new source. Read the id
+        // before the demote so setPrimaryDataSource can later promote the
+        // edit by identity (issue #1149).
+        final primarySource =
+            await (_db.select(_db.diveDataSources)
+                  ..where(
+                    (t) => t.diveId.equals(diveId) & t.isPrimary.equals(true),
+                  )
+                  ..limit(1))
+                .getSingleOrNull();
+
         // Demote all existing profiles to non-primary
         await (_db.update(_db.diveProfiles)
               ..where((t) => t.diveId.equals(diveId)))
@@ -603,6 +615,7 @@ class DiveRepository {
               DiveProfilesCompanion(
                 id: Value(_uuid.v4()),
                 diveId: Value(diveId),
+                sourceId: Value(primarySource?.id),
                 isPrimary: const Value(true),
                 timestamp: Value(point.timestamp),
                 depth: Value(point.depth),
@@ -825,15 +838,25 @@ class DiveRepository {
                 ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
               .get();
 
-      // A row belongs to the primary source's "family" when its computerId
-      // is null (schema convention for primary/manual/edited rows) or is the
-      // primary's own computer. Only family rows participate in
-      // edited-profile detection: an edit demotes the family originals to
-      // isPrimary=false and writes edited rows with isPrimary=true, whereas
-      // secondary computers' rows are ALWAYS isPrimary=false and must never
-      // be mistaken for demoted originals.
-      bool isPrimaryFamily(DiveProfile r) =>
-          r.computerId == null || r.computerId == primary.computerId;
+      // A row belongs to the primary source's "family" when the v154
+      // sourceId FK names the primary source, or -- for rows that carry no
+      // sourceId (written before the migration, or synced from a peer on an
+      // older schema) -- when its computerId is null (the pre-v154
+      // convention for primary/manual/edited rows) or is the primary's own
+      // computer. Only family rows participate in edited-profile detection:
+      // an edit demotes the family originals to isPrimary=false and writes
+      // edited rows with isPrimary=true, whereas secondary computers' rows
+      // are ALWAYS isPrimary=false and must never be mistaken for demoted
+      // originals.
+      //
+      // Preferring the FK is what stops a dive carrying two file-imported
+      // sources from being misread as edited: both sets are null-computerId,
+      // so the legacy rule sees one primary-flagged set beside one demoted
+      // set and drops the second source's samples outright (issue #1149).
+      final sourceIds = {for (final s in sourceRows) s.id};
+      bool isPrimaryFamily(DiveProfile r) => sourceIds.contains(r.sourceId)
+          ? r.sourceId == primary.id
+          : r.computerId == null || r.computerId == primary.computerId;
 
       final familyRows = rows.where(isPrimaryFamily);
       final hasEditedProfile =
@@ -846,7 +869,11 @@ class DiveRepository {
       var primaryIsEdited = false;
 
       for (final row in rows) {
-        final owner = row.computerId == null
+        // The FK is authoritative when present and still resolvable; the
+        // computerId convention is the fallback for unattributed rows.
+        final owner = sourceIds.contains(row.sourceId)
+            ? row.sourceId!
+            : row.computerId == null
             ? primary.id
             : (sourceIdByComputer[row.computerId!] ?? primary.id);
         if (hasEditedProfile && isPrimaryFamily(row)) {
@@ -5922,6 +5949,7 @@ class DiveRepository {
   Future<void> saveComputerReading(DiveDataSourcesCompanion reading) async {
     try {
       await _db.into(_db.diveDataSources).insert(reading);
+      await _adoptUnattributedProfiles(reading);
       SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(
@@ -5931,6 +5959,35 @@ class DiveRepository {
       );
       rethrow;
     }
+  }
+
+  /// Claim a dive's unattributed profile rows for a just-inserted source.
+  ///
+  /// The file-import pipeline writes samples before it writes the source row
+  /// describing them (createDive runs first, saveComputerReading second), so
+  /// those rows would carry no sourceId and depend on the pre-v154 computerId
+  /// convention forever. Adopting them the moment their owner first exists
+  /// closes that gap for newly imported dives (issue #1149).
+  ///
+  /// Only when this is the dive's sole source row. With a second source
+  /// present the unattributed rows could belong to either, and a guess would
+  /// be worse than leaving the documented fallback to handle them.
+  Future<void> _adoptUnattributedProfiles(
+    DiveDataSourcesCompanion reading,
+  ) async {
+    if (!reading.id.present || !reading.diveId.present) return;
+    final diveId = reading.diveId.value;
+
+    final sources =
+        await (_db.select(_db.diveDataSources)
+              ..where((t) => t.diveId.equals(diveId))
+              ..limit(2))
+            .get();
+    if (sources.length != 1) return;
+
+    await (_db.update(_db.diveProfiles)
+          ..where((t) => t.diveId.equals(diveId) & t.sourceId.isNull()))
+        .write(DiveProfilesCompanion(sourceId: Value(reading.id.value)));
   }
 
   /// Delete a computer reading snapshot by its ID.
@@ -6074,19 +6131,23 @@ class DiveRepository {
           ),
         );
 
-        // Swap isPrimary on dive_profiles:
-        // Demote all profiles for this dive.
-        await (_db.update(_db.diveProfiles)
-              ..where((t) => t.diveId.equals(diveId)))
-            .write(const DiveProfilesCompanion(isPrimary: Value(false)));
-
-        // Promote profiles belonging to the new primary computer.
-        if (newPrimary.computerId != null) {
-          await (_db.update(_db.diveProfiles)..where(
-                (t) =>
-                    t.diveId.equals(diveId) &
-                    t.computerId.equals(newPrimary.computerId!),
-              ))
+        // Swap isPrimary on dive_profiles.
+        //
+        // Resolve what to promote BEFORE demoting anything (issue #1149).
+        // The old order -- demote every row for the dive, then promote --
+        // stranded the dive with zero `is_primary = 1` rows whenever the
+        // promote matched nothing, which happened for every file-imported
+        // source (null computerId on both the source row and its profile
+        // rows) and for any metadata-only source that owns no samples. The
+        // dive kept rendering, because getDiveById and getMergedProfile do
+        // not filter on the flag, while getDiveProfile, getAscentDescentRates
+        // and the data-quality prefilters silently skipped it.
+        final promote = await _profileIdsOwnedBySource(diveId, newPrimary);
+        if (promote.isNotEmpty) {
+          await (_db.update(_db.diveProfiles)
+                ..where((t) => t.diveId.equals(diveId)))
+              .write(const DiveProfilesCompanion(isPrimary: Value(false)));
+          await (_db.update(_db.diveProfiles)..where((t) => t.id.isIn(promote)))
               .write(const DiveProfilesCompanion(isPrimary: Value(true)));
         }
       });
@@ -6099,6 +6160,75 @@ class DiveRepository {
       );
       rethrow;
     }
+  }
+
+  /// Ids of the [DiveProfiles] rows on [diveId] that [source] owns, reduced
+  /// to a single generation.
+  ///
+  /// Ownership prefers the v154 `sourceId` FK and falls back to the pre-v154
+  /// convention for rows that carry none -- rows written before the migration
+  /// backfilled them, and rows synced from a peer still on an older schema.
+  /// That convention, which [getProfilesByDataSource] also implements, is:
+  /// a row belongs to [source] when their `computerId`s match, and a
+  /// null-`computerId` row belongs to whichever source is primary.
+  ///
+  /// The two are unioned rather than tried in order, because a database can
+  /// legitimately hold both shapes at once after syncing with an older peer.
+  ///
+  /// The dedupe by timestamp is what keeps an edited profile from rendering
+  /// twice. [saveEditedProfile] does not replace the rows it supersedes: it
+  /// demotes them and inserts a second, null-`computerId` generation
+  /// alongside. Both generations belong to the same source, so promoting the
+  /// owned set wholesale would resurrect the originals next to the edit.
+  /// Null-`computerId` rows win the tie, which is the same "the edit is the
+  /// live one" rule [restoreOriginalProfile] encodes.
+  Future<List<String>> _profileIdsOwnedBySource(
+    String diveId,
+    DiveDataSourcesData source,
+  ) async {
+    final rows =
+        await (_db.select(_db.diveProfiles)
+              ..where((t) => t.diveId.equals(diveId))
+              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+            .get();
+    if (rows.isEmpty) return const [];
+
+    // `source.isPrimary` is deliberately not consulted: callers load the row
+    // before swapping the source flags, so it still reads false for the very
+    // source being promoted. The convention is applied prospectively -- this
+    // source is about to be primary, so the dive's unattributed
+    // null-computerId rows are the ones it will own.
+    bool ownedByLegacyConvention(DiveProfile row) {
+      if (row.sourceId != null) return false;
+      return source.computerId != null
+          ? row.computerId == source.computerId
+          : row.computerId == null;
+    }
+
+    final owned = rows
+        .where((r) => r.sourceId == source.id || ownedByLegacyConvention(r))
+        .toList();
+
+    // Deterministic on purpose. A null computerId marks the edit, so it wins
+    // the tie; where that cannot separate them (two generations of the same
+    // file-imported source) the greater id does. Ids are shared across
+    // devices, so every peer resolves the same winner and the flag does not
+    // ping-pong through sync.
+    bool supersedes(DiveProfile candidate, DiveProfile held) {
+      if ((candidate.computerId == null) != (held.computerId == null)) {
+        return candidate.computerId == null;
+      }
+      return candidate.id.compareTo(held.id) > 0;
+    }
+
+    final liveByTimestamp = <int, DiveProfile>{};
+    for (final row in owned) {
+      final held = liveByTimestamp[row.timestamp];
+      if (held == null || supersedes(row, held)) {
+        liveByTimestamp[row.timestamp] = row;
+      }
+    }
+    return [for (final row in liveByTimestamp.values) row.id];
   }
 
   /// Resolves a `{ computerId -> friendly name }` map for the given source

--- a/lib/features/dive_log/data/services/dive_consolidation_service.dart
+++ b/lib/features/dive_log/data/services/dive_consolidation_service.dart
@@ -167,15 +167,23 @@ class DiveConsolidationService {
         final secSources = snapshot.dataSourceRows
             .where((r) => r.diveId == secondary.id)
             .toList();
+        // Owning-source ids for the copied profile rows (issue #1149).
+        // Maps the secondary's source id to the freshly minted row on the
+        // target; `null` keys the synthesized case, where the secondary had
+        // no source row for its profiles to point at.
+        final sourceIdMap = <String?, String>{};
+
         if (secSources.isEmpty) {
           // Synthesize from the dives row -- same companion mergeDives
           // builds today (dive_repository_impl.dart:4616-4652), attributed
           // to the secondary's own computer.
+          final synthesizedId = _uuid.v4();
+          sourceIdMap[null] = synthesizedId;
           await _db
               .into(_db.diveDataSources)
               .insert(
                 DiveDataSourcesCompanion(
-                  id: Value(_uuid.v4()),
+                  id: Value(synthesizedId),
                   diveId: Value(targetDiveId),
                   computerId: Value(secRow.computerId),
                   isPrimary: const Value(false),
@@ -212,18 +220,28 @@ class DiveConsolidationService {
               );
         } else {
           for (final row in secSources) {
+            final copiedId = _uuid.v4();
+            sourceIdMap[row.id] = copiedId;
             await _db
                 .into(_db.diveDataSources)
                 .insert(
                   row
                       .toCompanion(false)
                       .copyWith(
-                        id: Value(_uuid.v4()),
+                        id: Value(copiedId),
                         diveId: Value(targetDiveId),
                         isPrimary: const Value(false),
                       ),
                 );
           }
+          // A profile row whose sourceId names none of the copied rows (an
+          // old row that never got attributed) still needs an owner on the
+          // target, so fall back to the secondary's primary source.
+          final fallback = secSources.firstWhere(
+            (r) => r.isPrimary,
+            orElse: () => secSources.first,
+          );
+          sourceIdMap[null] = sourceIdMap[fallback.id]!;
         }
 
         // Tanks: merged ones map, kept ones copy with attribution.
@@ -271,6 +289,14 @@ class DiveConsolidationService {
                     diveId: Value(targetDiveId),
                     timestamp: Value(row.timestamp + offset),
                     computerId: Value(row.computerId ?? secRow.computerId),
+                    // Re-point at the target's copy of the owning source
+                    // (issue #1149). Without this the copied samples would
+                    // reference a source row on the now-deleted secondary,
+                    // and two file-imported sources -- both null computerId
+                    // -- would be indistinguishable on the merged dive.
+                    sourceId: Value(
+                      sourceIdMap[row.sourceId] ?? sourceIdMap[null],
+                    ),
                     isPrimary: const Value(false),
                   ),
             );

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -178,6 +178,77 @@ class DiveMergeService {
         ),
       );
 
+      // Owning-source ids for the merged dive (issue #1149). The source
+      // rows themselves are not inserted until step 10, but the profile
+      // copy below has to reference them, so mint the ids up front and let
+      // step 10 reuse them. A profile row whose sourceId names no copied row
+      // falls back to its own segment's source, so samples never end up
+      // pointing at a row on a dive this merge is about to consume.
+      final mergedSourceIds = <String, String>{
+        for (final row in snapshot.dataSourceRows) row.id: _uuid.v4(),
+      };
+      // Inserted here rather than at their step-10 slot: dive_profiles.
+      // sourceId is a real FK and foreign_keys is ON, so the parent rows must
+      // land before the samples that reference them.
+      //
+      // Carried as provenance; NEVER primary (a merged profile is
+      // user-authored -- reparse must not rewrite it).
+      //     CAVEAT (#1164): isPrimary false only stops reparse from
+      //     rewriting the dives row and tanks. ReparseService step 4 calls
+      //     _replaceDiveProfiles unconditionally, so re-parsing a merged
+      //     dive today still wipes the merged profile. Tracked separately.
+      // DiveRepository.saveComputerReading does not call
+      // markRecordPending for diveDataSources rows either -- it relies on
+      // the parent dive's pending record (step 1) to carry the change, so
+      // no per-row markRecordPending here mirrors that.
+      //
+      // EVERY row is carried, including several sharing one computerId --
+      // the shape a same-computer split-pair merge produces. Do NOT collapse
+      // them here (#1045): rows that share a computerId are not duplicates.
+      // Each is the sole surviving copy of one download's rawData,
+      // rawFingerprint and sourceUuid once step 13 deletes the originals, and
+      // all three are load-bearing:
+      //   - getSourceKeysByDiveId unions source_uuid/raw_fingerprint across
+      //     ALL of a dive's rows so a re-download of EITHER half resolves as
+      //     a duplicate; dropping a row makes that half import as a new dive.
+      //   - ReparseService.getSourcesForDiveReparse selects on rawData, so a
+      //     dropped row's bytes can never be re-parsed by a later
+      //     libdivecomputer.
+      // The duplicate is a display-side concern only, and is canonicalized on
+      // read by _canonicalDataSourceRows (#1005). The underlying gap that
+      // comment described -- dive_profiles attributing samples by computerId
+      // alone, so computerId gets treated as a per-dive unique source key the
+      // schema never guaranteed -- is what dive_profiles.sourceId now closes
+      // (#1149); each carried row keeps its own id here and the copied samples
+      // point at it, so the strands stay separable without a lossy write.
+      for (final row in snapshot.dataSourceRows) {
+        await _db
+            .into(_db.diveDataSources)
+            .insert(
+              row
+                  .toCompanion(false)
+                  .copyWith(
+                    id: Value(mergedSourceIds[row.id]!),
+                    diveId: Value(mergedId),
+                    isPrimary: const Value(false),
+                  ),
+            );
+      }
+
+      String? mergedSourceIdFor(String diveId, String? sourceId) {
+        final mapped = mergedSourceIds[sourceId];
+        if (mapped != null) return mapped;
+        final segment = snapshot.dataSourceRows
+            .where((r) => r.diveId == diveId)
+            .toList();
+        if (segment.isEmpty) return null;
+        final owner = segment.firstWhere(
+          (r) => r.isPrimary,
+          orElse: () => segment.first,
+        );
+        return mergedSourceIds[owner.id];
+      }
+
       // 2. Profile rows copied directly (preserves computerId/isPrimary/
       //    temperature/sensor columns), re-based onto the merged timeline.
       await _db.batch((batch) {
@@ -191,6 +262,7 @@ class DiveMergeService {
                   id: Value(_uuid.v4()),
                   diveId: Value(mergedId),
                   timestamp: Value(row.timestamp + offset),
+                  sourceId: Value(mergedSourceIdFor(row.diveId, row.sourceId)),
                 ),
           );
         }
@@ -232,6 +304,11 @@ class DiveMergeService {
                 timestamp: ts,
                 depth: 0,
                 computerId: Value(adjacent?.computerId),
+                sourceId: Value(
+                  adjacent == null
+                      ? null
+                      : mergedSourceIdFor(adjacent.diveId, adjacent.sourceId),
+                ),
                 isPrimary: Value(adjacent?.isPrimary ?? true),
               ),
             );
@@ -387,48 +464,7 @@ class DiveMergeService {
         );
       }
 
-      // 10. Data sources carried as provenance; NEVER primary (a merged
-      //     profile is user-authored -- reparse must not rewrite it).
-      //     CAVEAT (#1164): isPrimary false only stops reparse from
-      //     rewriting the dives row and tanks. ReparseService step 4 calls
-      //     _replaceDiveProfiles unconditionally, so re-parsing a merged
-      //     dive today still wipes the merged profile. Tracked separately.
-      // DiveRepository.saveComputerReading does not call
-      // markRecordPending for diveDataSources rows either -- it relies on
-      // the parent dive's pending record (step 1) to carry the change, so
-      // no per-row markRecordPending here mirrors that.
-      //
-      // EVERY row is carried, including several sharing one computerId --
-      // the shape a same-computer split-pair merge produces. Do NOT collapse
-      // them here (#1045): rows that share a computerId are not duplicates.
-      // Each is the sole surviving copy of one download's rawData,
-      // rawFingerprint and sourceUuid once step 13 deletes the originals, and
-      // all three are load-bearing:
-      //   - getSourceKeysByDiveId unions source_uuid/raw_fingerprint across
-      //     ALL of a dive's rows so a re-download of EITHER half resolves as
-      //     a duplicate; dropping a row makes that half import as a new dive.
-      //   - ReparseService.getSourcesForDiveReparse selects on rawData, so a
-      //     dropped row's bytes can never be re-parsed by a later
-      //     libdivecomputer.
-      // The duplicate is a display-side concern only, and is canonicalized on
-      // read by _canonicalDataSourceRows (#1005). The underlying gap is that
-      // dive_profiles attributes samples by computerId alone, so computerId
-      // gets treated as a per-dive unique source key the schema never
-      // guaranteed -- fixing that needs a dive_profiles.data_source_id FK,
-      // not a lossy write here.
-      for (final row in snapshot.dataSourceRows) {
-        await _db
-            .into(_db.diveDataSources)
-            .insert(
-              row
-                  .toCompanion(false)
-                  .copyWith(
-                    id: Value(_uuid.v4()),
-                    diveId: Value(mergedId),
-                    isPrimary: const Value(false),
-                  ),
-            );
-      }
+      // 10. Data sources are inserted ahead of step 2 -- see the note there.
 
       // 11. Tide record: first dive's only.
       final firstTide = snapshot.tideRows

--- a/lib/features/dive_log/data/services/dive_split_service.dart
+++ b/lib/features/dive_log/data/services/dive_split_service.dart
@@ -127,13 +127,14 @@ class DiveSplitService {
       );
 
       // 2. The source row becomes the new dive's primary source.
+      final newSourceId = _uuid.v4();
       await _db
           .into(_db.diveDataSources)
           .insert(
             source
                 .toCompanion(false)
                 .copyWith(
-                  id: Value(_uuid.v4()),
+                  id: Value(newSourceId),
                   diveId: Value(newDiveId),
                   isPrimary: const Value(true),
                 ),
@@ -270,6 +271,10 @@ class DiveSplitService {
                 .copyWith(
                   id: Value(_uuid.v4()),
                   diveId: Value(newDiveId),
+                  // Follow the source to its row on the new dive (issue
+                  // #1149); the original row is deleted at step 8, and
+                  // ON DELETE SET NULL would otherwise strip attribution.
+                  sourceId: Value(newSourceId),
                   isPrimary: source.isPrimary
                       ? Value(row.isPrimary)
                       : const Value(true),
@@ -387,11 +392,21 @@ class DiveSplitService {
                   )
                   ..limit(1))
                 .get();
-        if (remainingPrimary.isEmpty && promoted.computerId != null) {
+        if (remainingPrimary.isEmpty) {
+          // Match on the owning-source FK first, and only fall back to the
+          // pre-v154 computerId convention for rows that carry none. The
+          // old code gated the whole promote on `promoted.computerId !=
+          // null`, so a file-imported source promoted nothing and left the
+          // remaining dive with zero is_primary rows -- the same stranding
+          // as issue #1149.
           await (_db.update(_db.diveProfiles)..where(
                 (t) =>
                     t.diveId.equals(diveId) &
-                    t.computerId.equals(promoted.computerId!),
+                    (t.sourceId.equals(promoted.id) |
+                        (t.sourceId.isNull() &
+                            (promoted.computerId != null
+                                ? t.computerId.equals(promoted.computerId!)
+                                : t.computerId.isNull()))),
               ))
               .write(const DiveProfilesCompanion(isPrimary: Value(true)));
         }

--- a/lib/features/dive_log/data/services/dive_split_service.dart
+++ b/lib/features/dive_log/data/services/dive_split_service.dart
@@ -250,17 +250,27 @@ class DiveSplitService {
       // sources take their computer's rows, promoted to primary on the new
       // dive. A computer-less source moves only non-primary null rows
       // (user-edited primary rows stay with the original dive).
+      // Every branch below is additionally gated on the row not being spoken
+      // for by a DIFFERENT source (issue #1149). The computerId rules cannot
+      // separate two file-imported sources -- both sides are null -- so on a
+      // dive carrying two of them the null-family branch swept up the other
+      // source's samples and carried them onto the new dive, taking them off
+      // the dive being split from entirely. A row whose sourceId names
+      // another source is never this source's to move; rows with no sourceId
+      // still fall through to the legacy rules below.
       final profileRows =
-          await (_db.select(_db.diveProfiles)..where(
-                (t) => source.computerId == null
-                    ? t.diveId.equals(diveId) &
-                          t.computerId.isNull() &
-                          t.isPrimary.equals(false)
+          await (_db.select(_db.diveProfiles)..where((t) {
+                final notOwnedByAnotherSource =
+                    t.sourceId.isNull() | t.sourceId.equals(source.id);
+                final byLegacyRule = source.computerId == null
+                    ? t.computerId.isNull() & t.isPrimary.equals(false)
                     : source.isPrimary
-                    ? t.diveId.equals(diveId) &
-                          (ownedBySource(t.computerId) | t.computerId.isNull())
-                    : t.diveId.equals(diveId) & ownedBySource(t.computerId),
-              ))
+                    ? ownedBySource(t.computerId) | t.computerId.isNull()
+                    : ownedBySource(t.computerId);
+                return t.diveId.equals(diveId) &
+                    notOwnedByAnotherSource &
+                    byLegacyRule;
+              }))
               .get();
       await _db.batch((batch) {
         for (final row in profileRows) {

--- a/test/core/database/migration_v158_profile_source_id_test.dart
+++ b/test/core/database/migration_v158_profile_source_id_test.dart
@@ -1,0 +1,178 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Pre-v158 dive_profiles shape: samples are correlated to a data source only
+/// through computer_id, which is null for every file import and manual entry.
+const _preV158DiveProfiles = '''
+  CREATE TABLE dive_profiles (
+    id TEXT NOT NULL PRIMARY KEY,
+    dive_id TEXT NOT NULL,
+    computer_id TEXT,
+    is_primary INTEGER NOT NULL DEFAULT 1,
+    timestamp INTEGER NOT NULL,
+    depth REAL NOT NULL
+  )
+''';
+
+const _preV158DiveDataSources = '''
+  CREATE TABLE dive_data_sources (
+    id TEXT NOT NULL PRIMARY KEY,
+    dive_id TEXT NOT NULL,
+    computer_id TEXT,
+    is_primary INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER
+  )
+''';
+
+/// A dive with one computer source and one file-imported source, plus the
+/// four profile shapes the backfill has to sort out.
+void _seedMixedDive(dynamic rawDb) {
+  rawDb.execute(
+    "INSERT INTO dive_data_sources (id, dive_id, computer_id, is_primary, "
+    "created_at) VALUES ('src-computer', 'd1', 'comp-1', 0, 100)",
+  );
+  rawDb.execute(
+    "INSERT INTO dive_data_sources (id, dive_id, computer_id, is_primary, "
+    "created_at) VALUES ('src-file', 'd1', NULL, 1, 200)",
+  );
+
+  void profile(String id, String diveId, String? computerId) {
+    final computer = computerId == null ? 'NULL' : "'$computerId'";
+    rawDb.execute(
+      "INSERT INTO dive_profiles (id, dive_id, computer_id, timestamp, depth) "
+      "VALUES ('$id', '$diveId', $computer, 60, 20.0)",
+    );
+  }
+
+  profile('p-computer', 'd1', 'comp-1');
+  profile('p-null', 'd1', null);
+  profile('p-unmatched', 'd1', 'comp-99');
+  // A dive with no data-source rows at all: nothing to attribute to.
+  profile('p-orphan', 'd2', null);
+}
+
+Future<String?> _sourceIdOf(AppDatabase db, String profileId) async {
+  final row = await db
+      .customSelect(
+        "SELECT source_id FROM dive_profiles WHERE id = '$profileId'",
+      )
+      .getSingle();
+  return row.data['source_id'] as String?;
+}
+
+void main() {
+  test('v158 adds the owning-source column, preserving rows', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 157');
+        rawDb.execute(_preV158DiveProfiles);
+        rawDb.execute(_preV158DiveDataSources);
+        _seedMixedDive(rawDb);
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('dive_profiles')")
+        .get();
+    expect(cols.map((c) => c.read<String>('name')), contains('source_id'));
+
+    final row = await db
+        .customSelect(
+          "SELECT depth, timestamp FROM dive_profiles WHERE id = 'p-computer'",
+        )
+        .getSingle();
+    expect(row.data['depth'], 20.0);
+    expect(row.data['timestamp'], 60);
+  });
+
+  test('v158 attributes rows the way the pre-v158 read path did', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 157');
+        rawDb.execute(_preV158DiveProfiles);
+        rawDb.execute(_preV158DiveDataSources);
+        _seedMixedDive(rawDb);
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    // A matching computer_id names the owner outright.
+    expect(await _sourceIdOf(db, 'p-computer'), 'src-computer');
+
+    // Null computer_id belongs to the primary source -- the convention
+    // getProfilesByDataSource has always implemented. Reproducing it here is
+    // what keeps the upgrade from moving anyone's samples between sources.
+    expect(await _sourceIdOf(db, 'p-null'), 'src-file');
+
+    // A computer_id matching no source falls back the same way.
+    expect(await _sourceIdOf(db, 'p-unmatched'), 'src-file');
+
+    // Nothing to attribute to: left null, and the code falls back to the
+    // legacy convention for these.
+    expect(await _sourceIdOf(db, 'p-orphan'), isNull);
+  });
+
+  test('migration list includes v158 and schema is at least 158', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(158));
+    expect(AppDatabase.migrationVersions, contains(158));
+  });
+
+  test('v158 is idempotent when source_id already exists', () async {
+    // An interrupted upgrade, or a database that reached this version number
+    // from a parallel branch, leaves the column already added. The PRAGMA
+    // guard must skip the ALTER rather than fail on a duplicate column, and
+    // the backfill must not move a row that already has an owner.
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 157');
+        rawDb.execute(_preV158DiveProfiles);
+        rawDb.execute(_preV158DiveDataSources);
+        rawDb.execute('ALTER TABLE dive_profiles ADD COLUMN source_id TEXT');
+        _seedMixedDive(rawDb);
+        rawDb.execute(
+          "UPDATE dive_profiles SET source_id = 'src-computer' "
+          "WHERE id = 'p-null'",
+        );
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('dive_profiles')")
+        .get();
+    expect(
+      cols.map((c) => c.read<String>('name')).where((n) => n == 'source_id'),
+      hasLength(1),
+    );
+
+    // Already attributed: the backfill only fills nulls, so this stays put
+    // even though the convention would have chosen src-file.
+    expect(await _sourceIdOf(db, 'p-null'), 'src-computer');
+    expect(await _sourceIdOf(db, 'p-computer'), 'src-computer');
+  });
+
+  test('the helper no-ops when dive_profiles is absent', () async {
+    // Partial-schema case: migration tests instantiate databases without
+    // unrelated tables, and unguarded DDL would fail with "no such table".
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('PRAGMA user_version = 157');
+        // Deliberately no dive_profiles table at all.
+      },
+    );
+
+    final db = AppDatabase(nativeDb);
+    addTearDown(() => db.close());
+
+    final result = await db.customSelect('SELECT 1 AS ok').getSingle();
+    expect(result.data['ok'], 1);
+  });
+}

--- a/test/features/dive_log/data/repositories/dive_consolidation_test.dart
+++ b/test/features/dive_log/data/repositories/dive_consolidation_test.dart
@@ -246,6 +246,71 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('split into separate dive', () {
+    // Two file-imported sources both carry a null computerId, so the legacy
+    // "null belongs to the primary family" rule cannot tell their samples
+    // apart. Splitting one used to sweep up the other's demoted rows and
+    // reattribute them to the new dive, which is the same identify-by-
+    // computerId mistake as issue #1149 in a different method.
+    test('does not move another source\'s samples off the dive', () async {
+      final diveId = await insertTestDive(
+        id: 'dive-two-imports',
+        diveComputerModel: 'Imported file A',
+      );
+
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'source-a',
+          diveId: diveId,
+          isPrimary: true,
+          computerModel: 'Imported file A',
+        ),
+      );
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'source-b',
+          diveId: diveId,
+          isPrimary: false,
+          computerModel: 'Imported file B',
+        ),
+      );
+
+      // Source A's own samples, demoted the way a profile edit leaves the
+      // superseded originals: null computerId, isPrimary false, owned by A.
+      await insertTestProfile(
+        diveId: diveId,
+        sourceTag: 'a-original',
+        sourceId: 'source-a',
+        isPrimary: false,
+        timestamp: 0,
+        depth: 5.0,
+      );
+      // Source B's samples: identical shape apart from the owning source.
+      await insertTestProfile(
+        diveId: diveId,
+        sourceTag: 'b1',
+        sourceId: 'source-b',
+        isPrimary: false,
+        timestamp: 0,
+        depth: 9.0,
+      );
+
+      await DiveSplitService(
+        repository,
+      ).split(diveId: diveId, sourceId: 'source-b');
+
+      final remaining = await (db.select(
+        db.diveProfiles,
+      )..where((t) => t.diveId.equals(diveId))).get();
+
+      expect(
+        remaining.map((r) => r.sourceId),
+        contains('source-a'),
+        reason:
+            "source A's samples belong to the dive being split FROM and must "
+            'not follow source B onto the new dive',
+      );
+    });
+
     test('creates a new standalone dive from detached data', () async {
       final diveId = await insertTestDive(
         id: 'dive-multi',

--- a/test/features/dive_log/data/repositories/dive_consolidation_test.dart
+++ b/test/features/dive_log/data/repositories/dive_consolidation_test.dart
@@ -1203,6 +1203,64 @@ void main() {
       );
     });
 
+    // A long dive holds one row per sample, and the promote used to bind one
+    // SQL variable per id. SQLite caps bound variables per statement (999 on
+    // builds before 3.32, 32766 after), so a long enough dive failed outright
+    // with "too many SQL variables". The promote must not scale its variable
+    // count with the sample count.
+    test('promotes a dive with more samples than SQLite can bind', () async {
+      final diveId = await insertTestDive(
+        id: 'dive-many-samples',
+        diveComputerModel: 'Imported file',
+      );
+
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-a',
+          diveId: diveId,
+          isPrimary: true,
+          computerModel: 'Imported file',
+        ),
+      );
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-b',
+          diveId: diveId,
+          isPrimary: false,
+          computerModel: 'Other file',
+        ),
+      );
+
+      // One past the 32766 cap of the bundled SQLite, which is also well past
+      // the 999 cap older builds enforce. Generated with a recursive CTE
+      // rather than 32767 companion inserts, which took ~45s on its own and
+      // would have made this the slowest test in the suite by far.
+      const sampleCount = 32767;
+      await db.customStatement(
+        'INSERT INTO dive_profiles '
+        '(id, dive_id, source_id, is_primary, timestamp, depth) '
+        'WITH RECURSIVE seq(n) AS ('
+        'SELECT 0 UNION ALL SELECT n + 1 FROM seq WHERE n < ?2 - 1) '
+        "SELECT 'p-b-' || n, ?1, 'reading-b', 0, n, 10.0 FROM seq",
+        [diveId, sampleCount],
+      );
+
+      await repository.setPrimaryDataSource(
+        diveId: diveId,
+        computerReadingId: 'reading-b',
+      );
+
+      final promoted =
+          await (db.selectOnly(db.diveProfiles)
+                ..addColumns([db.diveProfiles.id.count()])
+                ..where(
+                  db.diveProfiles.diveId.equals(diveId) &
+                      db.diveProfiles.isPrimary.equals(true),
+                ))
+              .getSingle();
+      expect(promoted.read(db.diveProfiles.id.count()), sampleCount);
+    });
+
     test(
       'promotes an edited profile without resurrecting the originals',
       () async {

--- a/test/features/dive_log/data/repositories/dive_consolidation_test.dart
+++ b/test/features/dive_log/data/repositories/dive_consolidation_test.dart
@@ -119,6 +119,7 @@ void main() {
   Future<String> insertTestProfile({
     required String diveId,
     String? sourceTag,
+    String? sourceId,
     bool isPrimary = true,
     int timestamp = 0,
     double depth = 5.0,
@@ -132,6 +133,7 @@ void main() {
             id: Value(id),
             diveId: Value(diveId),
             // computerId left null to avoid FK constraints
+            sourceId: Value(sourceId),
             isPrimary: Value(isPrimary),
             timestamp: Value(timestamp),
             depth: Value(depth),
@@ -996,16 +998,16 @@ void main() {
     );
 
     test(
-      'swaps isPrimary flags on dive_profiles when computerId is available',
+      'keeps unattributed null-computerId profiles primary across a swap',
       () async {
-        // This test uses null computerId since FK refs are unavailable in tests.
-        // Profile swapping by computerId is exercised in the implementation;
-        // here we verify the demotion step (all profiles demoted to non-primary)
-        // and that profiles associated with a non-null computerId get promoted.
+        // Rows carrying neither a computerId nor a sourceId are the pre-v154
+        // shape: file imports and manual entries. The promoted source has no
+        // computerId either, so the legacy convention applies -- those rows
+        // are the ones it owns, and they stay primary.
         //
-        // Since we cannot insert real DiveComputer rows, we verify the
-        // demotion side: after swapping, profiles that were primary become
-        // non-primary (computerId-less profiles remain demoted).
+        // This asserted the opposite until issue #1149: the old code demoted
+        // every row and then skipped the promote entirely, so it codified
+        // the stranding as expected behavior.
         final diveId = await insertTestDive(
           id: 'dive-profile-swap',
           diveComputerModel: 'Computer A',
@@ -1049,8 +1051,6 @@ void main() {
           computerReadingId: 'reading-b',
         );
 
-        // All profiles (null computerId) should be demoted to non-primary
-        // since reading-b has no computerId to match for promotion.
         final profiles = await (db.select(
           db.diveProfiles,
         )..where((t) => t.diveId.equals(diveId))).get();
@@ -1058,10 +1058,10 @@ void main() {
         for (final p in profiles) {
           expect(
             p.isPrimary,
-            isFalse,
+            isTrue,
             reason:
-                'All profiles should be demoted when new primary has no '
-                'matching computerId',
+                'A null-computerId source owns the dive\'s unattributed '
+                'null-computerId rows, so promoting it must keep them primary',
           );
         }
 
@@ -1071,6 +1071,212 @@ void main() {
         final readingB = readings.firstWhere((r) => r.id == 'reading-b');
         expect(readingA.isPrimary, isFalse);
         expect(readingB.isPrimary, isTrue);
+      },
+    );
+
+    // Issue #1149: promoting a source that owns no profile rows used to
+    // demote every row for the dive and then promote nothing, leaving zero
+    // `is_primary = 1` rows. The dive kept rendering (the display paths are
+    // unfiltered) while every is_primary consumer silently skipped it.
+    test(
+      'leaves a primary profile row when the new primary source owns none',
+      () async {
+        final diveId = await insertTestDive(
+          id: 'dive-no-owned-profiles',
+          diveComputerModel: 'Computer A',
+        );
+
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-a',
+            diveId: diveId,
+            isPrimary: true,
+            computerModel: 'Computer A',
+          ),
+        );
+        // A file-imported source: null computerId, and no profile rows of
+        // its own (metadata only).
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-b',
+            diveId: diveId,
+            isPrimary: false,
+            computerModel: 'Imported file',
+          ),
+        );
+
+        await insertTestProfile(
+          diveId: diveId,
+          sourceTag: 'a1',
+          isPrimary: true,
+          timestamp: 0,
+          depth: 5.0,
+        );
+        await insertTestProfile(
+          diveId: diveId,
+          sourceTag: 'a2',
+          isPrimary: true,
+          timestamp: 60,
+          depth: 10.0,
+        );
+
+        await repository.setPrimaryDataSource(
+          diveId: diveId,
+          computerReadingId: 'reading-b',
+        );
+
+        final profiles = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals(diveId))).get();
+
+        expect(
+          profiles.where((p) => p.isPrimary),
+          isNotEmpty,
+          reason:
+              'A dive that has profile rows must never be left with zero '
+              'is_primary rows: getDiveProfile and getAscentDescentRates '
+              'would silently skip it (issue #1149)',
+        );
+      },
+    );
+
+    // The case the sourceId FK exists for: two file-imported sources on one
+    // dive. Both carry a null computerId, so nothing about the computer can
+    // tell their samples apart -- only the owning-source row can.
+    test('promotes exactly the new primary source\'s own samples', () async {
+      final diveId = await insertTestDive(
+        id: 'dive-two-file-imports',
+        diveComputerModel: 'Imported file A',
+      );
+
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-a',
+          diveId: diveId,
+          isPrimary: true,
+          computerModel: 'Imported file A',
+        ),
+      );
+      await repository.saveComputerReading(
+        buildReading(
+          id: 'reading-b',
+          diveId: diveId,
+          isPrimary: false,
+          computerModel: 'Imported file B',
+        ),
+      );
+
+      await insertTestProfile(
+        diveId: diveId,
+        sourceTag: 'a1',
+        sourceId: 'reading-a',
+        isPrimary: true,
+        timestamp: 0,
+        depth: 5.0,
+      );
+      await insertTestProfile(
+        diveId: diveId,
+        sourceTag: 'b1',
+        sourceId: 'reading-b',
+        isPrimary: false,
+        timestamp: 0,
+        depth: 6.0,
+      );
+
+      await repository.setPrimaryDataSource(
+        diveId: diveId,
+        computerReadingId: 'reading-b',
+      );
+
+      final profiles = await (db.select(
+        db.diveProfiles,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      final primary = profiles.where((p) => p.isPrimary).toList();
+
+      expect(primary, hasLength(1));
+      expect(
+        primary.single.sourceId,
+        equals('reading-b'),
+        reason:
+            'Promotion follows the owning-source FK, not the computerId, '
+            'which is null on both sides here (issue #1149)',
+      );
+    });
+
+    test(
+      'promotes an edited profile without resurrecting the originals',
+      () async {
+        final diveId = await insertTestDive(
+          id: 'dive-edited-swap',
+          diveComputerModel: 'Imported file',
+        );
+
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-a',
+            diveId: diveId,
+            isPrimary: true,
+            computerModel: 'Imported file',
+          ),
+        );
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-b',
+            diveId: diveId,
+            isPrimary: false,
+            computerModel: 'Other file',
+          ),
+        );
+
+        // saveEditedProfile's shape: the superseded original demoted, the edit
+        // inserted alongside it at the same timestamp, both owned by source A.
+        await insertTestProfile(
+          diveId: diveId,
+          sourceTag: 'original',
+          sourceId: 'reading-a',
+          isPrimary: false,
+          timestamp: 0,
+          depth: 5.0,
+        );
+        await insertTestProfile(
+          diveId: diveId,
+          sourceTag: 'edited',
+          sourceId: 'reading-a',
+          isPrimary: true,
+          timestamp: 0,
+          depth: 7.0,
+        );
+        await insertTestProfile(
+          diveId: diveId,
+          sourceTag: 'b1',
+          sourceId: 'reading-b',
+          isPrimary: false,
+          timestamp: 0,
+          depth: 9.0,
+        );
+
+        // Swap away to B, then back to A.
+        await repository.setPrimaryDataSource(
+          diveId: diveId,
+          computerReadingId: 'reading-b',
+        );
+        await repository.setPrimaryDataSource(
+          diveId: diveId,
+          computerReadingId: 'reading-a',
+        );
+
+        final profiles = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals(diveId))).get();
+        final primary = profiles.where((p) => p.isPrimary).toList();
+
+        expect(
+          primary,
+          hasLength(1),
+          reason:
+              'Both of source A\'s generations sit at timestamp 0; promoting '
+              'the whole owned set would render the series twice',
+        );
       },
     );
   });

--- a/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_new_methods_test.dart
@@ -1704,59 +1704,65 @@ void main() {
       }
     });
 
-    test('handles reading with null computerId (no profile swap)', () async {
-      final diveId = await insertTestDive(id: 'dive-null-comp');
+    test(
+      'promoting a null-computerId reading keeps a primary profile',
+      () async {
+        final diveId = await insertTestDive(id: 'dive-null-comp');
 
-      // Save a reading without computerId.
-      await repository.saveComputerReading(
-        buildReading(
-          id: 'reading-no-comp',
-          diveId: diveId,
-          isPrimary: false,
-          computerModel: 'Manual Entry',
-          maxDepth: 20.0,
-        ),
-      );
+        // Save a reading without computerId.
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-no-comp',
+            diveId: diveId,
+            isPrimary: false,
+            computerModel: 'Manual Entry',
+            maxDepth: 20.0,
+          ),
+        );
 
-      await repository.saveComputerReading(
-        buildReading(
-          id: 'reading-primary',
+        await repository.saveComputerReading(
+          buildReading(
+            id: 'reading-primary',
+            diveId: diveId,
+            isPrimary: true,
+            computerModel: 'Original',
+          ),
+        );
+
+        // Insert a profile with no computerId.
+        await insertTestProfile(
           diveId: diveId,
+          sourceTag: 'p1',
           isPrimary: true,
-          computerModel: 'Original',
-        ),
-      );
+          timestamp: 0,
+          depth: 15.0,
+        );
 
-      // Insert a profile with no computerId.
-      await insertTestProfile(
-        diveId: diveId,
-        sourceTag: 'p1',
-        isPrimary: true,
-        timestamp: 0,
-        depth: 15.0,
-      );
+        // Switch primary to reading with no computerId.
+        await repository.setPrimaryDataSource(
+          diveId: diveId,
+          computerReadingId: 'reading-no-comp',
+        );
 
-      // Switch primary to reading with no computerId.
-      await repository.setPrimaryDataSource(
-        diveId: diveId,
-        computerReadingId: 'reading-no-comp',
-      );
+        // The data source should be promoted.
+        final sources = await repository.getDataSources(diveId);
+        final promoted = sources.firstWhere((s) => s.id == 'reading-no-comp');
+        expect(promoted.isPrimary, isTrue);
 
-      // The data source should be promoted.
-      final sources = await repository.getDataSources(diveId);
-      final promoted = sources.firstWhere((s) => s.id == 'reading-no-comp');
-      expect(promoted.isPrimary, isTrue);
+        // The unattributed null-computerId row belongs to whichever source is
+        // primary, so promoting a null-computerId reading takes it along.
+        //
+        // This asserted the opposite until issue #1149 ("no profiles are
+        // re-promoted"), which is precisely the stranding: the dive kept its
+        // samples but every is_primary consumer -- getDiveProfile,
+        // getAscentDescentRates, the data-quality prefilters -- skipped it.
+        final profiles = await (db.select(
+          db.diveProfiles,
+        )..where((t) => t.diveId.equals(diveId))).get();
 
-      // Profile should be demoted (since computerId is null, no profiles
-      // are re-promoted).
-      final profiles = await (db.select(
-        db.diveProfiles,
-      )..where((t) => t.diveId.equals(diveId))).get();
-
-      for (final p in profiles) {
-        expect(p.isPrimary, isFalse);
-      }
-    });
+        expect(profiles.where((p) => p.isPrimary), isNotEmpty);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1149. `setPrimaryDataSource` demoted every `dive_profiles` row for a dive, then re-promoted only rows matching the new primary's `computerId`, and only inside an `if (computerId != null)` guard. File-imported sources carry a null `computerId` on both sides (the `dive_data_sources` row and the sample rows), so promoting one demoted everything and promoted nothing, leaving the dive with **zero** `is_primary` rows.

It is silent because the display paths do not filter on the flag. `getDiveById` and `getMergedProfile` keep rendering the profile while `getDiveProfile`, `getAscentDescentRates` and the data-quality prefilters skip the dive entirely, so a subset of aggregates quietly loses a dive whose samples are visibly still there. Two call sites reach it: the dive detail source picker and the data-quality "set primary source" repair.

This takes option 1 from the issue: give sample rows a real owner instead of re-deriving one from `computerId`.

## Changes

- **`dive_profiles.source_id`**: nullable FK to `dive_data_sources`, `ON DELETE SET NULL` so samples outlive the metadata row describing them. `computerId` cannot identify an owner on its own, and two file-imported sources on one dive are reachable today by consolidating two file imports (the same-computer guard compares computer ids, and two nulls pass it).
- **Migration v154**: PRAGMA-guarded `ADD COLUMN` plus a one-time backfill that reproduces exactly what `getProfilesByDataSource` already did, so no existing row changes owner as a result of upgrading. The backfill probes **both** tables' columns, because `PRAGMA table_info` returns empty for a missing table and migration fixtures routinely hold `dive_profiles` without `dive_data_sources`. `beforeOpen` re-asserts the column only, never the full-table pass.
- **`setPrimaryDataSource`**: resolves the promote set **before** demoting, and only demotes when that set is non-empty. The stranding was never limited to a null `computerId`: demote-then-promote meant promoting *any* source owning no sample rows stranded the dive, including a metadata-only snapshot with a good computer id. This makes the stranded state unreachable rather than merely detected, and no legitimate action fails with an exception.
- **`dive_split_service`**: carried the identical `promoted.computerId != null` gate on its own re-promote, with the same result on the dive left behind. Fixed with the same rule.
- **Edited profiles**: promoting a source wholesale would have traded stranding for a visible double, since `saveEditedProfile` does not replace the rows it supersedes but demotes them and inserts a second null-`computerId` generation in the same source. The promote set is deduplicated by timestamp preferring the null-`computerId` row, the same "the edit is the live one" rule `restoreOriginalProfile` encodes, with a deterministic tiebreak so peers do not disagree and flip the flag back and forth through sync.
- **Writers carry attribution**: the download path stamps the source it just wrote, `saveEditedProfile` claims the source primary at edit time, reparse rewrites in place under the same source, and consolidate/merge/split remap old source ids to the copies they mint. `dive_merge_service` now inserts its data-source rows ahead of the profile copy, because `source_id` is a real FK and `foreign_keys` is ON, so SQLite enforces the reference immediately rather than at COMMIT.
- **`getProfilesByDataSource`** prefers the FK, which also stops a dive carrying two file-imported sources from being misread as edited and silently dropping the second source's samples.
- **Sync**: no serializer work needed (`dive_profiles` round-trips through generated `toJson`/`fromJson`), but `source_id` is registered in `parentRefs` as nullable so a profile whose source row is absent has the reference cleared instead of dangling the deferred-FK COMMIT.

### Tests

Two existing tests asserted the bug as intended behaviour, each with a comment presenting the broken output as the design ("All profiles should be demoted when new primary has no matching computerId", "no profiles are re-promoted"). Both now assert the dive keeps a primary profile.

New coverage:
- promotion follows the FK when `computerId` is null on both sides
- a source owning no samples leaves the existing primary alone
- an edited profile survives a swap away and back without duplicating
- v154 adds the column, attributes rows the way the pre-v154 read path did, and re-runs idempotently

## Test Plan

- [x] `flutter test` passes — 18932 tests, 0 failures, exit 0
- [x] `flutter analyze` passes — no issues found, whole project
- [x] `dart format` clean
- [x] Manual testing: not yet exercised against a real multi-source library; the repro (a dive with a file-imported source plus one other, then "Set Primary" on the file-imported one) is covered by automated tests only

### Note for reviewers

An earlier local run reported a `sync_retirement_fence_test` failure that did **not** reproduce; two other test suites were running concurrently on the same machine at the time. The whole sync directory passes in isolation (666 tests), as does the clean full run above.
