### PR TITLE
feat(release): credit contributors in the stable release notes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,6 +400,12 @@ jobs:
       - name: Run changelog generator test
         run: ./scripts/release/generate_changelog_test.sh
 
+      - name: Run release contributors test
+        # Stubs the GitHub API, so no token or network is needed here. Guards
+        # the two properties the credits depend on: PR numbers resolve from
+        # git alone, and no API failure can abort a release.
+        run: ./scripts/release/contributors_test.sh
+
       - name: Run fastlane beta changelog test
         run: ruby scripts/release/fastlane_beta_changelog_test.rb
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -121,6 +121,11 @@ jobs:
       - name: Generate release notes and stable appcast
         env:
           TAG_NAME: ${{ steps.resolve.outputs.tag }}
+          # The changelog credits each bullet to its author and lists
+          # first-time contributors, which needs the API to turn commit emails
+          # into GitHub logins. Without a token it quietly falls back to
+          # unattributed bullets rather than failing the promotion.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git checkout "${{ steps.resolve.outputs.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,9 @@ jobs:
           merge-multiple: true
 
       - name: Generate release notes HTML
+        env:
+          # Needed to resolve contributor logins; see promote.yml.
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/release/generate_changelog.sh --notes-only | \
             ./scripts/generate_release_notes_html.sh > release-notes.html
@@ -367,6 +370,9 @@ jobs:
           fetch-depth: 0
 
       - name: Generate release notes
+        env:
+          # Needed to resolve contributor logins; see promote.yml.
+          GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/release/generate_changelog.sh --notes-only > release-notes.md
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -92,6 +92,48 @@ Two things still want a human:
   `phased_release: true` in `ios/fastlane/Fastfile` for a haltable 7-day iOS
   rollout, or put `automatic_release` back to `false` in both Fastfiles.
 
+## Contributor credits
+
+The stable release body credits work as it goes. `generate_changelog.sh`
+attributes every bullet to the person who wrote it and the PR that merged it
+(`- fixed a thing by @octocat in #42`), and closes with a **New Contributors**
+section naming anyone whose first commit to the repository landed in this
+release. Nothing to run by hand: `promote.yml` generates it.
+
+Where the authorship comes from, in `scripts/release/contributors.sh`:
+
+- **PR numbers come from git alone.** A merge commit records
+  `Merge pull request #N`, and its second parent names the commits that PR
+  contributed. A squash-merged commit carries `(#N)` in its subject instead.
+  Either way no network is involved.
+- **GitHub logins come from the API.** Git records a name and an email, never
+  a login, so an @mention that actually notifies someone has to be looked up
+  through `repos/.../compare`. First contributions are a second lookup per
+  contributor.
+
+Credits never block a release. If the API is unavailable the script falls back
+to logins derived from `@users.noreply.github.com` commit emails, and where
+even that fails the bullet simply renders without a name. First contributions
+are only ever claimed from the API, because announcing someone as a first-time
+contributor when they are not is worse than saying nothing. Bots are never
+credited and never announced.
+
+Two consumers treat the credits differently, from the same source:
+
+- The **Sparkle update dialog** and the GitHub release page show them in full.
+- The **App Store "What's New"** does not.
+  `sanitize_apple_store_notes.py` strips the handles, the PR numbers and the
+  whole New Contributors section, because `promote.yml` derives that field
+  from the published release body and an @handle is not a name.
+
+Pass `--no-attribution` to `generate_changelog.sh` to reproduce the older,
+uncredited body.
+
+**In the announcement, too.** Every `docs/releases/v<version>.md` ends with a
+`## Contributors` section thanking the release's contributors by name and
+handle, with first-time contributors called out. Take the list from the
+generated release body rather than reconstructing it.
+
 ## Play Store state
 
 Until Google grants production access (earned by a closed test with 12+
@@ -123,6 +165,7 @@ a build number above the current commit count. Expected to be rare.
 - Secrets (App Store, Play, Sparkle, `BETA_BUILDS_TOKEN`,
   `RELEASE_BOT_TOKEN`): `docs/developer/release-secrets-setup.md`
 - Workflows: `.github/workflows/{build-all,beta,promote,release}.yml`
-- Scripts: `scripts/release/` (`promote.sh`, `bump_version.sh`; the old
-  `release.sh` orchestrator belongs to the legacy tag path)
+- Scripts: `scripts/release/` (`promote.sh`, `bump_version.sh`,
+  `contributors.sh`; the old `release.sh` orchestrator belongs to the legacy
+  tag path)
 - Beta artifact host: `github.com/submersion-app/beta-builds`

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -130,9 +130,16 @@ Pass `--no-attribution` to `generate_changelog.sh` to reproduce the older,
 uncredited body.
 
 **In the announcement, too.** Every `docs/releases/v<version>.md` ends with a
-`## Contributors` section thanking the release's contributors by name and
-handle, with first-time contributors called out. Take the list from the
-generated release body rather than reconstructing it.
+`## 🙏 Contributors` section thanking the release's contributors by handle,
+with first-time contributors called out. Take the list from the generated
+release body rather than reconstructing it.
+
+The emoji is deliberate and local to these files. `docs/releases/*.md` are
+ScubaBoard posts rather than developer documentation, and every section
+heading in them carries one (`## ✨ New and improved`, `## 🐞 Bug fixes`,
+`## 🔧 Under the hood`, `## ⚠️ Upgrade notes`). No other document under
+`docs/` does. A bare `## Contributors` would be the odd heading out in its own
+file; the no-emoji rule in CLAUDE.md governs everything except this format.
 
 ## Play Store state
 

--- a/docs/releases/v1.7.4.6062.md
+++ b/docs/releases/v1.7.4.6062.md
@@ -31,3 +31,10 @@ Submersion now builds on Flutter 3.47 and Dart 3.13, up from 3.44. That is maint
 
 ---
 
+## 🙏 Contributors
+
+Thank you to everyone whose work is in this release: @Apoplexi, who built the
+profile editor's trim function, @readme42, who added raw O2 cell millivolt
+reporting for Shearwater CCR dives, and @ericgriffin.
+
+---

--- a/scripts/release/contributors.sh
+++ b/scripts/release/contributors.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Map every commit in a release range to the person who wrote it and the PR
+# that merged it, for the credits in the release notes.
+#
+# Two sources, deliberately layered so a release is never blocked on credits:
+#
+#   PR numbers come from git alone. A merge commit records "Merge pull request
+#   #N", and `git rev-list <merge>^1..<merge>^2` names the commits that PR
+#   contributed, so the #N on every bullet works with no network at all.
+#
+#   GitHub logins come from the API. Git records a name and an email, never a
+#   login, so an @mention that actually notifies the contributor has to be
+#   looked up. The fallback derives a login from a
+#   `NNN+login@users.noreply.github.com` address, which covers commits made
+#   through the GitHub UI but not ones pushed from a workstation.
+#
+# Merge commits are not in the output: their author is whoever pressed the
+# button, and the changelog walks --no-merges anyway.
+#
+# Usage:
+#   contributors.sh --range <gitrange> [--repo owner/name] [--no-network]
+#
+# Output is TSV on stdout and nothing else:
+#   commit<TAB><sha><TAB><login><TAB><pr>      login and pr may be empty
+#   new<TAB><login><TAB><pr>                   first contribution to the repo
+#
+# Bots are never credited: their commit row survives with an empty login so
+# the bullet still resolves, and they are never announced as new contributors.
+#
+# All progress and diagnostics go to stderr; stdout is only ever the TSV.
+set -euo pipefail
+
+# Injectable so the test suite can stub the API without touching the network.
+GH="${GH:-gh}"
+
+RANGE=""
+SLUG=""
+NETWORK=true
+
+die() { echo "contributors: $*" >&2; exit 1; }
+note() { echo "contributors: $*" >&2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --range) RANGE="${2:-}"; shift 2 ;;
+    --repo)  SLUG="${2:-}"; shift 2 ;;
+    --no-network) NETWORK=false; shift ;;
+    --help|-h) sed -nE '2,/^$/s/^# ?//p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$RANGE" ] || die "--range is required"
+
+if [ -z "$SLUG" ]; then
+  SLUG="${GITHUB_REPOSITORY:-}"
+fi
+if [ -z "$SLUG" ]; then
+  SLUG=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##' || echo "")
+fi
+
+# A range is "<base>..<head>"; a bare ref means all of history, which has no
+# base to compare against.
+BASE="${RANGE%%..*}"
+HEAD_REF="${RANGE##*..}"
+[ "$BASE" != "$RANGE" ] || BASE=""
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- The commits under consideration ---------------------------------------
+git log --no-merges --format='%H%x09%ae%x09%s' "$RANGE" > "$TMP/commits" 2>/dev/null || :
+if [ ! -s "$TMP/commits" ]; then
+  note "no commits in $RANGE"
+  exit 0
+fi
+
+# --- PR numbers, from git ---------------------------------------------------
+: > "$TMP/prmap"
+while IFS=$'\t' read -r merge_sha subject; do
+  [ -n "$merge_sha" ] || continue
+  pr=$(printf '%s\n' "$subject" \
+    | sed -nE 's/^Merge pull request #([0-9]+) .*/\1/p')
+  [ -n "$pr" ] || continue
+  # Second parent minus first parent is exactly the PR's own commits.
+  # awk, not sed: BSD sed does not expand \t in a replacement, so the column
+  # separator would have to be a literal tab that is invisible to the next
+  # person editing this line.
+  git rev-list "${merge_sha}^1..${merge_sha}^2" 2>/dev/null \
+    | awk -v pr="$pr" '{ print $0 "\t" pr }' >> "$TMP/prmap" || :
+done < <(git log --first-parent --merges --format='%H%x09%s' "$RANGE")
+
+# A squash merge leaves no merge commit at all: GitHub records the number by
+# appending "(#N)" to the subject instead. Consulted only when the merge-commit
+# map has nothing, so a normal merge is never second-guessed.
+pr_for() {
+  local pr
+  pr=$(awk -F'\t' -v s="$1" '$1 == s { print $2; exit }' "$TMP/prmap")
+  if [ -z "$pr" ]; then
+    pr=$(printf '%s\n' "$2" | sed -nE 's/.*\(#([0-9]+)\)$/\1/p')
+  fi
+  printf '%s' "$pr"
+}
+
+# --- Logins, from the API where possible ------------------------------------
+API_OK=false
+: > "$TMP/api"
+if [ "$NETWORK" = false ]; then
+  note "offline mode: logins derived from commit emails, no first-contribution check"
+elif [ -z "$BASE" ]; then
+  note "no base ref in '$RANGE': logins derived from commit emails"
+elif [ -z "$SLUG" ]; then
+  note "could not determine the repository: logins derived from commit emails"
+elif "$GH" api --paginate "repos/$SLUG/compare/$BASE...$HEAD_REF" \
+       -q '.commits[] | [.sha, (.author.login // "")] | @tsv' \
+       > "$TMP/api" 2>"$TMP/apierr"; then
+  API_OK=true
+else
+  note "GitHub API unavailable, falling back to commit emails:"
+  sed 's/^/  /' "$TMP/apierr" >&2 || :
+fi
+
+# A GitHub noreply address is "NNN+login@users.noreply.github.com" or, for
+# older accounts, "login@users.noreply.github.com".
+login_from_email() {
+  printf '%s\n' "$1" \
+    | sed -nE 's/^([0-9]+\+)?([^@]+)@users\.noreply\.github\.com$/\2/p'
+}
+
+# Bots author real commits but are not contributors to thank.
+is_bot() {
+  case "$1" in
+    *"[bot]") return 0 ;;
+    Copilot|copilot) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+login_for() {
+  local sha="$1" email="$2" login=""
+  if [ "$API_OK" = true ]; then
+    login=$(awk -F'\t' -v s="$sha" '$1 == s { print $2; exit }' "$TMP/api")
+  fi
+  [ -n "$login" ] || login=$(login_from_email "$email")
+  if [ -n "$login" ] && is_bot "$login"; then
+    login=""
+  fi
+  printf '%s' "$login"
+}
+
+# --- Emit the commit rows, remembering who appeared and where ---------------
+: > "$TMP/authors"
+while IFS=$'\t' read -r sha email subject; do
+  [ -n "$sha" ] || continue
+  login=$(login_for "$sha" "$email")
+  pr=$(pr_for "$sha" "$subject")
+  printf 'commit\t%s\t%s\t%s\n' "$sha" "$login" "$pr"
+  [ -n "$login" ] && printf '%s\t%s\n' "$login" "$pr" >> "$TMP/authors"
+done < "$TMP/commits"
+
+# --- First contributions ----------------------------------------------------
+# Only ever claimed from the API. Announcing someone as a first-time
+# contributor when they are not is worse than saying nothing.
+[ "$API_OK" = true ] || exit 0
+
+# The "+" of a UTC offset decodes to a space inside a query string, so the
+# timestamp is percent-encoded before it becomes an `until` parameter.
+BASE_DATE=$(git log -1 --format=%cI "$BASE" 2>/dev/null | sed 's/+/%2B/' || echo "")
+if [ -z "$BASE_DATE" ]; then
+  note "could not date $BASE: skipping the first-contribution check"
+  exit 0
+fi
+
+# git log is newest first, so the last row for a login is their earliest
+# commit in the range, and its PR is the one that introduced them.
+awk -F'\t' '{ pr[$1] = $2; if (!($1 in seen)) { seen[$1]; order[n++] = $1 } }
+            END { for (i = 0; i < n; i++) print order[i] "\t" pr[order[i]] }' \
+  "$TMP/authors" > "$TMP/unique"
+
+while IFS=$'\t' read -r login pr; do
+  [ -n "$login" ] || continue
+  prior=$("$GH" api \
+    "repos/$SLUG/commits?author=$login&until=$BASE_DATE&per_page=1" \
+    -q 'length' 2>/dev/null) || {
+      note "could not check prior commits for @$login: not claiming a first contribution"
+      continue
+    }
+  [ "$prior" = "0" ] || continue
+  printf 'new\t%s\t%s\n' "$login" "$pr"
+done < "$TMP/unique"

--- a/scripts/release/contributors_test.sh
+++ b/scripts/release/contributors_test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Tests for contributors.sh, the authorship map behind release-note credits.
+#
+# Two properties matter more than the formatting: the PR number for every
+# commit is derived from git alone, so it survives with no network at all, and
+# no GitHub API failure is ever fatal. A release must not be blocked because
+# credits could not be looked up.
+#
+# The GitHub calls are exercised through a stub binary injected with GH=, so
+# this suite never touches the network.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRIB="$SCRIPT_DIR/contributors.sh"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# --- A scratch repository shaped like a real release range -----------------
+# One merged PR from an outside contributor (two commits, one of them the
+# intra-PR noise that per-commit bullets carry), plus one commit pushed
+# straight to main.
+TMPREPO=$(mktemp -d)
+STUBDIR=$(mktemp -d)
+trap 'rm -rf "$TMPREPO" "$STUBDIR"' EXIT
+
+git_c() { git -c user.name=t -c user.email=t@t "$@"; }
+
+(
+  cd "$TMPREPO"
+  git init -q -b main
+  git_c commit -q --allow-empty -m "chore: initial"
+  git tag v1.0.0.1
+
+  git checkout -q -b feat/x
+  git_c commit -q --allow-empty \
+    --author "Octo Cat <123+octocat@users.noreply.github.com>" \
+    -m "feat: report a new thing"
+  git_c commit -q --allow-empty \
+    --author "Octo Cat <123+octocat@users.noreply.github.com>" \
+    -m "Fixed formatting defects."
+
+  git checkout -q main
+  git_c merge -q --no-ff feat/x \
+    -m "Merge pull request #42 from octocat/feat/x" \
+    -m "feat: report a new thing"
+
+  git_c commit -q --allow-empty -m "docs: release notes"
+
+  # A squash-merged PR: no merge commit exists, and GitHub records the number
+  # by appending it to the subject instead. Older ranges in this repo are
+  # shaped this way.
+  git_c commit -q --allow-empty \
+    --author "Squashy <9+squashy@users.noreply.github.com>" \
+    -m "fix(import): handle an empty file (#7)"
+
+  # A dependabot PR: its author must never be credited.
+  git checkout -q -b deps/bump
+  git_c commit -q --allow-empty \
+    --author "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>" \
+    -m "chore(deps): bump a package"
+  git checkout -q main
+  git_c merge -q --no-ff deps/bump \
+    -m "Merge pull request #43 from submersion-app/deps/bump" \
+    -m "chore(deps): bump a package"
+)
+
+RANGE="v1.0.0.1..HEAD"
+run() { (cd "$TMPREPO" && "$CONTRIB" --range "$RANGE" --repo o/r "$@"); }
+
+sha_of() { (cd "$TMPREPO" && git log --format='%H' --no-merges --grep="$1" -1); }
+
+# --- Offline: PR numbers come from git, logins from noreply emails ---------
+OFFLINE=$(run --no-network 2>/dev/null)
+OFFLINE_ERR=$(run --no-network 2>&1 >/dev/null)
+
+echo "$OFFLINE" | grep -qE '^(Resolving|Looking|Found )' \
+  && fail "progress output leaked onto stdout"
+
+# Merge commits are not part of the map: the changelog walks --no-merges, and
+# a merge's author is whoever clicked the button, not the contributor.
+[ "$(echo "$OFFLINE" | grep -c '^commit')" -eq 5 ] \
+  || fail "expected 5 commit rows, got: $(echo "$OFFLINE" | grep -c '^commit')"
+
+FEAT_SHA=$(sha_of "report a new thing")
+echo "$OFFLINE" | grep -q "^commit	$FEAT_SHA	octocat	42$" \
+  || fail "PR-mapped feat commit missing or wrong: $(echo "$OFFLINE" | grep "$FEAT_SHA")"
+
+NOISE_SHA=$(sha_of "Fixed formatting defects")
+echo "$OFFLINE" | grep -q "^commit	$NOISE_SHA	octocat	42$" \
+  || fail "intra-PR commit not attributed to its PR"
+
+# A commit pushed straight to main has an author but no PR, and its git
+# identity is not a GitHub noreply address, so there is no login to claim.
+DOC_SHA=$(sha_of "release notes")
+echo "$OFFLINE" | grep -q "^commit	$DOC_SHA		$" \
+  || fail "direct commit should carry neither login nor PR: $(echo "$OFFLINE" | grep "$DOC_SHA")"
+
+# Bots are filtered: the row survives (so the commit still resolves) with an
+# empty login, so the bullet renders unattributed.
+# A squash merge leaves the PR number only in the subject.
+SQUASH_SHA=$(sha_of "handle an empty file")
+echo "$OFFLINE" | grep -q "^commit	$SQUASH_SHA	squashy	7$" \
+  || fail "squash-merged PR number not recovered from the subject: $(echo "$OFFLINE" | grep "$SQUASH_SHA")"
+
+BOT_SHA=$(sha_of "bump a package")
+echo "$OFFLINE" | grep -q "^commit	$BOT_SHA		43$" \
+  || fail "bot author was not filtered: $(echo "$OFFLINE" | grep "$BOT_SHA")"
+
+# First-contribution claims need the API; guessing them offline would be wrong.
+echo "$OFFLINE" | grep -q '^new' \
+  && fail "new-contributor rows must not be emitted without the API"
+
+echo "$OFFLINE_ERR" | grep -q . || fail "offline mode should say so on stderr"
+
+# --- With the API: logins come from GitHub, first-timers are detected ------
+cat > "$STUBDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub gh. Dispatches on the API path; fixtures come from the environment.
+for arg in "$@"; do
+  case "$arg" in
+    */compare/*) cat "$STUB_COMPARE_TSV"; exit 0 ;;
+    */commits\?author=*)
+      # A raw "+" in a query string decodes to a space. The offset must be
+      # percent-encoded before it reaches the API.
+      case "$arg" in *"until="*"+"*) echo "unencoded + in: $arg" >&2; exit 9 ;; esac
+      echo "$STUB_PRIOR_COMMITS"; exit 0 ;;
+  esac
+done
+exit 1
+STUB
+chmod +x "$STUBDIR/gh"
+
+# The API reports a display login that the email heuristic could not produce,
+# which is the whole reason for the call.
+{
+  echo "$FEAT_SHA	OctoCat"
+  echo "$NOISE_SHA	OctoCat"
+  echo "$DOC_SHA	ericgriffin"
+  echo "$BOT_SHA	dependabot[bot]"
+  echo "$SQUASH_SHA	squashy"
+} > "$STUBDIR/compare.tsv"
+
+ONLINE=$(STUB_COMPARE_TSV="$STUBDIR/compare.tsv" STUB_PRIOR_COMMITS=0 \
+  GH="$STUBDIR/gh" run 2>/dev/null)
+
+echo "$ONLINE" | grep -q "^commit	$FEAT_SHA	OctoCat	42$" \
+  || fail "API login did not win over the email heuristic"
+echo "$ONLINE" | grep -q "^commit	$DOC_SHA	ericgriffin	$" \
+  || fail "API login missing for the direct commit"
+echo "$ONLINE" | grep -q "^commit	$BOT_SHA		43$" \
+  || fail "bot login from the API was not filtered"
+
+# Zero prior commits means a first contribution, credited to the earliest PR
+# the contributor appears in.
+[ "$(echo "$ONLINE" | grep -c '^new')" -eq 3 ] \
+  || fail "expected 3 new-contributor rows, got: $(echo "$ONLINE" | grep '^new')"
+echo "$ONLINE" | grep -q "^new	OctoCat	42$" \
+  || fail "new-contributor row missing for OctoCat"
+echo "$ONLINE" | grep -q '^new	dependabot' \
+  && fail "a bot must never be announced as a new contributor"
+
+# A contributor with prior commits is not new.
+NOTNEW=$(STUB_COMPARE_TSV="$STUBDIR/compare.tsv" STUB_PRIOR_COMMITS=1 \
+  GH="$STUBDIR/gh" run 2>/dev/null)
+echo "$NOTNEW" | grep -q '^new' \
+  && fail "contributor with prior commits announced as new"
+
+# --- A failing gh must degrade, never abort --------------------------------
+cat > "$STUBDIR/gh-broken" <<'STUB'
+#!/usr/bin/env bash
+echo "gh: HTTP 403" >&2
+exit 1
+STUB
+chmod +x "$STUBDIR/gh-broken"
+
+set +e
+BROKEN=$(GH="$STUBDIR/gh-broken" run 2>/dev/null)
+BROKEN_STATUS=$?
+set -e
+[ "$BROKEN_STATUS" -eq 0 ] || fail "a failing gh aborted the script (exit $BROKEN_STATUS)"
+echo "$BROKEN" | grep -q "^commit	$FEAT_SHA	octocat	42$" \
+  || fail "PR mapping should survive an API failure"
+echo "$BROKEN" | grep -q '^new' \
+  && fail "no first-contribution claims when the API is unavailable"
+
+# --- An empty range is not an error ----------------------------------------
+set +e
+EMPTY=$( (cd "$TMPREPO" && "$CONTRIB" --range "HEAD..HEAD" --repo o/r --no-network 2>/dev/null) )
+EMPTY_STATUS=$?
+set -e
+[ "$EMPTY_STATUS" -eq 0 ] || fail "empty range exited $EMPTY_STATUS"
+[ -z "$EMPTY" ] || fail "empty range produced output: $EMPTY"
+
+echo "PASS: contributors.sh"

--- a/scripts/release/generate_changelog.sh
+++ b/scripts/release/generate_changelog.sh
@@ -8,7 +8,14 @@
 #   ./scripts/release/generate_changelog.sh              # prepend to CHANGELOG.md
 #   ./scripts/release/generate_changelog.sh --notes-only # output to stdout only
 #   ./scripts/release/generate_changelog.sh --dry-run    # preview without writing
+#   ./scripts/release/generate_changelog.sh --no-attribution  # no credits
 #   ./scripts/release/generate_changelog.sh --help
+#
+# Each bullet is credited to the person who wrote it and the PR that merged it,
+# and first-time contributors get their own closing section. The authorship map
+# comes from contributors.sh, which degrades to unattributed bullets rather
+# than failing when the GitHub API is unavailable. Set
+# CHANGELOG_ATTRIBUTION_FILE to inject a map instead of resolving one.
 
 set -euo pipefail
 
@@ -20,18 +27,20 @@ CHANGELOG="$PROJECT_DIR/CHANGELOG.md"
 # --- Parse arguments ---
 NOTES_ONLY=false
 DRY_RUN=false
+ATTRIBUTION=true
 
 for arg in "$@"; do
   case "$arg" in
     --notes-only) NOTES_ONLY=true ;;
     --dry-run)    DRY_RUN=true ;;
+    --no-attribution) ATTRIBUTION=false ;;
     --help|-h)
       sed -nE '2,/^$/s/^# ?//p' "$0"
       exit 0
       ;;
     *)
       echo "Unknown argument: $arg"
-      echo "Usage: $0 [--notes-only] [--dry-run]"
+      echo "Usage: $0 [--notes-only] [--dry-run] [--no-attribution]"
       exit 1
       ;;
   esac
@@ -103,12 +112,43 @@ for t in $TYPES; do
 done
 : > "$TMPDIR_CL/other"
 
+# --- Resolve who wrote what -------------------------------------------------
+# An injected map keeps the test suite off the network. Otherwise the lookup
+# runs here; it is allowed to come back empty, in which case every bullet
+# renders exactly as it did before credits existed.
+ATTR_FILE=""
+if [ "$ATTRIBUTION" = true ]; then
+  if [ -n "${CHANGELOG_ATTRIBUTION_FILE:-}" ]; then
+    ATTR_FILE="$CHANGELOG_ATTRIBUTION_FILE"
+  else
+    ATTR_FILE="$TMPDIR_CL/attribution"
+    "$SCRIPT_DIR/contributors.sh" --range "$COMMIT_RANGE" > "$ATTR_FILE" \
+      || : > "$ATTR_FILE"
+  fi
+fi
+
+# " by @octocat in #42", degrading to " by @octocat" and then to nothing. A
+# commit with no login is left bare rather than credited to a display name:
+# an @mention that does not resolve is worse than no credit at all.
+attribution_for() {
+  [ -n "$ATTR_FILE" ] || return 0
+  [ -f "$ATTR_FILE" ] || return 0
+  awk -F'\t' -v s="$1" '
+    $1 == "commit" && $2 == s {
+      if ($3 == "") exit
+      printf " by @%s", $3
+      if ($4 != "") printf " in #%s", $4
+      exit
+    }' "$ATTR_FILE"
+}
+
 COMMIT_COUNT=0
 
 # Read commits and sort into type buckets
-while IFS= read -r line; do
+while IFS=$'\t' read -r sha line; do
   [ -z "$line" ] && continue
   COMMIT_COUNT=$((COMMIT_COUNT + 1))
+  SUFFIX=$(attribution_for "$sha")
 
   # Match "type: description" or "type(scope): description"
   if echo "$line" | grep -qE '^[a-z]+(\([^)]*\))?!?:'; then
@@ -118,20 +158,20 @@ while IFS= read -r line; do
     MATCHED=false
     for t in $TYPES; do
       if [ "$TYPE" = "$t" ]; then
-        echo "- $MSG" >> "$TMPDIR_CL/$t"
+        echo "- $MSG$SUFFIX" >> "$TMPDIR_CL/$t"
         MATCHED=true
         break
       fi
     done
 
     if [ "$MATCHED" = false ]; then
-      echo "- $MSG" >> "$TMPDIR_CL/other"
+      echo "- $MSG$SUFFIX" >> "$TMPDIR_CL/other"
     fi
   else
-    echo "- $line" >> "$TMPDIR_CL/other"
+    echo "- $line$SUFFIX" >> "$TMPDIR_CL/other"
   fi
 done <<EOF
-$(git log --format='%s' --no-merges $COMMIT_RANGE 2>/dev/null)
+$(git log --format='%H%x09%s' --no-merges $COMMIT_RANGE 2>/dev/null)
 EOF
 
 if [ "$COMMIT_COUNT" -eq 0 ]; then
@@ -159,6 +199,26 @@ $(cat "$TMPDIR_CL/$t")
     SECTION_COUNT=$((SECTION_COUNT + 1))
   fi
 done
+
+# Last, the way GitHub's own generated notes place it: the reader has seen
+# what shipped before being told who is new.
+if [ -n "$ATTR_FILE" ] && [ -f "$ATTR_FILE" ]; then
+  NEW_CONTRIBUTORS=$(awk -F'\t' '
+    $1 == "new" && $2 != "" {
+      line = "- @" $2 " made their first contribution"
+      if ($3 != "") line = line " in #" $3
+      print line
+    }' "$ATTR_FILE")
+  if [ -n "$NEW_CONTRIBUTORS" ]; then
+    NOTES="$NOTES
+### New Contributors
+"
+    NOTES="$NOTES
+$NEW_CONTRIBUTORS
+"
+    SECTION_COUNT=$((SECTION_COUNT + 1))
+  fi
+fi
 
 echo "Found $COMMIT_COUNT commit(s) in $SECTION_COUNT section(s)." >&2
 echo "" >&2

--- a/scripts/release/generate_changelog_test.sh
+++ b/scripts/release/generate_changelog_test.sh
@@ -44,4 +44,64 @@ echo "$STDOUT" | grep -q "an old thing" || fail "fix commit missing from notes"
 echo "$STDERR" | grep -q "^Changelog: " || fail "progress summary missing from stderr"
 echo "$STDERR" | grep -q "commit(s) in" || fail "commit count missing from stderr"
 
+
+# --- Contributor attribution ------------------------------------------------
+# The authorship map is injected rather than looked up, so this suite never
+# needs a network or a GitHub token. contributors.sh has its own tests.
+FEAT_SHA=$(cd "$TMPREPO" && git log --format='%H' --grep='a new thing' -1)
+FIX_SHA=$(cd "$TMPREPO" && git log --format='%H' --grep='an old thing' -1)
+
+ATTR=$(mktemp)
+trap 'rm -rf "$TMPREPO" "$ATTR"' EXIT
+{
+  printf 'commit\t%s\t%s\t%s\n' "$FEAT_SHA" "octocat" "42"
+  printf 'commit\t%s\t%s\t%s\n' "$FIX_SHA" "ericgriffin" ""
+  printf 'new\t%s\t%s\n' "octocat" "42"
+} > "$ATTR"
+
+ATTRIBUTED=$(cd "$TMPREPO" && CHANGELOG_ATTRIBUTION_FILE="$ATTR" \
+  "$GEN" --notes-only 2>/dev/null)
+
+echo "$ATTRIBUTED" | grep -q '^- a new thing by @octocat in #42$' \
+  || fail "bullet is missing its author and PR: $(echo "$ATTRIBUTED" | grep 'a new thing')"
+
+# A commit that reached main without a PR still credits its author.
+echo "$ATTRIBUTED" | grep -q '^- an old thing by @ericgriffin$' \
+  || fail "bullet without a PR should still name the author"
+
+# The first-contribution callout goes last, after every type section.
+echo "$ATTRIBUTED" | grep -q '^### New Contributors$' \
+  || fail "New Contributors section missing"
+echo "$ATTRIBUTED" | grep -q '^- @octocat made their first contribution in #42$' \
+  || fail "first-contribution line missing or misworded"
+[ "$(echo "$ATTRIBUTED" | grep -n '^### ' | tail -1 | cut -d: -f2-)" = "### New Contributors" ] \
+  || fail "New Contributors is not the last section"
+
+# An unmapped commit renders exactly as it did before attribution existed.
+PARTIAL=$(mktemp)
+printf 'commit\t%s\t%s\t%s\n' "$FEAT_SHA" "octocat" "42" > "$PARTIAL"
+UNMAPPED=$(cd "$TMPREPO" && CHANGELOG_ATTRIBUTION_FILE="$PARTIAL" \
+  "$GEN" --notes-only 2>/dev/null)
+echo "$UNMAPPED" | grep -q '^- an old thing$' \
+  || fail "an unmapped commit must render as a plain bullet"
+echo "$UNMAPPED" | grep -q '^### New Contributors$' \
+  && fail "New Contributors must be suppressed when there are none"
+rm -f "$PARTIAL"
+
+# --no-attribution reproduces the pre-credits body byte for byte.
+PLAIN=$(cd "$TMPREPO" && CHANGELOG_ATTRIBUTION_FILE="$ATTR" \
+  "$GEN" --notes-only --no-attribution 2>/dev/null)
+echo "$PLAIN" | grep -q '@' && fail "--no-attribution still emitted a handle"
+[ "$PLAIN" = "$STDOUT" ] || fail "--no-attribution differs from the un-attributed body"
+
+# The default path resolves authorship itself. This scratch repo has no
+# remote and the test environment has no token, so it exercises the
+# degradation: notes are still produced, with no handles invented.
+DEFAULT=$(cd "$TMPREPO" && GH=/nonexistent-gh "$GEN" --notes-only 2>/dev/null)
+[ -n "$DEFAULT" ] || fail "the default path produced no notes"
+echo "$DEFAULT" | grep -q '^- a new thing' \
+  || fail "the default path lost the commit content"
+echo "$DEFAULT" | grep -q 'made their first contribution' \
+  && fail "a first contribution was claimed with no API available"
+
 echo "PASS: all generate_changelog tests passed"

--- a/scripts/release/sanitize_apple_store_notes.py
+++ b/scripts/release/sanitize_apple_store_notes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Strip non-Apple platform references out of App Store Connect note fields.
+"""Strip non-Apple platform references and contributor credits out of App Store Connect note fields.
 
 App Review guideline 2.3.10 forbids referring to other platforms in App Store
 metadata, but the text both Apple-bound note fields are generated from is
@@ -14,9 +14,14 @@ on wording. Redaction is word-level: platform names are dropped out of lists
 with a neutral phrase. The accepted trade-off is that a clause written about
 one platform can survive as a non-sequitur.
 
+The same input also carries contributor credits: the release body attributes
+every bullet to its author and closes with a New Contributors section. Those
+are removed here too, because an @handle is not a name and a PR number is not
+something a store reader can follow.
+
 Only Apple-bound text passes through here. Google Play notes, the GitHub
 release body, the Sparkle appcast and docs/releases/*.md keep every platform
-name.
+name and every credit.
 
 Usage: sanitize_apple_store_notes.py [--fallback TEXT] [--report] < in > out
 
@@ -247,6 +252,40 @@ def tidy(text):
     return text
 
 
+# " by @octocat in #42", and the shorter " by @octocat" a commit that reached
+# main without a PR gets. The "@" is what makes this safe: ordinary prose such
+# as "Reported by a tester" and "Fixes the crash described in #1182" cannot
+# match, so only a real credit is ever removed.
+_ATTRIBUTION_RE = re.compile(
+    r"[ \t]by @[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:[ \t]in #[0-9]+)?"
+)
+
+# The closing credits section, from its heading to the next heading or the end
+# of the body. Unlike every other pass here this one removes lines, which is
+# why it runs on the input before the line-count invariant is established.
+_NEW_CONTRIBUTORS_RE = re.compile(
+    r"^#{1,6}[ \t]*New Contributors[ \t]*$.*?(?=^#{1,6}[ \t]|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def strip_attribution(text):
+    """Remove contributor credits. Returns (text, number of removals).
+
+    The GitHub release body credits every bullet to its author and closes with
+    the first-time contributors, which is the point of the release page. None
+    of it belongs in App Store "What's New": an @handle is not a name, a PR
+    number is not something a store reader can follow, and the section reads as
+    project bookkeeping rather than as what changed in the app.
+
+    This is the only pass that changes the line count, so it runs before
+    sanitize() rather than inside it.
+    """
+    text, dropped = _NEW_CONTRIBUTORS_RE.subn("", text)
+    text, credits = _ATTRIBUTION_RE.subn("", text)
+    return text, dropped + credits
+
+
 def sanitize(text, terms=None):
     """Run every pass. The result may be empty; the caller supplies a fallback.
 
@@ -326,8 +365,15 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     terms = load_terms()
-    original = sys.stdin.read()
+    original, credits = strip_attribution(sys.stdin.read())
     result = sanitize(original, terms)
+
+    if credits:
+        print(
+            "sanitize_apple_store_notes: removed %d contributor credit(s)"
+            % credits,
+            file=sys.stderr,
+        )
 
     if args.report:
         _report(original, result, terms)

--- a/scripts/release/sanitize_apple_store_notes_test.py
+++ b/scripts/release/sanitize_apple_store_notes_test.py
@@ -459,6 +459,80 @@ class TestMain(unittest.TestCase):
         self.assertIn("survived", err)
 
 
+class TestStripAttribution(unittest.TestCase):
+    """Contributor credits belong in the release body, not in store copy.
+
+    The App Store "What's New" is derived from the published GitHub release
+    body, so the @handles and #PR numbers the changelog adds arrive here. They
+    mean nothing to a store reader, and an @handle is not a name.
+    """
+
+    def test_drops_handle_and_pr(self):
+        self.assertEqual(
+            san.strip_attribution("- fixed a thing by @octocat in #42")[0],
+            "- fixed a thing",
+        )
+
+    def test_drops_handle_without_a_pr(self):
+        self.assertEqual(
+            san.strip_attribution("- fixed a thing by @octo-cat")[0],
+            "- fixed a thing",
+        )
+
+    def test_leaves_ordinary_prose_alone(self):
+        for line in (
+            "Reported by a tester in the field.",
+            "Sorted by depth, then by date.",
+            "Fixes the crash described in #1182.",
+        ):
+            with self.subTest(line=line):
+                self.assertEqual(san.strip_attribution(line)[0], line)
+
+    def test_drops_the_new_contributors_section(self):
+        body = (
+            "### Bug Fixes\n"
+            "\n"
+            "- fixed a thing by @octocat in #42\n"
+            "\n"
+            "### New Contributors\n"
+            "\n"
+            "- @octocat made their first contribution in #42\n"
+        )
+        result, count = san.strip_attribution(body)
+        self.assertNotIn("New Contributors", result)
+        self.assertNotIn("@octocat", result)
+        self.assertIn("- fixed a thing", result)
+        self.assertEqual(count, 2)
+
+    def test_a_later_section_survives_the_drop(self):
+        body = (
+            "### New Contributors\n"
+            "\n"
+            "- @octocat made their first contribution in #42\n"
+            "\n"
+            "## Upgrade notes\n"
+            "\n"
+            "- the schema is unchanged\n"
+        )
+        result, _count = san.strip_attribution(body)
+        self.assertNotIn("@octocat", result)
+        self.assertIn("the schema is unchanged", result)
+
+    def test_end_to_end_through_main(self):
+        body = "- fixed a thing on Windows by @octocat in #42\n"
+        stdin, stdout = sys.stdin, sys.stdout
+        sys.stdin, sys.stdout = io.StringIO(body), io.StringIO()
+        try:
+            code = san.main([])
+            result = sys.stdout.getvalue()
+        finally:
+            sys.stdin, sys.stdout = stdin, stdout
+        self.assertEqual(code, 0)
+        self.assertNotIn("@octocat", result)
+        self.assertNotIn("#42", result)
+        self.assertNotIn("Windows", result)
+
+
 class TestReleaseNotesCorpus(unittest.TestCase):
     """The real input distribution: every historical release announcement."""
 


### PR DESCRIPTION
## Summary

Closes #1201.

Release bodies listed what changed but never who wrote it, so outside contributions were invisible on the releases page. Every bullet in the stable release notes is now credited to its author and the PR that merged it, and the body closes with a **New Contributors** section naming anyone whose first commit to the repository landed in that release.

```
### Features

- report raw O2 cell millivolts for Shearwater CCR dives by @readme42 in #1034

### New Contributors

- @dotanalon made their first contribution in #1102
- @etlami made their first contribution in #952
```

Nothing to run by hand: `promote.yml` already generates the body.

Beta notes are deliberately untouched. The per-merge beta pipeline has its own generator and its own store-caps problem, and credits belong on the public release page.

## Changes

- **New `scripts/release/contributors.sh`**, the only piece that knows about authorship. It maps a commit range to `commit<TAB>sha<TAB>login<TAB>pr` rows plus `new<TAB>login<TAB>pr` rows, from two layered sources:
  - **PR numbers come from git alone.** A merge commit records `Merge pull request #N` and its second parent names that PR's commits; a squash-merged commit carries `(#N)` in its subject instead. Either way, no network.
  - **GitHub logins come from the API**, because git records a name and an email but never a login, and an @mention that does not resolve is worse than no credit. Fallback is a login derived from a `users.noreply.github.com` address, then nothing.
  - First contributions are **only ever claimed from the API**: announcing someone as a first-time contributor when they are not is worse than saying nothing.
  - Bots keep their commit row, so the bullet still resolves, but with an empty login. They are never credited and never announced.
- **`generate_changelog.sh`** renders `- <msg> by @<login> in #<pr>`, degrading to `by @<login>` and then to a bare bullet. `--no-attribution` reproduces the previous body byte for byte; `CHANGELOG_ATTRIBUTION_FILE` injects a map so tests stay off the network. Bucketing and message parsing are unchanged.
- **`sanitize_apple_store_notes.py`** strips the handles, the PR numbers and the whole New Contributors section. App Store "What's New" is derived from the *published* release body (`promote.yml` reads it back with `gh release view`), so this is the only choke point, and the file already exists to say that a release body is not store copy. The pass runs before `sanitize()` because it is the only one that changes the line count, which `--report`'s line-by-line diff depends on.
- **`promote.yml` / `release.yml`** gain `GH_TOKEN` on their three notes-generating steps. Without it the lookup would have degraded silently to unattributed bullets.
- **`ci.yaml`** runs the new `contributors_test.sh` in `script-tests`.
- **Docs:** a Contributor credits section in `docs/developer/release-process.md`, and a `## Contributors` section added to `docs/releases/v1.7.4.6062.md` as the worked example for the announcement format.

Credits never block a release: every API failure path degrades and the script exits 0.

## Test Plan

No Dart changed (0 `.dart` files in the diff), so `flutter test` / `flutter analyze` are not the relevant gates here; the script suites are.

- [x] `scripts/release/contributors_test.sh` (new) - PR mapping offline, squash-subject recovery, bot filtering, API login precedence, first-contribution detection, a failing `gh` degrading rather than aborting, empty range. The GitHub API is stubbed via a `GH=` injection, so it never touches the network.
- [x] `scripts/release/generate_changelog_test.sh` - attribution rendering and its two degradations, New Contributors placed last and suppressed when empty, `--no-attribution` byte-identical to the old body, and the default path still producing notes with no API available.
- [x] `scripts/release/sanitize_apple_store_notes_test.py` - 56 tests including the full `docs/releases/*.md` corpus.
- [x] `beta_release_notes_test.sh`, `generate_release_notes_html_test.sh`, `generate_appcast_beta_test.sh`, `pre_push_hook_test.sh` as regression guards.
- [x] All of the above under **bash 3.2.57** with BSD `sed`/`awk`, the oldest shell this repo has to support.

Verified against real history, not only fixtures:

| Check | Result |
| --- | --- |
| `7d37e62f8^..7d37e62f8` | `steinbil` and PR `#42` recovered from a squash subject, correctly flagged as a first contribution |
| `v1.7.4.6062..HEAD` | every bullet attributed; `@dotanalon` (#1102) and `@etlami` (#952) detected as new |
| release body -> sanitizer | 436 lines carrying `@` in, 0 out, no New Contributors section |
| release body -> Sparkle HTML | New Contributors renders as a proper heading and list in the desktop update dialog |
