### PR TITLE
fix: stop fire-and-forget work failing unrelated tests in CI

### DIFF
--- a/lib/core/utils/log_failure.dart
+++ b/lib/core/utils/log_failure.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:submersion/core/services/logger_service.dart';
 
 /// Start [work] without awaiting it, attributing a failure to [owner] in the
@@ -22,9 +24,14 @@ import 'package:submersion/core/services/logger_service.dart';
 /// Dart future may carry several listeners, so anything that also awaits it
 /// still sees the error and still has to handle it.
 void logFailure(Future<void> work, Type owner, String task) {
-  work.catchError((Object error, StackTrace stackTrace) {
-    LoggerService.forClass(
-      owner,
-    ).error('Failed to $task', error: error, stackTrace: stackTrace);
-  });
+  // The future catchError hands back is of no interest: attaching the listener
+  // is the entire point, and unawaited says that rather than leaving a reader
+  // to wonder whether the drop was an oversight.
+  unawaited(
+    work.catchError((Object error, StackTrace stackTrace) {
+      LoggerService.forClass(
+        owner,
+      ).error('Failed to $task', error: error, stackTrace: stackTrace);
+    }),
+  );
 }

--- a/lib/core/utils/log_failure.dart
+++ b/lib/core/utils/log_failure.dart
@@ -1,0 +1,30 @@
+import 'package:submersion/core/services/logger_service.dart';
+
+/// Start [work] without awaiting it, attributing a failure to [owner] in the
+/// log rather than leaving it to the zone handler.
+///
+/// A Dart future with NO listener sends its error to the zone. In the running
+/// app `main`'s `runZonedGuarded` catches that and logs it, so nothing is lost,
+/// but it arrives as a bare "Uncaught zone error" with no clue what started it.
+///
+/// Under `package:test` there is no such safety net. The error is attributed to
+/// whichever test happens to be running when it surfaces, so work that outlives
+/// its own test fails a LATER, unrelated test with "This test failed after it
+/// had already completed". Which test that is depends on timing, which is why
+/// re-running the job usually clears it and why the failure never seems to
+/// belong to the branch that hit it.
+///
+/// A load started in a notifier constructor or an `initState` is the common
+/// case: the test finishes, teardown closes the database, and the query that
+/// is still in flight fails with nobody listening.
+///
+/// Attaching a listener is the whole fix. [work] itself is untouched, and a
+/// Dart future may carry several listeners, so anything that also awaits it
+/// still sees the error and still has to handle it.
+void logFailure(Future<void> work, Type owner, String task) {
+  work.catchError((Object error, StackTrace stackTrace) {
+    LoggerService.forClass(
+      owner,
+    ).error('Failed to $task', error: error, stackTrace: stackTrace);
+  });
+}

--- a/lib/features/buddies/presentation/providers/buddy_providers.dart
+++ b/lib/features/buddies/presentation/providers/buddy_providers.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final buddyRepositoryProvider = Provider<BuddyRepository>((ref) {
@@ -221,7 +222,7 @@ class BuddyListNotifier extends StateNotifier<AsyncValue<List<Buddy>>> {
 
   BuddyListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(_initializeAndLoad(), BuddyListNotifier, 'initialize and load');
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -229,7 +230,11 @@ class BuddyListNotifier extends StateNotifier<AsyncValue<List<Buddy>>> {
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allBuddiesProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          BuddyListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/certifications/presentation/providers/certification_providers.dart
+++ b/lib/features/certifications/presentation/providers/certification_providers.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/dive_log/presentation/providers/view_config_
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final certificationRepositoryProvider = Provider<CertificationRepository>((
@@ -174,7 +175,11 @@ class CertificationListNotifier
 
   CertificationListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      CertificationListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -182,7 +187,11 @@ class CertificationListNotifier
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allCertificationsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          CertificationListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/courses/presentation/providers/course_providers.dart
+++ b/lib/features/courses/presentation/providers/course_providers.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final courseRepositoryProvider = Provider<CourseRepository>((ref) {
@@ -218,7 +219,7 @@ class CourseListNotifier extends StateNotifier<AsyncValue<List<Course>>> {
 
   CourseListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(_initializeAndLoad(), CourseListNotifier, 'initialize and load');
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -228,7 +229,11 @@ class CourseListNotifier extends StateNotifier<AsyncValue<List<Course>>> {
         _ref.invalidate(allCoursesProvider);
         _ref.invalidate(inProgressCoursesProvider);
         _ref.invalidate(completedCoursesProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          CourseListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/cylinder_configs/presentation/pages/cylinder_config_edit_page.dart
+++ b/lib/features/cylinder_configs/presentation/pages/cylinder_config_edit_page.dart
@@ -12,6 +12,7 @@ import 'package:submersion/features/equipment/domain/entities/equipment_item.dar
 import 'package:submersion/features/equipment/presentation/providers/equipment_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Creates or edits one configuration. Cylinders are a reorderable list;
 /// their sortOrder is derived from list position on save.
@@ -47,7 +48,7 @@ class _CylinderConfigEditPageState
     if (widget.configId == null) {
       _loaded = true;
     } else {
-      _load();
+      logFailure(_load(), _CylinderConfigEditPageState, 'load');
     }
   }
 

--- a/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
+++ b/lib/features/dive_centers/presentation/pages/dive_center_edit_page.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/dive_sites/presentation/widgets/location_pic
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/shared/widgets/forms/coordinate_field_group.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 class DiveCenterEditPage extends ConsumerStatefulWidget {
   final String? centerId;
@@ -125,7 +126,11 @@ class _DiveCenterEditPageState extends ConsumerState<DiveCenterEditPage> {
 
     // Only trigger when all address fields have lost focus
     if (!anyAddressFieldHasFocus) {
-      _onAddressFieldBlur();
+      logFailure(
+        _onAddressFieldBlur(),
+        _DiveCenterEditPageState,
+        'on address field blur',
+      );
     }
   }
 
@@ -588,7 +593,11 @@ class _DiveCenterEditPageState extends ConsumerState<DiveCenterEditPage> {
         canPop: !_hasChanges,
         onPopInvokedWithResult: (didPop, result) {
           if (!didPop && _hasChanges) {
-            _showDiscardDialog();
+            logFailure(
+              _showDiscardDialog(),
+              _DiveCenterEditPageState,
+              'show discard dialog',
+            );
           }
         },
         child: Column(

--- a/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
+++ b/lib/features/dive_centers/presentation/providers/dive_center_providers.dart
@@ -13,6 +13,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final diveCenterRepositoryProvider = Provider<DiveCenterRepository>((ref) {
@@ -155,7 +156,11 @@ class DiveCenterListNotifier
 
   DiveCenterListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      DiveCenterListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -163,7 +168,11 @@ class DiveCenterListNotifier
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allDiveCentersProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          DiveCenterListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
+++ b/lib/features/dive_computer/presentation/widgets/download_step_widget.dart
@@ -9,6 +9,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
 import 'package:submersion/features/dive_computer/presentation/widgets/pin_code_dialog.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/app_date_picker.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Widget for the download step of the discovery wizard.
 class DownloadStepWidget extends ConsumerStatefulWidget {
@@ -84,7 +85,11 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
     if (!_promptApplies) {
       // Start download when widget is shown.
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _startDownload();
+        logFailure(
+          _startDownload(),
+          _DownloadStepWidgetState,
+          'start download',
+        );
       });
     }
   }
@@ -151,7 +156,7 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
       _useCutoff = useCutoff;
       _promptResolved = true;
     });
-    _startDownload();
+    logFailure(_startDownload(), _DownloadStepWidgetState, 'start download');
   }
 
   @override
@@ -401,7 +406,11 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
     final retryButton = OutlinedButton.icon(
       onPressed: () {
         _hasStarted = false;
-        _startDownload();
+        logFailure(
+          _startDownload(),
+          _DownloadStepWidgetState,
+          'start download',
+        );
       },
       icon: const Icon(Icons.refresh),
       label: Text(context.l10n.diveComputer_downloadStep_retry),
@@ -416,7 +425,11 @@ class _DownloadStepWidgetState extends ConsumerState<DownloadStepWidget> {
         FilledButton.icon(
           onPressed: () {
             _hasStarted = false;
-            _startDownload();
+            logFailure(
+              _startDownload(),
+              _DownloadStepWidgetState,
+              'start download',
+            );
           },
           icon: const Icon(Icons.refresh),
           label: Text(context.l10n.diveComputer_downloadStep_retry),

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -110,6 +110,7 @@ import 'package:submersion/core/constants/tank_presets.dart';
 import 'package:submersion/features/tank_presets/domain/entities/tank_preset_entity.dart';
 import 'package:submersion/features/tank_presets/domain/services/default_tank_preset_resolver.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 const _createNewSiteSentinel = '__create_new__';
 const _createNewDiveCenterSentinel = '__create_new_dive_center__';
@@ -369,7 +370,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     _entryTime = TimeOfDay.now();
 
     // Eagerly resolve built-in presets (sync), async for custom
-    _loadDefaultPreset();
+    logFailure(_loadDefaultPreset(), _DiveEditPageState, 'load default preset');
 
     // New single dive: auto-apply the diver's default/geofenced equipment set
     // once the form is up, only when no gear is present.
@@ -403,9 +404,9 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       // default would make enabling the collection silently operate on it.
       _selectedDiveTypeIds = <String>[];
       _suppressDirty = false;
-      _loadBulkMembers();
+      logFailure(_loadBulkMembers(), _DiveEditPageState, 'load bulk members');
     } else if (widget.isEditing) {
-      _loadExistingDive();
+      logFailure(_loadExistingDive(), _DiveEditPageState, 'load existing dive');
     } else {
       // For new dives, capture GPS in the background to suggest nearby sites
       _captureLocationForNearby();

--- a/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
@@ -4,6 +4,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider for dive computers
 final diveComputerRepositoryProvider = Provider<DiveComputerRepository>((ref) {
@@ -90,7 +91,11 @@ class SelectedComputerNotifier extends StateNotifier<String?> {
   final String _diveId;
 
   SelectedComputerNotifier(this._repository, this._diveId) : super(null) {
-    _loadPrimaryComputer();
+    logFailure(
+      _loadPrimaryComputer(),
+      SelectedComputerNotifier,
+      'load primary computer',
+    );
   }
 
   Future<void> _loadPrimaryComputer() async {
@@ -135,7 +140,11 @@ class DiveComputerNotifier
 
   DiveComputerNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      DiveComputerNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -143,7 +152,11 @@ class DiveComputerNotifier
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allDiveComputersProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          DiveComputerNotifier,
+          'initialize and load',
+        );
       }
     });
   }

--- a/lib/features/dive_roles/presentation/providers/dive_role_providers.dart
+++ b/lib/features/dive_roles/presentation/providers/dive_role_providers.dart
@@ -3,6 +3,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_roles/data/repositories/dive_role_repository.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final diveRoleRepositoryProvider = Provider<DiveRoleRepository>((ref) {
@@ -37,7 +38,11 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
 
   DiveRoleListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      DiveRoleListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -45,7 +50,11 @@ class DiveRoleListNotifier extends StateNotifier<AsyncValue<List<DiveRole>>> {
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allDiveRolesProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          DiveRoleListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/dive_sites/presentation/providers/site_providers.dart
+++ b/lib/features/dive_sites/presentation/providers/site_providers.dart
@@ -19,6 +19,7 @@ import 'package:submersion/features/marine_life/presentation/providers/species_p
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 // ============================================================================
 // Site Filter State
@@ -352,7 +353,7 @@ class SiteListNotifier
 
   SiteListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(_initializeAndLoad(), SiteListNotifier, 'initialize and load');
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -361,7 +362,11 @@ class SiteListNotifier
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(sitesProvider);
         _ref.invalidate(sitesWithCountsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          SiteListNotifier,
+          'initialize and load',
+        );
       }
     });
   }

--- a/lib/features/dive_types/presentation/providers/dive_type_providers.dart
+++ b/lib/features/dive_types/presentation/providers/dive_type_providers.dart
@@ -4,6 +4,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_reposit
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
 import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final diveTypeRepositoryProvider = Provider<DiveTypeRepository>((ref) {
@@ -83,7 +84,11 @@ class DiveTypeListNotifier
 
   DiveTypeListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      DiveTypeListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -96,7 +101,11 @@ class DiveTypeListNotifier
         _ref.invalidate(diveTypesProvider);
         _ref.invalidate(customDiveTypesProvider);
         _ref.invalidate(diveTypeStatisticsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          DiveTypeListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/equipment/presentation/providers/equipment_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_providers.dart
@@ -23,6 +23,7 @@ import 'package:submersion/features/trips/presentation/providers/trip_providers.
 import 'package:submersion/shared/models/entity_card_view_config.dart';
 import 'package:submersion/shared/models/entity_table_config.dart';
 import 'package:submersion/shared/providers/entity_table_config_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final equipmentRepositoryProvider = Provider<EquipmentRepository>((ref) {
@@ -249,7 +250,11 @@ class EquipmentListNotifier
 
   EquipmentListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      EquipmentListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -257,7 +262,11 @@ class EquipmentListNotifier
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(allEquipmentProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          EquipmentListNotifier,
+          'initialize and load',
+        );
       }
     });
   }

--- a/lib/features/equipment/presentation/providers/equipment_set_providers.dart
+++ b/lib/features/equipment/presentation/providers/equipment_set_providers.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/divers/presentation/providers/diver_provider
 import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_set.dart';
 import 'package:submersion/features/equipment/domain/entities/equipment_set_geofence.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final equipmentSetRepositoryProvider = Provider<EquipmentSetRepository>((ref) {
@@ -121,7 +122,11 @@ class EquipmentSetListNotifier
 
   EquipmentSetListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      EquipmentSetListNotifier,
+      'initialize and load',
+    );
 
     // A StateNotifier cannot self-invalidate the way the FutureProviders above
     // do, and the sets list renders itemCount straight off equipmentIds -- so
@@ -138,7 +143,11 @@ class EquipmentSetListNotifier
         state = const AsyncValue.loading();
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(equipmentSetsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          EquipmentSetListNotifier,
+          'initialize and load',
+        );
       }
     });
   }

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final speciesRepositoryProvider = Provider<SpeciesRepository>((ref) {
@@ -80,7 +81,7 @@ class SightingsNotifier extends StateNotifier<List<Sighting>> {
 
   SightingsNotifier(this._repository, this._diveId) : super([]) {
     if (_diveId != null) {
-      _loadSightings();
+      logFailure(_loadSightings(), SightingsNotifier, 'load sightings');
     }
   }
 
@@ -301,7 +302,11 @@ class SiteExpectedSpeciesNotifier
   final String _siteId;
 
   SiteExpectedSpeciesNotifier(this._repository, this._siteId) : super([]) {
-    _loadExpectedSpecies();
+    logFailure(
+      _loadExpectedSpecies(),
+      SiteExpectedSpeciesNotifier,
+      'load expected species',
+    );
   }
 
   Future<void> _loadExpectedSpecies() async {
@@ -340,7 +345,11 @@ class SiteExpectedSpeciesNotifier
   }
 
   void refresh() {
-    _loadExpectedSpecies();
+    logFailure(
+      _loadExpectedSpecies(),
+      SiteExpectedSpeciesNotifier,
+      'load expected species',
+    );
   }
 }
 

--- a/lib/features/media/presentation/pages/photo_picker_page.dart
+++ b/lib/features/media/presentation/pages/photo_picker_page.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/media/presentation/widgets/files_tab.dart';
 import 'package:submersion/features/media/presentation/widgets/url_tab.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/widgets/drag_select_grid_view.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Page for selecting photos from the device gallery within a date range.
 ///
@@ -61,7 +62,11 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
   void initState() {
     super.initState();
     Future.microtask(_clearStaleStaging);
-    _checkPermissionAndLoad();
+    logFailure(
+      _checkPermissionAndLoad(),
+      _PhotoPickerPageState,
+      'check permission and load',
+    );
   }
 
   /// Drops files staged by an earlier session that was abandoned rather than
@@ -86,7 +91,7 @@ class _PhotoPickerPageState extends ConsumerState<PhotoPickerPage> {
 
     final state = ref.read(photoPickerNotifierProvider);
     if (state.hasPermission) {
-      _loadAssets();
+      logFailure(_loadAssets(), _PhotoPickerPageState, 'load assets');
     }
   }
 

--- a/lib/features/media/presentation/providers/media_library_providers.dart
+++ b/lib/features/media/presentation/providers/media_library_providers.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/media/data/repositories/media_library_reposi
 import 'package:submersion/features/media/domain/entities/media_library_filter.dart';
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Library browse presentations. Values are persisted by name via the app
 /// settings key-value store.
@@ -35,7 +36,7 @@ final mediaLibraryViewModeProvider =
 class MediaLibraryViewModeNotifier extends StateNotifier<MediaLibraryViewMode> {
   MediaLibraryViewModeNotifier(this._settings)
     : super(MediaLibraryViewMode.grid) {
-    _prime();
+    logFailure(_prime(), MediaLibraryViewModeNotifier, 'prime');
   }
 
   static const String _settingKey = 'media_library_view_mode';

--- a/lib/features/media/presentation/providers/media_watcher_providers.dart
+++ b/lib/features/media/presentation/providers/media_watcher_providers.dart
@@ -11,6 +11,7 @@ import 'package:submersion/features/media/presentation/providers/media_library_p
 import 'package:submersion/features/media/presentation/providers/media_repair_providers.dart';
 import 'package:submersion/features/settings/data/repositories/app_settings_repository.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 final watchedFolderRepositoryProvider = Provider<WatchedFolderRepository>(
   (ref) => WatchedFolderRepository(),
@@ -53,7 +54,7 @@ const String kWatcherAutoApplySettingKey = 'media_watcher_auto_apply';
 
 class WatcherAutoApplyNotifier extends StateNotifier<bool> {
   WatcherAutoApplyNotifier(this._settings) : super(true) {
-    _prime();
+    logFailure(_prime(), WatcherAutoApplyNotifier, 'prime');
   }
 
   final AppSettingsRepository _settings;

--- a/lib/features/media/presentation/widgets/dive_picker_sheet.dart
+++ b/lib/features/media/presentation/widgets/dive_picker_sheet.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Modal dive picker used by "Move to dive" and inbox linking. Resolves to
 /// the chosen dive id, or null on dismiss.
@@ -31,7 +32,7 @@ class _DivePickerSheetState extends ConsumerState<_DivePickerSheet> {
   @override
   void initState() {
     super.initState();
-    _load();
+    logFailure(_load(), _DivePickerSheetState, 'load');
   }
 
   Future<void> _load() async {

--- a/lib/features/media_store/presentation/pages/media_storage_page.dart
+++ b/lib/features/media_store/presentation/pages/media_storage_page.dart
@@ -17,6 +17,7 @@ import 'package:submersion/features/media_store/presentation/widgets/media_trans
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Configuration page for the media store's S3 backend (design spec
 /// section 14). Sibling of the sync backend's S3ConfigPage: same field
@@ -61,7 +62,7 @@ class _MediaStoragePageState extends ConsumerState<MediaStoragePage> {
     _regionController.addListener(_onRegionChanged);
     _loadExisting();
     _checkSyncConfig();
-    _loadPolicies();
+    logFailure(_loadPolicies(), _MediaStoragePageState, 'load policies');
   }
 
   Future<void> _loadPolicies() async {

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -33,6 +33,7 @@ import 'package:submersion/features/planner/presentation/widgets/plan_status_chi
 import 'package:submersion/features/planner/presentation/widgets/saved_plans_sheet.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Whether [id] refers to a plan that already exists in the store. Drives the
 /// visibility of the destructive "Delete plan" action: a brand-new, never-saved
@@ -272,15 +273,15 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
       case 'settings':
         _focusSetup('deco');
       case 'convert':
-        _convertToDive();
+        logFailure(_convertToDive(), _PlanCanvasPageState, 'convert to dive');
       case 'slate':
-        _exportSlate();
+        logFailure(_exportSlate(), _PlanCanvasPageState, 'export slate');
       case 'share':
-        _sharePlanFile();
+        logFailure(_sharePlanFile(), _PlanCanvasPageState, 'share plan file');
       case 'reset':
         _resetPlan();
       case 'delete':
-        _deletePlan();
+        logFailure(_deletePlan(), _PlanCanvasPageState, 'delete plan');
     }
   }
 

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -977,6 +977,7 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   SettingsNotifier(this._repository, this._ref) : super(const AppSettings()) {
     _initialLoad = _initializeAndLoad();
+    _logIfItFails(_initialLoad);
 
     // Listen for diver changes and reload settings
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -985,8 +986,33 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
         _validatedDiverId = null;
         _isLoading =
             false; // Allow loading even if previous load was in progress
-        _initializeAndLoad();
+        _logIfItFails(_initializeAndLoad());
       }
+    });
+  }
+
+  /// Give [load] a listener so a failure is logged instead of reaching the
+  /// zone handler.
+  ///
+  /// State starts at, and stays at, the [AppSettings] defaults when a load
+  /// fails, so nothing downstream acts on the error. Left unlistened it
+  /// escapes to the zone, and package:test blames whichever test happens to be
+  /// running at that moment: a test that sets up a database, touches any
+  /// settings-derived provider and finishes while this read is still in flight
+  /// tears the database down underneath it, and an unrelated test later in the
+  /// shard fails with "This test failed after it had already completed". Which
+  /// test that is depends on timing, which is why re-running usually clears it.
+  ///
+  /// This does not change what [initialLoad] does. A Dart future may carry
+  /// several listeners, so callers that await it still see the error and still
+  /// have to fall back to the defaults themselves.
+  void _logIfItFails(Future<void> load) {
+    load.catchError((Object error, StackTrace stackTrace) {
+      LoggerService.forClass(SettingsNotifier).error(
+        'Failed to load diver settings',
+        error: error,
+        stackTrace: stackTrace,
+      );
     });
   }
 

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/domain/visibility/visibility_scale.dart';
 import 'package:submersion/core/utils/coordinates/coordinate_format.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 import 'package:submersion/features/dive_sites/domain/matching/site_match_sensitivity.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/theme/app_theme_preset.dart';
@@ -977,7 +978,7 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   SettingsNotifier(this._repository, this._ref) : super(const AppSettings()) {
     _initialLoad = _initializeAndLoad();
-    _logIfItFails(_initialLoad);
+    logFailure(_initialLoad, SettingsNotifier, 'load diver settings');
 
     // Listen for diver changes and reload settings
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -986,33 +987,12 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
         _validatedDiverId = null;
         _isLoading =
             false; // Allow loading even if previous load was in progress
-        _logIfItFails(_initializeAndLoad());
+        logFailure(
+          _initializeAndLoad(),
+          SettingsNotifier,
+          'reload settings after a diver change',
+        );
       }
-    });
-  }
-
-  /// Give [load] a listener so a failure is logged instead of reaching the
-  /// zone handler.
-  ///
-  /// State starts at, and stays at, the [AppSettings] defaults when a load
-  /// fails, so nothing downstream acts on the error. Left unlistened it
-  /// escapes to the zone, and package:test blames whichever test happens to be
-  /// running at that moment: a test that sets up a database, touches any
-  /// settings-derived provider and finishes while this read is still in flight
-  /// tears the database down underneath it, and an unrelated test later in the
-  /// shard fails with "This test failed after it had already completed". Which
-  /// test that is depends on timing, which is why re-running usually clears it.
-  ///
-  /// This does not change what [initialLoad] does. A Dart future may carry
-  /// several listeners, so callers that await it still see the error and still
-  /// have to fall back to the defaults themselves.
-  void _logIfItFails(Future<void> load) {
-    load.catchError((Object error, StackTrace stackTrace) {
-      LoggerService.forClass(SettingsNotifier).error(
-        'Failed to load diver settings',
-        error: error,
-        stackTrace: stackTrace,
-      );
     });
   }
 

--- a/lib/features/tags/presentation/providers/tag_providers.dart
+++ b/lib/features/tags/presentation/providers/tag_providers.dart
@@ -4,6 +4,7 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
 import 'package:submersion/features/tags/domain/entities/tag.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final tagRepositoryProvider = Provider<TagRepository>((ref) {
@@ -80,7 +81,7 @@ class TagListNotifier extends StateNotifier<AsyncValue<List<Tag>>> {
 
   TagListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(_initializeAndLoad(), TagListNotifier, 'initialize and load');
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -89,7 +90,11 @@ class TagListNotifier extends StateNotifier<AsyncValue<List<Tag>>> {
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(tagsProvider);
         _ref.invalidate(tagStatisticsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          TagListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/lib/features/tags/presentation/widgets/tag_merge_sheet.dart
+++ b/lib/features/tags/presentation/widgets/tag_merge_sheet.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/tags/domain/entities/tag.dart';
 import 'package:submersion/features/tags/presentation/providers/tag_providers.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_input_widget.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 class TagMergeSheet extends ConsumerStatefulWidget {
   final List<TagStatistic> selectedStats;
@@ -40,7 +41,11 @@ class _TagMergeSheetState extends ConsumerState<TagMergeSheet> {
     _selectedColor = mostUsed.tag.colorHex ?? TagColors.predefined.first;
     _selectedNameFromTag = mostUsed.tag.id;
 
-    _loadAffectedDives();
+    logFailure(
+      _loadAffectedDives(),
+      _TagMergeSheetState,
+      'load affected dives',
+    );
   }
 
   Future<void> _loadAffectedDives() async {

--- a/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
+++ b/lib/features/tank_presets/presentation/providers/tank_preset_providers.dart
@@ -3,6 +3,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/tank_presets/data/repositories/tank_preset_repository.dart';
 import 'package:submersion/features/tank_presets/domain/entities/tank_preset_entity.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 
 /// Repository provider
 final tankPresetRepositoryProvider = Provider<TankPresetRepository>((ref) {
@@ -57,7 +58,11 @@ class TankPresetListNotifier
 
   TankPresetListNotifier(this._repository, this._ref)
     : super(const AsyncValue.loading()) {
-    _initializeAndLoad();
+    logFailure(
+      _initializeAndLoad(),
+      TankPresetListNotifier,
+      'initialize and load',
+    );
 
     // Listen for diver changes and reload
     _ref.listen<String?>(currentDiverIdProvider, (previous, next) {
@@ -69,7 +74,11 @@ class TankPresetListNotifier
         _ref.invalidate(validatedCurrentDiverIdProvider);
         _ref.invalidate(tankPresetsProvider);
         _ref.invalidate(customTankPresetsProvider);
-        _initializeAndLoad();
+        logFailure(
+          _initializeAndLoad(),
+          TankPresetListNotifier,
+          'initialize and load',
+        );
       }
     });
 

--- a/test/core/utils/log_failure_test.dart
+++ b/test/core/utils/log_failure_test.dart
@@ -1,0 +1,55 @@
+// The helper that keeps fire-and-forget work out of the zone handler.
+//
+// Every one of these tests would fail if logFailure stopped attaching a
+// listener: an unlistened future's error reaches the zone, and package:test
+// reports that as a failure against whichever test is running.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/log_failure.dart';
+
+Future<void> _settle() async {
+  for (var i = 0; i < 5; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+class _Owner {}
+
+void main() {
+  test('a failing future does not reach the zone handler', () async {
+    logFailure(Future<void>.error(StateError('boom')), _Owner, 'do the thing');
+    await _settle();
+    // Reaching here at all is the assertion.
+  });
+
+  test('a failure that arrives late still does not reach the zone', () async {
+    // The real shape: work started during a test that outlives it.
+    logFailure(
+      Future<void>.delayed(
+        const Duration(milliseconds: 5),
+        () => throw StateError('late boom'),
+      ),
+      _Owner,
+      'do the slow thing',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  });
+
+  test('a succeeding future is left alone', () async {
+    var ran = false;
+    logFailure(Future<void>(() => ran = true), _Owner, 'do the thing');
+    await _settle();
+    expect(ran, isTrue);
+  });
+
+  test(
+    'the caller can still await the same future and see the error',
+    () async {
+      // A Dart future carries several listeners, so attaching one here does not
+      // consume the error. Anything that also awaits it still has to handle it.
+      final work = Future<void>.error(StateError('boom'));
+      logFailure(work, _Owner, 'do the thing');
+      await expectLater(work, throwsA(isA<StateError>()));
+    },
+  );
+}

--- a/test/features/settings/presentation/providers/settings_load_failure_test.dart
+++ b/test/features/settings/presentation/providers/settings_load_failure_test.dart
@@ -1,0 +1,128 @@
+// A failing settings load must not escape to the zone.
+//
+// SettingsNotifier starts its load in the constructor and nothing listens to
+// the resulting future. In Dart a future with no listener delivers its error to
+// the zone handler, and package:test attributes a zone error to whichever test
+// happens to be running at that moment. So a settings load that fails after its
+// own test has finished fails a LATER, unrelated test with "This test failed
+// after it had already completed", and which test that is depends on timing.
+//
+// That is the mechanism behind the intermittent CI failures on shard runs: a
+// test sets up a database, touches any settings-derived provider, and finishes
+// while the load is still in flight. Teardown closes the database, the pending
+// Drift query fails, and the error lands on a stranger.
+//
+// Reproduced from a real CI failure of
+// test/features/weight_planner/presentation/providers/
+// plan_buoyancy_twin_provider_test.dart, which reads divePlanNotifierProvider
+// and so pulls in settingsProvider through the gradient factor providers.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
+import 'package:submersion/features/divers/domain/entities/diver.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+/// Stands in for the database going away underneath an in-flight read, which
+/// is what a test teardown does to a load started by a provider.
+class _FailingDiverRepository extends DiverRepository {
+  @override
+  Future<List<Diver>> getAllDivers() async =>
+      throw StateError('database closed');
+
+  @override
+  Future<Diver?> getDefaultDiver() async => throw StateError('database closed');
+
+  @override
+  Future<Diver?> getDiverById(String id) async =>
+      throw StateError('database closed');
+}
+
+class _UnusedSettingsRepository extends DiverSettingsRepository {}
+
+class _NullDiverIdNotifier extends StateNotifier<String?>
+    implements CurrentDiverIdNotifier {
+  _NullDiverIdNotifier() : super(null);
+
+  @override
+  Future<void> setCurrentDiver(String id) async => state = id;
+
+  @override
+  Future<void> clearCurrentDiver() async => state = null;
+}
+
+Future<ProviderContainer> _container() async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      diverSettingsRepositoryProvider.overrideWithValue(
+        _UnusedSettingsRepository(),
+      ),
+      diverRepositoryProvider.overrideWithValue(_FailingDiverRepository()),
+      currentDiverIdProvider.overrideWith((ref) => _NullDiverIdNotifier()),
+    ],
+  );
+}
+
+/// Several event-loop turns, enough for the constructor's load to run through
+/// its awaits and fail.
+Future<void> _settle() async {
+  for (var i = 0; i < 10; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  test('a failing load does not escape to the zone', () async {
+    final container = await _container();
+    addTearDown(container.dispose);
+
+    // Deliberately NOT awaiting initialLoad: awaiting it would add a listener
+    // and mask the very bug under test. This is what production does, and what
+    // every test that merely touches a settings-derived provider does.
+    container.read(settingsProvider.notifier);
+    await _settle();
+
+    // Reaching here without the runner reporting an uncaught error is the
+    // assertion. The settings themselves stay at the defaults.
+    expect(container.read(settingsProvider), const AppSettings());
+  });
+
+  test(
+    'a failing reload after a diver change does not escape either',
+    () async {
+      final container = await _container();
+      addTearDown(container.dispose);
+
+      container.read(settingsProvider.notifier);
+      await _settle();
+
+      // The diver-change listener calls the same load fire-and-forget, without
+      // even storing the future, so it is the second escape route.
+      await container
+          .read(currentDiverIdProvider.notifier)
+          .setCurrentDiver('d1');
+      await _settle();
+
+      expect(container.read(settingsProvider), const AppSettings());
+    },
+  );
+
+  test('awaiting initialLoad still surfaces the failure', () async {
+    // The contract documented on initialLoad is preserved: callers that await
+    // it still see the error and fall back to the defaults themselves. Only
+    // the unlistened path changes.
+    final container = await _container();
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(settingsProvider.notifier).initialLoad,
+      throwsA(isA<StateError>()),
+    );
+  });
+}


### PR DESCRIPTION
CI shards intermittently fail with **"This test failed after it had already
completed"** on a test that has nothing to do with the branch, and re-running
the job clears it. The blamed test moves around between runs, which is why it
reads as general CI flakiness rather than as a bug with an address.

It has an address.

## The mechanism

In Dart, a `Future` with **no listener** delivers its error to the zone handler.
`package:test` attributes a zone error to whichever test happens to be running
at that instant, so work that outlives its own test fails a **later, unrelated**
test. Which one depends on timing.

The common shape is a load started in a notifier constructor or an `initState`
and never awaited. The test finishes, teardown closes the database, and the
Drift query still in flight fails with nobody listening.

Worked example, from the failure that prompted this:

```
plan_buoyancy_twin_provider_test  (weight planner)
  reads divePlanNotifierProvider
    -> planCalculatorServiceProvider
      -> gfLowProvider -> settingsProvider
        -> SettingsNotifier constructor starts an async load
          -> DiverRepository.getDefaultDiver()   <- still in flight
test ends -> database torn down -> query fails -> zone -> blamed on a stranger
```

That test passes 8/8 in isolation. It needs shard contention to lose the race,
so reproducing it by running the named file alone proves nothing. The named
file is a bystander, not a suspect.

## The fix

One helper, `lib/core/utils/log_failure.dart`:

```dart
logFailure(_initializeAndLoad(), BuddyListNotifier, 'initialize and load');
```

It attaches a listener and logs. That is the whole fix: the error stops being
"unhandled" and gains an owner and a task name.

**`catchError`, not a `try/catch` inside the load**, deliberately. A Dart future
can carry several listeners, so attaching one keeps the error out of the zone
while anything that *also* awaits it still sees it. `SettingsNotifier.initialLoad`
documents that it may throw and `post_restore_safety_review.dart` relies on
that; a `try/catch` inside would have rewritten that contract silently. There is
a test pinning it.

## Scope

`SettingsNotifier` first, because it caused the observed failure and has by far
the widest fan-out: gradient factors, ppO2 ceilings, deco increments, the
planner, charts and the gas calculators all pull it in transitively, which is
how a weight-planner test came to die on a settings read. It had **two**
unlistened loads, the stored `_initialLoad` and the diver-change listener that
did not even store its future.

Then the same treatment for every other fire-and-forget async call found by a
source scan: 49 sites across 24 files, covering notifier constructors and
diver-change listeners, `initState` loads, and user-action handlers such as
plan export, share and delete.

## What this is and is not worth

Mostly **test stability**. `main` already runs
`runZonedGuarded(_bootstrap, logUncaughtZoneError)`, so in the running app these
errors were already caught and logged; `flutter_test` has no such safety net and
fails the test instead. The production gain is real but smaller: a log line that
names the class and the task instead of a bare "Uncaught zone error".

## Notes

- Four candidates in `database.dart` were **not** fixed. The scan flagged them,
  but they are `Future<void> fooForTest() => _foo();` expression-bodied returns,
  awaited by their caller, and never a leak. The analyzer caught the bad rewrite
  and it was reverted.
- Not every red CI run is this. A survey of six recent failures found most were
  deterministic count-assertion failures on branches that legitimately changed a
  count (`import_enums_test`, `view_field_config_test` "has 22 columns"), which
  reproduced identically across reruns. Those are deliberate change-detectors
  and a rerun never fixes them; they should not be loosened.
- No architecture test guards against a 50th site appearing. The repo has
  precedent for one (`provider_tick_scanner_test.dart` scans source this way),
  and it would be a reasonable follow-up.

## Testing

Seven new tests: four on the helper (including one proving a caller can still
await the same future and see the error, since 24 files now depend on that), and
three on `SettingsNotifier` driving both escape routes directly with a
repository that throws and a load nobody awaits. The two escape-route tests fail
without the fix.
