### PR TITLE
Document and test why same-computer source rows survive a merge

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -730,6 +730,12 @@ class DiveRepository {
   /// and silently misroutes every profile point to whichever row is
   /// iterated last, and getDataSources shows a second, empty, selectable
   /// chip for the row that lost the collision.
+  ///
+  /// Canonicalizing on READ is deliberate, not a stopgap for a bad write
+  /// (#1045): the row that loses here still owns the only copy of its half's
+  /// rawData/rawFingerprint/sourceUuid, which reparse and the import
+  /// duplicate checker (getSourceKeysByDiveId) both read directly. It must
+  /// stay in the table -- only the display collapses it.
   List<DiveDataSourcesData> _canonicalDataSourceRows(
     List<DiveDataSourcesData> rows,
   ) {

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -389,10 +389,33 @@ class DiveMergeService {
 
       // 10. Data sources carried as provenance; NEVER primary (a merged
       //     profile is user-authored -- reparse must not rewrite it).
+      //     CAVEAT (#1164): isPrimary false only stops reparse from
+      //     rewriting the dives row and tanks. ReparseService step 4 calls
+      //     _replaceDiveProfiles unconditionally, so re-parsing a merged
+      //     dive today still wipes the merged profile. Tracked separately.
       // saveComputerReading (dive_repository_impl.dart:4437) does not call
       // markRecordPending for diveDataSources rows either -- it relies on
       // the parent dive's pending record (step 1) to carry the change, so
       // no per-row markRecordPending here mirrors that.
+      //
+      // EVERY row is carried, including several sharing one computerId --
+      // the shape a same-computer split-pair merge produces. Do NOT collapse
+      // them here (#1045): rows that share a computerId are not duplicates.
+      // Each is the sole surviving copy of one download's rawData,
+      // rawFingerprint and sourceUuid once step 13 deletes the originals, and
+      // all three are load-bearing:
+      //   - getSourceKeysByDiveId unions source_uuid/raw_fingerprint across
+      //     ALL of a dive's rows so a re-download of EITHER half resolves as
+      //     a duplicate; dropping a row makes that half import as a new dive.
+      //   - ReparseService.getSourcesForDiveReparse selects on rawData, so a
+      //     dropped row's bytes can never be re-parsed by a later
+      //     libdivecomputer.
+      // The duplicate is a display-side concern only, and is canonicalized on
+      // read by _canonicalDataSourceRows (#1005). The underlying gap is that
+      // dive_profiles attributes samples by computerId alone, so computerId
+      // gets treated as a per-dive unique source key the schema never
+      // guaranteed -- fixing that needs a dive_profiles.data_source_id FK,
+      // not a lossy write here.
       for (final row in snapshot.dataSourceRows) {
         await _db
             .into(_db.diveDataSources)

--- a/lib/features/dive_log/data/services/dive_merge_service.dart
+++ b/lib/features/dive_log/data/services/dive_merge_service.dart
@@ -393,7 +393,7 @@ class DiveMergeService {
       //     rewriting the dives row and tanks. ReparseService step 4 calls
       //     _replaceDiveProfiles unconditionally, so re-parsing a merged
       //     dive today still wipes the merged profile. Tracked separately.
-      // saveComputerReading (dive_repository_impl.dart:4437) does not call
+      // DiveRepository.saveComputerReading does not call
       // markRecordPending for diveDataSources rows either -- it relies on
       // the parent dive's pending record (step 1) to carry the change, so
       // no per-row markRecordPending here mirrors that.

--- a/test/features/dive_log/data/services/dive_merge_service_test.dart
+++ b/test/features/dive_log/data/services/dive_merge_service_test.dart
@@ -535,4 +535,85 @@ void main() {
       expect(pressures.map((p) => p.id).toSet(), {'tp-a', 'tp-b'});
     });
   });
+
+  group('same-computer provenance (#1045)', () {
+    /// Stamps [diveId]'s seeded data source row with a shared [computerId]
+    /// and payloads unique to that download, mirroring what a real
+    /// dive-computer download writes for each half of a split pair.
+    Future<void> stampSource(
+      String diveId, {
+      required String computerId,
+      required String sourceUuid,
+      required int fingerprintByte,
+    }) async {
+      await (db.update(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).write(
+        DiveDataSourcesCompanion(
+          computerId: Value(computerId),
+          sourceUuid: Value(sourceUuid),
+          rawFingerprint: Value(Uint8List.fromList([fingerprintByte])),
+          rawData: Value(Uint8List.fromList([fingerprintByte, 0xFF])),
+        ),
+      );
+    }
+
+    test(
+      'both source rows survive the merge with their own raw payloads, while '
+      'the read side collapses them to one canonical source',
+      () async {
+        await seedDive(
+          'a',
+          entry: DateTime.utc(2026, 7, 1, 9),
+          computerId: 'comp-1',
+        );
+        await seedDive(
+          'b',
+          entry: DateTime.utc(2026, 7, 1, 10),
+          computerId: 'comp-1',
+        );
+        await stampSource(
+          'a',
+          computerId: 'comp-1',
+          sourceUuid: 'uuid-a',
+          fingerprintByte: 0xA1,
+        );
+        await stampSource(
+          'b',
+          computerId: 'comp-1',
+          sourceUuid: 'uuid-b',
+          fingerprintByte: 0xB2,
+        );
+
+        final outcome = await service.apply(['a', 'b']);
+        final mergedId = outcome.mergedDive.id;
+
+        // Both rows are carried. They share a computerId but are NOT
+        // duplicates: each is the only surviving copy of one download's
+        // rawData / rawFingerprint / sourceUuid, since step 13 deletes the
+        // originals. Collapsing them here would destroy that half's bytes.
+        final rows = await (db.select(
+          db.diveDataSources,
+        )..where((t) => t.diveId.equals(mergedId))).get();
+        expect(rows, hasLength(2));
+        expect(rows.every((r) => r.computerId == 'comp-1'), isTrue);
+        expect(rows.map((r) => r.sourceUuid).toSet(), {'uuid-a', 'uuid-b'});
+        expect(rows.map((r) => r.rawFingerprint?.first).toSet(), {0xA1, 0xB2});
+        // ReparseService.getSourcesForDiveReparse selects on rawData, so
+        // both halves stay re-parseable after a libdivecomputer upgrade.
+        expect(rows.where((r) => r.rawData != null), hasLength(2));
+
+        // The import duplicate checker unions keys across ALL rows: a
+        // re-download of EITHER half must still resolve as a duplicate of
+        // the merged dive rather than landing as a new dive.
+        final keys = await diveRepo.getSourceKeysByDiveId();
+        expect(keys[mergedId], containsAll(<String>{'uuid-a', 'uuid-b'}));
+
+        // Read side: one computer, one chip. The duplicate is a display
+        // concern, canonicalized on read (#1005), not a storage defect.
+        final canonical = await diveRepo.getDataSources(mergedId);
+        expect(canonical, hasLength(1));
+      },
+    );
+  });
 }


### PR DESCRIPTION
Follow-up to #1045, which asked to stop `DiveMergeService.apply` from writing two `dive_data_sources` rows sharing one `computer_id` on a same-computer split-pair merge. Investigating it showed the proposed change would lose data, so this PR documents and tests the current behavior instead of changing it. #1045 is closed as won't-fix with the full analysis.

**No behavior change.** Purely comments plus one new test.

## Why the rows are kept

They are duplicates on `computer_id` and on nothing else. Each row independently owns `raw_data`, `raw_fingerprint` and `source_uuid` (`database.dart:2417-2419`), and step 13 of `apply` deletes the original dives, so the carried rows are the only surviving copy of each half's payloads. Two consumers read them per-row:

- **`getSourceKeysByDiveId`** (`dive_repository_impl.dart:5662-5709`) deliberately unions `source_uuid` and `raw_fingerprint` across *all* of a dive's rows so a re-download from any consolidated source resolves as an exact duplicate. The live download path consumes it (`dive_import_service.dart:290,452`). Dropping the losing row means re-downloading that computer imports that half as a brand new dive, which is exactly the situation a split-pair merge sets up.
- **`ReparseService.getSourcesForDiveReparse`** (`reparse_service.dart:192-199`) iterates every row with non-null `raw_data`. Dropping a row destroys the only copy of that half's bytes, unrecoverable by any future libdivecomputer.

There is also nowhere to put the losing row's payloads on the survivor, since all three are single-valued columns.

## The real gap, for the record

The collision is not caused by the merge writing two rows. `dive_profiles` attributes samples to a source by `computer_id` alone, with no `data_source_id` FK (`database.dart:770`), so `computer_id` gets treated as a per-dive unique source key the schema never guaranteed. A dive assembled from two downloads legitimately has two provenance rows, which makes #1005's read-time canonicalization the correct response rather than a workaround. Closing the gap properly means adding `dive_profiles.data_source_id`, a migration touching every profile write path plus sync, and belongs in its own issue if per-source disambiguation is ever needed.

## Changes

- `dive_merge_service.dart` step 10: why every row is carried, which two consumers read the per-row payloads, and where the real gap is.
- `dive_merge_service.dart` step 10: records the #1164 caveat, since the existing comment claims `isPrimary: false` stops reparse from rewriting a merged profile and that turns out to be only partly true.
- `dive_repository_impl.dart` `_canonicalDataSourceRows`: notes that collapsing on read is deliberate and the losing row must stay in the table.
- `dive_merge_service_test.dart`: regression test seeding two dives whose source rows share a `computer_id` but carry distinct `raw_data` / `raw_fingerprint` / `source_uuid`. Asserts both rows survive the merge with their own payloads, that `getSourceKeysByDiveId` still returns both halves' keys, and that `getDataSources` still collapses them to one chip.

The existing suite seeded only null-`computer_id` source rows, so this collision case had no coverage at all.

## Related

Filed #1164 while investigating: re-parsing a merged dive destroys the merged profile, because `applyParsedUpdate` calls `_replaceDiveProfiles` regardless of `isPrimary`. Separate bug, not fixed here, and collapsing the source rows would not have fixed it either.

## Verification

`dart format .` clean, `flutter analyze` clean, full test suite green via pre-push hooks.
