### PR TITLE
fix(dive-log): derive chart overlays from the drawn source, not the merged profile

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1518,45 +1518,6 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // Get range selection state
     final rangeState = ref.watch(rangeSelectionProvider(dive.id));
 
-    // Initialize providers with dive duration if needed
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (dive.profile.isNotEmpty) {
-        final maxTimestamp = dive.profile.last.timestamp;
-        final currentPlaybackMax = ref
-            .read(playbackProvider(dive.id))
-            .maxTimestamp;
-        if (currentPlaybackMax == 0) {
-          ref.read(playbackProvider(dive.id).notifier).initialize(maxTimestamp);
-        }
-        final currentRangeMax = ref
-            .read(rangeSelectionProvider(dive.id))
-            .maxTimestamp;
-        if (currentRangeMax == 0) {
-          ref
-              .read(rangeSelectionProvider(dive.id).notifier)
-              .initialize(maxTimestamp);
-        }
-      }
-    });
-
-    // Calculate profile markers (with tank pressure data for accurate thresholds)
-    final markers = _calculateProfileMarkers(
-      dive: dive,
-      analysis: analysis,
-      showMaxDepth: showMaxDepthMarker,
-      showPressureThresholds: showPressureThresholdMarkers,
-      tankPressures: tankPressures,
-    );
-
-    final photoMedia =
-        ref.watch(mediaForDiveProvider(dive.id)).valueOrNull ?? const [];
-    final photoMarkers = dive.profile.isEmpty
-        ? const <PhotoChartMarker>[]
-        : photoMarkersFromMedia(
-            photoMedia,
-            maxProfileSeconds: dive.profile.last.timestamp,
-          );
-
     // Profiles grouped by owning data source, plus the active-source and
     // overlay view state driving the whole page.
     final sourceProfiles =
@@ -1593,9 +1554,56 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // A metadata-only active source has an entry with no points; the chart
     // then renders its empty-profile placeholder instead of silently
     // falling back to the primary's profile (mixed attribution).
+    //
+    // Everything overlaid on the chart is derived from THIS series, never
+    // from dive.profile: the merged series spans every source, so markers
+    // computed against it can report a depth the drawn curve never reaches
+    // and a range extent that runs past its end (#1167).
     final chartProfile = (isMultiSource && activeProfile != null)
         ? activeProfile.points
         : dive.profile;
+
+    // Keep the playback and range extents on the drawn series.
+    //
+    // Deliberately not a one-shot "initialize if still zero": the data
+    // sources load asynchronously, so the first build falls back to
+    // dive.profile and a zero-guard would freeze the merged series' extent
+    // in place forever. The active source can also change at any time. Both
+    // cases leave the range slider running past the end of the visible curve
+    // (#1167). Re-initializing resets playback position and range selection,
+    // which is the wanted behavior when the series underneath them changed.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (chartProfile.isEmpty) return;
+      final maxTimestamp = chartProfile.last.timestamp;
+      if (ref.read(playbackProvider(dive.id)).maxTimestamp != maxTimestamp) {
+        ref.read(playbackProvider(dive.id).notifier).initialize(maxTimestamp);
+      }
+      if (ref.read(rangeSelectionProvider(dive.id)).maxTimestamp !=
+          maxTimestamp) {
+        ref
+            .read(rangeSelectionProvider(dive.id).notifier)
+            .initialize(maxTimestamp);
+      }
+    });
+
+    // Calculate profile markers (with tank pressure data for accurate thresholds)
+    final markers = _calculateProfileMarkers(
+      profile: chartProfile,
+      tanks: dive.tanks,
+      analysis: analysis,
+      showMaxDepth: showMaxDepthMarker,
+      showPressureThresholds: showPressureThresholdMarkers,
+      tankPressures: tankPressures,
+    );
+
+    final photoMedia =
+        ref.watch(mediaForDiveProvider(dive.id)).valueOrNull ?? const [];
+    final photoMarkers = chartProfile.isEmpty
+        ? const <PhotoChartMarker>[]
+        : photoMarkersFromMedia(
+            photoMedia,
+            maxProfileSeconds: chartProfile.last.timestamp,
+          );
 
     // Overlay ids are session state and can briefly outlive their source
     // rows (e.g. right after a split); skip any stale entries instead of
@@ -3159,8 +3167,16 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   );
 
   /// Calculate profile markers for max depth and pressure thresholds
+  /// Markers to overlay on the profile chart.
+  ///
+  /// [profile] must be the series the chart is actually drawing (the active
+  /// source's points), not `dive.profile`. The analysis these markers are
+  /// positioned from is the active source's, so indexing it into the merged
+  /// series would place the max-depth flag at another computer's reading
+  /// (#1167).
   List<ProfileMarker> _calculateProfileMarkers({
-    required Dive dive,
+    required List<DiveProfilePoint> profile,
+    required List<DiveTank> tanks,
     required ProfileAnalysis? analysis,
     required bool showMaxDepth,
     required bool showPressureThresholds,
@@ -3168,12 +3184,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }) {
     final markers = <ProfileMarker>[];
 
-    if (dive.profile.isEmpty) return markers;
+    if (profile.isEmpty) return markers;
 
     // Add max depth marker
     if (showMaxDepth && analysis != null) {
       final maxDepthMarker = ProfileMarkersService.getMaxDepthMarker(
-        profile: dive.profile,
+        profile: profile,
         maxDepthTimestamp: analysis.maxDepthTimestamp,
         maxDepth: analysis.maxDepth,
       );
@@ -3183,11 +3199,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     }
 
     // Add pressure threshold markers (using per-tank data when available)
-    if (showPressureThresholds && dive.tanks.isNotEmpty) {
+    if (showPressureThresholds && tanks.isNotEmpty) {
       markers.addAll(
         ProfileMarkersService.getPressureThresholdMarkers(
-          profile: dive.profile,
-          tanks: dive.tanks,
+          profile: profile,
+          tanks: tanks,
           tankPressures: tankPressures,
         ),
       );

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -1572,19 +1572,34 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     // cases leave the range slider running past the end of the visible curve
     // (#1167). Re-initializing resets playback position and range selection,
     // which is the wanted behavior when the series underneath them changed.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (chartProfile.isEmpty) return;
+    //
+    // The comparison runs here in build, against state this method already
+    // watches, so a frame callback is only scheduled on the rare build that
+    // has work to do. Scheduling unconditionally would queue a no-op closure
+    // 40 times a second while a profile plays: the playback timer ticks every
+    // 25ms and this page watches its state.
+    if (chartProfile.isNotEmpty) {
       final maxTimestamp = chartProfile.last.timestamp;
-      if (ref.read(playbackProvider(dive.id)).maxTimestamp != maxTimestamp) {
-        ref.read(playbackProvider(dive.id).notifier).initialize(maxTimestamp);
+      if (playbackState.maxTimestamp != maxTimestamp ||
+          rangeState.maxTimestamp != maxTimestamp) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          // Re-read rather than trusting the build-time snapshot: the rest of
+          // the frame may have moved either extent already.
+          if (ref.read(playbackProvider(dive.id)).maxTimestamp !=
+              maxTimestamp) {
+            ref
+                .read(playbackProvider(dive.id).notifier)
+                .initialize(maxTimestamp);
+          }
+          if (ref.read(rangeSelectionProvider(dive.id)).maxTimestamp !=
+              maxTimestamp) {
+            ref
+                .read(rangeSelectionProvider(dive.id).notifier)
+                .initialize(maxTimestamp);
+          }
+        });
       }
-      if (ref.read(rangeSelectionProvider(dive.id)).maxTimestamp !=
-          maxTimestamp) {
-        ref
-            .read(rangeSelectionProvider(dive.id).notifier)
-            .initialize(maxTimestamp);
-      }
-    });
+    }
 
     // Calculate profile markers (with tank pressure data for accurate thresholds)
     final markers = _calculateProfileMarkers(

--- a/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
+++ b/lib/features/dive_log/presentation/pages/fullscreen_profile_page.dart
@@ -297,13 +297,6 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
 
     final notifier = ref.read(playbackProvider(widget.diveId).notifier);
 
-    final photoMarkers = dive.profile.isEmpty
-        ? const <PhotoChartMarker>[]
-        : photoMarkersFromMedia(
-            photoMedia,
-            maxProfileSeconds: dive.profile.last.timestamp,
-          );
-
     // Active source and overlays (mirrors the detail page's wiring).
     final labels = SourceNameLabels(
       unknownComputer: context.l10n.diveLog_sources_unknownComputer,
@@ -324,9 +317,21 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     // A metadata-only active source has an entry with no points; the chart
     // then renders its empty-profile placeholder instead of silently
     // falling back to the primary's profile (mixed attribution).
+    //
+    // Everything overlaid on the chart is derived from THIS series, never
+    // from dive.profile: the merged series spans every source, so markers
+    // computed against it can report a depth the drawn curve never reaches
+    // and photo pins scaled to it drift off the visible span (#1167).
     final chartProfile = (dataSources.length >= 2 && activeProfile != null)
         ? activeProfile.points
         : dive.profile;
+
+    final photoMarkers = chartProfile.isEmpty
+        ? const <PhotoChartMarker>[]
+        : photoMarkersFromMedia(
+            photoMedia,
+            maxProfileSeconds: chartProfile.last.timestamp,
+          );
     final sourceColorById = <String, Color>{
       for (final (index, s) in dataSources.indexed) s.id: sourceColorAt(index),
     };
@@ -441,7 +446,8 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
                           sacNormalizationFactor:
                               calculateSacNormalizationFactor(dive, analysis),
                           markers: _calculateMarkers(
-                            dive: dive,
+                            profile: chartProfile,
+                            tanks: dive.tanks,
                             analysis: analysis,
                             tankPressures: tankPressures,
                             showMaxDepth: showMaxDepthMarker,
@@ -628,30 +634,38 @@ class _FullscreenProfilePageState extends ConsumerState<FullscreenProfilePage> {
     );
   }
 
+  /// Markers to overlay on the profile chart.
+  ///
+  /// [profile] must be the series the chart is actually drawing (the active
+  /// source's points), not `dive.profile`. The analysis these markers are
+  /// positioned from is the active source's, so indexing it into the merged
+  /// series would place the max-depth flag at another computer's reading
+  /// (#1167).
   List<ProfileMarker> _calculateMarkers({
-    required Dive dive,
+    required List<DiveProfilePoint> profile,
+    required List<DiveTank> tanks,
     required ProfileAnalysis? analysis,
     required Map<String, List<TankPressurePoint>>? tankPressures,
     required bool showMaxDepth,
     required bool showPressureThresholds,
   }) {
     final markers = <ProfileMarker>[];
-    if (dive.profile.isEmpty) return markers;
+    if (profile.isEmpty) return markers;
 
     if (showMaxDepth && analysis != null) {
       final maxDepthMarker = ProfileMarkersService.getMaxDepthMarker(
-        profile: dive.profile,
+        profile: profile,
         maxDepthTimestamp: analysis.maxDepthTimestamp,
         maxDepth: analysis.maxDepth,
       );
       if (maxDepthMarker != null) markers.add(maxDepthMarker);
     }
 
-    if (showPressureThresholds && dive.tanks.isNotEmpty) {
+    if (showPressureThresholds && tanks.isNotEmpty) {
       markers.addAll(
         ProfileMarkersService.getPressureThresholdMarkers(
-          profile: dive.profile,
-          tanks: dive.tanks,
+          profile: profile,
+          tanks: tanks,
           tankPressures: tankPressures,
         ),
       );

--- a/test/features/dive_log/presentation/pages/dive_detail_chart_series_consistency_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_chart_series_consistency_test.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/services/profile_analysis_service.dart';
+import 'package:submersion/features/dive_log/data/services/profile_markers_service.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_range_provider.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Regression cover for #1167.
+///
+/// On a multi-source dive the chart draws the ACTIVE source's points, but the
+/// markers and the playback/range extent were computed from `dive.profile` --
+/// the merged series across every source. The two disagree whenever the
+/// sources differ in depth or duration, so the "Max Depth" flag could report a
+/// depth the drawn curve never reaches and the range slider could run past the
+/// end of the visible series.
+void main() {
+  final now = DateTime(2026, 5, 7);
+
+  // Two computers on one dive, sampling the same seconds. dc-a (primary, and
+  // therefore the active source by default) reads 20 m; dc-b reads 30 m and
+  // keeps logging for two minutes after dc-a stops.
+  const pointsA = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 60, depth: 10.0),
+    DiveProfilePoint(timestamp: 120, depth: 20.0),
+    DiveProfilePoint(timestamp: 180, depth: 0.0),
+  ];
+  const pointsB = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 60, depth: 15.0),
+    DiveProfilePoint(timestamp: 120, depth: 30.0),
+    DiveProfilePoint(timestamp: 180, depth: 0.0),
+    DiveProfilePoint(timestamp: 240, depth: 0.0),
+    DiveProfilePoint(timestamp: 300, depth: 0.0),
+  ];
+
+  // What getDiveById returns: every source's samples, ordered by timestamp.
+  // dc-b's sample sorts first at each shared second, which is what made the
+  // marker's exact-timestamp lookup return the wrong computer's depth.
+  const mergedProfile = [
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 0, depth: 0.0),
+    DiveProfilePoint(timestamp: 60, depth: 15.0),
+    DiveProfilePoint(timestamp: 60, depth: 10.0),
+    DiveProfilePoint(timestamp: 120, depth: 30.0),
+    DiveProfilePoint(timestamp: 120, depth: 20.0),
+    DiveProfilePoint(timestamp: 180, depth: 0.0),
+    DiveProfilePoint(timestamp: 180, depth: 0.0),
+    DiveProfilePoint(timestamp: 240, depth: 0.0),
+    DiveProfilePoint(timestamp: 300, depth: 0.0),
+  ];
+
+  ProfileAnalysis analysisOf(List<DiveProfilePoint> points) =>
+      ProfileAnalysisService().analyze(
+        diveId: 'test-dive-1',
+        depths: [for (final p in points) p.depth],
+        timestamps: [for (final p in points) p.timestamp],
+      );
+
+  late Dive dive;
+  late List<DiveDataSource> sources;
+  late Map<String, SourceProfile> profiles;
+
+  setUp(() {
+    dive = createTestDiveWithBottomTime().copyWith(profile: mergedProfile);
+    sources = [
+      DiveDataSource(
+        id: 'src-a',
+        diveId: dive.id,
+        computerId: 'dc-a',
+        isPrimary: true,
+        computerName: 'Shallow Teric',
+        maxDepth: 20.0,
+        duration: 180,
+        importedAt: now,
+        createdAt: now,
+      ),
+      DiveDataSource(
+        id: 'src-b',
+        diveId: dive.id,
+        computerId: 'dc-b',
+        isPrimary: false,
+        computerName: 'Deep Teric',
+        maxDepth: 30.0,
+        duration: 300,
+        importedAt: now,
+        createdAt: now,
+      ),
+    ];
+    profiles = {
+      'src-a': const SourceProfile(
+        sourceId: 'src-a',
+        computerId: 'dc-a',
+        isEdited: false,
+        points: pointsA,
+      ),
+      'src-b': const SourceProfile(
+        sourceId: 'src-b',
+        computerId: 'dc-b',
+        isEdited: false,
+        points: pointsB,
+      ),
+    };
+  });
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    final base = await getBaseOverrides();
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (d) {
+      if (d.toString().contains('overflowed')) return;
+      originalOnError?.call(d);
+    };
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(dive.id).overrideWith((ref) async => sources),
+          sourceProfilesProvider(dive.id).overrideWith((ref) async => profiles),
+          gasSwitchesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+          tankPressuresProvider(
+            dive.id,
+          ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+          // The page asks for the ACTIVE source's analysis, so this is
+          // computed from dc-a's points: maxDepth 20 m at t=120.
+          sourceProfileAnalysisProvider((
+            diveId: dive.id,
+            sourceId: null,
+          )).overrideWith((ref) async => analysisOf(pointsA)),
+          computersForDiveProvider(dive.id).overrideWith(
+            (ref) async => [
+              DiveComputer(
+                id: 'dc-a',
+                name: 'Shallow Teric',
+                createdAt: now,
+                updatedAt: now,
+              ),
+              DiveComputer(
+                id: 'dc-b',
+                name: 'Deep Teric',
+                createdAt: now,
+                updatedAt: now,
+              ),
+            ],
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 1));
+    FlutterError.onError = originalOnError;
+  }
+
+  DiveProfileChart chartOf(WidgetTester tester) =>
+      tester.widget<DiveProfileChart>(find.byType(DiveProfileChart));
+
+  testWidgets('the chart draws the active source, not the merged series', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    // Guards the premise of the tests below.
+    expect(chartOf(tester).profile, pointsA);
+  });
+
+  testWidgets('the max depth marker sits on the drawn series', (tester) async {
+    await pumpPage(tester);
+
+    final markers = chartOf(tester).markers ?? const <ProfileMarker>[];
+    final maxDepth = markers
+        .where((m) => m.type == ProfileMarkerType.maxDepth)
+        .toList();
+
+    expect(
+      maxDepth,
+      isNotEmpty,
+      reason: 'showMaxDepthMarker defaults to true, so a marker is expected',
+    );
+    // dc-b reached 30 m at the same second; the active source only reached 20.
+    expect(
+      maxDepth.single.depth,
+      20.0,
+      reason: 'marker must come from the drawn source, not the merged profile',
+    );
+  });
+
+  testWidgets('every marker lands on a point of the drawn series', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    final chart = chartOf(tester);
+    final drawn = {for (final p in chart.profile) (p.timestamp, p.depth)};
+
+    for (final marker in chart.markers ?? const <ProfileMarker>[]) {
+      expect(
+        drawn.contains((marker.timestamp, marker.depth)),
+        isTrue,
+        reason:
+            'marker ${marker.type} at t=${marker.timestamp} d=${marker.depth} '
+            'is not a point on the drawn series',
+      );
+    }
+  });
+
+  testWidgets('the range extent stops at the end of the drawn series', (
+    tester,
+  ) async {
+    await pumpPage(tester);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(DiveProfileChart)),
+    );
+    final rangeMax = container
+        .read(rangeSelectionProvider(dive.id))
+        .maxTimestamp;
+
+    // The merged series runs to 300s because dc-b kept logging; the drawn
+    // source ends at 180s.
+    expect(rangeMax, 180);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_chart_series_consistency_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_chart_series_consistency_test.dart
@@ -120,6 +120,10 @@ void main() {
   Future<void> pumpPage(WidgetTester tester) async {
     final base = await getBaseOverrides();
     final originalOnError = FlutterError.onError;
+    // The explicit restore below runs on the happy path so assertions see the
+    // real handler. This tearDown is the safety net: if pumpWidget throws, the
+    // suppressing handler would otherwise leak into every later test here.
+    addTearDown(() => FlutterError.onError = originalOnError);
     FlutterError.onError = (d) {
       if (d.toString().contains('overflowed')) return;
       originalOnError?.call(d);


### PR DESCRIPTION
## Summary

Fixes #1167. On a multi-source dive the profile chart draws the **active source's** points, but its overlays were computed from `dive.profile`, the **merged** series across every source. The two disagree whenever the sources differ in depth or duration.

This turned out to be two independent defects sharing one symptom.

**1. Markers read the wrong series.** `getMaxDepthMarker` positions the flag by looking up the active source's `maxDepthTimestamp` inside whatever profile it is handed. Handed the merged series, it finds that second and returns whichever computer's sample sorted first there. With two computers sampling the same seconds, one reading 20 m and one 30 m, the **Max Depth flag rendered at 30.0 m on a curve that only reaches 20.0 m**. That is a wrong reading, not a cosmetic offset. Photo pins were scaled to the merged final timestamp and drifted the same way.

**2. The range extent was latched by an async race.** This is not what the issue originally described, and it matters because swapping in `chartProfile` does not fix it. The initializer was guarded by `if (currentRangeMax == 0)`, i.e. first-write-wins. `sourceProfilesProvider` and `diveDataSourcesProvider` are async, so the **first** build has no sources yet, `isMultiSource` is false, `chartProfile` falls back to `dive.profile`, and that build latches the merged extent. The zero-guard then prevents any correction once the sources resolve. The failing test caught this: after the marker fix it still failed, `300` vs `180`.

## Changes

- **`dive_detail_page.dart`** — move the active-source resolution above the marker and extent wiring (it was computed ~50 lines below its first consumer), then derive markers, photo pins, and the playback/range extent from `chartProfile`.
- **Extent guard** — replace `if (maxTimestamp == 0)` with "re-initialize when the extent stops matching the drawn series". This fixes the async race and additionally makes the extent follow a source switch, which it never did before. Re-initializing resets playback position and range selection; that is the wanted behavior when the series underneath them has changed, and it cannot loop because the write makes the two agree.
- **`fullscreen_profile_page.dart`** — same defect, and self-inconsistent within one file: it already used `chartProfile` for the chart, gas segments, duration, and tooltips while its markers and photo pins read `dive.profile`. Not mentioned in the original issue; found while fixing the detail page.
- **`_calculateProfileMarkers` / `_calculateMarkers`** now take `profile` and `tanks` explicitly rather than the whole `Dive`, so a caller cannot reach past the parameter to `dive.profile` again. Both carry a doc comment saying which series is required and why.

Single-source dives are unaffected: `chartProfile` is `dive.profile` on that branch, so nothing changes for them.

## Test Plan

- [x] `flutter test` passes — 19202 passed, 19 skipped, 0 failed (full suite, run in the worktree)
- [x] `flutter analyze` passes — whole project, no issues found
- [x] `dart format` — 0 files changed

New file `test/features/dive_log/presentation/pages/dive_detail_chart_series_consistency_test.dart`, 4 cases. **3 failed before the fix.** The fixture is two computers on one dive sampling the same seconds: dc-a (primary, active) reaches 20 m and stops at 180 s; dc-b reaches 30 m and logs to 300 s.

| Case | Before | Guards |
| --- | --- | --- |
| The chart draws the active source | passed | Premise guard, so the rest cannot pass vacuously |
| The max depth marker sits on the drawn series | **failed** `30.0` vs `20.0` | The wrong-depth reading |
| Every marker lands on a point of the drawn series | **failed** | General invariant; catches future marker types too |
| The range extent stops at the end of the drawn series | **failed** `300` vs `180` | The async-race latch |

Manual testing: not performed. Reproducing this on a device needs a genuine two-computer dive whose computers disagree on depth and duration; the widget test builds exactly that condition and asserts on the chart's own inputs.

## Notes

The premise guard and the "every marker" invariant are deliberate. Without the guard, a future change that made the chart draw the merged series again would turn the other assertions green while the bug was back.
