### PR TITLE
Show dive mode badge in dive detail header

### DIFF
--- a/lib/core/constants/dive_field_extractor.dart
+++ b/lib/core/constants/dive_field_extractor.dart
@@ -189,6 +189,8 @@ extension DiveFieldExtractor on DiveField {
         return summary.rating;
       case DiveField.isFavorite:
         return summary.isFavorite;
+      case DiveField.diveMode:
+        return summary.diveMode.name.toUpperCase();
       case DiveField.diveTypeName:
         return summary.diveTypeIds
             .map(diveTypeLabel ?? Dive.diveTypeDisplayName)

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1803,7 +1803,7 @@ class DiveRepository {
             'd.id, d.dive_number, d.name AS dive_name, '
             'd.dive_date_time, d.entry_time, '
             'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
-            'd.is_favorite, d.dive_type, '
+            'd.is_favorite, d.dive_type, d.dive_mode, '
             'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
             's.name AS site_name, s.country AS site_country, '
             's.region AS site_region, s.latitude AS site_latitude, '
@@ -2393,7 +2393,7 @@ class DiveRepository {
           'd.id, d.dive_number, d.name AS dive_name, '
           'd.dive_date_time, d.entry_time, '
           'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
-          'd.is_favorite, d.dive_type, '
+          'd.is_favorite, d.dive_type, d.dive_mode, '
           'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
           's.name AS site_name, s.country AS site_country, '
           's.region AS site_region, s.latitude AS site_latitude, '
@@ -2456,6 +2456,7 @@ class DiveRepository {
         waterTemp: row.readNullable<double>('water_temp'),
         rating: row.readNullable<int>('rating'),
         isFavorite: row.read<int>('is_favorite') == 1,
+        diveMode: DiveMode.fromCode(row.read<String>('dive_mode')),
         diveTypeIds: diveTypesByDive[id] ?? [row.read<String>('dive_type')],
         tags: tagsByDive[id] ?? [],
         siteName: row.readNullable<String>('site_name'),

--- a/lib/features/dive_log/domain/entities/dive_summary.dart
+++ b/lib/features/dive_log/domain/entities/dive_summary.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
 
@@ -20,6 +21,7 @@ class DiveSummary extends Equatable {
   final double? waterTemp;
   final int? rating;
   final bool isFavorite;
+  final DiveMode diveMode;
   final List<String> diveTypeIds;
   final List<Tag> tags;
 
@@ -49,6 +51,7 @@ class DiveSummary extends Equatable {
     this.waterTemp,
     this.rating,
     this.isFavorite = false,
+    this.diveMode = DiveMode.oc,
     this.diveTypeIds = const ['recreational'],
     this.tags = const [],
     this.siteName,
@@ -79,6 +82,7 @@ class DiveSummary extends Equatable {
       waterTemp: dive.waterTemp,
       rating: dive.rating,
       isFavorite: dive.isFavorite,
+      diveMode: dive.diveMode,
       diveTypeIds: dive.diveTypeIds,
       tags: dive.tags,
       siteName: dive.site?.name,
@@ -129,6 +133,7 @@ class DiveSummary extends Equatable {
     double? waterTemp,
     int? rating,
     bool? isFavorite,
+    DiveMode? diveMode,
     List<String>? diveTypeIds,
     List<Tag>? tags,
     String? siteName,
@@ -151,6 +156,7 @@ class DiveSummary extends Equatable {
       waterTemp: waterTemp ?? this.waterTemp,
       rating: rating ?? this.rating,
       isFavorite: isFavorite ?? this.isFavorite,
+      diveMode: diveMode ?? this.diveMode,
       diveTypeIds: diveTypeIds ?? this.diveTypeIds,
       tags: tags ?? this.tags,
       siteName: siteName ?? this.siteName,
@@ -176,6 +182,7 @@ class DiveSummary extends Equatable {
     waterTemp,
     rating,
     isFavorite,
+    diveMode,
     diveTypeIds,
     tags,
     siteName,

--- a/lib/features/dive_log/domain/entities/view_field_config.dart
+++ b/lib/features/dive_log/domain/entities/view_field_config.dart
@@ -55,7 +55,7 @@ class TableViewConfig extends Equatable {
     this.sortAscending = true,
   });
 
-  /// Default table configuration with 22 standard columns.
+  /// Default table configuration with 23 standard columns.
   factory TableViewConfig.defaultConfig() {
     return TableViewConfig(
       columns: [
@@ -64,6 +64,7 @@ class TableViewConfig extends Equatable {
         TableColumnConfig(field: DiveField.siteName, isPinned: true),
         TableColumnConfig(field: DiveField.dateTime),
         TableColumnConfig(field: DiveField.diveTypeName),
+        TableColumnConfig(field: DiveField.diveMode),
         TableColumnConfig(field: DiveField.maxDepth),
         TableColumnConfig(field: DiveField.avgDepth),
         TableColumnConfig(field: DiveField.runtime),
@@ -290,6 +291,7 @@ class FieldPreset extends Equatable {
         TableColumnConfig(field: DiveField.siteName, isPinned: true),
         TableColumnConfig(field: DiveField.dateTime),
         TableColumnConfig(field: DiveField.diveTypeName),
+        TableColumnConfig(field: DiveField.diveMode),
         TableColumnConfig(field: DiveField.maxDepth),
         TableColumnConfig(field: DiveField.avgDepth),
         TableColumnConfig(field: DiveField.runtime),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -36,6 +36,8 @@ import 'package:submersion/features/dive_log/presentation/formatters/dive_mode_l
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_detail_ui_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badge.dart';
+import 'package:submersion/shared/utils/ink_centered_text_style.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_nav_buttons.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_analysis_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
@@ -1223,9 +1225,9 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   ],
                 ),
               ),
-              if (dive.rating != null)
-                Row(
-                  children: [
+              Row(
+                children: [
+                  if (dive.rating != null) ...[
                     ExcludeSemantics(
                       child: Icon(
                         Icons.star,
@@ -1236,10 +1238,20 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                     const SizedBox(width: 4),
                     Text(
                       '${dive.rating}',
-                      style: Theme.of(context).textTheme.titleMedium,
+                      // Same ink-centering fix as DiveModeBadge: without it
+                      // this number's default line leading isn't split
+                      // evenly around its own glyph, so it doesn't sit on
+                      // the same visual line as the star icon next to it.
+                      style: Theme.of(
+                        context,
+                      ).textTheme.titleMedium?.inkCentered,
+                      textHeightBehavior: inkCenteredTextHeightBehavior,
                     ),
+                    const SizedBox(width: 8),
                   ],
-                ),
+                  DiveModeBadge(mode: dive.diveMode),
+                ],
+              ),
             ],
           ),
           const SizedBox(height: 16),

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_field.dart';
 import 'package:submersion/core/constants/dive_search.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/constants/map_tile_config.dart';
@@ -24,6 +25,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/add_dive_botto
 import 'package:submersion/features/dive_log/presentation/widgets/dive_filter_sheet.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_list_content.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_map_content.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badge.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_numbering_dialog.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_chart.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/dive_profile_panel.dart';
@@ -35,6 +37,7 @@ import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
+import 'package:submersion/shared/utils/ink_centered_text_style.dart';
 import 'package:submersion/shared/widgets/debounced_search_results.dart';
 import 'package:submersion/shared/widgets/list_view_mode_toggle.dart';
 import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
@@ -850,6 +853,7 @@ class DiveListTile extends ConsumerWidget {
           final chartWidth = availableWidth < 400
               ? (availableWidth * 0.25).clamp(60.0, 120.0)
               : (availableWidth * 0.20).clamp(80.0, 120.0);
+          final titleStyle = Theme.of(context).textTheme.titleMedium;
 
           return Padding(
             padding: const EdgeInsets.all(12),
@@ -903,12 +907,24 @@ class DiveListTile extends ConsumerWidget {
                               Expanded(
                                 child: Text(
                                   buildTitleText(),
-                                  style: Theme.of(context).textTheme.titleMedium
+                                  // Same ink-centering fix as DiveModeBadge
+                                  // and the header's rating number, but
+                                  // without shrinking the space this line
+                                  // occupies: strutStyle pins the reserved
+                                  // line height to titleMedium's own natural
+                                  // value (so the date line below doesn't
+                                  // shift up) while textHeightBehavior only
+                                  // repositions the ink within that space.
+                                  style: titleStyle
                                       ?.copyWith(
                                         fontWeight: FontWeight.w600,
                                         color: primaryTextColor,
-                                      ),
+                                      )
+                                      .inkCentered,
                                   overflow: TextOverflow.ellipsis,
+                                  textHeightBehavior:
+                                      inkCenteredTextHeightBehavior,
+                                  strutStyle: titleStyle?.preservingStrut,
                                 ),
                               ),
                               if (isFavorite) ...[
@@ -957,6 +973,11 @@ class DiveListTile extends ConsumerWidget {
                                       ),
                                 ),
                               ],
+                              const SizedBox(width: 8),
+                              DiveModeBadge(
+                                mode: summary?.diveMode ?? DiveMode.oc,
+                                dense: true,
+                              ),
                             ],
                           ),
                           // Site location (country/region)

--- a/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
+++ b/lib/features/dive_log/presentation/widgets/compact_dive_list_tile.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
 import 'package:submersion/features/dive_log/presentation/formatters/dive_type_label_resolver.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_mode_badge.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
@@ -317,11 +319,19 @@ class CompactDiveListTile extends ConsumerWidget {
                         ),
                       ],
                       const SizedBox(width: 8),
-                      Text(
-                        dateText,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: secondaryTextColor,
+                      Flexible(
+                        child: Text(
+                          dateText,
+                          style: Theme.of(context).textTheme.bodySmall
+                              ?.copyWith(color: secondaryTextColor),
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
                         ),
+                      ),
+                      const SizedBox(width: 6),
+                      DiveModeBadge(
+                        mode: summary?.diveMode ?? DiveMode.oc,
+                        dense: true,
                       ),
                       ExcludeSemantics(
                         child: Icon(

--- a/lib/features/dive_log/presentation/widgets/dive_mode_badge.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_mode_badge.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/shared/utils/ink_centered_text_style.dart';
+
+/// Short-code badge (OC/CCR/SCR/GAUGE) for a dive's [DiveMode].
+///
+/// Uses the same abbreviation convention as [DiveModeSelector]'s segmented
+/// button labels rather than the full localized name, since these are widely
+/// recognized diving-community abbreviations.
+class DiveModeBadge extends StatelessWidget {
+  final DiveMode mode;
+
+  /// Tighter padding and type scale for list rows, where the full-size badge
+  /// (used in the dive detail header) would crowd the line.
+  final bool dense;
+
+  const DiveModeBadge({super.key, required this.mode, this.dense = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    // Non-dense sits next to the header's rating number (titleMedium) --
+    // close to that size rather than the smaller labelSmall default, but a
+    // touch under it so the badge doesn't outweigh the number.
+    final fontSize = dense
+        ? 10.0
+        : (Theme.of(context).textTheme.titleMedium?.fontSize ?? 16) - 3;
+    return Container(
+      // Vertical padding is deliberately asymmetric: even with
+      // textHeightBehavior forcing a tight ascent/descent box, the ink still
+      // renders a hair low within it (font hinting residual), so the box
+      // itself compensates with less padding above than below.
+      padding: EdgeInsets.only(
+        left: dense ? 3 : 4,
+        right: dense ? 3 : 4,
+        top: dense ? 1.5 : 2.5,
+        bottom: dense ? 2.5 : 3.5,
+      ),
+      decoration: BoxDecoration(
+        border: Border.all(color: colorScheme.outline),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        mode.name.toUpperCase(),
+        // Only visible next to a taller sibling (the header's star icon):
+        // alone, the badge is the only thing setting its row's height so any
+        // internal ink offset is invisible; next to the icon there's slack
+        // above/below and the ink turns out not to be centered in it.
+        style: Theme.of(context).textTheme.labelSmall
+            ?.copyWith(
+              fontSize: fontSize,
+              color: colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.bold,
+            )
+            .inkCentered,
+        textHeightBehavior: inkCenteredTextHeightBehavior,
+      ),
+    );
+  }
+}

--- a/lib/shared/utils/ink_centered_text_style.dart
+++ b/lib/shared/utils/ink_centered_text_style.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+/// Collapses a font's default ascent/descent leading so a [Text]'s ink sits
+/// centered in a tight box, instead of leaning on the font's own (often
+/// asymmetric) leading. Pair with [InkCenteredTextStyle.inkCentered] on the
+/// [Text]'s `style`.
+///
+/// Needed for short, isolated text next to a box-tight sibling (an icon, a
+/// bordered badge) -- the offset is invisible until something else on the
+/// same line gives the eye a true center line to compare against.
+const inkCenteredTextHeightBehavior = TextHeightBehavior(
+  applyHeightToFirstAscent: false,
+  applyHeightToLastDescent: false,
+);
+
+extension InkCenteredTextStyle on TextStyle {
+  /// This style with `height` pinned to 1, for use with
+  /// [inkCenteredTextHeightBehavior].
+  TextStyle get inkCentered => copyWith(height: 1);
+
+  /// A [StrutStyle] that reserves this (pre-[inkCentered]) style's own line
+  /// height, so switching a [Text] to [inkCentered] repositions its ink
+  /// without shrinking the space it occupies in its parent layout -- e.g. a
+  /// title line above a sibling line, which would otherwise shift up.
+  StrutStyle get preservingStrut =>
+      StrutStyle(fontSize: fontSize, height: height, forceStrutHeight: true);
+}

--- a/test/features/dive_log/domain/entities/view_field_config_test.dart
+++ b/test/features/dive_log/domain/entities/view_field_config_test.dart
@@ -78,7 +78,7 @@ void main() {
   group('TableViewConfig', () {
     test('defaultConfig has expected columns', () {
       final config = TableViewConfig.defaultConfig();
-      expect(config.columns.length, equals(22));
+      expect(config.columns.length, equals(23));
       expect(config.columns[0].field, equals(DiveField.diveNumber));
       expect(config.columns[0].isPinned, isTrue);
       expect(config.columns[1].field, equals(DiveField.siteName));
@@ -86,16 +86,17 @@ void main() {
       // Core fields
       expect(config.columns[2].field, equals(DiveField.dateTime));
       expect(config.columns[3].field, equals(DiveField.diveTypeName));
-      expect(config.columns[6].field, equals(DiveField.runtime));
+      expect(config.columns[4].field, equals(DiveField.diveMode));
+      expect(config.columns[7].field, equals(DiveField.runtime));
       // Gas/Tank fields
-      expect(config.columns[8].field, equals(DiveField.primaryGas));
-      expect(config.columns[11].field, equals(DiveField.sacRate));
+      expect(config.columns[9].field, equals(DiveField.primaryGas));
+      expect(config.columns[12].field, equals(DiveField.sacRate));
       // Environment fields
-      expect(config.columns[12].field, equals(DiveField.waterTemp));
+      expect(config.columns[13].field, equals(DiveField.waterTemp));
       // People fields
-      expect(config.columns[16].field, equals(DiveField.buddy));
+      expect(config.columns[17].field, equals(DiveField.buddy));
       // Metadata fields
-      expect(config.columns[21].field, equals(DiveField.notes));
+      expect(config.columns[22].field, equals(DiveField.notes));
       expect(config.sortField, isNull);
       expect(config.sortAscending, isTrue);
     });
@@ -603,11 +604,11 @@ void main() {
   });
 
   group('FieldPreset edge cases', () {
-    test('Standard preset has 22 columns with category grouping', () {
+    test('Standard preset has 23 columns with category grouping', () {
       final presets = FieldPreset.builtInTablePresets();
       final standard = presets.firstWhere((p) => p.name == 'Standard');
       final config = TableViewConfig.fromJson(standard.configJson);
-      expect(config.columns.length, equals(22));
+      expect(config.columns.length, equals(23));
       final fields = config.columns.map((c) => c.field).toList();
       // Verify key fields from each category are present
       expect(fields, contains(DiveField.waterTemp));

--- a/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/constants/buhlmann_coefficients.dart';
 import 'package:submersion/core/deco/entities/deco_status.dart';
@@ -1562,6 +1563,24 @@ void main() {
 
       chart.onSafetyFindingTap!(finding);
       expect(container.read(selectedSafetyFindingProvider(dive.id)), isNull);
+    });
+  });
+
+  group('DiveDetailPage dive mode badge', () {
+    testWidgets('shows the short code for a CCR dive', (tester) async {
+      final dive = createTestDiveWithBottomTime().copyWith(
+        diveMode: DiveMode.ccr,
+      );
+      await _pumpDetailPage(tester, dive);
+
+      expect(find.text('CCR'), findsOneWidget);
+    });
+
+    testWidgets('shows OC for the default open-circuit dive', (tester) async {
+      final dive = createTestDiveWithBottomTime();
+      await _pumpDetailPage(tester, dive);
+
+      expect(find.text('OC'), findsOneWidget);
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_list_tile_slots_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
@@ -174,6 +175,40 @@ void main() {
         findsOneWidget,
       );
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('DiveListTile dive mode badge', () {
+    testWidgets('shows the short code from the summary', (tester) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: CardViewConfig.defaultDetailed(),
+          diveSummary: DiveSummary(
+            id: 'd1',
+            diveNumber: 7,
+            dateTime: DateTime(2024, 6, 1),
+            siteName: 'Blue Hole',
+            maxDepth: 30.0,
+            sortTimestamp: 0,
+            diveMode: DiveMode.ccr,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('CCR'), findsOneWidget);
+    });
+
+    testWidgets('defaults to OC when the summary omits a mode', (tester) async {
+      await tester.pumpWidget(
+        buildTile(
+          config: CardViewConfig.defaultDetailed(),
+          diveSummary: summary(siteName: 'Blue Hole'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('OC'), findsOneWidget);
     });
   });
 }

--- a/test/features/dive_log/presentation/providers/view_config_providers_test.dart
+++ b/test/features/dive_log/presentation/providers/view_config_providers_test.dart
@@ -171,7 +171,7 @@ void main() {
       notifier.applyPreset(standard);
 
       final config = notifier.state;
-      expect(config.columns.length, equals(22));
+      expect(config.columns.length, equals(23));
       expect(config.columns.any((c) => c.field == DiveField.sacRate), isTrue);
       expect(config.columns.any((c) => c.field == DiveField.waterTemp), isTrue);
     });

--- a/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
+++ b/test/features/dive_log/presentation/widgets/compact_dive_list_tile_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/dive_field.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_summary.dart';
@@ -47,6 +48,31 @@ void main() {
       expect(find.text('Blue Corner Wall'), findsOneWidget);
       expect(find.textContaining('28'), findsWidgets);
       expect(find.textContaining('52'), findsWidgets);
+      // No summary provided -- defaults to the open-circuit badge.
+      expect(find.text('OC'), findsOneWidget);
+    });
+
+    testWidgets('shows the dive mode badge from the summary', (tester) async {
+      await tester.pumpWidget(
+        testApp(
+          overrides: [
+            settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+          ],
+          child: CompactDiveListTile(
+            diveId: 'test-id',
+            diveNumber: 7,
+            dateTime: DateTime(2026, 3, 15, 9, 30),
+            summary: DiveSummary(
+              id: 'test-id',
+              dateTime: DateTime(2026, 3, 15, 9, 30),
+              sortTimestamp: 0,
+              diveMode: DiveMode.ccr,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('CCR'), findsOneWidget);
     });
 
     testWidgets('large dive number stays on one line and scales to fit', (


### PR DESCRIPTION
## Summary
Adds a short-code badge (OC/CCR/SCR/GAUGE) next to the dive title in the dive detail header, so the dive type is visible at a glance without opening the Details section.

### Screenshots

Compact list view
<img width="2567" height="1342" alt="image" src="https://github.com/user-attachments/assets/5a1f4af8-081b-4d1d-a5d6-ae7f18d5c389" />

Detail list view
<img width="2567" height="1342" alt="image" src="https://github.com/user-attachments/assets/ade50b55-269d-4021-b1e1-fe18156cbbcc" />

Table list view 
<img width="2567" height="1342" alt="image" src="https://github.com/user-attachments/assets/6225dda6-66b2-4319-9723-748ff3e50164" />

## Test plan
- [x] `flutter analyze` clean on the changed file
- [x] New widget tests assert the badge text for CCR and default OC dives
- [x] Full affected-test suite passed via pre-push hook

Closes #1200