### PR TITLE
fix(ui): give every snackbar a close button

### DIFF
--- a/lib/core/theme/app_snack_bar_theme.dart
+++ b/lib/core/theme/app_snack_bar_theme.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// Snack bar defaults shared by every theme preset.
+///
+/// A snack bar overlays whatever sits at the bottom of the screen, which
+/// routinely means a form's confirm button or a bottom action bar. Material's
+/// only built-in escape hatch is a swipe-to-dismiss drag, which is an
+/// invisible affordance with a mouse, so on desktop a lingering "undo" snack
+/// bar reads as unhideable chrome covering the button underneath it.
+///
+/// Turning on the close icon at the theme level reaches every snack bar in the
+/// app at once: Flutter resolves `SnackBar.showCloseIcon` before falling back
+/// to `SnackBarThemeData.showCloseIcon`, so an individual snack bar can still
+/// opt out.
+ThemeData withAppSnackBarDefaults(ThemeData theme) {
+  return theme.copyWith(
+    snackBarTheme: theme.snackBarTheme.copyWith(showCloseIcon: true),
+  );
+}

--- a/lib/core/theme/app_theme_registry.dart
+++ b/lib/core/theme/app_theme_registry.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:submersion/core/theme/app_snack_bar_theme.dart';
 import 'package:submersion/core/theme/app_theme_preset.dart';
 import 'package:submersion/core/theme/full_themes/console_theme.dart';
 import 'package:submersion/core/theme/full_themes/deep_theme.dart';
@@ -10,37 +11,56 @@ class AppThemeRegistry {
   AppThemeRegistry._();
 
   static final List<AppThemePreset> presets = List.unmodifiable([
-    AppThemePreset(
+    _preset(
       id: 'submersion',
       nameKey: 'theme_submersion',
-      lightTheme: submersionLight,
-      darkTheme: submersionDark,
+      light: submersionLight,
+      dark: submersionDark,
     ),
-    AppThemePreset(
+    _preset(
       id: 'console',
       nameKey: 'theme_console',
-      lightTheme: consoleLight,
-      darkTheme: consoleDark,
+      light: consoleLight,
+      dark: consoleDark,
     ),
-    AppThemePreset(
+    _preset(
       id: 'tropical',
       nameKey: 'theme_tropical',
-      lightTheme: tropicalLight,
-      darkTheme: tropicalDark,
+      light: tropicalLight,
+      dark: tropicalDark,
     ),
-    AppThemePreset(
+    _preset(
       id: 'minimalist',
       nameKey: 'theme_minimalist',
-      lightTheme: minimalistLight,
-      darkTheme: minimalistDark,
+      light: minimalistLight,
+      dark: minimalistDark,
     ),
-    AppThemePreset(
+    _preset(
       id: 'deep',
       nameKey: 'theme_deep',
-      lightTheme: deepLight,
-      darkTheme: deepDark,
+      light: deepLight,
+      dark: deepDark,
     ),
   ]);
+
+  /// Builds a preset with the cross-preset component defaults folded in.
+  ///
+  /// Applied once, at registry initialisation, rather than in [resolveTheme]:
+  /// that runs on every app rebuild and would allocate a fresh [ThemeData]
+  /// each time.
+  static AppThemePreset _preset({
+    required String id,
+    required String nameKey,
+    required ThemeData light,
+    required ThemeData dark,
+  }) {
+    return AppThemePreset(
+      id: id,
+      nameKey: nameKey,
+      lightTheme: withAppSnackBarDefaults(light),
+      darkTheme: withAppSnackBarDefaults(dark),
+    );
+  }
 
   /// Find a preset by ID, falling back to Submersion if not found.
   static AppThemePreset findById(String id) {

--- a/test/core/theme/app_theme_registry_test.dart
+++ b/test/core/theme/app_theme_registry_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -95,6 +94,66 @@ void main() {
       final theme = AppThemeRegistry.resolveTheme(preset, Brightness.dark);
       expect(theme, isNotNull);
       expect(theme.brightness, Brightness.dark);
+    });
+  });
+
+  group('snack bar defaults', () {
+    test('every preset theme shows a snack bar close icon', () {
+      for (final preset in AppThemeRegistry.presets) {
+        expect(
+          preset.lightTheme.snackBarTheme.showCloseIcon,
+          isTrue,
+          reason: '${preset.id} lightTheme',
+        );
+        expect(
+          preset.darkTheme.snackBarTheme.showCloseIcon,
+          isTrue,
+          reason: '${preset.id} darkTheme',
+        );
+      }
+    });
+
+    test('resolveTheme carries the snack bar close icon default', () {
+      final preset = AppThemeRegistry.findById('submersion');
+      for (final brightness in Brightness.values) {
+        expect(
+          AppThemeRegistry.resolveTheme(
+            preset,
+            brightness,
+          ).snackBarTheme.showCloseIcon,
+          isTrue,
+          reason: brightness.name,
+        );
+      }
+    });
+
+    testWidgets('a snack bar can be dismissed with its close button', (
+      tester,
+    ) async {
+      final preset = AppThemeRegistry.findById('submersion');
+      final messengerKey = GlobalKey<ScaffoldMessengerState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          scaffoldMessengerKey: messengerKey,
+          theme: AppThemeRegistry.resolveTheme(preset, Brightness.light),
+          home: const Scaffold(body: SizedBox.shrink()),
+        ),
+      );
+
+      messengerKey.currentState!.showSnackBar(
+        SnackBar(
+          content: const Text('Linked 3 items'),
+          duration: const Duration(minutes: 5),
+          action: SnackBarAction(label: 'Undo', onPressed: () {}),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Linked 3 items'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+      expect(find.text('Linked 3 items'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #1160. On macOS the "undo" snackbar sits on top of whatever occupies the bottom of the screen, and in the reported flow that is the "Link N images" confirm button, whose text becomes unreadable.

Flutter's `SnackBar` does have a timer (4s default) and is technically dismissible, since it wraps itself in a `Dismissible` with `DismissDirection.down`. But a drag-to-dismiss gesture is an effectively invisible affordance with a mouse, so on desktop the bar reads as unhideable chrome. Turning on the Material 3 close icon gives it the explicit dismiss control the issue asks for.

The specific snackbar in the report is `files_tab.dart`'s "Linked N items", but the problem is systemic: there are 365 `showSnackBar` call sites and no central helper. Flutter resolves `SnackBar.showCloseIcon ?? snackBarTheme.showCloseIcon ?? false`, so setting it once on the theme reaches all of them while leaving any individual snackbar free to opt out.

## Changes

- New `lib/core/theme/app_snack_bar_theme.dart`: `withAppSnackBarDefaults(ThemeData)` sets `snackBarTheme.showCloseIcon: true`.
- `AppThemeRegistry` gains a private `_preset(...)` builder that folds the shared defaults into all five presets across light and dark. Applied at static-list initialisation rather than inside `resolveTheme`, which runs on every app rebuild and would otherwise allocate a fresh `ThemeData` per frame.
- Three tests in `app_theme_registry_test.dart`: every preset carries the flag, `resolveTheme` preserves it, and a widget test that shows a "Linked 3 items" snackbar with an `Undo` action under the real production theme and dismisses it by tapping the close button.

No new strings: the close button's tooltip comes from `MaterialLocalizations`, already wired up for every supported locale.

## Test Plan

- [x] `flutter test` passes (19201 passed, 19 skipped, 0 failed)
- [x] `flutter analyze` passes (no issues)
- [x] Manual testing on: not yet run against a desktop build. The widget test drives the exact production `ThemeData` and the exact snackbar shape from the report, so the mechanism is verified, but the icon's appearance alongside the `Undo` action has not been eyeballed in each of the five presets. The `console` preset is the tightest fit given its monospace text theme.

## Screenshots

Not captured; see the note above.
