### PR TITLE
fix(media_store): arm a wakeup for a row that comes due mid-drain

### DIFF
--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -66,13 +66,21 @@ class MediaStoreWorker {
   Future<void> drain() async {
     if (_disposed || _running) return;
     _running = true;
+    // Set only on the one exit that means "nothing was due, and I looked":
+    // every other way out of the loop - a failed preflight, a gate that
+    // stopped the drain, an exception out of the pipeline - leaves work
+    // behind on purpose, and must not arm the immediate wakeup below.
+    var drainedToEmpty = false;
     try {
       while (true) {
         // Re-checked per entry, not once per drain: a store wipe or user
         // disconnect mid-drain must suspend the rest of the queue.
         if (!await _preflightPasses()) return;
         final entry = await _queue.nextPending(DateTime.now());
-        if (entry == null) break;
+        if (entry == null) {
+          drainedToEmpty = true;
+          break;
+        }
         if (_gate != null) {
           final decision = await _gate(entry);
           if (decision == WorkerGate.stopDraining) {
@@ -99,7 +107,7 @@ class MediaStoreWorker {
       }
     } finally {
       _running = false;
-      await _armWakeup();
+      await _armWakeup(drainedToEmpty: drainedToEmpty);
     }
   }
 
@@ -147,7 +155,10 @@ class MediaStoreWorker {
   ///
   /// Runs in drain's finally and must never throw: an exception here would
   /// replace whatever the drain itself was reporting.
-  Future<void> _armWakeup() async {
+  ///
+  /// [drainedToEmpty] says the drain looked and found nothing due. That is
+  /// what makes the already-due branch below safe; see it for why.
+  Future<void> _armWakeup({required bool drainedToEmpty}) async {
     _wakeup?.cancel();
     _wakeup = null;
     _wakeupDelay = null;
@@ -160,6 +171,24 @@ class MediaStoreWorker {
       // One clock reading for both the query and the delay, so the timer
       // cannot be handed a negative duration by the query's own latency.
       final now = DateTime.now();
+      // The drain asked "what is due?" against its own clock reading, and
+      // earliestPendingWakeup asks "what is not due yet?" against this one.
+      // Those are complements only if no time passed in between, so a row
+      // whose backoff expired since - or one enqueued since, which the
+      // single-flight guard turned into a no-op kick - answers to neither
+      // query and would wait for an unrelated trigger (#1210). Hand it
+      // straight back to a fresh drain.
+      //
+      // Only when the drain reached an empty queue. A drain that declined to
+      // run (offline, failed preflight) left its due row behind deliberately,
+      // and re-kicking that would spin against a drain that keeps declining.
+      // A drain that emptied the queue cannot: every loop exit consumes its
+      // entry, so the next drain either takes this row or is itself a decline.
+      if (drainedToEmpty && await _queue.nextPending(now) != null) {
+        _wakeupDelay = Duration.zero;
+        _wakeup = Timer(Duration.zero, () => unawaited(drain()));
+        return;
+      }
       final due = await _queue.earliestPendingWakeup(now);
       if (due == null) return;
       final delay = due.difference(now);

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -440,6 +440,11 @@ class MediaTransferQueueRepository {
   /// suspended - offline, or a failed preflight - both of which have their
   /// own triggers. Arming a timer for an already-due row would spin a tight
   /// loop against a drain that keeps declining to run.
+  ///
+  /// That leaves a row whose backoff expired *during* a drain that ran fine
+  /// answering to neither this query nor the drain's own (#1210). The worker
+  /// closes that gap itself, before calling this, because only the worker
+  /// knows which of the two cases its drain was; see _armWakeup.
   Future<DateTime?> earliestPendingWakeup(DateTime now) async {
     final soonest = _db.mediaTransferQueue.nextAttemptAt.min();
     final query = _db.selectOnly(_db.mediaTransferQueue)

--- a/lib/features/media_store/data/media_transfer_queue_repository.dart
+++ b/lib/features/media_store/data/media_transfer_queue_repository.dart
@@ -442,9 +442,10 @@ class MediaTransferQueueRepository {
   /// loop against a drain that keeps declining to run.
   ///
   /// That leaves a row whose backoff expired *during* a drain that ran fine
-  /// answering to neither this query nor the drain's own (#1210). The worker
-  /// closes that gap itself, before calling this, because only the worker
-  /// knows which of the two cases its drain was; see _armWakeup.
+  /// answering to neither this query nor the drain's own (#1210). Closing that
+  /// gap is the caller's job rather than this query's, because only the worker
+  /// knows which of the two cases its drain was. See the immediate-wakeup
+  /// branch of `MediaStoreWorker._armWakeup`, in media_store_worker.dart.
   Future<DateTime?> earliestPendingWakeup(DateTime now) async {
     final soonest = _db.mediaTransferQueue.nextAttemptAt.min();
     final query = _db.selectOnly(_db.mediaTransferQueue)

--- a/test/features/media_store/media_store_worker_wakeup_test.dart
+++ b/test/features/media_store/media_store_worker_wakeup_test.dart
@@ -42,6 +42,30 @@ class _RecordingPipeline extends MediaUploadPipeline {
   }
 }
 
+/// Widens the window between the drain's last due-check and the moment the
+/// wakeup is armed. That window is where the row in #1210 fell through: too
+/// early for the drain's clock reading, already due by the arming one.
+///
+/// One-shot, and only on an empty result: the lag has to land after the last
+/// [nextPending] of the drain loop, and re-lagging every later drain would
+/// just pad the test.
+class _LaggingQueue extends MediaTransferQueueRepository {
+  _LaggingQueue({required super.database, required this.lag});
+
+  final Duration lag;
+  bool _lagged = false;
+
+  @override
+  Future<MediaTransferQueueEntry?> nextPending(DateTime now) async {
+    final entry = await super.nextPending(now);
+    if (entry == null && !_lagged) {
+      _lagged = true;
+      await Future<void>.delayed(lag);
+    }
+    return entry;
+  }
+}
+
 /// Polls [condition] until true or [within] elapses. Condition-based rather
 /// than a fixed sleep: the wakeup fires on a real timer, and a fixed delay
 /// either flakes under load or pads every run.
@@ -130,6 +154,87 @@ void main() {
       reason: 'wakeup timer should have re-drained the row',
     );
     expect(pipeline.processed, ['m1']);
+  });
+
+  // #1210: the drain checks "what is due?" at T0 and the arming query checks
+  // "what is not yet due?" at T1. A row that comes due in between satisfies
+  // neither, so before the fix nothing was armed for it and it sat until an
+  // unrelated trigger (app restart, connectivity flap) happened along.
+  test(
+    'a row that comes due while the drain finishes still gets a wakeup',
+    () async {
+      final lagging = _LaggingQueue(
+        database: cacheDb,
+        lag: const Duration(milliseconds: 400),
+      );
+      final laggingPipeline = _RecordingPipeline(
+        queueRef: lagging,
+        mediaRepository: mediaRepository,
+        queue: lagging,
+        store: InMemoryMediaObjectStore(),
+        registry: MediaSourceResolverRegistry({}),
+        cache: MediaCacheStore(database: cacheDb, root: root),
+      );
+      final laggingWorker = MediaStoreWorker(
+        queue: lagging,
+        pipeline: laggingPipeline,
+      );
+      addTearDown(laggingWorker.dispose);
+
+      final id = await lagging.enqueueUpload(mediaId: 'm1');
+      await lagging.defer(
+        id,
+        DateTime.now().add(const Duration(milliseconds: 80)),
+      );
+
+      await laggingWorker.drain();
+      expect(
+        laggingPipeline.processed,
+        isEmpty,
+        reason: 'not due at drain time',
+      );
+
+      expect(
+        await _waitFor(() => laggingPipeline.processed.isNotEmpty),
+        isTrue,
+        reason: 'the row came due during the drain and must still be picked up',
+      );
+    },
+  );
+
+  // The constraint the immediate wakeup must not break: a drain that declined
+  // to run leaves its due row behind on purpose, and arming a timer for it
+  // would spin that timer against a drain that keeps declining.
+  test('a preflight-suspended drain arms no wakeup for a due row', () async {
+    final suspended = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => false,
+    );
+    addTearDown(suspended.dispose);
+    await queue.enqueueUpload(mediaId: 'm1');
+
+    await suspended.drain();
+
+    expect(suspended.wakeupDelayForTesting, isNull);
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    expect(pipeline.processed, isEmpty, reason: 'no timer should have fired');
+  });
+
+  test('a gate-stopped drain arms no wakeup for a due row', () async {
+    final stopped = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      gate: (_) async => WorkerGate.stopDraining,
+    );
+    addTearDown(stopped.dispose);
+    await queue.enqueueUpload(mediaId: 'm1');
+
+    await stopped.drain();
+
+    expect(stopped.wakeupDelayForTesting, isNull);
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    expect(pipeline.processed, isEmpty, reason: 'no timer should have fired');
   });
 
   test(


### PR DESCRIPTION
Fixes #1210.

## The gap

`drain()` decides *what is due* against its own clock reading, and `_armWakeup`'s `earliestPendingWakeup` decides *what is not yet due* against a later one. Those two predicates are complements only if no time passes between them. A row whose backoff expires in that window answers to neither: too early for the drain that just ran, already due for the arming query, which excludes due rows deliberately. No timer is armed, and the row waits for an unrelated trigger (app restart, connectivity flap) while the settings page transfer count stays stale.

One correction to the issue's analysis: the window is not widened by a long drain. `nextPending` is called with a fresh `DateTime.now()` on *every* loop iteration, so only the final iteration's reading matters, and the gap is one query plus the hop to the `finally`. That is tiny in wall-clock terms but unbounded on a starved isolate, since every `await` is a chance to be descheduled, which is why it surfaces on a loaded CI shard and never locally.

## The fix

The exclusion in `earliestPendingWakeup` remains correct for a drain that *declined* to run (offline, failed preflight): arming a timer for its leftover due row would spin against a drain that keeps declining. So `drain()` now reports which of the two cases it was.

It reports it with a positive flag, `drainedToEmpty`, set only at the loop exit that means "I looked and nothing was due". This is deliberately not a "was I suspended?" flag: there is a third exit the issue does not mention, an exception out of `pipeline.process`, and a negative flag would default that to "completed normally" and arm an immediate wakeup for a row that is about to throw again. The positive form puts failed preflight, gate stop, and exception all on the safe side by construction.

When the drain *did* empty the queue and `nextPending` finds a row due at arming time, the row is handed straight back to a fresh drain on a zero-delay timer. That terminates: every loop exit consumes its entry, so the next drain either takes the row or is itself a decline, and a decline arms nothing.

Reusing the drain's own `nextPending` as the due-check (rather than adding an `includeDue` flag to the SQL) means "due" here is defined by exactly the query the drain admits on, so the two can't drift apart again.

## Also covered

The same gap has a second shape the issue does not mention: a row enqueued *during* a drain. `enqueueAndKick`'s `drain()` hits the single-flight guard and returns immediately, so if the enqueue lands after the drain's last look, the row is due, unkicked, and invisible to the arming query. The `drainedToEmpty` branch picks it up too.

## Tests

- `a row that comes due while the drain finishes still gets a wakeup`: a `_LaggingQueue` subclass delays one empty `nextPending` result by 400 ms, widening the arming window deterministically against an 80 ms backoff. Red before the fix (5 s poll, `Expected: true / Actual: <false>`, the same signature as the CI flake), green after, and unlike the existing case it gets *more* reliable under load rather than less.
- `a preflight-suspended drain arms no wakeup for a due row` and `a gate-stopped drain arms no wakeup for a due row`: pin the tight-loop protection that the new branch must not break.

## Verification

- `flutter test test/features/media_store/`: 293 passed, 1 skipped.
- `flutter analyze` over the whole project: no issues.
- `dart format --set-exit-if-changed lib/ test/`: clean.
