### PR TITLE
fix(reparse): stop re-parse destroying a combined dive's profile (#1164)

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -24,7 +24,10 @@ class ReparseService {
   ///
   /// [rawData] and [rawFingerprint] use `Value.absent()` when null to avoid
   /// overwriting existing blobs during the re-parse path.
-  Future<void> applyParsedUpdate({
+  ///
+  /// Returns whether the dive's profile strand was left untouched because
+  /// this source does not own it -- see [_sourceOwnsProfileStrand].
+  Future<({bool profilePreserved})> applyParsedUpdate({
     required String diveId,
     required String sourceRowId,
     required pigeon.ParsedDive parsed,
@@ -35,7 +38,7 @@ class ReparseService {
     Uint8List? rawData,
     Uint8List? rawFingerprint,
   }) async {
-    await db.transaction(() async {
+    return db.transaction(() async {
       final now = DateTime.now();
 
       // ------------------------------------------------------------------
@@ -67,16 +70,26 @@ class ReparseService {
         await _updateDiveRow(diveId: diveId, parsed: parsed, now: now);
       }
 
+      final sourceRows = await (db.select(
+        db.diveDataSources,
+      )..where((t) => t.diveId.equals(diveId))).get();
+      final isMultiSource = sourceRows.length > 1;
+      final ownsStrand = _sourceOwnsProfileStrand(sourceRow, sourceRows);
+
       // ------------------------------------------------------------------
-      // 4. Replace DiveProfiles for this source's computerId
+      // 4. Replace DiveProfiles for this source's computerId -- but only
+      //    when this source actually authored that strand in its own parse
+      //    frame (#1164).
       // ------------------------------------------------------------------
       final computerId = sourceRow.computerId;
-      await _replaceDiveProfiles(
-        diveId: diveId,
-        computerId: computerId,
-        parsed: parsed,
-        isPrimary: sourceRow.isPrimary,
-      );
+      if (ownsStrand) {
+        await _replaceDiveProfiles(
+          diveId: diveId,
+          computerId: computerId,
+          parsed: parsed,
+          isPrimary: sourceRow.isPrimary,
+        );
+      }
 
       // ------------------------------------------------------------------
       // 5. Replace DiveProfileEvents, GasSwitches, TankPressureProfiles
@@ -85,17 +98,13 @@ class ReparseService {
       //    with this source's computer below.
       // ------------------------------------------------------------------
 
-      // Check if this is a multi-source dive
-      final sourceRows = await (db.select(
-        db.diveDataSources,
-      )..where((t) => t.diveId.equals(diveId))).get();
-      final isMultiSource = sourceRows.length > 1;
-
       // Only replace events/switches/pressure for single-source dives.
       // Multi-source dives skip this to avoid destroying data from other
       // sources (gas_switches lacks a computerId column for per-source
-      // scoping).
-      if (!isMultiSource) {
+      // scoping). A combined dive can carry a single source row when only
+      // one original had one, so the ownership guard applies here too --
+      // otherwise the merge's own surface-gap markers are deleted (#1164).
+      if (!isMultiSource && ownsStrand) {
         await (db.delete(
           db.diveProfileEvents,
         )..where((t) => t.diveId.equals(diveId))).go();
@@ -139,7 +148,47 @@ class ReparseService {
           now: now,
         );
       }
+
+      return (profilePreserved: !ownsStrand);
     });
+  }
+
+  /// Whether [row] is the sole author of its `(dive_id, computer_id)` profile
+  /// strand, with that strand still in [row]'s own parse frame.
+  ///
+  /// Re-parsing deletes the strand and re-inserts the parsed samples at their
+  /// own `timeSeconds`, so it is only safe when both hold. A sequential
+  /// combine breaks both: [DiveMergeService.apply] re-bases each segment onto
+  /// the merged timeline and carries every original's source row over demoted
+  /// to non-primary, so re-parsing one of them would drop half a dive back at
+  /// the original download's timestamps and delete the synthesized
+  /// surface-gap samples along the way (#1164).
+  ///
+  /// Two signals, either of which disqualifies the row:
+  ///
+  /// - **No row on the dive is primary.** That is exactly a combined dive:
+  ///   the merge demotes all carried rows and the merged dive has no source
+  ///   row of its own. [DiveConsolidationService] demotes only its
+  ///   secondaries, so a consolidated dive keeps a primary row and its
+  ///   per-computer strands stay re-parseable.
+  /// - **A re-parseable sibling row shares this row's `computerId`** (null
+  ///   counts as equal to null). The strand has more than one author, so
+  ///   whichever source re-parses last would wipe out what the others wrote
+  ///   -- true of same-computer halves regardless of the primary flag. Only
+  ///   siblings carrying raw data count: deleting a computer nulls its
+  ///   sources' `computerId` (FK `setNull`) and
+  ///   `_backfillProvenanceSnapshots` adds rows with no `computerId` at all,
+  ///   so sharing a null strand with a row that can never be re-parsed is an
+  ///   ordinary shape, not contention.
+  bool _sourceOwnsProfileStrand(
+    DiveDataSourcesData row,
+    List<DiveDataSourcesData> allRowsForDive,
+  ) {
+    if (!allRowsForDive.any((r) => r.isPrimary)) return false;
+    return !allRowsForDive.any(
+      (r) =>
+          r.id != row.id && r.computerId == row.computerId && r.rawData != null,
+    );
   }
 
   /// Count how many sources for a given computer have raw data vs not.
@@ -256,8 +305,11 @@ class ReparseService {
   ///
   /// [parseFn] is the function that calls the native Pigeon API.
   ///
-  /// Returns a list of error messages (empty on full success).
-  Future<List<String>> reparseDive(
+  /// Returns the error messages (empty on full success) alongside the number
+  /// of sources whose profile strand was deliberately left alone -- see
+  /// [_sourceOwnsProfileStrand]. Callers surface that count so a re-parse on
+  /// a combined dive does not look like an unexplained no-op (#1164).
+  Future<({List<String> errors, int profilesPreserved})> reparseDive(
     String diveId, {
     required Future<pigeon.ParsedDive> Function(
       String vendor,
@@ -269,6 +321,7 @@ class ReparseService {
   }) async {
     final sources = await getSourcesForDiveReparse(diveId);
     final errors = <String>[];
+    var profilesPreserved = 0;
 
     for (final source in sources) {
       if (source.descriptorVendor == null ||
@@ -283,7 +336,7 @@ class ReparseService {
           source.descriptorModel!,
           source.rawData!,
         );
-        await applyParsedUpdate(
+        final outcome = await applyParsedUpdate(
           diveId: diveId,
           sourceRowId: source.id,
           parsed: parsed,
@@ -292,12 +345,13 @@ class ReparseService {
           descriptorModel: source.descriptorModel,
           libdivecomputerVersion: source.libdivecomputerVersion,
         );
+        if (outcome.profilePreserved) profilesPreserved++;
       } catch (e) {
         errors.add(e.toString());
       }
     }
 
-    return errors;
+    return (errors: errors, profilesPreserved: profilesPreserved);
   }
 
   // ==========================================================================

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -5112,10 +5112,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     final service = ref.read(reparseServiceProvider);
     final l10n = context.l10n;
 
-    final errors = await service.reparseDive(
+    final result = await service.reparseDive(
       dive.id,
       parseFn: pigeon.DiveComputerHostApi().parseRawDiveData,
     );
+    final errors = result.errors;
 
     // Invalidate providers so the UI reflects the re-parsed data.
     ref.invalidate(diveProvider(dive.id));
@@ -5125,8 +5126,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
     if (context.mounted) {
       if (errors.isEmpty) {
+        // A combined dive's profile is user-authored, so re-parse refreshes
+        // only the source provenance and says so -- otherwise the action
+        // looks like an unexplained no-op (#1164).
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.diveLog_detail_reparseSuccess)),
+          SnackBar(
+            content: Text(
+              result.profilesPreserved > 0
+                  ? l10n.diveLog_detail_reparseProfilePreserved
+                  : l10n.diveLog_detail_reparseSuccess,
+            ),
+          ),
         );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "إعادة تحليل البيانات الأولية",
   "diveLog_detail_reparseFailed": "فشلت إعادة التحليل: {error}",
   "diveLog_detail_reparseSuccess": "تمت إعادة تحليل الغطسة بنجاح",
+  "diveLog_detail_reparseProfilePreserved": "تم تحديث تفاصيل المصدر. دُمجت هذه الغطسة من غطسات أخرى، لذلك بقي مخططها دون تغيير.",
   "settings_appearance_mapStyle": "نمط الخريطة",
   "settings_appearance_mapStyle_esriSatellite": "قمر صناعي",
   "settings_appearance_mapStyle_openStreetMap": "خريطة الشوارع",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Rohdaten neu auswerten",
   "diveLog_detail_reparseFailed": "Neu-Auswertung fehlgeschlagen: {error}",
   "diveLog_detail_reparseSuccess": "Tauchgang erfolgreich neu ausgewertet",
+  "diveLog_detail_reparseProfilePreserved": "Quelldetails aktualisiert. Dieser Tauchgang wurde aus mehreren Tauchgängen zusammengeführt, daher blieb sein Profil unverändert.",
   "settings_appearance_mapStyle": "Kartenstil",
   "settings_appearance_mapStyle_esriSatellite": "Satellit",
   "settings_appearance_mapStyle_openStreetMap": "Straßenkarte",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -14080,6 +14080,10 @@
   "@diveLog_detail_reparseSuccess": {
     "description": "Snackbar message after successful re-parse"
   },
+  "diveLog_detail_reparseProfilePreserved": "Source details refreshed. This dive was combined from other dives, so its profile was left unchanged.",
+  "@diveLog_detail_reparseProfilePreserved": {
+    "description": "Snackbar message after re-parsing a combined dive, whose user-authored merged profile is deliberately not rewritten"
+  },
   "diveLog_detail_reparseFailed": "Re-parse failed: {error}",
   "@diveLog_detail_reparseFailed": {
     "placeholders": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Reanalizar datos sin procesar",
   "diveLog_detail_reparseFailed": "Error al reanalizar: {error}",
   "diveLog_detail_reparseSuccess": "Inmersión reanalizada correctamente",
+  "diveLog_detail_reparseProfilePreserved": "Detalles de la fuente actualizados. Esta inmersión se combinó a partir de otras inmersiones, por lo que su perfil no se modificó.",
   "settings_appearance_mapStyle": "Estilo del Mapa",
   "settings_appearance_mapStyle_esriSatellite": "Satélite",
   "settings_appearance_mapStyle_openStreetMap": "Mapa de Calles",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Réanalyser les données brutes",
   "diveLog_detail_reparseFailed": "Échec de la réanalyse : {error}",
   "diveLog_detail_reparseSuccess": "Plongée réanalysée avec succès",
+  "diveLog_detail_reparseProfilePreserved": "Détails de la source actualisés. Cette plongée a été combinée à partir d'autres plongées, son profil est donc resté inchangé.",
   "settings_appearance_mapStyle": "Style de carte",
   "settings_appearance_mapStyle_esriSatellite": "Satellite",
   "settings_appearance_mapStyle_openStreetMap": "Plan des rues",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "נתח מחדש נתונים גולמיים",
   "diveLog_detail_reparseFailed": "הניתוח מחדש נכשל: {error}",
   "diveLog_detail_reparseSuccess": "הצלילה נותחה מחדש בהצלחה",
+  "diveLog_detail_reparseProfilePreserved": "פרטי המקור רועננו. צלילה זו אוחדה מצלילות אחרות, ולכן הפרופיל שלה נותר ללא שינוי.",
   "settings_appearance_mapStyle": "סגנון מפה",
   "settings_appearance_mapStyle_esriSatellite": "לוויין",
   "settings_appearance_mapStyle_openStreetMap": "מפת רחובות",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Nyers adatok újraelemzése",
   "diveLog_detail_reparseFailed": "Újraelemzés sikertelen: {error}",
   "diveLog_detail_reparseSuccess": "Merülés sikeresen újraelemezve",
+  "diveLog_detail_reparseProfilePreserved": "A forrás adatai frissítve. Ez a merülés több merülésből lett összevonva, ezért a profilja változatlan maradt.",
   "settings_appearance_mapStyle": "Térképstílus",
   "settings_appearance_mapStyle_esriSatellite": "Műhold",
   "settings_appearance_mapStyle_openStreetMap": "Utcatérkép",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Rianalizza dati grezzi",
   "diveLog_detail_reparseFailed": "Rianalisi non riuscita: {error}",
   "diveLog_detail_reparseSuccess": "Immersione rianalizzata con successo",
+  "diveLog_detail_reparseProfilePreserved": "Dettagli della sorgente aggiornati. Questa immersione è stata combinata da altre immersioni, quindi il suo profilo è rimasto invariato.",
   "settings_appearance_mapStyle": "Stile della mappa",
   "settings_appearance_mapStyle_esriSatellite": "Satellite",
   "settings_appearance_mapStyle_openStreetMap": "Mappa stradale",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -36629,6 +36629,12 @@ abstract class AppLocalizations {
   /// **'Dive re-parsed successfully'**
   String get diveLog_detail_reparseSuccess;
 
+  /// Snackbar message after re-parsing a combined dive, whose user-authored merged profile is deliberately not rewritten
+  ///
+  /// In en, this message translates to:
+  /// **'Source details refreshed. This dive was combined from other dives, so its profile was left unchanged.'**
+  String get diveLog_detail_reparseProfilePreserved;
+
   /// No description provided for @diveLog_detail_reparseFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -21617,6 +21617,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'تمت إعادة تحليل الغطسة بنجاح';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'تم تحديث تفاصيل المصدر. دُمجت هذه الغطسة من غطسات أخرى، لذلك بقي مخططها دون تغيير.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'فشلت إعادة التحليل: $error';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -21962,6 +21962,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Tauchgang erfolgreich neu ausgewertet';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Quelldetails aktualisiert. Dieser Tauchgang wurde aus mehreren Tauchgängen zusammengeführt, daher blieb sein Profil unverändert.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Neu-Auswertung fehlgeschlagen: $error';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -21630,6 +21630,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'Dive re-parsed successfully';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Source details refreshed. This dive was combined from other dives, so its profile was left unchanged.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Re-parse failed: $error';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -22018,6 +22018,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Inmersión reanalizada correctamente';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Detalles de la fuente actualizados. Esta inmersión se combinó a partir de otras inmersiones, por lo que su perfil no se modificó.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Error al reanalizar: $error';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -22074,6 +22074,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'Plongée réanalysée avec succès';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Détails de la source actualisés. Cette plongée a été combinée à partir d\'autres plongées, son profil est donc resté inchangé.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Échec de la réanalyse : $error';
   }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -21463,6 +21463,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'הצלילה נותחה מחדש בהצלחה';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'פרטי המקור רועננו. צלילה זו אוחדה מצלילות אחרות, ולכן הפרופיל שלה נותר ללא שינוי.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'הניתוח מחדש נכשל: $error';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -21930,6 +21930,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'Merülés sikeresen újraelemezve';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'A forrás adatai frissítve. Ez a merülés több merülésből lett összevonva, ezért a profilja változatlan maradt.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Újraelemzés sikertelen: $error';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -22000,6 +22000,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Immersione rianalizzata con successo';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Dettagli della sorgente aggiornati. Questa immersione è stata combinata da altre immersioni, quindi il suo profilo è rimasto invariato.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Rianalisi non riuscita: $error';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -21831,6 +21831,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => 'Duik succesvol opnieuw verwerkt';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Brongegevens vernieuwd. Deze duik is samengevoegd uit andere duiken, dus het profiel is ongewijzigd gebleven.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Opnieuw verwerken mislukt: $error';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -22005,6 +22005,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mergulho reanalisado com sucesso';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      'Detalhes da fonte atualizados. Este mergulho foi combinado a partir de outros mergulhos, por isso o seu perfil não foi alterado.';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return 'Falha na reanálise: $error';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -20905,6 +20905,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_detail_reparseSuccess => '潜水已成功重新解析';
 
   @override
+  String get diveLog_detail_reparseProfilePreserved =>
+      '已刷新数据源详情。此潜水由多次潜水合并而成，因此其剖面保持不变。';
+
+  @override
   String diveLog_detail_reparseFailed(String error) {
     return '重新解析失败：$error';
   }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Ruwe data opnieuw verwerken",
   "diveLog_detail_reparseFailed": "Opnieuw verwerken mislukt: {error}",
   "diveLog_detail_reparseSuccess": "Duik succesvol opnieuw verwerkt",
+  "diveLog_detail_reparseProfilePreserved": "Brongegevens vernieuwd. Deze duik is samengevoegd uit andere duiken, dus het profiel is ongewijzigd gebleven.",
   "settings_appearance_mapStyle": "Kaartstijl",
   "settings_appearance_mapStyle_esriSatellite": "Satelliet",
   "settings_appearance_mapStyle_openStreetMap": "Stratenkaart",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "Reanalisar dados brutos",
   "diveLog_detail_reparseFailed": "Falha na reanálise: {error}",
   "diveLog_detail_reparseSuccess": "Mergulho reanalisado com sucesso",
+  "diveLog_detail_reparseProfilePreserved": "Detalhes da fonte atualizados. Este mergulho foi combinado a partir de outros mergulhos, por isso o seu perfil não foi alterado.",
   "settings_appearance_mapStyle": "Estilo do Mapa",
   "settings_appearance_mapStyle_esriSatellite": "Satélite",
   "settings_appearance_mapStyle_openStreetMap": "Mapa de Ruas",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6291,6 +6291,7 @@
   "diveLog_detail_menu_reparseRawData": "重新解析原始数据",
   "diveLog_detail_reparseFailed": "重新解析失败：{error}",
   "diveLog_detail_reparseSuccess": "潜水已成功重新解析",
+  "diveLog_detail_reparseProfilePreserved": "已刷新数据源详情。此潜水由多次潜水合并而成，因此其剖面保持不变。",
   "settings_appearance_mapStyle": "地图样式",
   "settings_appearance_mapStyle_esriSatellite": "卫星",
   "settings_appearance_mapStyle_openStreetMap": "街道地图",

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -423,7 +423,10 @@ void main() {
           );
         }
 
-        final errors = await service.reparseDive('dive-1', parseFn: fakeParse);
+        final errors = (await service.reparseDive(
+          'dive-1',
+          parseFn: fakeParse,
+        )).errors;
 
         expect(errors, isEmpty);
         final dive = await getDive('dive-1');
@@ -472,7 +475,10 @@ void main() {
           return makeParsedDive();
         }
 
-        final errors = await service.reparseDive('dive-1', parseFn: fakeParse);
+        final errors = (await service.reparseDive(
+          'dive-1',
+          parseFn: fakeParse,
+        )).errors;
 
         // Documents current behavior: no errors reported, parser not invoked.
         expect(errors, isEmpty);
@@ -2232,7 +2238,10 @@ void main() {
         computerId: 'comp-1',
       );
 
-      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+      final errors = (await service.reparseDive(
+        'dive-1',
+        parseFn: fakeParseFn,
+      )).errors;
 
       expect(errors, isEmpty);
     });
@@ -2249,7 +2258,10 @@ void main() {
         descriptorModel: null,
       );
 
-      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+      final errors = (await service.reparseDive(
+        'dive-1',
+        parseFn: fakeParseFn,
+      )).errors;
 
       expect(errors, isEmpty);
     });
@@ -2263,12 +2275,12 @@ void main() {
         computerId: 'comp-1',
       );
 
-      final errors = await service.reparseDive(
+      final errors = (await service.reparseDive(
         'dive-1',
         parseFn: (vendor, product, model, rawData) async {
           throw Exception('native bridge error');
         },
-      );
+      )).errors;
 
       expect(errors.length, 1);
       expect(errors.first, contains('native bridge error'));
@@ -2293,7 +2305,10 @@ void main() {
             ),
           );
 
-      final errors = await service.reparseDive('dive-1', parseFn: fakeParseFn);
+      final errors = (await service.reparseDive(
+        'dive-1',
+        parseFn: fakeParseFn,
+      )).errors;
 
       expect(errors, isEmpty);
     });
@@ -2323,7 +2338,7 @@ void main() {
           descriptorModel: 99,
         );
 
-        final errors = await service.reparseDive(
+        final errors = (await service.reparseDive(
           'dive-1',
           parseFn: (vendor, product, model, rawData) async {
             if (vendor == 'Suunto') {
@@ -2331,7 +2346,7 @@ void main() {
             }
             return makeParsedDive();
           },
-        );
+        )).errors;
 
         expect(errors.length, 1);
         expect(errors.first, contains('Suunto parse failure'));
@@ -2758,5 +2773,298 @@ void main() {
       // Maximum CNS across all samples is 45.0
       expect(dive.cnsEnd, 45.0);
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1164: a source row may only rewrite the profile strand it exclusively
+  // authored, in its own parse frame. A sequential combine (DiveMergeService)
+  // carries every original's source row onto the merged dive demoted to
+  // non-primary and re-bases the samples, so no carried row satisfies that.
+  // ---------------------------------------------------------------------------
+  group('ReparseService merged-dive profile guard', () {
+    /// The shape DiveMergeService.apply leaves behind: a brand-new dive whose
+    /// only dive_data_sources rows are carried provenance, every one demoted.
+    Future<void> insertMergedDive(
+      List<({String sourceId, String? computerId})> carried,
+    ) async {
+      await insertDive('merged-1', maxDepth: 25.0, runtime: 4200);
+      final seenComputers = <String>{};
+      for (final c in carried) {
+        if (c.computerId != null && seenComputers.add(c.computerId!)) {
+          await insertComputer(c.computerId!);
+        }
+        await insertSource(
+          id: c.sourceId,
+          diveId: 'merged-1',
+          computerId: c.computerId,
+          isPrimary: false,
+        );
+      }
+    }
+
+    /// First half at 0..180, surface gap filled at 240..300, second half
+    /// re-based to 360..540 -- the timeline DiveMergeService produces.
+    const mergedTimestamps = [0, 60, 120, 180, 240, 300, 360, 420, 480, 540];
+
+    Future<void> insertMergedProfile(String? computerId) async {
+      for (var i = 0; i < mergedTimestamps.length; i++) {
+        final ts = mergedTimestamps[i];
+        await insertProfile(
+          id: 'merged-prof-$i',
+          diveId: 'merged-1',
+          computerId: computerId,
+          timestamp: ts,
+          depth: ts >= 240 && ts <= 300 ? 0.0 : 20.0,
+        );
+      }
+    }
+
+    Future<List<DiveProfile>> mergedProfiles() {
+      return (db.select(db.diveProfiles)
+            ..where((t) => t.diveId.equals('merged-1'))
+            ..orderBy([(t) => OrderingTerm(expression: t.timestamp)]))
+          .get();
+    }
+
+    test('both halves and the synthesized gap survive when the carried sources '
+        'share one computer', () async {
+      await insertMergedDive([
+        (sourceId: 'src-a', computerId: 'comp-1'),
+        (sourceId: 'src-b', computerId: 'comp-1'),
+      ]);
+      await insertMergedProfile('comp-1');
+
+      for (final sourceId in ['src-a', 'src-b']) {
+        await service.applyParsedUpdate(
+          diveId: 'merged-1',
+          sourceRowId: sourceId,
+          parsed: makeParsedDive(),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+      }
+
+      final profiles = await mergedProfiles();
+      expect(profiles.map((p) => p.timestamp), mergedTimestamps);
+      expect(profiles.map((p) => p.id), everyElement(startsWith('merged-')));
+      expect(profiles.every((p) => p.isPrimary), isTrue);
+    });
+
+    test(
+      'the profile survives when the halves came from different computers',
+      () async {
+        await insertMergedDive([
+          (sourceId: 'src-a', computerId: 'comp-1'),
+          (sourceId: 'src-b', computerId: 'comp-2'),
+        ]);
+        await insertMergedProfile('comp-1');
+
+        await service.applyParsedUpdate(
+          diveId: 'merged-1',
+          sourceRowId: 'src-a',
+          parsed: makeParsedDive(),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        expect(
+          (await mergedProfiles()).map((p) => p.timestamp),
+          mergedTimestamps,
+        );
+      },
+    );
+
+    test(
+      'surface-gap events survive when only one original had a source row',
+      () async {
+        // A single carried row leaves isMultiSource false, so step 5 would
+        // otherwise delete the merge's own surface markers.
+        await insertMergedDive([(sourceId: 'src-a', computerId: 'comp-1')]);
+        await insertMergedProfile('comp-1');
+        for (final ts in [240, 300]) {
+          await db
+              .into(db.diveProfileEvents)
+              .insert(
+                DiveProfileEventsCompanion.insert(
+                  id: 'gap-event-$ts',
+                  diveId: 'merged-1',
+                  timestamp: ts,
+                  eventType: 'surface',
+                  source: const Value('app'),
+                  createdAt: nowMs,
+                ),
+              );
+        }
+
+        await service.applyParsedUpdate(
+          diveId: 'merged-1',
+          sourceRowId: 'src-a',
+          parsed: makeParsedDive(),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final events = await (db.select(
+          db.diveProfileEvents,
+        )..where((t) => t.diveId.equals('merged-1'))).get();
+        expect(
+          events.map((e) => e.id),
+          containsAll(['gap-event-240', 'gap-event-300']),
+        );
+        expect((await mergedProfiles()).length, mergedTimestamps.length);
+      },
+    );
+
+    test(
+      'a consolidated dive still re-parses its non-primary secondary strand',
+      () async {
+        // DiveConsolidationService demotes only the secondaries, so the target
+        // keeps a primary source row -- that strand is genuinely the secondary
+        // source's to rewrite and must not be caught by the guard.
+        await insertDive('dive-1');
+        await insertComputer('comp-1');
+        await insertComputer('comp-2');
+        await insertSource(
+          id: 'src-primary',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+        await insertSource(
+          id: 'src-secondary',
+          diveId: 'dive-1',
+          computerId: 'comp-2',
+          isPrimary: false,
+        );
+        await insertProfile(
+          id: 'stale-secondary',
+          diveId: 'dive-1',
+          computerId: 'comp-2',
+          timestamp: 999,
+          depth: 40.0,
+          isPrimary: false,
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-secondary',
+          parsed: makeParsedDive(
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 60, depthMeters: 12.0),
+            ],
+          ),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final secondary =
+            await (db.select(db.diveProfiles)
+                  ..where((t) => t.computerId.equals('comp-2'))
+                  ..orderBy([(t) => OrderingTerm(expression: t.timestamp)]))
+                .get();
+        expect(secondary.map((p) => p.timestamp), [0, 60]);
+        expect(secondary.any((p) => p.isPrimary), isFalse);
+      },
+    );
+
+    test(
+      'a provenance-only sibling sharing the strand does not block a re-parse',
+      () async {
+        // Deleting a computer nulls its sources' computerId (FK setNull) and
+        // _backfillProvenanceSnapshots adds rows with no computerId of their
+        // own, so two rows sharing a null strand is an ordinary shape. A
+        // sibling with no raw data can never be re-parsed, so it cannot
+        // contend for the strand.
+        await insertDive('dive-1');
+        await insertSource(id: 'src-download', diveId: 'dive-1');
+        await insertSource(
+          id: 'src-provenance',
+          diveId: 'dive-1',
+          isPrimary: false,
+        );
+        await (db.update(
+          db.diveDataSources,
+        )..where((t) => t.id.equals('src-download'))).write(
+          DiveDataSourcesCompanion(
+            rawData: Value(Uint8List.fromList([1, 2, 3])),
+          ),
+        );
+        await insertProfile(
+          id: 'stale',
+          diveId: 'dive-1',
+          timestamp: 999,
+          depth: 40.0,
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-download',
+          parsed: makeParsedDive(
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 60, depthMeters: 12.0),
+            ],
+          ),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final profiles =
+            await (db.select(db.diveProfiles)
+                  ..where((t) => t.diveId.equals('dive-1'))
+                  ..orderBy([(t) => OrderingTerm(expression: t.timestamp)]))
+                .get();
+        expect(profiles.map((p) => p.timestamp), [0, 60]);
+      },
+    );
+
+    test(
+      'reparseDive reports how many sources had their profile preserved',
+      () async {
+        await insertMergedDive([
+          (sourceId: 'src-a', computerId: 'comp-1'),
+          (sourceId: 'src-b', computerId: 'comp-1'),
+        ]);
+        await insertMergedProfile('comp-1');
+        for (final sourceId in ['src-a', 'src-b']) {
+          await (db.update(
+            db.diveDataSources,
+          )..where((t) => t.id.equals(sourceId))).write(
+            DiveDataSourcesCompanion(
+              rawData: Value(Uint8List.fromList([1, 2, 3])),
+              descriptorVendor: const Value('Shearwater'),
+              descriptorProduct: const Value('Perdix'),
+              descriptorModel: const Value(42),
+            ),
+          );
+        }
+
+        Future<pigeon.ParsedDive> fakeParse(
+          String vendor,
+          String product,
+          int model,
+          Uint8List raw,
+        ) async => makeParsedDive();
+
+        final result = await service.reparseDive(
+          'merged-1',
+          parseFn: fakeParse,
+        );
+
+        expect(result.errors, isEmpty);
+        expect(result.profilesPreserved, 2);
+      },
+    );
   });
 }

--- a/test/features/dive_log/data/services/dive_merge_service_test.dart
+++ b/test/features/dive_log/data/services/dive_merge_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_merge_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
@@ -600,7 +602,10 @@ void main() {
         expect(rows.map((r) => r.sourceUuid).toSet(), {'uuid-a', 'uuid-b'});
         expect(rows.map((r) => r.rawFingerprint?.first).toSet(), {0xA1, 0xB2});
         // ReparseService.getSourcesForDiveReparse selects on rawData, so
-        // both halves stay re-parseable after a libdivecomputer upgrade.
+        // both halves keep their bytes for a libdivecomputer upgrade. What
+        // a re-parse does with them is scoped by
+        // ReparseService._sourceOwnsProfileStrand: it refreshes each row's
+        // provenance snapshot but leaves the merged profile alone (#1164).
         expect(rows.where((r) => r.rawData != null), hasLength(2));
 
         // The import duplicate checker unions keys across ALL rows: a
@@ -615,5 +620,89 @@ void main() {
         expect(canonical, hasLength(1));
       },
     );
+  });
+
+  group('re-parsing a merged dive (#1164)', () {
+    /// Gives both originals' source rows the raw blob and descriptor triple
+    /// that make them eligible for re-parse, so the merged dive inherits two
+    /// re-parseable carried rows sharing one computer.
+    Future<void> makeSourceReparseable(String diveId) async {
+      await (db.update(
+        db.diveDataSources,
+      )..where((t) => t.id.equals('src-$diveId'))).write(
+        DiveDataSourcesCompanion(
+          computerId: const Value('comp-1'),
+          rawData: Value(Uint8List.fromList([1, 2, 3, 4])),
+          descriptorVendor: const Value('Shearwater'),
+          descriptorProduct: const Value('Perdix'),
+          descriptorModel: const Value(42),
+        ),
+      );
+    }
+
+    test('leaves the combined profile and its surface gap intact', () async {
+      await seedDive(
+        'a',
+        entry: DateTime.utc(2026, 7, 1, 9),
+        depth: 10,
+        computerId: 'comp-1',
+      );
+      await seedDive(
+        'b',
+        entry: DateTime.utc(2026, 7, 1, 10),
+        depth: 20,
+        runtimeMin: 20,
+        computerId: 'comp-1',
+      );
+      await makeSourceReparseable('a');
+      await makeSourceReparseable('b');
+
+      final mergedId = (await service.apply(['a', 'b'])).mergedDive.id;
+
+      Future<List<int>> profileTimestamps() async {
+        final rows =
+            await (db.select(db.diveProfiles)
+                  ..where((t) => t.diveId.equals(mergedId))
+                  ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+                .get();
+        return rows.map((r) => r.timestamp).toList();
+      }
+
+      final before = await profileTimestamps();
+      // Both halves plus the synthesized surface-gap fill.
+      expect(before.length, greaterThan(6));
+      expect(before.any((t) => t > 1800 && t < 3600), isTrue);
+
+      // The parser returns the first half's download verbatim: four samples
+      // in the original dive's frame, exactly what would overwrite the
+      // merged timeline if the guard were missing.
+      final result = await ReparseService(db: db).reparseDive(
+        mergedId,
+        parseFn: (vendor, product, model, rawData) async => pigeon.ParsedDive(
+          fingerprint: 'fp',
+          dateTimeYear: 2026,
+          dateTimeMonth: 7,
+          dateTimeDay: 1,
+          dateTimeHour: 9,
+          dateTimeMinute: 0,
+          dateTimeSecond: 0,
+          maxDepthMeters: 10,
+          avgDepthMeters: 5,
+          durationSeconds: 1800,
+          samples: [
+            pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0),
+            pigeon.ProfileSample(timeSeconds: 900, depthMeters: 10),
+            pigeon.ProfileSample(timeSeconds: 1800, depthMeters: 0),
+          ],
+          tanks: const [],
+          gasMixes: const [],
+          events: const [],
+        ),
+      );
+
+      expect(await profileTimestamps(), before);
+      expect(result.errors, isEmpty);
+      expect(result.profilesPreserved, 2);
+    });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_reparse_menu_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_reparse_menu_test.dart
@@ -1,0 +1,184 @@
+import 'package:drift/drift.dart' show Uint8List;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Exercises the "Re-parse raw data" overflow action. The outcome message is
+/// not uniform: a combined dive's profile is deliberately left alone (#1164),
+/// so re-parse refreshes only the source provenance and has to say so rather
+/// than reporting a plain success for what looks like a no-op.
+///
+/// [ReparseService] is faked rather than driven for real, so the page's
+/// `pigeon.DiveComputerHostApi().parseRawDiveData` tear-off is never invoked
+/// and no platform channel is touched.
+class _FakeReparseService extends ReparseService {
+  _FakeReparseService({required super.db, required this.result});
+
+  final ({List<String> errors, int profilesPreserved}) result;
+  final reparsedDiveIds = <String>[];
+
+  @override
+  Future<({List<String> errors, int profilesPreserved})> reparseDive(
+    String diveId, {
+    required Future<pigeon.ParsedDive> Function(
+      String vendor,
+      String product,
+      int model,
+      Uint8List rawData,
+    )
+    parseFn,
+  }) async {
+    reparsedDiveIds.add(diveId);
+    return result;
+  }
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<_FakeReparseService> pumpDetail(
+    WidgetTester tester, {
+    required ({List<String> errors, int profilesPreserved}) result,
+    bool embedded = false,
+  }) async {
+    final dive = createTestDiveWithBottomTime();
+    final overrides = await getBaseOverrides();
+    final service = _FakeReparseService(db: db, result: result);
+
+    final router = GoRouter(
+      initialLocation: '/detail',
+      routes: [
+        GoRoute(
+          path: '/detail',
+          // The embedded variant renders no Scaffold of its own -- it lives
+          // inside the master-detail host's. Without one, showSnackBar has
+          // nothing to present to.
+          builder: (context, state) => embedded
+              ? Scaffold(body: DiveDetailPage(diveId: dive.id, embedded: true))
+              : DiveDetailPage(diveId: dive.id),
+        ),
+      ],
+    );
+
+    // The detail page intentionally overflows its fixed test viewport; that is
+    // not what this test asserts, so swallow only overflow errors.
+    final originalOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details.toString().contains('overflowed')) return;
+      originalOnError?.call(details);
+    };
+    addTearDown(() => FlutterError.onError = originalOnError);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          // Gates the menu item; without it the action never renders.
+          diveHasRawDataProvider(dive.id).overrideWith((ref) async => true),
+          reparseServiceProvider.overrideWithValue(service),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    return service;
+  }
+
+  Future<void> tapReparse(WidgetTester tester) async {
+    // The header overflow menu is the last more_vert on the page (a source bar,
+    // when present, renders earlier).
+    await tester.tap(find.byIcon(Icons.more_vert).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Re-parse raw data'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a preserved profile is reported instead of a plain success', (
+    tester,
+  ) async {
+    final service = await pumpDetail(
+      tester,
+      result: (errors: <String>[], profilesPreserved: 2),
+    );
+
+    await tapReparse(tester);
+
+    expect(service.reparsedDiveIds, ['test-dive-1']);
+    expect(
+      find.text(
+        'Source details refreshed. This dive was combined from other dives, '
+        'so its profile was left unchanged.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('an ordinary dive reports a plain success', (tester) async {
+    await pumpDetail(
+      tester,
+      result: (errors: <String>[], profilesPreserved: 0),
+    );
+
+    await tapReparse(tester);
+
+    expect(find.text('Dive re-parsed successfully'), findsOneWidget);
+  });
+
+  testWidgets('the first error is surfaced when a source fails to parse', (
+    tester,
+  ) async {
+    await pumpDetail(
+      tester,
+      result: (errors: <String>['native bridge error'], profilesPreserved: 0),
+    );
+
+    await tapReparse(tester);
+
+    expect(find.text('Re-parse failed: native bridge error'), findsOneWidget);
+  });
+
+  testWidgets('the embedded app bar runs the same action', (tester) async {
+    final service = await pumpDetail(
+      tester,
+      result: (errors: <String>[], profilesPreserved: 1),
+      embedded: true,
+    );
+
+    await tapReparse(tester);
+
+    expect(service.reparsedDiveIds, ['test-dive-1']);
+    expect(
+      find.text(
+        'Source details refreshed. This dive was combined from other dives, '
+        'so its profile was left unchanged.',
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
Closes #1164.

Re-parsing a merged (sequentially combined) dive destroyed the merged profile and replaced it with one half of the original download, at the original half's timestamps, flagged non-primary.

## The bug

`DiveMergeService.apply` step 10 carries each original's `dive_data_sources` row onto the merged dive with `isPrimary: false`, and says why:

```dart
// 10. Data sources carried as provenance; NEVER primary (a merged
//     profile is user-authored -- reparse must not rewrite it).
```

That flag guarded the `dives` row (step 2) and the tank carry-over (step 6), but not the profile. `applyParsedUpdate` called `_replaceDiveProfiles` unconditionally, passing `isPrimary` through as data rather than using it as a gate.

`_replaceDiveProfiles` deletes every `dive_profiles` row matching `(dive_id, computer_id)` and re-inserts the parsed samples at their own `timeSeconds`. On a merged dive that means:

- **The whole merged profile is deleted.** The merge copies profile rows verbatim, preserving `computer_id`, so the delete matches both halves plus the synthesized surface-gap samples.
- **Timestamps are not re-based.** The merge shifts the later segment by `segmentOffsetsSeconds`; the re-insert uses the raw parse frame, so the second half comes back overlapping the first instead of following it.
- **`isPrimary` is inherited from the carried row**, which is `false`, so the dive can be left with no primary profile rows at all.
- **It runs once per source row.** Two carried rows sharing a `computer_id` means the second pass deletes what the first just wrote. Net result: one half of the dive.

`reparseAllForComputer` from the device detail page hits the same rows, so a bulk re-parse after a libdivecomputer upgrade would have damaged every merged dive for that computer at once.

## The fix

A new predicate in `ReparseService`:

```dart
bool _sourceOwnsProfileStrand(DiveDataSourcesData row, List<DiveDataSourcesData> allRowsForDive)
```

A source row may rewrite a profile strand only when it exclusively authored that strand *and* the strand is still in the source's own parse frame. Two signals disqualify a row:

1. **No row on the dive is primary.** That is exactly a combined dive: the merge demotes every carried row, and the merged dive has no source row of its own.
2. **A re-parseable sibling shares the row's `computerId`** (null equal to null). The strand has more than one author, so whichever source re-parses last wipes out the others' work.

Only siblings carrying raw data count for (2). Deleting a computer nulls its sources' `computerId` (FK `setNull`) and `_backfillProvenanceSnapshots` inserts rows with none, so sharing a null strand with a row that can never be re-parsed is an ordinary shape, not contention.

The guard also covers step 5. Events, gas switches, and tank pressure were gated on `!isMultiSource` alone, so a combined dive carrying a *single* source row (when only one original had one) would have had the merge's own surface-gap markers deleted. That hole is not in the issue report.

### Multi-computer consolidation is deliberately untouched

`DiveConsolidationService` demotes only its secondaries, so a consolidated dive keeps a primary source row and its per-computer strands stay re-parseable. There is a regression test asserting exactly that.

### Reporting

`applyParsedUpdate` returns `({bool profilePreserved})` and `reparseDive` returns `({List<String> errors, int profilesPreserved})`. The dive detail page shows a distinct message when a profile was preserved, so the action does not read as an unexplained no-op:

> Source details refreshed. This dive was combined from other dives, so its profile was left unchanged.

New l10n key across all 11 locales. The bulk device-page snackbar wording is unchanged: it is a per-computer aggregate where "N dives re-parsed" stays true, and the guard protects that path regardless.

## Tests

Seven new tests, each watched failing before the fix:

- `reparse_service_test.dart` — merged shape with a shared `computerId` (the destructive repro), merged shape with differing `computerId`s, merged shape with a single carried row (the events hole), a provenance-only sibling that must *not* block a legitimate re-parse, a consolidation shape asserting the non-primary secondary strand still re-parses, and the `profilesPreserved` count.
- `dive_merge_service_test.dart` — end-to-end: combine two dives, re-parse, assert the merged timeline survives. With the guard disabled this test produces the issue's exact symptom, `[0, 900, 1800, 1801, 2701, 3599, 3600, 4200, 4800]` collapsing to `[0, 900, 1800]`.

Full suite green (19205 passed, 19 skipped), `flutter analyze` clean, `dart format` clean.

## Follow-up filed separately

`DiveConsolidationService.apply` re-bases its secondary strand by `plan.offsetsSeconds`, but nothing records that offset, so re-parsing a consolidated secondary re-inserts at un-rebased timestamps and slides the strand against the primary. Not destructive (different computers mean different `computer_id`, so the delete stays scoped) and out of scope here, since fixing it properly needs the offset persisted on the source row via a schema column. Filed as #1177.
