### PR TITLE
fix(media): bound every media fetch, and never let the app outlive its window

### DIFF
--- a/docs/superpowers/plans/2026-08-20-media-availability-and-shutdown.md
+++ b/docs/superpowers/plans/2026-08-20-media-availability-and-shutdown.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- No em-dashes (`—`, U+2014) anywhere: code, comments, docs, ARB strings, commit messages. En-dashes and " - " as prose punctuation are equally forbidden. Rewrite with commas, parentheses, colons, or semicolons.
+- No em-dashes (U+2014) anywhere: code, comments, docs, ARB strings, commit messages. En-dashes (U+2013) and " - " used as prose punctuation are equally forbidden. Rewrite with commas, parentheses, colons, or semicolons. The characters are named by code point rather than shown, so that this line does not itself violate the rule it states.
 - No emojis in code, comments, or documentation.
 - `dart format .` must leave the tree unchanged before every commit.
 - `flutter analyze` must report "No issues found!" over the whole project. Infos are fatal in CI.

--- a/docs/superpowers/plans/2026-08-20-media-availability-and-shutdown.md
+++ b/docs/superpowers/plans/2026-08-20-media-availability-and-shutdown.md
@@ -1,0 +1,1576 @@
+# Media Availability and Clean Shutdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop slow or not-yet-available media from freezing the Media section, and stop the macOS process from surviving its own window when the user quits from that section.
+
+**Architecture:** Both symptoms come from one habit: unbounded media I/O on threads that must stay responsive. Three changes address it. (1) The two media concurrency gates gain a *slot budget*: a fetch that overruns it hands its permit to the next waiter and keeps running, so one stalled item can no longer block every other tile; a caller that overruns a larger *total budget* gives up with a new, recoverable `UnavailableKind.stillFetching` state instead of waiting forever. (2) The Apple `LocalMediaHandler` bookmark methods move off the platform main thread, which is both the UI thread and the thread that must answer `applicationShouldTerminate`. (3) The exit handler is made total: Dart always replies within a hard budget, and a background-queue watchdog in `AppDelegate` force-terminates if it does not.
+
+**Tech Stack:** Flutter 3.x / Dart, Riverpod 3, Drift, Swift (macOS + iOS Runner), `flutter gen-l10n` across 11 locales.
+
+**Spec:** This document. No separate spec exists; the Findings section below is the spec, and every claim in it was verified by reading the cited lines in this worktree.
+
+## Global Constraints
+
+- No em-dashes (`—`, U+2014) anywhere: code, comments, docs, ARB strings, commit messages. En-dashes and " - " as prose punctuation are equally forbidden. Rewrite with commas, parentheses, colons, or semicolons.
+- No emojis in code, comments, or documentation.
+- `dart format .` must leave the tree unchanged before every commit.
+- `flutter analyze` must report "No issues found!" over the whole project. Infos are fatal in CI.
+- Every user-visible string goes in all 11 ARB files: `ar de en es fr he hu it nl pt zh`. Translate them; do not leave English placeholders in non-English files.
+- Immutability: never mutate an existing object or list in place.
+- TDD: the failing test comes first, and you must watch it fail before writing the implementation.
+- Commit after each task.
+- Baseline for this worktree: `flutter analyze` is clean as of branch creation. Any new issue is yours.
+
+---
+
+## Findings (the spec)
+
+Verified read-outs. File paths are relative to the repo root.
+
+**F1. The Media feature contains exactly one `.timeout(...)`**, at `lib/features/media/data/services/pdf_thumbnail_service.dart:126`. Every other fetch on every source type awaits with no deadline.
+
+**F2. `MediaFetchGate` converts one slow item into a global stall.** `lib/features/media/data/resolvers/media_fetch_gate.dart:68-89`: `_run` holds its permit for the whole of `await fetch()`, and `_acquire` parks on a `Completer` that nothing ever completes with an error. Two instances exist: `MediaStoreResolver` with 4 permits, `LocalFileResolver` with 8 (`lib/features/media/data/resolvers/local_file_resolver.dart:32`). The gate is deliberately FIFO (`media_fetch_gate.dart:99-107`), so parked waiters belonging to disposed tiles are served first.
+
+**F3. `GalleryThumbnailCache` has the same defect** at `lib/features/media/data/services/gallery_thumbnail_cache.dart:101-137`, with 4 permits. This is the PhotoKit path, so four iCloud assets still downloading from the cloud block every gallery thumbnail in the app. photo_manager sets `networkAccessAllowed = YES` unconditionally, and the Dart side simply awaits.
+
+**F4. `readBookmarkBytes` reads the whole file synchronously on the platform main thread.** `macos/Runner/LocalMediaHandler.swift:269` and `ios/Runner/LocalMediaHandler.swift:224`: `let data = try Data(contentsOf: url)`. `FlutterMethodChannel` handlers run on the platform thread, which on macOS is the main thread. On a sandboxed build this is the normal path for any local file, and `LocalFileResolver.resolveThumbnail` falls through to `resolve()` for non-video items (`local_file_resolver.dart:347`). `resolveBookmark` (`:250` macOS) and `createBookmark` (`:181` macOS) also touch the volume on the main thread.
+
+**F5. macOS defers termination to Dart and never re-checks.** `macos/Runner/AppDelegate.swift:90` returns `true` from `applicationShouldTerminateAfterLastWindowClosed`, so "alive by design" is ruled out. `applicationShouldTerminate` is not overridden, so the inherited `FlutterAppDelegate` implementation returns `NSTerminateLater` and asks Dart. There is no timer, no fallback, and no `exit()` anywhere in the Runner.
+
+**F6. The Dart exit handler is not total.** `lib/app.dart:129-133`:
+```dart
+Future<AppExitResponse> _closeDatabases() async {
+  await DatabaseService.instance.close();
+  await LocalCacheDatabaseService.instance.close();
+  return AppExitResponse.exit;
+}
+```
+No `try`, no `.timeout()`, no fallback return. It is the only `onExitRequested` handler in the repo. If it throws or never completes, the reply is never sent and AppKit stays in `NSTerminateLater` forever: window gone, process alive. Its internal budgets (`lib/core/database/background_database_connection.dart:48-77`) are all `Future.timeout`, which cannot interrupt work already in progress and cannot fire at all if the isolate is blocked.
+
+**F7. F4 and F6 compose.** The main thread blocked in `Data(contentsOf:)` against a hung mount is the same thread that must run `applicationShouldTerminate` and deliver `replyToApplicationShouldTerminate:`. That is why the zombie reproduces specifically in the Media section.
+
+**F8. A store-backed video tile downloads the whole video.** `MediaStoreResolver.tryResolveRemote` deliberately returns `null` for a video thumbnail rather than download the original (`lib/features/media/data/resolvers/media_store_resolver.dart:54-60`, with an explicit comment). `MediaStoreSourceResolver.resolveThumbnail` then undoes that: `return await fn(item, thumbnail: true) ?? resolve(item);` (`lib/features/media/data/resolvers/media_store_source_resolver.dart:57`), and `resolve` calls `fn(item, thumbnail: false)`, which is `_fetchOriginal`. One full video download per grid tile, holding one of the 4 store permits.
+
+### Product decisions already made (do not relitigate)
+
+- **Slow media:** at the slot budget the fetch releases its permit and keeps running, so the tile keeps shimmering while every other tile proceeds. At the total budget the caller gives up and the tile shows a tappable "Still loading, tap to retry" placeholder. Nothing is abandoned merely for being slow.
+- **Shutdown:** guard the Dart handler so it always replies within a hard budget, **and** add a native watchdog that force-terminates if Dart does not answer. The watchdog must not depend on the main run loop, because the case it exists for is a blocked main thread.
+
+### Explicitly out of scope
+
+Record these as follow-ups; do not build them here.
+- Real download progress (`PMProgressHandler`, byte progress through the resolver stack).
+- `LocalFileResolver.resolveThumbnail` pulling the full original across the channel per tile instead of a native downscale.
+- Synchronous filesystem I/O in the EXIF/import path (`exif_extractor.dart:29-30`, `files_tab.dart:102`).
+- `reverifyAll` sweeping the library on the UI isolate.
+- The unclosed media-store `S3ApiClient` and the uncancelled `HostRateLimiter` wakeup timer (leaks, not hangs).
+- The modal `barrierDismissible: false` spinner in `media_share_helper.dart:22-38`.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/core/app/app_exit.dart` - the total, budgeted exit close routine, extracted from `app.dart` so it is unit-testable without a widget tree.
+- `test/core/app/app_exit_test.dart`
+- `test/features/media/presentation/widgets/media_item_view_retry_test.dart`
+
+**Modify:**
+- `lib/features/media/domain/value_objects/media_source_data.dart` - add `UnavailableKind.stillFetching`.
+- `lib/features/media/presentation/widgets/unavailable_media_placeholder.dart:48-78` - two exhaustive switches (the only two in `lib/`).
+- `lib/l10n/arb/app_{ar,de,en,es,fr,he,hu,it,nl,pt,zh}.arb` - one new key.
+- `lib/features/media/data/resolvers/media_fetch_gate.dart` - slot budget, detach cap, total budget.
+- `lib/features/media/data/services/gallery_thumbnail_cache.dart:101-137` - slot budget.
+- `lib/features/media/data/resolvers/media_store_source_resolver.dart:57` - video fall-through.
+- `lib/features/media/presentation/widgets/media_item_view.dart` - retry on tap.
+- `macos/Runner/LocalMediaHandler.swift` and `ios/Runner/LocalMediaHandler.swift` - background queue.
+- `macos/Runner/AppDelegate.swift` - terminate watchdog.
+- `lib/app.dart:129-133` - delegate to `app_exit.dart`.
+
+**Existing tests that must keep passing:**
+- `test/features/media/data/resolvers/media_fetch_gate_test.dart`
+- `test/features/media/data/resolvers/local_file_resolver_test.dart`
+- `test/features/media/data/services/gallery_thumbnail_cache_test.dart` (if present; check)
+
+---
+
+### Task 1: A recoverable "still loading" state
+
+**Files:**
+- Modify: `lib/features/media/domain/value_objects/media_source_data.dart:4-26`
+- Modify: `lib/features/media/presentation/widgets/unavailable_media_placeholder.dart:48-78`
+- Modify: `lib/l10n/arb/app_en.arb` plus the other 10 ARB files
+- Test: `test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `UnavailableKind.stillFetching`, and `AppLocalizations.media_unavailablePlaceholder_stillFetching` (a plain `String` getter, no parameters).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart`. If the file does not exist, create it with the same imports the neighbouring widget tests use (`flutter_test`, `flutter_localizations`, `package:submersion/l10n/arb/app_localizations.dart`).
+
+```dart
+testWidgets('stillFetching renders the retry-able loading message', (
+  tester,
+) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SizedBox(
+          width: 140,
+          height: 140,
+          child: UnavailableMediaPlaceholder(
+            data: UnavailableData(kind: UnavailableKind.stillFetching),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+  expect(find.text('Still loading. Tap to retry.'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart`
+Expected: FAIL to **compile**, with "The getter 'stillFetching' isn't defined for the type 'UnavailableKind'".
+
+- [ ] **Step 3: Add the enum value**
+
+In `lib/features/media/domain/value_objects/media_source_data.dart`, append to `UnavailableKind` (after `volumeOffline`):
+
+```dart
+  /// The fetch is still running and outlived the caller's budget.
+  ///
+  /// Distinct from every other kind because nothing is wrong: the bytes
+  /// exist and are on their way. It exists so a slow source (a network
+  /// share, a cold store object, an iCloud asset still coming down) can
+  /// stop occupying a concurrency slot without the tile claiming the item
+  /// is missing. Always recoverable by retrying, and the underlying fetch
+  /// may well have finished by the time the user does.
+  stillFetching,
+```
+
+- [ ] **Step 4: Add the two switch arms**
+
+In `lib/features/media/presentation/widgets/unavailable_media_placeholder.dart`, add to `_iconFor` (after the `volumeOffline` arm):
+
+```dart
+    UnavailableKind.stillFetching => Icons.hourglass_empty,
+```
+
+and to `_messageFor` (after the `volumeOffline` arm):
+
+```dart
+      UnavailableKind.stillFetching =>
+        l10n.media_unavailablePlaceholder_stillFetching,
+```
+
+- [ ] **Step 5: Add the localized string to all 11 ARB files**
+
+In `lib/l10n/arb/app_en.arb`, next to `"media_unavailablePlaceholder_volumeOffline"` (around line 15012):
+
+```json
+  "media_unavailablePlaceholder_stillFetching": "Still loading. Tap to retry.",
+```
+
+Add the same key to each of the other 10 files, at the same position relative to `media_unavailablePlaceholder_volumeOffline`:
+
+| File | Value |
+| --- | --- |
+| `app_ar.arb` | `"ما زال قيد التحميل. اضغط لإعادة المحاولة."` |
+| `app_de.arb` | `"Wird noch geladen. Zum Wiederholen tippen."` |
+| `app_es.arb` | `"Aún se está cargando. Toca para reintentar."` |
+| `app_fr.arb` | `"Chargement en cours. Touchez pour réessayer."` |
+| `app_he.arb` | `"עדיין נטען. הקש כדי לנסות שוב."` |
+| `app_hu.arb` | `"Még töltődik. Koppintson az újrapróbálkozáshoz."` |
+| `app_it.arb` | `"Ancora in caricamento. Tocca per riprovare."` |
+| `app_nl.arb` | `"Nog aan het laden. Tik om opnieuw te proberen."` |
+| `app_pt.arb` | `"Ainda a carregar. Toque para tentar novamente."` |
+| `app_zh.arb` | `"仍在加载。点按重试。"` |
+
+- [ ] **Step 6: Regenerate localizations**
+
+Run: `flutter gen-l10n`
+Expected: exit 0. `lib/l10n/arb/app_localizations*.dart` are checked in, so they will show as modified. Confirm with `git status` that all 11 generated files changed.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `flutter test test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart`
+Expected: PASS.
+
+- [ ] **Step 8: Verify nothing else switched exhaustively on the enum**
+
+Run: `flutter analyze`
+Expected: "No issues found!". A non-exhaustive switch elsewhere would surface here as an error. (Only the two arms above exist in `lib/`; this step proves it.)
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/domain/value_objects/media_source_data.dart lib/features/media/presentation/widgets/unavailable_media_placeholder.dart lib/l10n/arb test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart
+git commit -m "feat(media): add a recoverable still-loading placeholder state"
+```
+
+---
+
+### Task 2: Bound MediaFetchGate so one stalled fetch cannot block the rest
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/media_fetch_gate.dart`
+- Test: `test/features/media/data/resolvers/media_fetch_gate_test.dart`
+
+**Interfaces:**
+- Consumes: `UnavailableKind.stillFetching` from Task 1.
+- Produces: `MediaFetchGate({int maxConcurrent, Duration slotBudget, Duration totalBudget, int? maxDetached})`, plus `int get detachedCount`. `run(String key, Future<MediaSourceData?> Function() fetch)` keeps its signature and now never returns a future that outlives `totalBudget`.
+
+**Design, so the implementer does not have to infer it:**
+
+Three numbers, each doing one job.
+
+- `maxConcurrent` (unchanged defaults: 4 for the store, 8 for local files) is how many fetches hold a *slot*.
+- `slotBudget` (default 5s) is how long a fetch may hold that slot. On expiry the slot passes to the next waiter and the fetch keeps running, now "detached". This is what stops head-of-line blocking.
+- `totalBudget` (default 30s) is how long a *caller* waits. On expiry the caller gets `UnavailableData(kind: stillFetching)`. The fetch is not cancelled; Dart cannot cancel a `Future`.
+
+Detaching without a ceiling would leak: on a dead mount the gate would start `maxConcurrent` new fetches every `slotBudget`, each parking a `dart:io` pool thread, which is the exact starvation this whole change exists to remove. So `maxDetached` (default `maxConcurrent * 3`) caps it. At the cap a fetch keeps its slot rather than detaching, which restores back-pressure. Maximum outstanding is therefore `maxConcurrent + maxDetached`, a fixed number.
+
+`_inFlight` must map the key to the **raw** fetch future, not to the caller's bounded view of it. Otherwise a retry after `totalBudget` starts a second download of bytes already on the way. Keeping the raw future means a retry coalesces onto the fetch still in flight and gets a fresh `totalBudget` to wait out.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/media/data/resolvers/media_fetch_gate_test.dart`. Match the file's existing imports and add `package:fake_async/fake_async.dart` if it is not already there.
+
+```dart
+group('slot budget', () {
+  test('a fetch that overruns the slot budget frees it for the next waiter', () {
+    fakeAsync((async) {
+      final gate = MediaFetchGate(
+        maxConcurrent: 1,
+        slotBudget: const Duration(seconds: 5),
+        totalBudget: const Duration(seconds: 30),
+      );
+      final slow = Completer<MediaSourceData?>();
+      var secondStarted = false;
+
+      gate.run('slow', () => slow.future);
+      async.flushMicrotasks();
+      gate.run('other', () async {
+        secondStarted = true;
+        return const BytesData(bytes: <int>[] as dynamic);
+      });
+      async.flushMicrotasks();
+
+      expect(
+        secondStarted,
+        isFalse,
+        reason: 'the only slot is held by the slow fetch',
+      );
+
+      async.elapse(const Duration(seconds: 5));
+      async.flushMicrotasks();
+
+      expect(
+        secondStarted,
+        isTrue,
+        reason: 'the slot budget expired and handed the slot on',
+      );
+      expect(gate.detachedCount, 1);
+
+      slow.complete(null);
+      async.flushMicrotasks();
+      expect(gate.detachedCount, 0);
+    });
+  });
+
+  test('the caller gives up at the total budget with stillFetching', () {
+    fakeAsync((async) {
+      final gate = MediaFetchGate(
+        maxConcurrent: 1,
+        slotBudget: const Duration(seconds: 5),
+        totalBudget: const Duration(seconds: 30),
+      );
+      final never = Completer<MediaSourceData?>();
+      MediaSourceData? seen;
+      gate.run('never', () => never.future).then((v) => seen = v);
+
+      async.elapse(const Duration(seconds: 29));
+      async.flushMicrotasks();
+      expect(seen, isNull);
+
+      async.elapse(const Duration(seconds: 2));
+      async.flushMicrotasks();
+      expect(seen, isA<UnavailableData>());
+      expect(
+        (seen! as UnavailableData).kind,
+        UnavailableKind.stillFetching,
+      );
+
+      // Not cancelled: completing late must not throw into the void.
+      never.complete(null);
+      async.flushMicrotasks();
+    });
+  });
+
+  test('detaching is capped so outstanding fetches cannot grow without bound', () {
+    fakeAsync((async) {
+      final gate = MediaFetchGate(
+        maxConcurrent: 1,
+        maxDetached: 2,
+        slotBudget: const Duration(seconds: 5),
+        totalBudget: const Duration(minutes: 5),
+      );
+      final held = <Completer<MediaSourceData?>>[];
+      for (var i = 0; i < 4; i++) {
+        final c = Completer<MediaSourceData?>();
+        held.add(c);
+        gate.run('k$i', () => c.future);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+      }
+
+      expect(
+        gate.detachedCount,
+        2,
+        reason: 'at the cap a fetch keeps its slot instead of detaching',
+      );
+      expect(gate.runningCount, 1);
+
+      for (final c in held) {
+        c.complete(null);
+      }
+      async.flushMicrotasks();
+    });
+  });
+
+  test('a retry after the total budget coalesces onto the live fetch', () {
+    fakeAsync((async) {
+      final gate = MediaFetchGate(
+        maxConcurrent: 4,
+        slotBudget: const Duration(seconds: 5),
+        totalBudget: const Duration(seconds: 30),
+      );
+      final slow = Completer<MediaSourceData?>();
+      var starts = 0;
+      Future<MediaSourceData?> fetch() {
+        starts++;
+        return slow.future;
+      }
+
+      gate.run('k', fetch);
+      async.elapse(const Duration(seconds: 31));
+      async.flushMicrotasks();
+
+      MediaSourceData? retried;
+      gate.run('k', fetch).then((v) => retried = v);
+      async.flushMicrotasks();
+      expect(starts, 1, reason: 'the first fetch is still running');
+
+      slow.complete(const NetworkData(url: Uri.parse('https://x/y') as dynamic));
+      async.flushMicrotasks();
+      expect(retried, isNotNull);
+    });
+  });
+});
+```
+
+Note on the two `as dynamic` casts above: they are there only so the snippet compiles standalone. Replace them with whatever `MediaSourceData` constructor the existing tests in this file already use for a dummy value (check the top of the file first, it very likely has a helper), and delete the casts.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/media/data/resolvers/media_fetch_gate_test.dart`
+Expected: FAIL to compile with "No named parameter with the name 'slotBudget'".
+
+- [ ] **Step 3: Rewrite the gate**
+
+Replace the body of `class MediaFetchGate` in `lib/features/media/data/resolvers/media_fetch_gate.dart` (keep the existing class doc comment, and append the new paragraph shown at the end of this step):
+
+```dart
+/// Default time a fetch may hold a slot before it is handed on (#1182 follow-up).
+const Duration kMediaFetchSlotBudget = Duration(seconds: 5);
+
+/// Default time a caller waits before showing the still-loading placeholder.
+const Duration kMediaFetchTotalBudget = Duration(seconds: 30);
+
+class MediaFetchGate {
+  MediaFetchGate({
+    this.maxConcurrent = 4,
+    this.slotBudget = kMediaFetchSlotBudget,
+    this.totalBudget = kMediaFetchTotalBudget,
+    int? maxDetached,
+  }) : assert(maxConcurrent > 0),
+       assert(slotBudget <= totalBudget),
+       maxDetached = maxDetached ?? maxConcurrent * 3;
+
+  /// Ceiling on fetches holding a slot.
+  final int maxConcurrent;
+
+  /// Ceiling on fetches that overran [slotBudget] and are still running.
+  ///
+  /// Without this, a dead mount would start [maxConcurrent] fresh fetches
+  /// every [slotBudget] forever, each parking a `dart:io` pool thread: the
+  /// exact starvation this class exists to prevent. At the cap a fetch keeps
+  /// its slot instead of detaching, which restores back-pressure. Outstanding
+  /// work is therefore never more than [maxConcurrent] + [maxDetached].
+  final int maxDetached;
+
+  /// How long a fetch may hold a slot.
+  final Duration slotBudget;
+
+  /// How long a caller waits before settling for [UnavailableKind.stillFetching].
+  final Duration totalBudget;
+
+  /// Raw fetches in flight, keyed for coalescing.
+  ///
+  /// Deliberately the fetch itself rather than the caller's bounded view of
+  /// it: a caller that gave up at [totalBudget] leaves the fetch running, and
+  /// a retry must join that one rather than start a second download of bytes
+  /// already on the way.
+  final Map<String, Future<MediaSourceData?>> _inFlight =
+      <String, Future<MediaSourceData?>>{};
+
+  /// Callers parked waiting for a slot.
+  final Queue<Completer<void>> _waiting = Queue<Completer<void>>();
+
+  int _running = 0;
+  int _detached = 0;
+
+  /// Fetches holding a slot, for tests.
+  int get runningCount => _running;
+
+  /// Fetches that outlived [slotBudget] and are still running, for tests.
+  int get detachedCount => _detached;
+
+  /// Callers currently parked, for tests.
+  int get waitingCount => _waiting.length;
+
+  /// Runs [fetch] under the cap, sharing the result with any caller that asks
+  /// for the same [key] while it is still running.
+  ///
+  /// Never waits longer than [totalBudget]; past that the caller is handed
+  /// [UnavailableKind.stillFetching] and the fetch carries on without it.
+  Future<MediaSourceData?> run(
+    String key,
+    Future<MediaSourceData?> Function() fetch,
+  ) {
+    final pending = _inFlight[key];
+    if (pending != null) return _bounded(pending);
+    final future = _withSlot(fetch);
+    _inFlight[key] = future;
+    // Cleared when the fetch really settles, not when a caller stops waiting.
+    future
+        .whenComplete(() {
+          if (identical(_inFlight[key], future)) _inFlight.remove(key);
+        })
+        .ignore();
+    return _bounded(future);
+  }
+
+  /// A caller's view of [future]: the fetch itself is never cancelled.
+  Future<MediaSourceData?> _bounded(Future<MediaSourceData?> future) {
+    return future.timeout(
+      totalBudget,
+      onTimeout: () =>
+          const UnavailableData(kind: UnavailableKind.stillFetching),
+    );
+  }
+
+  Future<MediaSourceData?> _withSlot(
+    Future<MediaSourceData?> Function() fetch,
+  ) async {
+    await _acquire();
+    var holdsSlot = true;
+    var detached = false;
+
+    void detach() {
+      // At the cap, keep the slot: back-pressure beats fairness once the
+      // detached pool is full.
+      if (!holdsSlot || _detached >= maxDetached) return;
+      holdsSlot = false;
+      detached = true;
+      _detached++;
+      _release();
+    }
+
+    final timer = Timer(slotBudget, detach);
+    try {
+      return await fetch();
+    } finally {
+      timer.cancel();
+      if (detached) {
+        _detached--;
+      } else if (holdsSlot) {
+        holdsSlot = false;
+        _release();
+      }
+    }
+  }
+
+  Future<void> _acquire() {
+    if (_running < maxConcurrent) {
+      _running++;
+      return Future<void>.value();
+    }
+    final waiter = Completer<void>();
+    _waiting.add(waiter);
+    return waiter.future;
+  }
+
+  /// FIFO, unlike `GalleryThumbnailCache`'s LIFO.
+  ///
+  /// That class serves newest-first on the argument that older waiters belong
+  /// to tiles already scrolled away. It does not hold here: [run] hands a
+  /// parked future to any later caller asking for the same key, so a waiter
+  /// can have live tiles behind it, and newest-first would leave them
+  /// shimmering for the whole of a long fling. Fairness is worth more than
+  /// recency when a slot is 30-60 tiles deep.
+  void _release() {
+    if (_waiting.isEmpty) {
+      _running--;
+      return;
+    }
+    // The slot passes straight to the next waiter: _running stays put because
+    // one fetch ends exactly as another begins.
+    _waiting.removeFirst().complete();
+  }
+}
+```
+
+Add these imports at the top of the file if they are not already present:
+
+```dart
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+```
+
+(`dart:async` and `dart:collection` are already imported.)
+
+Append to the existing class doc comment, before `class MediaFetchGate`:
+
+```dart
+/// A third problem, added after #1182: **time**. A cap with no deadline turns
+/// one unreachable item into a stalled gallery, because a permit held by a
+/// fetch against a dead share is a permit no live tile can have. So a fetch
+/// that outlives [slotBudget] hands its slot on and keeps running, and a
+/// caller that outlives [totalBudget] settles for
+/// [UnavailableKind.stillFetching] rather than waiting forever. Neither
+/// cancels anything: Dart cannot cancel a `Future`, and the honest thing to
+/// tell the user about a slow download is that it is slow, not that it failed.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/media/data/resolvers/media_fetch_gate_test.dart`
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 5: Run the resolver tests that depend on the gate**
+
+Run: `flutter test test/features/media/data/resolvers/`
+Expected: all pass. `local_file_resolver_test.dart` constructs the gate; if any test asserted on unbounded parking, fix the test to pass an explicit long `totalBudget` rather than weakening the implementation.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/media_fetch_gate.dart test/features/media/data/resolvers/media_fetch_gate_test.dart
+git commit -m "fix(media): give the fetch gate a slot budget so one stall cannot block the rest"
+```
+
+---
+
+### Task 3: The same slot budget for the PhotoKit path
+
+**Files:**
+- Modify: `lib/features/media/data/services/gallery_thumbnail_cache.dart:28-32, 101-155`
+- Test: `test/features/media/data/services/gallery_thumbnail_cache_test.dart`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (this class deals in `Uint8List?`, not `MediaSourceData`).
+- Produces: `GalleryThumbnailCache({int maxBytes, int maxConcurrent, Duration slotBudget, int? maxDetached})` and `int get detachedCount`.
+
+**Why this is separate from Task 2:** the class caches `Uint8List?` and has no `MediaSourceData` vocabulary, so it cannot return `stillFetching`. It gets the slot budget only. Its caller (`platform_gallery_resolver.dart:83`) sits inside a `MediaFetchGate`-governed resolve, so the total budget is already applied one level up. `null` here still means "no bytes right now" and is still not cached, which is the existing documented contract at `:65-68`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/features/media/data/services/gallery_thumbnail_cache_test.dart` (create it if absent, mirroring the imports of the media_fetch_gate test):
+
+```dart
+test('an iCloud fetch that overruns the slot budget frees it', () {
+  fakeAsync((async) {
+    final cache = GalleryThumbnailCache(
+      maxConcurrent: 1,
+      slotBudget: const Duration(seconds: 5),
+    );
+    final stuck = Completer<Uint8List?>();
+    var secondStarted = false;
+
+    cache.getOrFetch('cloud', () => stuck.future);
+    async.flushMicrotasks();
+    cache.getOrFetch('local', () async {
+      secondStarted = true;
+      return Uint8List.fromList(<int>[1, 2, 3]);
+    });
+    async.flushMicrotasks();
+    expect(secondStarted, isFalse);
+
+    async.elapse(const Duration(seconds: 5));
+    async.flushMicrotasks();
+    expect(secondStarted, isTrue);
+    expect(cache.detachedCount, 1);
+
+    stuck.complete(null);
+    async.flushMicrotasks();
+    expect(cache.detachedCount, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/media/data/services/gallery_thumbnail_cache_test.dart`
+Expected: FAIL to compile with "No named parameter with the name 'slotBudget'".
+
+- [ ] **Step 3: Implement**
+
+Change the constructor at `lib/features/media/data/services/gallery_thumbnail_cache.dart:28-32` to:
+
+```dart
+  GalleryThumbnailCache({
+    this.maxBytes = 32 * 1024 * 1024,
+    this.maxConcurrent = 4,
+    this.slotBudget = kGalleryThumbnailSlotBudget,
+    int? maxDetached,
+  }) : assert(maxBytes > 0),
+       assert(maxConcurrent > 0),
+       maxDetached = maxDetached ?? maxConcurrent * 3;
+```
+
+Above the class, add:
+
+```dart
+/// How long a PhotoKit fetch may hold a concurrency slot.
+///
+/// photo_manager asks PhotoKit with `networkAccessAllowed = YES`, so an
+/// iCloud-only asset triggers a full cloud download behind a plain `await`.
+/// Four of those used to hold every slot this cache has, which is a gallery
+/// of permanent shimmer on a slow connection.
+const Duration kGalleryThumbnailSlotBudget = Duration(seconds: 5);
+```
+
+Add the fields next to `maxConcurrent`:
+
+```dart
+  /// How long a fetch may hold a slot before handing it to the next waiter.
+  final Duration slotBudget;
+
+  /// Ceiling on fetches that overran [slotBudget] and are still running.
+  final int maxDetached;
+```
+
+Add `int _detached = 0;` next to `int _running = 0;`, and a getter next to `byteCount`:
+
+```dart
+  /// Fetches that outlived [slotBudget] and are still running, for tests.
+  int get detachedCount => _detached;
+```
+
+Replace `_run` (`:101-114`) with:
+
+```dart
+  Future<Uint8List?> _run(
+    String key,
+    Future<Uint8List?> Function() fetch,
+  ) async {
+    await _acquire();
+    var holdsSlot = true;
+    var detached = false;
+
+    void detach() {
+      if (!holdsSlot || _detached >= maxDetached) return;
+      holdsSlot = false;
+      detached = true;
+      _detached++;
+      _release();
+    }
+
+    final timer = Timer(slotBudget, detach);
+    try {
+      final bytes = await fetch();
+      if (bytes != null) _store(key, bytes);
+      return bytes;
+    } finally {
+      timer.cancel();
+      if (detached) {
+        _detached--;
+      } else if (holdsSlot) {
+        holdsSlot = false;
+        _release();
+      }
+      _inFlight.remove(key);
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/media/data/services/gallery_thumbnail_cache_test.dart`
+Expected: PASS, pre-existing tests included.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/services/gallery_thumbnail_cache.dart test/features/media/data/services/gallery_thumbnail_cache_test.dart
+git commit -m "fix(media): free a gallery thumbnail slot when an iCloud fetch overruns"
+```
+
+---
+
+### Task 4: Stop a store-backed video tile downloading the whole video
+
+**Files:**
+- Modify: `lib/features/media/data/resolvers/media_store_source_resolver.dart:48-58`
+- Test: `test/features/media/data/resolvers/media_store_source_resolver_test.dart` (create if absent)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: no signature change.
+
+**Why:** see finding F8. `tryResolveRemote` returns `null` for a video thumbnail on purpose, with a comment saying so; the `?? resolve(item)` on line 57 immediately re-asks with `thumbnail: false` and downloads the original. `MediaItemView` already knows how to draw the right thing when a video has no poster: it checks `widget.item.remoteThumbUploadedAt == null` and renders `_VideoThumbnailPlaceholder`. So the fix is to not fall through for a video that has no stamped remote thumb.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+test('a video thumbnail with no stamped thumb does not fetch the original', () async {
+  final calls = <bool>[];
+  final resolver = MediaStoreSourceResolver(
+    remote: () => (MediaItem item, {required bool thumbnail}) async {
+      calls.add(thumbnail);
+      return null;
+    },
+  );
+
+  final data = await resolver.resolveThumbnail(
+    _videoItem(remoteThumbUploadedAt: null),
+    target: const Size(140, 140),
+  );
+
+  expect(
+    calls,
+    [true],
+    reason: 'asking again with thumbnail:false is a full video download',
+  );
+  expect(data, isA<UnavailableData>());
+  expect((data as UnavailableData).kind, UnavailableKind.notFound);
+});
+
+test('a photo thumbnail still degrades to the original', () async {
+  final calls = <bool>[];
+  final resolver = MediaStoreSourceResolver(
+    remote: () => (MediaItem item, {required bool thumbnail}) async {
+      calls.add(thumbnail);
+      return thumbnail ? null : const BytesData(bytes: _oneByte);
+    },
+  );
+
+  final data = await resolver.resolveThumbnail(
+    _photoItem(),
+    target: const Size(140, 140),
+  );
+
+  expect(calls, [true, false]);
+  expect(data, isA<BytesData>());
+});
+```
+
+Build `_videoItem`, `_photoItem` and `_oneByte` with whatever `MediaItem` factory the neighbouring resolver tests already use. Check `test/features/media/data/resolvers/media_store_resolver_test.dart` first, it almost certainly has one; reuse it rather than writing a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/features/media/data/resolvers/media_store_source_resolver_test.dart`
+Expected: FAIL on the first test with `calls` being `[true, false]` instead of `[true]`.
+
+- [ ] **Step 3: Implement**
+
+Replace `resolveThumbnail`'s body (`:48-58`) with:
+
+```dart
+  @override
+  Future<MediaSourceData> resolveThumbnail(
+    MediaItem item, {
+    required Size target,
+  }) async {
+    final fn = remote();
+    if (fn == null) {
+      return const UnavailableData(kind: UnavailableKind.unauthenticated);
+    }
+    final thumb = await fn(item, thumbnail: true);
+    if (thumb != null) return thumb;
+    // A video's original and rendition are both video, so degrading to them
+    // renders the same movie placeholder the caller already has and costs a
+    // full download per grid tile. MediaStoreResolver.tryResolveRemote
+    // declines for exactly this reason; falling through here would undo it.
+    if (item.isVideo) {
+      return const UnavailableData(kind: UnavailableKind.notFound);
+    }
+    return resolve(item);
+  }
+```
+
+Confirm `MediaItem.isVideo` exists (it is used at `media_item_view.dart:311`); if the row's type lives elsewhere, use `item.mediaType == MediaType.video` and import `media_type.dart` as `media_store_resolver.dart` does.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/media/data/resolvers/`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/data/resolvers/media_store_source_resolver.dart test/features/media/data/resolvers/media_store_source_resolver_test.dart
+git commit -m "fix(media): stop a store video tile downloading the whole video"
+```
+
+---
+
+### Task 5: Let the user retry a still-loading tile
+
+**Files:**
+- Modify: `lib/features/media/presentation/widgets/media_item_view.dart:326-345`
+- Test: `test/features/media/presentation/widgets/media_item_view_retry_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `UnavailableKind.stillFetching` (Task 1); the gate returning it (Task 2).
+- Produces: no public signature change.
+
+**Why:** without this the new state is a dead end. The placeholder's copy says "tap to retry", so tapping must actually re-resolve. Re-running `_resolve()` is cheap and correct: `MediaFetchGate.run` coalesces the retry onto the fetch still in flight (Task 2), so the tap joins the live download rather than starting a second one.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+testWidgets('tapping a still-loading tile re-resolves it', (tester) async {
+  var attempts = 0;
+  final registry = _FakeRegistry(
+    onResolve: (item) async {
+      attempts++;
+      return attempts == 1
+          ? const UnavailableData(kind: UnavailableKind.stillFetching)
+          : BytesData(bytes: _transparentPngBytes);
+    },
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWithValue(registry),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 140,
+            height: 140,
+            child: MediaItemView(item: _photoItem(), thumbnail: true),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+  expect(attempts, 1);
+
+  await tester.tap(find.byType(UnavailableMediaPlaceholder));
+  await tester.pumpAndSettle();
+
+  expect(attempts, 2);
+  expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
+});
+
+testWidgets('tapping a genuinely missing tile does not re-resolve', (
+  tester,
+) async {
+  var attempts = 0;
+  final registry = _FakeRegistry(
+    onResolve: (item) async {
+      attempts++;
+      return const UnavailableData(kind: UnavailableKind.notFound);
+    },
+  );
+  // ... same pumpWidget as above ...
+  await tester.tap(find.byType(UnavailableMediaPlaceholder));
+  await tester.pumpAndSettle();
+  expect(attempts, 1);
+});
+```
+
+Build `_FakeRegistry` and `_photoItem` from the existing media widget-test harness. Read `test/features/media/presentation/widgets/media_item_view_test.dart` first and reuse its fakes verbatim; that file already overrides `mediaSourceResolverRegistryProvider`, so copy that setup rather than inventing one. Use its transparent-PNG helper for `_transparentPngBytes`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/features/media/presentation/widgets/media_item_view_retry_test.dart`
+Expected: FAIL with `attempts` still 1 after the tap.
+
+- [ ] **Step 3: Implement**
+
+In `lib/features/media/presentation/widgets/media_item_view.dart`, add this method to `_MediaItemViewState`, next to `_resolve`:
+
+```dart
+  /// Re-runs resolution after the user taps a still-loading tile.
+  ///
+  /// Only [UnavailableKind.stillFetching] is retryable by tapping: it is the
+  /// one kind that means "nothing is wrong, this is just slow", so a retry has
+  /// a real chance of a different answer. Retrying a dead pointer or an
+  /// offline volume on tap would be a placebo. The gate coalesces this onto
+  /// the fetch still in flight, so the tap joins the live download rather than
+  /// starting a second one.
+  void _retry() => setState(() => _future = _resolve());
+```
+
+Then, in `build`, replace the final `UnavailableData()` switch arm:
+
+```dart
+          UnavailableData() => UnavailableMediaPlaceholder(data: data),
+```
+
+with:
+
+```dart
+          UnavailableData(kind: UnavailableKind.stillFetching) => GestureDetector(
+            onTap: _retry,
+            // The placeholder paints its own opaque background, but the
+            // Column inside it does not fill the tile; without this the gaps
+            // are not hit-testable and the tap lands on whatever is behind.
+            behavior: HitTestBehavior.opaque,
+            child: UnavailableMediaPlaceholder(data: data),
+          ),
+          UnavailableData() => UnavailableMediaPlaceholder(data: data),
+```
+
+Also update the `snapshot.hasError` branch at `:329-333` so a thrown resolution is not silently reported as `notFound` forever. Leave the kind alone (an exception really is a failure, not a slow fetch) but make it retryable is **not** required here; do not change it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/features/media/presentation/widgets/`
+Expected: PASS, including the pre-existing `media_item_view_test.dart`.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+dart format .
+git add lib/features/media/presentation/widgets/media_item_view.dart test/features/media/presentation/widgets/media_item_view_retry_test.dart
+git commit -m "feat(media): let the user retry a still-loading tile by tapping it"
+```
+
+---
+
+### Task 6: Get the Apple bookmark methods off the platform main thread
+
+**Files:**
+- Modify: `macos/Runner/LocalMediaHandler.swift:172-273`
+- Modify: `ios/Runner/LocalMediaHandler.swift:~150-228`
+- Test: manual, plus `flutter analyze` and the full Dart suite for regressions. There is a `macos/RunnerTests` target but it is the stock stub, and these methods are private on a handler that needs a `FlutterBinaryMessenger`; adding an XCTest harness for them is more scaffolding than the change warrants. Verification is the manual repro in Task 9.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: no channel contract change. Same method names, same arguments, same result payloads and error codes. Only the thread the work runs on changes.
+
+**Why:** finding F4 and F7. `FlutterMethodChannel` handlers run on the platform thread, which on macOS is the main thread. `Data(contentsOf:)` against an SMB mount or an evicted iCloud Drive file blocks it, which freezes the UI **and** blocks the thread that must answer `applicationShouldTerminate`.
+
+**The rule to follow:** do the filesystem work on `DispatchQueue.global(qos: .userInitiated)`, and call `result(...)` and touch any handler state (`active`) back on `DispatchQueue.main`. `FlutterResult` must be invoked on the platform thread, and `active` is unsynchronised mutable state owned by the main thread.
+
+- [ ] **Step 1: Rewrite `readBookmarkBytes` (macOS)**
+
+In `macos/Runner/LocalMediaHandler.swift`, replace `readBookmarkBytes` (`:250-273`) with:
+
+```swift
+    /// Reads the bookmarked file's bytes.
+    ///
+    /// Runs off the platform thread. `Data(contentsOf:)` is a synchronous
+    /// whole-file read, and on a sandboxed build this is the normal path for
+    /// every local media item, including grid thumbnails. Against a network
+    /// share or an evicted iCloud Drive file it blocks until the mount's own
+    /// timeout, and on macOS the platform thread is the main thread: the same
+    /// thread that paints frames and that must answer
+    /// applicationShouldTerminate. Blocking it froze the Media section and
+    /// left the process alive after its window closed.
+    private func readBookmarkBytes(blob: Data, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: .withSecurityScope,
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                let data = try Data(contentsOf: url)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "READ_FAILED",
+                            message:
+                                "Could not read bookmark bytes: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Rewrite `resolveBookmark` (macOS)**
+
+Same file, replace `resolveBookmark` (`:200-231`). Note that `active[ref] = url` must stay on the main thread:
+
+```swift
+    /// Resolves a bookmark and starts security-scoped access.
+    ///
+    /// Off the platform thread for the same reason as readBookmarkBytes:
+    /// resolving a bookmark touches the volume it points at, so a dead mount
+    /// blocks here too. The `active` map is main-thread-owned state and is
+    /// mutated back on main.
+    private func resolveBookmark(blob: Data, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: .withSecurityScope,
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                let ref = UUID().uuidString
+                let isStale = stale
+                DispatchQueue.main.async {
+                    self.active[ref] = url
+                    result([
+                        "bookmarkRef": ref,
+                        "filePath": url.path,
+                        "stale": isStale,
+                    ])
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "RESOLVE_FAILED",
+                            message:
+                                "Could not resolve bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Rewrite `createBookmark` (macOS)**
+
+Same file, replace `createBookmark` (`:181-198`):
+
+```swift
+    /// Mints a security-scoped bookmark. Off the platform thread: bookmarking
+    /// a file on an unreachable share blocks in the same way a read does.
+    private func createBookmark(filePath: String, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let url = URL(fileURLWithPath: filePath)
+            do {
+                let data = try url.bookmarkData(
+                    options: .withSecurityScope,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "BOOKMARK_FAILED",
+                            message:
+                                "Could not create bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Move the bookmark resolution inside `generateVideoThumbnail` off the main thread (macOS)**
+
+`QLThumbnailGenerator.generateBestRepresentation` is already asynchronous, but the `URL(resolvingBookmarkData:)` above it at `:141-148` is not. Wrap the whole body of `generateVideoThumbnail` from `var url: URL?` through the closing of the QuickLook call in `DispatchQueue.global(qos: .userInitiated).async { ... }`. The existing `DispatchQueue.main.async { result(...) }` calls inside the QuickLook completion already do the right thing and need no change. Add `[weak self]` only if the compiler requires it; this method does not touch `self`.
+
+- [ ] **Step 5: Apply the same three changes to iOS**
+
+`ios/Runner/LocalMediaHandler.swift` mirrors the macOS file with `options: []` instead of `.withSecurityScope`. Apply Steps 1 to 3 there, preserving each method's existing `options:` value exactly. iOS has no `generateVideoThumbnail`, so skip Step 4.
+
+- [ ] **Step 6: Verify it builds**
+
+Run: `flutter build macos --debug`
+Expected: exit 0, no Swift warnings introduced.
+
+If a Mac is unavailable to the executor, run `swift -frontend -parse macos/Runner/LocalMediaHandler.swift` as a syntax-only check and flag that the build was not run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add macos/Runner/LocalMediaHandler.swift ios/Runner/LocalMediaHandler.swift
+git commit -m "fix(media): read bookmarked media off the platform main thread"
+```
+
+---
+
+### Task 7: Make the Dart exit reply total
+
+**Files:**
+- Create: `lib/core/app/app_exit.dart`
+- Create: `test/core/app/app_exit_test.dart`
+- Modify: `lib/app.dart:120-133`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```dart
+  const Duration kAppExitCloseBudget = Duration(seconds: 8);
+
+  Future<AppExitResponse> closeDatabasesForExit({
+    required Future<void> Function() closeMain,
+    required Future<void> Function() closeCache,
+    Duration budget = kAppExitCloseBudget,
+    void Function(Object error, StackTrace stack)? onError,
+  });
+  ```
+  It always completes with `AppExitResponse.exit`, never throws, and never takes longer than `budget`.
+
+**Why:** finding F6. Extracted from `_SubmersionAppState` because a private method on a `ConsumerState` cannot be unit-tested without standing up a widget tree and a real `AppLifecycleListener`, and this routine's whole contract is "always replies, whatever happens", which is exactly what wants a fast unit test.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/core/app/app_exit_test.dart`:
+
+```dart
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/app/app_exit.dart';
+
+void main() {
+  test('closes both databases in order and replies exit', () async {
+    final calls = <String>[];
+    final response = await closeDatabasesForExit(
+      closeMain: () async => calls.add('main'),
+      closeCache: () async => calls.add('cache'),
+    );
+    expect(calls, ['main', 'cache']);
+    expect(response, AppExitResponse.exit);
+  });
+
+  test('still replies exit when the main database close throws', () async {
+    final errors = <Object>[];
+    final calls = <String>[];
+    final response = await closeDatabasesForExit(
+      closeMain: () async => throw StateError('boom'),
+      closeCache: () async => calls.add('cache'),
+      onError: (e, _) => errors.add(e),
+    );
+    expect(response, AppExitResponse.exit);
+    expect(errors, hasLength(1));
+    expect(
+      calls,
+      ['cache'],
+      reason: 'a failed main close must not strand the cache database',
+    );
+  });
+
+  test('still replies exit when a close never completes', () {
+    fakeAsync((async) {
+      AppExitResponse? response;
+      final errors = <Object>[];
+      closeDatabasesForExit(
+        closeMain: () => Completer<void>().future,
+        closeCache: () async {},
+        budget: const Duration(seconds: 8),
+        onError: (e, _) => errors.add(e),
+      ).then((r) => response = r);
+
+      async.elapse(const Duration(seconds: 7));
+      async.flushMicrotasks();
+      expect(response, isNull);
+
+      async.elapse(const Duration(seconds: 2));
+      async.flushMicrotasks();
+      expect(response, AppExitResponse.exit);
+      expect(errors.single, isA<TimeoutException>());
+    });
+  });
+
+  test('the cache close gets the remainder of the budget, not a fresh one', () {
+    fakeAsync((async) {
+      AppExitResponse? response;
+      closeDatabasesForExit(
+        closeMain: () => Future<void>.delayed(const Duration(seconds: 6)),
+        closeCache: () => Completer<void>().future,
+        budget: const Duration(seconds: 8),
+      ).then((r) => response = r);
+
+      async.elapse(const Duration(seconds: 9));
+      async.flushMicrotasks();
+      expect(
+        response,
+        AppExitResponse.exit,
+        reason: 'the total must be bounded by budget, not by 2 x budget',
+      );
+    });
+  });
+}
+```
+
+Add `import 'dart:async';` at the top for `Completer` and `TimeoutException`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/core/app/app_exit_test.dart`
+Expected: FAIL to compile, "Target of URI doesn't exist: 'package:submersion/core/app/app_exit.dart'".
+
+- [ ] **Step 3: Implement**
+
+Create `lib/core/app/app_exit.dart`:
+
+```dart
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+/// Hard ceiling on database closing during app exit.
+///
+/// Deliberately shorter than the sum of the close helpers' own internal
+/// timeouts (roughly 13s worst case across the two databases). Those are
+/// `Future.timeout`s, which cannot interrupt work already in progress and
+/// cannot fire at all if the isolate is blocked, so they bound the happy path
+/// and nothing else. This is the bound that holds regardless.
+const Duration kAppExitCloseBudget = Duration(seconds: 8);
+
+/// Closes both databases, then answers the platform's exit request.
+///
+/// **Always** completes with [AppExitResponse.exit], never throws, and never
+/// takes longer than [budget].
+///
+/// That totality is the whole point. On macOS the inherited
+/// `FlutterAppDelegate.applicationShouldTerminate` returns `NSTerminateLater`
+/// and hands the decision to Dart; this handler is the only thing that can
+/// send the reply, and nothing on the native side re-checks. An unguarded
+/// throw or a close that never returns therefore left AppKit waiting forever:
+/// the window was already dismissed, so the user saw the app quit while the
+/// process stayed alive. Reported against the Media section, whose local-file
+/// reads are the likeliest thing to be mid-flight at quit.
+///
+/// The two closes run sequentially and share one budget. Sequentially because
+/// racing two shutdown sequences is not worth the second or two it saves; one
+/// shared budget because a per-close budget would make the worst case twice
+/// what the name promises. [closeCache] is attempted even when [closeMain]
+/// fails, so one bad database cannot strand the other.
+Future<AppExitResponse> closeDatabasesForExit({
+  required Future<void> Function() closeMain,
+  required Future<void> Function() closeCache,
+  Duration budget = kAppExitCloseBudget,
+  void Function(Object error, StackTrace stack)? onError,
+}) async {
+  final deadline = Stopwatch()..start();
+
+  Duration remaining() {
+    final left = budget - deadline.elapsed;
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  Future<void> attempt(Future<void> Function() close) async {
+    try {
+      await close().timeout(remaining());
+    } catch (error, stack) {
+      onError?.call(error, stack);
+    }
+  }
+
+  await attempt(closeMain);
+  await attempt(closeCache);
+  return AppExitResponse.exit;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/core/app/app_exit_test.dart`
+Expected: PASS, all four.
+
+- [ ] **Step 5: Wire it into the app**
+
+In `lib/app.dart`, replace `_closeDatabases` (`:120-133`, doc comment included) with:
+
+```dart
+  /// Closes databases before the app exits.
+  ///
+  /// Uses `onExitRequested` (mapped from
+  /// `NSApplicationDelegate.applicationShouldTerminate:` on macOS), which is
+  /// async and fires before the Dart VM begins isolate/FFI teardown. Without
+  /// it the Drift background isolate can outlive the FFI subsystem and crash
+  /// in `sqlite3_close_v2` -> `functionDestroy` ("GetFfiCallbackMetadata
+  /// called after shutdown"), which stalls the quit.
+  ///
+  /// The guarantees that make this safe to be the platform's only reply path
+  /// live in [closeDatabasesForExit]; see its doc for why totality matters
+  /// here.
+  Future<AppExitResponse> _closeDatabases() => closeDatabasesForExit(
+    closeMain: () => DatabaseService.instance.close(),
+    closeCache: () => LocalCacheDatabaseService.instance.close(),
+    onError: (error, stack) => LoggerService.forClass(SubmersionApp).warning(
+      'Database close during app exit did not finish cleanly',
+      error,
+      stack,
+    ),
+  );
+```
+
+Add `import 'package:submersion/core/app/app_exit.dart';` to `lib/app.dart`. Check whether `LoggerService` is already imported there and whether `warning` takes `(String, Object, StackTrace)`; match the signature the rest of the file uses, or use `LoggerService.forClass(SubmersionApp).severe(...)` if that is the convention. Read a neighbouring call site before writing this.
+
+- [ ] **Step 6: Verify**
+
+Run: `flutter analyze`
+Expected: "No issues found!".
+
+Run: `flutter test test/core/ test/app_test.dart`
+Expected: PASS. (Drop `test/app_test.dart` from the command if no such file exists.)
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+dart format .
+git add lib/core/app/app_exit.dart lib/app.dart test/core/app/app_exit_test.dart
+git commit -m "fix(app): always answer the platform exit request within a hard budget"
+```
+
+---
+
+### Task 8: A native watchdog for a wedged main thread
+
+**Files:**
+- Modify: `macos/Runner/AppDelegate.swift`
+- Test: manual (Task 9). A blocked main thread cannot be reproduced in XCTest without the very hang it guards against.
+
+**Interfaces:**
+- Consumes: nothing. Independent of Task 7 by design: Task 7 guards a Dart-level stall, this guards a stall Dart cannot answer at all.
+- Produces: no Dart-visible surface.
+
+**Why:** finding F5 plus the decision recorded above. Task 7 cannot help when the main isolate or the macOS main thread is genuinely blocked, because there is no thread left to run the timeout. The watchdog must therefore live off the main run loop.
+
+**Budget:** 20 seconds, comfortably past Task 7's 8-second Dart budget plus the platform round-trip, so a healthy quit never reaches it.
+
+- [ ] **Step 1: Add the watchdog state and override**
+
+In `macos/Runner/AppDelegate.swift`, add next to the other private properties (after `displayChannel` at `:15`):
+
+```swift
+  /// Guards `terminateAnswered` across the watchdog queue and the main thread.
+  private let terminateLock = NSLock()
+  private var terminateAnswered = false
+```
+
+Add these methods before `applicationWillTerminate`:
+
+```swift
+  /// How long to wait for Dart's answer to the exit request before quitting
+  /// anyway.
+  ///
+  /// Generous next to the 8s budget `closeDatabasesForExit` holds itself to,
+  /// so a healthy quit never reaches this. It exists for the case that budget
+  /// cannot cover: a blocked main isolate or a blocked main thread has no
+  /// thread left to run a `Future.timeout` or a run-loop `Timer`.
+  private static let terminateWatchdogInterval: TimeInterval = 20
+
+  override func applicationShouldTerminate(
+    _ sender: NSApplication
+  ) -> NSApplication.TerminateReply {
+    let reply = super.applicationShouldTerminate(sender)
+    guard reply == .terminateLater else { return reply }
+    armTerminateWatchdog()
+    return reply
+  }
+
+  /// Force-quits if Dart never answers the exit request.
+  ///
+  /// FlutterAppDelegate returns `NSTerminateLater` and asks Dart over the
+  /// `flutter/platform` channel. Nothing on the native side re-checks, so a
+  /// Dart side that never replies leaves AppKit deferring forever: AppKit has
+  /// already dismissed the window, so the user sees the app quit while the
+  /// process lives on. That is the reported symptom, and the Media section's
+  /// local-file reads are the likeliest thing to be mid-flight at quit.
+  ///
+  /// Runs on a background queue, not a `Timer` on the main run loop, because
+  /// a wedged main thread is precisely the case this guards. For the same
+  /// reason it cannot rely on `reply(toApplicationShouldTerminate:)` landing:
+  /// that has to be called on the main thread, so it is attempted first and
+  /// `exit(0)` follows if the process is still here a moment later. By then
+  /// the databases have had their own budget and drift runs in WAL mode, so
+  /// an abrupt exit is recoverable.
+  private func armTerminateWatchdog() {
+    let deadline: DispatchTime =
+      .now() + AppDelegate.terminateWatchdogInterval
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
+      [weak self] in
+      guard let self, !self.hasAnsweredTerminate() else { return }
+      NSLog(
+        "[AppDelegate] No exit-request answer after "
+          + "\(AppDelegate.terminateWatchdogInterval)s; forcing termination"
+      )
+      DispatchQueue.main.async {
+        NSApplication.shared.reply(toApplicationShouldTerminate: true)
+      }
+      DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
+        NSLog("[AppDelegate] Exit still pending; calling exit(0)")
+        exit(0)
+      }
+    }
+  }
+
+  private func hasAnsweredTerminate() -> Bool {
+    terminateLock.lock()
+    defer { terminateLock.unlock() }
+    return terminateAnswered
+  }
+```
+
+- [ ] **Step 2: Disarm the watchdog on a normal quit**
+
+Replace `applicationWillTerminate` (`:94-97`) with:
+
+```swift
+  override func applicationWillTerminate(_ notification: Notification) {
+    terminateLock.lock()
+    terminateAnswered = true
+    terminateLock.unlock()
+    bookmarkHandler?.cleanup()
+    backupBookmarkHandler?.releaseAll()
+    // Released here as well as in its own deinit, which does not run on
+    // terminate: these are security-scoped URLs the Media section opened.
+    localMediaHandler?.releaseAll()
+  }
+```
+
+Check `macos/Runner/LocalMediaHandler.swift:44-52` for the exact name of its cleanup method (`deinit` calls something; it may be `releaseAll()` or inline). If the cleanup is inlined in `deinit`, extract it into an internal `releaseAll()` and call that from both places. If no such cleanup exists, drop that line and the comment rather than inventing one.
+
+- [ ] **Step 3: Verify it builds**
+
+Run: `flutter build macos --debug`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add macos/Runner/AppDelegate.swift macos/Runner/LocalMediaHandler.swift
+git commit -m "fix(macos): force termination if Dart never answers the exit request"
+```
+
+---
+
+### Task 9: Verification
+
+**Files:** none modified unless a failure demands it.
+
+- [ ] **Step 1: Format check**
+
+Run: `dart format --set-exit-if-changed lib/ test/`
+Expected: exit 0.
+
+- [ ] **Step 2: Analyze the whole project**
+
+Run: `flutter analyze`
+Expected: "No issues found!". Infos are fatal.
+
+- [ ] **Step 3: Run the full suite, twice**
+
+Run: `flutter test 2>&1 | tail -40` is **forbidden**: a piped `flutter test` returns the pipe's exit status, so a five-failure run reads as exit 0. Instead:
+
+```bash
+flutter test > /tmp/suite-run-1.txt 2>&1; echo "exit=$?"
+flutter test > /tmp/suite-run-2.txt 2>&1; echo "exit=$?"
+tail -20 /tmp/suite-run-1.txt /tmp/suite-run-2.txt
+```
+
+Expected: exit 0 both times.
+
+Run it twice because this repo has known pre-existing flakes (a recovery-code yo-yo split, a security-settings recovery dialog, a 50ms zip temp-dir delete, a media share-helper temp-bytes case). **Disjoint failure sets across the two runs disprove your diff; a single green run proves nothing.** Do not overlap the two runs, and do not run anything else concurrently: a sibling `pkill` will kill your run and it looks exactly like a lone failure (no summary plus exit 0).
+
+- [ ] **Step 4: Manual repro, symptom one (media availability)**
+
+On macOS, with a debug build:
+
+1. `flutter run -d macos`.
+2. Attach a media item on a network share, then make that share unreachable (disconnect Wi-Fi, or use a mounted share on a host you then power off). If no share is available, an iCloud Drive file whose local copy has been evicted works too.
+3. Open the Media section and scroll the grid.
+
+Expected: the grid scrolls smoothly. Unresolvable tiles shimmer, and after about 30 seconds they show "Still loading. Tap to retry."; tiles from reachable sources paint normally throughout. Before this change the whole window froze.
+
+- [ ] **Step 5: Manual repro, symptom two (shutdown)**
+
+1. Relaunch, open the Media section with the same unreachable source, and scroll so several fetches are in flight.
+2. Close the window with the red button (not Cmd-Q, which takes a different AppKit path).
+3. `ps aux | grep -i submersion` immediately, then again after 30 seconds.
+
+Expected: the process is gone within a couple of seconds. If it survives, `Console.app` will carry the `[AppDelegate] No exit-request answer` line, which tells you the watchdog fired and that a Dart-side stall remains to be found: return to Phase 1 rather than raising the budget.
+
+- [ ] **Step 6: Commit anything the verification forced**
+
+```bash
+dart format .
+git add -A
+git commit -m "test: verification fixes for media availability and shutdown"
+```
+
+Skip this step if nothing changed.
+
+---
+
+## Self-Review
+
+**Spec coverage.** F1 and F2 are Task 2. F3 is Task 3. F4 is Task 6. F5 is Task 8. F6 is Task 7. F7 is Tasks 6 plus 8 together. F8 is Task 4. The "slow media UX" decision is Tasks 1, 2, and 5. The "shutdown" decision is Tasks 7 and 8. Out-of-scope items have no task, deliberately, and are listed as such.
+
+**Placeholder scan.** Every code step carries real code. Four steps deliberately tell the implementer to read an existing file before writing (the `MediaItem` test factory in Task 4, the widget-test fakes in Task 5, the `LocalMediaHandler` cleanup name in Task 8, the `LoggerService` call shape in Task 7). Those are named files with named symbols to copy, not "figure it out": inventing a second `MediaItem` factory or a second fake registry when the suite already has one is the failure mode being avoided.
+
+**Type consistency.** `UnavailableKind.stillFetching` is defined in Task 1 and used in Tasks 2 and 5. `slotBudget` / `totalBudget` / `maxDetached` / `detachedCount` are defined in Task 2 and reused with identical names in Task 3 (minus `totalBudget`, which Task 3's `Uint8List?` vocabulary cannot express, stated explicitly there). `closeDatabasesForExit` and `kAppExitCloseBudget` are defined in Task 7 and referenced in Task 8's doc comment only. `MediaFetchGate.run`'s signature is unchanged, so no caller needs updating.

--- a/ios/Runner/LocalMediaHandler.swift
+++ b/ios/Runner/LocalMediaHandler.swift
@@ -133,57 +133,96 @@ class LocalMediaHandler: NSObject {
         }
     }
 
+    /// Mints a bookmark.
+    ///
+    /// Off the platform thread: bookmarking a file in a Files-provider
+    /// location that is not downloaded yet blocks in the same way reading one
+    /// does, and the platform thread is the one that paints frames.
     private func createBookmark(filePath: String, result: @escaping FlutterResult) {
-        let url = URL(fileURLWithPath: filePath)
-        do {
-            let data = try url.bookmarkData(
-                options: .minimalBookmark,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            result(FlutterStandardTypedData(bytes: data))
-        } catch {
-            result(
-                FlutterError(
-                    code: "BOOKMARK_FAILED",
-                    message: "Could not create bookmark: \(error.localizedDescription)",
-                    details: nil
-                ))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let url = URL(fileURLWithPath: filePath)
+            do {
+                let data = try url.bookmarkData(
+                    options: .minimalBookmark,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "BOOKMARK_FAILED",
+                            message:
+                                "Could not create bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
+            }
         }
     }
 
+    /// Resolves a bookmark and starts security-scoped access.
+    ///
+    /// Off the platform thread for the same reason as readBookmarkBytes:
+    /// resolving a bookmark touches the location it points at. `active` is
+    /// main-thread-owned state and is mutated back on main.
     private func resolveBookmark(blob: Data, result: @escaping FlutterResult) {
-        var stale = false
-        do {
-            let url = try URL(
-                resolvingBookmarkData: blob,
-                options: [],
-                relativeTo: nil,
-                bookmarkDataIsStale: &stale
-            )
-            guard url.startAccessingSecurityScopedResource() else {
-                result(
-                    FlutterError(
-                        code: "ACCESS_DENIED",
-                        message: "Security-scoped resource access denied",
-                        details: nil
-                    ))
-                return
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: [],
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                let ref = UUID().uuidString
+                let isStale = stale
+                DispatchQueue.main.async {
+                    guard let self else {
+                        // The handler went away mid-resolve, so nothing will
+                        // ever release this scope. Balance it here.
+                        url.stopAccessingSecurityScopedResource()
+                        result(
+                            FlutterError(
+                                code: "RESOLVE_FAILED",
+                                message: "Handler released before the bookmark resolved",
+                                details: nil
+                            ))
+                        return
+                    }
+                    self.active[ref] = url
+                    result([
+                        "bookmarkRef": ref,
+                        "filePath": url.path,
+                        "stale": isStale,
+                    ])
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "RESOLVE_FAILED",
+                            message:
+                                "Could not resolve bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
             }
-            let ref = UUID().uuidString
-            active[ref] = url
-            result([
-                "bookmarkRef": ref,
-                "filePath": url.path,
-                "stale": stale,
-            ])
-        } catch {
-            result(
-                FlutterError(
-                    code: "RESOLVE_FAILED",
-                    message: "Could not resolve bookmark: \(error.localizedDescription)",
-                    details: nil
-                ))
         }
     }
 
@@ -202,34 +241,50 @@ class LocalMediaHandler: NSObject {
         result(nil)
     }
 
+    /// Reads the bookmarked file's bytes.
+    ///
+    /// Runs off the platform thread. `Data(contentsOf:)` is a synchronous
+    /// whole-file read and this is the ordinary path for every local media
+    /// item, grid thumbnails included. Against a Files-provider location that
+    /// has not been downloaded yet it blocks until the provider answers, and a
+    /// FlutterMethodChannel handler body runs on the thread that paints frames.
     private func readBookmarkBytes(blob: Data, result: @escaping FlutterResult) {
-        var stale = false
-        do {
-            let url = try URL(
-                resolvingBookmarkData: blob,
-                options: [],
-                relativeTo: nil,
-                bookmarkDataIsStale: &stale
-            )
-            guard url.startAccessingSecurityScopedResource() else {
-                result(
-                    FlutterError(
-                        code: "ACCESS_DENIED",
-                        message: "Security-scoped resource access denied",
-                        details: nil
-                    ))
-                return
+        DispatchQueue.global(qos: .userInitiated).async {
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: [],
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                let data = try Data(contentsOf: url)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "READ_FAILED",
+                            message:
+                                "Could not read bookmark bytes: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
             }
-            defer { url.stopAccessingSecurityScopedResource() }
-            let data = try Data(contentsOf: url)
-            result(FlutterStandardTypedData(bytes: data))
-        } catch {
-            result(
-                FlutterError(
-                    code: "READ_FAILED",
-                    message: "Could not read bookmark bytes: \(error.localizedDescription)",
-                    details: nil
-                ))
         }
     }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/core/app/app_exit.dart';
 import 'package:submersion/core/presentation/providers/app_lock_provider.dart';
 import 'package:submersion/core/presentation/widgets/lock_barrier.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -26,6 +27,7 @@ import 'package:submersion/shared/services/file_share_handler.dart';
 import 'package:submersion/shared/services/incoming_file_handler.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/local_cache_database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/library_epoch.dart';
 
 const Locale _defaultFallbackLocale = Locale('en');
@@ -121,16 +123,22 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
   /// NSApplicationDelegate.applicationShouldTerminate: on macOS) which is
   /// async and fires before the Dart VM begins isolate/FFI teardown. Without
   /// this, the Drift background isolate can outlive the FFI subsystem and
-  /// crash in sqlite3_close_v2 → functionDestroy ("GetFfiCallbackMetadata
-  /// called after shutdown"), which stalls the quit. The close() calls run
-  /// sequentially — awaiting the databases in parallel is not worth racing
-  /// two shutdown sequences, and each one is bounded by its own timeouts
-  /// (see closeDatabaseForAppShutdown).
-  Future<AppExitResponse> _closeDatabases() async {
-    await DatabaseService.instance.close();
-    await LocalCacheDatabaseService.instance.close();
-    return AppExitResponse.exit;
-  }
+  /// crash in sqlite3_close_v2 -> functionDestroy ("GetFfiCallbackMetadata
+  /// called after shutdown"), which stalls the quit.
+  ///
+  /// The guarantees that make this safe to be the platform's only reply path
+  /// (always answers, never throws, never exceeds its budget) live in
+  /// [closeDatabasesForExit]; see its doc for why totality matters here and
+  /// what happens natively when the reply never arrives.
+  Future<AppExitResponse> _closeDatabases() => closeDatabasesForExit(
+    closeMain: () => DatabaseService.instance.close(),
+    closeCache: () => LocalCacheDatabaseService.instance.close(),
+    onError: (error, stack) => LoggerService.forClass(SubmersionApp).warning(
+      'Database close during app exit did not finish cleanly',
+      error: error,
+      stackTrace: stack,
+    ),
+  );
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {

--- a/lib/core/app/app_exit.dart
+++ b/lib/core/app/app_exit.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:ui' show AppExitResponse;
+
+import 'package:clock/clock.dart';
+
+/// Hard ceiling on database closing during app exit.
+///
+/// Deliberately shorter than the sum of the close helpers' own internal
+/// timeouts, which come to roughly 13 seconds across the two databases. Those
+/// are `Future.timeout`s: they cannot interrupt work already in progress, and
+/// they cannot fire at all if the isolate is blocked, so they bound the happy
+/// path and nothing else. This is the bound that holds regardless.
+const Duration kAppExitCloseBudget = Duration(seconds: 8);
+
+/// Closes both databases, then answers the platform's exit request.
+///
+/// **Always** completes with [AppExitResponse.exit], never throws, and never
+/// takes longer than [budget].
+///
+/// That totality is the whole point of the function existing. On macOS the
+/// inherited `FlutterAppDelegate.applicationShouldTerminate` returns
+/// `NSTerminateLater` and hands the decision to Dart; this handler is the only
+/// thing that can send the reply, and nothing on the native side re-checks. An
+/// unguarded throw, or a close that never returns, therefore left AppKit
+/// deferring forever: the window had already been dismissed, so the user saw
+/// the app quit while the process stayed alive. Reported against the Media
+/// section, whose local-file reads are the likeliest thing to be in flight at
+/// quit. `AppDelegate`'s watchdog is the backstop for the case this cannot
+/// reach, a main isolate too blocked to run any of these timers.
+///
+/// The two closes run sequentially and share one budget. Sequentially because
+/// racing two shutdown sequences is not worth the second it saves; one shared
+/// budget because a budget per close would make the worst case twice what the
+/// name promises. [closeCache] is attempted even when [closeMain] fails or
+/// times out, so one bad database cannot strand the other, and it is attempted
+/// even when the remainder is zero: `Future.timeout(Duration.zero)` still runs
+/// the close, it just does not wait, which is strictly better than skipping it.
+Future<AppExitResponse> closeDatabasesForExit({
+  required Future<void> Function() closeMain,
+  required Future<void> Function() closeCache,
+  Duration budget = kAppExitCloseBudget,
+  void Function(Object error, StackTrace stack)? onError,
+}) async {
+  // clock.now() rather than a Stopwatch: a Stopwatch reads the wall clock, so
+  // under fake_async the budget would never deplete and the shared-budget
+  // guarantee below would be untestable, which is how the two-closes case got
+  // written wrong the first time.
+  final startedAt = clock.now();
+
+  Duration remaining() {
+    final left = budget - clock.now().difference(startedAt);
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  Future<void> attempt(Future<void> Function() close) async {
+    try {
+      await close().timeout(remaining());
+    } catch (error, stack) {
+      onError?.call(error, stack);
+    }
+  }
+
+  await attempt(closeMain);
+  await attempt(closeCache);
+  return AppExitResponse.exit;
+}

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -384,6 +384,14 @@ class LocalFileResolver implements MediaSourceResolver {
     if (data.kind == UnavailableKind.volumeOffline) {
       return VerifyResult.volumeOffline;
     }
+    // "Still fetching" is a statement about time, not about whether the file
+    // is there: the read outlived the gate's budget and is very likely still
+    // running. Falling through would put a hung-but-mounted share on the
+    // notFound path below, and notFound flips isOrphaned, so a share that was
+    // merely slow during a sweep would mark its whole library missing.
+    if (data.kind == UnavailableKind.stillFetching) {
+      return VerifyResult.transientError;
+    }
     // A file that is present but unreadable (sandbox denial, revoked
     // permission) is not a dead pointer: the bytes are still on disk and a
     // re-grant restores access. Reporting notFound here would let the

--- a/lib/features/media/data/resolvers/media_fetch_gate.dart
+++ b/lib/features/media/data/resolvers/media_fetch_gate.dart
@@ -3,6 +3,23 @@ import 'dart:collection';
 
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 
+/// How long a fetch may hold a concurrency slot before it is handed on.
+///
+/// Short, because its job is to stop one unreachable item monopolising a
+/// permit, not to give a healthy fetch a generous allowance. A store thumbnail
+/// off a working endpoint lands in well under a second; anything past five is
+/// already an outlier, and the cost of guessing wrong is only that the fetch
+/// finishes without a slot.
+const Duration kMediaFetchSlotBudget = Duration(seconds: 5);
+
+/// How long a caller waits before settling for the still-loading placeholder.
+///
+/// Long, because this one is user-visible: it is the point at which a tile
+/// stops shimmering and admits it does not have the bytes yet. Six times the
+/// slot budget, so a merely slow source has ample room to arrive before the
+/// user is told anything at all.
+const Duration kMediaFetchTotalBudget = Duration(seconds: 30);
+
 /// Caps simultaneous media-store fetches and collapses duplicate ones.
 ///
 /// Nothing gated the store read path before #1175. Every visible grid tile
@@ -14,7 +31,7 @@ import 'package:submersion/features/media/domain/value_objects/media_source_data
 /// is a gallery of permanent shimmer; against a healthy one it is still a
 /// burst most S3-compatible servers throttle.
 ///
-/// Two independent problems, one object:
+/// Three independent problems, one object:
 ///
 /// * **Concurrency.** [maxConcurrent] fetches run at a time; the rest queue.
 ///   Matching `GalleryThumbnailCache`'s cap, which solved the same shape of
@@ -24,17 +41,55 @@ import 'package:submersion/features/media/domain/value_objects/media_source_data
 ///   so the same photo linked to two dives is two rows with one hash, and
 ///   without this each issues its own download of identical bytes and both
 ///   race to write the same cache entry.
+/// * **Time.** A cap with no deadline turns one unreachable item into a
+///   stalled gallery, because a permit held by a fetch against a dead share is
+///   a permit no live tile can have. A fetch that outlives [slotBudget] hands
+///   its slot to the next waiter and keeps running; a caller that outlives
+///   [totalBudget] settles for [UnavailableKind.stillFetching]. Neither
+///   cancels anything: Dart cannot cancel a `Future`, and the honest thing to
+///   tell the user about a slow download is that it is slow, not that it
+///   failed.
 ///
 /// Deliberately NOT a byte cache. The bytes already have one -- `MediaCacheStore`,
 /// on disk -- and holding them in memory as well is what the viewer's own
 /// providers were doing wrong.
 class MediaFetchGate {
-  MediaFetchGate({this.maxConcurrent = 4}) : assert(maxConcurrent > 0);
+  MediaFetchGate({
+    this.maxConcurrent = 4,
+    this.slotBudget = kMediaFetchSlotBudget,
+    this.totalBudget = kMediaFetchTotalBudget,
+    int? maxDetached,
+  }) : assert(maxConcurrent > 0),
+       assert(slotBudget <= totalBudget),
+       maxDetached = maxDetached ?? maxConcurrent * 3;
 
-  /// Ceiling on simultaneous fetches.
+  /// Ceiling on fetches holding a slot.
   final int maxConcurrent;
 
-  /// Fetches currently running, so concurrent callers can share one.
+  /// Ceiling on fetches that outlived [slotBudget] and are still running.
+  ///
+  /// Without it, detaching would leak: against a dead mount the gate would
+  /// start [maxConcurrent] fresh fetches every [slotBudget] forever, each
+  /// parking a `dart:io` pool thread, which is the exact starvation this class
+  /// exists to prevent (#1182). At the cap a fetch keeps its slot instead of
+  /// detaching, restoring back-pressure. Outstanding work is therefore never
+  /// more than [maxConcurrent] + [maxDetached], whatever the source does.
+  final int maxDetached;
+
+  /// How long a fetch may hold a slot.
+  final Duration slotBudget;
+
+  /// How long a caller waits before settling for
+  /// [UnavailableKind.stillFetching].
+  final Duration totalBudget;
+
+  /// Raw fetches in flight, keyed for coalescing.
+  ///
+  /// Deliberately the fetch itself rather than a caller's bounded view of it.
+  /// A caller that gave up at [totalBudget] leaves the fetch running, and a
+  /// retry must join that one: starting a second download of bytes already on
+  /// the way is the waste this map exists to prevent, and it is exactly what a
+  /// user who taps a still-loading tile would trigger.
   final Map<String, Future<MediaSourceData?>> _inFlight =
       <String, Future<MediaSourceData?>>{};
 
@@ -42,39 +97,81 @@ class MediaFetchGate {
   final Queue<Completer<void>> _waiting = Queue<Completer<void>>();
 
   int _running = 0;
+  int _detached = 0;
 
-  /// In-flight fetch count, for tests.
+  /// Fetches holding a slot, for tests.
   int get runningCount => _running;
+
+  /// Fetches that outlived [slotBudget] and are still running, for tests.
+  int get detachedCount => _detached;
 
   /// Callers currently parked, for tests.
   int get waitingCount => _waiting.length;
 
   /// Runs [fetch] under the cap, sharing the result with any caller that asks
   /// for the same [key] while it is still running.
+  ///
+  /// Never leaves the caller waiting longer than [totalBudget]; past that it
+  /// answers [UnavailableKind.stillFetching] and the fetch carries on without
+  /// it.
   Future<MediaSourceData?> run(
     String key,
     Future<MediaSourceData?> Function() fetch,
   ) {
     final pending = _inFlight[key];
-    if (pending != null) return pending;
+    if (pending != null) return _bounded(pending);
 
-    // _run suspends at its first await before returning, so the assignment
-    // below always lands before the finally block that clears it.
-    final future = _run(key, fetch);
+    // _withSlot suspends at its first await before returning, so the
+    // assignment below always lands before the callback that clears it.
+    final future = _withSlot(fetch);
     _inFlight[key] = future;
-    return future;
+    // Cleared when the fetch really settles, not when a caller stops waiting.
+    // The identity check keeps a late-settling fetch from evicting the entry a
+    // subsequent call already replaced it with.
+    future.whenComplete(() {
+      if (identical(_inFlight[key], future)) _inFlight.remove(key);
+    }).ignore();
+    return _bounded(future);
   }
 
-  Future<MediaSourceData?> _run(
-    String key,
+  /// One caller's bounded view of [future]. The fetch itself is untouched.
+  Future<MediaSourceData?> _bounded(Future<MediaSourceData?> future) {
+    return future.timeout(
+      totalBudget,
+      onTimeout: () =>
+          const UnavailableData(kind: UnavailableKind.stillFetching),
+    );
+  }
+
+  Future<MediaSourceData?> _withSlot(
     Future<MediaSourceData?> Function() fetch,
   ) async {
     await _acquire();
+    var holdsSlot = true;
+    var detached = false;
+
+    void detach() {
+      if (!holdsSlot || _detached >= maxDetached) return;
+      holdsSlot = false;
+      detached = true;
+      _detached++;
+      _release();
+    }
+
+    // Cancelled in the finally block rather than left to fire harmlessly: a
+    // stale firing would release a slot this fetch no longer holds, letting
+    // the effective cap drift upward for the life of the process.
+    final timer = Timer(slotBudget, detach);
     try {
       return await fetch();
     } finally {
-      _inFlight.remove(key);
-      _release();
+      timer.cancel();
+      if (detached) {
+        _detached--;
+      } else if (holdsSlot) {
+        holdsSlot = false;
+        _release();
+      }
     }
   }
 

--- a/lib/features/media/data/resolvers/media_store_source_resolver.dart
+++ b/lib/features/media/data/resolvers/media_store_source_resolver.dart
@@ -54,7 +54,18 @@ class MediaStoreSourceResolver implements MediaSourceResolver {
     if (fn == null) {
       return const UnavailableData(kind: UnavailableKind.unauthenticated);
     }
-    return await fn(item, thumbnail: true) ?? resolve(item);
+    final thumb = await fn(item, thumbnail: true);
+    if (thumb != null) return thumb;
+    // A video's original and its rendition are both video, so degrading to
+    // either renders the same movie placeholder the caller already has, at the
+    // cost of a full download per grid tile.
+    // `MediaStoreResolver.tryResolveRemote` returns null for exactly this
+    // reason and says so; falling through to [resolve] asked it again with
+    // `thumbnail: false` and undid the whole decision.
+    if (item.isVideo) {
+      return const UnavailableData(kind: UnavailableKind.notFound);
+    }
+    return resolve(item);
   }
 
   @override

--- a/lib/features/media/data/services/gallery_thumbnail_cache.dart
+++ b/lib/features/media/data/services/gallery_thumbnail_cache.dart
@@ -2,6 +2,16 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:typed_data';
 
+/// How long a PhotoKit fetch may hold a concurrency slot.
+///
+/// photo_manager asks PhotoKit with `networkAccessAllowed = YES`, so an
+/// iCloud-only asset triggers a full cloud download behind a plain `await`.
+/// Four of those used to hold every slot this cache has, which is a gallery of
+/// permanent shimmer on a slow connection. Matching `MediaFetchGate`'s budget:
+/// the two caps govern the same grid and staggering them would only make the
+/// slower one invisible.
+const Duration kGalleryThumbnailSlotBudget = Duration(seconds: 5);
+
 /// Bounded, deduplicating, concurrency-capped cache for gallery thumbnail
 /// bytes.
 ///
@@ -24,16 +34,6 @@ import 'dart:typed_data';
 /// bytes` and `Uint8List` does not override `==`, so its `ImageCache` key is
 /// reference identity. Handing back a fresh copy would make every `ImageCache`
 /// lookup miss, which is what made gallery thumbnails uncacheable before.
-/// How long a PhotoKit fetch may hold a concurrency slot.
-///
-/// photo_manager asks PhotoKit with `networkAccessAllowed = YES`, so an
-/// iCloud-only asset triggers a full cloud download behind a plain `await`.
-/// Four of those used to hold every slot this cache has, which is a gallery of
-/// permanent shimmer on a slow connection. Matching `MediaFetchGate`'s budget:
-/// the two caps govern the same grid and staggering them would only make the
-/// slower one invisible.
-const Duration kGalleryThumbnailSlotBudget = Duration(seconds: 5);
-
 class GalleryThumbnailCache {
   GalleryThumbnailCache({
     this.maxBytes = 32 * 1024 * 1024,

--- a/lib/features/media/data/services/gallery_thumbnail_cache.dart
+++ b/lib/features/media/data/services/gallery_thumbnail_cache.dart
@@ -24,12 +24,25 @@ import 'dart:typed_data';
 /// bytes` and `Uint8List` does not override `==`, so its `ImageCache` key is
 /// reference identity. Handing back a fresh copy would make every `ImageCache`
 /// lookup miss, which is what made gallery thumbnails uncacheable before.
+/// How long a PhotoKit fetch may hold a concurrency slot.
+///
+/// photo_manager asks PhotoKit with `networkAccessAllowed = YES`, so an
+/// iCloud-only asset triggers a full cloud download behind a plain `await`.
+/// Four of those used to hold every slot this cache has, which is a gallery of
+/// permanent shimmer on a slow connection. Matching `MediaFetchGate`'s budget:
+/// the two caps govern the same grid and staggering them would only make the
+/// slower one invisible.
+const Duration kGalleryThumbnailSlotBudget = Duration(seconds: 5);
+
 class GalleryThumbnailCache {
   GalleryThumbnailCache({
     this.maxBytes = 32 * 1024 * 1024,
     this.maxConcurrent = 4,
+    this.slotBudget = kGalleryThumbnailSlotBudget,
+    int? maxDetached,
   }) : assert(maxBytes > 0),
-       assert(maxConcurrent > 0);
+       assert(maxConcurrent > 0),
+       maxDetached = maxDetached ?? maxConcurrent * 3;
 
   /// Total retained thumbnail bytes before least-recently-used eviction.
   /// Thumbnails run tens of KB each, so the default holds a large library.
@@ -37,6 +50,21 @@ class GalleryThumbnailCache {
 
   /// Ceiling on simultaneous [getOrFetch] fetches.
   final int maxConcurrent;
+
+  /// How long a fetch may hold a slot before handing it to the next waiter.
+  ///
+  /// The fetch is not cancelled and its bytes are still cached when they land:
+  /// an iCloud asset that took twenty seconds to come down is a hit for every
+  /// later request, and throwing that away because it was slow would mean
+  /// downloading it again.
+  final Duration slotBudget;
+
+  /// Ceiling on fetches that outlived [slotBudget] and are still running.
+  ///
+  /// Without it, detaching would leak: a stalled photo library would start
+  /// [maxConcurrent] fresh PhotoKit requests every [slotBudget] forever. At the
+  /// cap a fetch keeps its slot instead, restoring back-pressure.
+  final int maxDetached;
 
   /// Insertion-ordered, so the first key is the least recently used. Dart map
   /// literals are LinkedHashMap, and a hit re-inserts to move the entry to the
@@ -52,12 +80,19 @@ class GalleryThumbnailCache {
 
   int _bytesHeld = 0;
   int _running = 0;
+  int _detached = 0;
 
   bool containsKey(String key) => _entries.containsKey(key);
 
   int get byteCount => _bytesHeld;
 
   int get length => _entries.length;
+
+  /// Fetches holding a slot, for tests.
+  int get runningCount => _running;
+
+  /// Fetches that outlived [slotBudget] and are still running, for tests.
+  int get detachedCount => _detached;
 
   /// Cached bytes for [key], else [fetch]'s result — run under the concurrency
   /// cap and cached on success.
@@ -103,12 +138,33 @@ class GalleryThumbnailCache {
     Future<Uint8List?> Function() fetch,
   ) async {
     await _acquire();
+    var holdsSlot = true;
+    var detached = false;
+
+    void detach() {
+      if (!holdsSlot || _detached >= maxDetached) return;
+      holdsSlot = false;
+      detached = true;
+      _detached++;
+      _release();
+    }
+
+    // Cancelled below rather than left to fire harmlessly: a stale firing
+    // would release a slot this fetch no longer holds, letting the effective
+    // cap drift upward for the life of the process.
+    final timer = Timer(slotBudget, detach);
     try {
       final bytes = await fetch();
       if (bytes != null) _store(key, bytes);
       return bytes;
     } finally {
-      _release();
+      timer.cancel();
+      if (detached) {
+        _detached--;
+      } else if (holdsSlot) {
+        holdsSlot = false;
+        _release();
+      }
       _inFlight.remove(key);
     }
   }

--- a/lib/features/media/domain/value_objects/media_source_data.dart
+++ b/lib/features/media/domain/value_objects/media_source_data.dart
@@ -23,6 +23,16 @@ enum UnavailableKind {
   /// The file's volume (network share, external disk) is not mounted right
   /// now. Recovers by itself when the volume comes back; never orphaned.
   volumeOffline,
+
+  /// The fetch is still running and outlived the caller's budget.
+  ///
+  /// Distinct from every other kind because nothing is wrong: the bytes exist
+  /// and are on their way. It exists so a slow source (a network share, a cold
+  /// store object, an iCloud asset still coming down) can stop occupying a
+  /// concurrency slot without the tile claiming the item is missing. Always
+  /// recoverable by retrying, and the underlying fetch may well have finished
+  /// by the time the user does.
+  stillFetching,
 }
 
 /// Which concrete source produced a [MediaSourceData]'s bytes.

--- a/lib/features/media/presentation/widgets/media_item_view.dart
+++ b/lib/features/media/presentation/widgets/media_item_view.dart
@@ -160,6 +160,23 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
     return resolution;
   }
 
+  /// Re-runs resolution after the user taps a still-loading tile.
+  ///
+  /// Only [UnavailableKind.stillFetching] is retryable by tapping. It is the
+  /// one kind that means "nothing is wrong, this is just slow", so a retry has
+  /// a real chance of a different answer; offering one for a dead pointer or an
+  /// unmounted volume would be a placebo. `MediaFetchGate` coalesces the retry
+  /// onto the fetch still in flight, so the tap joins the live download rather
+  /// than starting a second one.
+  /// A block body, not an arrow: `setState(() => _future = _resolve())` makes
+  /// the closure evaluate to the assigned Future, and setState asserts that
+  /// its callback returns nothing so an `async` body cannot slip through.
+  void _retry() {
+    setState(() {
+      _future = _resolve();
+    });
+  }
+
   // Declared `async` (not just returning a Future from a sync body) so any
   // synchronous throw — e.g. `MediaSourceResolverRegistry.resolverFor`
   // throwing UnsupportedError when a row's source_type has no registered
@@ -416,6 +433,16 @@ class _MediaItemViewState extends ConsumerState<MediaItemView> {
             cacheWidth: cacheWidth,
             errorBuilder: _imageError,
           ),
+          UnavailableData(kind: UnavailableKind.stillFetching) =>
+            GestureDetector(
+              onTap: _retry,
+              // The placeholder paints an opaque background, but the Column
+              // inside it does not fill the tile, so without this the gaps
+              // around the icon are not hit-testable and the tap falls through
+              // to whatever is behind the grid.
+              behavior: HitTestBehavior.opaque,
+              child: UnavailableMediaPlaceholder(data: data),
+            ),
           UnavailableData() => UnavailableMediaPlaceholder(data: data),
         };
       },

--- a/lib/features/media/presentation/widgets/unavailable_media_placeholder.dart
+++ b/lib/features/media/presentation/widgets/unavailable_media_placeholder.dart
@@ -52,6 +52,7 @@ class UnavailableMediaPlaceholder extends StatelessWidget {
     UnavailableKind.fromOtherDevice => Icons.devices_other,
     UnavailableKind.networkError => Icons.cloud_off_outlined,
     UnavailableKind.volumeOffline => Icons.usb_off_outlined,
+    UnavailableKind.stillFetching => Icons.hourglass_empty,
   };
 
   String _messageFor(BuildContext context, UnavailableData d) {
@@ -74,6 +75,8 @@ class UnavailableMediaPlaceholder extends StatelessWidget {
         l10n.media_unavailablePlaceholder_networkError,
       UnavailableKind.volumeOffline =>
         l10n.media_unavailablePlaceholder_volumeOffline,
+      UnavailableKind.stillFetching =>
+        l10n.media_unavailablePlaceholder_stillFetching,
     };
   }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "فتح",
   "settings_connectedAccounts_loadError": "تعذر تحميل الحسابات",
   "media_unavailablePlaceholder_volumeOffline": "وحدة التخزين غير مثبتة",
+  "media_unavailablePlaceholder_stillFetching": "ما زال قيد التحميل. اضغط لإعادة المحاولة.",
   "attrLabel_size": "المقاس",
   "attrLabel_thickness_mm": "السماكة (مم)",
   "attrLabel_suit_style": "نوع البدلة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Öffnen",
   "settings_connectedAccounts_loadError": "Konten konnten nicht geladen werden",
   "media_unavailablePlaceholder_volumeOffline": "Volume nicht eingebunden",
+  "media_unavailablePlaceholder_stillFetching": "Wird noch geladen. Zum Wiederholen tippen.",
   "attrLabel_size": "Größe",
   "attrLabel_thickness_mm": "Dicke (mm)",
   "attrLabel_suit_style": "Anzugtyp",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15010,6 +15010,7 @@
   "settings_setupGuide_open": "Open",
   "settings_connectedAccounts_loadError": "Could not load accounts",
   "media_unavailablePlaceholder_volumeOffline": "Volume not mounted",
+  "media_unavailablePlaceholder_stillFetching": "Still loading. Tap to retry.",
   "attrLabel_size": "Size",
   "attrLabel_thickness_mm": "Thickness (mm)",
   "attrLabel_suit_style": "Suit style",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Abrir",
   "settings_connectedAccounts_loadError": "No se pudieron cargar las cuentas",
   "media_unavailablePlaceholder_volumeOffline": "Volumen no montado",
+  "media_unavailablePlaceholder_stillFetching": "Aún se está cargando. Toca para reintentar.",
   "attrLabel_size": "Talla",
   "attrLabel_thickness_mm": "Grosor (mm)",
   "attrLabel_suit_style": "Tipo de traje",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Ouvrir",
   "settings_connectedAccounts_loadError": "Impossible de charger les comptes",
   "media_unavailablePlaceholder_volumeOffline": "Volume non monté",
+  "media_unavailablePlaceholder_stillFetching": "Chargement en cours. Touchez pour réessayer.",
   "attrLabel_size": "Taille",
   "attrLabel_thickness_mm": "Épaisseur (mm)",
   "attrLabel_suit_style": "Type de combinaison",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "פתח",
   "settings_connectedAccounts_loadError": "לא ניתן לטעון חשבונות",
   "media_unavailablePlaceholder_volumeOffline": "הכונן אינו מחובר",
+  "media_unavailablePlaceholder_stillFetching": "עדיין נטען. הקש כדי לנסות שוב.",
   "attrLabel_size": "מידה",
   "attrLabel_thickness_mm": "עובי (מ\"מ)",
   "attrLabel_suit_style": "סוג חליפה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Megnyitás",
   "settings_connectedAccounts_loadError": "A fiókok nem tölthetők be",
   "media_unavailablePlaceholder_volumeOffline": "A kötet nincs csatlakoztatva",
+  "media_unavailablePlaceholder_stillFetching": "Még töltődik. Koppintson az újrapróbálkozáshoz.",
   "attrLabel_size": "Méret",
   "attrLabel_thickness_mm": "Vastagság (mm)",
   "attrLabel_suit_style": "Ruha fazonja",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Apri",
   "settings_connectedAccounts_loadError": "Impossibile caricare gli account",
   "media_unavailablePlaceholder_volumeOffline": "Volume non montato",
+  "media_unavailablePlaceholder_stillFetching": "Ancora in caricamento. Tocca per riprovare.",
   "attrLabel_size": "Taglia",
   "attrLabel_thickness_mm": "Spessore (mm)",
   "attrLabel_suit_style": "Tipo di muta",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -38680,6 +38680,12 @@ abstract class AppLocalizations {
   /// **'Volume not mounted'**
   String get media_unavailablePlaceholder_volumeOffline;
 
+  /// No description provided for @media_unavailablePlaceholder_stillFetching.
+  ///
+  /// In en, this message translates to:
+  /// **'Still loading. Tap to retry.'**
+  String get media_unavailablePlaceholder_stillFetching;
+
   /// No description provided for @attrLabel_size.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -22814,6 +22814,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'وحدة التخزين غير مثبتة';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'ما زال قيد التحميل. اضغط لإعادة المحاولة.';
+
+  @override
   String get attrLabel_size => 'المقاس';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23188,6 +23188,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Volume nicht eingebunden';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Wird noch geladen. Zum Wiederholen tippen.';
+
+  @override
   String get attrLabel_size => 'Größe';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -22836,6 +22836,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'Volume not mounted';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Still loading. Tap to retry.';
+
+  @override
   String get attrLabel_size => 'Size';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23245,6 +23245,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'Volumen no montado';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Aún se está cargando. Toca para reintentar.';
+
+  @override
   String get attrLabel_size => 'Talla';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23303,6 +23303,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'Volume non monté';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Chargement en cours. Touchez pour réessayer.';
+
+  @override
   String get attrLabel_size => 'Taille';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -22648,6 +22648,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'הכונן אינו מחובר';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'עדיין נטען. הקש כדי לנסות שוב.';
+
+  @override
   String get attrLabel_size => 'מידה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23152,6 +23152,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'A kötet nincs csatlakoztatva';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Még töltődik. Koppintson az újrapróbálkozáshoz.';
+
+  @override
   String get attrLabel_size => 'Méret';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23231,6 +23231,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'Volume non montato';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Ancora in caricamento. Tocca per riprovare.';
+
+  @override
   String get attrLabel_size => 'Taglia';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23055,6 +23055,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Volume niet gekoppeld';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Nog aan het laden. Tik om opnieuw te proberen.';
+
+  @override
   String get attrLabel_size => 'Maat';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23228,6 +23228,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => 'Volume não montado';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching =>
+      'Ainda a carregar. Toque para tentar novamente.';
+
+  @override
   String get attrLabel_size => 'Tamanho';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22061,6 +22061,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get media_unavailablePlaceholder_volumeOffline => '卷未挂载';
 
   @override
+  String get media_unavailablePlaceholder_stillFetching => '仍在加载。点按重试。';
+
+  @override
   String get attrLabel_size => '尺码';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Openen",
   "settings_connectedAccounts_loadError": "Accounts konden niet worden geladen",
   "media_unavailablePlaceholder_volumeOffline": "Volume niet gekoppeld",
+  "media_unavailablePlaceholder_stillFetching": "Nog aan het laden. Tik om opnieuw te proberen.",
   "attrLabel_size": "Maat",
   "attrLabel_thickness_mm": "Dikte (mm)",
   "attrLabel_suit_style": "Type pak",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "Abrir",
   "settings_connectedAccounts_loadError": "Não foi possível carregar as contas",
   "media_unavailablePlaceholder_volumeOffline": "Volume não montado",
+  "media_unavailablePlaceholder_stillFetching": "Ainda a carregar. Toque para tentar novamente.",
   "attrLabel_size": "Tamanho",
   "attrLabel_thickness_mm": "Espessura (mm)",
   "attrLabel_suit_style": "Tipo de roupa",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6795,6 +6795,7 @@
   "settings_setupGuide_open": "打开",
   "settings_connectedAccounts_loadError": "无法加载账户",
   "media_unavailablePlaceholder_volumeOffline": "卷未挂载",
+  "media_unavailablePlaceholder_stillFetching": "仍在加载。点按重试。",
   "attrLabel_size": "尺码",
   "attrLabel_thickness_mm": "厚度（毫米）",
   "attrLabel_suit_style": "潜水服款式",

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -14,6 +14,10 @@ class AppDelegate: FlutterAppDelegate {
   private var updateChannel: FlutterMethodChannel?
   private var displayChannel: FlutterMethodChannel?
 
+  /// Guards `terminateAnswered` across the watchdog queue and the main thread.
+  private let terminateLock = NSLock()
+  private var terminateAnswered = false
+
   /// Mac App Store and TestFlight builds contain a receipt file;
   /// direct-distribution (DMG / GitHub) builds do not.
   private var isAppStoreBuild: Bool {
@@ -91,9 +95,82 @@ class AppDelegate: FlutterAppDelegate {
     return true
   }
 
+  /// How long to wait for Dart's answer to the exit request before quitting
+  /// anyway.
+  ///
+  /// Generous next to the 8s budget `closeDatabasesForExit` holds itself to, so
+  /// a healthy quit never comes near it. It exists for the case that budget
+  /// cannot cover: a blocked main isolate or a blocked main thread has no
+  /// thread left to run a `Future.timeout` or a run-loop `Timer`.
+  private static let terminateWatchdogInterval: TimeInterval = 20
+
+  /// Extra grace after the watchdog asks AppKit nicely, before it stops asking.
+  private static let terminateWatchdogGrace: TimeInterval = 2
+
+  override func applicationShouldTerminate(
+    _ sender: NSApplication
+  ) -> NSApplication.TerminateReply {
+    let reply = super.applicationShouldTerminate(sender)
+    guard reply == .terminateLater else { return reply }
+    armTerminateWatchdog()
+    return reply
+  }
+
+  /// Force-quits if Dart never answers the exit request.
+  ///
+  /// FlutterAppDelegate returns `NSTerminateLater` and asks Dart over the
+  /// `flutter/platform` channel. Nothing on the native side re-checks, so a
+  /// Dart side that never replies leaves AppKit deferring forever. AppKit has
+  /// already dismissed the window by then, so the user sees the app quit while
+  /// the process lives on. That is the reported symptom, and the Media
+  /// section's local-file reads are the likeliest thing to be in flight at
+  /// quit.
+  ///
+  /// Runs on a background queue rather than a `Timer` on the main run loop,
+  /// because a wedged main thread is precisely the case this guards. For the
+  /// same reason it cannot rely on `reply(toApplicationShouldTerminate:)`
+  /// landing: that must be called on the main thread, so it is attempted first
+  /// and `exit(0)` follows if the process is still here a moment later. By then
+  /// both databases have had their own budget and drift runs in WAL mode, so an
+  /// abrupt exit is recoverable.
+  private func armTerminateWatchdog() {
+    let deadline: DispatchTime = .now() + AppDelegate.terminateWatchdogInterval
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
+      [weak self] in
+      guard let self, !self.hasAnsweredTerminate() else { return }
+      NSLog(
+        "[AppDelegate] No exit-request answer after "
+          + "\(AppDelegate.terminateWatchdogInterval)s; forcing termination")
+      DispatchQueue.main.async {
+        NSApplication.shared.reply(toApplicationShouldTerminate: true)
+      }
+      DispatchQueue.global(qos: .utility).asyncAfter(
+        deadline: .now() + AppDelegate.terminateWatchdogGrace
+      ) { [weak self] in
+        // applicationWillTerminate sets the flag, so reaching here means the
+        // polite reply never ran: the main thread is not turning.
+        guard let self, !self.hasAnsweredTerminate() else { return }
+        NSLog("[AppDelegate] Exit still pending; calling exit(0)")
+        exit(0)
+      }
+    }
+  }
+
+  private func hasAnsweredTerminate() -> Bool {
+    terminateLock.lock()
+    defer { terminateLock.unlock() }
+    return terminateAnswered
+  }
+
   override func applicationWillTerminate(_ notification: Notification) {
+    terminateLock.lock()
+    terminateAnswered = true
+    terminateLock.unlock()
     bookmarkHandler?.cleanup()
     backupBookmarkHandler?.releaseAll()
+    // Released here as well as in its own deinit, which does not run on
+    // terminate: these are security-scoped URLs the Media section opened.
+    localMediaHandler?.releaseAllActiveBookmarks()
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -130,9 +130,14 @@ class AppDelegate: FlutterAppDelegate {
   /// because a wedged main thread is precisely the case this guards. For the
   /// same reason it cannot rely on `reply(toApplicationShouldTerminate:)`
   /// landing: that must be called on the main thread, so it is attempted first
-  /// and `exit(0)` follows if the process is still here a moment later. By then
-  /// both databases have had their own budget and drift runs in WAL mode, so an
-  /// abrupt exit is recoverable.
+  /// and `exit(0)` follows only if the main queue never ran the block that
+  /// delivers it. By then both databases have had their own budget and drift
+  /// runs in WAL mode, so an abrupt exit is recoverable.
+  ///
+  /// `exit(0)` is deliberately gated on the *reply* having been delivered, not
+  /// on termination having completed: once AppKit has the reply, finishing the
+  /// quit is its business and however long it takes is not this watchdog's to
+  /// cut short.
   private func armTerminateWatchdog() {
     let deadline: DispatchTime = .now() + AppDelegate.terminateWatchdogInterval
     DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
@@ -141,16 +146,25 @@ class AppDelegate: FlutterAppDelegate {
       NSLog(
         "[AppDelegate] No exit-request answer after "
           + "\(AppDelegate.terminateWatchdogInterval)s; forcing termination")
-      DispatchQueue.main.async {
+      DispatchQueue.main.async { [weak self] in
+        // Marked answered HERE rather than left to applicationWillTerminate.
+        // Delivering the reply is the single event this watchdog exists to
+        // force; what follows it is AppKit's own teardown, whose duration is
+        // nothing to do with the grace period. Deciding on willTerminate
+        // instead would let the grace path call exit(0) in the middle of an
+        // orderly termination that was already under way.
+        self?.markTerminateAnswered()
         NSApplication.shared.reply(toApplicationShouldTerminate: true)
       }
       DispatchQueue.global(qos: .utility).asyncAfter(
         deadline: .now() + AppDelegate.terminateWatchdogGrace
       ) { [weak self] in
-        // applicationWillTerminate sets the flag, so reaching here means the
-        // polite reply never ran: the main thread is not turning.
+        // The flag is set by the block above, on the main queue. Reaching here
+        // unset therefore means that block never ran: the main thread is not
+        // turning, so no reply can ever be delivered and there is nothing left
+        // to wait for.
         guard let self, !self.hasAnsweredTerminate() else { return }
-        NSLog("[AppDelegate] Exit still pending; calling exit(0)")
+        NSLog("[AppDelegate] Main thread never delivered the reply; calling exit(0)")
         exit(0)
       }
     }
@@ -162,10 +176,18 @@ class AppDelegate: FlutterAppDelegate {
     return terminateAnswered
   }
 
-  override func applicationWillTerminate(_ notification: Notification) {
+  /// Records that the exit request has been answered, so the watchdog stands
+  /// down. Called on the main queue when the reply is delivered, and again
+  /// from `applicationWillTerminate` as a backstop for a termination this
+  /// watchdog never had to force.
+  private func markTerminateAnswered() {
     terminateLock.lock()
     terminateAnswered = true
     terminateLock.unlock()
+  }
+
+  override func applicationWillTerminate(_ notification: Notification) {
+    markTerminateAnswered()
     bookmarkHandler?.cleanup()
     backupBookmarkHandler?.releaseAll()
     // Released here as well as in its own deinit, which does not run on

--- a/macos/Runner/LocalMediaHandler.swift
+++ b/macos/Runner/LocalMediaHandler.swift
@@ -54,6 +54,18 @@ class LocalMediaHandler: NSObject {
     /// Internal rather than private so `applicationWillTerminate` can call it
     /// too: `deinit` does not run when the process terminates, and the app
     /// delegate holds this handler for the whole session.
+    ///
+    /// **Call this on the main thread.** `active` is main-thread-owned (see
+    /// `resolveBookmark`, which hops back to main purely to mutate it), so a
+    /// caller on any other queue would race the dictionary. The two callers
+    /// today both satisfy that: `applicationWillTerminate` runs on main, and
+    /// `deinit` runs only once the reference count reaches zero, which means no
+    /// other reference exists and therefore nothing can be concurrently inside
+    /// a method that touches `active`.
+    ///
+    /// Not enforced with `dispatchPrecondition`: that traps in release builds,
+    /// and trading a theoretical race for a definite crash on the path the user
+    /// takes to quit is the worse of the two failures.
     func releaseAllActiveBookmarks() {
         for (_, url) in active {
             url.stopAccessingSecurityScopedResource()

--- a/macos/Runner/LocalMediaHandler.swift
+++ b/macos/Runner/LocalMediaHandler.swift
@@ -42,11 +42,19 @@ class LocalMediaHandler: NSObject {
     }
 
     deinit {
-        // Defensive cleanup: balance any startAccessingSecurityScopedResource()
-        // calls whose matching releaseBookmark never came in (Dart-side bug,
-        // missed teardown, etc.). On normal app exit the OS would reclaim
-        // these anyway, but draining the dictionary keeps long-lived sandbox
-        // accounting clean if the handler is ever recreated mid-process.
+        releaseAllActiveBookmarks()
+    }
+
+    /// Defensive cleanup: balances any startAccessingSecurityScopedResource()
+    /// calls whose matching releaseBookmark never came in (Dart-side bug,
+    /// missed teardown, etc.). On normal app exit the OS would reclaim these
+    /// anyway, but draining the dictionary keeps long-lived sandbox accounting
+    /// clean if the handler is ever recreated mid-process.
+    ///
+    /// Internal rather than private so `applicationWillTerminate` can call it
+    /// too: `deinit` does not run when the process terminates, and the app
+    /// delegate holds this handler for the whole session.
+    func releaseAllActiveBookmarks() {
         for (_, url) in active {
             url.stopAccessingSecurityScopedResource()
         }

--- a/macos/Runner/LocalMediaHandler.swift
+++ b/macos/Runner/LocalMediaHandler.swift
@@ -136,99 +136,145 @@ class LocalMediaHandler: NSObject {
         path: String?, bookmarkBlob: Data?, maxDimension: Int,
         result: @escaping FlutterResult
     ) {
-        var url: URL?
-        var scoped = false
-        if let blob = bookmarkBlob {
-            var stale = false
-            url = try? URL(
-                resolvingBookmarkData: blob,
-                options: [.withSecurityScope],
-                relativeTo: nil, bookmarkDataIsStale: &stale)
-            if let u = url { scoped = u.startAccessingSecurityScopedResource() }
-        } else if let p = path {
-            url = URL(fileURLWithPath: p)
-        }
-        guard let fileURL = url else {
-            result(nil)
-            return
-        }
-
-        let size = CGSize(width: maxDimension, height: maxDimension)
-        let request = QLThumbnailGenerator.Request(
-            fileAt: fileURL, size: size, scale: 1.0,
-            representationTypes: .thumbnail)
-
-        QLThumbnailGenerator.shared.generateBestRepresentation(for: request) {
-            rep, _ in
-            defer { if scoped { fileURL.stopAccessingSecurityScopedResource() } }
-            guard let cg = rep?.cgImage else {
+        // QuickLook's own call is already asynchronous, but the bookmark
+        // resolution ahead of it is not, and resolving a bookmark touches the
+        // volume it points at. One video tile per unreachable share was enough
+        // to block the platform thread before the generator was ever reached.
+        DispatchQueue.global(qos: .userInitiated).async {
+            var url: URL?
+            var scoped = false
+            if let blob = bookmarkBlob {
+                var stale = false
+                url = try? URL(
+                    resolvingBookmarkData: blob,
+                    options: [.withSecurityScope],
+                    relativeTo: nil, bookmarkDataIsStale: &stale)
+                if let u = url { scoped = u.startAccessingSecurityScopedResource() }
+            } else if let p = path {
+                url = URL(fileURLWithPath: p)
+            }
+            guard let fileURL = url else {
                 DispatchQueue.main.async { result(nil) }
                 return
             }
-            let bitmap = NSBitmapImageRep(cgImage: cg)
-            let jpeg = bitmap.representation(
-                using: .jpeg, properties: [.compressionFactor: 0.8])
-            DispatchQueue.main.async {
-                if let data = jpeg {
-                    result(FlutterStandardTypedData(bytes: data))
-                } else {
-                    result(nil)
+
+            let size = CGSize(width: maxDimension, height: maxDimension)
+            let request = QLThumbnailGenerator.Request(
+                fileAt: fileURL, size: size, scale: 1.0,
+                representationTypes: .thumbnail)
+
+            QLThumbnailGenerator.shared.generateBestRepresentation(for: request) {
+                rep, _ in
+                defer { if scoped { fileURL.stopAccessingSecurityScopedResource() } }
+                guard let cg = rep?.cgImage else {
+                    DispatchQueue.main.async { result(nil) }
+                    return
+                }
+                let bitmap = NSBitmapImageRep(cgImage: cg)
+                let jpeg = bitmap.representation(
+                    using: .jpeg, properties: [.compressionFactor: 0.8])
+                DispatchQueue.main.async {
+                    if let data = jpeg {
+                        result(FlutterStandardTypedData(bytes: data))
+                    } else {
+                        result(nil)
+                    }
                 }
             }
         }
     }
 
+    /// Mints a security-scoped bookmark.
+    ///
+    /// Off the platform thread: bookmarking a file on an unreachable share
+    /// blocks in the same way reading one does.
     private func createBookmark(filePath: String, result: @escaping FlutterResult) {
-        let url = URL(fileURLWithPath: filePath)
-        do {
-            let data = try url.bookmarkData(
-                options: .withSecurityScope,
-                includingResourceValuesForKeys: nil,
-                relativeTo: nil
-            )
-            result(FlutterStandardTypedData(bytes: data))
-        } catch {
-            result(
-                FlutterError(
-                    code: "BOOKMARK_FAILED",
-                    message: "Could not create bookmark: \(error.localizedDescription)",
-                    details: nil
-                ))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let url = URL(fileURLWithPath: filePath)
+            do {
+                let data = try url.bookmarkData(
+                    options: .withSecurityScope,
+                    includingResourceValuesForKeys: nil,
+                    relativeTo: nil
+                )
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "BOOKMARK_FAILED",
+                            message:
+                                "Could not create bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
+            }
         }
     }
 
+    /// Resolves a bookmark and starts security-scoped access.
+    ///
+    /// Off the platform thread for the same reason as readBookmarkBytes:
+    /// resolving a bookmark touches the volume it points at, so a dead mount
+    /// blocks here too. `active` is main-thread-owned state and is mutated back
+    /// on main, which also keeps the ref's registration ordered ahead of the
+    /// Dart side ever seeing it.
     private func resolveBookmark(blob: Data, result: @escaping FlutterResult) {
-        var stale = false
-        do {
-            let url = try URL(
-                resolvingBookmarkData: blob,
-                options: .withSecurityScope,
-                relativeTo: nil,
-                bookmarkDataIsStale: &stale
-            )
-            guard url.startAccessingSecurityScopedResource() else {
-                result(
-                    FlutterError(
-                        code: "ACCESS_DENIED",
-                        message: "Security-scoped resource access denied",
-                        details: nil
-                    ))
-                return
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: .withSecurityScope,
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                let ref = UUID().uuidString
+                let isStale = stale
+                DispatchQueue.main.async {
+                    guard let self else {
+                        // The handler went away mid-resolve, so nothing will
+                        // ever release this scope. Balance it here.
+                        url.stopAccessingSecurityScopedResource()
+                        result(
+                            FlutterError(
+                                code: "RESOLVE_FAILED",
+                                message: "Handler released before the bookmark resolved",
+                                details: nil
+                            ))
+                        return
+                    }
+                    self.active[ref] = url
+                    result([
+                        "bookmarkRef": ref,
+                        "filePath": url.path,
+                        "stale": isStale,
+                    ])
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "RESOLVE_FAILED",
+                            message:
+                                "Could not resolve bookmark: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
             }
-            let ref = UUID().uuidString
-            active[ref] = url
-            result([
-                "bookmarkRef": ref,
-                "filePath": url.path,
-                "stale": stale,
-            ])
-        } catch {
-            result(
-                FlutterError(
-                    code: "RESOLVE_FAILED",
-                    message: "Could not resolve bookmark: \(error.localizedDescription)",
-                    details: nil
-                ))
         }
     }
 
@@ -247,34 +293,54 @@ class LocalMediaHandler: NSObject {
         result(nil)
     }
 
+    /// Reads the bookmarked file's bytes.
+    ///
+    /// Runs off the platform thread. `Data(contentsOf:)` is a synchronous
+    /// whole-file read, and on a sandboxed build this is the ordinary path for
+    /// every local media item, grid thumbnails included. Against a network
+    /// share or an evicted iCloud Drive file it blocks until the mount's own
+    /// timeout, and on macOS the platform thread IS the main thread: the thread
+    /// that paints frames, and the thread that must run
+    /// applicationShouldTerminate and deliver its reply. Blocking it froze the
+    /// Media section outright and left the process alive after its window had
+    /// already closed.
     private func readBookmarkBytes(blob: Data, result: @escaping FlutterResult) {
-        var stale = false
-        do {
-            let url = try URL(
-                resolvingBookmarkData: blob,
-                options: .withSecurityScope,
-                relativeTo: nil,
-                bookmarkDataIsStale: &stale
-            )
-            guard url.startAccessingSecurityScopedResource() else {
-                result(
-                    FlutterError(
-                        code: "ACCESS_DENIED",
-                        message: "Security-scoped resource access denied",
-                        details: nil
-                    ))
-                return
+        DispatchQueue.global(qos: .userInitiated).async {
+            var stale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: blob,
+                    options: .withSecurityScope,
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &stale
+                )
+                guard url.startAccessingSecurityScopedResource() else {
+                    DispatchQueue.main.async {
+                        result(
+                            FlutterError(
+                                code: "ACCESS_DENIED",
+                                message: "Security-scoped resource access denied",
+                                details: nil
+                            ))
+                    }
+                    return
+                }
+                defer { url.stopAccessingSecurityScopedResource() }
+                let data = try Data(contentsOf: url)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: data))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(
+                        FlutterError(
+                            code: "READ_FAILED",
+                            message:
+                                "Could not read bookmark bytes: \(error.localizedDescription)",
+                            details: nil
+                        ))
+                }
             }
-            defer { url.stopAccessingSecurityScopedResource() }
-            let data = try Data(contentsOf: url)
-            result(FlutterStandardTypedData(bytes: data))
-        } catch {
-            result(
-                FlutterError(
-                    code: "READ_FAILED",
-                    message: "Could not read bookmark bytes: \(error.localizedDescription)",
-                    details: nil
-                ))
         }
     }
 }

--- a/macos/Runner/LocalMediaHandler.swift
+++ b/macos/Runner/LocalMediaHandler.swift
@@ -55,17 +55,24 @@ class LocalMediaHandler: NSObject {
     /// too: `deinit` does not run when the process terminates, and the app
     /// delegate holds this handler for the whole session.
     ///
-    /// **Call this on the main thread.** `active` is main-thread-owned (see
-    /// `resolveBookmark`, which hops back to main purely to mutate it), so a
-    /// caller on any other queue would race the dictionary. The two callers
-    /// today both satisfy that: `applicationWillTerminate` runs on main, and
-    /// `deinit` runs only once the reference count reaches zero, which means no
-    /// other reference exists and therefore nothing can be concurrently inside
-    /// a method that touches `active`.
+    /// **Contract: the caller must have exclusive access to `active`.** That is
+    /// the real requirement; being on the main thread is just the ordinary way
+    /// to satisfy it, since `active` is main-thread-owned (see
+    /// `resolveBookmark`, which hops back to main purely to mutate it).
     ///
-    /// Not enforced with `dispatchPrecondition`: that traps in release builds,
-    /// and trading a theoretical race for a definite crash on the path the user
-    /// takes to quit is the worse of the two failures.
+    /// The two callers satisfy it in different ways, which is why the contract
+    /// is stated as exclusivity rather than as "call this on main":
+    ///   * `applicationWillTerminate` runs on the main thread.
+    ///   * `deinit` may run on any thread, and does not need to be on main:
+    ///     it runs only once the reference count reaches zero, so no other
+    ///     reference exists and nothing can be concurrently inside a method
+    ///     that touches `active`. Exclusivity holds by construction.
+    ///
+    /// A third caller on some other queue would break it. Not enforced with
+    /// `dispatchPrecondition`, which would be wrong twice over: it would reject
+    /// the legitimate `deinit` case, and it traps in release builds, so it
+    /// would trade a theoretical race for a definite crash on the path the user
+    /// takes to quit.
     func releaseAllActiveBookmarks() {
         for (_, url) in active {
             url.stopAccessingSecurityScopedResource()

--- a/test/core/app/app_exit_test.dart
+++ b/test/core/app/app_exit_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+import 'dart:ui' show AppExitResponse;
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/app/app_exit.dart';
+
+/// The platform's only reply path on macOS, so its whole contract is that it
+/// always answers, whatever the databases do.
+void main() {
+  test('closes both databases in order and replies exit', () async {
+    final calls = <String>[];
+    final response = await closeDatabasesForExit(
+      closeMain: () async => calls.add('main'),
+      closeCache: () async => calls.add('cache'),
+    );
+
+    expect(calls, ['main', 'cache']);
+    expect(response, AppExitResponse.exit);
+  });
+
+  test('still replies exit when the main database close throws', () async {
+    final errors = <Object>[];
+    final calls = <String>[];
+
+    final response = await closeDatabasesForExit(
+      closeMain: () async => throw StateError('boom'),
+      closeCache: () async => calls.add('cache'),
+      onError: (error, _) => errors.add(error),
+    );
+
+    expect(response, AppExitResponse.exit);
+    expect(errors.single, isA<StateError>());
+    expect(calls, [
+      'cache',
+    ], reason: 'a failed main close must not strand the cache database');
+  });
+
+  test('still replies exit when the cache close throws', () async {
+    final errors = <Object>[];
+
+    final response = await closeDatabasesForExit(
+      closeMain: () async {},
+      closeCache: () async => throw StateError('boom'),
+      onError: (error, _) => errors.add(error),
+    );
+
+    expect(response, AppExitResponse.exit);
+    expect(errors.single, isA<StateError>());
+  });
+
+  test('still replies exit when a close never completes', () {
+    fakeAsync((async) {
+      AppExitResponse? response;
+      final errors = <Object>[];
+
+      closeDatabasesForExit(
+        closeMain: () => Completer<void>().future,
+        closeCache: () async {},
+        budget: const Duration(seconds: 8),
+        onError: (error, _) => errors.add(error),
+      ).then((r) => response = r);
+
+      async.elapse(const Duration(seconds: 7));
+      async.flushMicrotasks();
+      expect(response, isNull);
+
+      async.elapse(const Duration(seconds: 2));
+      async.flushMicrotasks();
+      expect(response, AppExitResponse.exit);
+      expect(errors.single, isA<TimeoutException>());
+    });
+  });
+
+  test('the two closes share one budget rather than getting one each', () {
+    fakeAsync((async) {
+      AppExitResponse? response;
+
+      closeDatabasesForExit(
+        closeMain: () => Future<void>.delayed(const Duration(seconds: 6)),
+        closeCache: () => Completer<void>().future,
+        budget: const Duration(seconds: 8),
+      ).then((r) => response = r);
+
+      async.elapse(const Duration(seconds: 9));
+      async.flushMicrotasks();
+
+      expect(
+        response,
+        AppExitResponse.exit,
+        reason: 'a per-close budget would make the worst case 2 x budget',
+      );
+    });
+  });
+
+  test('an exhausted budget still attempts the cache close', () {
+    fakeAsync((async) {
+      var cacheAttempted = false;
+
+      closeDatabasesForExit(
+        closeMain: () => Completer<void>().future,
+        closeCache: () async => cacheAttempted = true,
+        budget: const Duration(seconds: 8),
+      );
+
+      async.elapse(const Duration(seconds: 9));
+      async.flushMicrotasks();
+
+      expect(
+        cacheAttempted,
+        isTrue,
+        reason: 'a zero remainder must not silently skip the second close',
+      );
+    });
+  });
+}

--- a/test/features/media/data/media_store_source_resolver_test.dart
+++ b/test/features/media/data/media_store_source_resolver_test.dart
@@ -8,9 +8,13 @@ import 'package:submersion/features/media/domain/entities/media_source_type.dart
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
 
-MediaItem item({String? contentHash, DateTime? remoteUploadedAt}) => MediaItem(
+MediaItem item({
+  String? contentHash,
+  DateTime? remoteUploadedAt,
+  MediaType mediaType = MediaType.photo,
+}) => MediaItem(
   id: 'm1',
-  mediaType: MediaType.photo,
+  mediaType: mediaType,
   sourceType: MediaSourceType.mediaStore,
   contentHash: contentHash,
   remoteUploadedAt: remoteUploadedAt,
@@ -67,6 +71,67 @@ void main() {
     );
     final data = await resolver.resolve(item());
     expect((data as UnavailableData).kind, UnavailableKind.notFound);
+  });
+
+  /// `MediaStoreResolver.tryResolveRemote` declines a video thumbnail on
+  /// purpose rather than download the original for a grid tile. Falling
+  /// through to `resolve` undoes that, one full video per tile.
+  test('a video thumbnail never degrades to the original', () async {
+    final seen = <bool>[];
+    final resolver = MediaStoreSourceResolver(
+      remote: () => (mediaItem, {required bool thumbnail}) async {
+        seen.add(thumbnail);
+        return null;
+      },
+    );
+
+    final data = await resolver.resolveThumbnail(
+      item(mediaType: MediaType.video),
+      target: const Size(140, 140),
+    );
+
+    expect(seen, [
+      true,
+    ], reason: 'asking again with thumbnail:false is a full video download');
+    expect((data as UnavailableData).kind, UnavailableKind.notFound);
+  });
+
+  test('a photo thumbnail still degrades to the original', () async {
+    final seen = <bool>[];
+    final file = File('${Directory.systemTemp.path}/store-src-test.jpg');
+    final resolver = MediaStoreSourceResolver(
+      remote: () => (mediaItem, {required bool thumbnail}) async {
+        seen.add(thumbnail);
+        return thumbnail ? null : FileData(file: file);
+      },
+    );
+
+    final data = await resolver.resolveThumbnail(
+      item(),
+      target: const Size(140, 140),
+    );
+
+    expect(seen, [true, false]);
+    expect(data, isA<FileData>());
+  });
+
+  test('a video thumbnail that the store does have is served', () async {
+    final file = File('${Directory.systemTemp.path}/store-src-poster.jpg');
+    final seen = <bool>[];
+    final resolver = MediaStoreSourceResolver(
+      remote: () => (mediaItem, {required bool thumbnail}) async {
+        seen.add(thumbnail);
+        return FileData(file: file, isPoster: true);
+      },
+    );
+
+    final data = await resolver.resolveThumbnail(
+      item(mediaType: MediaType.video),
+      target: const Size(140, 140),
+    );
+
+    expect(seen, [true]);
+    expect((data as FileData).isPoster, isTrue);
   });
 
   test('verify never orphans when the store is unavailable', () async {

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -764,6 +764,49 @@ void main() {
           .timeout(const Duration(seconds: 5));
     });
   });
+
+  /// Only notFound and unauthenticated flip `MediaItem.isOrphaned`, so a slow
+  /// share must never reach either. The gate answers stillFetching once a read
+  /// outlives its budget, which is a statement about time, not about whether
+  /// the file exists.
+  group('verify does not orphan a row for being slow', () {
+    test('a still-fetching read reports transientError', () async {
+      final platform = _StubPlatform()
+        // Never completes: the shape of a read against a hung-but-mounted
+        // share, which is exactly what the budget exists to bound.
+        ..onReadBookmarkBytes = ((_) => Completer<Uint8List>().future);
+
+      final resolver = LocalFileResolver(
+        bookmarkStorage: _StubBookmarkStorage(Uint8List.fromList([1, 2, 3])),
+        platform: platform,
+        exifExtractor: ExifExtractor(),
+        usesSecurityScopedBookmarks: () => true,
+        gate: MediaFetchGate(
+          maxConcurrent: 1,
+          slotBudget: Duration.zero,
+          totalBudget: Duration.zero,
+        ),
+      );
+
+      final data = await resolver
+          .resolve(_localFile(bookmarkRef: 'ref'))
+          .timeout(const Duration(seconds: 5));
+      expect(
+        (data as UnavailableData).kind,
+        UnavailableKind.stillFetching,
+        reason: 'precondition: the budget produced the state under test',
+      );
+
+      final result = await resolver
+          .verify(_localFile(bookmarkRef: 'ref'))
+          .timeout(const Duration(seconds: 5));
+      expect(
+        result,
+        VerifyResult.transientError,
+        reason: 'notFound here would flag a reachable file missing, stickily',
+      );
+    });
+  });
 }
 
 /// A [VolumeStatus] that treats every path as living on one mount root.

--- a/test/features/media/data/resolvers/media_fetch_gate_test.dart
+++ b/test/features/media/data/resolvers/media_fetch_gate_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/media/data/resolvers/media_fetch_gate.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
@@ -120,5 +121,164 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     blockers['c']!.complete(result('c'));
     await Future.wait(futures);
+  });
+
+  /// Time budgets: a cap with no deadline turns one unreachable item into a
+  /// stalled gallery, because a permit held by a fetch against a dead share is
+  /// a permit no live tile can have.
+  group('budgets', () {
+    test('a fetch that overruns the slot budget hands the slot on', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+          totalBudget: const Duration(seconds: 30),
+        );
+        final stuck = Completer<MediaSourceData?>();
+        var secondStarted = false;
+
+        gate.run('stuck', () => stuck.future);
+        async.flushMicrotasks();
+        gate.run('live', () async {
+          secondStarted = true;
+          return result('live');
+        });
+        async.flushMicrotasks();
+        expect(
+          secondStarted,
+          isFalse,
+          reason: 'the only slot is held by the stuck fetch',
+        );
+
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+        expect(
+          secondStarted,
+          isTrue,
+          reason: 'the slot budget expired and handed the slot on',
+        );
+        expect(gate.detachedCount, 1);
+
+        stuck.complete(null);
+        async.flushMicrotasks();
+        expect(gate.detachedCount, 0);
+      });
+    });
+
+    test('a fetch that finishes inside the slot budget never detaches', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+        );
+        gate.run('quick', () async => result('quick'));
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(gate.detachedCount, 0);
+        expect(gate.runningCount, 0);
+
+        // The slot timer must be cancelled, not merely ignored: a stale
+        // firing would release a slot this fetch no longer holds and let
+        // maxConcurrent drift upward for the life of the process.
+        async.elapse(const Duration(seconds: 30));
+        expect(gate.runningCount, 0);
+      });
+    });
+
+    test('the caller gives up at the total budget with stillFetching', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+          totalBudget: const Duration(seconds: 30),
+        );
+        final never = Completer<MediaSourceData?>();
+        MediaSourceData? seen;
+        gate.run('never', () => never.future).then((v) => seen = v);
+
+        async.elapse(const Duration(seconds: 29));
+        async.flushMicrotasks();
+        expect(seen, isNull);
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(seen, isA<UnavailableData>());
+        expect((seen! as UnavailableData).kind, UnavailableKind.stillFetching);
+
+        // Giving up is not cancelling: the fetch is still live, and its late
+        // completion must not throw into a listener that has gone away.
+        never.complete(null);
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 1));
+      });
+    });
+
+    test('detaching is capped so outstanding work cannot grow unbounded', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(
+          maxConcurrent: 1,
+          maxDetached: 2,
+          slotBudget: const Duration(seconds: 5),
+          totalBudget: const Duration(minutes: 5),
+        );
+        final held = <Completer<MediaSourceData?>>[];
+
+        for (var i = 0; i < 4; i++) {
+          final blocker = Completer<MediaSourceData?>();
+          held.add(blocker);
+          gate.run('k$i', () => blocker.future);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 5));
+          async.flushMicrotasks();
+        }
+
+        expect(
+          gate.detachedCount,
+          2,
+          reason: 'at the cap a fetch keeps its slot instead of detaching',
+        );
+        expect(gate.runningCount, 1);
+
+        for (final blocker in held) {
+          blocker.complete(null);
+        }
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 6));
+      });
+    });
+
+    test('a retry after the total budget joins the fetch still in flight', () {
+      fakeAsync((async) {
+        final gate = MediaFetchGate(
+          maxConcurrent: 4,
+          slotBudget: const Duration(seconds: 5),
+          totalBudget: const Duration(seconds: 30),
+        );
+        final slow = Completer<MediaSourceData?>();
+        var starts = 0;
+        Future<MediaSourceData?> fetch() {
+          starts++;
+          return slow.future;
+        }
+
+        gate.run('k', fetch);
+        async.elapse(const Duration(seconds: 31));
+        async.flushMicrotasks();
+
+        MediaSourceData? retried;
+        gate.run('k', fetch).then((v) => retried = v);
+        async.flushMicrotasks();
+        expect(
+          starts,
+          1,
+          reason: 'a second download of bytes already on the way is waste',
+        );
+
+        slow.complete(result('arrived'));
+        async.flushMicrotasks();
+        expect((retried! as FileData).file.path, 'arrived');
+      });
+    });
   });
 }

--- a/test/features/media/data/services/gallery_thumbnail_cache_test.dart
+++ b/test/features/media/data/services/gallery_thumbnail_cache_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/features/media/data/services/gallery_thumbnail_cache.dart';
@@ -234,6 +235,112 @@ void main() {
 
       final recovered = await cache.getOrFetch('a', () async => _bytes(10));
       expect(recovered, isNotNull);
+    });
+  });
+
+  /// photo_manager asks PhotoKit with `networkAccessAllowed = YES`, so an
+  /// iCloud-only asset triggers a full cloud download behind a plain await.
+  group('slot budget', () {
+    test('a fetch that overruns the slot budget frees it', () {
+      fakeAsync((async) {
+        final cache = GalleryThumbnailCache(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+        );
+        final stuck = Completer<Uint8List?>();
+        var secondStarted = false;
+
+        cache.getOrFetch('cloud', () => stuck.future);
+        async.flushMicrotasks();
+        cache.getOrFetch('local', () async {
+          secondStarted = true;
+          return _bytes(10);
+        });
+        async.flushMicrotasks();
+        expect(
+          secondStarted,
+          isFalse,
+          reason: 'the only slot is held by the iCloud download',
+        );
+
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+        expect(secondStarted, isTrue);
+        expect(cache.detachedCount, 1);
+
+        stuck.complete(null);
+        async.flushMicrotasks();
+        expect(cache.detachedCount, 0);
+      });
+    });
+
+    test('a fetch inside the budget never detaches and cancels its timer', () {
+      fakeAsync((async) {
+        final cache = GalleryThumbnailCache(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+        );
+        cache.getOrFetch('quick', () async => _bytes(10));
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(cache.detachedCount, 0);
+        expect(cache.runningCount, 0);
+
+        // A stale firing would release a slot nobody holds, drifting the
+        // effective cap upward for the life of the process.
+        async.elapse(const Duration(seconds: 30));
+        expect(cache.runningCount, 0);
+      });
+    });
+
+    test('detaching is capped so outstanding work cannot grow unbounded', () {
+      fakeAsync((async) {
+        final cache = GalleryThumbnailCache(
+          maxConcurrent: 1,
+          maxDetached: 2,
+          slotBudget: const Duration(seconds: 5),
+        );
+        final held = <Completer<Uint8List?>>[];
+
+        for (var i = 0; i < 4; i++) {
+          final blocker = Completer<Uint8List?>();
+          held.add(blocker);
+          cache.getOrFetch('k$i', () => blocker.future);
+          async.flushMicrotasks();
+          async.elapse(const Duration(seconds: 5));
+          async.flushMicrotasks();
+        }
+
+        expect(cache.detachedCount, 2);
+        expect(cache.runningCount, 1);
+
+        for (final blocker in held) {
+          blocker.complete(null);
+        }
+        async.flushMicrotasks();
+      });
+    });
+
+    test('a detached fetch still caches its bytes when it lands', () {
+      fakeAsync((async) {
+        final cache = GalleryThumbnailCache(
+          maxConcurrent: 1,
+          slotBudget: const Duration(seconds: 5),
+        );
+        final late = Completer<Uint8List?>();
+        cache.getOrFetch('slow', () => late.future);
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+
+        late.complete(_bytes(10));
+        async.flushMicrotasks();
+        expect(
+          cache.containsKey('slow'),
+          isTrue,
+          reason: 'losing the slot must not lose the memoization',
+        );
+      });
     });
   });
 }

--- a/test/features/media/presentation/widgets/media_item_view_retry_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_retry_test.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/services/media_source_resolver.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
+import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/features/media/presentation/widgets/unavailable_media_placeholder.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// A 1x1 transparent PNG, so Image.memory has something it can decode.
+final Uint8List _png = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+);
+
+/// Answers with [first] once, then [then] on every later call.
+class _RelentingResolver implements MediaSourceResolver {
+  _RelentingResolver({required this.first, required this.then});
+
+  final MediaSourceData first;
+  final MediaSourceData then;
+  int calls = 0;
+
+  @override
+  MediaSourceType get sourceType => MediaSourceType.platformGallery;
+
+  @override
+  bool canResolveOnThisDevice(MediaItem item) => true;
+
+  @override
+  Future<MediaSourceData> resolve(MediaItem item) async {
+    calls++;
+    return calls == 1 ? first : then;
+  }
+
+  @override
+  Future<MediaSourceData> resolveThumbnail(
+    MediaItem item, {
+    required Size target,
+  }) => resolve(item);
+
+  @override
+  Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async => null;
+
+  @override
+  Future<VerifyResult> verify(MediaItem item) async => VerifyResult.available;
+}
+
+MediaItem _item() => MediaItem(
+  id: 'x',
+  mediaType: MediaType.photo,
+  sourceType: MediaSourceType.platformGallery,
+  takenAt: DateTime.utc(2026, 1, 1),
+  createdAt: DateTime.utc(2026, 1, 1),
+  updatedAt: DateTime.utc(2026, 1, 1),
+);
+
+Widget _wrap(MediaSourceResolver resolver) => ProviderScope(
+  overrides: [
+    mediaSourceResolverRegistryProvider.overrideWithValue(
+      MediaSourceResolverRegistry({resolver.sourceType: resolver}),
+    ),
+  ],
+  child: MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 140,
+          height: 140,
+          child: MediaItemView(item: _item(), thumbnail: true),
+        ),
+      ),
+    ),
+  ),
+);
+
+/// A still-loading tile is a dead end unless tapping it re-resolves: the
+/// placeholder's own copy promises a retry.
+void main() {
+  testWidgets('tapping a still-loading tile re-resolves it', (tester) async {
+    final resolver = _RelentingResolver(
+      first: const UnavailableData(kind: UnavailableKind.stillFetching),
+      then: BytesData(bytes: _png),
+    );
+
+    await tester.pumpWidget(_wrap(resolver));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+    expect(resolver.calls, 1);
+
+    await tester.tap(find.byType(UnavailableMediaPlaceholder));
+    await tester.pumpAndSettle();
+
+    expect(resolver.calls, 2);
+    expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
+    expect(find.byType(Image), findsOneWidget);
+  });
+
+  testWidgets('tapping a genuinely missing tile does not re-resolve', (
+    tester,
+  ) async {
+    final resolver = _RelentingResolver(
+      first: const UnavailableData(kind: UnavailableKind.notFound),
+      then: BytesData(bytes: _png),
+    );
+
+    await tester.pumpWidget(_wrap(resolver));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+
+    await tester.tap(find.byType(UnavailableMediaPlaceholder));
+    await tester.pumpAndSettle();
+
+    expect(
+      resolver.calls,
+      1,
+      reason: 'retrying a dead pointer on tap would be a placebo',
+    );
+    expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+  });
+
+  testWidgets('a retry that is still slow stays retryable', (tester) async {
+    final resolver = _RelentingResolver(
+      first: const UnavailableData(kind: UnavailableKind.stillFetching),
+      then: const UnavailableData(kind: UnavailableKind.stillFetching),
+    );
+
+    await tester.pumpWidget(_wrap(resolver));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(UnavailableMediaPlaceholder));
+    await tester.pumpAndSettle();
+    expect(resolver.calls, 2);
+
+    await tester.tap(find.byType(UnavailableMediaPlaceholder));
+    await tester.pumpAndSettle();
+    expect(resolver.calls, 3);
+  });
+}

--- a/test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart
+++ b/test/features/media/presentation/widgets/unavailable_media_placeholder_test.dart
@@ -95,4 +95,18 @@ void main() {
     );
     expect(find.text("Couldn't connect"), findsOneWidget);
   });
+
+  testWidgets('renders stillFetching as a retryable loading message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        const UnavailableMediaPlaceholder(
+          data: UnavailableData(kind: UnavailableKind.stillFetching),
+        ),
+      ),
+    );
+    expect(find.text('Still loading. Tap to retry.'), findsOneWidget);
+    expect(find.byIcon(Icons.hourglass_empty), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Two reported symptoms in the Media section:

1. When a piece of media is not immediately available (a network share, an S3
   object, an iCloud asset still coming down), the UI hangs until it arrives.
2. On macOS the app sometimes does not exit: the window disappears but the
   process keeps running.

They are one defect wearing two masks: unbounded media I/O running on threads
that have to stay responsive.

## 1. The Media feature had no deadlines at all

Before this PR the whole feature contained **exactly one** `.timeout(...)`, in
`pdf_thumbnail_service.dart`. Every other fetch, on every source type, awaited
forever.

`MediaFetchGate` and `GalleryThumbnailCache` capped **concurrency but not
time**. A permit was held for the whole of `await fetch()`, and `_acquire`
parked on a `Completer` that nothing ever completed with an error. Four stalled
store fetches, or four iCloud photos still downloading, blocked *every*
thumbnail in the app. `MediaFetchGate` is FIFO, so waiters belonging to
already-disposed tiles were served first.

Three numbers now, each doing one job:

- **`slotBudget` (5s).** A fetch that overruns hands its slot to the next waiter
  and keeps running. This is what removes head-of-line blocking.
- **`totalBudget` (30s).** A *caller* that overruns gets
  `UnavailableData(kind: stillFetching)`, a new, recoverable state. Nothing is
  cancelled: Dart cannot cancel a `Future`, and the honest thing to tell the
  user about a slow download is that it is slow, not that it failed.
- **`maxDetached` (`maxConcurrent * 3`).** Without this, detaching leaks: against
  a dead mount the gate would start `maxConcurrent` fresh fetches every
  `slotBudget` forever, each parking a `dart:io` pool thread, which is the
  #1182 starvation all over again. At the cap a fetch keeps its slot, restoring
  back-pressure. Outstanding work is now bounded by
  `maxConcurrent + maxDetached`, whatever the source does.

Two implementation details are load-bearing:

- `_inFlight` maps the key to the **raw** fetch, not to a caller's bounded view
  of it. Otherwise the entry is evicted the moment the first caller gives up,
  and the user's retry tap starts a second download of bytes already arriving.
- `timer.cancel()` in the `finally` is not tidiness. A stale firing would
  release a slot the fetch no longer holds, so `_running` would drift upward and
  the cap would quietly stop capping. Pinned by a test that elapses 30s past
  completion.

A still-loading tile is tappable and re-resolves. Only `stillFetching` is
retryable that way: it is the one kind that means "nothing is wrong, this is
just slow", so offering a retry for a dead pointer or an unmounted volume would
be a placebo.

## 2. `readBookmarkBytes` blocked the macOS main thread

`macos/Runner/LocalMediaHandler.swift` did `let data = try Data(contentsOf: url)`
inside a `FlutterMethodChannel` handler. Those run on the platform thread, which
on macOS **is the main thread**. On a sandboxed build this is the ordinary path
for every local media item, and `LocalFileResolver.resolveThumbnail` falls
through to `resolve()` for non-video items, so each grid tile dragged the full
original across the channel, synchronously, on the UI thread. Against an SMB
mount or an evicted iCloud Drive file that is a dead-stopped app, not a slow
one.

`readBookmarkBytes`, `resolveBookmark`, `createBookmark` and the bookmark
resolution inside `generateVideoThumbnail` now run on
`DispatchQueue.global(qos: .userInitiated)` and reply on main. Same change on
iOS, preserving each method's own `options:` value.

`resolveBookmark` takes `[weak self]` and balances
`stopAccessingSecurityScopedResource()` if the handler is deallocated
mid-resolve: moving work off a thread turns a previously impossible
interleaving into a real one, and that scope would otherwise leak for the life
of the process.

## 3. The exit reply was a single point of failure

`applicationShouldTerminateAfterLastWindowClosed` returns `true`, so "alive by
design" was never the explanation. `applicationShouldTerminate` was not
overridden, so the inherited `FlutterAppDelegate` implementation returns
**`NSTerminateLater`** and asks Dart. **Nothing on the native side ever
re-checks.**

`_closeDatabases` in `lib/app.dart` was the only `onExitRequested` handler in
the repo, and it had no `try`, no `.timeout()`, and no fallback return. Any
throw or any never-completing await left AppKit deferring forever, with the
window already dismissed. The internal budgets in
`closeDatabaseForAppShutdown` are not a defense: they are all `Future.timeout`,
so they cannot interrupt work already in progress and cannot fire at all if the
isolate is blocked.

And the two halves compose: the thread blocked by `Data(contentsOf:)` is the
same thread that must run `applicationShouldTerminate` and deliver
`replyToApplicationShouldTerminate:`. That is why this reproduced specifically
in the Media section.

Two layers:

- **`lib/core/app/app_exit.dart`.** `closeDatabasesForExit` always returns
  `AppExitResponse.exit`, never throws, and never exceeds one budget **shared**
  by both closes (a budget per close would make the worst case twice what the
  name promises). The cache close is attempted even when the main close fails or
  times out. Extracted out of the `ConsumerState` precisely so this contract is
  unit-testable.
- **A native watchdog.** `applicationShouldTerminate` is overridden to arm a 20s
  watchdog on a background `DispatchQueue`, not a run-loop `Timer`, because a
  wedged main thread is exactly the case it guards. It attempts
  `reply(toApplicationShouldTerminate:)` on main and falls back to `exit(0)`
  after a 2s grace. By then both databases have had their budget and drift runs
  in WAL mode, so an abrupt exit is recoverable.
  `applicationWillTerminate` sets the answered flag under an `NSLock` and now
  also drains `LocalMediaHandler`'s security-scoped URLs, whose `deinit` does
  not run on terminate.

## Two things worth calling out in review

**A data-safety bug this PR introduced and then fixed.** Only
`VerifyResult.notFound` and `unauthenticated` flip `MediaItem.isOrphaned`.
`LocalFileResolver.verify` fell through to `File(localPath).exists()` and
returned `notFound` for a `stillFetching` answer, so a share that was merely
*slow* during a re-verify sweep would have marked its whole library missing,
stickily. It now returns `transientError` explicitly. Found by auditing every
`verify()` in the feature against the new enum value; the other resolvers are
not exposed (`signature_resolver` reads inline BLOBs, `connector` and
`media_store` do not route `verify` through `resolve`).

**A silent budget bug a test caught.** The exit budget was first written with a
`Stopwatch`, which reads the wall clock and is invisible to `fake_async`, so the
"one shared budget" guarantee was really a per-close budget with a 16s worst
case. Switched to `package:clock`'s `clock.now()`, which the repo already
depends on for this reason. The test that caught it asserts the *sharing*, not
just that the call eventually returns.

## Also fixed

`MediaStoreResolver.tryResolveRemote` returns `null` for a video thumbnail on
purpose, with a comment saying it declines rather than download the original for
a grid tile. `MediaStoreSourceResolver.resolveThumbnail`'s `?? resolve(item)`
immediately re-asked with `thumbnail: false`, undoing that decision: one full
video download per tile, holding one of the four store permits. The store
fallback in `MediaItemView` still yields `videoPosterMissing`, so the tile draws
the same movie placeholder as before, now without the download.

## Deliberately out of scope

Recorded as follow-ups rather than built here:

- Real download progress (`PMProgressHandler`, byte progress plumbed through the
  resolver stack).
- `LocalFileResolver.resolveThumbnail` pulling the full original across the
  channel per tile instead of a native downscale.
- Synchronous filesystem I/O in the EXIF/import path.
- `reverifyAll` sweeping the library on the UI isolate.
- The unclosed media-store `S3ApiClient` and the uncancelled `HostRateLimiter`
  wakeup timer (leaks, not hangs).

## Testing

New coverage, all TDD (test written and watched to fail first):

- `media_fetch_gate_test.dart`: 5 new cases covering slot hand-off, the
  cancelled slot timer, the total budget, the detach cap, and a retry coalescing
  onto the live fetch. 5 pre-existing cases unchanged.
- `gallery_thumbnail_cache_test.dart`: 4 new, including that a detached fetch
  still caches its bytes when they land.
- `media_store_source_resolver_test.dart`: 3 new; the first reproduces the video
  bug exactly (`[true, false]` where only `[true]` is acceptable).
- `media_item_view_retry_test.dart` (new): retryable, not-retryable, and a retry
  that is still slow.
- `app_exit_test.dart` (new): 6 cases; ordering, both throw paths, the hang, the
  shared budget, and that an exhausted budget still attempts the cache close.
- `local_file_resolver_test.dart`: 1 new, the orphan guard above.

Verification:

- `flutter analyze`: **No issues found!** across the whole project.
- `dart format --set-exit-if-changed lib/ test/`: clean.
- `flutter build macos --debug`: succeeds, no new Swift warnings.
- Full suite run **three times**, unpiped: **19,551 passed / 19 skipped / 0
  failed**, exit 0 every time. No flakes, so nothing here is attributable to
  this diff.

Not done: the two manual repros (a genuinely unreachable mount plus a physical
window-close quit) need hardware staging and were not performed.

New user-facing string `media_unavailablePlaceholder_stillFetching` added and
translated across all 11 locales.

Plan: `docs/superpowers/plans/2026-08-20-media-availability-and-shutdown.md`
