### PR TITLE
feat(dive-log): edit buddy roles and My role in the bulk dive editor

### DIFF
--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -645,6 +645,44 @@ class BuddyRepository {
     }
   }
 
+  /// Rewrite the role on the links each dive ALREADY has for [buddies],
+  /// inserting nothing. The role-only counterpart to [bulkAddBuddies]: a dive
+  /// the buddy is missing from stays missing, so changing someone's role
+  /// across a mixed selection cannot quietly add them to the rest (#1220).
+  ///
+  /// No notify/transaction; the caller wraps this like every other bulk op.
+  Future<void> bulkUpdateBuddyRoles(
+    List<String> diveIds,
+    List<domain.BuddyWithRole> buddies,
+  ) async {
+    if (diveIds.isEmpty || buddies.isEmpty) return;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final touched = <String>{};
+    for (final bwr in buddies) {
+      final existing =
+          await (_db.select(_db.diveBuddies)..where(
+                (t) => t.diveId.isIn(diveIds) & t.buddyId.equals(bwr.buddy.id),
+              ))
+              .get();
+      if (existing.isEmpty) continue;
+      await (_db.update(_db.diveBuddies)..where(
+            (t) => t.diveId.isIn(diveIds) & t.buddyId.equals(bwr.buddy.id),
+          ))
+          .write(DiveBuddiesCompanion(role: Value(bwr.role.id)));
+      for (final row in existing) {
+        await _syncRepository.markRecordPending(
+          entityType: 'diveBuddies',
+          recordId: row.id,
+          localUpdatedAt: now,
+        );
+        touched.add(row.diveId);
+      }
+    }
+    for (final diveId in touched) {
+      await _bumpDive(diveId, now);
+    }
+  }
+
   /// Remove each buddy id from every dive. No notify/transaction.
   Future<void> bulkRemoveBuddies(
     List<String> diveIds,

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -282,8 +282,11 @@ class BulkDiveEditService {
           case BulkCollectionMode.replace:
             await _buddyRepo.bulkReplaceBuddies(ids, buddies);
           case BulkCollectionMode.update:
-            // A role change travels as an add with overwriteRole (#893).
-            throw UnsupportedError('Buddies have no in-place update');
+            // Role-only: rewrite the links each dive already has and insert
+            // nothing, so re-roling a buddy who is on some of the selection
+            // cannot add them to the rest (#1220). A role change that SHOULD
+            // travel with membership still rides add + overwriteRole (#893).
+            await _buddyRepo.bulkUpdateBuddyRoles(ids, buddies);
         }
       // Owned collections never support remove; reject it explicitly so a
       // misconstructed op fails fast instead of silently doing an add. Tanks

--- a/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
+++ b/lib/features/dive_log/data/services/bulk_dive_edit_service.dart
@@ -283,9 +283,10 @@ class BulkDiveEditService {
             await _buddyRepo.bulkReplaceBuddies(ids, buddies);
           case BulkCollectionMode.update:
             // Role-only: rewrite the links each dive already has and insert
-            // nothing, so re-roling a buddy who is on some of the selection
-            // cannot add them to the rest (#1220). A role change that SHOULD
-            // travel with membership still rides add + overwriteRole (#893).
+            // nothing, so changing the role of a buddy who is on some of the
+            // selection cannot add them to the rest (#1220). A role change
+            // that SHOULD travel with membership still rides
+            // add + overwriteRole (#893).
             await _buddyRepo.bulkUpdateBuddyRoles(ids, buddies);
         }
       // Owned collections never support remove; reject it explicitly so a

--- a/lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart
+++ b/lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart
@@ -39,6 +39,11 @@ enum BulkField {
   diluentGas,
   scrubberType,
   scrubberDuration,
+
+  /// The active diver's own role on the dive. Lives in the Buddies group of
+  /// the form even though it is a scalar column, because that is where the
+  /// single-dive editor puts it (#1220).
+  diverRole,
   notes,
 }
 
@@ -91,6 +96,7 @@ class BulkScalarInputs {
     this.diluentHe,
     this.scrubberType,
     this.scrubberDuration,
+    this.diverRoleId,
     this.notes,
   });
 
@@ -132,6 +138,9 @@ class BulkScalarInputs {
   final double? diluentHe;
   final String? scrubberType;
   final int? scrubberDuration;
+
+  /// dive_roles id for the active diver's own role, or null to clear it.
+  final String? diverRoleId;
   final String? notes;
 }
 
@@ -213,6 +222,7 @@ DivesCompanion buildScalarCompanion(
       BulkField.scrubberDuration => c.copyWith(
         scrubberDurationMinutes: Value(i.scrubberDuration),
       ),
+      BulkField.diverRole => c.copyWith(diverRole: Value(i.diverRoleId)),
       BulkField.notes => c.copyWith(notes: Value(i.notes ?? '')),
     };
   }

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -20,6 +20,9 @@ import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/presentation/formatters/visibility_display.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/dive_roles/presentation/dive_role_display.dart';
+import 'package:submersion/features/dive_roles/presentation/providers/dive_role_providers.dart';
+import 'package:submersion/features/dive_roles/presentation/widgets/dive_role_selector_sheet.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
 import 'package:submersion/features/buddies/presentation/widgets/buddy_picker.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
@@ -1105,6 +1108,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       diveCenterId: _selectedDiveCenter?.id,
       tripId: _selectedTrip?.id,
       courseId: _selectedCourse?.id,
+      diverRoleId: _diverRoleId,
       rating: _rating > 0 ? _rating : null,
       isFavorite: _bulkFavorite,
       waterType: _waterType?.name,
@@ -1187,6 +1191,39 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         if (mode != null) editor,
       ],
     );
+  }
+
+  /// Localized name of the role currently staged for the bulk "My role" gate,
+  /// or null when no role is staged (the row then shows its placeholder).
+  String? _bulkDiverRoleLabel() {
+    // Watched before the null check so the row stays subscribed while no role
+    // is staged and relabels itself once the role list resolves.
+    final rolesById =
+        ref.watch(diveRoleMapProvider).value ?? const <String, DiveRole>{};
+    final id = _diverRoleId;
+    if (id == null) return null;
+    return (rolesById[id] ?? DiveRole.synthetic(id)).localizedName(
+      context.l10n,
+    );
+  }
+
+  Future<void> _showBulkDiverRolePicker() async {
+    // Awaited rather than read off the AsyncValue: nothing here watches the
+    // role list, so a plain read can hand back a still-loading empty list.
+    final roles = await ref.read(allDiveRolesProvider.future);
+    if (!mounted) return;
+    final selection = await showDiveRoleSelector(
+      context,
+      title: context.l10n.buddies_picker_selectMyRole,
+      roles: roles,
+      allowNone: true,
+      selectedRoleId: _diverRoleId,
+    );
+    if (selection == null || !mounted) return;
+    setState(() {
+      _markDirty();
+      _diverRoleId = selection.role?.id;
+    });
   }
 
   Widget _bulkTanksEditor(UnitFormatter units) {
@@ -1283,6 +1320,24 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           counts: _buddyCounts,
           onAdd: _bulkAddBuddies,
           onChanged: (d) => setState(() => _buddyDelta = d),
+        ),
+        // The diver's own role is a scalar column, not a membership row, so it
+        // rides the gate lane. It sits with Buddies because that is where the
+        // single-dive editor keeps it (#1220).
+        _gatedRow(
+          BulkField.diverRole,
+          FormRow.picker(
+            label: l10n.diveLog_bulkEdit_fieldMyRole,
+            value: _bulkDiverRoleLabel(),
+            placeholder: l10n.diveLog_edit_row_notSet,
+            onTap: _showBulkDiverRolePicker,
+            onClear: _diverRoleId == null
+                ? null
+                : () => setState(() {
+                    _markDirty();
+                    _diverRoleId = null;
+                  }),
+          ),
         ),
         _collectionEntry(
           type: BulkCollectionType.weights,

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1226,6 +1226,49 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     });
   }
 
+  /// The role id to show for a buddy row, or null when the selection has no
+  /// single answer: the buddy's links disagree across the selected dives, so
+  /// [_existingBuddyRoleIds] (unanimous only) has nothing for them.
+  String? _bulkBuddyRoleId(String id) {
+    final picked = _buddyRoleById[id];
+    if (picked != null) return picked.id;
+    final existing = _existingBuddyRoleIds[id];
+    if (existing != null) return existing;
+    // Not on any selected dive yet (a fresh picker add): the link the save
+    // will create defaults to Buddy, so say so rather than "Mixed".
+    return (_buddyCounts[id] ?? 0) == 0 ? DiveRole.buddyId : null;
+  }
+
+  String _bulkBuddyRoleLabel(String id) {
+    final rolesById =
+        ref.watch(diveRoleMapProvider).value ?? const <String, DiveRole>{};
+    final roleId = _bulkBuddyRoleId(id);
+    if (roleId == null) return context.l10n.diveLog_bulkEdit_buddyRoleMixed;
+    return (rolesById[roleId] ?? DiveRole.synthetic(roleId)).localizedName(
+      context.l10n,
+    );
+  }
+
+  Future<void> _showBulkBuddyRolePicker(BulkMembershipItem item) async {
+    final roles = await ref.read(allDiveRolesProvider.future);
+    if (!mounted) return;
+    final selection = await showDiveRoleSelector(
+      context,
+      title: context.l10n.buddies_picker_selectRole(item.label),
+      roles: roles,
+      selectedRoleId: _bulkBuddyRoleId(item.id),
+      onCreateCustomRole: (name) => ref
+          .read(diveRoleListNotifierProvider.notifier)
+          .addDiveRoleByName(name),
+    );
+    final role = selection?.role;
+    if (role == null || !mounted) return;
+    setState(() {
+      _markDirty();
+      _buddyRoleById[item.id] = role;
+    });
+  }
+
   Widget _bulkTanksEditor(UnitFormatter units) {
     // Update edits the tanks each dive already has, so it takes a template plus
     // a field mask instead of a tank list (#797).
@@ -1320,6 +1363,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           counts: _buddyCounts,
           onAdd: _bulkAddBuddies,
           onChanged: (d) => setState(() => _buddyDelta = d),
+          // Each dive_buddies link carries a role, so the row needs an
+          // affordance membership alone cannot express (#1220).
+          trailingBuilder: (item) => TextButton(
+            key: ValueKey('buddy-role-${item.id}'),
+            onPressed: () => _showBulkBuddyRolePicker(item),
+            child: Text(_bulkBuddyRoleLabel(item.id)),
+          ),
         ),
         // The diver's own role is a scalar column, not a membership row, so it
         // rides the gate lane. It sits with Buddies because that is where the
@@ -1409,18 +1459,27 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       );
     }
     // Membership and role are separate instructions. A row the user only
-    // ticked on must not rewrite the role of links that already exist, while a
-    // role picked in the picker applies even when membership does not change
-    // because the buddy is already on every selected dive (#893).
+    // ticked on must not rewrite the role of links that already exist (#893).
     final membershipOnlyAdds = _buddyDelta.addIds
         .where((id) => !_buddyRoleById.containsKey(id))
         .toList();
+    // A picked role on a buddy who is also being added rides the add, so the
+    // links it creates carry that role from the start.
     final pickedRoleAdds = _buddyRoleById.keys
         .where(
           (id) =>
               !_buddyDelta.removeIds.contains(id) &&
-              (_buddyDelta.addIds.contains(id) ||
-                  _buddyOnEverySelectedDive(id)),
+              _buddyDelta.addIds.contains(id),
+        )
+        .toList();
+    // A picked role with no membership change is role-only: rewrite the links
+    // that exist and create none, so re-roling a buddy who is on some of the
+    // selection cannot add them to the rest (#1220).
+    final roleOnlyUpdates = _buddyRoleById.keys
+        .where(
+          (id) =>
+              !_buddyDelta.removeIds.contains(id) &&
+              !_buddyDelta.addIds.contains(id),
         )
         .toList();
     if (membershipOnlyAdds.isNotEmpty) {
@@ -1437,6 +1496,14 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         BuddiesOp(
           mode: BulkCollectionMode.add,
           buddies: pickedRoleAdds.map(_buddyWithRole).toList(),
+        ),
+      );
+    }
+    if (roleOnlyUpdates.isNotEmpty) {
+      ops.add(
+        BuddiesOp(
+          mode: BulkCollectionMode.update,
+          buddies: roleOnlyUpdates.map(_buddyWithRole).toList(),
         ),
       );
     }
@@ -3647,13 +3714,6 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         ),
     role: _roleForBuddy(id),
   );
-
-  /// Mirrors BulkMembershipEditor's "on all" presence, which is what makes a
-  /// picked role a no-op for the membership delta.
-  bool _buddyOnEverySelectedDive(String id) {
-    final total = widget.bulkDiveIds!.length;
-    return total > 0 && (_buddyCounts[id] ?? 0) >= total;
-  }
 
   /// A picked role wins; otherwise reuse the role the buddy already has across
   /// the selection so a membership-only add cannot demote them to Buddy. Only

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1473,8 +1473,8 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         )
         .toList();
     // A picked role with no membership change is role-only: rewrite the links
-    // that exist and create none, so re-roling a buddy who is on some of the
-    // selection cannot add them to the rest (#1220).
+    // that exist and create none, so changing the role of a buddy who is on
+    // some of the selection cannot add them to the rest (#1220).
     final roleOnlyUpdates = _buddyRoleById.keys
         .where(
           (id) =>

--- a/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
+++ b/lib/features/dive_log/presentation/widgets/bulk_membership_editor.dart
@@ -75,6 +75,7 @@ class BulkMembershipEditor extends StatefulWidget {
     required this.onChanged,
     this.addLabel,
     this.secondaryAction,
+    this.trailingBuilder,
   });
 
   final String title;
@@ -85,6 +86,12 @@ class BulkMembershipEditor extends StatefulWidget {
   final ValueChanged<MembershipDelta> onChanged;
   final String? addLabel;
   final Widget? secondaryAction;
+
+  /// Optional per-row control rendered at the trailing edge, for collections
+  /// whose links carry an attribute beyond membership. Buddies use it for the
+  /// role on each dive_buddies link (#1220); the attribute-free collections
+  /// (tags, dive types, equipment) leave it null.
+  final Widget Function(BulkMembershipItem item)? trailingBuilder;
 
   @override
   State<BulkMembershipEditor> createState() => _BulkMembershipEditorState();
@@ -263,6 +270,7 @@ class _BulkMembershipEditorState extends State<BulkMembershipEditor> {
                   final s? => Text(s),
                   _ => null,
                 },
+                trailing: widget.trailingBuilder?.call(item),
                 onTap: () => _cycle(item.id),
               ),
         ],

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "الطقس",
   "diveLog_bulkEdit_groupCollections": "الوسوم والمعدات والحياة",
   "diveLog_bulkEdit_fieldFavorite": "مفضّل",
+  "diveLog_bulkEdit_fieldMyRole": "دوري",
   "diveLog_bulkEdit_collectionWeights": "الأوزان",
   "diveLog_bulkEdit_collectionTanks": "الأسطوانات",
   "diveLog_bulkEdit_notesSet": "تعيين",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "الوسوم والمعدات والحياة",
   "diveLog_bulkEdit_fieldFavorite": "مفضّل",
   "diveLog_bulkEdit_fieldMyRole": "دوري",
+  "diveLog_bulkEdit_buddyRoleMixed": "متنوع",
   "diveLog_bulkEdit_collectionWeights": "الأوزان",
   "diveLog_bulkEdit_collectionTanks": "الأسطوانات",
   "diveLog_bulkEdit_notesSet": "تعيين",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Wetter",
   "diveLog_bulkEdit_groupCollections": "Tags, Ausrüstung & Leben",
   "diveLog_bulkEdit_fieldFavorite": "Favorit",
+  "diveLog_bulkEdit_fieldMyRole": "Meine Rolle",
   "diveLog_bulkEdit_collectionWeights": "Gewichte",
   "diveLog_bulkEdit_collectionTanks": "Flaschen",
   "diveLog_bulkEdit_notesSet": "Setzen",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Tags, Ausrüstung & Leben",
   "diveLog_bulkEdit_fieldFavorite": "Favorit",
   "diveLog_bulkEdit_fieldMyRole": "Meine Rolle",
+  "diveLog_bulkEdit_buddyRoleMixed": "Gemischt",
   "diveLog_bulkEdit_collectionWeights": "Gewichte",
   "diveLog_bulkEdit_collectionTanks": "Flaschen",
   "diveLog_bulkEdit_notesSet": "Setzen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -315,6 +315,7 @@
   "diveLog_bulkEdit_groupWeather": "Weather",
   "diveLog_bulkEdit_groupCollections": "Tags, Gear & Life",
   "diveLog_bulkEdit_fieldFavorite": "Favorite",
+  "diveLog_bulkEdit_fieldMyRole": "My role",
   "diveLog_bulkEdit_collectionWeights": "Weights",
   "diveLog_bulkEdit_collectionTanks": "Tanks",
   "diveLog_bulkEdit_notesSet": "Set",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -316,6 +316,7 @@
   "diveLog_bulkEdit_groupCollections": "Tags, Gear & Life",
   "diveLog_bulkEdit_fieldFavorite": "Favorite",
   "diveLog_bulkEdit_fieldMyRole": "My role",
+  "diveLog_bulkEdit_buddyRoleMixed": "Mixed",
   "diveLog_bulkEdit_collectionWeights": "Weights",
   "diveLog_bulkEdit_collectionTanks": "Tanks",
   "diveLog_bulkEdit_notesSet": "Set",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Etiquetas, equipo y vida",
   "diveLog_bulkEdit_fieldFavorite": "Favorito",
   "diveLog_bulkEdit_fieldMyRole": "Mi rol",
+  "diveLog_bulkEdit_buddyRoleMixed": "Variado",
   "diveLog_bulkEdit_collectionWeights": "Lastres",
   "diveLog_bulkEdit_collectionTanks": "Botellas",
   "diveLog_bulkEdit_notesSet": "Establecer",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Clima",
   "diveLog_bulkEdit_groupCollections": "Etiquetas, equipo y vida",
   "diveLog_bulkEdit_fieldFavorite": "Favorito",
+  "diveLog_bulkEdit_fieldMyRole": "Mi rol",
   "diveLog_bulkEdit_collectionWeights": "Lastres",
   "diveLog_bulkEdit_collectionTanks": "Botellas",
   "diveLog_bulkEdit_notesSet": "Establecer",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Tags, équipement et faune",
   "diveLog_bulkEdit_fieldFavorite": "Favori",
   "diveLog_bulkEdit_fieldMyRole": "Mon rôle",
+  "diveLog_bulkEdit_buddyRoleMixed": "Variable",
   "diveLog_bulkEdit_collectionWeights": "Lestage",
   "diveLog_bulkEdit_collectionTanks": "Blocs",
   "diveLog_bulkEdit_notesSet": "Définir",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Météo",
   "diveLog_bulkEdit_groupCollections": "Tags, équipement et faune",
   "diveLog_bulkEdit_fieldFavorite": "Favori",
+  "diveLog_bulkEdit_fieldMyRole": "Mon rôle",
   "diveLog_bulkEdit_collectionWeights": "Lestage",
   "diveLog_bulkEdit_collectionTanks": "Blocs",
   "diveLog_bulkEdit_notesSet": "Définir",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "מזג אוויר",
   "diveLog_bulkEdit_groupCollections": "תגיות, ציוד וחיים",
   "diveLog_bulkEdit_fieldFavorite": "מועדף",
+  "diveLog_bulkEdit_fieldMyRole": "התפקיד שלי",
   "diveLog_bulkEdit_collectionWeights": "משקולות",
   "diveLog_bulkEdit_collectionTanks": "מכלים",
   "diveLog_bulkEdit_notesSet": "הגדר",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "תגיות, ציוד וחיים",
   "diveLog_bulkEdit_fieldFavorite": "מועדף",
   "diveLog_bulkEdit_fieldMyRole": "התפקיד שלי",
+  "diveLog_bulkEdit_buddyRoleMixed": "מעורב",
   "diveLog_bulkEdit_collectionWeights": "משקולות",
   "diveLog_bulkEdit_collectionTanks": "מכלים",
   "diveLog_bulkEdit_notesSet": "הגדר",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Címkék, felszerelés és élővilág",
   "diveLog_bulkEdit_fieldFavorite": "Kedvenc",
   "diveLog_bulkEdit_fieldMyRole": "Saját szerep",
+  "diveLog_bulkEdit_buddyRoleMixed": "Vegyes",
   "diveLog_bulkEdit_collectionWeights": "Súlyok",
   "diveLog_bulkEdit_collectionTanks": "Palackok",
   "diveLog_bulkEdit_notesSet": "Beállítás",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Időjárás",
   "diveLog_bulkEdit_groupCollections": "Címkék, felszerelés és élővilág",
   "diveLog_bulkEdit_fieldFavorite": "Kedvenc",
+  "diveLog_bulkEdit_fieldMyRole": "Saját szerep",
   "diveLog_bulkEdit_collectionWeights": "Súlyok",
   "diveLog_bulkEdit_collectionTanks": "Palackok",
   "diveLog_bulkEdit_notesSet": "Beállítás",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Meteo",
   "diveLog_bulkEdit_groupCollections": "Tag, attrezzatura e vita",
   "diveLog_bulkEdit_fieldFavorite": "Preferito",
+  "diveLog_bulkEdit_fieldMyRole": "Il mio ruolo",
   "diveLog_bulkEdit_collectionWeights": "Zavorre",
   "diveLog_bulkEdit_collectionTanks": "Bombole",
   "diveLog_bulkEdit_notesSet": "Imposta",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Tag, attrezzatura e vita",
   "diveLog_bulkEdit_fieldFavorite": "Preferito",
   "diveLog_bulkEdit_fieldMyRole": "Il mio ruolo",
+  "diveLog_bulkEdit_buddyRoleMixed": "Misto",
   "diveLog_bulkEdit_collectionWeights": "Zavorre",
   "diveLog_bulkEdit_collectionTanks": "Bombole",
   "diveLog_bulkEdit_notesSet": "Imposta",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -655,6 +655,12 @@ abstract class AppLocalizations {
   /// **'Favorite'**
   String get diveLog_bulkEdit_fieldFavorite;
 
+  /// No description provided for @diveLog_bulkEdit_fieldMyRole.
+  ///
+  /// In en, this message translates to:
+  /// **'My role'**
+  String get diveLog_bulkEdit_fieldMyRole;
+
   /// No description provided for @diveLog_bulkEdit_collectionWeights.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -661,6 +661,12 @@ abstract class AppLocalizations {
   /// **'My role'**
   String get diveLog_bulkEdit_fieldMyRole;
 
+  /// No description provided for @diveLog_bulkEdit_buddyRoleMixed.
+  ///
+  /// In en, this message translates to:
+  /// **'Mixed'**
+  String get diveLog_bulkEdit_buddyRoleMixed;
+
   /// No description provided for @diveLog_bulkEdit_collectionWeights.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -364,6 +364,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'دوري';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'متنوع';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'الأوزان';
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -361,6 +361,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'مفضّل';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'دوري';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'الأوزان';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -363,6 +363,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Meine Rolle';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Gemischt';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Gewichte';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -360,6 +360,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favorit';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Meine Rolle';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Gewichte';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -360,6 +360,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favorite';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'My role';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Weights';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -363,6 +363,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'My role';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Mixed';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Weights';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -364,6 +364,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favorito';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Mi rol';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lastres';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -367,6 +367,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Mi rol';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Variado';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lastres';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -368,6 +368,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Mon rôle';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Variable';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lestage';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -365,6 +365,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favori';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Mon rôle';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lestage';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -361,6 +361,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'התפקיד שלי';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'מעורב';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'משקולות';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -358,6 +358,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'מועדף';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'התפקיד שלי';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'משקולות';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -362,6 +362,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Kedvenc';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Saját szerep';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Súlyok';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -365,6 +365,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Saját szerep';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Vegyes';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Súlyok';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -364,6 +364,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Preferito';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Il mio ruolo';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Zavorre';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -367,6 +367,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Il mio ruolo';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Misto';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Zavorre';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -361,6 +361,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favoriet';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Mijn rol';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Loodgewichten';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -364,6 +364,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Mijn rol';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Gemengd';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Loodgewichten';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -363,6 +363,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => 'Favorito';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => 'Minha função';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lastros';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -366,6 +366,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => 'Minha função';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => 'Variado';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => 'Lastros';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -353,6 +353,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_bulkEdit_fieldMyRole => '我的角色';
 
   @override
+  String get diveLog_bulkEdit_buddyRoleMixed => '不一致';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => '配重';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -350,6 +350,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get diveLog_bulkEdit_fieldFavorite => '收藏';
 
   @override
+  String get diveLog_bulkEdit_fieldMyRole => '我的角色';
+
+  @override
   String get diveLog_bulkEdit_collectionWeights => '配重';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Tags, uitrusting & leven",
   "diveLog_bulkEdit_fieldFavorite": "Favoriet",
   "diveLog_bulkEdit_fieldMyRole": "Mijn rol",
+  "diveLog_bulkEdit_buddyRoleMixed": "Gemengd",
   "diveLog_bulkEdit_collectionWeights": "Loodgewichten",
   "diveLog_bulkEdit_collectionTanks": "Flessen",
   "diveLog_bulkEdit_notesSet": "Instellen",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Weer",
   "diveLog_bulkEdit_groupCollections": "Tags, uitrusting & leven",
   "diveLog_bulkEdit_fieldFavorite": "Favoriet",
+  "diveLog_bulkEdit_fieldMyRole": "Mijn rol",
   "diveLog_bulkEdit_collectionWeights": "Loodgewichten",
   "diveLog_bulkEdit_collectionTanks": "Flessen",
   "diveLog_bulkEdit_notesSet": "Instellen",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "Tags, equipamento e vida",
   "diveLog_bulkEdit_fieldFavorite": "Favorito",
   "diveLog_bulkEdit_fieldMyRole": "Minha função",
+  "diveLog_bulkEdit_buddyRoleMixed": "Variado",
   "diveLog_bulkEdit_collectionWeights": "Lastros",
   "diveLog_bulkEdit_collectionTanks": "Cilindros",
   "diveLog_bulkEdit_notesSet": "Definir",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "Clima",
   "diveLog_bulkEdit_groupCollections": "Tags, equipamento e vida",
   "diveLog_bulkEdit_fieldFavorite": "Favorito",
+  "diveLog_bulkEdit_fieldMyRole": "Minha função",
   "diveLog_bulkEdit_collectionWeights": "Lastros",
   "diveLog_bulkEdit_collectionTanks": "Cilindros",
   "diveLog_bulkEdit_notesSet": "Definir",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -138,6 +138,7 @@
   "diveLog_bulkEdit_groupCollections": "标签、装备和生物",
   "diveLog_bulkEdit_fieldFavorite": "收藏",
   "diveLog_bulkEdit_fieldMyRole": "我的角色",
+  "diveLog_bulkEdit_buddyRoleMixed": "不一致",
   "diveLog_bulkEdit_collectionWeights": "配重",
   "diveLog_bulkEdit_collectionTanks": "气瓶",
   "diveLog_bulkEdit_notesSet": "设置",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -137,6 +137,7 @@
   "diveLog_bulkEdit_groupWeather": "天气",
   "diveLog_bulkEdit_groupCollections": "标签、装备和生物",
   "diveLog_bulkEdit_fieldFavorite": "收藏",
+  "diveLog_bulkEdit_fieldMyRole": "我的角色",
   "diveLog_bulkEdit_collectionWeights": "配重",
   "diveLog_bulkEdit_collectionTanks": "气瓶",
   "diveLog_bulkEdit_notesSet": "设置",

--- a/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
+++ b/test/features/buddies/data/repositories/buddy_repository_bulk_test.dart
@@ -49,6 +49,46 @@ void main() {
     expect(d2.length, 2);
   });
 
+  test('bulkUpdateBuddyRoles rewrites the role on links that exist', () async {
+    await repository.bulkAddBuddies(['d1', 'd2'], [bwr('x')]);
+    await repository.bulkUpdateBuddyRoles(
+      ['d1', 'd2'],
+      [bwrRole('x', DiveRole.instructorId)],
+    );
+    final rows = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.buddyId.equals('x'))).get();
+    expect(rows, hasLength(2));
+    expect(rows.every((r) => r.role == DiveRole.instructorId), isTrue);
+  });
+
+  test('bulkUpdateBuddyRoles never creates a missing link', () async {
+    // x is on d1 only. A role-only edit must leave d2 without the buddy.
+    await repository.bulkAddBuddies(['d1'], [bwr('x')]);
+    await repository.bulkUpdateBuddyRoles(
+      ['d1', 'd2'],
+      [bwrRole('x', DiveRole.instructorId)],
+    );
+    final rows = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.buddyId.equals('x'))).get();
+    expect(rows, hasLength(1));
+    expect(rows.single.diveId, 'd1');
+    expect(rows.single.role, DiveRole.instructorId);
+  });
+
+  test('bulkUpdateBuddyRoles leaves other buddies on the dive alone', () async {
+    await repository.bulkAddBuddies(['d1'], [bwr('x'), bwr('y')]);
+    await repository.bulkUpdateBuddyRoles(
+      ['d1'],
+      [bwrRole('x', DiveRole.instructorId)],
+    );
+    final y = await (db.select(
+      db.diveBuddies,
+    )..where((t) => t.buddyId.equals('y'))).getSingle();
+    expect(y.role, DiveRole.buddyId);
+  });
+
   test('buddyCountsForDives returns per-buddy dive counts', () async {
     await repository.bulkAddBuddies(['d1', 'd2'], [bwr('shared')]);
     await repository.bulkAddBuddies(['d1'], [bwr('onlyD1')]);

--- a/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
+++ b/test/features/dive_log/data/services/bulk_dive_edit_service_test.dart
@@ -66,6 +66,14 @@ void main() {
     ),
     role: DiveRole.builtInBuddy(),
   );
+  domain.BuddyWithRole bwrRole(String id, String roleId) =>
+      domain.BuddyWithRole(
+        buddy: bwr(id).buddy,
+        role: DiveRole.synthetic(roleId),
+      );
+  Future<List<String>> buddyRolesOf(String d) async => (await (db.select(
+    db.diveBuddies,
+  )..where((t) => t.diveId.equals(d))).get()).map((r) => r.role).toList();
   domain.DiveTank tank(String name, {TankMaterial? material}) =>
       domain.DiveTank(id: '', name: name, material: material);
   domain.DiveWeight weight(double kg) => domain.DiveWeight(
@@ -249,6 +257,48 @@ void main() {
     expect(await equipOf('d1'), isEmpty);
     expect(await buddiesOf('d1'), isEmpty);
   });
+
+  test(
+    'BuddiesOp update rewrites roles without adding missing links',
+    () async {
+      await seed('d1');
+      await seed('d2');
+      // Real buddy rows: the undo snapshot reads links back through a join
+      // on `buddies`, so orphan junction rows would not survive the trip.
+      await seedBuddy('b1');
+      await seedBuddy('b2');
+      // b1 is on both dives; b2 only on d1.
+      await buddyRepo.bulkAddBuddies(['d1', 'd2'], [bwr('b1')]);
+      await buddyRepo.bulkAddBuddies(['d1'], [bwr('b2')]);
+
+      final snap = await service.apply(
+        BulkEditRequest(
+          diveIds: const ['d1', 'd2'],
+          ops: [
+            BuddiesOp(
+              mode: BulkCollectionMode.update,
+              buddies: [
+                bwrRole('b1', DiveRole.instructorId),
+                bwrRole('b2', DiveRole.diveGuideId),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect((await buddyRolesOf('d2')).single, DiveRole.instructorId);
+      expect((await buddiesOf('d2')).toSet(), {'b1'});
+      expect((await buddyRolesOf('d1')).toSet(), {
+        DiveRole.instructorId,
+        DiveRole.diveGuideId,
+      });
+
+      await service.undo(snap);
+      expect((await buddyRolesOf('d1')).toSet(), {DiveRole.buddyId});
+      expect((await buddyRolesOf('d2')).single, DiveRole.buddyId);
+      expect((await buddiesOf('d2')).toSet(), {'b1'});
+    },
+  );
 
   test('EquipmentOp add preserves existing gear on each dive', () async {
     // Reproduces the r/submersion report at the service layer: adding one

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -268,6 +268,144 @@ void main() {
       );
     });
 
+    testWidgets('a buddy row shows its role and re-roles every link', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final buddy = await BuddyRepository().createBuddy(
+        Buddy(
+          id: '',
+          name: 'Casey Diver',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      );
+      final d1 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'row-role-1'),
+      );
+      final d2 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'row-role-2'),
+      );
+      await BuddyRepository().bulkAddBuddies(
+        [d1.id, d2.id],
+        [BuddyWithRole(buddy: buddy, role: DiveRole.builtInBuddy())],
+      );
+
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(bulkDiveIds: [d1.id, d2.id], embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The row surfaces the role the buddy already carries on both dives.
+      final roleButton = find.byKey(ValueKey('buddy-role-${buddy.id}'));
+      await tester.ensureVisible(roleButton);
+      expect(
+        find.descendant(of: roleButton, matching: find.text('Buddy')),
+        findsOneWidget,
+      );
+
+      await tester.tap(roleButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+      expect(
+        find.descendant(of: roleButton, matching: find.text('Instructor')),
+        findsOneWidget,
+      );
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      for (final id in [d1.id, d2.id]) {
+        final saved = await BuddyRepository().getBuddiesForDive(id);
+        expect(saved.single.role.id, DiveRole.instructorId);
+      }
+    });
+
+    testWidgets('re-roling a buddy on some dives does not add them to the '
+        'rest', (tester) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final buddy = await BuddyRepository().createBuddy(
+        Buddy(
+          id: '',
+          name: 'Casey Diver',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      );
+      final d1 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'partial-role-1'),
+      );
+      final d2 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'partial-role-2'),
+      );
+      // Only d1 has the buddy.
+      await BuddyRepository().bulkAddBuddies(
+        [d1.id],
+        [BuddyWithRole(buddy: buddy, role: DiveRole.builtInBuddy())],
+      );
+
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(bulkDiveIds: [d1.id, d2.id], embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final roleButton = find.byKey(ValueKey('buddy-role-${buddy.id}'));
+      await tester.ensureVisible(roleButton);
+      await tester.tap(roleButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      final onD1 = await BuddyRepository().getBuddiesForDive(d1.id);
+      expect(onD1.single.role.id, DiveRole.instructorId);
+      // The membership checkbox was left on "some", so d2 stays untouched.
+      expect(await BuddyRepository().getBuddiesForDive(d2.id), isEmpty);
+    });
+
     testWidgets('toggling a gate enables its checkbox', (tester) async {
       await pumpBulk(tester);
 

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/shared/widgets/forms/form_row.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
@@ -70,9 +71,10 @@ void main() {
     testWidgets('renders gated Logistics + Notes fields', (tester) async {
       await pumpBulk(tester);
 
-      // 4 Logistics + 9 Conditions + 6 Weather + 6 Rebreather + 1 Notes gates.
+      // 4 Logistics + 9 Conditions + 6 Weather + 6 Rebreather + 1 Buddies
+      // (my role, #1220) + 1 Notes gates.
       // (dive type moved from a scalar gate to the collection lane, #414)
-      expect(find.byType(BulkFieldGate), findsNWidgets(26));
+      expect(find.byType(BulkFieldGate), findsNWidgets(27));
       expect(find.text('Favorite'), findsOneWidget);
       // Only the 3 owned collections (weights, tanks, sightings) still use a
       // mode selector; the 4 reference collections (tags, diveTypes,
@@ -199,6 +201,72 @@ void main() {
         expect(saved.single.role.id, DiveRole.instructorId);
       },
     );
+
+    testWidgets('the My role gate applies the picked role to every dive', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final d1 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'my-role-1'),
+      );
+      final d2 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'my-role-2'),
+      );
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(bulkDiveIds: [d1.id, d2.id], embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final roleGate = find.ancestor(
+        of: find.text('My role'),
+        matching: find.byType(BulkFieldGate),
+      );
+      await tester.ensureVisible(roleGate);
+      await tester.tap(
+        find.descendant(of: roleGate, matching: find.byType(Checkbox)),
+      );
+      await tester.pumpAndSettle();
+
+      // Open the role selector from the picker row and choose Instructor.
+      await tester.tap(
+        find.descendant(of: roleGate, matching: find.byType(FormRow)),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      expect(
+        (await repository.getDiveById(d1.id))!.diverRoleId,
+        DiveRole.instructorId,
+      );
+      expect(
+        (await repository.getDiveById(d2.id))!.diverRoleId,
+        DiveRole.instructorId,
+      );
+    });
 
     testWidgets('toggling a gate enables its checkbox', (tester) async {
       await pumpBulk(tester);

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -268,7 +268,7 @@ void main() {
       );
     });
 
-    testWidgets('a buddy row shows its role and re-roles every link', (
+    testWidgets('a buddy row shows its role and changes it on every link', (
       tester,
     ) async {
       tester.view.physicalSize = const Size(800, 1600);
@@ -342,8 +342,8 @@ void main() {
       }
     });
 
-    testWidgets('re-roling a buddy on some dives does not add them to the '
-        'rest', (tester) async {
+    testWidgets('changing the role of a buddy on some dives does not add '
+        'them to the rest', (tester) async {
       tester.view.physicalSize = const Size(800, 1600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(() {

--- a/test/features/dive_log/presentation/pages/bulk_edit_field_set_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_edit_field_set_test.dart
@@ -38,6 +38,7 @@ void main() {
       diveCenterId: 'dc',
       tripId: 't',
       courseId: 'c',
+      diverRoleId: 'dive_master',
       rating: 4,
       isFavorite: true,
       waterType: 'salt',
@@ -84,5 +85,20 @@ void main() {
     expect(c.scrubberType.present, isTrue);
     expect(c.scrubberDurationMinutes.present, isTrue);
     expect(c.notes.present, isTrue);
+    expect(c.diverRole.present, isTrue);
+  });
+
+  test('the diverRole gate writes the active diver\'s own role (#1220)', () {
+    final c = buildScalarCompanion({
+      BulkField.diverRole,
+    }, BulkScalarInputs(diverRoleId: 'instructor'));
+    expect(c.diverRole.present, isTrue);
+    expect(c.diverRole.value, 'instructor');
+  });
+
+  test('an enabled diverRole gate with no role clears the column', () {
+    final c = buildScalarCompanion({BulkField.diverRole}, BulkScalarInputs());
+    expect(c.diverRole.present, isTrue);
+    expect(c.diverRole.value, isNull);
   });
 }


### PR DESCRIPTION
Closes #1220.

Two role gaps in the bulk dive editor, both of which the single-dive editor already covers.

## 1. Buddy roles (the main one)

The bulk editor's Buddies list is a `BulkMembershipEditor`, and its rows are membership-only: a tristate checkbox, the name, and a "on 1 of 2" status line. **The role each `dive_buddies` link carries was neither displayed nor editable.** The only path to a role was to reopen the Add dialog and re-pick a buddy who is already on the dives, since `_bulkAddBuddies` seeds its `BuddyPicker` with an empty selection. Nothing on screen suggests that.

Each buddy row now carries a role control that:

- shows the role the buddy holds across the selection, or **Mixed** when the links disagree (`unanimousBuddyRolesForDives` returns nothing for those),
- opens the same `showDiveRoleSelector` sheet the single-dive editor uses, custom-role creation included.

### Role-only edits never change membership

A role change with no membership change now travels as `BuddiesOp(mode: update)`, which previously threw `UnsupportedError` for buddies because role changes were routed through `add + overwriteRole`. That routing is the bug: `bulkAddBuddies` inserts a link wherever one is missing, so re-roling a buddy who is on 1 of 2 selected dives would have quietly added them to the second.

The new `BuddyRepository.bulkUpdateBuddyRoles` rewrites only the links that exist and inserts nothing. Roles picked for a buddy who *is* being added still ride the add, so new links are born with the right role.

## 2. The diver's own role

`BuddyPicker` renders the pinned "Me" chip only when a caller passes `onDiverRoleChanged`, and the bulk form passed null. `diverRole` is a scalar column on `dives` rather than a join-table row, so it joins the gated scalar lane as `BulkField.diverRole` and renders as a gated **My role** picker row beside Buddies, with `allowNone: true` so it can also be cleared across the selection.

Undo needed no work for it: `BulkEditSnapshot` already captures whole prior rows and restores them with `row.toCompanion(false)`.

## Notes for review

- `_showBulkBuddyRolePicker` and `_showBulkDiverRolePicker` both `await ref.read(provider.future)` rather than reading `.value` off the `AsyncValue`. Nothing else in the bulk form watches the role list, so a cold `.value` read returns null and the selector opens empty.
- `BulkMembershipEditor` gains an optional `trailingBuilder`. Only the buddies instance passes one; tags, dive types, and equipment have no per-link attribute and leave it null.
- `_buddyOnEverySelectedDive` is deleted. It existed to let a picked role reach a buddy who was on every dive without a membership change; the role-only op covers that case and the partial-membership case it could not.
- l10n: `diveLog_bulkEdit_fieldMyRole` and `diveLog_bulkEdit_buddyRoleMixed`, translated across all 11 locales.

## Testing

Every test below was written first and watched fail.

**Repository** (`buddy_repository_bulk_test.dart`) — `bulkUpdateBuddyRoles` rewrites existing links, never creates a missing one, and leaves other buddies on the dive alone.

**Engine** (`bulk_dive_edit_service_test.dart`) — `BuddiesOp(update)` re-roles across a mixed selection without adding the buddy to the dive that lacks them, and undo restores both the prior roles and the prior membership.

**Widget** (`bulk_dive_edit_form_test.dart`) — a buddy row shows its current role and re-roles every link end to end; re-roling a buddy on some dives leaves the others without the link; the My role gate applies to every selected dive. The gate-count assertion moves 26 to 27.

`flutter test test/features/dive_log test/features/buddies test/features/dive_roles` passes (3048 tests). `flutter analyze` clean, `dart format .` reports no changes.
