### PR TITLE
fix(dive-detail): show the linked training course in read-only mode

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -4947,49 +4947,63 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // spaceBetween with two loose Flexible children, never a Spacer:
+            // a Spacer is tight and claims its half of the free space whether
+            // or not the chip needs it, which both strands a gap after the
+            // chip and leaves the chip itself unbounded. An unbounded chip
+            // overflowed this header by 15px on a phone-width pane as soon as
+            // the course name ran past a word or two.
             Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  context.l10n.diveLog_detail_section_trainingSignature,
-                  style: Theme.of(context).textTheme.titleMedium,
+                Flexible(
+                  child: Text(
+                    context.l10n.diveLog_detail_section_trainingSignature,
+                    style: Theme.of(context).textTheme.titleMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
-                const Spacer(),
                 if (courseAsync.hasValue && courseAsync.value != null) ...[
-                  Semantics(
-                    button: true,
-                    label: context.l10n.diveLog_detail_semantics_viewCourse(
-                      courseAsync.value!.name,
-                    ),
-                    child: InkWell(
-                      onTap: () =>
-                          context.push('/courses/${courseAsync.value!.id}'),
-                      borderRadius: BorderRadius.circular(8),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 4,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colorScheme.primaryContainer,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(
-                              Icons.school,
-                              size: 14,
-                              color: colorScheme.onPrimaryContainer,
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              courseAsync.value!.name,
-                              style: Theme.of(context).textTheme.labelSmall
-                                  ?.copyWith(
-                                    color: colorScheme.onPrimaryContainer,
-                                  ),
-                            ),
-                          ],
+                  Flexible(
+                    child: Semantics(
+                      button: true,
+                      label: context.l10n.diveLog_detail_semantics_viewCourse(
+                        courseAsync.value!.name,
+                      ),
+                      child: InkWell(
+                        onTap: () =>
+                            context.push('/courses/${courseAsync.value!.id}'),
+                        borderRadius: BorderRadius.circular(8),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colorScheme.primaryContainer,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.school,
+                                size: 14,
+                                color: colorScheme.onPrimaryContainer,
+                              ),
+                              const SizedBox(width: 4),
+                              Flexible(
+                                child: Text(
+                                  courseAsync.value!.name,
+                                  style: Theme.of(context).textTheme.labelSmall
+                                      ?.copyWith(
+                                        color: colorScheme.onPrimaryContainer,
+                                      ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -3080,6 +3080,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             ),
             if (dive.trip != null) _buildTripRow(context, dive),
             if (dive.diveCenter != null) _buildDiveCenterRow(context, dive),
+            if (dive.courseId != null) _buildCourseRow(context, ref, dive),
             if (dive.visibility != null)
               _buildDetailRow(
                 context,
@@ -4311,6 +4312,63 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                     ),
                   ),
                 ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Training-course row for the Details card (#1219).
+  ///
+  /// The linked course used to surface only as a chip in the Signatures card
+  /// header, which is an optional section far down the page, so read-only
+  /// viewers had no way to see the link short of opening the edit form.
+  /// Callers gate on `dive.courseId != null`, so the provider is only reached
+  /// for dives that actually carry a link; the row stays empty until the
+  /// lookup resolves rather than reserving blank space.
+  Widget _buildCourseRow(BuildContext context, WidgetRef ref, Dive dive) {
+    final course = ref.watch(courseForDiveProvider(dive.id)).valueOrNull;
+    if (course == null) return const SizedBox.shrink();
+
+    return Semantics(
+      button: true,
+      label: context.l10n.diveLog_detail_semantics_viewCourse(course.name),
+      child: InkWell(
+        onTap: () => context.push('/courses/${course.id}'),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                context.l10n.diveLog_edit_section_trainingCourse,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Flexible(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        course.name,
+                        style: Theme.of(context).textTheme.bodyMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    ExcludeSemantics(
+                      child: Icon(
+                        Icons.chevron_right,
+                        size: 16,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),

--- a/test/features/dive_log/presentation/pages/dive_detail_course_row_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_course_row_test.dart
@@ -82,6 +82,11 @@ void main() {
         ],
         child: MaterialApp.router(
           routerConfig: router,
+          // Pinned: an unpinned MaterialApp resolves against the HOST
+          // machine's locale list, and this app ships 11 locales, so the
+          // English literals below would vanish for a contributor whose
+          // primary locale is one of them.
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
         ),
@@ -96,7 +101,6 @@ void main() {
 
     expect(find.text('Training Course'), findsOneWidget);
     expect(find.text('Advanced Open Water'), findsWidgets);
-    tester.takeException();
   });
 
   testWidgets('Details card omits the course row when none is linked', (
@@ -105,22 +109,18 @@ void main() {
     await pumpDetail(tester, diveWith());
 
     expect(find.text('Training Course'), findsNothing);
-    tester.takeException();
   });
 
   testWidgets('tapping the course row opens the course', (tester) async {
     await pumpDetail(tester, diveWith(courseId: course.id));
 
-    final row = find.ancestor(
-      of: find.text('Training Course'),
-      matching: find.byType(InkWell),
-    );
-    expect(row, findsWidgets);
-    tester.widget<InkWell>(row.first).onTap!();
+    // Drive a REAL pointer rather than invoking InkWell.onTap directly: the
+    // row sits inside a Card full of stacked decorated boxes, and only a real
+    // tap proves it is not a hit-test dead zone.
+    await tester.tap(find.text('Training Course'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('COURSE_STUB_PAGE'), findsOneWidget);
-    tester.takeException();
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_course_row_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_course_row_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/courses/domain/entities/course.dart';
+import 'package:submersion/features/courses/presentation/providers/course_providers.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// #1219: a dive linked to a training course showed the link only in edit
+/// mode. The read-only Details card now carries a Training Course row next to
+/// Trip and Dive Center.
+void main() {
+  final course = Course(
+    id: 'course-1',
+    diverId: 'diver-1',
+    name: 'Advanced Open Water',
+    agency: CertificationAgency.padi,
+    startDate: DateTime(2023, 1, 1),
+    createdAt: DateTime(2023, 1, 1),
+    updatedAt: DateTime(2023, 1, 1),
+  );
+
+  Dive diveWith({String? courseId}) => Dive(
+    id: 'dive-1',
+    diveNumber: 1,
+    dateTime: DateTime(2023, 1, 1),
+    courseId: courseId,
+  );
+
+  Future<void> pumpDetail(WidgetTester tester, Dive dive) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(600, 2400);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final overrides = await getBaseOverrides();
+
+    final router = GoRouter(
+      initialLocation: '/test',
+      routes: [
+        GoRoute(
+          path: '/test',
+          builder: (context, state) => DiveDetailPage(diveId: dive.id),
+        ),
+        GoRoute(
+          path: '/courses/:id',
+          builder: (context, state) =>
+              const Scaffold(body: Text('COURSE_STUB_PAGE')),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides,
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+          diveDataSourcesProvider(
+            dive.id,
+          ).overrideWith((ref) async => <DiveDataSource>[]),
+          courseForDiveProvider(
+            dive.id,
+          ).overrideWith((ref) async => dive.courseId == null ? null : course),
+          // The Signatures card also renders once a course is linked; stub its
+          // dependencies so the test never reaches a real repository.
+          signatureForDiveProvider(dive.id).overrideWith((ref) async => null),
+          buddiesForDiveProvider(
+            dive.id,
+          ).overrideWith((ref) async => <BuddyWithRole>[]),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  testWidgets('Details card shows the linked training course', (tester) async {
+    await pumpDetail(tester, diveWith(courseId: course.id));
+
+    expect(find.text('Training Course'), findsOneWidget);
+    expect(find.text('Advanced Open Water'), findsWidgets);
+    tester.takeException();
+  });
+
+  testWidgets('Details card omits the course row when none is linked', (
+    tester,
+  ) async {
+    await pumpDetail(tester, diveWith());
+
+    expect(find.text('Training Course'), findsNothing);
+    tester.takeException();
+  });
+
+  testWidgets('tapping the course row opens the course', (tester) async {
+    await pumpDetail(tester, diveWith(courseId: course.id));
+
+    final row = find.ancestor(
+      of: find.text('Training Course'),
+      matching: find.byType(InkWell),
+    );
+    expect(row, findsWidgets);
+    tester.widget<InkWell>(row.first).onTap!();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('COURSE_STUB_PAGE'), findsOneWidget);
+    tester.takeException();
+  });
+}


### PR DESCRIPTION
Closes #1219.

## Problem

A dive linked to a training course showed no sign of that link in read-only
mode. The only way to discover it was to open the dive in edit mode.

The link was not actually missing from the page: it rendered as a chip in the
header of the **Signatures** card (`_buildSignatureSection`). That card is
doubly buried, though. It is an optional section users can switch off in
Settings > Dive Detail Sections, and even when enabled it sits far down the
page beside Buddies. A diver who had disabled Signatures had no read-only
surface for the course link anywhere.

## Change

Adds a **Training Course** row to the read-only Details card, immediately
after Trip and Dive Center, which is where the reporter suggested it belongs.
The row shows the course name with a chevron and taps through to
`/courses/<id>`.

- Gated on `dive.courseId != null`, so dives without a course never reach
  `courseForDiveProvider` and their Details card is byte-identical to before.
- Reuses the existing `diveLog_edit_section_trainingCourse` and
  `diveLog_detail_semantics_viewCourse` keys, so there are no new ARB strings
  and no translation fan-out across locale files.
- The value group is wrapped in `Flexible` so a long course name ellipsizes
  instead of overflowing a narrow pane. (`_buildDiveCenterRow` puts a bare
  inner `Row` in a `spaceBetween` parent, which works only because dive-center
  names are short.)
- Uses `.valueOrNull` rather than a spinner or error string, so the card grows
  once as the lookup lands instead of jumping mid-render. Same behavior the
  page already has for `surfaceIntervalProvider`.

The Signatures chip stays as it is. It is meaningful in that context, naming
the course the instructor signature belongs to.

## Tests

New `test/features/dive_log/presentation/pages/dive_detail_course_row_test.dart`,
written before the fix and confirmed red first (2 of 3 failing):

- Details card shows the linked training course
- Details card omits the row entirely when no course is linked
- tapping the course row opens the course page

## Verification

- `dart format lib test`: clean, 0 files changed
- `flutter analyze`: no issues found
- Full `flutter test`: 19671 passed, 0 failed

One full-suite run failed a single unrelated sync test
(`sync_replace_library_test.dart`, "replaceCloudLibraryFromThisDevice without
a provider it errors and mints nothing"). It passes in isolation and the
whole suite passes clean on a re-run, so it is a load-only flake, not this
diff. There is no causal path from a presentation widget to the sync
replace-library service.

## Out of scope

- The Details section's settings blurb still reads "Type, location, trip,
  dive center, interval". It is already non-exhaustive (it omits visibility,
  avg depth, water type, buddy, SAC, GF), and changing it means editing every
  locale file.
- No change to the PDF logbook export or the dive table columns. The issue
  was scoped to the detail view.
