### PR TITLE
fix(import): say why MacDive XML brings in no certifications

### DIFF
--- a/lib/features/universal_import/data/parsers/macdive_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/macdive_xml_parser.dart
@@ -30,6 +30,23 @@ import 'package:submersion/features/universal_import/data/services/macdive_xml_r
 class MacDiveXmlParser implements ImportParser {
   const MacDiveXmlParser();
 
+  /// MacDive's XML exporter writes neither certifications nor equipment
+  /// service records, so those two entity types can never come out of this
+  /// parser no matter what the diver's library holds (issue #1135: a 540-dive
+  /// export whose `MacDive.sqlite` had 4 certifications and 1 service record
+  /// produced an XML file containing no element for either).
+  ///
+  /// `MacDiveDbReader` does read both from `ZCERTIFICATION` and
+  /// `ZSERVICERECORD`, so the diver has a real remedy. Say so on every import
+  /// rather than letting the gap look like a failed parse.
+  static const _formatGapNotice = ImportWarning(
+    severity: ImportWarningSeverity.info,
+    message:
+        'MacDive XML exports do not contain certifications or equipment '
+        'service records, so none were found in this file. To import those, '
+        'choose your MacDive.sqlite database instead of the XML export.',
+  );
+
   @override
   List<ImportFormat> get supportedFormats => const [ImportFormat.macdiveXml];
 
@@ -237,6 +254,10 @@ class MacDiveXmlParser implements ImportParser {
     }
     if (tagsByName.isNotEmpty) {
       entities[ImportEntityType.tags] = tagsByName.values.toList();
+    }
+
+    if (diveMaps.isNotEmpty) {
+      warnings.add(_formatGapNotice);
     }
 
     return ImportPayload(

--- a/lib/features/universal_import/data/parsers/macdive_xml_parser.dart
+++ b/lib/features/universal_import/data/parsers/macdive_xml_parser.dart
@@ -39,12 +39,18 @@ class MacDiveXmlParser implements ImportParser {
   /// `MacDiveDbReader` does read both from `ZCERTIFICATION` and
   /// `ZSERVICERECORD`, so the diver has a real remedy. Say so on every import
   /// rather than letting the gap look like a failed parse.
+  ///
+  /// Worded as a claim about *this file*, not about the import. A batch parses
+  /// each file with its own detected format and `PayloadMerger` concatenates
+  /// every file's warnings, so a MacDive.sqlite alongside the XML export puts
+  /// this notice next to a non-zero Certifications count. Scoped this way it
+  /// stays true there and still names the remedy.
   static const _formatGapNotice = ImportWarning(
     severity: ImportWarningSeverity.info,
     message:
-        'MacDive XML exports do not contain certifications or equipment '
-        'service records, so none were found in this file. To import those, '
-        'choose your MacDive.sqlite database instead of the XML export.',
+        'This MacDive XML file contains no certifications or equipment '
+        'service records: MacDive omits both from its XML export. To bring '
+        'them in, add your MacDive.sqlite database to this import.',
   );
 
   @override

--- a/test/features/universal_import/data/parsers/macdive_xml_parser_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_xml_parser_test.dart
@@ -239,6 +239,50 @@ void main() {
       // value.
       expect(dive.containsKey('entryMethod'), isFalse);
     });
+
+    // #1135: MacDive's native XML exporter never writes certification or
+    // service-record elements, even when the library has them. Verified
+    // against a 540-dive export whose MacDive.sqlite held 4 certifications
+    // and 1 service record while the XML held neither. Nothing can be parsed
+    // out of the file, so the parser says so rather than leaving the diver to
+    // wonder why their cards never arrived.
+    test('warns that MacDive XML omits certifications and service '
+        'records', () async {
+      final payload = await const MacDiveXmlParser().parse(bytes);
+
+      final notices = payload.warnings
+          .where((w) => w.severity == ImportWarningSeverity.info)
+          .where((w) => w.message.contains('certifications'))
+          .toList();
+      expect(notices, hasLength(1));
+
+      final message = notices.single.message;
+      expect(message, contains('service records'));
+      expect(
+        message,
+        contains('MacDive.sqlite'),
+        reason: 'the notice must name the export that does carry them',
+      );
+      expect(
+        payload.entitiesOf(ImportEntityType.certifications),
+        isEmpty,
+        reason: 'the notice explains an absence, it does not invent entities',
+      );
+    });
+
+    test('omits the format notice when the file has no dives', () async {
+      const xml = '''<?xml version="1.0"?>
+<dives><units>Metric</units><schema>2.2.0</schema></dives>''';
+      final payload = await const MacDiveXmlParser().parse(
+        Uint8List.fromList(utf8.encode(xml)),
+      );
+
+      expect(
+        payload.warnings.where((w) => w.message.contains('certifications')),
+        isEmpty,
+        reason: 'an empty logbook has no import for the notice to qualify',
+      );
+    });
   });
 
   group('MacDiveXmlParser dedup behavior', () {

--- a/test/features/universal_import/data/parsers/macdive_xml_real_sample_test.dart
+++ b/test/features/universal_import/data/parsers/macdive_xml_real_sample_test.dart
@@ -70,6 +70,27 @@ void main() {
       );
     });
 
+    // #1135: the library behind this sample holds 4 certifications and 1
+    // service record in its MacDive.sqlite, yet MacDive's XML export of that
+    // same library contains no element for either. This asserts both halves:
+    // the export really is empty of them, and the parser tells the diver so.
+    test(
+      'real export carries no certifications, and the notice says so',
+      () async {
+        if (skipIfNoFixture()) return;
+        final payload = await const MacDiveXmlParser().parse(bytes);
+
+        expect(payload.entitiesOf(ImportEntityType.certifications), isEmpty);
+        expect(payload.entitiesOf(ImportEntityType.serviceRecords), isEmpty);
+        expect(
+          payload.warnings
+              .where((w) => w.severity == ImportWarningSeverity.info)
+              .where((w) => w.message.contains('MacDive.sqlite')),
+          hasLength(1),
+        );
+      },
+    );
+
     test('every dive has a sourceUuid from <identifier>', () async {
       if (skipIfNoFixture()) return;
       final payload = await const MacDiveXmlParser().parse(bytes);


### PR DESCRIPTION
## Summary

Fixes #1135.

Not a parser bug. **MacDive's XML exporter never writes certifications.** The evidence is one library exported three ways:

| Export | Certifications | Service records |
| --- | --- | --- |
| `MacDive.sqlite` | 4 (`ZCERTIFICATION`) | 1 (`ZSERVICERECORD`) |
| native XML, 540 dives, 30 MB | 0 | 0 |
| UDDF | 0 | 0 |

Every distinct tag name in the XML was enumerated; there is no certification element and no service-record element. So there is nothing in the file for `MacDiveXmlReader` to read and no mapping gap to close in `MacDiveXmlParser`. The SQLite path emits nine entity types, the XML path emits seven, missing exactly `certifications` and `serviceRecords`.

Until now that difference was silent, which is what made it read as a failed import rather than a limitation of the source format. This PR makes it visible and actionable instead.

## Changes

- `MacDiveXmlParser` attaches an info-level `ImportWarning` naming both gaps and pointing at `MacDive.sqlite`, which does carry them. It renders under the entity counts on the Import Complete screen, where a diver scanning for a Certifications row and not finding it would look.
- One notice rather than one per entity type. The two absences have a single cause and a single remedy, and `_WarningsSection` renders each warning as its own block, so two would read as two unrelated problems.
- Gated on the payload having dives. The three early-return paths (empty file, bad UTF-8, malformed XML) build their own payloads and cannot reach it, but a well-formed MacDive file with zero dives falls through to the normal path, and there a "use SQLite instead" hint is noise on top of an already-empty import. A test pins that boundary.
- The real-sample suite gains a guard asserting both halves at once: that a real MacDive export really is empty of certifications and service records, and that the notice fires exactly once. It skips cleanly without the sample, as the rest of that suite does.

Deliberately not done: no change to format detection or the source-confirmation step. Payload warnings have exactly one render site today, and routing this one through detection would mean new plumbing for no extra reach.

## Test Plan

- [x] `flutter test` passes. `test/features/universal_import/` + `test/features/dive_import/`: 1803 passed, 6 skipped (real-data). The new assertion was confirmed failing first, with `Expected: length of <1>, Actual: []`.
- [x] `flutter analyze` passes, clean.
- [x] Real-sample run against a 540-dive MacDive XML export: 10 passed, including the new guard.

```
flutter test --dart-define=MACDIVE_XML_SAMPLE=/path/to/sample.xml \
  --run-skipped --tags=real-data \
  test/features/universal_import/data/parsers/macdive_xml_real_sample_test.dart
```

## Note for the issue reporter

There is no code fix that recovers these records from an XML file. Anyone hitting this should re-import from `MacDive.sqlite`, which brings in certifications and equipment service records along with everything the XML path already handles.
