### PR TITLE
fix(media): stop the gallery hanging on Windows and dying on Android

### DIFF
--- a/lib/core/services/cloud_storage/s3/s3_api_client.dart
+++ b/lib/core/services/cloud_storage/s3/s3_api_client.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
 import 'package:xml/xml.dart';
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
@@ -60,6 +61,9 @@ class S3ApiClient {
     Duration retryDelay = const Duration(milliseconds: 500),
     int maxAttempts = defaultMaxAttempts,
     Duration maxRetryDelay = defaultMaxRetryDelay,
+    Duration responseTimeout = defaultResponseTimeout,
+    Duration uploadTimeout = defaultUploadTimeout,
+    Duration idleTimeout = defaultIdleTimeout,
     Random? random,
     this.onRegionCorrected,
   }) : assert(maxAttempts >= 1, 'a request must be attempted at least once'),
@@ -70,12 +74,24 @@ class S3ApiClient {
        ),
        _config = config,
        _region = config.region,
-       _http = httpClient ?? http.Client(),
+       _http = httpClient ?? _defaultClient(),
        _now = now ?? DateTime.now,
        _retryDelay = retryDelay,
        _maxAttempts = maxAttempts,
        _maxRetryDelay = maxRetryDelay,
+       _responseTimeout = responseTimeout,
+       _uploadTimeout = uploadTimeout,
+       _idleTimeout = idleTimeout,
        _random = random ?? Random();
+
+  /// The client used when the caller injects none.
+  ///
+  /// A bare `http.Client()` leaves `HttpClient.connectionTimeout` null, so a
+  /// TCP connect to an unreachable endpoint waits on the OS default -- minutes
+  /// on some Windows configurations. The deadlines in [_send] bound a socket
+  /// that connects and then stalls; this bounds one that never connects.
+  static http.Client _defaultClient() =>
+      IOClient(HttpClient()..connectionTimeout = defaultConnectTimeout);
 
   /// Attempts per request, including the first.
   ///
@@ -97,12 +113,41 @@ class S3ApiClient {
   /// request that is retried to exhaustion.
   static const Duration defaultMaxRetryDelay = Duration(seconds: 16);
 
+  /// How long to wait for the TCP connection itself.
+  static const Duration defaultConnectTimeout = Duration(seconds: 15);
+
+  /// How long to wait for a response's status and headers on a request with
+  /// no body. Covers TLS setup and the server's own think time.
+  static const Duration defaultResponseTimeout = Duration(seconds: 30);
+
+  /// The same deadline for a request that CARRIES a body.
+  ///
+  /// Separate and far more generous, because `Client.send` does not complete
+  /// until the body has been written: for a PUT the "wait for a response"
+  /// window contains the whole upload. A multipart part is 8 MiB, which at
+  /// 110 kbps takes ten minutes, and killing a part that was making progress
+  /// is exactly the failure mode that left large first syncs failing nine
+  /// times in ten (#942). Ten minutes still bounds a socket that has genuinely
+  /// wedged, which is all this needs to do.
+  static const Duration defaultUploadTimeout = Duration(minutes: 10);
+
+  /// How long a response body may go without delivering a single byte.
+  ///
+  /// Deliberately an IDLE gap rather than a total budget: a legitimate 8 MiB
+  /// download over a weak mobile link takes minutes and must not be killed,
+  /// while a connection that has stopped delivering is dead regardless of how
+  /// little it had left to send.
+  static const Duration defaultIdleTimeout = Duration(seconds: 30);
+
   final S3Config _config;
   final http.Client _http;
   final DateTime Function() _now;
   final Duration _retryDelay;
   final int _maxAttempts;
   final Duration _maxRetryDelay;
+  final Duration _responseTimeout;
+  final Duration _uploadTimeout;
+  final Duration _idleTimeout;
   final Random _random;
 
   /// Called after a server region hint led to a successful replay, so the
@@ -671,7 +716,29 @@ class S3ApiClient {
     // SigV4 signature, so S3 accepts these alongside it.
     request.headers.addAll(extraHeaders);
     if (body != null) request.bodyBytes = body;
-    return http.Response.fromStream(await _http.send(request));
+
+    // Two deadlines rather than one. Without them a stalled socket parks the
+    // request forever, and since nothing caps concurrency on the media store's
+    // read path, a gallery opens one such request per visible tile (#1175).
+    // _sendWithRetry already classifies TimeoutException as a retryable
+    // transport fault, so both surface as an ordinary retry and then, at
+    // budget exhaustion, as a CloudStorageException.
+    final hasBody = body != null && body.isNotEmpty;
+    final streamed = await _http
+        .send(request)
+        .timeout(hasBody ? _uploadTimeout : _responseTimeout);
+    final bytes = await http.ByteStream(
+      streamed.stream.timeout(_idleTimeout),
+    ).toBytes();
+    return http.Response.bytes(
+      bytes,
+      streamed.statusCode,
+      request: streamed.request,
+      headers: streamed.headers,
+      isRedirect: streamed.isRedirect,
+      persistentConnection: streamed.persistentConnection,
+      reasonPhrase: streamed.reasonPhrase,
+    );
   }
 
   Never _throwFor(String operation, String key, http.Response response) {

--- a/lib/core/services/media_store/s3_media_object_store.dart
+++ b/lib/core/services/media_store/s3_media_object_store.dart
@@ -315,6 +315,25 @@ class S3MediaObjectStore implements MediaObjectStore {
             start: received,
             endInclusive: end,
           );
+          // A chunk that delivers nothing leaves `received` where it was, so
+          // the loop would re-issue the identical request forever -- a silent
+          // spin that downloads no bytes and never terminates (#1175). It
+          // means the object is shorter than the HEAD claimed, or something
+          // between here and the bucket is dropping the Range. Either way it
+          // is a failed transfer, and the queue's retry is the right place to
+          // deal with it.
+          if (range.bytes.isEmpty) {
+            // Thrown directly rather than through _map, which classifies by
+            // message text and would land this in `fatal`. Transient is the
+            // honest reading: an empty range says something on the path
+            // between here and the bucket answered badly, not that the object
+            // is permanently unusable, and the queue's backoff is the right
+            // response. The retry restarts getFile from byte zero.
+            throw MediaStoreException(
+              'empty range for $key at byte $received of $total',
+              kind: MediaStoreErrorKind.transient,
+            );
+          }
           await raf.writeFrom(range.bytes);
           received += range.bytes.length;
           onProgress?.call(received, total);

--- a/lib/features/media/data/repositories/media_library_repository.dart
+++ b/lib/features/media/data/repositories/media_library_repository.dart
@@ -3,6 +3,8 @@ import 'package:drift/drift.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/utils/stream_debounce.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/data/repositories/media_row_mapper.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/domain/entities/media_library_filter.dart';
@@ -219,9 +221,22 @@ class MediaLibraryRepository {
   /// Emits whenever the media table changes. Deliberately coarse: consumers
   /// reload page one rather than patching rows (per the Media section spec's
   /// invalidation-storm avoidance).
-  Stream<void> watchMediaChanges() {
-    final m = _db.media;
-    final count = countAll();
-    return (_db.selectOnly(m)..addColumns([count])).watchSingle().map((_) {});
-  }
+  ///
+  /// Built on `tableUpdates`, exactly like [MediaRepository.watchMediaChanges],
+  /// and NOT on a watched COUNT query. A Drift query stream delivers its
+  /// current value the moment it is listened to, and every consumer here feeds
+  /// this stream to `ref.invalidateSelfWhen`. That combination is a live loop:
+  /// build subscribes, the subscription immediately ticks, the tick invalidates
+  /// the provider that just subscribed, the rebuild subscribes again. It ran
+  /// one COUNT(*) over `media` per event-loop turn for as long as the Media
+  /// section stayed open, which is enough to starve the UI isolate on a large
+  /// library (#1175). `tableUpdates` only fires on a real write.
+  ///
+  /// Debounced on the same window as [MediaRepository.changeTickDebounce] so a
+  /// sync's per-changeset commits -- or the media store worker stamping
+  /// `remote_uploaded_at` row by row as it drains -- collapse into one reload
+  /// instead of one per write.
+  Stream<void> watchMediaChanges() => _db
+      .tableUpdates(TableUpdateQuery.onTable(_db.media))
+      .debounce(MediaRepository.changeTickDebounce);
 }

--- a/lib/features/media/data/resolvers/media_fetch_gate.dart
+++ b/lib/features/media/data/resolvers/media_fetch_gate.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// Caps simultaneous media-store fetches and collapses duplicate ones.
+///
+/// Nothing gated the store read path before #1175. Every visible grid tile
+/// resolves independently -- `MediaItemView` kicks its own future from
+/// `initState` -- so a screenful of store-backed thumbnails opened one HEAD
+/// plus one GET per tile, all at once. A 140 px grid puts 30-60 tiles on
+/// screen on desktop, each request is retried up to six times with backoff,
+/// and none of them shared work with any other. Against a slow endpoint that
+/// is a gallery of permanent shimmer; against a healthy one it is still a
+/// burst most S3-compatible servers throttle.
+///
+/// Two independent problems, one object:
+///
+/// * **Concurrency.** [maxConcurrent] fetches run at a time; the rest queue.
+///   Matching `GalleryThumbnailCache`'s cap, which solved the same shape of
+///   problem for PhotoKit.
+/// * **Coalescing.** Two callers asking for the same key share one fetch.
+///   That is not a micro-optimisation here: media rows are content-addressed,
+///   so the same photo linked to two dives is two rows with one hash, and
+///   without this each issues its own download of identical bytes and both
+///   race to write the same cache entry.
+///
+/// Deliberately NOT a byte cache. The bytes already have one -- `MediaCacheStore`,
+/// on disk -- and holding them in memory as well is what the viewer's own
+/// providers were doing wrong.
+class MediaFetchGate {
+  MediaFetchGate({this.maxConcurrent = 4}) : assert(maxConcurrent > 0);
+
+  /// Ceiling on simultaneous fetches.
+  final int maxConcurrent;
+
+  /// Fetches currently running, so concurrent callers can share one.
+  final Map<String, Future<MediaSourceData?>> _inFlight =
+      <String, Future<MediaSourceData?>>{};
+
+  /// Callers parked waiting for a slot.
+  final Queue<Completer<void>> _waiting = Queue<Completer<void>>();
+
+  int _running = 0;
+
+  /// In-flight fetch count, for tests.
+  int get runningCount => _running;
+
+  /// Callers currently parked, for tests.
+  int get waitingCount => _waiting.length;
+
+  /// Runs [fetch] under the cap, sharing the result with any caller that asks
+  /// for the same [key] while it is still running.
+  Future<MediaSourceData?> run(
+    String key,
+    Future<MediaSourceData?> Function() fetch,
+  ) {
+    final pending = _inFlight[key];
+    if (pending != null) return pending;
+
+    // _run suspends at its first await before returning, so the assignment
+    // below always lands before the finally block that clears it.
+    final future = _run(key, fetch);
+    _inFlight[key] = future;
+    return future;
+  }
+
+  Future<MediaSourceData?> _run(
+    String key,
+    Future<MediaSourceData?> Function() fetch,
+  ) async {
+    await _acquire();
+    try {
+      return await fetch();
+    } finally {
+      _inFlight.remove(key);
+      _release();
+    }
+  }
+
+  Future<void> _acquire() {
+    if (_running < maxConcurrent) {
+      _running++;
+      return Future<void>.value();
+    }
+    final waiter = Completer<void>();
+    _waiting.add(waiter);
+    return waiter.future;
+  }
+
+  /// FIFO, unlike `GalleryThumbnailCache`'s LIFO.
+  ///
+  /// That class serves newest-first on the argument that older waiters belong
+  /// to tiles already scrolled away. It does not hold here: [run] hands a
+  /// parked future to any later caller asking for the same key, so a waiter
+  /// can have live tiles behind it, and newest-first would leave them shimmering
+  /// for the whole of a long fling. Fairness is worth more than recency when a
+  /// slot is 30-60 tiles deep.
+  void _release() {
+    if (_waiting.isEmpty) {
+      _running--;
+      return;
+    }
+    // The slot passes straight to the next waiter: _running stays put because
+    // one fetch ends exactly as another begins.
+    _waiting.removeFirst().complete();
+  }
+}

--- a/lib/features/media/data/resolvers/media_store_resolver.dart
+++ b/lib/features/media/data/resolvers/media_store_resolver.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/resolvers/media_fetch_gate.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
@@ -15,11 +16,19 @@ class MediaStoreResolver {
   MediaStoreResolver({
     required MediaObjectStore store,
     required MediaCacheStore cache,
+    MediaFetchGate? gate,
   }) : _store = store,
-       _cache = cache;
+       _cache = cache,
+       _gate = gate ?? MediaFetchGate();
 
   final MediaObjectStore _store;
   final MediaCacheStore _cache;
+
+  /// Caps and coalesces the fetches below. One per resolver, and the resolver
+  /// is built once per store runtime, so every display surface sharing that
+  /// runtime shares the budget -- which is the point: the grid, an open
+  /// viewer and the dive-detail strip are all pulling from the same endpoint.
+  final MediaFetchGate _gate;
   final _log = LoggerService.forClass(MediaStoreResolver);
 
   /// Returns FileData when the bytes are cached or fetched (originals are
@@ -59,7 +68,10 @@ class MediaStoreResolver {
     return null;
   }
 
-  Future<MediaSourceData?> _fetchThumb(MediaItem item, String hash) async {
+  Future<MediaSourceData?> _fetchThumb(MediaItem item, String hash) =>
+      _gate.run('$hash#thumb', () => _fetchThumbInner(item, hash));
+
+  Future<MediaSourceData?> _fetchThumbInner(MediaItem item, String hash) async {
     // The pipeline always uploads thumbs as JPEG, whatever the source's own
     // format. For a video that JPEG is a poster frame and for a document it
     // is a page-1 render, so the result is decodable as an image even though
@@ -107,7 +119,19 @@ class MediaStoreResolver {
   /// Fetches the compressed rendition (spec section 11). Derived bytes, so no
   /// hash verification; validated against remoteCompressedUploadedAt so a
   /// re-uploaded (overwritten) rendition invalidates a stale cache entry.
-  Future<MediaSourceData?> _fetchCompressed(MediaItem item, String hash) async {
+  Future<MediaSourceData?> _fetchCompressed(MediaItem item, String hash) =>
+      // The rendition's freshness is checked against the row's own stamp, so
+      // two rows sharing a hash but not a stamp must not share a fetch.
+      _gate.run(
+        '$hash#rendition'
+        '#${item.remoteCompressedUploadedAt?.millisecondsSinceEpoch ?? 0}',
+        () => _fetchCompressedInner(item, hash),
+      );
+
+  Future<MediaSourceData?> _fetchCompressedInner(
+    MediaItem item,
+    String hash,
+  ) async {
     final ext = item.mediaType == MediaType.video ? 'mp4' : 'jpg';
     File? staging;
     try {
@@ -145,7 +169,13 @@ class MediaStoreResolver {
     }
   }
 
-  Future<MediaSourceData?> _fetchOriginal(MediaItem item, String hash) async {
+  Future<MediaSourceData?> _fetchOriginal(MediaItem item, String hash) =>
+      _gate.run('$hash#original', () => _fetchOriginalInner(item, hash));
+
+  Future<MediaSourceData?> _fetchOriginalInner(
+    MediaItem item,
+    String hash,
+  ) async {
     File? staging;
     try {
       final cached = await _cache.get(hash, MediaCacheKind.original);

--- a/lib/features/media/presentation/providers/media_byte_retention.dart
+++ b/lib/features/media/presentation/providers/media_byte_retention.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// How long a byte-carrying media provider is held exempt from auto-disposal,
+/// measured from when it builds. See [retainFor] for the exact semantics.
+///
+/// Riverpod 3 flipped a default that matters a great deal here: `FutureProvider`
+/// takes `isAutoDispose = false` (riverpod 3.4.2,
+/// `providers/future_provider.dart:107`), so a `.family` returning a
+/// `Uint8List` retains one full-resolution image buffer PER KEY for the whole
+/// process lifetime. Every photo the user opened stayed on the heap until the
+/// app died, which on Android means it gets killed first (#1175).
+///
+/// The answer is not "cache nothing": the providers were made caching on
+/// purpose, so that a swipe back to the previous photo does not re-read it
+/// from the photo library. A window keeps that and drops the permanence.
+/// [fullResolutionRetention] is short because the objects are megabytes each;
+/// [thumbnailRetention] is longer because they are tens of kilobytes and
+/// re-fetching one costs a PhotoKit round-trip.
+const Duration fullResolutionRetention = Duration(seconds: 30);
+
+/// See [fullResolutionRetention].
+const Duration thumbnailRetention = Duration(minutes: 5);
+
+/// Exempts this provider from auto-disposal for [window], measured from
+/// BUILD, then lets normal auto-disposal resume.
+///
+/// The timer starts when the provider builds, not when its last watcher
+/// leaves -- `KeepAliveLink` has no notion of the latter. So the value
+/// survives an unwatched gap only within [window] of being computed, and a
+/// provider still watched when the timer fires disposes as soon as its last
+/// watcher goes. That is the behaviour wanted here: a bounded lifetime for a
+/// megabyte-scale buffer, not an idle timer that a busy surface could keep
+/// resetting.
+///
+/// Only meaningful on a provider declared `isAutoDispose: true`; on a
+/// keep-forever provider the link has nothing to release. Mirrors the
+/// `_keepAliveWithExpiry` idiom in `statistics_providers.dart`.
+void retainFor(Ref ref, Duration window) {
+  final link = ref.keepAlive();
+  final timer = Timer(window, link.close);
+  ref.onDispose(timer.cancel);
+}

--- a/lib/features/media/presentation/providers/media_bytes_providers.dart
+++ b/lib/features/media/presentation/providers/media_bytes_providers.dart
@@ -7,6 +7,7 @@ import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_byte_retention.dart';
 import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
 import 'package:submersion/features/media/presentation/providers/media_serving_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
@@ -33,6 +34,10 @@ const _log = LoggerService('mediaBytesProvider');
 /// purpose, indistinguishable from an absent one.
 final mediaBytesProvider =
     FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      // A full-resolution buffer per item. Riverpod 3 keeps a family entry
+      // forever unless told otherwise, so before #1175 every document and
+      // photo opened stayed on the heap for the process lifetime.
+      retainFor(ref, fullResolutionRetention);
       // Always thumbnail: false. This provider resolves full-resolution
       // bytes only; grid thumbnails go through MediaItemView.
       final recorder = ref.read(mediaServingRecorderProvider);
@@ -88,7 +93,7 @@ final mediaBytesProvider =
         storeFallbackUsed: true,
       );
       return const ResolvedAssetResult(status: ResolutionStatus.unavailable);
-    });
+    }, isAutoDispose: true);
 
 /// Resolves [item] through its registered source resolver.
 ///

--- a/lib/features/media/presentation/providers/media_provenance_providers.dart
+++ b/lib/features/media/presentation/providers/media_provenance_providers.dart
@@ -16,6 +16,15 @@ import 'package:submersion/features/media_store/presentation/providers/media_sto
 /// from `watchLatestForMedia` rather than from the watch, and both must sit
 /// inside the guard. Widget tests routinely run without that database, and a
 /// media item's provenance is not worth failing a tree over.
+///
+/// AUTO-DISPOSING, unlike Riverpod 3's default for StreamProvider. Every
+/// rendered grid tile opens one entry here, and each entry holds a live Drift
+/// watch on `media_transfer_queue`. Kept forever, a scrolled library
+/// accumulated one permanent subscription per row it had ever shown -- and
+/// Drift re-runs every registered watch query on every write to that table, so
+/// an upload drain cost O(rows ever rendered) queries per row it stamped
+/// (#1175). Disposing when the tile scrolls away bounds that to what is
+/// on screen.
 // no-tick: already reactive on a real change stream (watchLatestForMedia).
 final mediaQueueFactsProvider = StreamProvider.family<QueueFacts?, String>((
   ref,
@@ -33,7 +42,7 @@ final mediaQueueFactsProvider = StreamProvider.family<QueueFacts?, String>((
   } on StateError {
     return Stream.value(null);
   }
-});
+}, isAutoDispose: true);
 
 /// Origin and backup facts for one media item.
 ///
@@ -50,6 +59,10 @@ final mediaQueueFactsProvider = StreamProvider.family<QueueFacts?, String>((
 /// synchronously. "Not yet known" reads the same as "not attached", which is
 /// the conservative direction: it under-claims backup coverage rather than
 /// over-claiming it.
+///
+/// Auto-disposing for the same reason as [mediaQueueFactsProvider], which it
+/// keeps alive by watching. The family key is a whole [MediaItem] -- Equatable
+/// over ~40 props -- so a retained entry is not free either.
 final mediaProvenanceProvider = Provider.family<MediaProvenance, MediaItem>((
   ref,
   item,
@@ -57,7 +70,7 @@ final mediaProvenanceProvider = Provider.family<MediaProvenance, MediaItem>((
   final attached = ref.watch(mediaStoreAttachedProvider).value ?? false;
   final queue = ref.watch(mediaQueueFactsProvider(item.id)).value;
   return MediaProvenance.from(item, storeAttached: attached, queue: queue);
-});
+}, isAutoDispose: true);
 
 /// Checks one item's source and persists the outcome.
 ///

--- a/lib/features/media/presentation/providers/photo_picker_providers.dart
+++ b/lib/features/media/presentation/providers/photo_picker_providers.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/media/data/services/media_import_service.dar
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service_desktop.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service_mobile.dart';
+import 'package:submersion/features/media/presentation/providers/media_byte_retention.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_enqueue_provider.dart';
 
 /// Provider for the platform-appropriate PhotoPickerService.
@@ -60,25 +61,35 @@ final photoPermissionProvider = FutureProvider<PhotoPermissionStatus>((
 });
 
 /// Provider for getting a thumbnail for a specific asset.
+///
+/// Auto-disposing with a retention window. Riverpod 3 keeps a family entry
+/// forever by default, so scrolling a large picker used to leave one thumbnail
+/// buffer per asset on the heap for the process lifetime (#1175).
 final assetThumbnailProvider = FutureProvider.family<Uint8List?, String>((
   ref,
   assetId,
 ) async {
+  retainFor(ref, thumbnailRetention);
   final service = ref.watch(photoPickerServiceProvider);
   return service.getThumbnail(assetId);
-});
+}, isAutoDispose: true);
 
 /// Provider for getting full-resolution image bytes for a specific asset.
 ///
 /// Use this for displaying photos in the full-screen viewer.
-/// Results are cached by Riverpod to avoid repeated fetches during swipe navigation.
+///
+/// Cached to avoid repeated fetches during swipe navigation, but only for
+/// [fullResolutionRetention] after the last watcher leaves. These are
+/// megabyte-scale buffers and the cache used to be permanent, so a long
+/// browsing session accumulated every photo it had shown (#1175).
 final assetFullResolutionProvider = FutureProvider.family<Uint8List?, String>((
   ref,
   assetId,
 ) async {
+  retainFor(ref, fullResolutionRetention);
   final service = ref.watch(photoPickerServiceProvider);
   return service.getFileBytes(assetId);
-});
+}, isAutoDispose: true);
 
 /// Provider for getting a video file path for playback.
 ///

--- a/lib/features/media/presentation/providers/resolved_asset_providers.dart
+++ b/lib/features/media/presentation/providers/resolved_asset_providers.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/media/data/repositories/local_asset_cache_re
 import 'package:submersion/features/media/data/services/asset_resolution_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_byte_retention.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 
@@ -44,6 +45,10 @@ class ResolvedAssetResult {
 // tick would re-run resolution every time the eviction itself wrote a row.
 final resolvedThumbnailProvider =
     FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      // Auto-disposing with a window rather than caching forever: this family
+      // holds decoded thumbnail bytes per item, and before #1175 every item
+      // ever displayed kept its buffer for the process lifetime.
+      retainFor(ref, thumbnailRetention);
       final service = ref.watch(assetResolutionServiceProvider);
       final resolution = await service.resolveAssetId(item);
 
@@ -65,7 +70,7 @@ final resolvedThumbnailProvider =
         bytes: bytes,
         status: ResolutionStatus.resolved,
       );
-    });
+    }, isAutoDispose: true);
 
 /// Resolved full-resolution provider for photo viewer.
 ///
@@ -74,6 +79,9 @@ final resolvedThumbnailProvider =
 // clearEntry cache eviction, not a read.
 final resolvedFullResolutionProvider =
     FutureProvider.family<ResolvedAssetResult, MediaItem>((ref, item) async {
+      // A FULL-RESOLUTION buffer per item, which is megabytes each. Kept only
+      // long enough to serve a swipe back to the photo just left (#1175).
+      retainFor(ref, fullResolutionRetention);
       final service = ref.watch(assetResolutionServiceProvider);
       final resolution = await service.resolveAssetId(item);
 
@@ -94,7 +102,7 @@ final resolvedFullResolutionProvider =
         bytes: bytes,
         status: ResolutionStatus.resolved,
       );
-    });
+    }, isAutoDispose: true);
 
 /// Resolved file path provider for video playback.
 ///

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -16,6 +16,16 @@ import 'package:submersion/features/media_store/presentation/providers/media_sto
 /// cheaper than the original.
 const Size kDefaultThumbnailTarget = Size(200, 200);
 
+/// How far past the viewport a full-screen image is decoded, so pinch-zoom
+/// still has pixels to show.
+///
+/// The viewers run `PhotoViewGallery` at `maxScale: covered * 3.0`, so a bound
+/// of exactly one viewport would go soft the moment the user zooms. Two keeps
+/// detail through the range people actually use while still cutting a 24 MP
+/// original (~96 MB of RGBA) to roughly a tenth of that on a phone. Raising it
+/// buys sharpness at 3x zoom for a quadratic cost in bytes.
+const double _viewerZoomHeadroom = 2.0;
+
 /// Universal display widget for any [MediaItem] regardless of its source
 /// type.
 ///
@@ -345,10 +355,23 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         // those decodes would otherwise stay resident for the whole visit.
         // Width only: passing both dimensions decodes to exact bounds and
         // distorts the aspect ratio.
+        //
+        // With no targetSize this used to pass null, which is the FULL-SCREEN
+        // viewer's case: media_viewer_page and site_media_viewer_page both
+        // build `MediaItemView(item: item, fit: BoxFit.contain)`. So the one
+        // surface that draws whole originals was the one with no decode bound
+        // at all -- a 24 MP JPEG at ~96 MB of RGBA, two of them alive while a
+        // PageView swipe is in flight, and neither evictable because
+        // ImageCache's budget only governs images with no listener. That is
+        // the Android OOM in #1175. Falling back to the viewport keeps the
+        // decode proportional to what can actually be displayed.
+        final dpr = MediaQuery.devicePixelRatioOf(context);
         final target = widget.targetSize;
-        final cacheWidth = target == null
-            ? null
-            : (target.longestSide * MediaQuery.devicePixelRatioOf(context))
+        final cacheWidth = target != null
+            ? (target.longestSide * dpr).round()
+            : (MediaQuery.sizeOf(context).longestSide *
+                      dpr *
+                      _viewerZoomHeadroom)
                   .round();
         return switch (data) {
           FileData() when widget.item.isDocument && !documentRenderable =>

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -365,8 +365,17 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
         // ImageCache's budget only governs images with no listener. That is
         // the Android OOM in #1175. Falling back to the viewport keeps the
         // decode proportional to what can actually be displayed.
+        //
+        // The effective target is computed exactly as [_resolveInner] computes
+        // it, and must stay that way. A sizeless `thumbnail: true` resolves
+        // against kDefaultThumbnailTarget, so decoding it at the full-screen
+        // bound would hand a 128 px tile the viewer's budget -- reintroducing,
+        // in the decode, the same "the flag does nothing unless you also pass
+        // a Size" defect this widget was fixed for once already.
         final dpr = MediaQuery.devicePixelRatioOf(context);
-        final target = widget.targetSize;
+        final target =
+            widget.targetSize ??
+            (widget.thumbnail ? kDefaultThumbnailTarget : null);
         final cacheWidth = target != null
             ? (target.longestSide * dpr).round()
             : (MediaQuery.sizeOf(context).longestSide *

--- a/lib/features/media_store/data/image_compressor.dart
+++ b/lib/features/media_store/data/image_compressor.dart
@@ -1,14 +1,12 @@
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' show Size;
-
-import 'package:image/image.dart' as img;
 
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media_store/data/image_resize_job.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
 import 'package:submersion/features/media_store/data/media_compressor.dart';
 import 'package:submersion/features/media_store/data/quality_presets.dart';
@@ -63,33 +61,54 @@ class ImageCompressor implements MediaCompressor {
         if (data is BytesData) return await _writeJpeg(data.bytes);
         return null;
       }
-      final bytes = await source.readAsBytes();
-      return await _encode(bytes, item.originalFilename, preset);
+      return await _encode(source, item.originalFilename, preset);
     } on Exception catch (e) {
       _log.warning('Image compression failed for ${item.id}: $e');
       return null;
     }
   }
 
+  /// Re-encode [source] down to the preset's ceiling, on a background isolate.
+  ///
+  /// The decode / resize / encode pass is pure-Dart package:image work, so
+  /// inline it ran on the caller's isolate -- the media store worker's, which
+  /// is the UI isolate. A single large frame is seconds of frozen app, and the
+  /// worker loops over its whole queue (#1175). Passing the PATH rather than
+  /// the bytes also keeps the original off this isolate's heap entirely.
+  ///
+  /// Both null returns are "upload the untouched original": one because
+  /// package:image cannot read the source (HEIC on desktop), one because it is
+  /// already within the ceiling and a re-encode would only lose quality.
   Future<CompressionResult?> _encode(
-    Uint8List bytes,
+    File source,
     String? name,
     PhotoQualityPreset preset,
   ) async {
-    final decoded = name != null && name.contains('.')
-        ? img.decodeNamedImage(name, bytes)
-        : img.decodeImage(bytes);
-    if (decoded == null) return null; // undecodable (e.g. HEIC on desktop)
-    final longest = decoded.width > decoded.height
-        ? decoded.width
-        : decoded.height;
-    if (longest <= preset.maxDimension) return null; // ceiling: upload original
-    final resized = img.copyResize(
-      decoded,
-      width: decoded.width >= decoded.height ? preset.maxDimension : null,
-      height: decoded.height > decoded.width ? preset.maxDimension : null,
+    final staged = await _cache.stagingFile();
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: staged.path,
+        declaredName: name,
+        maxDimension: preset.maxDimension,
+        jpegQuality: preset.jpegQuality,
+        skipWhenUnderCeiling: true,
+      ),
     );
-    return _writeJpeg(img.encodeJpg(resized, quality: preset.jpegQuality));
+    if (result.outcome != ImageResizeOutcome.written) {
+      // The job turns a decoder throw into an outcome, so this log is the only
+      // record left of a source package:image cannot read.
+      final error = result.error;
+      if (error != null) {
+        _log.warning('Compression source not decodable: $error');
+      }
+      return null;
+    }
+    return CompressionResult(
+      file: staged,
+      ext: 'jpg',
+      sizeBytes: result.sizeBytes,
+    );
   }
 
   Future<CompressionResult> _writeJpeg(List<int> jpeg) async {

--- a/lib/features/media_store/data/image_resize_job.dart
+++ b/lib/features/media_store/data/image_resize_job.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+/// Decode / resize / re-encode, on a background isolate.
+///
+/// [ThumbnailGenerator] and [ImageCompressor] both used to run
+/// `img.decodeImage` + `img.copyResize` + `img.encodeJpg` inline. Those are
+/// pure Dart, so they ran on whichever isolate called them -- and every caller
+/// is the media store's upload worker, which lives on the UI isolate. A single
+/// 24 MP frame is seconds of uninterrupted CPU there, and the worker drains
+/// its queue in a loop, so a backlog froze the app for as long as it took to
+/// clear. That is the Windows hang in #1175: a store-backed grid tile
+/// constructs the store runtime, the runtime kicks `worker.drain()`, and the
+/// drain starts decoding.
+///
+/// Desktop is the worst case and the platform the bug was reported on: a
+/// gallery photo arrives from photo_manager already sized and JPEG-encoded, so
+/// mobile often skips the decode entirely, while a local-file original never
+/// does.
+///
+/// Following the codebase's existing convention (`ExifExtractor`,
+/// `PhotoPickerServiceDesktop`), the hop is `compute` with a single sendable
+/// argument. Prefer [ImageResizeRequest.fromFile]: reading the source inside
+/// the isolate keeps multi-megabyte originals off the message channel
+/// altogether. The result is written straight to [destinationPath] for the
+/// same reason -- only a small record comes back.
+@immutable
+class ImageResizeRequest {
+  /// Reads the source inside the isolate. Preferred: no bytes cross the
+  /// message channel.
+  const ImageResizeRequest.fromFile({
+    required this.sourcePath,
+    required this.destinationPath,
+    required this.maxDimension,
+    required this.jpegQuality,
+    this.declaredName,
+    this.skipWhenUnderCeiling = false,
+  }) : sourceBytes = null;
+
+  /// For callers that already hold the bytes and have no file to point at
+  /// (a resolver that returned `BytesData`). The bytes are copied to the
+  /// isolate, which is still far cheaper than decoding them here.
+  const ImageResizeRequest.fromBytes({
+    required Uint8List bytes,
+    required this.destinationPath,
+    required this.maxDimension,
+    required this.jpegQuality,
+    this.declaredName,
+    this.skipWhenUnderCeiling = false,
+  }) : sourcePath = null,
+       sourceBytes = bytes;
+
+  final String? sourcePath;
+  final Uint8List? sourceBytes;
+
+  /// Where the JPEG lands. Written only on [ImageResizeOutcome.written], so a
+  /// caller that staged a path can leave it untouched otherwise.
+  final String destinationPath;
+
+  /// Longest edge of the output, in pixels.
+  final int maxDimension;
+
+  final int jpegQuality;
+
+  /// Filename whose extension picks the decoder. Decoding by declared
+  /// extension matters: package:image's generic probe tries every format and
+  /// the permissive ones (TGA) accept arbitrary bytes.
+  final String? declaredName;
+
+  /// When true, a source already within [maxDimension] reports
+  /// [ImageResizeOutcome.underCeiling] instead of being re-encoded, so the
+  /// caller can upload the untouched original rather than a lossy round-trip.
+  /// Thumbnails want the opposite: a small source is still copied out, because
+  /// the point is to strip EXIF, not to shrink.
+  final bool skipWhenUnderCeiling;
+}
+
+/// What [resizeToJpegFile] did.
+enum ImageResizeOutcome {
+  /// A JPEG was written to `destinationPath`.
+  written,
+
+  /// package:image could not decode the source (HEIC on desktop, a video, a
+  /// truncated file).
+  undecodable,
+
+  /// The source was already within `maxDimension` and
+  /// `skipWhenUnderCeiling` was set. Nothing was written.
+  underCeiling,
+}
+
+@immutable
+class ImageResizeResult {
+  const ImageResizeResult(this.outcome, {this.sizeBytes = 0, this.error});
+
+  final ImageResizeOutcome outcome;
+
+  /// Length of the written JPEG; 0 for the other outcomes.
+  final int sizeBytes;
+
+  /// Why the source could not be decoded, when the decoder said so out loud.
+  ///
+  /// Carried back as a STRING rather than by letting the exception escape the
+  /// isolate. package:image throws for a malformed source of a known
+  /// extension (`decodeNamedImage` on a truncated JPEG raises "Start Of Image
+  /// marker not found") and returns null for one it merely does not
+  /// recognise; both are the same fact to a caller, so the job normalises
+  /// them into [ImageResizeOutcome.undecodable] and keeps the detail here for
+  /// the log.
+  final String? error;
+}
+
+/// Runs [request] on a background isolate.
+Future<ImageResizeResult> resizeToJpegFile(ImageResizeRequest request) =>
+    compute(runImageResizeRequest, request);
+
+/// The isolate body. Top-level and public so a test can exercise the work
+/// itself without paying for an isolate spawn per case.
+@visibleForTesting
+ImageResizeResult runImageResizeRequest(ImageResizeRequest request) {
+  final path = request.sourcePath;
+  final bytes = path != null
+      ? File(path).readAsBytesSync()
+      : request.sourceBytes!;
+
+  final name = request.declaredName;
+  final img.Image? decoded;
+  try {
+    decoded = name != null && name.contains('.')
+        ? img.decodeNamedImage(name, bytes)
+        : img.decodeImage(bytes);
+  } on Exception catch (e) {
+    // A malformed source of a known extension throws instead of returning
+    // null. Left to escape, it would cross the isolate boundary and reach the
+    // caller as a bare exception, losing the outcome the caller switches on.
+    return ImageResizeResult(
+      ImageResizeOutcome.undecodable,
+      error: e.toString(),
+    );
+  }
+  if (decoded == null) {
+    return const ImageResizeResult(ImageResizeOutcome.undecodable);
+  }
+
+  final longest = decoded.width > decoded.height
+      ? decoded.width
+      : decoded.height;
+  if (request.skipWhenUnderCeiling && longest <= request.maxDimension) {
+    return const ImageResizeResult(ImageResizeOutcome.underCeiling);
+  }
+
+  // Width only: passing both dimensions resizes to exact bounds and distorts
+  // the aspect ratio.
+  final resized = longest > request.maxDimension
+      ? img.copyResize(
+          decoded,
+          width: decoded.width >= decoded.height ? request.maxDimension : null,
+          height: decoded.height > decoded.width ? request.maxDimension : null,
+        )
+      : decoded;
+
+  final jpeg = img.encodeJpg(resized, quality: request.jpegQuality);
+  File(request.destinationPath).writeAsBytesSync(jpeg, flush: true);
+  return ImageResizeResult(ImageResizeOutcome.written, sizeBytes: jpeg.length);
+}

--- a/lib/features/media_store/data/thumbnail_generator.dart
+++ b/lib/features/media_store/data/thumbnail_generator.dart
@@ -2,14 +2,13 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' show Size;
 
-import 'package:image/image.dart' as img;
-
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
 import 'package:submersion/features/media/data/services/pdf_page_renderer.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media_store/data/image_resize_job.dart';
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
 
 /// Best-effort thumbnail production for the upload pipeline (design spec
@@ -71,10 +70,10 @@ class ThumbnailGenerator {
           // EXIF/GPS never masquerade as a thumb.
           return await _resizeToJpeg(b, item.originalFilename);
         case FileData(file: final f):
-          return await _resizeToJpeg(
-            await f.readAsBytes(),
-            item.originalFilename,
-          );
+          // Pass the PATH, not the bytes: the isolate reads the file itself,
+          // so a 40 MB original never crosses the message channel and is
+          // never resident on the UI isolate at all.
+          return await _resizeFileToJpeg(f, item.originalFilename);
         case NetworkData():
         case UnavailableData():
           return null;
@@ -98,28 +97,54 @@ class ThumbnailGenerator {
     return staged;
   }
 
+  /// Decode, resize and re-encode [bytes] as a thumbnail JPEG.
+  ///
+  /// Hands the whole codec pass to a background isolate. It is pure-Dart
+  /// package:image work, so inline it ran on the caller's isolate -- and the
+  /// caller is the upload worker on the UI isolate, where one 24 MP frame is
+  /// seconds of frozen app (#1175). Decoding by declared extension is
+  /// preserved inside the job: the generic decoder probes every format and
+  /// permissive ones (TGA) accept arbitrary bytes.
   Future<File?> _resizeToJpeg(Uint8List bytes, String? name) async {
-    // Decode by declared extension when known: the generic decoder probes
-    // every format and permissive ones (TGA) accept arbitrary bytes.
-    final decoded = name != null && name.contains('.')
-        ? img.decodeNamedImage(name, bytes)
-        : img.decodeImage(bytes);
-    if (decoded == null) return null;
-    final longest = decoded.width > decoded.height
-        ? decoded.width
-        : decoded.height;
-    final resized = longest > maxDimension
-        ? img.copyResize(
-            decoded,
-            width: decoded.width >= decoded.height ? maxDimension : null,
-            height: decoded.height > decoded.width ? maxDimension : null,
-          )
-        : decoded;
     final staged = await _cache.stagingFile();
-    await staged.writeAsBytes(
-      img.encodeJpg(resized, quality: jpegQuality),
-      flush: true,
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromBytes(
+        bytes: bytes,
+        destinationPath: staged.path,
+        declaredName: name,
+        maxDimension: maxDimension,
+        jpegQuality: jpegQuality,
+      ),
     );
-    return staged;
+    return _staged(staged, result);
+  }
+
+  /// [_resizeToJpeg] for a source that is already a file on disk.
+  Future<File?> _resizeFileToJpeg(File source, String? name) async {
+    final staged = await _cache.stagingFile();
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: staged.path,
+        declaredName: name,
+        maxDimension: maxDimension,
+        jpegQuality: jpegQuality,
+      ),
+    );
+    return _staged(staged, result);
+  }
+
+  /// The staged file on success, null otherwise.
+  ///
+  /// The job normalises a decoder throw into an outcome, so the reason it
+  /// gives is the only record left of a source package:image cannot read;
+  /// without this the class would go silent where it used to log. Nothing to
+  /// clean up on failure: `stagingFile()` mints a path without creating it,
+  /// and the job writes only on success.
+  File? _staged(File staged, ImageResizeResult result) {
+    if (result.outcome == ImageResizeOutcome.written) return staged;
+    final error = result.error;
+    if (error != null) _log.warning('Thumbnail source not decodable: $error');
+    return null;
   }
 }

--- a/test/architecture/media_provider_disposal_test.dart
+++ b/test/architecture/media_provider_disposal_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_provenance_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
+import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
+
+/// Per-item media families must auto-dispose (#1175).
+///
+/// Riverpod 3 defaults `isAutoDispose` to FALSE for every provider type
+/// (riverpod 3.4.2, e.g. `providers/future_provider.dart:107` and
+/// `providers/stream_provider.dart:96`). That is the opposite of Riverpod 2's
+/// familiar `.autoDispose` opt-in, and it is easy to carry the old intuition
+/// across. For a `.family` keyed per media item the consequence is not a
+/// missed optimisation, it is an unbounded leak: one entry survives per key
+/// for the process lifetime.
+///
+/// For the byte families that entry is a full-resolution image buffer,
+/// megabytes each, so a browsing session accumulated every photo it had shown
+/// until Android killed the app. For [mediaQueueFactsProvider] it is a live
+/// Drift watch on `media_transfer_queue`, and Drift re-runs every registered
+/// watch query on every write to that table -- so an upload drain cost one
+/// query per row the grid had ever rendered, per row it stamped.
+///
+/// Retention is handled separately by `retainFor`, which holds a value for a
+/// bounded window so swipe-back still hits the cache. That is a window, not
+/// permanence, and it only works on a provider that auto-disposes at all.
+///
+/// Asserted through `dynamic` because the flag's declaring type,
+/// `ProviderOrFamily`, is not exported by `package:riverpod` or
+/// `package:flutter_riverpod` -- it lives in `src/core/foundation.dart` and
+/// `riverpod.dart`'s `show` clause omits it. `isAutoDispose` itself is a
+/// public field on it, so the read is stable; only the type name is
+/// unreachable. Importing the src path would trip `implementation_imports`.
+void main() {
+  final mustAutoDispose = <String, dynamic>{
+    'mediaBytesProvider': mediaBytesProvider,
+    'resolvedThumbnailProvider': resolvedThumbnailProvider,
+    'resolvedFullResolutionProvider': resolvedFullResolutionProvider,
+    'assetThumbnailProvider': assetThumbnailProvider,
+    'assetFullResolutionProvider': assetFullResolutionProvider,
+    'mediaQueueFactsProvider': mediaQueueFactsProvider,
+    'mediaProvenanceProvider': mediaProvenanceProvider,
+  };
+
+  for (final entry in mustAutoDispose.entries) {
+    test('${entry.key} auto-disposes', () {
+      expect(
+        entry.value.isAutoDispose,
+        isTrue,
+        reason:
+            '${entry.key} is keyed per media item and holds either image bytes '
+            'or a live database subscription. Riverpod 3 keeps a family entry '
+            'forever unless the provider passes isAutoDispose: true, so '
+            'without it this grows without bound for the whole process.',
+      );
+    });
+  }
+}

--- a/test/architecture/repository_tick_stream_test.dart
+++ b/test/architecture/repository_tick_stream_test.dart
@@ -10,6 +10,8 @@ import 'package:submersion/features/equipment/data/repositories/service_record_r
 import 'package:submersion/features/equipment/data/repositories/service_schedule_repository.dart';
 import 'package:submersion/features/maps/data/repositories/offline_map_repository.dart';
 import 'package:submersion/features/media/data/repositories/manifest_subscription_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_library_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
@@ -127,6 +129,82 @@ void main() {
     }
     return fired;
   }
+
+  /// Subscribes to [tick] and reports whether it emitted with NO write at all.
+  ///
+  /// The other half of the contract, and the half nothing checked before
+  /// #1175. Every consumer of these streams feeds them to
+  /// `Ref.invalidateSelfWhen`, which rebuilds the provider on each tick. A
+  /// stream that emits on subscribe therefore invalidates the provider that
+  /// just subscribed; the rebuild subscribes again and emits again, and the
+  /// provider spins for as long as anything watches it -- running its query
+  /// once per event-loop turn on the main-isolate database.
+  ///
+  /// This is exactly what a Drift QUERY stream does: `watchSingle()` and
+  /// friends deliver the current row set on listen. A tick must be built on
+  /// `tableUpdates`, which fires only on a real write.
+  Future<bool> firesWithoutAWrite(Stream<void> tick) async {
+    var fired = false;
+    final sub = tick.listen((_) => fired = true);
+    addTearDown(sub.cancel);
+
+    // Generous relative to the 300 ms debounce the slowest tick applies, so a
+    // late emission is not mistaken for silence.
+    for (var i = 0; i < 60 && !fired; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    return fired;
+  }
+
+  group('silence before a write', () {
+    // Regression guard for #1175: MediaLibraryRepository.watchMediaChanges was
+    // a watched COUNT query, so subscribing to it emitted immediately. Fed to
+    // invalidateSelfWhen by unlinkedCountProvider, missingCountProvider and
+    // sourceCountsProvider, that turned opening the Media section into an
+    // unbounded rebuild loop, one COUNT(*) over `media` per event-loop turn.
+    //
+    // Covers every tick this file already exercises for firing, so the two
+    // halves of the contract are checked over the same set.
+    final ticks = <String, Stream<void> Function()>{
+      'MediaLibraryRepository.watchMediaChanges':
+          MediaLibraryRepository().watchMediaChanges,
+      'MediaRepository.watchMediaChanges': MediaRepository().watchMediaChanges,
+      'StatisticsRepository.watchStatisticsChanges':
+          StatisticsRepository().watchStatisticsChanges,
+      'ServiceRecordRepository.watchServiceRecordsChanges':
+          ServiceRecordRepository().watchServiceRecordsChanges,
+      'ServiceKindRepository.watchServiceKindsChanges':
+          ServiceKindRepository().watchServiceKindsChanges,
+      'ServiceScheduleRepository.watchSchedulesChanges':
+          ServiceScheduleRepository().watchSchedulesChanges,
+      'CylinderConfigRepository.watchConfigsChanges':
+          CylinderConfigRepository().watchConfigsChanges,
+      'DiveComputerRepository.watchComputersChanges':
+          DiveComputerRepository().watchComputersChanges,
+      'OfflineMapRepository.watchRegionsChanges':
+          OfflineMapRepository().watchRegionsChanges,
+      'AppSettingsRepository.watchSettingsChanges':
+          AppSettingsRepository().watchSettingsChanges,
+      'ManifestSubscriptionRepository.watchSubscriptionsChanges':
+          ManifestSubscriptionRepository().watchSubscriptionsChanges,
+      'CsvPresetRepository.watchPresetsChanges':
+          CsvPresetRepository().watchPresetsChanges,
+    };
+
+    for (final entry in ticks.entries) {
+      test('${entry.key} stays silent until something is written', () async {
+        expect(
+          await firesWithoutAWrite(entry.value()),
+          isFalse,
+          reason:
+              '${entry.key} emitted on subscribe. Every caller feeds this to '
+              'Ref.invalidateSelfWhen, so an emit-on-listen tick makes the '
+              'provider rebuild, resubscribe and tick again forever. Build the '
+              'tick on tableUpdates(), not on a watched query.',
+        );
+      });
+    }
+  });
 
   group('statistics', () {
     test('watchStatisticsChanges fires on a dives write', () async {

--- a/test/core/services/cloud_storage/s3/s3_api_client_timeout_test.dart
+++ b/test/core/services/cloud_storage/s3/s3_api_client_timeout_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_api_client.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+
+/// Request deadlines (#1175).
+///
+/// `S3ApiClient` was built on a bare `http.Client()`, whose underlying
+/// `HttpClient` has no connect, response or read deadline. A stalled socket to
+/// the S3 endpoint therefore parked its request FOREVER. Nothing above caps
+/// concurrency on the store read path, so a media grid opens one such request
+/// per visible tile: the gallery filled with permanent shimmer and the app
+/// looked hung. `_sendWithRetry` already treats `TimeoutException` as a
+/// retryable transport fault -- there was simply nothing that could produce
+/// one.
+S3Config config() => S3Config(
+  endpoint: 'http://nas.local:9000',
+  bucket: 'dive-sync',
+  accessKeyId: 'ak',
+  secretAccessKey: 'sk',
+);
+
+/// A client that accepts the request and then never answers, or answers its
+/// headers and then never sends a body byte.
+class _StallingClient extends http.BaseClient {
+  _StallingClient({required this.stallBeforeHeaders});
+
+  final bool stallBeforeHeaders;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (stallBeforeHeaders) {
+      // Never completes: a half-open socket after the request was written.
+      return Completer<http.StreamedResponse>().future;
+    }
+    // Headers arrive, then the body stream goes quiet forever.
+    return http.StreamedResponse(
+      StreamController<List<int>>().stream,
+      200,
+      contentLength: 1024,
+    );
+  }
+}
+
+void main() {
+  S3ApiClient clientWith(_StallingClient stub) => S3ApiClient(
+    config(),
+    httpClient: stub,
+    now: () => DateTime.utc(2026, 6, 9, 12),
+    retryDelay: Duration.zero,
+    maxAttempts: 2,
+    responseTimeout: const Duration(milliseconds: 60),
+    idleTimeout: const Duration(milliseconds: 60),
+  );
+
+  test('a response that never arrives gives up instead of hanging', () async {
+    final client = clientWith(_StallingClient(stallBeforeHeaders: true));
+
+    await expectLater(
+      client.getObject('smv1/objects/abc'),
+      throwsA(isA<CloudStorageException>()),
+    );
+  });
+
+  test('a body that stops mid-stream gives up instead of hanging', () async {
+    final client = clientWith(_StallingClient(stallBeforeHeaders: false));
+
+    await expectLater(
+      client.getObject('smv1/objects/abc'),
+      throwsA(isA<CloudStorageException>()),
+    );
+  });
+
+  test('an upload gets its own, far longer deadline', () async {
+    // `Client.send` does not complete until the body has been written, so for
+    // a PUT the "wait for a response" window contains the whole upload. An
+    // 8 MiB multipart part on a weak link legitimately takes minutes, and
+    // killing a part that was making progress is the failure mode that left
+    // large first syncs failing nine times in ten (#942). A stalled upload
+    // must still eventually give up -- just on a different clock.
+    final stub = _StallingClient(stallBeforeHeaders: true);
+    final client = S3ApiClient(
+      config(),
+      httpClient: stub,
+      now: () => DateTime.utc(2026, 6, 9, 12),
+      retryDelay: Duration.zero,
+      maxAttempts: 1,
+      // A read would be killed at 1ms; the upload must outlive it.
+      responseTimeout: const Duration(milliseconds: 1),
+      uploadTimeout: const Duration(milliseconds: 400),
+      idleTimeout: const Duration(milliseconds: 400),
+    );
+
+    final started = DateTime.now();
+    await expectLater(
+      client.putObject('smv1/objects/abc', Uint8List.fromList([1, 2, 3])),
+      throwsA(isA<CloudStorageException>()),
+    );
+    expect(
+      DateTime.now().difference(started),
+      greaterThan(const Duration(milliseconds: 200)),
+      reason: 'the upload must not be cut off by the read deadline',
+    );
+  });
+
+  test('a prompt response is unaffected by the deadlines', () async {
+    final client = S3ApiClient(
+      config(),
+      httpClient: _EchoClient(),
+      now: () => DateTime.utc(2026, 6, 9, 12),
+      retryDelay: Duration.zero,
+      responseTimeout: const Duration(milliseconds: 60),
+      idleTimeout: const Duration(milliseconds: 60),
+    );
+
+    expect(await client.getObject('smv1/objects/abc'), Uint8List.fromList([7]));
+  });
+}
+
+class _EchoClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      http.StreamedResponse(
+        Stream<List<int>>.value(const [7]),
+        200,
+        contentLength: 1,
+      );
+}

--- a/test/core/services/media_store/s3_media_object_store_range_test.dart
+++ b/test/core/services/media_store/s3_media_object_store_range_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_api_client.dart';
+import 'package:submersion/core/services/cloud_storage/s3/s3_config.dart';
+import 'package:submersion/core/services/media_store/s3_media_object_store.dart';
+
+/// The chunked-download loop's termination guarantee (#1175).
+///
+/// `getFile` advanced its cursor by `range.bytes.length`. A server that
+/// answers a Range request with an empty body -- a misbehaving proxy, an
+/// object truncated between the HEAD and the GET, an S3-compatible
+/// implementation that ignores the Range header on a zero-byte read -- leaves
+/// the cursor where it was, so `while (received < total)` re-issued the exact
+/// same request forever. Each pass awaits, so the isolate keeps turning and
+/// the app never crashes; it just downloads nothing, at full speed, until the
+/// user kills it.
+class _EmptyRangeClient extends S3ApiClient {
+  _EmptyRangeClient({required this.objectSize})
+    : super(
+        S3Config(
+          endpoint: 'http://localhost:9000',
+          bucket: 'test-bucket',
+          accessKeyId: 'AK',
+          secretAccessKey: 'SK',
+        ),
+        httpClient: MockClient((_) async => http.Response('', 200)),
+      );
+
+  final int objectSize;
+  int rangeCalls = 0;
+
+  @override
+  Future<S3ObjectInfo?> headObject(String key) async => S3ObjectInfo(
+    key: key,
+    lastModified: DateTime.utc(2026),
+    size: objectSize,
+  );
+
+  @override
+  Future<({Uint8List bytes, int totalLength})> getObjectRange(
+    String key, {
+    required int start,
+    required int endInclusive,
+  }) async {
+    rangeCalls++;
+    return (bytes: Uint8List(0), totalLength: objectSize);
+  }
+}
+
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('s3_range_test');
+  });
+
+  tearDown(() async {
+    await root.delete(recursive: true);
+  });
+
+  test('an empty range response fails instead of looping forever', () async {
+    // Larger than downloadChunkBytes, so getFile takes the chunked branch.
+    final client = _EmptyRangeClient(objectSize: 32 * 1024 * 1024);
+    final store = S3MediaObjectStore(client: client, keyPrefix: '');
+    final destination = File('${root.path}${Platform.pathSeparator}out.bin');
+
+    await expectLater(
+      store.getFile('smv1/objects/abc', destination),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          // Retryable: a bad answer from the network path, not a permanent
+          // property of the object.
+          MediaStoreErrorKind.transient,
+        ),
+      ),
+    );
+    expect(
+      client.rangeCalls,
+      lessThan(5),
+      reason: 'the loop must stop at the first chunk that makes no progress',
+    );
+  });
+}

--- a/test/features/media/data/resolvers/media_fetch_gate_test.dart
+++ b/test/features/media/data/resolvers/media_fetch_gate_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/resolvers/media_fetch_gate.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+
+/// The store read path's concurrency cap and request coalescing (#1175).
+void main() {
+  MediaSourceData result(String path) => FileData(
+    file: File(path),
+    servedFrom: ServedFrom.storeNetwork,
+    servedTier: ServedTier.thumbnail,
+  );
+
+  test('caps in-flight fetches at maxConcurrent', () async {
+    final gate = MediaFetchGate(maxConcurrent: 2);
+    final blockers = <Completer<MediaSourceData?>>[];
+    var maxObserved = 0;
+
+    final futures = [
+      for (var i = 0; i < 6; i++)
+        gate.run('key-$i', () {
+          maxObserved = maxObserved > gate.runningCount
+              ? maxObserved
+              : gate.runningCount;
+          final blocker = Completer<MediaSourceData?>();
+          blockers.add(blocker);
+          return blocker.future;
+        }),
+    ];
+
+    await Future<void>.delayed(Duration.zero);
+    expect(blockers, hasLength(2), reason: 'only two may be running');
+    expect(gate.waitingCount, 4);
+    expect(maxObserved, lessThanOrEqualTo(2));
+
+    // Draining one admits exactly one waiter.
+    blockers[0].complete(result('a'));
+    await Future<void>.delayed(Duration.zero);
+    expect(blockers, hasLength(3));
+
+    // Drain by index: completing one admits a waiter, which appends to
+    // `blockers` mid-loop.
+    for (var i = 1; i < blockers.length; i++) {
+      if (!blockers[i].isCompleted) blockers[i].complete(result('x'));
+      await Future<void>.delayed(Duration.zero);
+    }
+    await Future.wait(futures);
+    expect(gate.runningCount, 0);
+  });
+
+  test('duplicate keys share one fetch', () async {
+    final gate = MediaFetchGate(maxConcurrent: 4);
+    var calls = 0;
+    final blocker = Completer<MediaSourceData?>();
+
+    Future<MediaSourceData?> ask() => gate.run('same-hash#thumb', () {
+      calls++;
+      return blocker.future;
+    });
+
+    final first = ask();
+    final second = ask();
+    await Future<void>.delayed(Duration.zero);
+    expect(calls, 1, reason: 'the second caller must join the first fetch');
+
+    blocker.complete(result('shared'));
+    expect((await first as FileData).file.path, 'shared');
+    expect((await second as FileData).file.path, 'shared');
+  });
+
+  test('a key is refetchable once its fetch finishes', () async {
+    final gate = MediaFetchGate(maxConcurrent: 4);
+    var calls = 0;
+
+    Future<MediaSourceData?> ask() => gate.run('k', () async {
+      calls++;
+      return result('f');
+    });
+
+    await ask();
+    await ask();
+    expect(calls, 2, reason: 'coalescing is for in-flight requests only');
+  });
+
+  test('a failed fetch releases its slot and clears the key', () async {
+    final gate = MediaFetchGate(maxConcurrent: 1);
+
+    await expectLater(
+      gate.run('k', () async => throw const FileSystemException('boom')),
+      throwsA(isA<FileSystemException>()),
+    );
+
+    expect(gate.runningCount, 0);
+    // A leaked in-flight entry would hand this caller the FAILED future
+    // forever, so the tile could never recover.
+    expect(await gate.run('k', () async => result('later')), isNotNull);
+  });
+
+  test('waiters are served in arrival order', () async {
+    final gate = MediaFetchGate(maxConcurrent: 1);
+    final started = <String>[];
+    final blockers = <String, Completer<MediaSourceData?>>{};
+
+    Future<MediaSourceData?> ask(String key) => gate.run(key, () {
+      started.add(key);
+      return (blockers[key] = Completer<MediaSourceData?>()).future;
+    });
+
+    final futures = [ask('a'), ask('b'), ask('c')];
+    await Future<void>.delayed(Duration.zero);
+    expect(started, ['a']);
+
+    blockers['a']!.complete(result('a'));
+    await Future<void>.delayed(Duration.zero);
+    expect(started, ['a', 'b'], reason: 'FIFO: b queued before c');
+
+    blockers['b']!.complete(result('b'));
+    await Future<void>.delayed(Duration.zero);
+    blockers['c']!.complete(result('c'));
+    await Future.wait(futures);
+  });
+}

--- a/test/features/media/presentation/widgets/media_item_view_decode_bounds_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_decode_bounds_test.dart
@@ -107,4 +107,23 @@ void main() {
     // 200 x 3.0 dpr = 600, unchanged by the viewport fallback.
     expect((image.image as ResizeImage).width, 600);
   });
+
+  testWidgets('a sizeless thumbnail decodes to the default thumbnail target', (
+    tester,
+  ) async {
+    // `thumbnail: true` alone is the caller's statement that a few hundred
+    // pixels are all this will ever draw, and `_resolveInner` already honours
+    // it by resolving against kDefaultThumbnailTarget when no size is given.
+    // The decode bound has to agree: taking the full-screen fallback here
+    // would hand a 128 px tile the viewer's budget, which is the same
+    // "the flag is a silent no-op unless you also pass a Size" bug this
+    // widget was fixed for once already.
+    useViewport(tester);
+
+    final image = await pumpViewer(tester, thumbnail: true);
+
+    // kDefaultThumbnailTarget is 200x200; 200 x 3.0 dpr = 600. The viewport
+    // fallback would be 2400.
+    expect((image.image as ResizeImage).width, 600);
+  });
 }

--- a/test/features/media/presentation/widgets/media_item_view_decode_bounds_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_decode_bounds_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../media_store/support/fake_local_file_resolver.dart';
+import '../support/media_widget_harness.dart';
+
+/// The full-screen viewer's decode budget (#1175).
+///
+/// Every `thumbnail: false` call site -- `media_viewer_page` and
+/// `site_media_viewer_page` -- is a full-screen pager, and none of them pass a
+/// [MediaItemView.targetSize]. `cacheWidth` used to be derived from that size
+/// alone, so all three decoded at the file's NATIVE resolution: a 24 MP JPEG
+/// becomes ~96 MB of RGBA. `PageView` keeps the outgoing and incoming pages
+/// mounted during a swipe, and an image with a live listener is exempt from
+/// `ImageCache`'s byte budget, so the peak is two of those regardless of the
+/// 75 MB cap `applyMediaCacheCaps` sets. That is the Android OOM in #1175.
+void main() {
+  Future<Image> pumpViewer(
+    WidgetTester tester, {
+    Size? targetSize,
+    bool thumbnail = false,
+  }) async {
+    final base = await getBaseOverrides();
+    final resolver = FakeLocalFileResolver(BytesData(bytes: onePixelPng()));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          mediaSourceResolverRegistryProvider.overrideWithValue(
+            MediaSourceResolverRegistry({
+              MediaSourceType.localFile: resolver,
+              MediaSourceType.platformGallery: resolver,
+            }),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MediaItemView(
+              item: testMediaItem(),
+              fit: BoxFit.contain,
+              thumbnail: thumbnail,
+              targetSize: targetSize,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return tester.widget<Image>(find.byType(Image));
+  }
+
+  /// 400x300 logical at 3x, so the expected bounds below are concrete numbers
+  /// rather than a restatement of the production formula.
+  void useViewport(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+  }
+
+  testWidgets('a full-screen image decodes bounded by the viewport', (
+    tester,
+  ) async {
+    useViewport(tester);
+
+    final image = await pumpViewer(tester);
+
+    final provider = image.image;
+    expect(
+      provider,
+      isA<ResizeImage>(),
+      reason:
+          'no cacheWidth means Image decodes at the source resolution, and a '
+          'full-frame original is tens of megabytes of bitmap',
+    );
+    // 400 logical longest side x 3.0 dpr x 2 (the zoom headroom PhotoView's
+    // maxScale needs) = 2400.
+    expect((provider as ResizeImage).width, 2400);
+    expect(
+      provider.height,
+      isNull,
+      reason: 'both dimensions would decode to exact bounds and distort',
+    );
+  });
+
+  testWidgets('an explicit targetSize still wins over the viewport bound', (
+    tester,
+  ) async {
+    useViewport(tester);
+
+    final image = await pumpViewer(
+      tester,
+      thumbnail: true,
+      targetSize: const Size(200, 200),
+    );
+
+    // 200 x 3.0 dpr = 600, unchanged by the viewport fallback.
+    expect((image.image as ResizeImage).width, 600);
+  });
+}

--- a/test/features/media_store/image_resize_job_test.dart
+++ b/test/features/media_store/image_resize_job_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:submersion/features/media_store/data/image_resize_job.dart';
+
+/// The off-isolate decode/resize/encode the media store's upload pipeline
+/// runs (#1175).
+///
+/// Both entry points are exercised through the real `compute` hop, not just
+/// the isolate body: the hop is the whole point of the class, and it is the
+/// part that can fail in ways the body cannot (an unsendable argument, a
+/// closure capturing something isolate-local).
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('image_resize_job_test');
+  });
+
+  tearDown(() async {
+    await root.delete(recursive: true);
+  });
+
+  String out(String name) => '${root.path}${Platform.pathSeparator}$name';
+
+  /// A solid PNG of the given size, big enough to exceed the ceilings below.
+  File writePng(String name, {required int width, required int height}) {
+    final image = img.Image(width: width, height: height);
+    img.fill(image, color: img.ColorRgb8(20, 80, 140));
+    final file = File(out(name))..writeAsBytesSync(img.encodePng(image));
+    return file;
+  }
+
+  test('resizes an oversized source down to the ceiling', () async {
+    final source = writePng('big.png', width: 900, height: 600);
+    final destination = out('thumb.jpg');
+
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: destination,
+        declaredName: 'big.png',
+        maxDimension: 512,
+        jpegQuality: 80,
+      ),
+    );
+
+    expect(result.outcome, ImageResizeOutcome.written);
+    expect(result.sizeBytes, greaterThan(0));
+
+    final decoded = img.decodeJpg(File(destination).readAsBytesSync())!;
+    expect(decoded.width, 512);
+    // Aspect ratio preserved: only the width is constrained.
+    expect(decoded.height, 341);
+  });
+
+  test('reports undecodable rather than throwing', () async {
+    final source = File(out('nonsense.jpg'))
+      ..writeAsBytesSync(List<int>.filled(64, 7));
+
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: out('never.jpg'),
+        declaredName: 'nonsense.jpg',
+        maxDimension: 512,
+        jpegQuality: 80,
+      ),
+    );
+
+    expect(result.outcome, ImageResizeOutcome.undecodable);
+    expect(
+      File(out('never.jpg')).existsSync(),
+      isFalse,
+      reason: 'a failed job must not leave a truncated staging file behind',
+    );
+  });
+
+  test('skipWhenUnderCeiling declines a source already small enough', () async {
+    final source = writePng('small.png', width: 100, height: 80);
+
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: out('never.jpg'),
+        declaredName: 'small.png',
+        maxDimension: 512,
+        jpegQuality: 80,
+        skipWhenUnderCeiling: true,
+      ),
+    );
+
+    expect(result.outcome, ImageResizeOutcome.underCeiling);
+    expect(File(out('never.jpg')).existsSync(), isFalse);
+  });
+
+  test('without skipWhenUnderCeiling a small source is still re-encoded', () {
+    // Thumbnails take this branch: re-encoding is what strips EXIF/GPS, so a
+    // small source must not short-circuit.
+    final source = writePng('small.png', width: 100, height: 80);
+    final destination = out('thumb.jpg');
+
+    final result = runImageResizeRequest(
+      ImageResizeRequest.fromFile(
+        sourcePath: source.path,
+        destinationPath: destination,
+        declaredName: 'small.png',
+        maxDimension: 512,
+        jpegQuality: 80,
+      ),
+    );
+
+    expect(result.outcome, ImageResizeOutcome.written);
+    final decoded = img.decodeJpg(File(destination).readAsBytesSync())!;
+    expect(decoded.width, 100, reason: 'never upscaled to the ceiling');
+  });
+
+  test('the bytes entry point survives the isolate hop', () async {
+    final image = img.Image(width: 700, height: 700);
+    img.fill(image, color: img.ColorRgb8(200, 30, 30));
+    final destination = out('from_bytes.jpg');
+
+    final result = await resizeToJpegFile(
+      ImageResizeRequest.fromBytes(
+        bytes: img.encodePng(image),
+        destinationPath: destination,
+        declaredName: 'rendition.png',
+        maxDimension: 512,
+        jpegQuality: 80,
+      ),
+    );
+
+    expect(result.outcome, ImageResizeOutcome.written);
+    expect(img.decodeJpg(File(destination).readAsBytesSync())!.width, 512);
+  });
+}


### PR DESCRIPTION
Fixes #1175.

Opening the Media gallery froze the app on Windows and made it lag and
sometimes die on Android, in both cases with an S3-backed library. Tracing
that path turned up seven independent defects, each on its own sufficient to
produce one of the reported symptoms. All seven are fixed here; none of them
had a test that could have caught it.

## 1. The Media section spun in a self-invalidation loop from its first frame

`MediaLibraryRepository.watchMediaChanges()` was a watched `COUNT` query. A
Drift query stream delivers its current value the moment you listen, and all
three consumers feed this stream to `Ref.invalidateSelfWhen`:
`unlinkedCountProvider`, `missingCountProvider` and `sourceCountsProvider`.

So: build subscribes, the subscription immediately ticks, the tick invalidates
the provider that just subscribed, the rebuild subscribes again. A measured
25 rebuilds in 25 event-loop turns, each running a `COUNT(*)` over `media` on
the main-isolate database, for as long as the Media section stays open. On a
large library that alone is enough to stop the app pumping frames, which is
what Windows reports as "Not responding".

Rebuilt on `tableUpdates`, matching `MediaRepository.watchMediaChanges()`, and
debounced on the same 300 ms window so a sync's per-changeset commits (or the
media store worker stamping `remote_uploaded_at` row by row as it drains)
collapse into one reload rather than one per write.

The existing fake in `media_library_providers_test.dart` is a plain
`StreamController.broadcast()`, which never emits on listen — more polite than
the real thing, so the behaviour that mattered was never exercised. The guard
is now in `test/architecture/repository_tick_stream_test.dart`, which already
asserted that every tick *fires* on a write and now also asserts that none of
them fires *without* one.

## 2. The full-screen viewer decoded at native resolution

`MediaItemView` derived `cacheWidth` from `targetSize` alone. Every
`thumbnail: false` call site — `media_viewer_page` (x2) and
`site_media_viewer_page` — passes no `targetSize`, so the one surface that
draws whole originals was the one with no decode bound at all. A 24 MP JPEG is
~96 MB of RGBA; `PageView` keeps the outgoing and incoming pages mounted
during a swipe, and an image with a live listener is exempt from `ImageCache`'s
byte budget, so the peak was two of those regardless of the 75 MB cap
`applyMediaCacheCaps` sets. That is the Android OOM.

`cacheWidth` now falls back to the viewport's longest side in physical pixels,
times a documented 2x zoom headroom for `PhotoView`'s `maxScale`.

## 3. Image decode/resize/encode ran on the UI isolate

`ThumbnailGenerator` and `ImageCompressor` called `img.decodeImage` +
`img.copyResize` + `img.encodeJpg` inline. That is pure-Dart `package:image`
work, so it ran on the caller's isolate — and the caller is the media store's
upload worker, which lives on the UI isolate and drains its queue in a loop.
One large frame is seconds of frozen app; a backlog is the whole clear time.
A store-backed grid tile constructs the store runtime, the runtime kicks
`worker.drain()`, and the drain starts decoding: opening Media is what sets it
off.

Desktop is the worst case, and the platform this was reported on: a gallery
photo arrives from photo_manager already sized and JPEG-encoded so mobile
often skips the decode, while a local-file original never does.

Both now go through `ImageResizeJob`, a `compute` hop following the
convention already used by `ExifExtractor` and `PhotoPickerServiceDesktop`.
The file-based entry point passes a PATH, so a 40 MB original is read inside
the isolate and never crosses the message channel or lands on the UI isolate's
heap at all.

One behaviour note: `decodeNamedImage` *throws* on a malformed source of a
known extension rather than returning null. Inline that was swallowed by the
caller's `on Exception catch`; across an isolate boundary it would have
arrived as a bare exception rather than the outcome the caller switches on.
The job normalises it and carries the message back for the log.

## 4. S3 requests had no deadline of any kind

`S3ApiClient` was built on a bare `http.Client()`, whose underlying
`HttpClient` has no connect, response or read timeout. A stalled socket parked
its request forever. `_sendWithRetry` already classified `TimeoutException` as
a retryable transport fault — there was simply nothing that could produce one.

Three bounds, all injectable:

- `connectionTimeout` (15 s) on the default client, for a socket that never
  connects.
- A response deadline (30 s) for status and headers.
- An IDLE deadline (30 s) between body chunks — deliberately not a total
  budget, because a legitimate 8 MiB download over a weak link takes minutes
  and must not be killed, while a connection that has stopped delivering is
  dead regardless of how little it had left to send.

## 5. The chunked download loop could not terminate

`S3MediaObjectStore.getFile` advanced its cursor by `range.bytes.length`. A
server answering a Range request with an empty body left the cursor where it
was, so `while (received < total)` re-issued the identical request forever.
Each pass awaits, so the isolate keeps turning and nothing crashes; it just
downloads nothing, at full speed, until the user kills it. Now raises a
transient `MediaStoreException` at the first chunk that makes no progress, so
the queue's backoff handles it.

## 6. Nothing capped or coalesced store fetches

Every visible grid tile resolves independently — `MediaItemView` kicks its own
future from `initState` — so a screenful of store-backed thumbnails opened one
HEAD plus one GET per tile, all at once. A 140 px grid puts 30-60 tiles on
screen on desktop, each request retried up to six times with backoff, none of
them sharing work with any other.

New `MediaFetchGate` on `MediaStoreResolver`: 4 concurrent fetches, and
callers asking for a key already in flight share its result. The coalescing is
not cosmetic — store objects are content-addressed, so the same photo linked
to two dives is two rows with one hash, and without this each issued its own
download of identical bytes and both raced to write the same cache entry.

FIFO rather than `GalleryThumbnailCache`'s LIFO: that class serves newest-first
on the argument that older waiters belong to tiles already scrolled away,
which stops holding once a parked future can be handed to later callers.

## 7. Per-item families never disposed

Riverpod 3 defaults `isAutoDispose` to false for every provider type — the
opposite of Riverpod 2's `.autoDispose` opt-in. For a `.family` keyed per
media item that is an unbounded leak, one entry per key for the process
lifetime:

- `mediaBytesProvider`, `resolvedFullResolutionProvider`,
  `assetFullResolutionProvider` — a full-resolution buffer each.
- `resolvedThumbnailProvider`, `assetThumbnailProvider` — thumbnail bytes.
- `mediaQueueFactsProvider` — a live Drift watch on `media_transfer_queue`,
  one per row the grid ever rendered. Drift re-runs every registered watch
  query on every write to that table, so an upload drain cost O(rows ever
  rendered) queries per row it stamped.
- `mediaProvenanceProvider` — keeps the above alive, and is keyed by a whole
  `MediaItem`.

All seven now auto-dispose. The byte families keep a bounded retention window
(`retainFor`) so a swipe back to the photo just left still hits the cache:
30 s for full-resolution buffers, 5 minutes for thumbnails.

## Testing

`flutter analyze` clean, `dart format` clean, full suite green.

New tests:

- `repository_tick_stream_test.dart` — a "stays silent until something is
  written" case for twelve tick streams. Verified red against the old
  `watchMediaChanges` and green with the fix.
- `media_item_view_decode_bounds_test.dart` — the viewer decodes bounded by
  the viewport; an explicit `targetSize` still wins.
- `image_resize_job_test.dart` — resize, undecodable, under-ceiling and the
  bytes entry point, all through the real `compute` hop.
- `s3_api_client_timeout_test.dart` — a response that never arrives and a body
  that stops mid-stream both give up.
- `s3_media_object_store_range_test.dart` — an empty range fails instead of
  looping.
- `media_fetch_gate_test.dart` — the cap, coalescing, slot release on failure,
  FIFO ordering.
- `media_provider_disposal_test.dart` — the per-item families auto-dispose.

Not reproduced on Windows or Android from here; the fixes are derived from
reading the path and each is pinned by a regression test. Worth a look on real
hardware before release.

## Deliberately not in scope

`MediaItemView` reads `mediaStoreRuntimeProvider` from a grid tile, and
constructing that runtime does a credentials read, builds the object store,
fires `worker.drain()` and can kick a whole-bucket verify sweep — all because
a thumbnail scrolled into view. Fix 3 removes the harm (the drain no longer
blocks the UI isolate), but splitting a read-only store handle out of the
runtime is a lifecycle change that belongs in its own PR.

`MediaItem.props` includes `imageData`, a `Uint8List`. Equatable deep-hashes
iterables, so any family keyed by a whole `MediaItem` walks those bytes on
every lookup. Null for ordinary library rows today, so not a live cost, but
worth revisiting.
