### PR TITLE
fix(dive-log): drop superseded originals so a saved profile trim sticks

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -3207,11 +3207,17 @@ class DiveRepository {
       tankPressuresByTankId.putIfAbsent(p.tankId, () => []).add(p);
     }
 
-    // Get profile for this dive
+    // Get profile for this dive. Every source is kept; only the originals a
+    // saved profile edit superseded are dropped (see
+    // [_dropSupersededOriginals]). [getMergedProfile] mirrors this query and
+    // the two must stay in step.
     final profileQuery = _db.select(_db.diveProfiles)
       ..where((t) => t.diveId.equals(row.id))
       ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]);
-    final profileRows = await profileQuery.get();
+    final profileRows = await _dropSupersededOriginals(
+      row.id,
+      await profileQuery.get(),
+    );
 
     // Get equipment for this dive
     final equipmentQuery = _db.select(_db.diveEquipment).join([
@@ -4430,24 +4436,102 @@ class DiveRepository {
   }
 
   /// All profile samples for [diveId] across every source, ordered by
-  /// timestamp (one SQL statement). Matches the shape of `Dive.profile`.
+  /// timestamp (one SQL statement, two for an edited dive). Matches the shape
+  /// of `Dive.profile`.
   ///
-  /// Deliberately unfiltered, mirroring the `profileRows` query in
-  /// [getDiveById]: [getDiveForAnalysis] must feed the analysis pipeline the
-  /// exact same samples the pre-WS2 `diveProvider` -> `getDiveById` path did,
-  /// which the parity test locks in. This is intentionally NOT the
-  /// `isPrimary`-filtered view used by [getDiveProfile] /
-  /// [getProfilesByDataSource]: for an edited dive it still returns the demoted
-  /// originals alongside the edited rows, exactly as [getDiveById] does. Any
-  /// change to that merge semantics (e.g. dropping demoted originals) must be
-  /// made in both places together, and measured, rather than diverging here.
+  /// Every source is kept -- this is NOT the `isPrimary`-filtered view used by
+  /// [getDiveProfile] -- except for the originals a profile edit superseded,
+  /// which [_dropSupersededOriginals] removes. It mirrors the `profileRows`
+  /// query in [getDiveById] exactly: [getDiveForAnalysis] must feed the
+  /// analysis pipeline the same samples the `diveProvider` -> [getDiveById]
+  /// path shows, which the parity test locks in. Any change to that merge
+  /// semantics must be made in both places together rather than diverging
+  /// here.
   Future<List<domain.DiveProfilePoint>> getMergedProfile(String diveId) async {
-    final rows =
-        await (_db.select(_db.diveProfiles)
-              ..where((t) => t.diveId.equals(diveId))
-              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
-            .get();
+    final rows = await _dropSupersededOriginals(
+      diveId,
+      await (_db.select(_db.diveProfiles)
+            ..where((t) => t.diveId.equals(diveId))
+            ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+          .get(),
+    );
     return _dropDuplicateSamples(rows).map(_profilePointFromRow).toList();
+  }
+
+  /// Drops the originals that a saved profile edit superseded.
+  ///
+  /// [saveEditedProfile] does not delete the rows it replaces: it demotes them
+  /// to `isPrimary = false` and inserts the edited samples as the new primary,
+  /// so [restoreOriginalProfile] can put them back. A read that returns both
+  /// sets shows the union of the two profiles, which makes a deletion-shaped
+  /// edit look like it never saved -- the reported symptom of the "Trim End"
+  /// bug (#1161), where the trimmed tail reappeared from the demoted rows.
+  ///
+  /// Only the primary source's family is affected. A row belongs to it when
+  /// its computerId is null (the schema convention for primary/manual/edited
+  /// rows) or matches the primary data source's computer; a secondary
+  /// computer's rows are ALWAYS demoted and must never be mistaken for
+  /// superseded originals. This is the same rule
+  /// [getProfilesByDataSource] applies to the grouped view.
+  ///
+  /// The `dive_data_sources` lookup only runs when a demoted row actually
+  /// carries a computerId, so the common shapes -- an unedited single-source
+  /// dive (every row primary) and an edited file import (demoted rows all
+  /// null-computerId) -- add no query at all.
+  Future<List<DiveProfile>> _dropSupersededOriginals(
+    String diveId,
+    List<DiveProfile> rows,
+  ) async {
+    // An edit leaves both demoted and promoted rows behind. Either one missing
+    // means there is nothing to supersede: an untouched dive, or one
+    // setPrimaryDataSource stranded with no primary rows at all.
+    if (!rows.any((r) => !r.isPrimary) || !rows.any((r) => r.isPrimary)) {
+      return rows;
+    }
+
+    String? primaryComputerId;
+    var everyRowIsFamily = false;
+    if (rows.any((r) => !r.isPrimary && r.computerId != null)) {
+      final primary = await _primarySourceComputer(diveId);
+      primaryComputerId = primary.computerId;
+      // With no dive_data_sources row there is a single conceptual source, so
+      // any demoted row can only be an edit leftover -- the same reading
+      // getProfilesByDataSource's no-source fallback takes.
+      everyRowIsFamily = !primary.hasSources;
+    }
+
+    bool isPrimaryFamily(DiveProfile r) =>
+        everyRowIsFamily ||
+        r.computerId == null ||
+        r.computerId == primaryComputerId;
+
+    final family = rows.where(isPrimaryFamily);
+    final hasEditedProfile =
+        family.any((r) => r.isPrimary) && family.any((r) => !r.isPrimary);
+    if (!hasEditedProfile) return rows;
+
+    return [
+      for (final row in rows)
+        if (row.isPrimary || !isPrimaryFamily(row)) row,
+    ];
+  }
+
+  /// The computer owning [diveId]'s primary data source, and whether the dive
+  /// has any `dive_data_sources` rows to read that from.
+  Future<({bool hasSources, String? computerId})> _primarySourceComputer(
+    String diveId,
+  ) async {
+    final sourceRows = _canonicalDataSourceRows(
+      await (_db.select(_db.diveDataSources)
+            ..where((t) => t.diveId.equals(diveId))
+            ..orderBy([
+              (t) => OrderingTerm.desc(t.isPrimary),
+              (t) => OrderingTerm.asc(t.createdAt),
+            ]))
+          .get(),
+    );
+    if (sourceRows.isEmpty) return (hasSources: false, computerId: null);
+    return (hasSources: true, computerId: sourceRows.first.computerId);
   }
 
   /// Drops rows that repeat a sample already seen, comparing every column

--- a/test/features/dive_log/data/repositories/edited_profile_supersedes_originals_test.dart
+++ b/test/features/dive_log/data/repositories/edited_profile_supersedes_originals_test.dart
@@ -1,0 +1,308 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Regression cover for #1161 ("Trim End does not work").
+///
+/// `saveEditedProfile` demotes the original rows to `isPrimary = false` and
+/// inserts the edited rows as the new primary, so the originals stay
+/// restorable. `Dive.profile` is built from an unfiltered `dive_profiles`
+/// read, so before this fix an edited dive surfaced the demoted originals
+/// alongside the edited rows: a trim (which removes points rather than
+/// changing their depth) appeared to do nothing once the editor was saved.
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  const now = 1750000000000;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+
+    await db
+        .into(db.dives)
+        .insert(
+          const DivesCompanion(
+            id: Value('dive-1'),
+            diveDateTime: Value(now),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  var profileRowCounter = 0;
+  Future<void> insertProfileRow({
+    required int timestamp,
+    required double depth,
+    required String? computerId,
+    required bool isPrimary,
+  }) async {
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          DiveProfilesCompanion(
+            id: Value('prof-${profileRowCounter++}'),
+            diveId: const Value('dive-1'),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            timestamp: Value(timestamp),
+            depth: Value(depth),
+          ),
+        );
+  }
+
+  Future<void> insertComputer(String id) => db
+      .into(db.diveComputers)
+      .insert(
+        DiveComputersCompanion(
+          id: Value(id),
+          name: Value('Computer $id'),
+          createdAt: const Value(now),
+          updatedAt: const Value(now),
+        ),
+      );
+
+  Future<void> insertDataSource({
+    required String id,
+    required String? computerId,
+    required bool isPrimary,
+  }) => db
+      .into(db.diveDataSources)
+      .insert(
+        DiveDataSourcesCompanion(
+          id: Value(id),
+          diveId: const Value('dive-1'),
+          computerId: Value(computerId),
+          isPrimary: Value(isPrimary),
+          importedAt: Value(DateTime(2026, 1, 1)),
+          createdAt: Value(DateTime(2026, 1, 1)),
+        ),
+      );
+
+  List<(int, double)> asPairs(List<DiveProfilePoint> points) => [
+    for (final p in points) (p.timestamp, p.depth),
+  ];
+
+  group('trim end persists (#1161)', () {
+    test('file-imported dive: getDiveById drops the trimmed tail', () async {
+      // A file import writes profile rows with a null computerId.
+      for (final (ts, depth) in [
+        (0, 0.0),
+        (4, 10.0),
+        (8, 20.0),
+        (12, 10.0),
+        (16, 0.0),
+        (20, 0.0),
+        (24, 0.0),
+      ]) {
+        await insertProfileRow(
+          timestamp: ts,
+          depth: depth,
+          computerId: null,
+          isPrimary: true,
+        );
+      }
+
+      // Trim End keeps a single surface point after the last real depth.
+      await repository.saveEditedProfile('dive-1', const [
+        DiveProfilePoint(timestamp: 0, depth: 0.0),
+        DiveProfilePoint(timestamp: 4, depth: 10.0),
+        DiveProfilePoint(timestamp: 8, depth: 20.0),
+        DiveProfilePoint(timestamp: 12, depth: 10.0),
+        DiveProfilePoint(timestamp: 16, depth: 0.0),
+      ]);
+
+      final dive = await repository.getDiveById('dive-1');
+
+      expect(asPairs(dive!.profile), [
+        (0, 0.0),
+        (4, 10.0),
+        (8, 20.0),
+        (12, 10.0),
+        (16, 0.0),
+      ]);
+    });
+
+    test(
+      'computer-downloaded dive: getDiveById drops the trimmed tail',
+      () async {
+        await insertComputer('dc-a');
+        await insertDataSource(
+          id: 'src-a',
+          computerId: 'dc-a',
+          isPrimary: true,
+        );
+        for (final (ts, depth) in [(0, 0.0), (4, 20.0), (8, 0.0), (12, 0.0)]) {
+          await insertProfileRow(
+            timestamp: ts,
+            depth: depth,
+            computerId: 'dc-a',
+            isPrimary: true,
+          );
+        }
+
+        await repository.saveEditedProfile('dive-1', const [
+          DiveProfilePoint(timestamp: 0, depth: 0.0),
+          DiveProfilePoint(timestamp: 4, depth: 20.0),
+          DiveProfilePoint(timestamp: 8, depth: 0.0),
+        ]);
+
+        final dive = await repository.getDiveById('dive-1');
+
+        expect(asPairs(dive!.profile), [(0, 0.0), (4, 20.0), (8, 0.0)]);
+      },
+    );
+
+    test(
+      'getMergedProfile agrees with getDiveById for an edited dive',
+      () async {
+        await insertComputer('dc-a');
+        await insertDataSource(
+          id: 'src-a',
+          computerId: 'dc-a',
+          isPrimary: true,
+        );
+        for (final (ts, depth) in [(0, 0.0), (4, 20.0), (8, 0.0), (12, 0.0)]) {
+          await insertProfileRow(
+            timestamp: ts,
+            depth: depth,
+            computerId: 'dc-a',
+            isPrimary: true,
+          );
+        }
+
+        await repository.saveEditedProfile('dive-1', const [
+          DiveProfilePoint(timestamp: 0, depth: 0.0),
+          DiveProfilePoint(timestamp: 4, depth: 20.0),
+          DiveProfilePoint(timestamp: 8, depth: 0.0),
+        ]);
+
+        final dive = await repository.getDiveById('dive-1');
+        final merged = await repository.getMergedProfile('dive-1');
+
+        expect(asPairs(merged), asPairs(dive!.profile));
+      },
+    );
+  });
+
+  group('non-edited reads are unchanged', () {
+    test(
+      'a second computer keeps its samples after the primary is edited',
+      () async {
+        await insertComputer('dc-a');
+        await insertComputer('dc-b');
+        await insertDataSource(
+          id: 'src-a',
+          computerId: 'dc-a',
+          isPrimary: true,
+        );
+        await insertDataSource(
+          id: 'src-b',
+          computerId: 'dc-b',
+          isPrimary: false,
+        );
+
+        for (final (ts, depth) in [(0, 0.0), (4, 20.0), (8, 0.0)]) {
+          await insertProfileRow(
+            timestamp: ts,
+            depth: depth,
+            computerId: 'dc-a',
+            isPrimary: true,
+          );
+        }
+        // Secondary computers are always stored demoted.
+        for (final (ts, depth) in [(0, 0.1), (4, 20.5), (8, 0.2)]) {
+          await insertProfileRow(
+            timestamp: ts,
+            depth: depth,
+            computerId: 'dc-b',
+            isPrimary: false,
+          );
+        }
+
+        await repository.saveEditedProfile('dive-1', const [
+          DiveProfilePoint(timestamp: 0, depth: 0.0),
+          DiveProfilePoint(timestamp: 4, depth: 20.0),
+        ]);
+
+        final dive = await repository.getDiveById('dive-1');
+
+        // dc-a's demoted originals are superseded by the edit; dc-b's are not.
+        // Rows sharing a timestamp have no defined order, so compare unordered.
+        expect(
+          asPairs(dive!.profile),
+          unorderedEquals(<(int, double)>[
+            (0, 0.0),
+            (0, 0.1),
+            (4, 20.0),
+            (4, 20.5),
+            (8, 0.2),
+          ]),
+        );
+      },
+    );
+
+    test('an unedited multi-computer dive keeps every sample', () async {
+      await insertComputer('dc-a');
+      await insertComputer('dc-b');
+      await insertDataSource(id: 'src-a', computerId: 'dc-a', isPrimary: true);
+      await insertDataSource(id: 'src-b', computerId: 'dc-b', isPrimary: false);
+
+      for (final (ts, depth) in [(0, 0.0), (4, 20.0)]) {
+        await insertProfileRow(
+          timestamp: ts,
+          depth: depth,
+          computerId: 'dc-a',
+          isPrimary: true,
+        );
+      }
+      for (final (ts, depth) in [(0, 0.1), (4, 20.5)]) {
+        await insertProfileRow(
+          timestamp: ts,
+          depth: depth,
+          computerId: 'dc-b',
+          isPrimary: false,
+        );
+      }
+
+      final dive = await repository.getDiveById('dive-1');
+
+      expect(
+        asPairs(dive!.profile),
+        unorderedEquals(<(int, double)>[
+          (0, 0.0),
+          (0, 0.1),
+          (4, 20.0),
+          (4, 20.5),
+        ]),
+      );
+    });
+
+    test('a dive with no primary rows at all keeps its samples', () async {
+      // setPrimaryDataSource can strand a file import with zero primary rows;
+      // nothing was edited, so nothing may be dropped.
+      for (final (ts, depth) in [(0, 0.0), (4, 20.0), (8, 0.0)]) {
+        await insertProfileRow(
+          timestamp: ts,
+          depth: depth,
+          computerId: null,
+          isPrimary: false,
+        );
+      }
+
+      final dive = await repository.getDiveById('dive-1');
+
+      expect(asPairs(dive!.profile), [(0, 0.0), (4, 20.0), (8, 0.0)]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #1161. In the dive profile editor, "Trim End" removed the trailing string of 0 m samples on screen, but after saving the profile came back unchanged.

The editor was never at fault; the trim saved correctly every time. The read path put the deleted points back.

`saveEditedProfile` does not delete the rows it replaces. It demotes them to `is_primary = 0` and inserts the edited samples as the new primary, which is what keeps `restoreOriginalProfile` available as the undo. But `Dive.profile` was built from an **unfiltered** `dive_profiles` query in `_mapRowToDive`, so an edited dive returned the union of the demoted originals and the edited rows.

That is why the bug is specific to Trim End. Depth-changing edits (smooth, despike) rewrite the same timestamps, so the union largely overlaps and looks correct. Trim End *deletes* points, so the trimmed tail reappeared verbatim from the demoted rows and the save read as a no-op.

It also explains the reported inconsistency between dives: the detail chart uses `getProfilesByDataSource` (which already dropped superseded originals) once a dive has 2+ data sources, and falls back to `dive.profile` otherwise. Only single-source dives showed the bug.

## Changes

- Add `DiveRepository._dropSupersededOriginals(diveId, rows)`, and call it from both `_mapRowToDive`'s profile query and `getMergedProfile`. The two had to change together: the `getDiveForAnalysis` matches `getDiveById` parity test locks them to the same sample list, so filtering one alone would fail CI and silently diverge edited-dive analysis.
- The helper reuses `getProfilesByDataSource`'s existing rule rather than introducing a second one. A bare `is_primary` filter would be wrong in the opposite direction: a **secondary computer's rows are always demoted by convention**, so that filter would erase its trace from every multi-computer dive. Only the primary source's family is affected (`computerId` null, or matching the primary data source's computer), and only when that family holds both promoted and demoted rows.
- Add `_primarySourceComputer(diveId)`. It only runs when a demoted row actually carries a non-null `computerId`, so unedited single-source dives (every row primary) and edited file imports (demoted rows all null-`computerId`) add no query at all.
- Add `test/features/dive_log/data/repositories/edited_profile_supersedes_originals_test.dart`.

Two side effects worth calling out:

- **Retroactive.** This is a read-path change, so dives edited before this build render correctly with no migration.
- **Removes a sample double-count in analysis.** The same union fed duplicated, overlapping samples to the CNS/tissue/OTU/runtime pipeline for any edited dive. This was documented as a known latent issue when `getMergedProfile` was added in #536, which deliberately preserved the behavior rather than diverging from `getDiveById`; fixing both together is what that note asked for.

## Test Plan

- [x] `flutter test` passes — 19135 passed, 19 skipped, 0 failed (full suite, run in the worktree)
- [x] `flutter analyze` passes — whole project, no issues found
- [x] `dart format` applied

New regression cover, 6 cases. **3 failed before the fix**, asserting the exact untrimmed tail the bug produced:

| Case | Guards |
| --- | --- |
| File-imported dive: `getDiveById` drops the trimmed tail | The reported bug (null-`computerId` rows) |
| Computer-downloaded dive: `getDiveById` drops the trimmed tail | Same, with `computerId`-bearing rows |
| `getMergedProfile` agrees with `getDiveById` | Analysis parity |
| A second computer keeps its samples after the primary is edited | Multi-computer trace is not erased |
| An unedited multi-computer dive keeps every sample | No over-filtering |
| A dive with no primary rows at all keeps its samples | The `setPrimaryDataSource` stranding case (#1149-adjacent) |

The last three passed both before and after, confirming the change is scoped to superseded originals.

Manual testing: not performed. The behavior is fully exercised at the repository layer, where the defect actually lived.

## Notes

One pre-existing inconsistency surfaced while tracing the detail page, **not** addressed here: profile markers (`_calculateProfileMarkers`) read `dive.profile` while the chart may be drawing `activeProfile.points` from `getProfilesByDataSource`. This PR narrows the gap (the two now agree for single-source dives) but does not close it. Happy to file it separately.
