### PR TITLE
fix(dive computer): keep a consolidated strand aligned across a re-parse (#1177)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -2439,6 +2439,15 @@ class DiveDataSources extends Table {
   TextColumn get libdivecomputerVersion => text().nullable()();
   DateTimeColumn get lastParsedAt => dateTime().nullable()();
 
+  /// Seconds added to this source's own sample times to place them on the
+  /// dive's timeline (issue #1177). Multi-computer consolidation re-bases a
+  /// folded-in computer's profile so both strands share one clock; the shift
+  /// it applied is recorded here because it cannot be recovered from the raw
+  /// bytes. Re-parsing this source must add it back, or the strand slides
+  /// away from the primary's. Null and 0 both mean "already on the dive's
+  /// time base", which is every source that was never consolidated.
+  IntColumn get timeOffsetSeconds => integer().nullable()();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -3096,7 +3105,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 157;
+  static const int currentSchemaVersion = 158;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3356,6 +3365,11 @@ class AppDatabase extends _$AppDatabase {
     // Renumbered from 154 and then 156, which #1104, #828 and #1127 claimed
     // first on main.
     157,
+    // v158 (issue #1177): dive_data_sources.time_offset_seconds, the shift
+    // multi-computer consolidation applied to a folded-in source's timeline.
+    // Without it a re-parse re-inserts the secondary strand on the raw
+    // download's clock and it slides away from the primary's.
+    158,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4827,6 +4841,23 @@ class AppDatabase extends _$AppDatabase {
           'ALTER TABLE $table ADD COLUMN default_currency TEXT',
         );
       }
+    }
+  }
+
+  /// Idempotent DDL for the v158 dive_data_sources.time_offset_seconds
+  /// column (issue #1177). Same dual-call contract (onUpgrade + beforeOpen
+  /// backstop) as the other column-assert helpers. Nullable with no default,
+  /// so every pre-existing row reads back as "no offset applied".
+  Future<void> _assertDataSourceTimeOffsetColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('dive_data_sources')",
+    ).get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('time_offset_seconds')) {
+      await customStatement(
+        'ALTER TABLE dive_data_sources ADD COLUMN time_offset_seconds INTEGER',
+      );
     }
   }
 
@@ -8250,6 +8281,13 @@ class AppDatabase extends _$AppDatabase {
           await _assertServiceCostColumns();
         }
         if (from < 157) await reportProgress();
+        // v158: the consolidation time offset carried on a folded-in
+        // source, so a re-parse can put its strand back on the dive's
+        // clock (issue #1177).
+        if (from < 158) {
+          await _assertDataSourceTimeOffsetColumn();
+        }
+        if (from < 158) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -8418,6 +8456,11 @@ class AppDatabase extends _$AppDatabase {
         // v157 backstop: re-assert the default service price columns (issue
         // #829; same parallel-branch version-collision self-heal).
         await _assertServiceCostColumns();
+
+        // v158 backstop: re-assert the consolidation time offset column
+        // (issue #1177; same parallel-branch version-collision self-heal).
+        // Reading a consolidated dive's sources throws without it.
+        await _assertDataSourceTimeOffsetColumn();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -71,11 +71,19 @@ class ReparseService {
       // 4. Replace DiveProfiles for this source's computerId
       // ------------------------------------------------------------------
       final computerId = sourceRow.computerId;
+      // Parsed times are on this computer's own clock. Multi-computer
+      // consolidation re-based the folded-in strand onto the dive's clock and
+      // recorded the shift here; the raw bytes carry no trace of it, so
+      // re-applying it is the only way the re-parsed strand still lines up
+      // with the primary's (issue #1177). Zero for every unconsolidated
+      // source, which is the overwhelming majority.
+      final timeOffset = sourceRow.timeOffsetSeconds ?? 0;
       await _replaceDiveProfiles(
         diveId: diveId,
         computerId: computerId,
         parsed: parsed,
         isPrimary: sourceRow.isPrimary,
+        timeOffset: timeOffset,
       );
 
       // ------------------------------------------------------------------
@@ -112,6 +120,7 @@ class ReparseService {
           computerId: computerId,
           parsed: parsed,
           now: now,
+          timeOffset: timeOffset,
         );
       }
 
@@ -131,12 +140,14 @@ class ReparseService {
           computerId: computerId,
           parsed: parsed,
           tankIdsByIndex: tankIdsByIndex,
+          timeOffset: timeOffset,
         );
         await _insertGasSwitches(
           diveId: diveId,
           parsed: parsed,
           tankIdsByIndex: tankIdsByIndex,
           now: now,
+          timeOffset: timeOffset,
         );
       }
     });
@@ -405,11 +416,14 @@ class ReparseService {
     );
   }
 
+  /// [timeOffset] shifts every re-inserted sample onto the dive's timeline;
+  /// see the note at the call site (issue #1177).
   Future<void> _replaceDiveProfiles({
     required String diveId,
     required String? computerId,
     required pigeon.ParsedDive parsed,
     required bool isPrimary,
+    required int timeOffset,
   }) async {
     // Delete existing profiles for this (diveId, computerId)
     if (computerId != null) {
@@ -433,7 +447,7 @@ class ReparseService {
             diveId: Value(diveId),
             computerId: Value(computerId),
             isPrimary: Value(isPrimary),
-            timestamp: Value(s.timeSeconds),
+            timestamp: Value(s.timeSeconds + timeOffset),
             depth: Value(s.depthMeters),
             temperature: Value(s.temperatureCelsius),
             heartRate: Value(s.heartRate),
@@ -471,6 +485,7 @@ class ReparseService {
     required String? computerId,
     required pigeon.ParsedDive parsed,
     required DateTime now,
+    required int timeOffset,
   }) async {
     if (parsed.events.isEmpty) return;
 
@@ -487,7 +502,7 @@ class ReparseService {
             id: Value(_uuid.v4()),
             diveId: Value(diveId),
             computerId: Value(computerId),
-            timestamp: Value(e.timeSeconds),
+            timestamp: Value(e.timeSeconds + timeOffset),
             eventType: Value(eventType),
             severity: Value(_eventSeverity(eventType)),
             source: const Value('imported'), // native DC events are imports
@@ -514,6 +529,7 @@ class ReparseService {
     required pigeon.ParsedDive parsed,
     required Map<int, String> tankIdsByIndex,
     required DateTime now,
+    required int timeOffset,
   }) async {
     final switches = resolveGasSwitches(parsed);
     if (switches.isEmpty) return;
@@ -529,7 +545,7 @@ class ReparseService {
           GasSwitchesCompanion(
             id: Value(_uuid.v4()),
             diveId: Value(diveId),
-            timestamp: Value(sw.timeSeconds),
+            timestamp: Value(sw.timeSeconds + timeOffset),
             tankId: Value(tankId),
             depth: Value(sw.depth),
             createdAt: Value(nowMs),
@@ -630,6 +646,7 @@ class ReparseService {
     required String? computerId,
     required pigeon.ParsedDive parsed,
     required Map<int, String> tankIdsByIndex,
+    required int timeOffset,
   }) async {
     if (tankIdsByIndex.isEmpty) return;
 
@@ -640,7 +657,7 @@ class ReparseService {
       if (pressure != null) {
         final idx = s.tankIndex ?? 0;
         pressuresByTank.putIfAbsent(idx, () => []).add((
-          timestamp: s.timeSeconds,
+          timestamp: s.timeSeconds + timeOffset,
           pressure: pressure,
         ));
       }

--- a/lib/features/dive_log/data/services/dive_consolidation_service.dart
+++ b/lib/features/dive_log/data/services/dive_consolidation_service.dart
@@ -208,6 +208,7 @@ class DiveConsolidationService {
                   gradientFactorHigh: Value(secRow.gradientFactorHigh),
                   importedAt: Value(nowDt),
                   createdAt: Value(nowDt),
+                  timeOffsetSeconds: Value(offset),
                 ),
               );
         } else {
@@ -221,6 +222,15 @@ class DiveConsolidationService {
                         id: Value(_uuid.v4()),
                         diveId: Value(targetDiveId),
                         isPrimary: const Value(false),
+                        // Record the shift the profile rows below are
+                        // re-based by, so a re-parse can reapply it (#1177);
+                        // the raw bytes carry no trace of it. Composes when
+                        // the secondary was itself consolidated once
+                        // already: its own offset is relative to its
+                        // timeline, which this pass moves again.
+                        timeOffsetSeconds: Value(
+                          (row.timeOffsetSeconds ?? 0) + offset,
+                        ),
                       ),
                 );
           }

--- a/test/core/database/migration_v158_source_time_offset_test.dart
+++ b/test/core/database/migration_v158_source_time_offset_test.dart
@@ -1,0 +1,115 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// v158 adds `dive_data_sources.time_offset_seconds`: the number of seconds
+/// consolidation shifted this source's own timeline by to land it on the
+/// target dive's clock (issue #1177). Nullable, because null and 0 both mean
+/// "this source is already on the dive's time base", and a nullable column
+/// survives a payload from a pre-v158 writer that omits the key entirely.
+void main() {
+  test('v158 is in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(158));
+    expect(AppDatabase.migrationVersions, contains(158));
+  });
+
+  test('a fresh database has dive_data_sources.time_offset_seconds', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('dive_data_sources')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('time_offset_seconds'));
+  });
+
+  test('the column is nullable and carries no default', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('dive_data_sources')")
+        .get();
+    final column = cols.firstWhere(
+      (c) => c.read<String>('name') == 'time_offset_seconds',
+    );
+    // A NOT NULL column would reject inserts from every existing writer that
+    // does not know about it, and a non-null default would claim an offset
+    // was measured where none was.
+    expect(column.read<int>('notnull'), 0);
+    expect(column.read<String?>('dflt_value'), isNull);
+  });
+
+  test(
+    'a database stranded before v158 gains the column via beforeOpen',
+    () async {
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('''
+          CREATE TABLE dive_data_sources (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            computer_id TEXT,
+            is_primary INTEGER NOT NULL DEFAULT 0,
+            imported_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+        },
+      );
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('dive_data_sources')")
+          .get();
+      final names = cols.map((c) => c.read<String>('name')).toSet();
+      expect(names, contains('time_offset_seconds'));
+    },
+  );
+
+  test('existing rows read back as null, not as a bogus offset', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('''
+          CREATE TABLE dive_data_sources (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            computer_id TEXT,
+            is_primary INTEGER NOT NULL DEFAULT 0,
+            imported_at INTEGER NOT NULL,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+        rawDb.execute(
+          "INSERT INTO dive_data_sources "
+          "(id, dive_id, is_primary, imported_at, created_at) "
+          "VALUES ('src-1', 'dive-1', 0, 0, 0)",
+        );
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    final row = await db
+        .customSelect(
+          "SELECT time_offset_seconds FROM dive_data_sources WHERE id = 'src-1'",
+        )
+        .getSingle();
+    expect(row.read<int?>('time_offset_seconds'), isNull);
+  });
+
+  test('the assert is a no-op when the table is absent', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('CREATE TABLE unrelated (id TEXT)');
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    await db.customSelect('SELECT 1').get();
+  });
+}

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -216,6 +216,10 @@ void main() {
           'importedAt': 1700000000000,
           'createdAt': 1700000000000,
           'rawFingerprint': fingerprint,
+          // Consolidation's time re-base (#1177). It cannot be recovered from
+          // the raw bytes, so a peer that loses it re-parses the folded-in
+          // strand onto the wrong clock.
+          'timeOffsetSeconds': 60,
         });
 
         await seedPeerLog(cloud, 'device-a');
@@ -234,6 +238,7 @@ void main() {
           reason: 'data-source row (with BLOB) must round-trip',
         );
         expect(restored!['sourceFormat'], 'shearwater');
+        expect(restored['timeOffsetSeconds'], 60);
 
         // BLOB survives the JSON round-trip. The sync layer encodes BLOBs as
         // base64 strings (see sync_blob_base64_test.dart); fetchRecord decodes
@@ -249,6 +254,34 @@ void main() {
           restoredBytes = (restoredBlob as List).cast<int>();
         }
         expect(restoredBytes, [0x01, 0x02, 0x03, 0xFE, 0xFF]);
+      },
+    );
+
+    test(
+      'a DiveDataSources payload from a pre-v158 peer, with no '
+      'timeOffsetSeconds key at all, still applies (#1177)',
+      () async {
+        final serializer = SyncDataSerializer();
+        final diveRepo = DiveRepository();
+
+        await diveRepo.createDive(
+          createTestDiveWithBottomTime(id: 'dive-ds-2', diveNumber: 103),
+        );
+
+        // Older writers do not know the column exists. The receiving side
+        // must read that as "no offset", not reject the row.
+        await serializer.upsertRecord('diveDataSources', {
+          'id': 'ds-2',
+          'diveId': 'dive-ds-2',
+          'isPrimary': true,
+          'sourceFormat': 'shearwater',
+          'importedAt': 1700000000000,
+          'createdAt': 1700000000000,
+        });
+
+        final stored = await serializer.fetchRecord('diveDataSources', 'ds-2');
+        expect(stored, isNotNull);
+        expect(stored!['timeOffsetSeconds'], isNull);
       },
     );
   });

--- a/test/core/services/sync/sync_extra_entities_round_trip_test.dart
+++ b/test/core/services/sync/sync_extra_entities_round_trip_test.dart
@@ -257,32 +257,29 @@ void main() {
       },
     );
 
-    test(
-      'a DiveDataSources payload from a pre-v158 peer, with no '
-      'timeOffsetSeconds key at all, still applies (#1177)',
-      () async {
-        final serializer = SyncDataSerializer();
-        final diveRepo = DiveRepository();
+    test('a DiveDataSources payload from a pre-v158 peer, with no '
+        'timeOffsetSeconds key at all, still applies (#1177)', () async {
+      final serializer = SyncDataSerializer();
+      final diveRepo = DiveRepository();
 
-        await diveRepo.createDive(
-          createTestDiveWithBottomTime(id: 'dive-ds-2', diveNumber: 103),
-        );
+      await diveRepo.createDive(
+        createTestDiveWithBottomTime(id: 'dive-ds-2', diveNumber: 103),
+      );
 
-        // Older writers do not know the column exists. The receiving side
-        // must read that as "no offset", not reject the row.
-        await serializer.upsertRecord('diveDataSources', {
-          'id': 'ds-2',
-          'diveId': 'dive-ds-2',
-          'isPrimary': true,
-          'sourceFormat': 'shearwater',
-          'importedAt': 1700000000000,
-          'createdAt': 1700000000000,
-        });
+      // Older writers do not know the column exists. The receiving side
+      // must read that as "no offset", not reject the row.
+      await serializer.upsertRecord('diveDataSources', {
+        'id': 'ds-2',
+        'diveId': 'dive-ds-2',
+        'isPrimary': true,
+        'sourceFormat': 'shearwater',
+        'importedAt': 1700000000000,
+        'createdAt': 1700000000000,
+      });
 
-        final stored = await serializer.fetchRecord('diveDataSources', 'ds-2');
-        expect(stored, isNotNull);
-        expect(stored!['timeOffsetSeconds'], isNull);
-      },
-    );
+      final stored = await serializer.fetchRecord('diveDataSources', 'ds-2');
+      expect(stored, isNotNull);
+      expect(stored!['timeOffsetSeconds'], isNull);
+    });
   });
 }

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -92,6 +92,7 @@ void main() {
     double? avgDepth,
     int? duration,
     double? waterTemp,
+    int? timeOffsetSeconds,
   }) async {
     final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
     await db
@@ -107,6 +108,7 @@ void main() {
             avgDepth: Value(avgDepth),
             duration: Value(duration),
             waterTemp: Value(waterTemp),
+            timeOffsetSeconds: Value(timeOffsetSeconds),
             importedAt: Value(now),
             createdAt: Value(now),
           ),
@@ -775,6 +777,186 @@ void main() {
 
       expect(comp2Profiles.length, 1);
       expect(comp2Profiles[0].id, 'prof-other');
+    });
+
+    test('re-parsing a consolidated source re-bases its profile onto the '
+        "dive's time base, not the raw download's (#1177)", () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-primary');
+      await insertComputer('comp-secondary');
+      await insertSource(
+        id: 'src-primary',
+        diveId: 'dive-1',
+        computerId: 'comp-primary',
+        isPrimary: true,
+      );
+      // Consolidation folded this computer in and shifted its samples 60s
+      // forward to line them up with the primary's clock.
+      await insertSource(
+        id: 'src-secondary',
+        diveId: 'dive-1',
+        computerId: 'comp-secondary',
+        isPrimary: false,
+        timeOffsetSeconds: 60,
+      );
+      await insertProfile(
+        id: 'prof-secondary',
+        diveId: 'dive-1',
+        computerId: 'comp-secondary',
+        timestamp: 60,
+        depth: 0.0,
+        isPrimary: false,
+      );
+
+      final parsed = makeParsedDive(
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 30, depthMeters: 5.0),
+          pigeon.ProfileSample(timeSeconds: 60, depthMeters: 12.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-secondary',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final profiles =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.computerId.equals('comp-secondary'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+
+      // Without the offset these land at 0/30/60 and the secondary strand
+      // sits a minute to the left of the primary's on every comparison view.
+      expect(profiles.map((p) => p.timestamp), [60, 90, 120]);
+      expect(profiles.map((p) => p.depth), [0.0, 5.0, 12.0]);
+    });
+
+    test('re-parsing leaves the recorded offset intact, so a second '
+        're-parse lands on the same time base (#1177)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-primary');
+      await insertComputer('comp-secondary');
+      await insertSource(
+        id: 'src-primary',
+        diveId: 'dive-1',
+        computerId: 'comp-primary',
+        isPrimary: true,
+      );
+      await insertSource(
+        id: 'src-secondary',
+        diveId: 'dive-1',
+        computerId: 'comp-secondary',
+        isPrimary: false,
+        timeOffsetSeconds: 60,
+      );
+
+      final parsed = makeParsedDive(
+        samples: [pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0)],
+      );
+
+      // reparseAllForComputer walks every dive for a computer after a
+      // libdivecomputer upgrade, so the same row is re-parsed repeatedly over
+      // the app's life. Each pass must find the offset still there.
+      for (var i = 0; i < 2; i++) {
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-secondary',
+          parsed: parsed,
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+      }
+
+      expect((await getSource('src-secondary')).timeOffsetSeconds, 60);
+      final profiles = await (db.select(
+        db.diveProfiles,
+      )..where((t) => t.computerId.equals('comp-secondary'))).get();
+      expect(profiles.map((p) => p.timestamp), [60]);
+    });
+
+    test('a source with no recorded offset re-parses on the raw time base '
+        '(#1177)', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        samples: [
+          pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+          pigeon.ProfileSample(timeSeconds: 30, depthMeters: 5.0),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final profiles =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(profiles.map((p) => p.timestamp), [0, 30]);
+    });
+
+    test('a consolidated source that is the dive\'s only source re-bases its '
+        'events too (#1177)', () async {
+      // Reachable when the target had no dive_data_sources row of its own:
+      // consolidation carries the secondary\'s row over and the dive ends up
+      // single-source, which is the branch that re-inserts events.
+      await insertDive('dive-1');
+      await insertComputer('comp-secondary');
+      await insertSource(
+        id: 'src-secondary',
+        diveId: 'dive-1',
+        computerId: 'comp-secondary',
+        isPrimary: false,
+        timeOffsetSeconds: 90,
+      );
+
+      final parsed = makeParsedDive(
+        events: [
+          pigeon.DiveEvent(timeSeconds: 0, type: 'bookmark'),
+          pigeon.DiveEvent(timeSeconds: 120, type: 'deco'),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-secondary',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final events =
+          await (db.select(db.diveProfileEvents)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(events.map((e) => e.timestamp), [90, 210]);
     });
 
     test('does not overwrite existing rawData with null on re-parse', () async {

--- a/test/features/dive_log/data/services/dive_consolidation_service_test.dart
+++ b/test/features/dive_log/data/services/dive_consolidation_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_computer/data/services/reparse_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
@@ -101,6 +103,9 @@ void main() {
     bool isPrimary = true,
     Uint8List? rawData,
     Uint8List? rawFingerprint,
+    String? descriptorVendor,
+    String? descriptorProduct,
+    int? descriptorModel,
   }) async {
     await db
         .into(db.diveDataSources)
@@ -115,6 +120,9 @@ void main() {
             computerId: Value(computerId),
             rawData: Value(rawData),
             rawFingerprint: Value(rawFingerprint),
+            descriptorVendor: Value(descriptorVendor),
+            descriptorProduct: Value(descriptorProduct),
+            descriptorModel: Value(descriptorModel),
           ),
         );
   }
@@ -532,6 +540,32 @@ void main() {
       expect(repointed.rawData, [1, 2, 3]);
       expect(repointed.rawFingerprint, [9, 9]);
     });
+
+    test(
+      'scenario 3a: the carried source records the time offset its '
+      'profile was re-based by, and the primary records none (#1177)',
+      () async {
+        await seedConsolidatableFixture();
+
+        await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+        final sources = await (db.select(
+          db.diveDataSources,
+        )..where((t) => t.diveId.equals('t'))).get();
+
+        // The offset cannot be recovered from the raw bytes, so a re-parse can
+        // only put the secondary strand back on the dive's clock if the number
+        // is persisted here. The fixture's secondary starts 60s after the
+        // target, which is the same shift its profile rows were re-based by.
+        final carried = sources.firstWhere((s) => !s.isPrimary);
+        expect(carried.timeOffsetSeconds, 60);
+
+        // The target's own source was never re-based; claiming an offset for
+        // it would shift the primary strand on the next re-parse.
+        final primary = sources.firstWhere((s) => s.isPrimary);
+        expect(primary.timeOffsetSeconds, anyOf(isNull, 0));
+      },
+    );
 
     test('scenario 3b: secondary with NO dive_data_sources row (manual/file '
         'import) gets a synthesized non-primary source on the target, '
@@ -1158,5 +1192,102 @@ void main() {
         expect(target.exitLongitude, isNull);
       },
     );
+  });
+
+  group('consolidate then re-parse (#1177)', () {
+    test('the secondary strand stays aligned with the primary across a '
+        're-parse of the consolidated dive', () async {
+      await seedDive(
+        't',
+        entry: DateTime.utc(2026, 7, 1, 9),
+        computerId: 'comp-t',
+        serial: 'SER-T',
+        profile: const [
+          domain.DiveProfilePoint(timestamp: 0, depth: 0),
+          domain.DiveProfilePoint(timestamp: 60, depth: 12),
+          domain.DiveProfilePoint(timestamp: 120, depth: 18),
+        ],
+      );
+      await seedDataSource('src-t', diveId: 't', computerId: 'comp-t');
+
+      // The secondary computer's clock runs 60s behind the target's, which
+      // is exactly why consolidation re-bases it.
+      await seedDive(
+        's',
+        entry: DateTime.utc(2026, 7, 1, 9, 1),
+        computerId: 'comp-s',
+        serial: 'SER-S',
+        profile: const [
+          domain.DiveProfilePoint(timestamp: 0, depth: 0),
+          domain.DiveProfilePoint(timestamp: 60, depth: 11),
+          domain.DiveProfilePoint(timestamp: 120, depth: 17),
+        ],
+      );
+      await seedDataSource(
+        'src-s',
+        diveId: 's',
+        computerId: 'comp-s',
+        rawData: Uint8List.fromList([1, 2, 3]),
+        descriptorVendor: 'Suunto',
+        descriptorProduct: 'D5',
+        descriptorModel: 1,
+      );
+
+      await service.apply(targetDiveId: 't', secondaryDiveIds: ['s']);
+
+      final beforeReparse =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.computerId.equals('comp-s'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(beforeReparse.map((p) => p.timestamp), [60, 120, 180]);
+
+      // Re-parse the whole dive, as the dive detail page and a post-upgrade
+      // bulk re-parse from the device page both do.
+      final errors = await ReparseService(db: db).reparseDive(
+        't',
+        parseFn: (vendor, product, model, rawData) async => pigeon.ParsedDive(
+          fingerprint: 'fp',
+          dateTimeYear: 2026,
+          dateTimeMonth: 7,
+          dateTimeDay: 1,
+          dateTimeHour: 9,
+          dateTimeMinute: 1,
+          dateTimeSecond: 0,
+          maxDepthMeters: 17,
+          avgDepthMeters: 10,
+          durationSeconds: 120,
+          // Raw parse output is always on the computer's own clock: it has
+          // no idea consolidation moved it.
+          samples: [
+            pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0),
+            pigeon.ProfileSample(timeSeconds: 60, depthMeters: 11),
+            pigeon.ProfileSample(timeSeconds: 120, depthMeters: 17),
+          ],
+          tanks: const [],
+          gasMixes: const [],
+          events: const [],
+        ),
+      );
+      expect(errors, isEmpty);
+
+      final afterReparse =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.computerId.equals('comp-s'))
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(afterReparse.map((p) => p.timestamp), [60, 120, 180]);
+
+      // The primary strand is untouched, so the two still share a clock.
+      // Consolidation leaves the target's own profile rows on a null
+      // computerId (null means "the dive's primary source"); only tanks,
+      // pressures and events get stamped with the primary computer.
+      final primary =
+          await (db.select(db.diveProfiles)
+                ..where((t) => t.diveId.equals('t') & t.computerId.isNull())
+                ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+              .get();
+      expect(primary.map((p) => p.timestamp), [0, 60, 120]);
+    });
   });
 }


### PR DESCRIPTION
Fixes #1177.

## Problem

`DiveConsolidationService.apply` re-bases a folded-in computer's profile onto the
target dive's timeline (`row.timestamp + offset`), but nothing recorded the offset
it applied. The secondary's `dive_data_sources` row is carried onto the target
verbatim, raw blob included, so `ReparseService` picks it up and
`_replaceDiveProfiles` re-inserts the parsed samples at `s.timeSeconds` with no
offset.

The offset cannot be recovered from the raw bytes, so after a re-parse the
secondary strand slides by `-offset` relative to the primary and the two curves no
longer line up on the multi-computer comparison or any per-source overlay.
`reparseAllForComputer` from the device detail page hits these rows too, so one
bulk re-parse after a libdivecomputer upgrade shifts every consolidated secondary
strand for that computer at once.

Not destructive: the two computers have different `computer_id` values, so the
delete stays scoped to the secondary's own strand. The sample values are correct;
only the time base is wrong.

## Fix

Persist the offset and reapply it.

**Schema v159** adds a nullable `dive_data_sources.time_offset_seconds`. Null and
0 both mean "already on the dive's time base", which is every source that was
never consolidated, so existing rows need no backfill. Added through the usual
idempotent assert helper, called from both the `onUpgrade` ladder and the
`beforeOpen` backstop.

**`DiveConsolidationService.apply`** stamps the offset on the carried source row,
and on the row it synthesizes when the secondary had no source of its own. It
composes (`existing + offset`) rather than overwrites, so a secondary that was
itself consolidated once already stays correct on a second fold, mirroring how
`row.timestamp + offset` composes on the profile rows.

**`ReparseService.applyParsedUpdate`** reads `timeOffsetSeconds ?? 0` and adds it
to the samples it re-inserts into the profile strand, inside #1164's `ownsStrand`
guard.

The offset is applied there and nowhere else, deliberately. The
event/gas-switch/tank-pressure re-inserts are gated on `!isMultiSource`, and a
consolidated dive is always multi-source: `apply()` backfills a primary source row
on the target before folding anything in, so an offset-bearing row never arrives
alone. Were that shape reached some other way the row would be non-primary, which
`_sourceOwnsProfileStrand` already refuses. A test pins that, since it is what
licenses the narrow scope.

`_updateSourceRow` omits the column from its companion, so `Value.absent()` leaves
it untouched and repeated re-parses keep finding it.

## Notes

`minimumCompatibleSchemaVersion` stays at 137. The ladder's own rule is that a new
nullable column does not raise the floor.

Sync needed no serializer change. `dive_data_sources` round-trips through drift's
generated `toJson`/`fromJson` on the whole row rather than a hand-written column
list, so the column flows through for free. That is also why nullable matters: a
payload from a pre-v159 peer omits the key and reads back as null rather than
throwing. Both directions are covered by tests.

`DiveMergeService` re-bases too (`segmentOffsetsSeconds`), but its carried rows
never re-parse the profile, so it does not need the column for correctness.
Stamping it there would be a prerequisite for ever making a merged dive
re-parseable properly, which #1164 left out of scope.

## Interaction with #1164

#1176 landed while this was open and is merged in here. Its
`_sourceOwnsProfileStrand` guard and this change are complementary: the guard
decides *whether* a source may rewrite its strand, this decides *where on the
timeline* the rewrite lands. A consolidated dive keeps a primary source row, so
the guard permits the secondary strand to re-parse, which is exactly the case that
needs the offset. The end-to-end test asserts both halves (`profilesPreserved` is
0, and the strand comes back on the dive's clock).

Resolving the merge also narrowed this PR: the offset plumbing on events, gas
switches and tank pressures is gone, because the guard makes a non-zero offset
unreachable there.

## Interaction with #1149

#1162 landed while this was open and is merged in here too. It claimed schema 158
for the `dive_profiles` owning-source FK, so this migration renumbered to 159; the
ladder entry records that, matching the convention the surrounding entries already
use.

The two changes are independent in `ReparseService._replaceDiveProfiles` and in
`DiveConsolidationService.apply`: #1149's `sourceId` decides *which source owns* a
sample, this decides *where on the timeline* the sample lands. Both are threaded
through the same call sites without interacting.

## Tests

- `migration_v159_source_time_offset_test.dart` (new): ladder membership,
  fresh-schema column, nullability and absence of a default, the `beforeOpen`
  backstop on a database stranded before v159, pre-existing rows reading back
  null, and the helper no-oping when the table is absent.
- `reparse_service_test.dart`: a consolidated source re-parses onto the dive's
  time base; a source with no recorded offset is unaffected; the offset survives
  repeated re-parses; and an offset-bearing row that is a dive's only source is
  refused outright by #1164's guard.
- `dive_consolidation_service_test.dart`: the carried source records the offset
  and the primary records none; plus an end-to-end case that consolidates two
  computers 60s apart, re-parses the dive, and asserts both strands still share a
  clock.
- `sync_extra_entities_round_trip_test.dart`: the offset survives an A -> B round
  trip, and a payload from a pre-v159 peer with no such key still applies.

Each fix was driven from a failing test. The end-to-end case was confirmed to
catch the bug: with the fix temporarily neutered it reports `[0, 60, 120]` where
the primary's clock expects `[60, 120, 180]`.
