### PR TITLE
fix(buoyancy): count lead carried as weights-type equipment (#1103)

### DIFF
--- a/lib/features/dive_log/data/services/buoyancy_twin_assembler.dart
+++ b/lib/features/dive_log/data/services/buoyancy_twin_assembler.dart
@@ -7,6 +7,8 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/deco/entities/dive_environment.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/services/equipment_lead.dart';
+import 'package:submersion/features/equipment/domain/services/gear_feature_mapper.dart';
 
 /// The full result of running the twin for one dive: the raw series, the
 /// derived outputs, and the wing lift capacity (when the rig records one).
@@ -165,6 +167,10 @@ class BuoyancyTwinAssembler {
         material: t.material,
       );
     }
+    // Lead is deliberately absent from the displaced mass, whether it was
+    // typed as weight rows or built into the rig as weights gear: the water
+    // term scales displacement by mass, and lead at ~11x the density of water
+    // displaces roughly a tenth of what its mass would imply.
     final totalMass = bodyMass + gearDryMass + tankDryMass;
 
     staticTerms.add(
@@ -187,17 +193,23 @@ class BuoyancyTwinAssembler {
 
   /// Sum of droppable lead: belt and integrated rows are ditchable;
   /// backplate, trim, ankle, and mixed placements are treated as fixed.
+  ///
+  /// Gear-carried ballast contributes the share whose `weight_style` marks it
+  /// ditchable; an unstyled weights item counts as fixed, which understates
+  /// what the diver can drop rather than overstating it.
   static double droppableLeadKg(Dive dive) {
+    final gear = EquipmentLead.droppableKg(dive.equipment);
     if (dive.weights.isNotEmpty) {
       var sum = 0.0;
       for (final w in dive.weights) {
-        if (_isDroppable(w.weightType)) sum += w.amountKg;
+        if (EquipmentLead.isDroppable(w.weightType)) sum += w.amountKg;
       }
-      return sum;
+      return sum + gear;
     }
     final legacy = dive.weightAmount ?? 0.0;
     final type = dive.weightType;
-    return (type == null || _isDroppable(type)) ? legacy : 0.0;
+    return ((type == null || EquipmentLead.isDroppable(type)) ? legacy : 0.0) +
+        gear;
   }
 
   /// Sum of droppable lead from a planned per-[WeightType] breakdown (keys are
@@ -209,7 +221,7 @@ class BuoyancyTwinAssembler {
       final type = WeightType.values
           .where((t) => t.name == entry.key)
           .firstOrNull;
-      if (type != null && _isDroppable(type)) sum += entry.value;
+      if (EquipmentLead.isDroppable(type)) sum += entry.value;
     }
     return sum;
   }
@@ -253,11 +265,19 @@ class BuoyancyTwinAssembler {
     );
   }
 
+  /// Every kilogram of lead the diver carried: the typed weight rows (or the
+  /// legacy scalar when there are none) plus ballast built into the rig as
+  /// [EquipmentType.weights] gear.
+  ///
+  /// The two sources are additive, not a fallback ladder: a belt and a
+  /// weighted backplate are different lead. Gear only contributes when it
+  /// declares a mass, so rigs that list weights without numbers are
+  /// unaffected. See [EquipmentLead].
   static double _carriedLead(Dive dive) {
-    if (dive.weights.isNotEmpty) {
-      return dive.weights.fold(0.0, (sum, w) => sum + w.amountKg);
-    }
-    return dive.weightAmount ?? 0.0;
+    final typed = dive.weights.isNotEmpty
+        ? dive.weights.fold(0.0, (sum, w) => sum + w.amountKg)
+        : (dive.weightAmount ?? 0.0);
+    return typed + EquipmentLead.totalKg(dive.equipment);
   }
 
   static EquipmentItem? _exposureSuit(List<EquipmentItem> items) {
@@ -270,23 +290,6 @@ class BuoyancyTwinAssembler {
     return null;
   }
 
-  static bool _isDroppable(WeightType t) =>
-      t == WeightType.belt || t == WeightType.integrated;
-
-  /// Equivalent to the weight planner's gearFeatureFor, inlined so this data
-  /// service does not depend on a presentation-layer provider.
-  static GearFeature? _featureFor(EquipmentItem item) {
-    if (item.type == EquipmentType.weights || item.type == EquipmentType.tank) {
-      return null;
-    }
-    return GearFeature.fromEquipment(
-      id: item.id,
-      type: item.type,
-      name: item.name,
-      size: item.size,
-      thickness: item.thickness,
-      buoyancyKg: item.buoyancyKg,
-      weightKg: item.weightKg,
-    );
-  }
+  static GearFeature? _featureFor(EquipmentItem item) =>
+      gearFeatureFromEquipment(item);
 }

--- a/lib/features/dive_log/presentation/widgets/buoyancy_section.dart
+++ b/lib/features/dive_log/presentation/widgets/buoyancy_section.dart
@@ -167,6 +167,13 @@ class BuoyancySection extends ConsumerWidget {
     if (outcome.result.input.suit.kind == TwinSuitKind.none) {
       hints.add(context.l10n.buoyancy_linkSuitHint);
     }
+    // Lead can be recorded in two places: the dive's Weights section, or a
+    // dry weight on weights-type gear. Zero here means neither was filled in,
+    // and the modeled net will read far too buoyant -- the confusion behind
+    // issue #1103.
+    if (outcome.result.input.leadKg <= 0) {
+      hints.add(context.l10n.buoyancy_noLeadHint);
+    }
     return [
       for (final text in hints) ...[
         const SizedBox(height: 8),

--- a/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
+++ b/lib/features/equipment/domain/constants/equipment_attribute_catalog.dart
@@ -43,6 +43,7 @@ abstract final class EquipmentAttrKeys {
   static const bcdStyle = 'bcd_style';
   static const liftCapacityKg = 'lift_capacity_kg';
   static const gloveType = 'glove_type';
+  static const weightStyle = 'weight_style';
 }
 
 class EquipmentAttributeDef {
@@ -247,7 +248,7 @@ abstract final class EquipmentAttributeCatalog {
     ],
     EquipmentType.weights: [
       EquipmentAttributeDef(
-        key: 'weight_style',
+        key: EquipmentAttrKeys.weightStyle,
         kind: AttributeKind.choice,
         choiceKeys: ['belt', 'integrated', 'trim', 'ankle'],
       ),

--- a/lib/features/equipment/domain/services/equipment_lead.dart
+++ b/lib/features/equipment/domain/services/equipment_lead.dart
@@ -1,0 +1,97 @@
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+
+/// Lead a diver carries as gear rather than as typed per-dive weight rows.
+///
+/// Backplate-and-wing divers build their ballast into the rig -- weighted
+/// backplates, weighted single-tank adapters, bolt-on trim blocks, dumpable
+/// blocks -- record each as an [EquipmentType.weights] item, and leave the
+/// dive's Weights section empty because there is no belt to describe.
+///
+/// That lead used to be invisible to every buoyancy surface. Weights items
+/// are deliberately excluded from the gear features (lead is the quantity the
+/// weight engine predicts, so it cannot also be a predictor), and nothing
+/// else read them, so a rig carrying 30 lb of built-in ballast modeled as
+/// though it carried none (issue #1103).
+///
+/// Pure functions over already-loaded values: the raw-row callers (weight
+/// history) use [ballastKg] and [placementFor] directly, the entity callers
+/// (buoyancy twin, planner) use the [EquipmentItem] helpers.
+abstract final class EquipmentLead {
+  /// Ballast one weights item contributes, in kg, or 0 when it declares no
+  /// usable mass.
+  ///
+  /// Dry weight wins because it is unambiguously positive: a diver who typed
+  /// `8` meaning "an 8 lb block" cannot accidentally invert the sign. Signed
+  /// buoyancy is the fallback and is trusted only when negative, the one
+  /// physically sensible sign for lead. Non-finite values (the numeric
+  /// attribute fields parse with `double.tryParse`, which admits `Infinity`)
+  /// are treated as absent.
+  static double ballastKg({
+    required double? dryWeightKg,
+    required double? buoyancyKg,
+  }) {
+    if (dryWeightKg != null && dryWeightKg.isFinite && dryWeightKg > 0) {
+      return dryWeightKg;
+    }
+    if (buoyancyKg != null && buoyancyKg.isFinite && buoyancyKg < 0) {
+      return -buoyancyKg;
+    }
+    return 0.0;
+  }
+
+  /// The [WeightType] a weights item's `weight_style` attribute names, or
+  /// null when unset or a future catalog value.
+  static WeightType? placementFor(String? weightStyle) => switch (weightStyle) {
+    'belt' => WeightType.belt,
+    'integrated' => WeightType.integrated,
+    'trim' => WeightType.trimWeights,
+    'ankle' => WeightType.ankleWeights,
+    _ => null,
+  };
+
+  /// Whether ballast in [type] can be ditched in an emergency. A null (unset
+  /// or unrecognized) placement counts as fixed: understating how much weight
+  /// the diver can drop is the safe direction to be wrong in.
+  static bool isDroppable(WeightType? type) =>
+      type == WeightType.belt || type == WeightType.integrated;
+
+  /// Ballast [item] contributes; 0 for anything that is not weights gear.
+  static double kgFor(EquipmentItem item) => item.type == EquipmentType.weights
+      ? ballastKg(dryWeightKg: item.weightKg, buoyancyKg: item.buoyancyKg)
+      : 0.0;
+
+  /// Total gear-carried ballast across [items].
+  static double totalKg(Iterable<EquipmentItem> items) =>
+      items.fold(0.0, (sum, item) => sum + kgFor(item));
+
+  /// The ditchable share of the gear-carried ballast across [items].
+  static double droppableKg(Iterable<EquipmentItem> items) {
+    var sum = 0.0;
+    for (final item in items) {
+      final placement = placementFor(
+        item.attrText(EquipmentAttrKeys.weightStyle),
+      );
+      if (isDroppable(placement)) sum += kgFor(item);
+    }
+    return sum;
+  }
+
+  /// `WeightType.name` -> kg for gear-carried ballast that names a placement.
+  /// Ballast with no placement is omitted rather than guessed at, so callers
+  /// can tell "carried, placement unknown" from "carried on the belt".
+  static Map<String, double> placementKg(Iterable<EquipmentItem> items) {
+    final byType = <String, double>{};
+    for (final item in items) {
+      final kg = kgFor(item);
+      if (kg <= 0) continue;
+      final placement = placementFor(
+        item.attrText(EquipmentAttrKeys.weightStyle),
+      );
+      if (placement == null) continue;
+      byType.update(placement.name, (v) => v + kg, ifAbsent: () => kg);
+    }
+    return byType;
+  }
+}

--- a/lib/features/equipment/domain/services/gear_feature_mapper.dart
+++ b/lib/features/equipment/domain/services/gear_feature_mapper.dart
@@ -1,0 +1,53 @@
+import 'package:submersion/core/buoyancy/gear_buoyancy_traits.dart';
+import 'package:submersion/core/buoyancy/gear_feature.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+
+/// Converts an equipment item to a buoyancy-engine feature.
+///
+/// The single bridge between the equipment data model and `core/buoyancy`,
+/// which stays free of any [EquipmentAttribute] import. Both the Weight
+/// Planner and the buoyancy twin's rig assembler go through here, so a logged
+/// dive and a planned dive derive the same priors from the same attributes
+/// (before #1103 the assembler had its own copy that dropped [traits], so a
+/// trilaminate drysuit or a rated wing informed the planner but not the
+/// dive-detail Buoyancy section).
+///
+/// Returns null for the excluded types: lead ([EquipmentType.weights]) is the
+/// predicted quantity -- see `EquipmentLead` for how it is counted instead --
+/// and tanks are modeled from the tank list.
+GearFeature? gearFeatureFromEquipment(EquipmentItem item) {
+  if (item.type == EquipmentType.weights || item.type == EquipmentType.tank) {
+    return null;
+  }
+  // Index the curated attributes once. attrText/attrNum are each an O(n)
+  // scan, and reading them individually would rescan thickness_mm three
+  // times; putIfAbsent preserves their first-match semantics.
+  final attrs = <String, EquipmentAttribute>{};
+  for (final a in item.attributes) {
+    if (!a.isCustom) attrs.putIfAbsent(a.key, () => a);
+  }
+  final thicknessText = attrs[EquipmentAttrKeys.thicknessMm]?.valueText;
+  return GearFeature.fromEquipment(
+    id: item.id,
+    type: item.type,
+    name: item.name,
+    size: attrs[EquipmentAttrKeys.size]?.valueText,
+    thickness: thicknessText,
+    buoyancyKg: attrs[EquipmentAttrKeys.buoyancyKg]?.valueNum,
+    weightKg: attrs[EquipmentAttrKeys.dryWeightKg]?.valueNum,
+    traits: GearBuoyancyTraits(
+      primaryThicknessMm: attrs[EquipmentAttrKeys.thicknessMm]?.valueNum,
+      panelThicknessesMm: thicknessText == null
+          ? const []
+          : GearBuoyancyTraits.parsePanelsMm(thicknessText),
+      suitStyle: attrs[EquipmentAttrKeys.suitStyle]?.valueText,
+      shellMaterial: attrs[EquipmentAttrKeys.shellMaterial]?.valueText,
+      bcdStyle: attrs[EquipmentAttrKeys.bcdStyle]?.valueText,
+      liftCapacityKg: attrs[EquipmentAttrKeys.liftCapacityKg]?.valueNum,
+      gloveType: attrs[EquipmentAttrKeys.gloveType]?.valueText,
+    ),
+  );
+}

--- a/lib/features/weight_planner/data/repositories/weight_history_repository.dart
+++ b/lib/features/weight_planner/data/repositories/weight_history_repository.dart
@@ -4,11 +4,14 @@ import 'package:submersion/core/buoyancy/weight_observation.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/services/equipment_lead.dart';
 
 /// Assembles weight-prediction training rows from the dive log.
 ///
-/// Four batch queries (dives, dive_weights, dive_equipment, dive_tanks) --
-/// no per-dive N+1. Only dives that recorded any weight qualify.
+/// Six batch queries (dives, dive_weights, dive_equipment, dive_tanks, and
+/// equipment + equipment_attributes for gear-carried lead) -- no per-dive
+/// N+1. Only dives that recorded any weight qualify.
 class WeightHistoryRepository {
   WeightHistoryRepository([AppDatabase? db]) : _dbOverride = db;
 
@@ -44,6 +47,9 @@ class WeightHistoryRepository {
     for (final row in equipmentRows) {
       equipmentByDive.putIfAbsent(row.diveId, () => []).add(row.equipmentId);
     }
+    final leadByEquipment = await _gearCarriedLead(
+      equipmentRows.map((e) => e.equipmentId).toSet(),
+    );
     final tanksByDive = <String, List<ObservedTank>>{};
     for (final row in tankRows) {
       tanksByDive
@@ -79,6 +85,23 @@ class WeightHistoryRepository {
       if (typedWeights.isEmpty) {
         carried = dive.weightAmount ?? 0.0;
       }
+      // Ballast built into the rig (weighted plates, weighted STAs, bolt-on
+      // trim) is lead the diver carried even when the Weights section is
+      // empty. Without it these dives failed the `carried <= 0` gate below
+      // and never became training rows at all (issue #1103).
+      for (final equipmentId in equipmentByDive[dive.id] ?? const <String>[]) {
+        final gear = leadByEquipment[equipmentId];
+        if (gear == null) continue;
+        carried += gear.kg;
+        final placedAs = gear.placement?.name;
+        if (placedAs != null) {
+          placement.update(
+            placedAs,
+            (v) => v + gear.kg,
+            ifAbsent: () => gear.kg,
+          );
+        }
+      }
       if (carried <= 0) continue;
 
       observations.add(
@@ -102,4 +125,62 @@ class WeightHistoryRepository {
     }
     return observations;
   }
+
+  /// Ballast and placement for every [EquipmentType.weights] item among
+  /// [equipmentIds], keyed by equipment id. Items that declare no usable mass
+  /// are omitted, so a weights item with no numbers changes nothing.
+  ///
+  /// Two more batch queries (equipment, equipment_attributes), keeping the
+  /// no-N+1 property of the caller.
+  Future<Map<String, _GearLead>> _gearCarriedLead(
+    Set<String> equipmentIds,
+  ) async {
+    if (equipmentIds.isEmpty) return const {};
+    final ids = equipmentIds.toList();
+
+    final gearRows =
+        await (_db.select(_db.equipment)..where(
+              (e) => e.id.isIn(ids) & e.type.equals(EquipmentType.weights.name),
+            ))
+            .get();
+    if (gearRows.isEmpty) return const {};
+
+    final weightsIds = gearRows.map((e) => e.id).toList();
+    final attrRows =
+        await (_db.select(_db.equipmentAttributes)..where(
+              (a) => a.equipmentId.isIn(weightsIds) & a.isCustom.equals(false),
+            ))
+            .get();
+
+    final attrsByEquipment = <String, Map<String, EquipmentAttributeRow>>{};
+    for (final row in attrRows) {
+      attrsByEquipment
+          .putIfAbsent(row.equipmentId, () => {})
+          .putIfAbsent(row.attrKey, () => row);
+    }
+
+    final result = <String, _GearLead>{};
+    for (final gear in gearRows) {
+      final attrs = attrsByEquipment[gear.id] ?? const {};
+      final kg = EquipmentLead.ballastKg(
+        dryWeightKg: attrs[EquipmentAttrKeys.dryWeightKg]?.valueNum,
+        buoyancyKg: attrs[EquipmentAttrKeys.buoyancyKg]?.valueNum,
+      );
+      if (kg <= 0) continue;
+      result[gear.id] = _GearLead(
+        kg: kg,
+        placement: EquipmentLead.placementFor(
+          attrs[EquipmentAttrKeys.weightStyle]?.valueText,
+        ),
+      );
+    }
+    return result;
+  }
+}
+
+/// One weights item's contribution to a dive's carried lead.
+class _GearLead {
+  final double kg;
+  final WeightType? placement;
+  const _GearLead({required this.kg, required this.placement});
 }

--- a/lib/features/weight_planner/data/repositories/weight_history_repository.dart
+++ b/lib/features/weight_planner/data/repositories/weight_history_repository.dart
@@ -18,6 +18,17 @@ class WeightHistoryRepository {
   final AppDatabase? _dbOverride;
   AppDatabase get _db => _dbOverride ?? DatabaseService.instance.database;
 
+  /// Emits when the gear side of an observation's carried lead changes.
+  ///
+  /// Since #1103 an observation's `carriedKg` also comes from weights-type
+  /// equipment, whose mass lives in `equipment_attributes`. `saveAttributes`
+  /// writes that table alone, so watching `equipment` would miss an
+  /// attribute-only write (a sync apply, for instance) entirely; both tables
+  /// are needed. Dives-table changes are watched separately by the caller.
+  Stream<void> watchGearLeadChanges() => _db.tableUpdates(
+    TableUpdateQuery.onAllTables([_db.equipment, _db.equipmentAttributes]),
+  );
+
   /// All dives of [diverId] that recorded any weight, ordered oldest-first.
   Future<List<WeightObservation>> observationsForDiver(String diverId) async {
     final diveRows =

--- a/lib/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider.dart
+++ b/lib/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider.dart
@@ -8,6 +8,7 @@ import 'package:submersion/features/dive_planner/domain/entities/plan_segment.da
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_weight_entry_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/services/equipment_lead.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/weight_planner/presentation/providers/weight_planner_providers.dart';
 
@@ -61,7 +62,21 @@ final planBuoyancyTwinProvider = Provider<BuoyancyTwinOutcome?>((ref) {
 
   if (model == null || equipment == null || state.tanks.isEmpty) return null;
 
-  final lead = state.plannedWeightKg ?? prediction?.totalKg ?? 0.0;
+  final itemsById = {for (final e in equipment) e.id: e};
+  final items = <EquipmentItem>[
+    for (final id in state.equipmentIds) ?itemsById[id],
+  ];
+
+  // Ballast built into the planned rig (weighted plates, weighted STAs) is
+  // lead the diver will carry but never types into the planned-weight field.
+  // Only the explicit figure needs it added: the prediction is trained on
+  // observations that already count gear-carried lead (issue #1103), so
+  // adding it there would double-count.
+  final gearLead = EquipmentLead.totalKg(items);
+  final planned = state.plannedWeightKg;
+  final lead = planned != null
+      ? planned + gearLead
+      : (prediction?.totalKg ?? 0.0);
   if (lead <= 0) return null;
 
   final consumptionByTank = {
@@ -87,11 +102,6 @@ final planBuoyancyTwinProvider = Provider<BuoyancyTwinOutcome?>((ref) {
       ),
   ];
 
-  final itemsById = {for (final e in equipment) e.id: e};
-  final items = <EquipmentItem>[
-    for (final id in state.equipmentIds) ?itemsById[id],
-  ];
-
   final rig = BuoyancyTwinAssembler.composeRigTerms(
     items: items,
     tanks: tanks,
@@ -103,11 +113,17 @@ final planBuoyancyTwinProvider = Provider<BuoyancyTwinOutcome?>((ref) {
 
   // Some planned lead may be non-ditchable (e.g. backplate/trim). When the
   // planner carries a per-WeightType placement, count only the droppable
-  // (belt + integrated) portion; otherwise assume all lead is droppable.
+  // (belt + integrated) portion; otherwise fall back to the coarse
+  // everything-is-droppable assumption, gear ballast included.
+  //
+  // On the placement branch, gear-carried ballast is added separately: the
+  // planner's placement map only ever describes typed lead, so the gear share
+  // is classified by each item's own weight_style (unstyled counts as fixed).
   final placement = state.plannedWeightPlacement;
   final droppableLead = placement == null
       ? lead
-      : BuoyancyTwinAssembler.droppableLeadFromPlacement(placement);
+      : BuoyancyTwinAssembler.droppableLeadFromPlacement(placement) +
+            EquipmentLead.droppableKg(items);
 
   final input = TwinInput(
     profile: synthesizePlanProfile(state.segments),

--- a/lib/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider.dart
+++ b/lib/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider.dart
@@ -8,7 +8,6 @@ import 'package:submersion/features/dive_planner/domain/entities/plan_segment.da
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_weight_entry_providers.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
-import 'package:submersion/features/equipment/domain/services/equipment_lead.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/weight_planner/presentation/providers/weight_planner_providers.dart';
 
@@ -62,22 +61,19 @@ final planBuoyancyTwinProvider = Provider<BuoyancyTwinOutcome?>((ref) {
 
   if (model == null || equipment == null || state.tanks.isEmpty) return null;
 
+  // Both branches are the same quantity: plannedWeightKg is only ever written
+  // as a snapshot of prediction.totalKg (see plan_gear_weights_section), and
+  // the prediction is a TOTAL trained on observations whose carriedKg now
+  // includes ballast built into the rig (issue #1103). Do not add
+  // EquipmentLead here -- gear lead is already inside this figure, and adding
+  // it again would double-count every rig the model has seen.
+  final lead = state.plannedWeightKg ?? prediction?.totalKg ?? 0.0;
+  if (lead <= 0) return null;
+
   final itemsById = {for (final e in equipment) e.id: e};
   final items = <EquipmentItem>[
     for (final id in state.equipmentIds) ?itemsById[id],
   ];
-
-  // Ballast built into the planned rig (weighted plates, weighted STAs) is
-  // lead the diver will carry but never types into the planned-weight field.
-  // Only the explicit figure needs it added: the prediction is trained on
-  // observations that already count gear-carried lead (issue #1103), so
-  // adding it there would double-count.
-  final gearLead = EquipmentLead.totalKg(items);
-  final planned = state.plannedWeightKg;
-  final lead = planned != null
-      ? planned + gearLead
-      : (prediction?.totalKg ?? 0.0);
-  if (lead <= 0) return null;
 
   final consumptionByTank = {
     for (final g in planResult.gasConsumptions) g.tankId: g,
@@ -113,17 +109,17 @@ final planBuoyancyTwinProvider = Provider<BuoyancyTwinOutcome?>((ref) {
 
   // Some planned lead may be non-ditchable (e.g. backplate/trim). When the
   // planner carries a per-WeightType placement, count only the droppable
-  // (belt + integrated) portion; otherwise fall back to the coarse
-  // everything-is-droppable assumption, gear ballast included.
+  // (belt + integrated) portion; otherwise assume all lead is droppable.
   //
-  // On the placement branch, gear-carried ballast is added separately: the
-  // planner's placement map only ever describes typed lead, so the gear share
-  // is classified by each item's own weight_style (unstyled counts as fixed).
+  // PlacementPredictor builds that map by splitting the whole predicted total
+  // across the diver's habitual placement fractions, which since #1103 are
+  // learned from observations that include styled gear ballast. The gear's
+  // ditchable share is therefore already inside this figure; adding
+  // EquipmentLead.droppableKg on top would count it twice.
   final placement = state.plannedWeightPlacement;
   final droppableLead = placement == null
       ? lead
-      : BuoyancyTwinAssembler.droppableLeadFromPlacement(placement) +
-            EquipmentLead.droppableKg(items);
+      : BuoyancyTwinAssembler.droppableLeadFromPlacement(placement);
 
   final input = TwinInput(
     profile: synthesizePlanProfile(state.segments),

--- a/lib/features/weight_planner/presentation/providers/weight_planner_providers.dart
+++ b/lib/features/weight_planner/presentation/providers/weight_planner_providers.dart
@@ -1,56 +1,23 @@
-import 'package:submersion/core/buoyancy/gear_buoyancy_traits.dart';
 import 'package:submersion/core/buoyancy/gear_feature.dart';
 import 'package:submersion/core/buoyancy/weight_observation.dart';
 import 'package:submersion/core/buoyancy/weight_prediction_engine.dart';
-import 'package:submersion/core/constants/enums.dart';
-import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_weight_entry_providers.dart';
-import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/services/gear_feature_mapper.dart';
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/weight_planner/data/repositories/weight_history_repository.dart';
 
 /// Converts an equipment item to an engine feature.
 ///
-/// Returns null for the excluded types: lead ([EquipmentType.weights]) is
-/// the predicted quantity, and tanks are modeled from the tank list.
-GearFeature? gearFeatureFor(EquipmentItem item) {
-  if (item.type == EquipmentType.weights || item.type == EquipmentType.tank) {
-    return null;
-  }
-  // Index the curated attributes once. attrText/attrNum are each an O(n)
-  // scan, and reading them individually would rescan thickness_mm three
-  // times; putIfAbsent preserves their first-match semantics.
-  final attrs = <String, EquipmentAttribute>{};
-  for (final a in item.attributes) {
-    if (!a.isCustom) attrs.putIfAbsent(a.key, () => a);
-  }
-  final thicknessText = attrs[EquipmentAttrKeys.thicknessMm]?.valueText;
-  return GearFeature.fromEquipment(
-    id: item.id,
-    type: item.type,
-    name: item.name,
-    size: attrs[EquipmentAttrKeys.size]?.valueText,
-    thickness: thicknessText,
-    buoyancyKg: attrs[EquipmentAttrKeys.buoyancyKg]?.valueNum,
-    weightKg: attrs[EquipmentAttrKeys.dryWeightKg]?.valueNum,
-    traits: GearBuoyancyTraits(
-      primaryThicknessMm: attrs[EquipmentAttrKeys.thicknessMm]?.valueNum,
-      panelThicknessesMm: thicknessText == null
-          ? const []
-          : GearBuoyancyTraits.parsePanelsMm(thicknessText),
-      suitStyle: attrs[EquipmentAttrKeys.suitStyle]?.valueText,
-      shellMaterial: attrs[EquipmentAttrKeys.shellMaterial]?.valueText,
-      bcdStyle: attrs[EquipmentAttrKeys.bcdStyle]?.valueText,
-      liftCapacityKg: attrs[EquipmentAttrKeys.liftCapacityKg]?.valueNum,
-      gloveType: attrs[EquipmentAttrKeys.gloveType]?.valueText,
-    ),
-  );
-}
+/// Thin alias for the shared bridge in the equipment domain; both this
+/// planner surface and the buoyancy twin's rig assembler resolve priors
+/// through the same code path.
+GearFeature? gearFeatureFor(EquipmentItem item) =>
+    gearFeatureFromEquipment(item);
 
 /// A weak zero-prior feature for gear ids that no longer resolve (deleted
 /// items): their dives still inform the personal term without inventing a

--- a/lib/features/weight_planner/presentation/providers/weight_planner_providers.dart
+++ b/lib/features/weight_planner/presentation/providers/weight_planner_providers.dart
@@ -38,7 +38,8 @@ final weightHistoryRepositoryProvider = Provider<WeightHistoryRepository>((
 
 /// The active diver's weight-bearing dive history, oldest first.
 ///
-/// Self-invalidates on any dives-table change (edits, imports, sync).
+/// Self-invalidates on any dives-table change (edits, imports, sync) and on
+/// equipment or equipment-attribute changes, which feed gear-carried lead.
 final weightObservationsProvider = FutureProvider<List<WeightObservation>>((
   ref,
 ) async {
@@ -47,6 +48,11 @@ final weightObservationsProvider = FutureProvider<List<WeightObservation>>((
   if (diverId == null) return const [];
 
   ref.invalidateSelfWhen(DiveRepository().watchDivesChanges());
+  // Carried lead is also read off weights-type equipment and its attributes
+  // (#1103), which a dives-table write does not cover: editing a weight
+  // block's dry weight would otherwise leave carriedKg stale and refit the
+  // calibration against the old ballast until some dive happened to change.
+  ref.invalidateSelfWhen(repository.watchGearLeadChanges());
 
   return repository.observationsForDiver(diverId);
 });

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1345,6 +1345,7 @@
   "buoyancy_drysuitGas": "غاز البدلة الجافة المُضاف",
   "buoyancy_estimatedPressures": "ضغوط الأسطوانات تقديرية",
   "buoyancy_linkSuitHint": "اربط بدلة تعرّض بهذه الغطسة للحصول على صورة أوفى",
+  "buoyancy_noLeadHint": "لم يتم تسجيل أي أثقال: أضف أثقالًا إلى هذه الغطسة أو وزنًا جافًا إلى معدات الأثقال",
   "buoyancy_chartNet": "الصافي",
   "buoyancy_chartRig": "المعدات + الرصاص",
   "buoyancy_chartMinutes": "الزمن (دقيقة)",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1468,6 +1468,7 @@
   "buoyancy_drysuitGas": "Trocki-Gas zugegeben",
   "buoyancy_estimatedPressures": "Flaschendrücke sind geschätzt",
   "buoyancy_linkSuitHint": "Verknüpfe einen Tauchanzug mit diesem Tauchgang für ein vollständigeres Bild",
+  "buoyancy_noLeadHint": "Kein Blei erfasst: Füge diesem Tauchgang Blei hinzu oder trage bei deiner Bleiausrüstung ein Trockengewicht ein",
   "buoyancy_chartNet": "Netto",
   "buoyancy_chartRig": "Rig + Blei",
   "buoyancy_chartMinutes": "Zeit (min)",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -8430,6 +8430,7 @@
   "buoyancy_drysuitGas": "Drysuit gas added",
   "buoyancy_estimatedPressures": "Tank pressures are estimated",
   "buoyancy_linkSuitHint": "Link an exposure suit to this dive for a fuller picture",
+  "buoyancy_noLeadHint": "No lead recorded: add weights to this dive, or a dry weight to your weights gear",
   "buoyancy_chartNet": "Net",
   "buoyancy_chartRig": "Rig + lead",
   "buoyancy_chartMinutes": "Time (min)",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1468,6 +1468,7 @@
   "buoyancy_drysuitGas": "Gas de traje seco añadido",
   "buoyancy_estimatedPressures": "Las presiones de botella son estimadas",
   "buoyancy_linkSuitHint": "Asocia un traje a esta inmersión para un panorama más completo",
+  "buoyancy_noLeadHint": "No se registró lastre: añade lastre a esta inmersión o un peso en seco a tu equipo de lastre",
   "buoyancy_chartNet": "Neto",
   "buoyancy_chartRig": "Equipo + lastre",
   "buoyancy_chartMinutes": "Tiempo (min)",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6034,6 +6034,7 @@
   "buoyancy_drysuitGas": "Gaz d'étanche ajouté",
   "buoyancy_estimatedPressures": "Les pressions des blocs sont estimées",
   "buoyancy_linkSuitHint": "Associez une combinaison à cette plongée pour un tableau plus complet",
+  "buoyancy_noLeadHint": "Aucun lest enregistré : ajoutez du lest à cette plongée ou un poids à sec à votre équipement de lestage",
   "buoyancy_chartNet": "Net",
   "buoyancy_chartRig": "Équipement + lest",
   "buoyancy_chartMinutes": "Temps (min)",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4339,6 +4339,7 @@
   "buoyancy_drysuitGas": "גז יבשה שנוסף",
   "buoyancy_estimatedPressures": "לחצי המכלים משוערים",
   "buoyancy_linkSuitHint": "קשר חליפת חשיפה לצלילה זו לתמונה מלאה יותר",
+  "buoyancy_noLeadHint": "לא נרשמו משקולות: הוסף משקולות לצלילה זו או משקל יבש לציוד המשקולות שלך",
   "buoyancy_chartNet": "נטו",
   "buoyancy_chartRig": "ציוד + משקולות",
   "buoyancy_chartMinutes": "זמן (דק')",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6034,6 +6034,7 @@
   "buoyancy_drysuitGas": "Hozzáadott szárazruha-gáz",
   "buoyancy_estimatedPressures": "A palacknyomások becsültek",
   "buoyancy_linkSuitHint": "Kapcsolj egy búvárruhát ehhez a merüléshez a teljesebb képért",
+  "buoyancy_noLeadHint": "Nincs rögzített ólom: adj ólmot ehhez a merüléshez, vagy száraz tömeget az ólomfelszerelésedhez",
   "buoyancy_chartNet": "Nettó",
   "buoyancy_chartRig": "Felszerelés + ólom",
   "buoyancy_chartMinutes": "Idő (perc)",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6074,6 +6074,7 @@
   "buoyancy_drysuitGas": "Gas muta stagna aggiunto",
   "buoyancy_estimatedPressures": "Le pressioni delle bombole sono stimate",
   "buoyancy_linkSuitHint": "Associa una muta a questa immersione per un quadro più completo",
+  "buoyancy_noLeadHint": "Nessuna zavorra registrata: aggiungi zavorra a questa immersione o un peso a secco alla tua attrezzatura di zavorra",
   "buoyancy_chartNet": "Netto",
   "buoyancy_chartRig": "Attrezzatura + zavorra",
   "buoyancy_chartMinutes": "Tempo (min)",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23772,6 +23772,12 @@ abstract class AppLocalizations {
   /// **'Link an exposure suit to this dive for a fuller picture'**
   String get buoyancy_linkSuitHint;
 
+  /// No description provided for @buoyancy_noLeadHint.
+  ///
+  /// In en, this message translates to:
+  /// **'No lead recorded: add weights to this dive, or a dry weight to your weights gear'**
+  String get buoyancy_noLeadHint;
+
   /// No description provided for @buoyancy_chartNet.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13835,6 +13835,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'اربط بدلة تعرّض بهذه الغطسة للحصول على صورة أوفى';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'لم يتم تسجيل أي أثقال: أضف أثقالًا إلى هذه الغطسة أو وزنًا جافًا إلى معدات الأثقال';
+
+  @override
   String get buoyancy_chartNet => 'الصافي';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -14066,6 +14066,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verknüpfe einen Tauchanzug mit diesem Tauchgang für ein vollständigeres Bild';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Kein Blei erfasst: Füge diesem Tauchgang Blei hinzu oder trage bei deiner Bleiausrüstung ein Trockengewicht ein';
+
+  @override
   String get buoyancy_chartNet => 'Netto';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13853,6 +13853,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Link an exposure suit to this dive for a fuller picture';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'No lead recorded: add weights to this dive, or a dry weight to your weights gear';
+
+  @override
   String get buoyancy_chartNet => 'Net';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -14076,6 +14076,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Asocia un traje a esta inmersión para un panorama más completo';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'No se registró lastre: añade lastre a esta inmersión o un peso en seco a tu equipo de lastre';
+
+  @override
   String get buoyancy_chartNet => 'Neto';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14124,6 +14124,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Associez une combinaison à cette plongée pour un tableau plus complet';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Aucun lest enregistré : ajoutez du lest à cette plongée ou un poids à sec à votre équipement de lestage';
+
+  @override
   String get buoyancy_chartNet => 'Net';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13741,6 +13741,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'קשר חליפת חשיפה לצלילה זו לתמונה מלאה יותר';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'לא נרשמו משקולות: הוסף משקולות לצלילה זו או משקל יבש לציוד המשקולות שלך';
+
+  @override
   String get buoyancy_chartNet => 'נטו';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -14038,6 +14038,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Kapcsolj egy búvárruhát ehhez a merüléshez a teljesebb képért';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Nincs rögzített ólom: adj ólmot ehhez a merüléshez, vagy száraz tömeget az ólomfelszerelésedhez';
+
+  @override
   String get buoyancy_chartNet => 'Nettó';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -14083,6 +14083,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Associa una muta a questa immersione per un quadro più completo';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Nessuna zavorra registrata: aggiungi zavorra a questa immersione o un peso a secco alla tua attrezzatura di zavorra';
+
+  @override
   String get buoyancy_chartNet => 'Netto';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13978,6 +13978,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Koppel een duikpak aan deze duik voor een vollediger beeld';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Geen lood vastgelegd: voeg lood toe aan deze duik of een drooggewicht aan je loodmateriaal';
+
+  @override
   String get buoyancy_chartNet => 'Netto';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -14082,6 +14082,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Associe uma roupa de exposição a este mergulho para um quadro mais completo';
 
   @override
+  String get buoyancy_noLeadHint =>
+      'Nenhum lastro registado: adicione lastro a este mergulho ou um peso seco ao seu equipamento de lastro';
+
+  @override
   String get buoyancy_chartNet => 'Líquido';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13425,6 +13425,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get buoyancy_linkSuitHint => '为本次潜水关联一件暴露服以获得更完整的分析';
 
   @override
+  String get buoyancy_noLeadHint => '未记录配重：请为本次潜水添加配重，或为配重装备填写干重';
+
+  @override
   String get buoyancy_chartNet => '净值';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1468,6 +1468,7 @@
   "buoyancy_drysuitGas": "Droogpakgas toegevoegd",
   "buoyancy_estimatedPressures": "Flesdrukken zijn geschat",
   "buoyancy_linkSuitHint": "Koppel een duikpak aan deze duik voor een vollediger beeld",
+  "buoyancy_noLeadHint": "Geen lood vastgelegd: voeg lood toe aan deze duik of een drooggewicht aan je loodmateriaal",
   "buoyancy_chartNet": "Netto",
   "buoyancy_chartRig": "Uitrusting + lood",
   "buoyancy_chartMinutes": "Tijd (min)",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1468,6 +1468,7 @@
   "buoyancy_drysuitGas": "Gás de roupa seca adicionado",
   "buoyancy_estimatedPressures": "As pressões dos cilindros são estimadas",
   "buoyancy_linkSuitHint": "Associe uma roupa de exposição a este mergulho para um quadro mais completo",
+  "buoyancy_noLeadHint": "Nenhum lastro registado: adicione lastro a este mergulho ou um peso seco ao seu equipamento de lastro",
   "buoyancy_chartNet": "Líquido",
   "buoyancy_chartRig": "Equipamento + lastro",
   "buoyancy_chartMinutes": "Tempo (min)",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1560,6 +1560,7 @@
   "buoyancy_drysuitGas": "干式潜水服充气量",
   "buoyancy_estimatedPressures": "气瓶压力为估算值",
   "buoyancy_linkSuitHint": "为本次潜水关联一件暴露服以获得更完整的分析",
+  "buoyancy_noLeadHint": "未记录配重：请为本次潜水添加配重，或为配重装备填写干重",
   "buoyancy_chartNet": "净值",
   "buoyancy_chartRig": "装备 + 配重",
   "buoyancy_chartMinutes": "时间（分钟）",

--- a/test/architecture/repository_tick_stream_test.dart
+++ b/test/architecture/repository_tick_stream_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/connected_accounts_repository.dart';
 import 'package:submersion/core/database/database.dart';
@@ -18,6 +19,7 @@ import 'package:submersion/features/statistics/data/repositories/statistics_repo
 import 'package:submersion/features/trips/data/repositories/itinerary_day_repository.dart';
 import 'package:submersion/features/trips/data/repositories/liveaboard_details_repository.dart';
 import 'package:submersion/features/universal_import/data/repositories/csv_preset_repository.dart';
+import 'package:submersion/features/weight_planner/data/repositories/weight_history_repository.dart';
 
 import '../helpers/test_database.dart';
 
@@ -187,6 +189,8 @@ void main() {
           AppSettingsRepository().watchSettingsChanges,
       'ManifestSubscriptionRepository.watchSubscriptionsChanges':
           ManifestSubscriptionRepository().watchSubscriptionsChanges,
+      'WeightHistoryRepository.watchGearLeadChanges':
+          WeightHistoryRepository().watchGearLeadChanges,
       'CsvPresetRepository.watchPresetsChanges':
           CsvPresetRepository().watchPresetsChanges,
     };
@@ -313,6 +317,36 @@ void main() {
         isTrue,
       );
     });
+
+    test(
+      'watchGearLeadChanges fires on an equipment_attributes write',
+      () async {
+        await seedParents();
+        // Not the headline table: since #1103 a weight observation's carriedKg
+        // also comes from weights-type gear, whose mass lives in
+        // equipment_attributes. saveAttributes writes that table ALONE, so a
+        // tick watching only `equipment` would be inert for an attribute-only
+        // write and leave the calibration refitting against stale ballast.
+        expect(
+          await fires(
+            WeightHistoryRepository().watchGearLeadChanges(),
+            () => db
+                .into(db.equipmentAttributes)
+                .insert(
+                  EquipmentAttributesCompanion.insert(
+                    id: 'attr_e1_dry_weight_kg',
+                    equipmentId: 'e1',
+                    attrKey: 'dry_weight_kg',
+                    valueNum: const Value(3.63),
+                    createdAt: now,
+                    updatedAt: now,
+                  ),
+                ),
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('watchSchedulesChanges fires on a diver_settings write', () async {
       await seedParents();

--- a/test/features/dive_log/data/services/buoyancy_twin_assembler_test.dart
+++ b/test/features/dive_log/data/services/buoyancy_twin_assembler_test.dart
@@ -5,6 +5,8 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/data/services/buoyancy_twin_assembler.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 
 void main() {
@@ -230,6 +232,187 @@ void main() {
         'nonsense': 10.0,
       });
       expect(droppable, closeTo(5.0, 1e-9));
+    });
+  });
+
+  group('gear-carried lead (issue #1103)', () {
+    EquipmentItem lead(
+      String id, {
+      double? dryWeightKg,
+      double? buoyancyKg,
+      String? style,
+    }) => EquipmentItem(
+      id: id,
+      name: id,
+      type: EquipmentType.weights,
+      attributes: [
+        if (dryWeightKg != null)
+          EquipmentAttribute.curated(
+            equipmentId: id,
+            key: EquipmentAttrKeys.dryWeightKg,
+            valueNum: dryWeightKg,
+          ),
+        if (buoyancyKg != null)
+          EquipmentAttribute.curated(
+            equipmentId: id,
+            key: EquipmentAttrKeys.buoyancyKg,
+            valueNum: buoyancyKg,
+          ),
+        if (style != null)
+          EquipmentAttribute.curated(
+            equipmentId: id,
+            key: EquipmentAttrKeys.weightStyle,
+            valueText: style,
+          ),
+      ],
+    );
+
+    test('ballast built into the rig counts as lead', () {
+      // The reporter's rig: every pound of lead lives in weighted gear and
+      // the dive's Weights section is empty. Before #1103 leadKg was 0.
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [
+            drysuit,
+            lead('dump', dryWeightKg: 3.63, buoyancyKg: -3.63),
+            lead('sta', dryWeightKg: 4.17),
+          ],
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.leadKg, closeTo(7.8, 1e-9));
+    });
+
+    test('typed weight rows and gear ballast are additive', () {
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [wetsuit, lead('sta', dryWeightKg: 2.0)],
+          weights: const [
+            DiveWeight(
+              id: 'w1',
+              diveId: 'd1',
+              weightType: WeightType.belt,
+              amountKg: 4.0,
+            ),
+          ],
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.leadKg, closeTo(6.0, 1e-9));
+    });
+
+    test('gear ballast adds to the legacy scalar too', () {
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [wetsuit, lead('sta', dryWeightKg: 2.0)],
+          weightAmount: 5.0,
+          weightType: WeightType.backplate,
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.leadKg, closeTo(7.0, 1e-9));
+      // Backplate lead is fixed, and the unstyled gear ballast is too.
+      expect(input.droppableLeadKg, closeTo(0.0, 1e-9));
+    });
+
+    test('weights gear with no declared mass changes nothing', () {
+      final bare = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [wetsuit, lead('unspecified')],
+          weights: const [
+            DiveWeight(
+              id: 'w1',
+              diveId: 'd1',
+              weightType: WeightType.belt,
+              amountKg: 4.0,
+            ),
+          ],
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(bare.leadKg, closeTo(4.0, 1e-9));
+      expect(bare.droppableLeadKg, closeTo(4.0, 1e-9));
+    });
+
+    test('only ballast styled belt or integrated is droppable', () {
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [
+            wetsuit,
+            lead('dump', dryWeightKg: 3.0, style: 'belt'),
+            lead('trim', dryWeightKg: 1.0, style: 'trim'),
+          ],
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.leadKg, closeTo(4.0, 1e-9));
+      expect(input.droppableLeadKg, closeTo(3.0, 1e-9));
+    });
+
+    test('weights gear never becomes a static buoyancy term', () {
+      // Double-counting guard: ballast belongs to leadKg alone.
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(
+          tanks: [tank('t1')],
+          equipment: [wetsuit, lead('dump', dryWeightKg: 3.0)],
+        ),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.staticTerms.map((t) => t.label), isNot(contains('dump')));
+    });
+  });
+
+  group('equipment attributes reach the logged-dive rig (issue #1103)', () {
+    test('drysuit shell material sets the suit anchor, as in the planner', () {
+      // The assembler used to build features without traits, so a trilaminate
+      // drysuit fell back to the flat 10 kg type default here while the
+      // Weight Planner used the 9 kg attribute prior for the same item.
+      const trilam = EquipmentItem(
+        id: 'dry1',
+        name: 'Drysuit',
+        type: EquipmentType.drysuit,
+        attributes: [
+          EquipmentAttribute(
+            id: 'a1',
+            equipmentId: 'dry1',
+            key: EquipmentAttrKeys.shellMaterial,
+            valueText: 'trilaminate',
+          ),
+        ],
+      );
+
+      final input = BuoyancyTwinAssembler.assemble(
+        dive: diveWith(tanks: [tank('t1')], equipment: [trilam]),
+        tankPressures: const {},
+        model: emptyModel(),
+        bodyWeightKg: 75,
+      )!;
+
+      expect(input.suit.kind, TwinSuitKind.drysuit);
+      expect(input.suit.anchorKg, closeTo(9.0, 1e-9));
     });
   });
 }

--- a/test/features/dive_log/data/services/buoyancy_twin_gear_lead_scenario_test.dart
+++ b/test/features/dive_log/data/services/buoyancy_twin_gear_lead_scenario_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/buoyancy/buoyancy_twin.dart';
+import 'package:submersion/core/buoyancy/twin_analyzer.dart';
+import 'package:submersion/core/buoyancy/weight_prediction_engine.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/data/services/buoyancy_twin_assembler.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+
+/// End-to-end reconstruction of the rig from issue #1103: a cold-water
+/// backplate-and-wing diver whose entire ~30 lb of ballast is built into
+/// weighted gear, with the dive's Weights section left empty.
+///
+/// Before the fix the twin saw zero lead and reported the diver 17.3 lb
+/// buoyant at the final stop -- the exact figure in the bug report -- while
+/// they were in fact holding a 6 ft stop on an empty wing.
+void main() {
+  const kgPerLb = 0.45359237;
+  double lb(double kg) => kg / kgPerLb;
+
+  EquipmentItem item(
+    String id,
+    String name,
+    EquipmentType type, {
+    double? buoyancyLb,
+    double? dryWeightLb,
+  }) => EquipmentItem(
+    id: id,
+    name: name,
+    type: type,
+    attributes: [
+      if (buoyancyLb != null)
+        EquipmentAttribute.curated(
+          equipmentId: id,
+          key: EquipmentAttrKeys.buoyancyKg,
+          valueNum: buoyancyLb * kgPerLb,
+        ),
+      if (dryWeightLb != null)
+        EquipmentAttribute.curated(
+          equipmentId: id,
+          key: EquipmentAttrKeys.dryWeightKg,
+          valueNum: dryWeightLb * kgPerLb,
+        ),
+    ],
+  );
+
+  // Ballast totals -29.9 lb, of which -17.2 lb sits in weights-type gear.
+  final rig = [
+    item('c1', 'Shearwater Petrel 3', EquipmentType.computer),
+    item(
+      'bpw',
+      'Weighted BPW',
+      EquipmentType.bcd,
+      buoyancyLb: -7.0,
+      dryWeightLb: 7.0,
+    ),
+    item(
+      'dump',
+      'Dump Weights',
+      EquipmentType.weights,
+      buoyancyLb: -8.0,
+      dryWeightLb: 8.0,
+    ),
+    item(
+      'sta',
+      'Weighted STA',
+      EquipmentType.weights,
+      buoyancyLb: -9.2,
+      dryWeightLb: 9.2,
+    ),
+    item('suit', 'Santi E.Motion+', EquipmentType.drysuit),
+    item(
+      'harness',
+      'Halcyon Vector Pro - weighted',
+      EquipmentType.other,
+      buoyancyLb: -5.7,
+      dryWeightLb: 5.7,
+    ),
+  ];
+
+  /// 55 min: descent to 20 m, bottom, ascent, then a long shallow stop.
+  List<DiveProfilePoint> profile() {
+    final points = <DiveProfilePoint>[];
+    for (var t = 0; t <= 55 * 60; t += 20) {
+      final minutes = t / 60.0;
+      final double depth;
+      if (minutes < 3) {
+        depth = minutes / 3 * 20;
+      } else if (minutes < 45) {
+        depth = 20.0;
+      } else if (minutes < 50) {
+        depth = 20 - (minutes - 45) / 5 * 17.9;
+      } else {
+        depth = 2.1;
+      }
+      points.add(DiveProfilePoint(timestamp: t, depth: depth));
+    }
+    return points;
+  }
+
+  Dive dive() => Dive(
+    id: 'd1',
+    dateTime: DateTime(2026, 8, 1),
+    waterType: WaterType.salt,
+    equipment: rig,
+    profile: profile(),
+    tanks: [
+      // AL80 run from 3000 psi down to the reported 642 psi.
+      const DiveTank(
+        id: 'tk1',
+        volume: 11.1,
+        workingPressure: 207,
+        startPressure: 3000 * 0.0689476,
+        endPressure: 642 * 0.0689476,
+        material: TankMaterial.aluminum,
+        presetName: 'al80',
+        gasMix: GasMix(o2: 21),
+      ),
+    ],
+  );
+
+  test('gear-carried ballast makes the final stop come out near neutral', () {
+    final model = WeightPredictionEngine.fit(
+      observations: const [],
+      gearById: (_) => null,
+      bodyWeightKg: 75,
+    );
+    final input = BuoyancyTwinAssembler.assemble(
+      dive: dive(),
+      tankPressures: const {},
+      model: model,
+      bodyWeightKg: 75,
+    )!;
+    final outputs = TwinAnalyzer.analyze(runBuoyancyTwin(input));
+
+    // The 17.2 lb of weighted gear is now lead, not nothing.
+    expect(lb(input.leadKg), closeTo(17.2, 0.05));
+
+    // Slightly heavy on a full tank, essentially neutral at the final stop:
+    // the dive the reporter described, against 17.3 lb buoyant before.
+    expect(lb(outputs.beginNetKg), lessThan(0.0));
+    expect(lb(outputs.endNetKg).abs(), lessThan(1.0));
+    expect(lb(outputs.verdict.netKg).abs(), lessThan(1.0));
+
+    // A rig this close to neutral does demand real lift and real ditchable
+    // weight; both read 0.0 while the lead was invisible.
+    expect(outputs.peakLiftDemandKg, greaterThan(0.0));
+    expect(outputs.minDitchableKg, greaterThan(0.0));
+  });
+}

--- a/test/features/dive_log/presentation/providers/buoyancy_twin_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/buoyancy_twin_provider_test.dart
@@ -9,6 +9,8 @@ import 'package:submersion/features/dive_log/presentation/providers/buoyancy_twi
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_weight_entry_providers.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/weight_planner/presentation/providers/weight_planner_providers.dart';
 
@@ -98,4 +100,68 @@ void main() {
       expect(lead.kg, closeTo(-6.0, 1e-9));
     },
   );
+
+  test('counts lead carried as weights-type equipment (issue #1103)', () async {
+    // The ballast lives in equipment_attributes, not on the equipment row, so
+    // this only works if the dive's equipment join hydrates attributes. Proved
+    // through the real provider + database for the same reason as above.
+    final plate = await EquipmentRepository().createEquipment(
+      EquipmentItem(
+        id: '',
+        name: 'Weighted backplate',
+        type: EquipmentType.weights,
+        attributes: [
+          EquipmentAttribute.curated(
+            equipmentId: '',
+            key: EquipmentAttrKeys.dryWeightKg,
+            valueNum: 3.63,
+          ),
+          EquipmentAttribute.curated(
+            equipmentId: '',
+            key: EquipmentAttrKeys.weightStyle,
+            valueText: 'trim',
+          ),
+        ],
+      ),
+    );
+    final suit = await EquipmentRepository().createEquipment(
+      const EquipmentItem(id: '', name: 'Drysuit', type: EquipmentType.drysuit),
+    );
+    final dive = await DiveRepository().createDive(
+      Dive(
+        id: '',
+        diveNumber: 2,
+        dateTime: DateTime(2026, 1, 2),
+        equipment: [plate, suit],
+        tanks: const [
+          DiveTank(
+            id: 't1',
+            volume: 11,
+            workingPressure: 207,
+            startPressure: 200,
+            endPressure: 50,
+            material: TankMaterial.aluminum,
+            presetName: 'al80',
+          ),
+        ],
+        waterType: WaterType.salt,
+      ),
+    );
+
+    final c = container();
+    addTearDown(c.dispose);
+
+    final outcome = await c.read(buoyancyTwinProvider(dive.id).future);
+    expect(outcome, isNotNull);
+
+    // No typed weight rows at all, yet the rig's ballast is counted.
+    expect(outcome!.result.input.leadKg, closeTo(3.63, 1e-9));
+    // Trim ballast is not ditchable.
+    expect(outcome.result.input.droppableLeadKg, closeTo(0.0, 1e-9));
+    // It is lead, never a static gear buoyancy term.
+    expect(
+      outcome.result.input.staticTerms.map((t) => t.label),
+      isNot(contains('Weighted backplate')),
+    );
+  });
 }

--- a/test/features/dive_log/presentation/widgets/buoyancy_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/buoyancy_section_test.dart
@@ -99,6 +99,9 @@ Future<void> _pump(WidgetTester tester, BuoyancyTwinOutcome? outcome) async {
         buoyancyTwinProvider('d1').overrideWith((ref) async => outcome),
       ],
       child: const MaterialApp(
+        // Pinned so the asserted strings and decimal separators do not depend
+        // on the host locale (repo convention).
+        locale: Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -135,6 +138,21 @@ void main() {
   ) async {
     await _pump(tester, _outcome(minDitchableKg: 6.0, droppableLeadKg: 2.0));
     expect(find.byIcon(Icons.warning_amber_rounded), findsWidgets);
+  });
+
+  testWidgets('hints that no lead was recorded when lead is zero', (
+    tester,
+  ) async {
+    // Lead lives either in the dive's Weights section or as a dry weight on
+    // weights-type gear; zero means neither, and the net reads far too
+    // buoyant (issue #1103).
+    await _pump(tester, _outcome(leadKg: 0.0, droppableLeadKg: 0.0));
+    expect(find.textContaining('No lead recorded'), findsOneWidget);
+  });
+
+  testWidgets('no lead hint is absent once lead is known', (tester) async {
+    await _pump(tester, _outcome());
+    expect(find.textContaining('No lead recorded'), findsNothing);
   });
 
   testWidgets('renders nothing when the outcome is null', (tester) async {

--- a/test/features/equipment/domain/services/equipment_lead_test.dart
+++ b/test/features/equipment/domain/services/equipment_lead_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/domain/services/equipment_lead.dart';
+
+void main() {
+  EquipmentItem weights(
+    String id, {
+    double? dryWeightKg,
+    double? buoyancyKg,
+    String? style,
+    EquipmentType type = EquipmentType.weights,
+  }) => EquipmentItem(
+    id: id,
+    name: id,
+    type: type,
+    attributes: [
+      if (dryWeightKg != null)
+        EquipmentAttribute.curated(
+          equipmentId: id,
+          key: EquipmentAttrKeys.dryWeightKg,
+          valueNum: dryWeightKg,
+        ),
+      if (buoyancyKg != null)
+        EquipmentAttribute.curated(
+          equipmentId: id,
+          key: EquipmentAttrKeys.buoyancyKg,
+          valueNum: buoyancyKg,
+        ),
+      if (style != null)
+        EquipmentAttribute.curated(
+          equipmentId: id,
+          key: EquipmentAttrKeys.weightStyle,
+          valueText: style,
+        ),
+    ],
+  );
+
+  group('ballastKg', () {
+    test('prefers dry weight over buoyancy', () {
+      expect(EquipmentLead.ballastKg(dryWeightKg: 3.6, buoyancyKg: -3.2), 3.6);
+    });
+
+    test('falls back to negated buoyancy when dry weight is absent', () {
+      expect(EquipmentLead.ballastKg(dryWeightKg: null, buoyancyKg: -3.2), 3.2);
+    });
+
+    test('ignores a positive buoyancy: lead never floats', () {
+      expect(EquipmentLead.ballastKg(dryWeightKg: null, buoyancyKg: 3.2), 0.0);
+    });
+
+    test('ignores a non-positive dry weight and falls through', () {
+      expect(EquipmentLead.ballastKg(dryWeightKg: 0, buoyancyKg: -2.0), 2.0);
+      expect(EquipmentLead.ballastKg(dryWeightKg: -1, buoyancyKg: -2.0), 2.0);
+    });
+
+    test('treats non-finite user numbers as absent', () {
+      // Numeric attributes parse with double.tryParse, which accepts 1e309.
+      expect(
+        EquipmentLead.ballastKg(dryWeightKg: double.infinity, buoyancyKg: -2.0),
+        2.0,
+      );
+      expect(
+        EquipmentLead.ballastKg(dryWeightKg: null, buoyancyKg: double.nan),
+        0.0,
+      );
+    });
+
+    test('is zero when the item declares nothing', () {
+      expect(EquipmentLead.ballastKg(dryWeightKg: null, buoyancyKg: null), 0.0);
+    });
+  });
+
+  group('kgFor / totalKg', () {
+    test('counts only weights-type gear', () {
+      final bcd = weights(
+        'bpw',
+        dryWeightKg: 3.2,
+        buoyancyKg: -3.2,
+        type: EquipmentType.bcd,
+      );
+      expect(EquipmentLead.kgFor(bcd), 0.0);
+      expect(EquipmentLead.totalKg([bcd]), 0.0);
+    });
+
+    test('sums declared ballast across weights gear', () {
+      expect(
+        EquipmentLead.totalKg([
+          weights('dump', dryWeightKg: 3.63),
+          weights('sta', buoyancyKg: -4.17),
+          weights('unspecified'),
+        ]),
+        closeTo(7.8, 0.001),
+      );
+    });
+
+    test('a weights item with no numbers contributes nothing', () {
+      expect(EquipmentLead.totalKg([weights('belt')]), 0.0);
+    });
+  });
+
+  group('placement', () {
+    test('maps catalog styles onto weight types', () {
+      expect(EquipmentLead.placementFor('belt'), WeightType.belt);
+      expect(EquipmentLead.placementFor('integrated'), WeightType.integrated);
+      expect(EquipmentLead.placementFor('trim'), WeightType.trimWeights);
+      expect(EquipmentLead.placementFor('ankle'), WeightType.ankleWeights);
+    });
+
+    test('unset and future catalog values resolve to null', () {
+      expect(EquipmentLead.placementFor(null), isNull);
+      expect(EquipmentLead.placementFor('harness_pocket'), isNull);
+    });
+
+    test('only belt and integrated ballast counts as droppable', () {
+      final rig = [
+        weights('dump', dryWeightKg: 3.63, style: 'belt'),
+        weights('pocket', dryWeightKg: 2.0, style: 'integrated'),
+        weights('trim', dryWeightKg: 1.0, style: 'trim'),
+      ];
+      expect(EquipmentLead.droppableKg(rig), closeTo(5.63, 0.001));
+    });
+
+    test('unstyled ballast counts as fixed, not droppable', () {
+      // Understating what the diver can ditch is the safe error; the twin's
+      // min-ditchable warning would otherwise go quiet on a guess.
+      expect(
+        EquipmentLead.droppableKg([weights('sta', dryWeightKg: 4.0)]),
+        0.0,
+      );
+    });
+
+    test('placementKg groups by weight type and omits unplaced ballast', () {
+      final rig = [
+        weights('a', dryWeightKg: 2.0, style: 'belt'),
+        weights('b', dryWeightKg: 1.5, style: 'belt'),
+        weights('c', dryWeightKg: 4.0),
+      ];
+      expect(EquipmentLead.placementKg(rig), {'belt': 3.5});
+    });
+  });
+}

--- a/test/features/weight_planner/data/weight_history_repository_test.dart
+++ b/test/features/weight_planner/data/weight_history_repository_test.dart
@@ -5,6 +5,8 @@ import 'package:submersion/features/dive_log/data/repositories/dive_repository_i
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/weight_planner/data/repositories/weight_history_repository.dart';
 
@@ -152,6 +154,137 @@ void main() {
       expect(observation.tanks.single.material, isNull);
     },
   );
+
+  group('gear-carried lead (issue #1103)', () {
+    Future<EquipmentItem> createWeights(
+      String name, {
+      double? dryWeightKg,
+      double? buoyancyKg,
+      String? style,
+    }) => equipmentRepository.createEquipment(
+      EquipmentItem(
+        id: '',
+        name: name,
+        type: EquipmentType.weights,
+        attributes: [
+          if (dryWeightKg != null)
+            EquipmentAttribute.curated(
+              equipmentId: '',
+              key: EquipmentAttrKeys.dryWeightKg,
+              valueNum: dryWeightKg,
+            ),
+          if (buoyancyKg != null)
+            EquipmentAttribute.curated(
+              equipmentId: '',
+              key: EquipmentAttrKeys.buoyancyKg,
+              valueNum: buoyancyKg,
+            ),
+          if (style != null)
+            EquipmentAttribute.curated(
+              equipmentId: '',
+              key: EquipmentAttrKeys.weightStyle,
+              valueText: style,
+            ),
+        ],
+      ),
+    );
+
+    test(
+      'a dive whose only lead is weighted gear becomes an observation',
+      () async {
+        final plate = await createWeights('Weighted BPW', dryWeightKg: 3.63);
+        final sta = await createWeights('Weighted STA', buoyancyKg: -4.17);
+
+        await diveRepository.createDive(
+          Dive(
+            id: '',
+            diverId: diverId,
+            dateTime: DateTime(2026, 1, 1),
+            equipment: [plate, sta],
+          ),
+        );
+
+        // Before #1103 this dive carried 0 and was dropped by the
+        // `carried <= 0` gate, so the diver had no training data at all.
+        final observation = (await repository.observationsForDiver(
+          diverId,
+        )).single;
+        expect(observation.carriedKg, closeTo(7.8, 1e-9));
+        // Neither item names a weight_style, so no placement is invented.
+        expect(observation.placement, isEmpty);
+      },
+    );
+
+    test('gear ballast adds to typed rows and merges into placement', () async {
+      final belt = await createWeights(
+        'Belt blocks',
+        dryWeightKg: 1.0,
+        style: 'belt',
+      );
+
+      await diveRepository.createDive(
+        Dive(
+          id: '',
+          diverId: diverId,
+          dateTime: DateTime(2026, 1, 1),
+          equipment: [belt],
+          weights: const [
+            DiveWeight(
+              id: 'w1',
+              diveId: '',
+              weightType: WeightType.belt,
+              amountKg: 3.0,
+            ),
+          ],
+        ),
+      );
+
+      final observation = (await repository.observationsForDiver(
+        diverId,
+      )).single;
+      expect(observation.carriedKg, closeTo(4.0, 1e-9));
+      expect(observation.placement, {'belt': closeTo(4.0, 1e-9)});
+    });
+
+    test('weights gear with no declared mass leaves a dive excluded', () async {
+      final bare = await createWeights('Unspecified weights');
+      await diveRepository.createDive(
+        Dive(
+          id: '',
+          diverId: diverId,
+          dateTime: DateTime(2026, 1, 1),
+          equipment: [bare],
+        ),
+      );
+      expect(await repository.observationsForDiver(diverId), isEmpty);
+    });
+
+    test('non-weights gear contributes no lead', () async {
+      final bcd = await equipmentRepository.createEquipment(
+        EquipmentItem(
+          id: '',
+          name: 'Wing',
+          type: EquipmentType.bcd,
+          attributes: [
+            EquipmentAttribute.curated(
+              equipmentId: '',
+              key: EquipmentAttrKeys.dryWeightKg,
+              valueNum: 3.5,
+            ),
+          ],
+        ),
+      );
+      await diveRepository.createDive(
+        Dive(
+          id: '',
+          diverId: diverId,
+          dateTime: DateTime(2026, 1, 1),
+          equipment: [bcd],
+        ),
+      );
+      expect(await repository.observationsForDiver(diverId), isEmpty);
+    });
+  });
 
   test('dives of other divers are excluded', () async {
     final db = DatabaseService.instance.database;

--- a/test/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider_test.dart
+++ b/test/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/buoyancy/buoyancy_twin.dart';
 import 'package:submersion/core/buoyancy/twin_analyzer.dart';
@@ -6,9 +8,21 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/deco/entities/dive_environment.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_planner/domain/entities/plan_segment.dart';
+import 'package:submersion/features/dive_planner/presentation/providers/dive_planner_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_weight_entry_providers.dart';
+import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_attribute.dart';
+import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
+import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/weight_planner/presentation/providers/plan_buoyancy_twin_provider.dart';
+import 'package:submersion/features/weight_planner/presentation/providers/weight_planner_providers.dart';
+
+import '../../../../helpers/test_database.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   PlanSegment seg(SegmentType type, double start, double end, int dur) =>
       PlanSegment(
         id: '$type$start',
@@ -99,6 +113,79 @@ void main() {
     final outputs = TwinAnalyzer.analyze(runBuoyancyTwin(input));
     expect(outputs.verdict.anchor.kind, TwinAnchorKind.detectedStop);
     expect(outputs.verdict.anchor.depthM, closeTo(5.0, 0.5));
+  });
+
+  test('planned lead is a total: gear ballast is not added on top', () async {
+    // plannedWeightKg is only ever written as a snapshot of
+    // prediction.totalKg, and since #1103 that prediction is trained on
+    // observations whose carriedKg already includes ballast built into the
+    // rig. Adding EquipmentLead here would double-count it, so the planned
+    // figure must pass through untouched even when the rig carries 5 kg of
+    // weights-type gear.
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    // settingsProvider reaches the database through DiverRepository, and the
+    // plan notifier is built from settings; the other cases in this file are
+    // pure, so the database is set up only for this one.
+    await setUpTestDatabase();
+    addTearDown(tearDownTestDatabase);
+
+    const plate = EquipmentItem(
+      id: 'plate',
+      name: 'Weighted backplate',
+      type: EquipmentType.weights,
+      attributes: [
+        EquipmentAttribute(
+          id: 'a1',
+          equipmentId: 'plate',
+          key: EquipmentAttrKeys.dryWeightKg,
+          valueNum: 5.0,
+        ),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        allEquipmentProvider.overrideWith((ref) async => [plate]),
+        latestDiverWeightProvider.overrideWith((ref) async => null),
+        weightCalibrationProvider.overrideWith(
+          (ref) async => WeightPredictionEngine.fit(
+            observations: const [],
+            gearById: (_) => null,
+            bodyWeightKg: 75,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Warm the async overrides the provider reads via valueOrNull.
+    await container.read(allEquipmentProvider.future);
+    await container.read(weightCalibrationProvider.future);
+    await container.read(latestDiverWeightProvider.future);
+
+    final notifier = container.read(divePlanNotifierProvider.notifier);
+    notifier.addTank(
+      const DiveTank(
+        id: 't1',
+        volume: 11,
+        workingPressure: 207,
+        startPressure: 200,
+        material: TankMaterial.aluminum,
+        presetName: 'al80',
+        gasMix: GasMix(o2: 21),
+      ),
+    );
+    for (final s in plan) {
+      notifier.addSegment(s);
+    }
+    notifier.setEquipmentIds(const ['plate']);
+    notifier.setPlannedWeight(6.0, null);
+
+    final outcome = container.read(planBuoyancyTwinProvider);
+    expect(outcome, isNotNull);
+    expect(outcome!.result.input.leadKg, closeTo(6.0, 1e-9));
   });
 }
 


### PR DESCRIPTION
Fixes #1103.

## The bug

A diver whose ballast is built into the rig (weighted backplate, weighted STA, bolt-on blocks) records it as `EquipmentType.weights` equipment and leaves the dive's Weights section empty, because there is no belt to describe. That lead was counted nowhere.

Lead lives in two unlinked places in the data model:

1. typed `dive_weights` rows (or the legacy `dives.weightAmount` scalar), and
2. `EquipmentType.weights` equipment attached to the dive, whose mass lives in `equipment_attributes` (`dry_weight_kg` / `buoyancy_kg`).

`BuoyancyTwinAssembler` read only the first. Weights gear could not fill the gap either, because `GearFeature.fromEquipment` deliberately excludes it: lead is the quantity the weight-prediction regression predicts, so it cannot also be a predictor. That exclusion is correct for the engine and was silently wrong for the twin, where lead is an *input*. The result was `leadKg = 0`, and the reporter's "Lead 0.0 lbs" in the Adjust sheet was the bug announcing itself.

## Reproduction

Rebuilding the reporter's rig from the issue screenshots (drysuit, weighted BPW, dump weights, weighted STA, weighted harness; -29.9 lb total; empty Weights section) reproduces their figures exactly:

| | Before | After |
| --- | --- | --- |
| Lead | 0.0 lb | 17.2 lb |
| Start of dive | +12.5 lb | -4.7 lb |
| Final stop | **+17.3 lb buoyant** | **+0.1 lb** |
| Min ditchable | 0.0 lb | 9.2 lb |
| Peak lift needed | 0.0 lb | 4.8 lb |

The 17.2 lb shortfall is precisely the two weights-typed items. The corrected result matches what the reporter described: holding a 6 ft stop on 642 psi with an empty wing, close enough to neutral to consider dropping a pound or two.

## The quieter second half

`WeightHistoryRepository` gates on `if (carried <= 0) continue;`, so every one of these dives was discarded before becoming a training observation. The diver was invisible to the entire weight-learning system, which is why every term in their breakdown sat at its prior forever: personal at 2.5 kg, and the drysuit at the flat 10 kg type default, which is the "Suit buoyancy: 22.0 lbs" they were fruitlessly adjusting.

## Changes

- **New `EquipmentLead` domain service.** Dry weight is preferred because it is unambiguously positive and cannot be sign-inverted by a user typing `8` for an 8 lb block; negative buoyancy is the fallback and is trusted only when negative; non-finite values are treated as absent (numeric attributes parse with `double.tryParse`, which admits `Infinity`). `weight_style` maps to `WeightType` for ditchability, and an unset or unrecognized style counts as **fixed**, so min-ditchable understates rather than overstates what the diver can drop.
- **Both lead sources now sum**, in the twin (dive detail and planner) and in weight-history observations. A belt and a weighted backplate are different lead. Gear only contributes when it declares a mass, so rigs listing weights without numbers are unaffected.
- **Extracted `gear_feature_mapper.dart`.** The assembler carried a stale copy of the planner's `gearFeatureFor` that dropped the `traits:` argument, so equipment attributes (drysuit shell material, BCD style, rated lift, multi-panel thickness) informed the Weight Planner but not the dive-detail Buoyancy section for the same item. Both now go through one bridge.
- **Hint on the Buoyancy card** when lead genuinely is zero, pointing at both places it can be recorded. Localized across all 11 locales.

No schema change, no migration.

## Notes for review

Two judgment calls worth a second opinion:

- **Additive, not a fallback ladder.** Someone who recorded the same 12 lb belt in *both* the Weights section and as an equipment item with its dry weight filled in will now read 24 lb. The mass guard limits this to people who filled in both, but it is a real behavior change, not only a fix for the reporter. The alternative (fallback ladder) never double-counts but under-counts anyone splitting lead between a belt and weighted gear.
- **`plan_buoyancy_twin_provider` branches asymmetrically.** Gear lead is added to an explicit `plannedWeightKg` but not to `prediction.totalKg`, because the prediction is now trained on observations that already include it. Correct but subtle; commented at the call site.

## Verification

- `flutter analyze` clean project-wide; `dart format` clean.
- Two consecutive green full suite runs (19,556 then 19,557 tests, 0 failures).
- New coverage: 14 `EquipmentLead` unit tests, 7 assembler regressions, 4 weight-history regressions, an end-to-end scenario test rebuilt from the bug report, and a provider-plus-database integration test proving `dive.equipment` actually hydrates `equipment_attributes`. That last one matters: the original twin PR shipped a hydration bug behind 16 green unit tests that all hand-built `Dive` objects and bypassed the provider.

Not yet smoke-tested on a device.
