### PR TITLE
fix(reparse): refresh dive_data_sources entry/exit time on re-parse

### DIFF
--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -373,6 +373,21 @@ class ReparseService {
   // Private helpers
   // ==========================================================================
 
+  /// The dive's start instant as this parse reports it, in the source's own
+  /// time frame.
+  ///
+  /// Both the source row's provenance window and the dive row's own clock
+  /// derive from this one expression so they cannot drift apart across a
+  /// re-parse (#1207).
+  static DateTime _parsedEntryTime(pigeon.ParsedDive parsed) => DateTime.utc(
+    parsed.dateTimeYear,
+    parsed.dateTimeMonth,
+    parsed.dateTimeDay,
+    parsed.dateTimeHour,
+    parsed.dateTimeMinute,
+    parsed.dateTimeSecond,
+  );
+
   Future<void> _updateSourceRow({
     required String sourceRowId,
     required pigeon.ParsedDive parsed,
@@ -384,6 +399,7 @@ class ReparseService {
     required Uint8List? rawFingerprint,
     required DateTime now,
   }) async {
+    final entryTime = _parsedEntryTime(parsed);
     await (db.update(
       db.diveDataSources,
     )..where((t) => t.id.equals(sourceRowId))).write(
@@ -401,6 +417,22 @@ class ReparseService {
         entryLongitude: Value(parsed.entryLongitude),
         exitLatitude: Value(parsed.exitLatitude),
         exitLongitude: Value(parsed.exitLongitude),
+        // The download path stamps this window when it inserts the row, so a
+        // re-parse has to refresh it or the source keeps advertising the
+        // original download's clock while the dive itself moves (#1207).
+        // These are load-bearing: DiveSplitService dates a split-out dive
+        // from them and DiveConsolidationService carries them onto the
+        // target.
+        //
+        // Raw parse frame, deliberately unshifted by timeOffsetSeconds. The
+        // samples in _replaceDiveProfiles are re-based onto the dive's
+        // timeline; this window is not, because consolidation copies a
+        // folded-in source's entry/exit across untouched and records the
+        // shift in timeOffsetSeconds instead.
+        entryTime: Value(entryTime),
+        exitTime: Value(
+          entryTime.add(Duration(seconds: parsed.durationSeconds)),
+        ),
         descriptorVendor: Value(descriptorVendor),
         descriptorProduct: Value(descriptorProduct),
         descriptorModel: Value(descriptorModel),
@@ -421,16 +453,7 @@ class ReparseService {
     required pigeon.ParsedDive parsed,
     required DateTime now,
   }) async {
-    // Build UTC DateTime from parsed components
-    final diveDateTime = DateTime.utc(
-      parsed.dateTimeYear,
-      parsed.dateTimeMonth,
-      parsed.dateTimeDay,
-      parsed.dateTimeHour,
-      parsed.dateTimeMinute,
-      parsed.dateTimeSecond,
-    );
-    final diveDateTimeMs = diveDateTime.millisecondsSinceEpoch;
+    final diveDateTimeMs = _parsedEntryTime(parsed).millisecondsSinceEpoch;
     final exitTimeMs = diveDateTimeMs + (parsed.durationSeconds * 1000);
     final bottomTimeSeconds = _calculateBottomTimeFromSamples(parsed.samples);
     final waterTemp = _minWaterTemp(parsed);

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -93,6 +93,8 @@ void main() {
     int? duration,
     double? waterTemp,
     int? timeOffsetSeconds,
+    DateTime? entryTime,
+    DateTime? exitTime,
   }) async {
     final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
     await db
@@ -109,6 +111,8 @@ void main() {
             duration: Value(duration),
             waterTemp: Value(waterTemp),
             timeOffsetSeconds: Value(timeOffsetSeconds),
+            entryTime: Value(entryTime),
+            exitTime: Value(exitTime),
             importedAt: Value(now),
             createdAt: Value(now),
           ),
@@ -744,6 +748,90 @@ void main() {
         expect(src.waterTemp, isNull);
       },
     );
+
+    test('refreshes the source row entry/exit window from the re-parsed '
+        'clock (#1207)', () async {
+      // Arrange: a source row stamped with the original download's window.
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+        duration: 2400,
+        entryTime: DateTime.utc(2026, 1, 15, 10, 0),
+        exitTime: DateTime.utc(2026, 1, 15, 10, 40),
+      );
+
+      // Act: re-parse moves the start by an hour and lengthens the dive.
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(hour: 11, durationSeconds: 3000),
+        descriptorVendor: 'Suunto',
+        descriptorProduct: 'EON Core',
+        descriptorModel: 99,
+        libdivecomputerVersion: '0.9.0',
+      );
+
+      // Assert: the source row's window tracks the dive's own clock.
+      final src = await getSource('src-1');
+      final dive = await getDive('dive-1');
+      expect(
+        src.entryTime!.millisecondsSinceEpoch,
+        DateTime.utc(2026, 1, 15, 11, 0).millisecondsSinceEpoch,
+      );
+      expect(
+        src.exitTime!.millisecondsSinceEpoch,
+        DateTime.utc(2026, 1, 15, 11, 50).millisecondsSinceEpoch,
+      );
+      expect(src.entryTime!.millisecondsSinceEpoch, dive.entryTime);
+      expect(src.exitTime!.millisecondsSinceEpoch, dive.exitTime);
+    });
+
+    test('records the raw parsed window on an offset-bearing source, not the '
+        're-based one (#1207)', () async {
+      // Arrange: a consolidated secondary whose profile is re-based by 10
+      // minutes. entry_time/exit_time stay in the source's own parse frame --
+      // the download path stamps them unshifted and consolidation copies them
+      // across untouched, recording the shift in timeOffsetSeconds instead.
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(id: 'src-primary', diveId: 'dive-1', isPrimary: true);
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: false,
+        timeOffsetSeconds: 600,
+        entryTime: DateTime.utc(2026, 1, 15, 10, 0),
+        exitTime: DateTime.utc(2026, 1, 15, 10, 40),
+      );
+
+      // Act
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: makeParsedDive(hour: 11, durationSeconds: 3000),
+        descriptorVendor: 'Suunto',
+        descriptorProduct: 'EON Core',
+        descriptorModel: 99,
+        libdivecomputerVersion: '0.9.0',
+      );
+
+      // Assert: no offset folded into the recorded window.
+      final src = await getSource('src-1');
+      expect(
+        src.entryTime!.millisecondsSinceEpoch,
+        DateTime.utc(2026, 1, 15, 11, 0).millisecondsSinceEpoch,
+      );
+      expect(
+        src.exitTime!.millisecondsSinceEpoch,
+        DateTime.utc(2026, 1, 15, 11, 50).millisecondsSinceEpoch,
+      );
+      expect(src.timeOffsetSeconds, 600);
+    });
 
     test(
       'is idempotent: same data applied twice yields identical DB state',


### PR DESCRIPTION
Fixes #1207.

## The defect

`ReparseService._updateSourceRow` built its `DiveDataSourcesCompanion` without
`entryTime` or `exitTime`. Drift reads an omitted companion field as
`Value.absent()` and emits an `UPDATE` that never mentions the column, so both
survived every re-parse untouched. Meanwhile `_updateDiveRow` in the same file
rewrote the dive's own `diveDateTime` / `entryTime` / `exitTime` from the freshly
parsed values.

A re-parse that shifts the parsed start time or duration (a libdivecomputer
upgrade fixing a timestamp or a profile length) therefore moved the dive and left
the provenance row pinned to whatever the original download recorded.

## Why it matters

These columns are load-bearing, not just display:

- `DiveSplitService` dates a split-out dive from `source.entryTime`, falling back
  to the dive row only when it is null.
- `DiveConsolidationService` reads `secRow.entryTime` when folding a secondary
  strand in.
- The Data Sources panel renders both, so the user sees the stale times next to
  the corrected ones on the dive itself.

## The fix

Both writes now derive from a single `_parsedEntryTime(parsed)` expression, so
the dive's clock and the source's provenance window are structurally incapable of
disagreeing again. Previously `_updateDiveRow` computed the UTC instant inline
and the source path had nothing to reuse.

### Which time frame the source row records

The issue asked to check this against the profile re-basing logic first. The
source row records the **raw parse frame, unshifted by `timeOffsetSeconds`**.
That is the existing convention, not a new choice:

- The download path stamps `profileStartTime` directly
  (`dive_computer_repository_impl.dart:1250-1253`), and at download time there is
  no offset.
- `DiveConsolidationService` copies a folded-in source's `entryTime`/`exitTime`
  across **untouched** and records the clock shift separately in
  `timeOffsetSeconds` (`dive_consolidation_service.dart:196-247`).
- `DiveSplitService` depends on exactly that frame: "date the new dive by its own
  source's entry time so it sorts where that computer actually recorded it".
- The Data Sources panel renders the values raw, with no offset applied.

So `timeOffsetSeconds` remains the transform onto the dive's timeline, applied to
profile samples in `_replaceDiveProfiles` and nowhere else. A comment at the write
site records this so the convention cannot be silently inverted later.

## Tests

Two new cases in `reparse_service_test.dart`, both watched failing first (stale
`10:00` where the re-parsed `11:00` was expected):

- `refreshes the source row entry/exit window from the re-parsed clock (#1207)` —
  asserts the source row's window tracks the dive row's, not the original
  download's.
- `records the raw parsed window on an offset-bearing source, not the re-based
  one (#1207)` — pins the frame convention above for a consolidated secondary
  carrying a 600s offset.

The `insertSource` test helper gained `entryTime` / `exitTime` parameters so a
stale window can be arranged.

## Verification

- `flutter analyze`: clean.
- `flutter test test/features/dive_computer test/features/dive_log/data`: 920
  passed, including the consolidation, merge, and split suites that consume these
  columns.
- Full local suite: 19,529 passed. One unrelated failure in
  `media_share_helper_test.dart` ("resolvable items reach the share sheet as
  files"), the known load-sensitive case under concurrent full-suite runs; this
  diff touches no media code and the file passes 6/6 in isolation.

## Noted, not changed

`ReparseService` never calls `markRecordPending` for any column it writes, so
none of its updates propagate through sync. That is pre-existing and uniform
across the service, so it is out of scope here.
