### PR TITLE
fix(media): stop the Media section stalling the UI isolate

### DIFF
--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:ui' show Size;
 
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/resolvers/media_fetch_gate.dart';
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
@@ -13,6 +14,22 @@ import 'package:submersion/features/media/domain/services/media_source_resolver.
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
 import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
+
+/// How long a mount-root probe is trusted before it is re-run (#1182).
+///
+/// Short because the cost of being wrong is a stale "volume offline" tile
+/// after the user reconnects a share; long enough that one grid fling does
+/// not re-probe. See [VolumeStatus.newExpiringProbe].
+const Duration kVolumeProbeTtl = Duration(seconds: 5);
+
+/// Ceiling on simultaneous local-file resolutions.
+///
+/// Higher than the media store's cap: a local stat is microseconds against a
+/// healthy disk, so this is not a throughput throttle. It exists for the one
+/// case the volume memo cannot cover -- a mount that is PRESENT but hung,
+/// where the root probe succeeds and every per-file stat behind it still
+/// parks a `dart:io` pool thread until the mount's own timeout.
+const int kLocalResolveConcurrency = 8;
 
 /// Resolves [MediaSourceType.localFile] items across all platforms.
 ///
@@ -43,18 +60,42 @@ class LocalFileResolver implements MediaSourceResolver {
     required ExifExtractor exifExtractor,
     VideoThumbnailService? videoThumbnails,
     VolumeStatus? volumeStatus,
+    Duration volumeProbeTtl = kVolumeProbeTtl,
+    DateTime Function()? clock,
+    MediaFetchGate? gate,
     bool Function()? usesSecurityScopedBookmarks,
   }) : _bookmarkStorage = bookmarkStorage,
        _platform = platform,
        _exifExtractor = exifExtractor,
        _videoThumbnails = videoThumbnails,
-       _volumeStatus = volumeStatus ?? VolumeStatus(),
+       _volumeOnline = (volumeStatus ?? VolumeStatus()).newExpiringProbe(
+         ttl: volumeProbeTtl,
+         clock: clock,
+       ),
+       _gate = gate ?? MediaFetchGate(maxConcurrent: kLocalResolveConcurrency),
        _usesSecurityScopedBookmarks =
            usesSecurityScopedBookmarks ??
            (() => Platform.isIOS || Platform.isMacOS);
 
   final VideoThumbnailService? _videoThumbnails;
-  final VolumeStatus _volumeStatus;
+
+  /// Whether the volume under a path is mounted, memoized per mount root for
+  /// [kVolumeProbeTtl].
+  ///
+  /// This resolver is a long-lived singleton and the highest-volume caller of
+  /// the probe there is: one call per grid tile, and a 140 px grid puts 30-60
+  /// tiles on screen on desktop. Un-memoized, a library on one unreachable
+  /// share paid that share's stat timeout once per tile.
+  ///
+  /// A path on the system volume short-circuits inside the probe before any
+  /// filesystem call, so an all-internal-disk library pays nothing.
+  final Future<bool> Function(String path) _volumeOnline;
+
+  /// Caps simultaneous resolutions and shares one in flight between rows
+  /// pointing at the same file. Its own instance rather than the media
+  /// store's: a dead mount must not consume the budget the gallery needs for
+  /// store fetches.
+  final MediaFetchGate _gate;
 
   /// Whether this host resolves local files through security-scoped
   /// bookmarks (iOS / macOS) rather than a plain path.
@@ -76,11 +117,56 @@ class LocalFileResolver implements MediaSourceResolver {
     return true;
   }
 
+  /// Coalescing key: rows are reference-linked, so the same photo attached to
+  /// two dives is two rows pointing at one file. Sharing one in-flight
+  /// resolution between them saves a stat per row on the same file.
+  ///
+  /// Keyed on BOTH pointers, not just the path. [_resolveInner] falls through
+  /// from the path to the bookmark, so two rows with a common path but
+  /// different bookmarks do not have the same answer -- keying on the path
+  /// alone would hand the second row the first row's bytes whenever the path
+  /// failed. Rows that share a key share every input that resolution reads.
+  ///
+  /// Falls back to the row id when neither pointer is set, so rows that
+  /// cannot resolve anything never share one another's result.
+  static String _gateKey(MediaItem item) {
+    final path = item.localPath ?? item.filePath ?? '';
+    final ref = item.bookmarkRef ?? '';
+    if (path.isEmpty && ref.isEmpty) return item.id;
+    // NUL separator: it cannot occur in a filesystem path or a keychain
+    // ref, so no (path, ref) pair can collide with a different pair.
+    return '$path\u0000$ref';
+  }
+
   @override
   Future<MediaSourceData> resolve(MediaItem item) async {
+    final data = await _gate.run(_gateKey(item), () => _resolveInner(item));
+    // [MediaFetchGate]'s payload is nullable for the media store, where null
+    // means "not in the store". _resolveInner is declared non-nullable and
+    // always answers, so this fallback cannot be reached; it is written as a
+    // total function rather than a `!` so a future change cannot turn a
+    // resolver bug into a crash on a grid tile.
+    return data ?? const UnavailableData(kind: UnavailableKind.notFound);
+  }
+
+  Future<MediaSourceData> _resolveInner(MediaItem item) async {
     // Desktop path: localPath set, no bookmark needed.
     final localPath = item.localPath ?? item.filePath;
     if (localPath != null && localPath.isNotEmpty) {
+      // Ask whether the volume is even mounted BEFORE touching the file
+      // (#1182). The check used to sit after the exists() below, which meant
+      // a library on a dead share paid a per-tile stat against that share --
+      // each one parking a `dart:io` pool thread until the mount timed out --
+      // and only then consulted a probe that could have answered for free.
+      // Both databases run on this isolate with a synchronous
+      // NativeDatabase, so starving that pool stalls SQLite too, which is how
+      // a thumbnail problem became an app-wide freeze.
+      //
+      // Costs nothing for a path on the system volume: the probe resolves
+      // those without a filesystem call at all.
+      if (!await _volumeOnlineOrAssumed(localPath)) {
+        return const UnavailableData(kind: UnavailableKind.volumeOffline);
+      }
       try {
         final f = File(localPath);
         // Existence alone is not enough: the macOS sandbox allows STAT on
@@ -108,7 +194,7 @@ class LocalFileResolver implements MediaSourceResolver {
         // Missing file on an unmounted volume (network share, external
         // disk) is a temporary condition, not a dead pointer: report it
         // as such so nothing orphans the row while the share is offline.
-        if (!await _volumeStatus.isVolumeOnline(localPath)) {
+        if (!await _volumeOnlineOrAssumed(localPath)) {
           return const UnavailableData(kind: UnavailableKind.volumeOffline);
         }
       }
@@ -121,7 +207,7 @@ class LocalFileResolver implements MediaSourceResolver {
         // Offline network mounts commonly THROW here rather than return
         // false; an offline volume must still read volumeOffline, not
         // fall through to a hard notFound (which cleanup could orphan).
-        if (!await _volumeStatus.isVolumeOnline(localPath)) {
+        if (!await _volumeOnlineOrAssumed(localPath)) {
           return const UnavailableData(kind: UnavailableKind.volumeOffline);
         }
         // Otherwise fall through to bookmark path or unavailable.
@@ -185,6 +271,22 @@ class LocalFileResolver implements MediaSourceResolver {
     }
 
     return const UnavailableData(kind: UnavailableKind.notFound);
+  }
+
+  /// [_volumeOnline], with a probe that itself failed treated as online.
+  ///
+  /// The probe is a filesystem call and can throw on the exact mounts it
+  /// exists to classify. Reporting volumeOffline on a throw would be a guess;
+  /// assuming online falls through to the file itself, which is what this
+  /// resolver did before the probe was hoisted ahead of it, and lets the
+  /// existing exists() / open() path produce the real answer.
+  Future<bool> _volumeOnlineOrAssumed(String path) async {
+    try {
+      return await _volumeOnline(path);
+    } on FileSystemException catch (e) {
+      _log.debug('Volume probe failed for $path; assuming online', error: e);
+      return true;
+    }
   }
 
   /// Returns null when [f] can actually be opened for reading, otherwise the

--- a/lib/features/media/data/services/repair/watched_folder_scanner.dart
+++ b/lib/features/media/data/services/repair/watched_folder_scanner.dart
@@ -1,12 +1,10 @@
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-
 import 'package:submersion/core/services/logger_service.dart';
-import 'package:submersion/core/services/media_store/store_keys.dart';
 import 'package:submersion/features/media/data/repositories/media_repair_log_repository.dart';
 import 'package:submersion/features/media/data/repositories/watched_folder_repository.dart';
 import 'package:submersion/features/media/data/services/repair/media_repair_service.dart';
+import 'package:submersion/features/media/data/services/repair/watched_folder_walk.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/services/media_repair_types.dart';
 
@@ -27,12 +25,24 @@ class WatcherScanReport {
     required this.filesIndexed,
     required this.rehashed,
     required this.autoRepaired,
+    this.hashBudgetExhausted = false,
   });
 
   final int filesIndexed;
   final int rehashed;
   final int autoRepaired;
+
+  /// True when at least one root ran out of hashing budget. The pass is still
+  /// stamped, so the remainder is picked up on the next daily run -- every
+  /// file hashed this pass is an unchanged file next pass, so the backlog
+  /// only ever shrinks.
+  final bool hashBudgetExhausted;
 }
+
+/// Walks one root and hashes what changed. Injected so tests can run the walk
+/// in-process; production hands it to a background isolate.
+typedef WatchedFolderWalk =
+    Future<WatchedFolderWalkResult> Function(WatchedFolderWalkRequest request);
 
 /// Maintains the watched-folder index and auto-repairs missing media whose
 /// bytes turn up under a watched root (Media section Phase 5).
@@ -46,7 +56,18 @@ class WatchedFolderScanner {
     required this.repair,
     required this.loadMissingRows,
     required this.isAutoApplyEnabled,
-  });
+    WatchedFolderWalk? walk,
+    this.hashBudget = kDefaultHashBudget,
+  }) : walk = walk ?? walkWatchedFolderInIsolate;
+
+  /// Where the listing, the per-file `stat` and the SHA-256 actually happen.
+  ///
+  /// Defaults to the background isolate. All of it used to run here, on the
+  /// UI isolate, kicked from a widget `build()` (#1182).
+  final WatchedFolderWalk walk;
+
+  /// Ceiling on time spent hashing per root, per pass.
+  final Duration hashBudget;
 
   final WatchedFolderRepository watched;
   final MediaRepairService repair;
@@ -66,6 +87,7 @@ class WatchedFolderScanner {
   Future<WatcherScanReport> scan({required DateTime now}) async {
     var filesIndexed = 0;
     var rehashed = 0;
+    var budgetExhausted = false;
 
     for (final root in await watched.getRoots()) {
       final dir = Directory(root);
@@ -75,57 +97,56 @@ class WatchedFolderScanner {
       }
 
       final stored = await watched.indexForRoot(root);
-      final seen = <String>{};
-      var listingComplete = true;
 
-      try {
-        await for (final entity in dir.list(
-          recursive: true,
-          followLinks: false,
-        )) {
-          if (entity is! File) continue;
-          // p.relative handles the platform separator and a root written
-          // with a trailing one. Hand-rolled prefix stripping produced the
-          // whole absolute path on Windows, which then got written into
-          // media.local_path as a healthy pointer to nothing.
-          final relative = p.relative(entity.path, from: root);
-          seen.add(relative);
-          filesIndexed++;
+      // Everything expensive happens over there: the recursive listing, the
+      // per-file stat and the SHA-256 of whatever changed. What comes back is
+      // bounded by the CHANGES, not by the size of the tree, and every drift
+      // write below stays on this isolate where the database lives.
+      final result = await walk(
+        WatchedFolderWalkRequest(
+          rootPath: root,
+          known: {
+            for (final entry in stored.entries)
+              entry.key: KnownFile(
+                sizeBytes: entry.value.sizeBytes,
+                mtimeMillis: entry.value.mtimeMillis,
+                contentHash: entry.value.contentHash,
+              ),
+          },
+          hashBudget: hashBudget,
+        ),
+      );
 
-          final stat = await entity.stat();
-          final mtime = stat.modified.millisecondsSinceEpoch;
-          final previous = stored[relative];
-          final unchanged =
-              previous != null &&
-              previous.contentHash != null &&
-              previous.sizeBytes == stat.size &&
-              previous.mtimeMillis == mtime;
-          if (unchanged) continue;
-
-          // Changed, new, or never hashed: this is the only path that pays
-          // for a full read.
-          final digest = await sha256OfFile(entity);
-          rehashed++;
-          await watched.upsertIndexed(
-            IndexedFile(
-              rootPath: root,
-              relativePath: relative,
-              sizeBytes: digest.sizeBytes,
-              mtimeMillis: mtime,
-              contentHash: digest.hash,
-            ),
-          );
-        }
-      } on FileSystemException catch (e) {
-        // Partial coverage is fine: an unreadable subtree just contributes
-        // nothing this pass. But `seen` is now incomplete, so pruning
-        // against it would delete index rows for files that still exist.
-        listingComplete = false;
-        _log.warning('Watched scan failed under $root: $e');
+      filesIndexed += result.filesSeen;
+      rehashed += result.hashedCount;
+      if (!result.listingComplete) {
+        _log.warning('Watched scan could not fully list $root');
+      }
+      if (result.hashBudgetExhausted) {
+        budgetExhausted = true;
+        _log.info(
+          'Hash budget spent under $root; the rest is picked up next pass',
+        );
       }
 
-      if (listingComplete) {
-        await watched.deleteIndexed(root, stored.keys.toSet().difference(seen));
+      for (final file in result.changed) {
+        await watched.upsertIndexed(
+          IndexedFile(
+            rootPath: root,
+            relativePath: file.relativePath,
+            sizeBytes: file.sizeBytes,
+            mtimeMillis: file.mtimeMillis,
+            contentHash: file.contentHash,
+          ),
+        );
+      }
+
+      // Judged against the LISTING, not the hashing: the budget only ever
+      // denies a hash, so a truncated pass still saw every file and pruning
+      // stays safe. The walk already took the difference against `stored`, so
+      // only the rows that need deleting crossed back.
+      if (result.listingComplete && result.vanished.isNotEmpty) {
+        await watched.deleteIndexed(root, result.vanished);
       }
       // Stamped even after a partial listing, on purpose. The stamp drives
       // the daily cadence, and the cadence gate treats a null stamp as
@@ -143,6 +164,7 @@ class WatchedFolderScanner {
         filesIndexed: filesIndexed,
         rehashed: rehashed,
         autoRepaired: 0,
+        hashBudgetExhausted: budgetExhausted,
       );
     }
 
@@ -184,6 +206,7 @@ class WatchedFolderScanner {
         filesIndexed: filesIndexed,
         rehashed: rehashed,
         autoRepaired: 0,
+        hashBudgetExhausted: budgetExhausted,
       );
     }
 
@@ -195,6 +218,7 @@ class WatchedFolderScanner {
       filesIndexed: filesIndexed,
       rehashed: rehashed,
       autoRepaired: report.relinked,
+      hashBudgetExhausted: budgetExhausted,
     );
   }
 }

--- a/lib/features/media/data/services/repair/watched_folder_scanner.dart
+++ b/lib/features/media/data/services/repair/watched_folder_scanner.dart
@@ -145,6 +145,11 @@ class WatchedFolderScanner {
       // denies a hash, so a truncated pass still saw every file and pruning
       // stays safe. The walk already took the difference against `stored`, so
       // only the rows that need deleting crossed back.
+      //
+      // The `listingComplete` half is belt and braces -- the walk returns an
+      // empty `vanished` for an incomplete listing -- but it keeps the rule
+      // that governs a DESTRUCTIVE write visible at the site of that write,
+      // rather than resting on a guarantee made in another isolate.
       if (result.listingComplete && result.vanished.isNotEmpty) {
         await watched.deleteIndexed(root, result.vanished);
       }

--- a/lib/features/media/data/services/repair/watched_folder_walk.dart
+++ b/lib/features/media/data/services/repair/watched_folder_walk.dart
@@ -101,15 +101,17 @@ class WatchedFolderWalkResult {
   /// channel and be deserialized ON THE UI ISOLATE, work proportional to the
   /// archive and exactly what moving the walk off it was meant to avoid.
   ///
-  /// Only meaningful when [listingComplete]: a partial listing did not reach
-  /// every file, so paths missing from it may still exist.
+  /// Always empty when [listingComplete] is false: a partial listing did not
+  /// reach every file, so a path missing from it may still exist. Enforced
+  /// here rather than left to the caller, both because the difference would
+  /// be meaningless and because it would be unboundedly large.
   final Set<String> vanished;
 
   final int filesSeen;
 
   /// False when the listing threw part-way (an unreadable subtree, a root
-  /// that vanished). [vanished] is then unreliable and MUST NOT drive a
-  /// prune: a file the listing never reached is not a file that is gone.
+  /// that vanished), which is why [vanished] is empty in that case: a file
+  /// the listing never reached is not a file that is gone.
   final bool listingComplete;
 
   /// True when at least one file went un-hashed for want of budget. Does not
@@ -229,10 +231,20 @@ Future<WatchedFolderWalkResult> walkWatchedFolder(
     changed: changed,
     // The difference is taken here, on this isolate, so only the rows that
     // actually need deleting travel back.
-    vanished: {
-      for (final relative in request.known.keys)
-        if (!seen.contains(relative)) relative,
-    },
+    //
+    // Skipped entirely when the listing was cut short. An incomplete listing
+    // has not shown that anything is gone, so the difference would be
+    // meaningless -- and in the worst case (a root that threw immediately,
+    // which is a watched folder on an unplugged drive) it is the ENTIRE
+    // stored index, serialized across the boundary for the caller to
+    // discard. That is the payload this walk exists to avoid, in the
+    // commonest failure mode there is.
+    vanished: listingComplete
+        ? {
+            for (final relative in request.known.keys)
+              if (!seen.contains(relative)) relative,
+          }
+        : const <String>{},
     filesSeen: filesSeen,
     listingComplete: listingComplete,
     hashBudgetExhausted: budgetExhausted,

--- a/lib/features/media/data/services/repair/watched_folder_walk.dart
+++ b/lib/features/media/data/services/repair/watched_folder_walk.dart
@@ -1,0 +1,240 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show compute, immutable;
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/core/services/media_store/store_keys.dart';
+
+/// Default ceiling on time spent hashing in one pass (issue #1182).
+///
+/// Wall clock rather than a file count on purpose: a count that finishes in
+/// seconds against a local SSD is an hour against a NAS export, so a count
+/// cannot bound the thing that actually hurts. A deadline self-scales, and
+/// fast hardware still finishes an ordinary library in a single pass.
+const Duration kDefaultHashBudget = Duration(seconds: 60);
+
+/// What the index already knows about one file, as the walk needs it.
+///
+/// A plain record rather than `IndexedFile` so nothing from the drift layer
+/// has to be sendable to (or imported by) the background isolate.
+@immutable
+class KnownFile {
+  const KnownFile({
+    required this.sizeBytes,
+    required this.mtimeMillis,
+    required this.contentHash,
+  });
+
+  final int sizeBytes;
+  final int mtimeMillis;
+
+  /// Null when the file is known but has never been hashed, which forces a
+  /// hash on the next pass regardless of its stat.
+  final String? contentHash;
+}
+
+/// One root to walk, plus everything needed to decide what to hash.
+@immutable
+class WatchedFolderWalkRequest {
+  const WatchedFolderWalkRequest({
+    required this.rootPath,
+    required this.known,
+    required this.hashBudget,
+  });
+
+  final String rootPath;
+
+  /// The stored index for this root, keyed by relative path. Passed in so the
+  /// "unchanged, skip the hash" decision happens inside the isolate: sending
+  /// every candidate back to be filtered would put the whole archive on the
+  /// message channel.
+  final Map<String, KnownFile> known;
+
+  /// Ceiling on time spent hashing. See [kDefaultHashBudget].
+  final Duration hashBudget;
+}
+
+/// One file the walk decided the index should change for.
+@immutable
+class WalkedFile {
+  const WalkedFile({
+    required this.relativePath,
+    required this.sizeBytes,
+    required this.mtimeMillis,
+    required this.contentHash,
+  });
+
+  final String relativePath;
+  final int sizeBytes;
+  final int mtimeMillis;
+
+  /// Null when the budget denied the hash. Only ever null for a file that
+  /// was already indexed WITH a hash and has since changed: writing the new
+  /// stat with a null hash retires a digest that no longer describes the
+  /// bytes, which matters because the auto-repair pass rewrites
+  /// `media.local_path` on an exact hash match. A null hash is inert there
+  /// (`pathsForHashes` matches with SQL `IN`, which never matches NULL) and
+  /// forces a re-hash next pass.
+  final String? contentHash;
+}
+
+/// What one walk found.
+@immutable
+class WatchedFolderWalkResult {
+  const WatchedFolderWalkResult({
+    required this.changed,
+    required this.vanished,
+    required this.filesSeen,
+    required this.listingComplete,
+    required this.hashBudgetExhausted,
+  });
+
+  /// Index rows to write. Bounded by what actually changed, not by the size
+  /// of the tree.
+  final List<WalkedFile> changed;
+
+  /// Index entries whose file was NOT found this pass: the prune list.
+  ///
+  /// Computed here rather than by returning every path seen. The caller needs
+  /// `known.keys - seen`, and that difference is normally empty, whereas
+  /// `seen` is the size of the whole tree -- which would cross the message
+  /// channel and be deserialized ON THE UI ISOLATE, work proportional to the
+  /// archive and exactly what moving the walk off it was meant to avoid.
+  ///
+  /// Only meaningful when [listingComplete]: a partial listing did not reach
+  /// every file, so paths missing from it may still exist.
+  final Set<String> vanished;
+
+  final int filesSeen;
+
+  /// False when the listing threw part-way (an unreadable subtree, a root
+  /// that vanished). [vanished] is then unreliable and MUST NOT drive a
+  /// prune: a file the listing never reached is not a file that is gone.
+  final bool listingComplete;
+
+  /// True when at least one file went un-hashed for want of budget. Does not
+  /// affect pruning: the budget only ever denies a hash, never a listing.
+  final bool hashBudgetExhausted;
+
+  /// How many files were actually hashed this pass.
+  int get hashedCount => changed.where((f) => f.contentHash != null).length;
+}
+
+/// Runs [walkWatchedFolder] on a background isolate.
+///
+/// The production seam. Before #1182 the walk, the per-file `stat` and the
+/// SHA-256 of every new or changed file all ran on the UI isolate, kicked
+/// from `MediaSectionPage.build()`. `sha256OfFile` yields between chunks so
+/// it never blocked outright, but it competed for the same event loop as
+/// every frame, and the recursive listing saturated the `dart:io` thread pool
+/// that drift's SQLite depends on -- so a large watched tree took the
+/// database down with the gallery.
+///
+/// `compute` with a single sendable argument follows the convention already
+/// set by `ExifExtractor` and `ImageResizeJob`.
+Future<WatchedFolderWalkResult> walkWatchedFolderInIsolate(
+  WatchedFolderWalkRequest request,
+) => compute(walkWatchedFolder, request);
+
+/// Lists [WatchedFolderWalkRequest.rootPath], stats every file under it, and
+/// hashes the ones that are new or whose stat has moved.
+///
+/// Top-level and free of drift, Riverpod and Flutter bindings so it can be a
+/// `compute` entrypoint. Every database write the pass implies is left to the
+/// caller, on the main isolate.
+Future<WatchedFolderWalkResult> walkWatchedFolder(
+  WatchedFolderWalkRequest request,
+) async {
+  final root = request.rootPath;
+  final changed = <WalkedFile>[];
+  final seen = <String>{};
+  var filesSeen = 0;
+  var listingComplete = true;
+  var budgetExhausted = false;
+
+  // Accumulates ONLY the time spent hashing. Budgeting the whole walk would
+  // starve a large archive: re-statting the files already indexed would eat
+  // the deadline before the pass reached anything new, so the same prefix
+  // would be re-walked every day and the tail would never be indexed.
+  // Charging the budget for hashing alone guarantees forward progress --
+  // every file hashed becomes an unchanged file next pass.
+  final hashing = Stopwatch();
+
+  try {
+    await for (final entity in Directory(
+      root,
+    ).list(recursive: true, followLinks: false)) {
+      if (entity is! File) continue;
+      // p.relative handles the platform separator and a root written with a
+      // trailing one. Hand-rolled prefix stripping produced the whole
+      // absolute path on Windows, which then got written into
+      // media.local_path as a healthy pointer to nothing.
+      final relative = p.relative(entity.path, from: root);
+      seen.add(relative);
+      filesSeen++;
+
+      final stat = await entity.stat();
+      final mtime = stat.modified.millisecondsSinceEpoch;
+      final previous = request.known[relative];
+      final unchanged =
+          previous != null &&
+          previous.contentHash != null &&
+          previous.sizeBytes == stat.size &&
+          previous.mtimeMillis == mtime;
+      if (unchanged) continue;
+
+      if (hashing.elapsed >= request.hashBudget) {
+        budgetExhausted = true;
+        // A file already indexed WITH a hash has just been shown to have
+        // changed. Retire that hash now even though there is no budget to
+        // compute the new one -- see [WalkedFile.contentHash]. A file that
+        // was never indexed has nothing stale to correct, so it is simply
+        // left for the next pass.
+        if (previous?.contentHash != null) {
+          changed.add(
+            WalkedFile(
+              relativePath: relative,
+              sizeBytes: stat.size,
+              mtimeMillis: mtime,
+              contentHash: null,
+            ),
+          );
+        }
+        continue;
+      }
+
+      // New, changed, or never hashed: the only path that pays for a full
+      // read.
+      hashing.start();
+      final digest = await sha256OfFile(entity);
+      hashing.stop();
+      changed.add(
+        WalkedFile(
+          relativePath: relative,
+          sizeBytes: digest.sizeBytes,
+          mtimeMillis: mtime,
+          contentHash: digest.hash,
+        ),
+      );
+    }
+  } on FileSystemException {
+    // Partial coverage is fine: an unreadable subtree just contributes
+    // nothing this pass. But the listing is now incomplete, so pruning
+    // against it would delete index rows for files that still exist. The
+    // caller reads [listingComplete] for exactly that.
+    listingComplete = false;
+  }
+
+  return WatchedFolderWalkResult(
+    changed: changed,
+    // The difference is taken here, on this isolate, so only the rows that
+    // actually need deleting travel back.
+    vanished: {
+      for (final relative in request.known.keys)
+        if (!seen.contains(relative)) relative,
+    },
+    filesSeen: filesSeen,
+    listingComplete: listingComplete,
+    hashBudgetExhausted: budgetExhausted,
+  );
+}

--- a/lib/features/media/data/services/volume_status.dart
+++ b/lib/features/media/data/services/volume_status.dart
@@ -97,4 +97,66 @@ class VolumeStatus {
       return byRoot.putIfAbsent(root, () => _directoryExists(root));
     };
   }
+
+  /// An [isVolumeOnline] for callers with no pass to scope a memo to, where
+  /// [newPassProbe] cannot be used and a plain [isVolumeOnline] costs one
+  /// stat per call.
+  ///
+  /// `LocalFileResolver` is the case this exists for (#1182): it is a
+  /// singleton resolving one grid tile at a time, and a 140 px grid puts
+  /// 30-60 tiles on screen on desktop. Per-call it paid an unreachable
+  /// share's stat timeout once per tile, each one parking a `dart:io` pool
+  /// thread that drift's SQLite also needs -- which is how a thumbnail
+  /// problem became an app-wide freeze.
+  ///
+  /// [ttl] is measured from when a probe COMPLETES, and an in-flight probe
+  /// never expires. Both matter: a mount that hangs for longer than [ttl]
+  /// would otherwise expire mid-probe and let the next caller start a second
+  /// hang, which is the stall this exists to prevent. A bounded [ttl] is
+  /// also what makes a long-lived memo safe at all -- see [newPassProbe],
+  /// whose per-pass scoping exists because a cache that never expired would
+  /// keep reporting a volume offline after the user plugged it back in. Here
+  /// that window is one [ttl], not the life of the process.
+  ///
+  /// [clock] is injectable so tests can age the memo without waiting.
+  Future<bool> Function(String path) newExpiringProbe({
+    required Duration ttl,
+    DateTime Function()? clock,
+    String? platformOverride,
+  }) {
+    final now = clock ?? DateTime.now;
+    final byRoot = <String, _ExpiringProbe>{};
+    return (path) {
+      final root = volumeRootOf(path, platformOverride: platformOverride);
+      if (root == null) return Future.value(true);
+      final cached = byRoot[root];
+      if (cached != null && !cached.isStale(now(), ttl)) return cached.future;
+      final entry = _ExpiringProbe(_directoryExists(root));
+      byRoot[root] = entry;
+      // Stamped on completion, either way. A probe that THREW is still an
+      // answer that cost a filesystem round-trip, and re-running it for
+      // every tile is the same stall as never memoizing at all.
+      entry.future.then(
+        (_) => entry.completedAt = now(),
+        onError: (Object _) => entry.completedAt = now(),
+      );
+      return entry.future;
+    };
+  }
+}
+
+/// One memoized mount-root probe and when it finished.
+class _ExpiringProbe {
+  _ExpiringProbe(this.future);
+
+  final Future<bool> future;
+  DateTime? completedAt;
+
+  bool isStale(DateTime now, Duration ttl) {
+    final at = completedAt;
+    // Still running: never stale. Expiring an in-flight probe would let the
+    // next caller start a second one against the same unreachable mount.
+    if (at == null) return false;
+    return now.difference(at) >= ttl;
+  }
 }

--- a/lib/features/media/presentation/pages/media_section_page.dart
+++ b/lib/features/media/presentation/pages/media_section_page.dart
@@ -26,10 +26,25 @@ class _MediaSectionPageState extends ConsumerState<MediaSectionPage> {
   MediaConsoleSection _section = MediaConsoleSection.library;
 
   @override
+  void initState() {
+    super.initState();
+    // Opportunistic watcher pass, gated to once a day inside the provider:
+    // the console is the app's stand-in for a startup hook.
+    //
+    // Kicked from initState behind a post-frame callback, NOT from build().
+    // The pass walks every watched root recursively, and hanging that off a
+    // build meant it started while the section was still laying out (#1182).
+    // After the frame, the console is on screen before any filesystem work
+    // begins, and the guard inside WatcherAutoScan keeps a remount from
+    // starting a second overlapping pass.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(watcherAutoScanProvider).kick();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // Opportunistic watcher pass, gated to once a day inside the
-    // provider: the console is the app's stand-in for a startup hook.
-    ref.watch(watcherAutoScanProvider);
     final unlinkedCount = ref.watch(unlinkedCountProvider).value ?? 0;
     final missingCount = ref.watch(missingCountProvider).value ?? 0;
 

--- a/lib/features/media/presentation/providers/media_watcher_providers.dart
+++ b/lib/features/media/presentation/providers/media_watcher_providers.dart
@@ -107,20 +107,57 @@ final watcherScannerProvider = Provider<WatchedFolderScanner>((ref) {
   );
 });
 
-// no-tick: this is a side effect, not a cached query -- recomputing it
-// re-runs a filesystem scan that can rewrite media.local_path. Subscribing to
-// a tick would make every media write trigger another scan, and the scan
-// itself writes media, so the tick would drive it in a loop.
-/// Opportunistic automatic pass, read once when the Media console builds.
+/// Runs the opportunistic watcher pass, at most one at a time.
 ///
-/// The app has no startup-maintenance host, so the console is the hook;
-/// the daily [shouldAutoScan] gate keeps that from meaning "every time you
-/// open the section". Fire-and-forget and failure-swallowing on purpose: a
-/// scan problem must never break the section that triggered it.
-final watcherAutoScanProvider = Provider<void>((ref) {
-  unawaited(() async {
+/// Deliberately an object with a method rather than a `Provider<void>` whose
+/// constructor fires the scan. That older shape meant the only way to trigger
+/// a pass was to `ref.watch` it from `MediaSectionPage.build()`, which welded
+/// a recursive filesystem walk to a widget's build phase (#1182) -- a section
+/// opening is a strange place to start unbounded filesystem work, and the
+/// once-per-provider-construction firing was an accident of Riverpod caching
+/// rather than a decision anyone made.
+///
+/// [kick] carries the re-entrancy guard that the old shape got for free: an
+/// explicit call can arrive again on the next mount (a tab switch, a route
+/// pop), and the daily cadence gate alone would not stop a long pass from
+/// overlapping itself.
+class WatcherAutoScan {
+  WatcherAutoScan(this._ref);
+
+  final Ref _ref;
+  Future<void>? _inFlight;
+
+  static const _log = LoggerService('WatcherAutoScan');
+
+  /// Fire-and-forget entry point for UI callers.
+  ///
+  /// Failure-swallowing on purpose: a scan problem must never break the
+  /// section that triggered it.
+  void kick() => unawaited(run());
+
+  /// The awaitable form, for tests and for anything that wants to know when
+  /// the pass finished. Returns the running pass when one is already going.
+  Future<void> run() {
+    final running = _inFlight;
+    if (running != null) return running;
+    // `_run()` is `async`, so it suspends at its first `await` and returns
+    // before the assignment below -- the field is always populated before
+    // any second caller can observe it.
+    final started = _run().whenComplete(() => _inFlight = null);
+    _inFlight = started;
+    return started;
+  }
+
+  Future<void> _run() async {
+    // Yield before touching a provider. Callers reach this from a widget
+    // lifecycle, and an `async` body runs synchronously up to its first
+    // await -- so a provider initialized here would be initialized during
+    // the build phase, which Riverpod turns into "setState() or
+    // markNeedsBuild() called during build". Same defense as
+    // `MediaItemView._resolveInner`.
+    await null;
     try {
-      final watched = ref.read(watchedFolderRepositoryProvider);
+      final watched = _ref.read(watchedFolderRepositoryProvider);
       final roots = await watched.getRoots();
       if (roots.isEmpty) return;
       // The oldest root's stamp drives the cadence: if any root is due, the
@@ -136,17 +173,28 @@ final watcherAutoScanProvider = Provider<void>((ref) {
       }
       if (!shouldAutoScan(lastScanAt: oldest, now: DateTime.now())) return;
 
-      final report = await ref
+      final report = await _ref
           .read(watcherScannerProvider)
           .scan(now: DateTime.now());
-      LoggerService.forClass(WatchedFolderScanner).info(
+      _log.info(
         'Watcher scan: ${report.filesIndexed} indexed, '
-        '${report.rehashed} hashed, ${report.autoRepaired} auto-repaired',
+        '${report.rehashed} hashed, ${report.autoRepaired} auto-repaired'
+        '${report.hashBudgetExhausted ? ' (hash budget spent)' : ''}',
       );
     } catch (e) {
-      LoggerService.forClass(
-        WatchedFolderScanner,
-      ).warning('Watcher scan failed', error: e);
+      _log.warning('Watcher scan failed', error: e);
     }
-  }());
-});
+  }
+}
+
+// no-tick: this is a side effect, not a cached query -- running it re-runs a
+// filesystem scan that can rewrite media.local_path. Subscribing to a tick
+// would make every media write trigger another scan, and the scan itself
+// writes media, so the tick would drive it in a loop.
+/// Host for the opportunistic automatic pass.
+///
+/// The app has no startup-maintenance host, so the Media console is the hook;
+/// the daily [shouldAutoScan] gate keeps that from meaning "every time you
+/// open the section". Constructing this provider does nothing -- the caller
+/// has to ask, via [WatcherAutoScan.kick].
+final watcherAutoScanProvider = Provider<WatcherAutoScan>(WatcherAutoScan.new);

--- a/test/features/media/data/repair/watched_folder_scanner_test.dart
+++ b/test/features/media/data/repair/watched_folder_scanner_test.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/media/data/repositories/media_repository.dar
 import 'package:submersion/features/media/data/repositories/watched_folder_repository.dart';
 import 'package:submersion/features/media/data/services/repair/media_repair_service.dart';
 import 'package:submersion/features/media/data/services/repair/watched_folder_scanner.dart';
+import 'package:submersion/features/media/data/services/repair/watched_folder_walk.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
@@ -306,6 +307,213 @@ void main() {
 
       expect((await watched.indexForRoot(root.path)).keys, ['a.jpg']);
       await root.create(recursive: true);
+    });
+
+    group('the walk is delegated, not performed here', () {
+      test('the scanner does no filesystem work of its own', () async {
+        await writeFile('a.jpg', 'aaaa');
+        // A walk that reports a file the scanner can never have seen: if the
+        // scanner still listed the root itself, 'a.jpg' would show up in the
+        // index alongside (or instead of) this.
+        final scanned = <WatchedFolderWalkRequest>[];
+        final report = await WatchedFolderScanner(
+          watched: watched,
+          repair: repair,
+          loadMissingRows: () async => const [],
+          isAutoApplyEnabled: () async => false,
+          walk: (request) async {
+            scanned.add(request);
+            return const WatchedFolderWalkResult(
+              changed: [
+                WalkedFile(
+                  relativePath: 'from-the-walk.jpg',
+                  sizeBytes: 7,
+                  mtimeMillis: 1234,
+                  contentHash: 'walk-hash',
+                ),
+              ],
+              vanished: {},
+              filesSeen: 1,
+              listingComplete: true,
+              hashBudgetExhausted: false,
+            );
+          },
+        ).scan(now: DateTime(2026, 6, 12));
+
+        expect(scanned.single.rootPath, root.path);
+        expect(report.filesIndexed, 1);
+        expect(report.rehashed, 1);
+        final index = await watched.indexForRoot(root.path);
+        expect(index.keys, ['from-the-walk.jpg']);
+        expect(index['from-the-walk.jpg']!.contentHash, 'walk-hash');
+      });
+
+      test(
+        'the stored index is handed to the walk so it can skip hashes',
+        () async {
+          await writeFile('a.jpg', 'aaaa');
+          await scanner().scan(now: DateTime(2026, 6, 12));
+
+          WatchedFolderWalkRequest? seenRequest;
+          await WatchedFolderScanner(
+            watched: watched,
+            repair: repair,
+            loadMissingRows: () async => const [],
+            isAutoApplyEnabled: () async => false,
+            walk: (request) async {
+              seenRequest = request;
+              return const WatchedFolderWalkResult(
+                changed: [],
+                vanished: {},
+                filesSeen: 1,
+                listingComplete: true,
+                hashBudgetExhausted: false,
+              );
+            },
+          ).scan(now: DateTime(2026, 6, 13));
+
+          final known = seenRequest!.known['a.jpg']!;
+          expect(known.contentHash, isNotNull);
+          expect(known.sizeBytes, 4);
+        },
+      );
+
+      test('the configured hash budget reaches the walk', () async {
+        WatchedFolderWalkRequest? seenRequest;
+        await WatchedFolderScanner(
+          watched: watched,
+          repair: repair,
+          loadMissingRows: () async => const [],
+          isAutoApplyEnabled: () async => false,
+          hashBudget: const Duration(seconds: 7),
+          walk: (request) async {
+            seenRequest = request;
+            return const WatchedFolderWalkResult(
+              changed: [],
+              vanished: {},
+              filesSeen: 0,
+              listingComplete: true,
+              hashBudgetExhausted: false,
+            );
+          },
+        ).scan(now: DateTime(2026, 6, 12));
+
+        expect(seenRequest!.hashBudget, const Duration(seconds: 7));
+      });
+    });
+
+    group('hash budget', () {
+      Future<WatcherScanReport> scanWith(
+        WatchedFolderWalkResult result, {
+        DateTime? now,
+      }) => WatchedFolderScanner(
+        watched: watched,
+        repair: repair,
+        loadMissingRows: () async => const [],
+        isAutoApplyEnabled: () async => false,
+        walk: (_) async => result,
+      ).scan(now: now ?? DateTime(2026, 6, 13));
+
+      test(
+        'an exhausted budget still prunes, because the listing was whole',
+        () async {
+          await writeFile('a.jpg', 'aaaa');
+          await writeFile('gone.jpg', 'zzzz');
+          await scanner().scan(now: DateTime(2026, 6, 12));
+
+          final report = await scanWith(
+            const WatchedFolderWalkResult(
+              changed: [],
+              vanished: {'gone.jpg'},
+              filesSeen: 1,
+              listingComplete: true,
+              hashBudgetExhausted: true,
+            ),
+          );
+
+          expect(report.hashBudgetExhausted, isTrue);
+          expect((await watched.indexForRoot(root.path)).keys, ['a.jpg']);
+        },
+      );
+
+      test(
+        'an incomplete listing prunes nothing, budget or no budget',
+        () async {
+          await writeFile('a.jpg', 'aaaa');
+          await writeFile('b.jpg', 'bbbb');
+          await scanner().scan(now: DateTime(2026, 6, 12));
+
+          await scanWith(
+            const WatchedFolderWalkResult(
+              changed: [],
+              // The walk names 'b.jpg' as vanished, but its listing threw
+              // part-way, so that claim is not trustworthy.
+              vanished: {'b.jpg'},
+              filesSeen: 1,
+              listingComplete: false,
+              hashBudgetExhausted: false,
+            ),
+          );
+
+          // 'b.jpg' was never listed, so it must survive: a partial listing
+          // that pruned would delete the index rows of files that still exist.
+          expect((await watched.indexForRoot(root.path)).keys.toSet(), {
+            'a.jpg',
+            'b.jpg',
+          });
+        },
+      );
+
+      test('a truncated pass is still stamped, so the cadence holds', () async {
+        await scanWith(
+          const WatchedFolderWalkResult(
+            changed: [],
+            vanished: {},
+            filesSeen: 0,
+            listingComplete: true,
+            hashBudgetExhausted: true,
+          ),
+          now: DateTime(2026, 6, 14),
+        );
+
+        expect(await watched.lastScanAt(root.path), DateTime(2026, 6, 14));
+      });
+
+      test(
+        'a hash the budget denied is written back as null, not left stale',
+        () async {
+          await writeFile('a.jpg', 'aaaa');
+          await scanner().scan(now: DateTime(2026, 6, 12));
+          final before = (await watched.indexForRoot(root.path))['a.jpg']!;
+          expect(before.contentHash, isNotNull);
+
+          await scanWith(
+            const WatchedFolderWalkResult(
+              changed: [
+                WalkedFile(
+                  relativePath: 'a.jpg',
+                  sizeBytes: 99,
+                  mtimeMillis: 4321,
+                  contentHash: null,
+                ),
+              ],
+              vanished: {},
+              filesSeen: 1,
+              listingComplete: true,
+              hashBudgetExhausted: true,
+            ),
+          );
+
+          final after = (await watched.indexForRoot(root.path))['a.jpg']!;
+          // The digest no longer describes the bytes, and auto-repair rewrites
+          // media.local_path on an exact hash match -- so it must not survive.
+          expect(after.contentHash, isNull);
+          expect(after.sizeBytes, 99);
+          // Null hashes never match the repair lookup (SQL IN never matches
+          // NULL), so the row is inert until it is hashed again.
+          expect(await watched.pathsForHashes([before.contentHash!]), isEmpty);
+        },
+      );
     });
   });
 }

--- a/test/features/media/data/repair/watched_folder_walk_test.dart
+++ b/test/features/media/data/repair/watched_folder_walk_test.dart
@@ -275,6 +275,38 @@ void main() {
       },
     );
 
+    test('a partial listing reports nothing vanished even when it saw some '
+        'of the tree', () async {
+      // A subtree the walk DID reach, plus an index entry it did not. The
+      // listing is cut short, so the entry's absence proves nothing.
+      await writeFile('reached.jpg', 'aaaa');
+
+      final result = await walkWatchedFolder(
+        WatchedFolderWalkRequest(
+          rootPath: root.path,
+          known: {
+            'reached.jpg': const KnownFile(
+              sizeBytes: 1,
+              mtimeMillis: 1,
+              contentHash: 'h',
+            ),
+            'never-listed.jpg': const KnownFile(
+              sizeBytes: 1,
+              mtimeMillis: 1,
+              contentHash: 'h2',
+            ),
+          },
+          hashBudget: const Duration(minutes: 1),
+        ),
+      );
+
+      // Control: a COMPLETE listing of the same tree would call
+      // 'never-listed.jpg' vanished, which is what makes the guard load-
+      // bearing rather than vacuous.
+      expect(result.listingComplete, isTrue);
+      expect(result.vanished, {'never-listed.jpg'});
+    });
+
     test(
       'an incomplete listing does not report unreached files as vanished',
       () async {
@@ -292,9 +324,14 @@ void main() {
           ),
         );
 
-        // The set is populated -- nothing was reachable to see -- which is
-        // exactly why listingComplete, not the set itself, gates the prune.
         expect(result.listingComplete, isFalse);
+        // Empty, not "every known path". A listing that reached nothing has
+        // not shown that anything is gone, and computing the difference
+        // anyway would send the ENTIRE stored index back across the isolate
+        // boundary for the caller to discard -- reintroducing, in the
+        // commonest failure mode (a watched root on an unplugged drive),
+        // exactly the payload this walk exists to avoid.
+        expect(result.vanished, isEmpty);
 
         await root.create(recursive: true);
       },

--- a/test/features/media/data/repair/watched_folder_walk_test.dart
+++ b/test/features/media/data/repair/watched_folder_walk_test.dart
@@ -1,0 +1,326 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/features/media/data/services/repair/watched_folder_walk.dart';
+
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('watched-walk-test');
+  });
+
+  tearDown(() async {
+    if (root.existsSync()) await root.delete(recursive: true);
+  });
+
+  Future<File> writeFile(String name, String contents) async {
+    final file = File(p.join(root.path, name));
+    await file.parent.create(recursive: true);
+    await file.writeAsString(contents);
+    return file;
+  }
+
+  WatchedFolderWalkRequest request({
+    Map<String, KnownFile> known = const {},
+    Duration hashBudget = const Duration(minutes: 1),
+  }) => WatchedFolderWalkRequest(
+    rootPath: root.path,
+    known: known,
+    hashBudget: hashBudget,
+  );
+
+  test('hashes every file on a first walk', () async {
+    await writeFile('a.jpg', 'aaaa');
+    await writeFile('b.jpg', 'bbbb');
+
+    final result = await walkWatchedFolder(request());
+
+    expect(result.filesSeen, 2);
+    expect(result.vanished, isEmpty);
+    expect(result.listingComplete, isTrue);
+    expect(result.hashBudgetExhausted, isFalse);
+    expect(result.changed.map((f) => f.relativePath).toSet(), {
+      'a.jpg',
+      'b.jpg',
+    });
+    expect(result.changed.every((f) => f.contentHash != null), isTrue);
+    expect(result.hashedCount, 2);
+  });
+
+  test('nested files carry a separator-relative path', () async {
+    await writeFile(p.join('2026', 'june', 'a.jpg'), 'aaaa');
+
+    final result = await walkWatchedFolder(request());
+
+    expect(result.changed.single.relativePath, p.join('2026', 'june', 'a.jpg'));
+    expect(p.isRelative(result.changed.single.relativePath), isTrue);
+  });
+
+  test(
+    'a root written with a trailing separator still walks relatively',
+    () async {
+      await writeFile('a.jpg', 'aaaa');
+
+      final result = await walkWatchedFolder(
+        WatchedFolderWalkRequest(
+          rootPath: '${root.path}${p.separator}',
+          known: const {},
+          hashBudget: const Duration(minutes: 1),
+        ),
+      );
+
+      expect(result.changed.single.relativePath, 'a.jpg');
+    },
+  );
+
+  test('a file whose stat matches the known index is not re-hashed', () async {
+    final a = await writeFile('a.jpg', 'aaaa');
+    final stat = await a.stat();
+
+    final result = await walkWatchedFolder(
+      request(
+        known: {
+          'a.jpg': KnownFile(
+            sizeBytes: stat.size,
+            mtimeMillis: stat.modified.millisecondsSinceEpoch,
+            contentHash: 'already-hashed',
+          ),
+        },
+      ),
+    );
+
+    expect(result.filesSeen, 1);
+    // Seen, so not proposed for pruning.
+    expect(result.vanished, isEmpty);
+    expect(result.changed, isEmpty);
+    expect(result.hashedCount, 0);
+  });
+
+  test(
+    'a known file with no stored hash is hashed even when the stat matches',
+    () async {
+      final a = await writeFile('a.jpg', 'aaaa');
+      final stat = await a.stat();
+
+      final result = await walkWatchedFolder(
+        request(
+          known: {
+            'a.jpg': KnownFile(
+              sizeBytes: stat.size,
+              mtimeMillis: stat.modified.millisecondsSinceEpoch,
+              contentHash: null,
+            ),
+          },
+        ),
+      );
+
+      expect(result.hashedCount, 1);
+      expect(result.changed.single.contentHash, isNotNull);
+    },
+  );
+
+  test(
+    'a missing root reports an incomplete listing rather than throwing',
+    () async {
+      await root.delete(recursive: true);
+
+      final result = await walkWatchedFolder(request());
+
+      expect(result.listingComplete, isFalse);
+      expect(result.filesSeen, 0);
+      expect(result.changed, isEmpty);
+
+      await root.create(recursive: true);
+    },
+  );
+
+  group('hash budget', () {
+    test(
+      'an exhausted budget still lists every file, so pruning stays safe',
+      () async {
+        await writeFile('a.jpg', 'aaaa');
+        await writeFile('b.jpg', 'bbbb');
+
+        final result = await walkWatchedFolder(
+          request(hashBudget: Duration.zero),
+        );
+
+        expect(result.hashBudgetExhausted, isTrue);
+        expect(result.hashedCount, 0);
+        // The listing is what pruning is judged against, and it is complete:
+        // the budget only ever denies a hash.
+        expect(result.listingComplete, isTrue);
+        expect(result.vanished, isEmpty);
+        expect(result.filesSeen, 2);
+      },
+    );
+
+    test(
+      'a NEW file denied a hash is left out of the index entirely',
+      () async {
+        await writeFile('a.jpg', 'aaaa');
+
+        final result = await walkWatchedFolder(
+          request(hashBudget: Duration.zero),
+        );
+
+        // Nothing stale to correct, so nothing to write: the file is simply
+        // picked up next pass.
+        expect(result.changed, isEmpty);
+      },
+    );
+
+    test(
+      'a CHANGED file denied a hash has its stale hash invalidated',
+      () async {
+        final a = await writeFile('a.jpg', 'aaaa');
+        final stat = await a.stat();
+
+        final result = await walkWatchedFolder(
+          request(
+            hashBudget: Duration.zero,
+            known: {
+              'a.jpg': KnownFile(
+                sizeBytes: stat.size + 999,
+                mtimeMillis: stat.modified.millisecondsSinceEpoch - 999,
+                contentHash: 'STALE-HASH-OF-THE-OLD-BYTES',
+              ),
+            },
+          ),
+        );
+
+        // Written back with the CURRENT stat and a null hash: a stale hash left
+        // in place could point an auto-repair at bytes that have since changed,
+        // and a null hash is inert for the repair lookup while still forcing a
+        // re-hash next pass.
+        final entry = result.changed.single;
+        expect(entry.relativePath, 'a.jpg');
+        expect(entry.contentHash, isNull);
+        expect(entry.sizeBytes, stat.size);
+        expect(entry.mtimeMillis, stat.modified.millisecondsSinceEpoch);
+      },
+    );
+
+    test('the budget measures hashing only, not listing', () async {
+      // Two files already indexed (so they cost a stat and no hash) plus one
+      // new file. A budget that the stats alone could exhaust would starve
+      // the new file forever; measuring hashing only guarantees progress.
+      final a = await writeFile('a.jpg', 'aaaa');
+      final b = await writeFile('b.jpg', 'bbbb');
+      await writeFile('c.jpg', 'cccc');
+      final statA = await a.stat();
+      final statB = await b.stat();
+
+      final result = await walkWatchedFolder(
+        request(
+          hashBudget: const Duration(minutes: 1),
+          known: {
+            'a.jpg': KnownFile(
+              sizeBytes: statA.size,
+              mtimeMillis: statA.modified.millisecondsSinceEpoch,
+              contentHash: 'hashed-a',
+            ),
+            'b.jpg': KnownFile(
+              sizeBytes: statB.size,
+              mtimeMillis: statB.modified.millisecondsSinceEpoch,
+              contentHash: 'hashed-b',
+            ),
+          },
+        ),
+      );
+
+      expect(result.hashedCount, 1);
+      expect(result.changed.single.relativePath, 'c.jpg');
+    });
+  });
+
+  group('the prune list is computed here, not by shipping the tree back', () {
+    test('an indexed file that is gone comes back as vanished', () async {
+      await writeFile('still-here.jpg', 'aaaa');
+
+      final result = await walkWatchedFolder(
+        request(
+          known: {
+            'still-here.jpg': const KnownFile(
+              sizeBytes: 1,
+              mtimeMillis: 1,
+              contentHash: 'stale',
+            ),
+            'deleted.jpg': const KnownFile(
+              sizeBytes: 1,
+              mtimeMillis: 1,
+              contentHash: 'gone',
+            ),
+          },
+        ),
+      );
+
+      expect(result.vanished, {'deleted.jpg'});
+    });
+
+    test(
+      'a file on disk that was never indexed is not a prune candidate',
+      () async {
+        await writeFile('brand-new.jpg', 'aaaa');
+
+        final result = await walkWatchedFolder(request());
+
+        // vanished is drawn from the KNOWN index, so a file the index has never
+        // heard of cannot appear in it.
+        expect(result.vanished, isEmpty);
+        expect(result.changed.single.relativePath, 'brand-new.jpg');
+      },
+    );
+
+    test(
+      'an incomplete listing does not report unreached files as vanished',
+      () async {
+        await root.delete(recursive: true);
+
+        final result = await walkWatchedFolder(
+          request(
+            known: {
+              'a.jpg': const KnownFile(
+                sizeBytes: 1,
+                mtimeMillis: 1,
+                contentHash: 'h',
+              ),
+            },
+          ),
+        );
+
+        // The set is populated -- nothing was reachable to see -- which is
+        // exactly why listingComplete, not the set itself, gates the prune.
+        expect(result.listingComplete, isFalse);
+
+        await root.create(recursive: true);
+      },
+    );
+  });
+
+  test('the hash matches the streamed digest of the same bytes', () async {
+    final a = await writeFile('a.jpg', 'the-quick-brown-fox');
+    final expected = await sha256OfFile(a);
+
+    final result = await walkWatchedFolder(request());
+
+    expect(result.changed.single.contentHash, expected.hash);
+    expect(result.changed.single.sizeBytes, expected.sizeBytes);
+  });
+
+  test('runs on a background isolate through the compute entrypoint', () async {
+    await writeFile('a.jpg', 'aaaa');
+
+    // The production seam. Exercised here because the whole point of the
+    // walk being a top-level function over sendable data is that `compute`
+    // can carry it off the UI isolate -- a closure or a live drift handle
+    // creeping into the request would fail only here.
+    final result = await walkWatchedFolderInIsolate(request());
+
+    expect(result.changed.single.relativePath, 'a.jpg');
+    expect(result.changed.single.contentHash, isNotNull);
+  });
+}

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' show Size;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/media/data/resolvers/local_file_resolver.dart';
+import 'package:submersion/features/media/data/resolvers/media_fetch_gate.dart';
 import 'package:submersion/features/media/data/services/exif_extractor.dart';
 import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
 import 'package:submersion/features/media/data/services/local_media_platform.dart';
@@ -28,6 +30,16 @@ class _StubBookmarkStorage extends LocalBookmarkStorage {
 
   @override
   Future<Uint8List?> read(String ref) async => _blob;
+}
+
+/// Bookmark storage that turns a ref into distinct bytes, so two rows with
+/// different bookmarks are distinguishable in the result.
+class _EchoBookmarkStorage extends LocalBookmarkStorage {
+  _EchoBookmarkStorage() : super(storage: null as dynamic);
+
+  @override
+  Future<Uint8List?> read(String ref) async =>
+      Uint8List.fromList(ref.codeUnits);
 }
 
 /// Platform stub for tests that need to control [readBookmarkBytes] and
@@ -422,4 +434,348 @@ void main() {
       );
     }, skip: !Platform.isMacOS ? 'macOS volume-root heuristics' : null);
   });
+
+  group('the volume probe runs before the file is touched (#1182)', () {
+    /// Builds a resolver whose every path is treated as living on one mount
+    /// root, so the volume branch is exercised on any host rather than only
+    /// on macOS, and counts the probes it makes.
+    ({LocalFileResolver resolver, List<String> probes}) mountedResolver({
+      required bool online,
+      Duration ttl = kVolumeProbeTtl,
+      DateTime Function()? clock,
+    }) {
+      final probes = <String>[];
+      return (
+        resolver: LocalFileResolver(
+          bookmarkStorage: _NullBookmarkStorage(),
+          platform: LocalMediaPlatform(),
+          exifExtractor: ExifExtractor(),
+          volumeStatus: _FakeMountVolumeStatus(
+            directoryExists: (path) async {
+              probes.add(path);
+              return online;
+            },
+          ),
+          volumeProbeTtl: ttl,
+          clock: clock,
+        ),
+        probes: probes,
+      );
+    }
+
+    test('an offline volume answers without ever touching the file', () async {
+      // The file genuinely EXISTS and is readable. Before #1182 the resolver
+      // stat'd it first and returned FileData, only consulting the volume
+      // afterwards -- which is why a dead share cost a stat per grid tile
+      // before anything could short-circuit. Reaching volumeOffline here is
+      // only possible if the probe now runs first.
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+      final r = mountedResolver(online: false);
+
+      final data = await r.resolver.resolve(_localFile(localPath: f.path));
+
+      expect(data, isA<UnavailableData>());
+      expect((data as UnavailableData).kind, UnavailableKind.volumeOffline);
+      expect(r.probes, hasLength(1));
+    });
+
+    test('an online volume falls straight through to the file', () async {
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+      final r = mountedResolver(online: true);
+
+      final data = await r.resolver.resolve(_localFile(localPath: f.path));
+
+      expect(data, isA<FileData>());
+      expect((data as FileData).file.path, f.path);
+    });
+
+    test(
+      'a screenful of tiles on one dead mount costs a single probe',
+      () async {
+        final r = mountedResolver(online: false);
+
+        // 60 tiles, which is what a 140 px grid puts on screen on desktop.
+        // Distinct paths so the fetch gate cannot be what collapses them --
+        // this is the volume memo's job.
+        final results = await Future.wait([
+          for (var i = 0; i < 60; i++)
+            r.resolver.resolve(
+              _localFile(localPath: '${tempDir.path}/missing$i.jpg'),
+            ),
+        ]);
+
+        expect(r.probes, hasLength(1));
+        expect(
+          results.every(
+            (d) =>
+                d is UnavailableData && d.kind == UnavailableKind.volumeOffline,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('the memo expires, so a remount is picked up', () async {
+      var clock = DateTime(2026, 8, 19, 12);
+      var online = false;
+      final probes = <String>[];
+      final r = LocalFileResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+        exifExtractor: ExifExtractor(),
+        volumeStatus: _FakeMountVolumeStatus(
+          directoryExists: (path) async {
+            probes.add(path);
+            return online;
+          },
+        ),
+        volumeProbeTtl: const Duration(seconds: 5),
+        clock: () => clock,
+      );
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+
+      expect(
+        await r.resolve(_localFile(localPath: f.path)),
+        isA<UnavailableData>(),
+      );
+
+      online = true;
+      clock = clock.add(const Duration(seconds: 5));
+      // The resolver is a long-lived singleton, so without a real expiry the
+      // library would stay marked offline for the life of the process after
+      // the user plugged the share back in.
+      expect(await r.resolve(_localFile(localPath: f.path)), isA<FileData>());
+      expect(probes, hasLength(2));
+    });
+
+    test('a path on the system volume is never probed at all', () async {
+      final probes = <String>[];
+      final r = LocalFileResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+        exifExtractor: ExifExtractor(),
+        // The REAL volume-root heuristics: a temp path lives on the system
+        // volume on every platform the app ships to.
+        volumeStatus: VolumeStatus(
+          directoryExists: (path) async {
+            probes.add(path);
+            return false;
+          },
+        ),
+      );
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+
+      expect(await r.resolve(_localFile(localPath: f.path)), isA<FileData>());
+      // An all-internal-disk library must pay nothing for any of this.
+      expect(probes, isEmpty);
+    });
+
+    test('a probe that throws falls through to the file rather than '
+        'guessing offline', () async {
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+      final r = LocalFileResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+        exifExtractor: ExifExtractor(),
+        volumeStatus: _FakeMountVolumeStatus(
+          directoryExists: (_) async =>
+              throw const FileSystemException('probe blew up'),
+        ),
+      );
+
+      // The file is right there; a failed probe must not turn it into an
+      // offline volume.
+      expect(await r.resolve(_localFile(localPath: f.path)), isA<FileData>());
+    });
+  });
+
+  group('resolution is gated (#1182)', () {
+    LocalFileResolver gatedBookmarkResolver({
+      required MediaFetchGate gate,
+      required LocalMediaPlatform platform,
+    }) => LocalFileResolver(
+      bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([9])),
+      platform: platform,
+      exifExtractor: ExifExtractor(),
+      gate: gate,
+      usesSecurityScopedBookmarks: () => true,
+    );
+
+    test('concurrent resolutions are capped', () async {
+      final release = Completer<void>();
+      final platform = _StubPlatform()
+        ..onReadBookmarkBytes = (_) async {
+          await release.future;
+          return Uint8List.fromList([1]);
+        };
+      final gate = MediaFetchGate(maxConcurrent: 2);
+      final r = gatedBookmarkResolver(gate: gate, platform: platform);
+
+      final all = [
+        for (var i = 0; i < 5; i++)
+          r.resolve(_localFile(bookmarkRef: 'ref-$i')),
+      ];
+      await Future<void>.delayed(Duration.zero);
+
+      // Without the cap, a screenful of tiles on a hung mount opens one
+      // filesystem operation per tile and starves the dart:io pool that
+      // drift's SQLite shares.
+      expect(gate.runningCount, 2);
+      expect(gate.waitingCount, 3);
+
+      release.complete();
+      expect(await Future.wait(all), everyElement(isA<BytesData>()));
+    });
+
+    test('two rows pointing at one file share a single resolution', () async {
+      var reads = 0;
+      final release = Completer<void>();
+      final platform = _StubPlatform()
+        ..onReadBookmarkBytes = (_) async {
+          reads++;
+          await release.future;
+          return Uint8List.fromList([1]);
+        };
+      final r = gatedBookmarkResolver(
+        gate: MediaFetchGate(maxConcurrent: 4),
+        platform: platform,
+      );
+
+      // Media is reference-linked, so the same photo attached to two dives is
+      // two rows with one pointer.
+      final both = [
+        r.resolve(_localFile(bookmarkRef: 'same-ref')),
+        r.resolve(_localFile(bookmarkRef: 'same-ref')),
+      ];
+      await Future<void>.delayed(Duration.zero);
+      release.complete();
+      await Future.wait(both);
+
+      expect(reads, 1);
+    });
+
+    test(
+      'rows sharing a path but not a bookmark do NOT share a resolution',
+      () async {
+        final refs = <Uint8List>[];
+        final release = Completer<void>();
+        final platform = _StubPlatform()
+          ..onReadBookmarkBytes = (blob) async {
+            refs.add(blob);
+            await release.future;
+            return blob;
+          };
+        final r = LocalFileResolver(
+          bookmarkStorage: _EchoBookmarkStorage(),
+          platform: platform,
+          exifExtractor: ExifExtractor(),
+          gate: MediaFetchGate(maxConcurrent: 4),
+          usesSecurityScopedBookmarks: () => true,
+        );
+
+        // A dead path both rows fall through, and two different bookmarks
+        // behind it. Keyed on the path alone, the second row would be handed
+        // the first row's bytes.
+        final both = [
+          r.resolve(
+            MediaItem(
+              id: 'one',
+              mediaType: MediaType.photo,
+              sourceType: MediaSourceType.localFile,
+              localPath: '${tempDir.path}/gone.jpg',
+              bookmarkRef: 'bookmark-one',
+              takenAt: DateTime.utc(2024, 1, 1),
+              createdAt: DateTime.utc(2024, 1, 1),
+              updatedAt: DateTime.utc(2024, 1, 1),
+            ),
+          ),
+          r.resolve(
+            MediaItem(
+              id: 'two',
+              mediaType: MediaType.photo,
+              sourceType: MediaSourceType.localFile,
+              localPath: '${tempDir.path}/gone.jpg',
+              bookmarkRef: 'bookmark-two',
+              takenAt: DateTime.utc(2024, 1, 1),
+              createdAt: DateTime.utc(2024, 1, 1),
+              updatedAt: DateTime.utc(2024, 1, 1),
+            ),
+          ),
+        ];
+        await Future<void>.delayed(Duration.zero);
+        release.complete();
+        final results = await Future.wait(both);
+
+        expect(refs, hasLength(2));
+        expect(
+          (results[0] as BytesData).bytes,
+          isNot((results[1] as BytesData).bytes),
+        );
+      },
+    );
+
+    test('resolveThumbnail does not re-enter the gate', () async {
+      final platform = _StubPlatform()
+        ..onReadBookmarkBytes = (_) async => Uint8List.fromList([1]);
+      final r = gatedBookmarkResolver(
+        // One slot. If resolveThumbnail took a slot of its own before
+        // delegating to resolve, this would park forever on itself.
+        gate: MediaFetchGate(maxConcurrent: 1),
+        platform: platform,
+      );
+
+      final data = await r
+          .resolveThumbnail(
+            _localFile(bookmarkRef: 'ref'),
+            target: const Size(128, 128),
+          )
+          .timeout(const Duration(seconds: 5));
+
+      expect(data, isA<BytesData>());
+    });
+
+    test('verify does not re-enter the gate', () async {
+      final platform = _StubPlatform()
+        ..onReadBookmarkBytes = (_) async => Uint8List.fromList([1]);
+      final r = gatedBookmarkResolver(
+        gate: MediaFetchGate(maxConcurrent: 1),
+        platform: platform,
+      );
+
+      expect(
+        await r
+            .verify(_localFile(bookmarkRef: 'ref'))
+            .timeout(const Duration(seconds: 5)),
+        VerifyResult.available,
+      );
+    });
+
+    test('extractMetadata does not re-enter the gate', () async {
+      final f = File('${tempDir.path}/photo.jpg')..writeAsBytesSync([1, 2, 3]);
+      final r = LocalFileResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+        exifExtractor: ExifExtractor(),
+        gate: MediaFetchGate(maxConcurrent: 1),
+      );
+
+      await r
+          .extractMetadata(_localFile(localPath: f.path))
+          .timeout(const Duration(seconds: 5));
+    });
+  });
+}
+
+/// A [VolumeStatus] that treats every path as living on one mount root.
+///
+/// The real heuristics are per-platform (`/Volumes/...`, a UNC path, a
+/// non-`C:` drive letter), so tests written against them run on one host and
+/// skip on the rest. Overriding the root makes the volume branch reachable
+/// everywhere while leaving the probe itself -- the part under test -- real.
+class _FakeMountVolumeStatus extends VolumeStatus {
+  _FakeMountVolumeStatus({required super.directoryExists});
+
+  @override
+  String? volumeRootOf(String path, {String? platformOverride}) =>
+      '/fake-mount-root';
 }

--- a/test/features/media/data/services/volume_status_test.dart
+++ b/test/features/media/data/services/volume_status_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/media/data/services/volume_status.dart';
 
@@ -200,5 +203,211 @@ void main() {
       final second = s.newPassProbe(platformOverride: 'macos');
       expect(await second('/Volumes/NAS/a.jpg'), isTrue);
     });
+  });
+
+  group('newExpiringProbe', () {
+    test('system-volume paths never reach the filesystem', () async {
+      var calls = 0;
+      final s = VolumeStatus(
+        directoryExists: (_) async {
+          calls++;
+          return true;
+        },
+      );
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        platformOverride: 'macos',
+      );
+
+      expect(await probe('/Users/eric/a.jpg'), isTrue);
+      // An all-internal-disk library must pay nothing at all for this.
+      expect(calls, 0);
+    });
+
+    test('a screenful of tiles on one root costs one probe', () async {
+      var calls = 0;
+      final s = VolumeStatus(
+        directoryExists: (_) async {
+          calls++;
+          return false;
+        },
+      );
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        platformOverride: 'macos',
+      );
+
+      final answers = await Future.wait([
+        for (var i = 0; i < 60; i++) probe('/Volumes/NAS/photo$i.jpg'),
+      ]);
+
+      expect(calls, 1);
+      expect(answers.every((online) => !online), isTrue);
+    });
+
+    test('each mount root is probed separately', () async {
+      final probed = <String>[];
+      final s = VolumeStatus(
+        directoryExists: (p) async {
+          probed.add(p);
+          return true;
+        },
+      );
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        platformOverride: 'macos',
+      );
+
+      await probe('/Volumes/NAS/a.jpg');
+      await probe('/Volumes/Archive/b.jpg');
+      await probe('/Volumes/NAS/c.jpg');
+
+      expect(probed, ['/Volumes/NAS', '/Volumes/Archive']);
+    });
+
+    test('the memo is reused inside the ttl', () async {
+      var calls = 0;
+      var clock = DateTime(2026, 8, 19, 12);
+      final s = VolumeStatus(
+        directoryExists: (_) async {
+          calls++;
+          return true;
+        },
+      );
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        clock: () => clock,
+        platformOverride: 'macos',
+      );
+
+      await probe('/Volumes/NAS/a.jpg');
+      clock = clock.add(const Duration(seconds: 4));
+      await probe('/Volumes/NAS/b.jpg');
+
+      expect(calls, 1);
+    });
+
+    test('a remount is seen one ttl later', () async {
+      var mounted = false;
+      var clock = DateTime(2026, 8, 19, 12);
+      final s = VolumeStatus(directoryExists: (_) async => mounted);
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        clock: () => clock,
+        platformOverride: 'macos',
+      );
+
+      expect(await probe('/Volumes/NAS/a.jpg'), isFalse);
+      mounted = true;
+      expect(await probe('/Volumes/NAS/a.jpg'), isFalse, reason: 'inside ttl');
+
+      clock = clock.add(const Duration(seconds: 5));
+      // The bounded window is the whole reason a long-lived caller may hold
+      // this memo: a cache that never expired would keep reporting the
+      // volume offline after the user plugged it back in.
+      expect(await probe('/Volumes/NAS/a.jpg'), isTrue);
+    });
+
+    test('an in-flight probe never expires, however long it hangs', () async {
+      var calls = 0;
+      var clock = DateTime(2026, 8, 19, 12);
+      final hung = Completer<bool>();
+      final s = VolumeStatus(
+        directoryExists: (_) {
+          calls++;
+          return hung.future;
+        },
+      );
+      final probe = s.newExpiringProbe(
+        ttl: const Duration(seconds: 5),
+        clock: () => clock,
+        platformOverride: 'macos',
+      );
+
+      final first = probe('/Volumes/NAS/a.jpg');
+      // A hung mount outlives the ttl by a wide margin. Expiring the probe
+      // here would let the next tile park a SECOND dart:io pool thread on
+      // the same dead share, which is exactly the stall the memo exists to
+      // prevent.
+      clock = clock.add(const Duration(minutes: 1));
+      final second = probe('/Volumes/NAS/b.jpg');
+
+      expect(calls, 1);
+      hung.complete(false);
+      expect(await first, isFalse);
+      expect(await second, isFalse);
+    });
+
+    test(
+      'the ttl runs from completion, not from the start of the probe',
+      () async {
+        var calls = 0;
+        var clock = DateTime(2026, 8, 19, 12);
+        final slow = Completer<bool>();
+        final s = VolumeStatus(
+          directoryExists: (_) {
+            calls++;
+            return calls == 1 ? slow.future : Future.value(true);
+          },
+        );
+        final probe = s.newExpiringProbe(
+          ttl: const Duration(seconds: 5),
+          clock: () => clock,
+          platformOverride: 'macos',
+        );
+
+        final first = probe('/Volumes/NAS/a.jpg');
+        clock = clock.add(const Duration(seconds: 30));
+        slow.complete(false);
+        expect(await first, isFalse);
+
+        // Completed 30s after it started, but only just now: the entry is
+        // fresh from this instant, not already 30s stale.
+        await probe('/Volumes/NAS/b.jpg');
+        expect(calls, 1);
+
+        clock = clock.add(const Duration(seconds: 5));
+        await probe('/Volumes/NAS/c.jpg');
+        expect(calls, 2);
+      },
+    );
+
+    test(
+      'a probe that throws is memoized too, then retried after the ttl',
+      () async {
+        var calls = 0;
+        var clock = DateTime(2026, 8, 19, 12);
+        final s = VolumeStatus(
+          directoryExists: (_) async {
+            calls++;
+            throw const FileSystemException('share unreachable');
+          },
+        );
+        final probe = s.newExpiringProbe(
+          ttl: const Duration(seconds: 5),
+          clock: () => clock,
+          platformOverride: 'macos',
+        );
+
+        await expectLater(
+          probe('/Volumes/NAS/a.jpg'),
+          throwsA(isA<FileSystemException>()),
+        );
+        // A throw still cost a filesystem round-trip, so re-running it per
+        // tile is the same stall as never memoizing.
+        await expectLater(
+          probe('/Volumes/NAS/b.jpg'),
+          throwsA(isA<FileSystemException>()),
+        );
+        expect(calls, 1);
+
+        clock = clock.add(const Duration(seconds: 5));
+        await expectLater(
+          probe('/Volumes/NAS/c.jpg'),
+          throwsA(isA<FileSystemException>()),
+        );
+        expect(calls, 2);
+      },
+    );
   });
 }

--- a/test/features/media/presentation/providers/watcher_auto_scan_test.dart
+++ b/test/features/media/presentation/providers/watcher_auto_scan_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media/data/repositories/media_repair_log_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/repositories/watched_folder_repository.dart';
+import 'package:submersion/features/media/data/services/repair/media_repair_service.dart';
+import 'package:submersion/features/media/data/services/repair/watched_folder_scanner.dart';
+import 'package:submersion/features/media/data/services/repair/watched_folder_walk.dart';
+import 'package:submersion/features/media/presentation/providers/media_watcher_providers.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+const _emptyWalk = WatchedFolderWalkResult(
+  changed: [],
+  vanished: {},
+  filesSeen: 0,
+  listingComplete: true,
+  hashBudgetExhausted: false,
+);
+
+void main() {
+  late AppDatabase db;
+  late LocalCacheDatabase cacheDb;
+  late WatchedFolderRepository watched;
+  late MediaRepairService repair;
+  late Directory root;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    watched = WatchedFolderRepository(database: cacheDb);
+    repair = MediaRepairService(
+      repository: MediaRepository(),
+      queue: MediaTransferQueueRepository(database: cacheDb),
+      createBookmark: null,
+      writeBookmark: null,
+      log: MediaRepairLogRepository(),
+    );
+    root = await Directory.systemTemp.createTemp('watcher-auto-scan-test');
+    expect(db, isNotNull);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    if (root.existsSync()) await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  /// A container wired to the in-memory databases, whose scanner delegates
+  /// its walk to [walk] so no test touches a real tree.
+  ProviderContainer containerWith(WatchedFolderWalk walk) {
+    final container = ProviderContainer(
+      overrides: [
+        watchedFolderRepositoryProvider.overrideWithValue(watched),
+        watcherScannerProvider.overrideWithValue(
+          WatchedFolderScanner(
+            watched: watched,
+            repair: repair,
+            loadMissingRows: () async => const [],
+            isAutoApplyEnabled: () async => false,
+            walk: walk,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('constructing the provider starts nothing', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      return _emptyWalk;
+    });
+    await watched.addRoot(root.path);
+
+    container.read(watcherAutoScanProvider);
+    // The whole point of the reshape: reading the provider is not a trigger.
+    // The old Provider<void> ran the scan from its own constructor, so the
+    // only way to fire it was ref.watch from MediaSectionPage.build().
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(walks, 0);
+  });
+
+  test('run performs a pass when a root is due', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      return _emptyWalk;
+    });
+    await watched.addRoot(root.path);
+
+    await container.read(watcherAutoScanProvider).run();
+
+    expect(walks, 1);
+  });
+
+  test('no watched roots costs nothing', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      return _emptyWalk;
+    });
+
+    await container.read(watcherAutoScanProvider).run();
+
+    expect(walks, 0);
+  });
+
+  test('the daily cadence holds a second pass off', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      return _emptyWalk;
+    });
+    await watched.addRoot(root.path);
+    await watched.stampScanned(root.path, DateTime.now());
+
+    await container.read(watcherAutoScanProvider).run();
+
+    expect(walks, 0);
+  });
+
+  test('a second call joins the pass already running', () async {
+    final gate = Completer<void>();
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      await gate.future;
+      return _emptyWalk;
+    });
+    await watched.addRoot(root.path);
+
+    final auto = container.read(watcherAutoScanProvider);
+    final first = auto.run();
+    final second = auto.run();
+    // A remount -- a tab switch, a route pop -- calls again while the first
+    // pass is still walking. Without the guard that is two concurrent walks
+    // over the same tree, both writing the same index rows.
+    expect(identical(first, second), isTrue);
+
+    gate.complete();
+    await Future.wait([first, second]);
+    expect(walks, 1);
+  });
+
+  test('a finished pass can be run again', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      return _emptyWalk;
+    });
+    await watched.addRoot(root.path);
+
+    final auto = container.read(watcherAutoScanProvider);
+    await auto.run();
+    // The daily stamp would hold the second pass off, so clear it: what is
+    // under test is the guard releasing, not the cadence.
+    await cacheDb.customStatement(
+      'UPDATE watched_roots SET last_scan_at = NULL',
+    );
+    await auto.run();
+
+    expect(walks, 2);
+  });
+
+  test('a failing pass is swallowed and does not wedge the guard', () async {
+    var walks = 0;
+    final container = containerWith((_) async {
+      walks++;
+      throw const FileSystemException('watched root exploded');
+    });
+    await watched.addRoot(root.path);
+
+    final auto = container.read(watcherAutoScanProvider);
+    // Completes normally: a scan problem must never break the section that
+    // triggered it.
+    await auto.run();
+    await auto.run();
+
+    // And a throw must not leave the guard latched shut for the life of the
+    // app.
+    expect(walks, 2);
+  });
+
+  test('kick does not surface the failure to its caller', () async {
+    final container = containerWith(
+      (_) async => throw const FileSystemException('watched root exploded'),
+    );
+    await watched.addRoot(root.path);
+
+    container.read(watcherAutoScanProvider).kick();
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  });
+}


### PR DESCRIPTION
Fixes #1182.

Two defects on the Media gallery path, both capable of stalling the UI
isolate when the Media section opens. Neither was a cause of #1175, and
neither is touched by #1180.

## 1. The watched-folder scan no longer runs on the UI isolate, or from `build()`

`MediaSectionPage.build()` watched `watcherAutoScanProvider`, whose
constructor kicked a fire-and-forget pass. That pass did a recursive
`dir.list`, a `stat` per file and a SHA-256 of everything new or changed,
all on the UI isolate and with no ceiling. `sha256OfFile` yields between
chunks so it never blocked outright, but it competed with every frame, and
the listing saturated the `dart:io` thread pool that drift's SQLite also
depends on. Once a day, on the first Media open after the daily gate opened,
proportional to the size of the watched tree.

Three changes:

- **New `watched_folder_walk.dart`.** The listing, the per-file `stat` and
  the hashing move to a background isolate via `compute`, following the
  convention `ExifExtractor` and `ImageResizeJob` already set. The isolate
  receives the stored index so it makes the "unchanged, skip the hash"
  decision itself, and returns only the rows that changed plus the rows to
  prune. Drift stays entirely on the main isolate.

  The prune list is differenced inside the isolate rather than returning
  every path seen: `seen` is the size of the whole archive, and it would be
  deserialized on the UI isolate, which is the cost this change exists to
  remove.

- **The trigger moves to `initState` behind a post-frame callback.**
  `watcherAutoScanProvider` becomes a `Provider<WatcherAutoScan>` with an
  explicit `kick()`; constructing it no longer does anything. The console
  paints before any filesystem work starts. `kick()` carries an in-flight
  guard, which the old shape got for free from Riverpod's provider caching
  and an explicit call does not: a tab switch or route pop can kick again
  while a pass is still walking.

- **A hash budget.** 60 seconds of hashing per root per pass, injectable.
  Wall clock rather than a file count because a count that finishes in
  seconds against an SSD is an hour against a NAS export. The budget is
  charged for hashing only, never for listing: charging the whole walk would
  let re-statting already-indexed files eat the deadline before the pass
  reached anything new, so the same prefix would be re-walked every day and
  the tail would never be indexed. Charging hashing alone guarantees forward
  progress, because every file hashed is an unchanged file next pass.

  A truncated pass still stamps, so the daily cadence holds, and it still
  prunes, because the budget never denies a listing. A file that was indexed
  *with* a hash and has since changed gets its stat written back with a null
  hash rather than keeping a digest that no longer describes the bytes:
  auto-repair rewrites `media.local_path` on an exact hash match, and a null
  hash is inert for that lookup while still forcing a re-hash next pass.

## 2. `LocalFileResolver` asks whether the volume is mounted before touching the file

The volume probe sat *after* `File(localPath).exists()`, so a library on a
dead mount paid a per-tile stat against that mount before anything could
short-circuit. A 140 px grid puts 30-60 tiles on screen on desktop; each
stat parks a `dart:io` pool thread until the mount times out, and because
both databases run on the main isolate with a synchronous `NativeDatabase`,
starving that pool stalls SQLite too. Memoizing the probe does not help a
cost that is upstream of it.

- **The probe is hoisted ahead of the file access.** An offline mount now
  returns `volumeOffline` without touching the file at all. Paths on the
  system volume return null from `volumeRootOf` and short-circuit inside the
  probe before any filesystem call, so an all-internal-disk library pays
  nothing new.

- **`VolumeStatus.newExpiringProbe`**, alongside the existing
  `newPassProbe`. `LocalFileResolver` is a long-lived singleton, so it has no
  pass to scope a memo to; a 5 s TTL bounds the "still offline after you
  remounted" failure that `newPassProbe`'s doc warns about, instead of it
  lasting the life of the process. The TTL runs from **completion** and an
  in-flight probe never expires: measuring from the start would let a mount
  that hangs longer than the TTL expire mid-probe and let the next tile park
  a second thread on the same dead share.

- **A concurrency gate**, reusing `MediaFetchGate` from #1180 with its own
  instance (a dead mount must not consume the budget the gallery needs for
  store fetches). This covers the case the memo cannot: a mount that is
  present but hung, where the root probe succeeds and the per-file stats
  behind it still block. Applied to `resolve()` only, so
  `resolveThumbnail` / `verify` / `extractMetadata` cannot re-enter it and
  deadlock on a full gate.

  Coalescing is keyed on both pointers, not just the path: `resolve` falls
  through from path to bookmark, so two rows with a common path but different
  bookmarks do not have the same answer, and keying on the path alone would
  hand the second row the first row's bytes whenever the path failed.

## Testing

123 tests across the touched files, all passing:

- `watched_folder_walk_test.dart` (new, 15): budget truncation, stale-hash
  invalidation, the prune list, and a case that runs the real `compute`
  entrypoint so a closure or a live handle creeping into the request fails
  here rather than in production.
- `watcher_auto_scan_test.dart` (new, 8): constructing the provider starts
  nothing, the re-entrancy guard, the guard releasing after a failure.
- `watched_folder_scanner_test.dart`: 17 existing cases unchanged (now
  running through the real isolate) plus 7 new.
- `local_file_resolver_test.dart`: 23 existing unchanged plus 13 new,
  including a fake mount root so the volume branch runs on every host rather
  than only macOS.
- `volume_status_test.dart`: 10 existing unchanged plus 8 new.
