### PR TITLE
fix(dive_computer): derive water temp from samples on re-parse

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -393,7 +393,7 @@ class ReparseService {
           parsed.avgDepthMeters != 0.0 ? parsed.avgDepthMeters : null,
         ),
         duration: Value(parsed.durationSeconds),
-        waterTemp: Value(parsed.minTemperatureCelsius),
+        waterTemp: Value(_minWaterTemp(parsed)),
         decoAlgorithm: Value(parsed.decoAlgorithm),
         gradientFactorLow: Value(parsed.gfLow),
         gradientFactorHigh: Value(parsed.gfHigh),
@@ -433,6 +433,7 @@ class ReparseService {
     final diveDateTimeMs = diveDateTime.millisecondsSinceEpoch;
     final exitTimeMs = diveDateTimeMs + (parsed.durationSeconds * 1000);
     final bottomTimeSeconds = _calculateBottomTimeFromSamples(parsed.samples);
+    final waterTemp = _minWaterTemp(parsed);
 
     await (db.update(db.dives)..where((t) => t.id.equals(diveId))).write(
       DivesCompanion(
@@ -445,7 +446,11 @@ class ReparseService {
         entryTime: Value(diveDateTimeMs),
         exitTime: Value(exitTimeMs),
         bottomTime: Value(bottomTimeSeconds ?? parsed.durationSeconds),
-        waterTemp: Value(parsed.minTemperatureCelsius),
+        // Only overwrite the dive's water temp when this parse produced one,
+        // for the same reason as the GPS fields below: Value.absent() keeps a
+        // temperature stamped by hand or by another source, while the
+        // dive_data_sources row above still records the computer's own answer.
+        waterTemp: waterTemp != null ? Value(waterTemp) : const Value.absent(),
         diveMode: Value(mapLibdcDiveModeCode(parsed.diveMode)),
         cnsEnd: Value(_extractMaxCns(parsed.samples)),
         otu: const Value.absent(), // OTU is not directly in ParsedDive
@@ -796,6 +801,27 @@ class ReparseService {
   }
 
   /// Extract maximum CNS percentage from profile samples.
+  /// Minimum water temperature for this parse, in Celsius.
+  ///
+  /// Some computers (Shearwater among them) report no top-level minimum and
+  /// carry temperature only in the per-sample stream, so the download path
+  /// derives the minimum from the samples when the header value is missing
+  /// (`parsed_dive_mapper.dart`, and the profile import in
+  /// `dive_computer_repository_impl.dart`). Re-parse mirrors that path; taking
+  /// `minTemperatureCelsius` at face value here blanked the water temp of any
+  /// already-downloaded dive from such a computer.
+  static double? _minWaterTemp(pigeon.ParsedDive parsed) {
+    final headerTemp = parsed.minTemperatureCelsius;
+    if (headerTemp != null) return headerTemp;
+    double? minTemp;
+    for (final s in parsed.samples) {
+      final t = s.temperatureCelsius;
+      if (t == null) continue;
+      if (minTemp == null || t < minTemp) minTemp = t;
+    }
+    return minTemp;
+  }
+
   static double? _extractMaxCns(List<pigeon.ProfileSample> samples) {
     double? maxCns;
     for (final s in samples) {

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -800,7 +800,6 @@ class ReparseService {
     ]);
   }
 
-  /// Extract maximum CNS percentage from profile samples.
   /// Minimum water temperature for this parse, in Celsius.
   ///
   /// Some computers (Shearwater among them) report no top-level minimum and
@@ -822,6 +821,7 @@ class ReparseService {
     return minTemp;
   }
 
+  /// Extract maximum CNS percentage from profile samples.
   static double? _extractMaxCns(List<pigeon.ProfileSample> samples) {
     double? maxCns;
     for (final s in samples) {

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -619,6 +619,132 @@ void main() {
       expect(src.lastParsedAt, isNotNull);
     });
 
+    test('derives water temp from profile samples when the computer reports no '
+        'top-level minimum', () async {
+      // Shearwater and friends leave ParsedDive.minTemperatureCelsius null
+      // and carry temperature only in the per-sample stream. The download
+      // path derives the minimum from those samples; re-parse must too, or
+      // re-parsing an already-downloaded dive blanks its water temp and the
+      // Data Sources row renders "-".
+      await insertDive('dive-1', waterTemp: 18.0);
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+        waterTemp: 18.0,
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(
+          minTemperatureCelsius: null,
+          samples: [
+            pigeon.ProfileSample(
+              timeSeconds: 0,
+              depthMeters: 0.0,
+              temperatureCelsius: 21.0,
+            ),
+            pigeon.ProfileSample(
+              timeSeconds: 60,
+              depthMeters: 20.0,
+              temperatureCelsius: 14.5,
+            ),
+            pigeon.ProfileSample(
+              timeSeconds: 120,
+              depthMeters: 10.0,
+              temperatureCelsius: 16.0,
+            ),
+          ],
+        ),
+        descriptorVendor: 'Shearwater',
+        descriptorProduct: 'Perdix',
+        descriptorModel: 42,
+        libdivecomputerVersion: '0.9.0',
+      );
+
+      final src = await getSource('src-1');
+      expect(src.waterTemp, 14.5);
+      final dive = await getDive('dive-1');
+      expect(dive.waterTemp, 14.5);
+    });
+
+    test('a top-level minimum still wins over the sample stream', () async {
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(
+          minTemperatureCelsius: 12.0,
+          samples: [
+            pigeon.ProfileSample(
+              timeSeconds: 0,
+              depthMeters: 0.0,
+              temperatureCelsius: 21.0,
+            ),
+          ],
+        ),
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final src = await getSource('src-1');
+      expect(src.waterTemp, 12.0);
+      final dive = await getDive('dive-1');
+      expect(dive.waterTemp, 12.0);
+    });
+
+    test(
+      'a re-parse with no temperature anywhere preserves the dive water temp '
+      'a diver entered by hand',
+      () async {
+        // Mirrors the entry/exit GPS treatment on the Dives row: the source
+        // row records exactly what the computer provided (null), but the dive
+        // keeps the value stamped from another source.
+        await insertDive('dive-1', waterTemp: 24.0);
+        await insertComputer('comp-1');
+        await insertSource(
+          id: 'src-1',
+          diveId: 'dive-1',
+          computerId: 'comp-1',
+          isPrimary: true,
+        );
+
+        await service.applyParsedUpdate(
+          diveId: 'dive-1',
+          sourceRowId: 'src-1',
+          parsed: makeParsedDive(
+            minTemperatureCelsius: null,
+            samples: [
+              pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+              pigeon.ProfileSample(timeSeconds: 60, depthMeters: 20.0),
+            ],
+          ),
+          descriptorVendor: null,
+          descriptorProduct: null,
+          descriptorModel: null,
+          libdivecomputerVersion: null,
+        );
+
+        final dive = await getDive('dive-1');
+        expect(dive.waterTemp, 24.0);
+        final src = await getSource('src-1');
+        expect(src.waterTemp, isNull);
+      },
+    );
+
     test(
       'is idempotent: same data applied twice yields identical DB state',
       () async {


### PR DESCRIPTION
## Problem

Re-parsing a dive that had already been downloaded blanked its water temp. The Data Sources panel rendered `-` for the field.

## Root cause

`ParsedDive.minTemperatureCelsius` is optional. Shearwater-class computers report no top-level minimum and carry temperature only in the per-sample stream. The download path knows this and falls back to the minimum of the sample temperatures, in both places it maps a parse:

- `lib/features/dive_computer/data/services/parsed_dive_mapper.dart:16`
- `lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart:1222`

`ReparseService` did not. It wrote `Value(parsed.minTemperatureCelsius)` raw into both `dive_data_sources.water_temp` and `dives.water_temp`, so every re-parse of a dive from such a computer overwrote a good value with NULL. `data_sources_section.dart:186` renders NULL as `-`.

## Fix

1. A static `_minWaterTemp(parsed)` helper beside the existing `_extractMaxCns`: prefer the header value, otherwise reduce the non-null sample temperatures. Used for the `dive_data_sources` row.
2. The `dives` row now writes water temp only when the parse produced one, guarding with `Value.absent()` otherwise. This matches the entry/exit GPS treatment twelve lines below it and closes a second consequence of the same root cause: re-parsing a temperature-free dive was wiping a water temp the diver had entered by hand.

## Tests

Three cases added to `reparse_service_test.dart`:

- water temp derived from the sample stream when the computer reports no top-level minimum
- a top-level minimum still wins over the sample stream
- a re-parse with no temperature anywhere preserves a hand-entered dive water temp while the source row correctly records NULL

The first and third failed before the fix with `Expected: <14.5>, Actual: <null>`.

## Verification

- `flutter test test/features/dive_computer/data/services/reparse_service_test.dart`: 66 passed
- `flutter test test/features/dive_computer/ test/features/dive_log/data/`: 921 passed, 3 skipped
- `flutter analyze`: no issues found
- `dart format lib/ test/`: clean

## Follow-ups filed

This is the fourth time `ReparseService` has lagged the download path (previously entry/exit GPS, air-integrated tank pressure, and the bottom-time algorithm). Two further divergences found in the same method are filed separately rather than bundled here, since they cause staleness rather than data loss:

- #1207: re-parse leaves `dive_data_sources.entry_time` / `exit_time` stale
- #1208: re-parse never refreshes `dive_data_sources.cns`
