### PR TITLE
Fix inverted hardware/software flow control in serial backends

### DIFF
--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/FtdiProtocol.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/FtdiProtocol.swift
@@ -144,10 +144,11 @@ enum FtdiProtocol {
     /// encoding, or nil if it is not a value libdivecomputer defines.
     ///
     /// Note the ordering: libdivecomputer defines HARDWARE as 1 and SOFTWARE
-    /// as 2 (`iostream.h`). The termios backends in this repository have those
-    /// two swapped. That is latent, because no driver requests anything but
-    /// NONE, but this mapping follows libdivecomputer rather than its
-    /// neighbours. Do not "align" it with them.
+    /// as 2 (`iostream.h`), which reads as the wrong way round to anyone who
+    /// thinks of XON/XOFF as the simpler case. The termios and DCB backends
+    /// once had the two swapped (issue #1155); they now share the
+    /// `LIBDC_FLOWCONTROL_*` constants in `libdc_wrapper.h`, which this file
+    /// cannot use because it is compiled standalone by `run_native_tests.sh`.
     static func flowControl(fromLibdc value: UInt32) -> FlowControl? {
         switch value {
         case 0: return FlowControl.none

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialIoStream.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/SerialIoStream.swift
@@ -170,7 +170,7 @@ class SerialIoStream {
     /// Darwin, speed_t constants equal their numeric baud values, so an
     /// arbitrary baud rate can be set directly without a Bxxxx lookup table.
     /// parity: 0=none, 1=odd, 2=even. stopbits: 2=two, else one.
-    /// flowcontrol: 0=none, 1=software (XON/XOFF), 2=hardware (RTS/CTS).
+    /// flowcontrol: see LIBDC_FLOWCONTROL_* in libdc_wrapper.h.
     private func performConfigure(
         baudRate: UInt32, dataBits: UInt32, parity: UInt32,
         stopBits: UInt32, flowControl: UInt32
@@ -212,14 +212,17 @@ class SerialIoStream {
             options.c_cflag &= ~UInt(CSTOPB)
         }
 
-        // Flow control.
-        if flowControl == 2 {
+        // Flow control. See LIBDC_FLOWCONTROL_* in libdc_wrapper.h: hardware is
+        // 1 and software is 2, not the other way round (issue #1155).
+        switch flowControl {
+        case UInt32(LIBDC_FLOWCONTROL_HARDWARE):
             options.c_cflag |= UInt(CRTSCTS)
             options.c_iflag &= ~UInt(IXON | IXOFF)
-        } else if flowControl == 1 {
+        case UInt32(LIBDC_FLOWCONTROL_SOFTWARE):
             options.c_cflag &= ~UInt(CRTSCTS)
             options.c_iflag |= UInt(IXON | IXOFF)
-        } else {
+        default:
+            // LIBDC_FLOWCONTROL_NONE, and anything libdivecomputer might add.
             options.c_cflag &= ~UInt(CRTSCTS)
             options.c_iflag &= ~UInt(IXON | IXOFF)
         }

--- a/packages/libdivecomputer_plugin/linux/serial_io_stream.c
+++ b/packages/libdivecomputer_plugin/linux/serial_io_stream.c
@@ -187,14 +187,16 @@ static int serial_configure(void* userdata, unsigned int baudrate,
     if (stopbits == 2) options.c_cflag |= CSTOPB;
     else options.c_cflag &= ~CSTOPB;
 
-    // Flow control: 0=none, 1=software, 2=hardware
-    if (flowcontrol == 2) {
+    // Flow control. See LIBDC_FLOWCONTROL_* in libdc_wrapper.h: hardware is 1
+    // and software is 2, not the other way round (issue #1155).
+    if (flowcontrol == LIBDC_FLOWCONTROL_HARDWARE) {
         options.c_cflag |= CRTSCTS;
         options.c_iflag &= ~(IXON | IXOFF);
-    } else if (flowcontrol == 1) {
+    } else if (flowcontrol == LIBDC_FLOWCONTROL_SOFTWARE) {
         options.c_cflag &= ~CRTSCTS;
         options.c_iflag |= (IXON | IXOFF);
     } else {
+        // LIBDC_FLOWCONTROL_NONE, and anything libdivecomputer might add.
         options.c_cflag &= ~CRTSCTS;
         options.c_iflag &= ~(IXON | IXOFF);
     }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -110,6 +110,20 @@ typedef int (*libdc_io_configure_fn)(void *userdata, unsigned int baudrate,
 typedef int (*libdc_io_set_dtr_fn)(void *userdata, unsigned int value);
 typedef int (*libdc_io_set_rts_fn)(void *userdata, unsigned int value);
 
+// Flow-control values passed to libdc_io_configure_fn (mirror dc_flowcontrol_t
+// in third_party/libdivecomputer/include/libdivecomputer/iostream.h).
+//
+// The callback signature uses plain unsigned int so a platform backend does not
+// have to include libdivecomputer's headers, which also costs it the enum's
+// names. Backends should compare against these constants rather than against
+// bare 1 and 2: hardware comes first in dc_flowcontrol_t, which reads as the
+// wrong way round to anyone who thinks of XON/XOFF as the simpler case, and
+// every termios and DCB backend here had the two swapped (issue #1155).
+// test_serial_callbacks.c pins these against the real enum.
+#define LIBDC_FLOWCONTROL_NONE     0  // No flow control
+#define LIBDC_FLOWCONTROL_HARDWARE 1  // RTS/CTS
+#define LIBDC_FLOWCONTROL_SOFTWARE 2  // XON/XOFF
+
 typedef struct {
     libdc_io_set_timeout_fn set_timeout;  // may be NULL
     libdc_io_read_fn read;                // required

--- a/packages/libdivecomputer_plugin/test/native/test_serial_callbacks.c
+++ b/packages/libdivecomputer_plugin/test/native/test_serial_callbacks.c
@@ -6,6 +6,8 @@
 #else
 #include <strings.h>
 #endif
+#include <libdivecomputer/iostream.h>
+
 #include "libdc_wrapper.h"
 
 static int dummy_configure(void *userdata, unsigned int baudrate,
@@ -224,6 +226,58 @@ static void test_com_port_detection(void) {
     printf("PASS: test_com_port_detection\n");
 }
 
+// Issue #1155: libdivecomputer orders dc_flowcontrol_t as NONE, HARDWARE,
+// SOFTWARE, so hardware RTS/CTS is 1 and software XON/XOFF is 2. Three of our
+// four serial backends had assumed the opposite and would have enabled the
+// wrong kind of handshaking. Pinning the wrapper's constants against the real
+// enum keeps the backends honest, and catches a future submodule bump that
+// reorders or extends it.
+static void test_flow_control_constants_match_libdivecomputer(void) {
+    assert(LIBDC_FLOWCONTROL_NONE == DC_FLOWCONTROL_NONE);
+    assert(LIBDC_FLOWCONTROL_HARDWARE == DC_FLOWCONTROL_HARDWARE);
+    assert(LIBDC_FLOWCONTROL_SOFTWARE == DC_FLOWCONTROL_SOFTWARE);
+
+    // Spelled out, so a reordered enum fails here rather than silently
+    // redefining what the backends mean by "hardware".
+    assert(LIBDC_FLOWCONTROL_NONE == 0);
+    assert(LIBDC_FLOWCONTROL_HARDWARE == 1);
+    assert(LIBDC_FLOWCONTROL_SOFTWARE == 2);
+
+    printf("PASS: test_flow_control_constants_match_libdivecomputer\n");
+}
+
+// Reproduces the flow-control decision the serial backends make. Each one
+// applies it through its own platform API (termios CRTSCTS and IXON/IXOFF on
+// darwin and Linux, DCB fOutxCtsFlow and fOutX/fInX on Windows), but they all
+// reduce to the same two independent choices, so the mapping is asserted here
+// in platform-neutral terms.
+static void flow_control_flags(unsigned int flowcontrol, int *rts_cts,
+                               int *xon_xoff) {
+    *rts_cts = (flowcontrol == LIBDC_FLOWCONTROL_HARDWARE);
+    *xon_xoff = (flowcontrol == LIBDC_FLOWCONTROL_SOFTWARE);
+}
+
+static void test_flow_control_maps_to_the_right_handshake(void) {
+    int rts_cts = 0, xon_xoff = 0;
+
+    flow_control_flags(LIBDC_FLOWCONTROL_NONE, &rts_cts, &xon_xoff);
+    assert(!rts_cts && !xon_xoff);
+
+    flow_control_flags(LIBDC_FLOWCONTROL_HARDWARE, &rts_cts, &xon_xoff);
+    assert(rts_cts && !xon_xoff);
+
+    flow_control_flags(LIBDC_FLOWCONTROL_SOFTWARE, &rts_cts, &xon_xoff);
+    assert(!rts_cts && xon_xoff);
+
+    // An unknown value must fall back to no flow control rather than picking
+    // one of the two handshakes, which is what the backends' default branch
+    // does.
+    flow_control_flags(99, &rts_cts, &xon_xoff);
+    assert(!rts_cts && !xon_xoff);
+
+    printf("PASS: test_flow_control_maps_to_the_right_handshake\n");
+}
+
 static void test_null_serial_callbacks_are_safe(void) {
     // When serial callbacks are NULL, bridge functions should be safe
     // to skip (the bridge_* functions check for NULL before calling).
@@ -242,6 +296,8 @@ int main(void) {
     test_auto_probe_port_filtering();
     test_windows_hw_id_filtering();
     test_com_port_detection();
+    test_flow_control_constants_match_libdivecomputer();
+    test_flow_control_maps_to_the_right_handshake();
     test_null_serial_callbacks_are_safe();
     printf("\nAll serial callback tests passed.\n");
     return 0;

--- a/packages/libdivecomputer_plugin/test/native/test_serial_callbacks.c
+++ b/packages/libdivecomputer_plugin/test/native/test_serial_callbacks.c
@@ -246,13 +246,22 @@ static void test_flow_control_constants_match_libdivecomputer(void) {
     printf("PASS: test_flow_control_constants_match_libdivecomputer\n");
 }
 
-// Reproduces the flow-control decision the serial backends make. Each one
-// applies it through its own platform API (termios CRTSCTS and IXON/IXOFF on
-// darwin and Linux, DCB fOutxCtsFlow and fOutX/fInX on Windows), but they all
-// reduce to the same two independent choices, so the mapping is asserted here
-// in platform-neutral terms.
-static void flow_control_flags(unsigned int flowcontrol, int *rts_cts,
-                               int *xon_xoff) {
+// Mirrors the flow-control decision the serial backends make, in the
+// platform-neutral terms all of them reduce to: hardware means RTS/CTS,
+// software means XON/XOFF, anything else means neither.
+//
+// Scope, to be clear about what this does and does not cover: it exercises the
+// mirror below, not the backends. Each backend applies the decision through its
+// own platform API in its own language (termios CRTSCTS and IXON/IXOFF on
+// darwin and Linux, DCB fOutxCtsFlow and fOutX/fInX on Windows), so there is no
+// one production mapping a C test could call; an abstraction whose only caller
+// was this test would not be worth the indirection. What keeps the backends
+// correct is that they now name the LIBDC_FLOWCONTROL_* constants instead of
+// bare 1 and 2, together with the pin above that fixes what those names mean.
+// This case records the intended decision in one readable place so a backend
+// can be checked against it by eye.
+static void mirrored_flow_control_flags(unsigned int flowcontrol, int *rts_cts,
+                                        int *xon_xoff) {
     *rts_cts = (flowcontrol == LIBDC_FLOWCONTROL_HARDWARE);
     *xon_xoff = (flowcontrol == LIBDC_FLOWCONTROL_SOFTWARE);
 }
@@ -260,19 +269,19 @@ static void flow_control_flags(unsigned int flowcontrol, int *rts_cts,
 static void test_flow_control_maps_to_the_right_handshake(void) {
     int rts_cts = 0, xon_xoff = 0;
 
-    flow_control_flags(LIBDC_FLOWCONTROL_NONE, &rts_cts, &xon_xoff);
+    mirrored_flow_control_flags(LIBDC_FLOWCONTROL_NONE, &rts_cts, &xon_xoff);
     assert(!rts_cts && !xon_xoff);
 
-    flow_control_flags(LIBDC_FLOWCONTROL_HARDWARE, &rts_cts, &xon_xoff);
+    mirrored_flow_control_flags(LIBDC_FLOWCONTROL_HARDWARE, &rts_cts, &xon_xoff);
     assert(rts_cts && !xon_xoff);
 
-    flow_control_flags(LIBDC_FLOWCONTROL_SOFTWARE, &rts_cts, &xon_xoff);
+    mirrored_flow_control_flags(LIBDC_FLOWCONTROL_SOFTWARE, &rts_cts, &xon_xoff);
     assert(!rts_cts && xon_xoff);
 
     // An unknown value must fall back to no flow control rather than picking
     // one of the two handshakes, which is what the backends' default branch
     // does.
-    flow_control_flags(99, &rts_cts, &xon_xoff);
+    mirrored_flow_control_flags(99, &rts_cts, &xon_xoff);
     assert(!rts_cts && !xon_xoff);
 
     printf("PASS: test_flow_control_maps_to_the_right_handshake\n");

--- a/packages/libdivecomputer_plugin/windows/serial_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/serial_io_stream.cc
@@ -140,11 +140,14 @@ int SerialIoStream::ConfigureCallback(void* userdata, unsigned int baudrate,
     dcb.ByteSize = static_cast<BYTE>(databits);
     dcb.Parity = static_cast<BYTE>(parity);
     dcb.StopBits = static_cast<BYTE>(stopbits);
-    // flowcontrol: 0=none, 1=software, 2=hardware (matches dc_flowcontrol_t)
-    dcb.fOutxCtsFlow = (flowcontrol == 2) ? TRUE : FALSE;
-    dcb.fRtsControl = (flowcontrol == 2) ? RTS_CONTROL_HANDSHAKE : RTS_CONTROL_ENABLE;
-    dcb.fOutX = (flowcontrol == 1) ? TRUE : FALSE;
-    dcb.fInX = (flowcontrol == 1) ? TRUE : FALSE;
+    // Flow control. See LIBDC_FLOWCONTROL_* in libdc_wrapper.h: hardware is 1
+    // and software is 2, not the other way round (issue #1155).
+    const bool hardware = (flowcontrol == LIBDC_FLOWCONTROL_HARDWARE);
+    const bool software = (flowcontrol == LIBDC_FLOWCONTROL_SOFTWARE);
+    dcb.fOutxCtsFlow = hardware ? TRUE : FALSE;
+    dcb.fRtsControl = hardware ? RTS_CONTROL_HANDSHAKE : RTS_CONTROL_ENABLE;
+    dcb.fOutX = software ? TRUE : FALSE;
+    dcb.fInX = software ? TRUE : FALSE;
 
     return SetCommState(stream->handle_, &dcb) ? LIBDC_STATUS_SUCCESS : LIBDC_STATUS_IO;
 }


### PR DESCRIPTION
Fixes #1155.

## The bug

libdivecomputer orders `dc_flowcontrol_t` as `NONE, HARDWARE, SOFTWARE`
(`third_party/libdivecomputer/include/libdivecomputer/iostream.h:61-65`), so
hardware RTS/CTS is `1` and software XON/XOFF is `2`. The serial backends had
the two swapped: a request for hardware flow control would have enabled
software flow control, and the other way round.

Latent today, because grepping `third_party/libdivecomputer/src/` shows only
the serial backends ever name those constants and every driver passes
`DC_FLOWCONTROL_NONE`. It becomes real the moment a driver asks for flow
control, and it is much harder to diagnose then than to fix now.

## What the sweep found

The issue named the darwin and Linux backends. Checking every backend that
acts on the value turned up a third:

| Backend | Before | Status |
| --- | --- | --- |
| `darwin/.../SerialIoStream.swift` | `2 -> CRTSCTS`, `1 -> IXON\|IXOFF` | fixed |
| `linux/serial_io_stream.c:190` | same inversion | fixed |
| `windows/serial_io_stream.cc:143` | same inversion, comment claimed "matches `dc_flowcontrol_t`" | **fixed, not named in the issue** |
| `darwin/.../FtdiProtocol.swift` | already correct (added in #1154) | comment updated |
| `android/.../UsbSerialIoStream.kt` | ignores flow control entirely, documents why | unchanged, correct as-is |

Both bridges that feed these callbacks (`macos/Classes/libdc_download.c:709`
and `android/src/main/cpp/libdc_jni.cpp:382`) pass `dc_flowcontrol_t` straight
through as an `unsigned int`, so the backends do receive the raw enum value.

## The fix

Rather than only flipping the branches, this names the values once in
`macos/Classes/libdc_wrapper.h`, the shared header already on the Linux,
Windows, Android JNI and Swift bridge include paths:

```c
#define LIBDC_FLOWCONTROL_NONE     0  // No flow control
#define LIBDC_FLOWCONTROL_HARDWARE 1  // RTS/CTS
#define LIBDC_FLOWCONTROL_SOFTWARE 2  // XON/XOFF
```

All three backends now compare against those names instead of bare `1` and
`2`, and each fallback branch is commented as covering `NONE` plus anything
libdivecomputer might add later.

The root cause is worth naming: the configure callback is typed as a plain
`unsigned int` on purpose, so no platform backend has to include
libdivecomputer's headers. That decoupling is sound, but it also erases the
enum's names, leaving each backend to re-derive "what is 1?" from memory.
Three did so identically wrong. Re-supplying the names on the near side of
that seam is what stops it recurring.

## Tests

`test/native/test_serial_callbacks.c` already had
`third_party/libdivecomputer/include` on its include path, so unlike the
backends it can `#include <libdivecomputer/iostream.h>` and pin the wrapper's
constants against the real enum:

- `test_flow_control_constants_match_libdivecomputer` asserts each
  `LIBDC_FLOWCONTROL_*` equals its `DC_FLOWCONTROL_*` counterpart, and spells
  out the numeric values so a reordered enum fails loudly instead of silently
  redefining what the backends mean by "hardware".
- `test_flow_control_maps_to_the_right_handshake` asserts the mapping each
  backend performs, in platform-neutral terms (RTS/CTS vs XON/XOFF), including
  that an unrecognised value falls back to no flow control rather than picking
  a handshake.

The pin was verified to have teeth: temporarily defining the constants the old
(wrong) way makes `test_serial_callbacks` abort. That is exactly what a future
submodule bump reordering `dc_flowcontrol_t` would trigger.

## Verification

- `ctest` on `test/native`: 9/9 passed, unchanged from the pre-change baseline.
- Darwin Swift: `swiftc -typecheck` of `SerialIoStream.swift` against the real
  `libdc_wrapper.h` via a bridging header is clean, and a probe binary confirms
  Swift imports the macros as `Int32` with values 0/1/2.
- The Linux and Windows sources cannot be compiled on macOS, but both
  `serial_io_stream.h` files include `libdc_wrapper.h`, and every changed file
  is under `packages/libdivecomputer_plugin/**`, so `native-plugin-tests.yml`
  runs its `build-linux`, `build-windows`, `c-wrapper-tests` and
  `darwin-swift-tests` jobs on this branch.

No Dart files are touched.
