### PR TITLE
fix(courses): make the embedded editor's header Save persist edits

### DIFF
--- a/lib/features/courses/data/repositories/course_repository.dart
+++ b/lib/features/courses/data/repositories/course_repository.dart
@@ -301,23 +301,33 @@ class CourseRepository {
       _log.info('Updating course: ${course.id}');
       final now = DateTime.now().millisecondsSinceEpoch;
 
-      await (_db.update(
-        _db.courses,
-      )..where((t) => t.id.equals(course.id))).write(
-        CoursesCompanion(
-          name: Value(course.name),
-          agency: Value(course.agency.name),
-          startDate: Value(course.startDate.millisecondsSinceEpoch),
-          completionDate: Value(course.completionDate?.millisecondsSinceEpoch),
-          instructorId: Value(course.instructorId),
-          instructorName: Value(course.instructorName),
-          instructorNumber: Value(course.instructorNumber),
-          certificationId: Value(course.certificationId),
-          location: Value(course.location),
-          notes: Value(course.notes),
-          updatedAt: Value(now),
-        ),
-      );
+      final rowsAffected =
+          await (_db.update(
+            _db.courses,
+          )..where((t) => t.id.equals(course.id))).write(
+            CoursesCompanion(
+              name: Value(course.name),
+              agency: Value(course.agency.name),
+              startDate: Value(course.startDate.millisecondsSinceEpoch),
+              completionDate: Value(
+                course.completionDate?.millisecondsSinceEpoch,
+              ),
+              instructorId: Value(course.instructorId),
+              instructorName: Value(course.instructorName),
+              instructorNumber: Value(course.instructorNumber),
+              certificationId: Value(course.certificationId),
+              location: Value(course.location),
+              notes: Value(course.notes),
+              updatedAt: Value(now),
+            ),
+          );
+
+      // A `where` clause that matches nothing is not an error to SQLite, so an
+      // update against a missing (or empty) id would otherwise report success
+      // while persisting nothing. Fail loudly instead of losing the edit.
+      if (rowsAffected == 0) {
+        throw StateError('No course found to update with id "${course.id}"');
+      }
 
       await _syncRepository.markRecordPending(
         entityType: 'courses',

--- a/lib/features/courses/presentation/pages/course_edit_page.dart
+++ b/lib/features/courses/presentation/pages/course_edit_page.dart
@@ -331,7 +331,7 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
     if (widget.embedded) {
       return Column(
         children: [
-          _buildEmbeddedHeader(context),
+          _buildEmbeddedHeader(context, existingCourse),
           Expanded(child: form),
         ],
       );
@@ -359,7 +359,12 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
     );
   }
 
-  Widget _buildEmbeddedHeader(BuildContext context) {
+  /// Header for the master-detail (embedded) editor.
+  ///
+  /// [existingCourse] must be forwarded to [_save]: without it the save builds
+  /// a course with an empty id while still taking the update branch, so the
+  /// write becomes an `UPDATE ... WHERE id = ''` that matches nothing.
+  Widget _buildEmbeddedHeader(BuildContext context, Course? existingCourse) {
     final colorScheme = Theme.of(context).colorScheme;
     return Container(
       padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 8, 8),
@@ -382,7 +387,7 @@ class _CourseEditPageState extends ConsumerState<CourseEditPage> {
               child: Text(context.l10n.common_action_cancel),
             ),
           TextButton(
-            onPressed: _isLoading ? null : () => _save(null),
+            onPressed: _isLoading ? null : () => _save(existingCourse),
             child: Text(context.l10n.common_action_save),
           ),
         ],

--- a/test/features/courses/presentation/pages/course_edit_embedded_save_test.dart
+++ b/test/features/courses/presentation/pages/course_edit_embedded_save_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/courses/data/repositories/course_repository.dart';
+import 'package:submersion/features/courses/domain/entities/course.dart';
+import 'package:submersion/features/courses/presentation/pages/course_edit_page.dart';
+import 'package:submersion/features/courses/presentation/providers/course_providers.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Regression coverage for the embedded (master-detail) course editor's header
+/// Save button. It used to call `_save(null)`, which built the course with an
+/// empty id while still taking the update branch, so the write became an
+/// `UPDATE ... WHERE id = ''` that matched no rows and failed silently.
+void main() {
+  late CourseRepository repository;
+  late Course seededCourse;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = CourseRepository();
+
+    // courses.diver_id has a foreign key to divers(id), so a real diver row
+    // must exist before a course can be inserted.
+    final diver = await DiverRepository().createDiver(
+      Diver(
+        id: '',
+        name: 'Test Diver',
+        isDefault: true,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+      ),
+    );
+
+    seededCourse = await repository.createCourse(
+      Course(
+        id: '',
+        diverId: diver.id,
+        name: 'Rescue Diver',
+        agency: CertificationAgency.padi,
+        startDate: DateTime(2024, 5, 1),
+        instructorName: 'Alice Instructor',
+        location: 'Blue Hole',
+        notes: 'Initial notes',
+        createdAt: DateTime(2024, 5, 1),
+        updatedAt: DateTime(2024, 5, 1),
+      ),
+    );
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Widget buildHarness({
+    required List<Override> overrides,
+    required String courseId,
+    VoidCallback? onSaved,
+  }) {
+    return ProviderScope(
+      overrides: [
+        ...overrides,
+        courseRepositoryProvider.overrideWithValue(repository),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: CourseEditPage(
+            courseId: courseId,
+            embedded: true,
+            onSaved: onSaved,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('embedded header Save persists edits to an existing course', (
+    tester,
+  ) async {
+    final overrides = await getBaseOverrides();
+    var savedCalled = false;
+
+    await tester.pumpWidget(
+      buildHarness(
+        overrides: overrides,
+        courseId: seededCourse.id,
+        onSaved: () => savedCalled = true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final numberField = find.widgetWithText(TextFormField, 'Instructor Number');
+    await tester.ensureVisible(numberField);
+    await tester.pumpAndSettle();
+    await tester.enterText(numberField, 'INS-4242');
+    await tester.pumpAndSettle();
+
+    // The embedded header's Save, not the "Save Changes" button at the bottom
+    // of the form.
+    final headerSave = find.widgetWithText(TextButton, 'Save');
+    expect(headerSave, findsOneWidget);
+    await tester.tap(headerSave);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(savedCalled, isTrue);
+
+    final reloaded = await repository.getCourseById(seededCourse.id);
+    expect(reloaded, isNotNull);
+    expect(reloaded!.instructorNumber, 'INS-4242');
+    // The rest of the course must survive the update untouched.
+    expect(reloaded.name, 'Rescue Diver');
+    expect(reloaded.location, 'Blue Hole');
+  });
+
+  testWidgets(
+    'embedded header Save updates the existing course instead of creating one',
+    (tester) async {
+      final overrides = await getBaseOverrides();
+
+      await tester.pumpWidget(
+        buildHarness(overrides: overrides, courseId: seededCourse.id),
+      );
+      await tester.pumpAndSettle();
+
+      final nameField = find.widgetWithText(TextFormField, 'Course Name');
+      await tester.ensureVisible(nameField);
+      await tester.pumpAndSettle();
+      await tester.enterText(nameField, 'Rescue Diver (Renamed)');
+      await tester.pumpAndSettle();
+
+      final headerSave = find.widgetWithText(TextButton, 'Save');
+      await tester.tap(headerSave);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      final all = await repository.getAllCourses();
+      expect(all, hasLength(1));
+      expect(all.single.id, seededCourse.id);
+      expect(all.single.name, 'Rescue Diver (Renamed)');
+    },
+  );
+}


### PR DESCRIPTION
## Problem

Reported by a user: editing an existing course (for example, filling in an
instructor's number once it is known) saves correctly with the **Save Changes**
button at the foot of the form, but the **Save** button in the top right corner
discards the edit. No error is shown; the change simply does not stick.

## Root cause

The master-detail (embedded) editor's header called `_save(null)`, while the
button at the foot of the form passed the loaded course.

That argument is the only source of the course id inside `_save`, but the
update-vs-create branch is chosen from `_isEditing`, which is derived from
`widget.courseId`. Editing a course and pressing the header button therefore
built a `Course` with `id: ''` and still took the update branch, issuing:

```sql
UPDATE courses ... WHERE id = ''
```

A `WHERE` clause that matches nothing is not an error to SQLite, so
`.write()` returned `0` and nothing threw. The repository discarded that count,
reported success, and the edit was lost silently.

The same argument also feeds the certification link diff, so `oldCertId` was
compared against `null` on that path, skipping the unlink invalidation.

## Fix

**`course_edit_page.dart`** forwards `existingCourse` into
`_buildEmbeddedHeader`, matching the pattern `equipment_edit_page.dart` already
uses. I audited every other embedded editor: only the course one had this
defect, since the rest either plumb their entity through or use a no-argument
`_save`.

**`course_repository.dart`** now captures the affected-row count from
`.write()` and throws when the update matched nothing. The edit page's existing
`catch` turns that into a visible error snackbar, so a lost write can no longer
masquerade as a success. It also stops `markRecordPending` from queueing a sync
record for an id that does not exist. All four callers of `updateCourse` pass a
course loaded from the database, and sync writes through its own path, so no
caller relied on the previous silent no-op.

## Testing

New `test/features/courses/presentation/pages/course_edit_embedded_save_test.dart`,
written before the fix and confirmed failing against the unpatched code in
exactly the reported way: `instructorNumber` unchanged, name unchanged, and no
duplicate row created, proving a pure no-op rather than a stray insert.

- `flutter test test/features/courses test/features/certifications`: 378 passed
- `flutter test test/features/dive_import test/features/import_wizard test/features/universal_import`: 2476 passed (these exercise `CourseRepository`, covering the new throw)
- `dart format .` clean, `flutter analyze` clean
