### PR TITLE
fix(media): show dive computer and mini profile in the Media section

### DIFF
--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -36,8 +36,20 @@ class MediaRepository {
   /// the joined `media_enrichment` values, and enrichment is backfilled on
   /// every dive-detail open (see `DiveMediaEnricher`), which would otherwise
   /// churn listeners for data they do not display.
+  /// Fires on writes to `media` AND `media_enrichment`.
+  ///
+  /// Every read behind this tick left-outer-joins the enrichment table, so a
+  /// row written there changes what consumers would return just as much as a
+  /// write to `media` itself. Watching only `media` made the enrichment
+  /// backfill invisible: it computed and saved the depth/elapsed values, no
+  /// provider re-read them, and the depth chips, mini profile and dive
+  /// computer stayed absent until the viewer was closed and reopened. Newly
+  /// linked media hit that every time, since linking is precisely when the
+  /// enrichment does not exist yet.
   Stream<void> watchMediaChanges() => _db
-      .tableUpdates(TableUpdateQuery.onTable(_db.media))
+      .tableUpdates(
+        TableUpdateQuery.onAllTables([_db.media, _db.mediaEnrichment]),
+      )
       .debounce(changeTickDebounce);
 
   /// Get all media for a dive, ordered by takenAt
@@ -676,6 +688,11 @@ class MediaRepository {
           _db.mediaEnrichment,
         )..where((t) => t.mediaId.equals(enrichment.mediaId))).write(
           MediaEnrichmentCompanion(
+            // The dive is part of the value, not just a back-pointer: an
+            // enrichment is the join product of this media and ONE dive's
+            // profile. Leaving it behind would let a row repaired against a
+            // different dive keep claiming the old one.
+            diveId: Value(enrichment.diveId),
             depthMeters: Value(enrichment.depthMeters),
             temperatureCelsius: Value(enrichment.temperatureCelsius),
             elapsedSeconds: Value(enrichment.elapsedSeconds),

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -27,11 +27,23 @@ class DiveMediaEnricher {
   final Future<void> Function(MediaEnrichment enrichment) saveEnrichment;
   final EnrichmentService enrichmentService;
 
-  /// Enriches every media item linked to [diveId] that has no enrichment yet.
-  /// Idempotent — already-enriched items are skipped — so it is safe to call
-  /// after a fresh link and repeatedly as a backfill. Returns the number of
-  /// items newly enriched (0 means nothing changed; callers can skip a
-  /// refresh).
+  /// Enriches every media item linked to [diveId] whose stored enrichment is
+  /// missing, or disagrees with what the dive's profile says it should be.
+  ///
+  /// Recomputing every item and writing only on a difference is what makes
+  /// this a repair as well as a backfill. Skipping anything that merely HAD a
+  /// row meant two classes of wrong data could never heal: rows surviving a
+  /// re-link still pointing at the previous dive, and rows written before the
+  /// taken_at wall-clock-UTC fix, whose elapsed time is skewed by the host's
+  /// offset and whose depth is clamped to the first profile point. The only
+  /// remedy used to be unlinking and re-adding the photo.
+  ///
+  /// Rows that already match are left untouched. That matters beyond saving a
+  /// query: mediaEnrichment is an HLC-synced entity, so rewriting an unchanged
+  /// row would bump its clock and ship a no-op to every other device.
+  ///
+  /// Returns the number of rows written (0 means nothing changed, so callers
+  /// can skip a refresh).
   Future<int> enrichMissingForDive(String diveId) async {
     final dive = await loadDive(diveId);
     if (dive == null || dive.profile.isEmpty) return 0;
@@ -39,7 +51,6 @@ class DiveMediaEnricher {
     final media = await loadMediaForDive(diveId);
     var enriched = 0;
     for (final item in media) {
-      if (item.enrichment != null) continue;
       // Signatures are attached to a dive but not moments within it, and the
       // chart excludes them regardless — don't fabricate a depth/time for one.
       if (item.mediaType == MediaType.instructorSignature) continue;
@@ -51,15 +62,21 @@ class DiveMediaEnricher {
       );
 
       // Mirror the gallery path: don't persist a row we couldn't actually
-      // place (no depth and no usable profile match).
+      // place (no depth and no usable profile match). An existing row is left
+      // alone rather than overwritten with the unplaceable result.
       if (result.depthMeters == null &&
           result.matchConfidence == MatchConfidence.noProfile) {
         continue;
       }
 
+      final existing = item.enrichment;
+      if (existing != null && _matches(existing, result, diveId)) continue;
+
       await saveEnrichment(
         MediaEnrichment(
-          id: '',
+          // Keep the row's identity so the repository updates in place
+          // instead of minting a second row for the same media.
+          id: existing?.id ?? '',
           mediaId: item.id,
           diveId: diveId,
           depthMeters: result.depthMeters,
@@ -74,4 +91,19 @@ class DiveMediaEnricher {
     }
     return enriched;
   }
+
+  /// Whether [existing] already records exactly what [result] computes for
+  /// [diveId]. Every persisted field is compared: a partial match still means
+  /// the stored row is wrong and has to be rewritten.
+  bool _matches(
+    MediaEnrichment existing,
+    EnrichmentResult result,
+    String diveId,
+  ) =>
+      existing.diveId == diveId &&
+      existing.depthMeters == result.depthMeters &&
+      existing.temperatureCelsius == result.temperatureCelsius &&
+      existing.elapsedSeconds == result.elapsedSeconds &&
+      existing.matchConfidence == result.matchConfidence &&
+      existing.timestampOffsetSeconds == result.timestampOffsetSeconds;
 }

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -24,6 +24,7 @@ import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/presentation/helpers/media_share_helper.dart';
 import 'package:submersion/features/media/presentation/providers/lightroom_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/features/media/presentation/widgets/media_nav_arrows.dart';
@@ -88,6 +89,10 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
 
   bool _showOverlay = true;
 
+  /// Dives whose enrichment backfill has already been attempted this session,
+  /// so a swipe through several un-enriched items of one dive runs it once.
+  final Set<String> _enrichAttempted = {};
+
   /// Live video controllers hoisted from _VideoItem, keyed by media id, so
   /// the Perdix overlay (mounted at page level) can follow playback. Entries
   /// come and go as gallery pages initialize/dispose.
@@ -110,6 +115,54 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
     } else {
       setState(() => _videoControllers[mediaId] = controller);
     }
+  }
+
+  /// Resolves the live record for the item on screen when the caller passed a
+  /// lean one.
+  ///
+  /// Two things make the passed item untrustworthy for dive context. The
+  /// Media section's library query hydrates rows without the enrichment join
+  /// on purpose (grids never render photo-time depth), so its items always
+  /// carry `enrichment == null`. And [MediaViewerPage.mediaList] is an
+  /// immutable snapshot taken when the route was pushed, so a re-link since
+  /// then leaves it reporting the *old* dive link, or none at all.
+  ///
+  /// Reading the one item actually on screen straight from the database
+  /// settles both: the library keeps its lean grid, and the viewer keeps
+  /// showing the truth. [mediaByIdProvider] self-invalidates on media
+  /// changes, so a re-link performed while the viewer is open lands too.
+  ///
+  /// The early return keeps the dive-detail path free of a second read: its
+  /// list already arrives enriched and reactive.
+  MediaItem _hydrate(MediaItem item) {
+    if (item.enrichment != null) return item;
+    return ref.watch(mediaByIdProvider(item.id)).value ?? item;
+  }
+
+  /// Computes and saves the missing [MediaEnrichment] rows for [diveId], the
+  /// same idempotent backfill dive detail runs on open.
+  ///
+  /// Media linked from a local file gets a row but no enrichment, and until
+  /// now only dive detail ever closed that gap: a photo could show its depth
+  /// and profile marker there and nothing at all in the Media section.
+  void _backfillEnrichment(String diveId) {
+    if (!_enrichAttempted.add(diveId)) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // The callback can fire after this state is disposed; touching `ref`
+      // then throws, so bail before using it.
+      if (!mounted) return;
+      try {
+        // Nothing to invalidate by hand: saving an enrichment ticks
+        // watchMediaChanges, and mediaByIdProvider self-invalidates on it, so
+        // the overlays pick the row up on the next frame. An invalidate here
+        // would also have to guess which ids were affected, and guessing from
+        // widget.mediaList is exactly what failed -- the snapshot still says
+        // diveId == null for the media that was just linked.
+        await ref.read(diveMediaEnricherProvider).enrichMissingForDive(diveId);
+      } catch (_) {
+        // Best-effort: a failure just leaves the overlays absent this session.
+      }
+    });
   }
 
   @override
@@ -202,9 +255,14 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
     final currentIndex = mediaList.isEmpty
         ? 0
         : _currentIndex.clamp(0, mediaList.length - 1);
-    final currentDiveId = mediaList.isEmpty
+    // Resolve the live record BEFORE reading any dive context off it. Taking
+    // the dive link from the snapshot instead is what left a freshly
+    // re-linked photo looking unlinked: no Go-to-dive, no depth chips, no
+    // mini profile, no dive computer.
+    final hydratedItem = mediaList.isEmpty
         ? null
-        : mediaList[currentIndex].diveId;
+        : _hydrate(mediaList[currentIndex]);
+    final currentDiveId = hydratedItem?.diveId;
     final diveAsync = currentDiveId == null
         ? const AsyncValue<Dive?>.data(null)
         : ref.watch(diveProvider(currentDiveId));
@@ -223,8 +281,15 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
             );
           }
 
-          final currentItem = mediaList[currentIndex];
+          // Non-null once mediaList is known non-empty. Every consumer below
+          // reads the hydrated record: the mini profile, the Perdix gate, the
+          // toolbar's Go-to-dive and hasEnrichment flags, the bottom
+          // depth/temp/elapsed chips and the info sheet.
+          final currentItem = hydratedItem!;
           final enrichment = currentItem.enrichment;
+          if (enrichment == null && currentDiveId != null) {
+            _backfillEnrichment(currentDiveId);
+          }
 
           // Get dive profile for the mini chart overlay
           final diveProfile = diveAsync.whenOrNull(

--- a/test/architecture/repository_tick_stream_test.dart
+++ b/test/architecture/repository_tick_stream_test.dart
@@ -590,6 +590,61 @@ void main() {
       );
     });
 
+    // Every read behind this tick (getMediaById, getMediaForDive, the library
+    // page) LEFT JOINs media_enrichment, so the enrichment table is part of
+    // the answer, not a detail of some other feature. Watching only `media`
+    // made the depth/elapsed chips, the mini profile and the dive computer
+    // stay absent after a backfill computed them: the row was written, the
+    // provider never re-read it, and the overlays only appeared if the viewer
+    // was closed and reopened. Newly linked media hit this every time, since
+    // linking is exactly when the enrichment does not exist yet.
+    test('watchMediaChanges fires on an enrichment-only write', () async {
+      await seedParents();
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion.insert(
+              id: 'd1',
+              diveDateTime: now,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      await db
+          .into(db.media)
+          .insert(
+            MediaCompanion.insert(
+              id: 'm1',
+              diveId: const Value('d1'),
+              filePath: '/photos/m1.jpg',
+              fileType: const Value('photo'),
+              sourceType: const Value('localFile'),
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+
+      expect(
+        await fires(
+          MediaRepository().watchMediaChanges(),
+          () => db
+              .into(db.mediaEnrichment)
+              .insert(
+                MediaEnrichmentCompanion.insert(
+                  id: 'e1',
+                  mediaId: 'm1',
+                  diveId: 'd1',
+                  createdAt: now,
+                ),
+              ),
+        ),
+        isTrue,
+        reason:
+            'a media read joins media_enrichment, so an enrichment write '
+            'changes what the tick s consumers would return',
+      );
+    });
+
     test('watchStoresChanges fires', () async {
       expect(
         await fires(

--- a/test/features/media/data/media_reassign_test.dart
+++ b/test/features/media/data/media_reassign_test.dart
@@ -1,7 +1,12 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+// Shares the `domain` prefix with the media entity below: Drift generates its
+// own `Dive` into database.dart, so the entity has to be qualified.
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/dive_media_enricher.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart'
     hide MediaEnrichment;
 import 'package:submersion/features/media/domain/entities/media_item.dart'
@@ -34,14 +39,14 @@ void main() {
         ),
       );
 
-  MediaItem item(String id, {String? diveId}) => MediaItem(
+  MediaItem item(String id, {String? diveId, DateTime? takenAt}) => MediaItem(
     id: id,
     diveId: diveId,
     mediaType: MediaType.photo,
     sourceType: MediaSourceType.localFile,
     filePath: '/tmp/$id',
     localPath: '/tmp/$id',
-    takenAt: DateTime(2026, 6, 1),
+    takenAt: takenAt ?? DateTime(2026, 6, 1),
     createdAt: DateTime(2026, 6, 1),
     updatedAt: DateTime(2026, 6, 1),
   );
@@ -79,6 +84,66 @@ void main() {
         tombstones.map((r) => r.read<String>('record_id')),
         contains('e1'),
       );
+    },
+  );
+
+  // The deletion above is only half of reassignMediaToDive's contract: its doc
+  // comment promises the rows are "recomputed lazily by DiveMediaEnricher the
+  // next time the new dive's media renders". Nothing pinned that half, and the
+  // recompute had exactly one trigger (the dive detail page) -- so a photo
+  // re-linked from the Media section stayed stripped of its depth, elapsed
+  // time and profile marker for as long as the user never opened the new
+  // dive's detail page.
+  test(
+    'the enrichment a reassign deletes is recomputed against the new dive',
+    () async {
+      await insertDive('d1');
+      await insertDive('d2');
+      // Both timestamps are wall-clock-as-UTC, the convention taken_at and
+      // entry_time are stored and hydrated under. Building either as a local
+      // DateTime here would encode the offset into elapsedSeconds and make
+      // the assertion pass or fail with the host timezone.
+      // Shutter at 12:08, 42 minutes after the d2 entry time below.
+      final m = await repo.createMedia(
+        item('m1', diveId: 'd1', takenAt: DateTime.utc(2026, 6, 1, 12, 8)),
+      );
+      await repo.saveEnrichment(
+        domain.MediaEnrichment(
+          id: 'e1',
+          mediaId: m.id,
+          diveId: 'd1',
+          elapsedSeconds: 999,
+          depthMeters: 10,
+          matchConfidence: MatchConfidence.exact,
+          createdAt: DateTime(2026, 6, 1),
+        ),
+      );
+
+      await repo.reassignMediaToDive([m.id], 'd2');
+      expect((await repo.getMediaById(m.id))!.enrichment, isNull);
+
+      final enricher = DiveMediaEnricher(
+        loadDive: (id) async => domain.Dive(
+          id: id,
+          dateTime: DateTime.utc(2026, 6, 1, 11, 26),
+          entryTime: DateTime.utc(2026, 6, 1, 11, 26),
+          profile: const [
+            domain.DiveProfilePoint(timestamp: 0, depth: 0),
+            domain.DiveProfilePoint(timestamp: 2520, depth: 20),
+            domain.DiveProfilePoint(timestamp: 2580, depth: 5),
+          ],
+        ),
+        loadMediaForDive: repo.getMediaForDive,
+        saveEnrichment: repo.saveEnrichment,
+      );
+
+      expect(await enricher.enrichMissingForDive('d2'), 1);
+
+      final restored = (await repo.getMediaById(m.id))!.enrichment;
+      expect(restored, isNotNull);
+      expect(restored!.diveId, 'd2', reason: 'recomputed against the new dive');
+      expect(restored.elapsedSeconds, 2520);
+      expect(restored.depthMeters, 20.0);
     },
   );
 

--- a/test/features/media/data/repositories/media_repository_test.dart
+++ b/test/features/media/data/repositories/media_repository_test.dart
@@ -460,6 +460,38 @@ void main() {
         final result = await repository.getEnrichmentForMedia(media.id);
         expect(result!.depthMeters, equals(20.0));
       });
+
+      // An enrichment is a join product of the media and ONE dive's profile,
+      // so its diveId is part of the value, not just a back-pointer. The
+      // update path used to leave it at whatever the row was first written
+      // with, which meant a row repaired against a different dive kept
+      // claiming the old one.
+      test('should update the dive link when saving over an existing '
+          'enrichment', () async {
+        final dive = await createTestDiveInDb(diveNumber: 1);
+        final otherDive = await createTestDiveInDb(diveNumber: 2);
+        final media = await repository.createMedia(
+          createTestMediaItem(diveId: dive.id, filePath: '/photos/moved.jpg'),
+        );
+
+        await repository.saveEnrichment(
+          createTestEnrichment(
+            mediaId: media.id,
+            diveId: otherDive.id,
+            depthMeters: 10.0,
+          ),
+        );
+        await repository.saveEnrichment(
+          createTestEnrichment(
+            mediaId: media.id,
+            diveId: dive.id,
+            depthMeters: 20.0,
+          ),
+        );
+
+        final result = await repository.getEnrichmentForMedia(media.id);
+        expect(result!.diveId, equals(dive.id));
+      });
     });
 
     group('media count', () {

--- a/test/features/media/data/services/dive_media_enricher_test.dart
+++ b/test/features/media/data/services/dive_media_enricher_test.dart
@@ -52,7 +52,82 @@ void main() {
     expect(saved.single.depthMeters, 20.0);
   });
 
-  test('is idempotent: skips items already enriched', () async {
+  /// The recompute is cheap arithmetic over an in-memory profile, but the
+  /// WRITE is not free: mediaEnrichment is an HLC-synced entity, so saving a
+  /// row that did not change would bump its clock and ship a no-op to every
+  /// other device. Matching rows must therefore be left completely alone.
+  test(
+    'is idempotent: writes nothing when the stored enrichment matches',
+    () async {
+      final saved = <MediaEnrichment>[];
+      final enricher = DiveMediaEnricher(
+        loadDive: (_) async => _diveWithProfile(),
+        loadMediaForDive: (_) async => [
+          _media(
+            'm1',
+            takenAt: DateTime.utc(2025, 12, 27, 12, 8),
+            enrichment: MediaEnrichment(
+              id: 'e1',
+              mediaId: 'm1',
+              diveId: 'd1',
+              elapsedSeconds: 2520,
+              depthMeters: 20,
+              temperatureCelsius: 26,
+              timestampOffsetSeconds: 0,
+              matchConfidence: MatchConfidence.exact,
+              createdAt: DateTime.utc(2025),
+            ),
+          ),
+        ],
+        saveEnrichment: (e) async => saved.add(e),
+      );
+
+      expect(await enricher.enrichMissingForDive('d1'), 0);
+      expect(saved, isEmpty);
+    },
+  );
+
+  /// Rows written before the taken_at wall-clock-UTC fix carry an elapsed
+  /// time skewed by the host's offset and a depth clamped to the first
+  /// profile point. Skipping every item that merely HAS a row meant those
+  /// never healed: the only remedy was unlinking and re-adding the photo.
+  test(
+    'recomputes a stored enrichment that disagrees with the profile',
+    () async {
+      final saved = <MediaEnrichment>[];
+      final enricher = DiveMediaEnricher(
+        loadDive: (_) async => _diveWithProfile(),
+        loadMediaForDive: (_) async => [
+          _media(
+            'm1',
+            takenAt: DateTime.utc(2025, 12, 27, 12, 8),
+            enrichment: MediaEnrichment(
+              id: 'e1',
+              mediaId: 'm1',
+              diveId: 'd1',
+              // The -5h skew and clamped surface depth the old bug produced.
+              elapsedSeconds: -16692,
+              depthMeters: 0.4572,
+              matchConfidence: MatchConfidence.estimated,
+              createdAt: DateTime.utc(2025),
+            ),
+          ),
+        ],
+        saveEnrichment: (e) async => saved.add(e),
+      );
+
+      expect(await enricher.enrichMissingForDive('d1'), 1);
+      expect(saved, hasLength(1));
+      expect(saved.single.elapsedSeconds, 2520);
+      expect(saved.single.depthMeters, 20.0);
+      expect(saved.single.matchConfidence, MatchConfidence.exact);
+    },
+  );
+
+  /// Defence in depth for the re-link path: reassignMediaToDive deletes the
+  /// stale rows itself, but a row that reaches the new dive still pointing at
+  /// the old one is wrong by definition and must not be trusted.
+  test('recomputes an enrichment still pointing at a different dive', () async {
     final saved = <MediaEnrichment>[];
     final enricher = DiveMediaEnricher(
       loadDive: (_) async => _diveWithProfile(),
@@ -63,8 +138,12 @@ void main() {
           enrichment: MediaEnrichment(
             id: 'e1',
             mediaId: 'm1',
-            diveId: 'd1',
+            // Values happen to match; only the dive is wrong.
+            diveId: 'some-other-dive',
             elapsedSeconds: 2520,
+            depthMeters: 20,
+            temperatureCelsius: 26,
+            timestampOffsetSeconds: 0,
             matchConfidence: MatchConfidence.exact,
             createdAt: DateTime.utc(2025),
           ),
@@ -73,8 +152,8 @@ void main() {
       saveEnrichment: (e) async => saved.add(e),
     );
 
-    expect(await enricher.enrichMissingForDive('d1'), 0);
-    expect(saved, isEmpty);
+    expect(await enricher.enrichMissingForDive('d1'), 1);
+    expect(saved.single.diveId, 'd1');
   });
 
   test('returns 0 and saves nothing when the dive has no profile', () async {

--- a/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/media/data/services/dive_media_enricher.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/domain/services/media_source_resolver.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
+import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
+import 'package:submersion/features/media/presentation/pages/media_viewer_page.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/mini_dive_profile_overlay.dart';
+import 'package:submersion/features/media/presentation/widgets/perdix_overlay/perdix_face.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// The Media section's library query hydrates rows lean: it left-joins no
+/// enrichment, because the grid never renders photo-time depth. The viewer,
+/// however, gates the mini profile chart, the dive computer face and the
+/// bottom depth/elapsed chips on exactly that enrichment. Opened from the
+/// library, an item that shows all three under dive detail therefore showed
+/// none of them.
+///
+/// These tests pin the viewer's own hydration: given a lean item with a dive
+/// link, it resolves the full record and renders the same dive context that
+/// dive detail does.
+class _UnavailableResolver implements MediaSourceResolver {
+  _UnavailableResolver(this.sourceType);
+  @override
+  final MediaSourceType sourceType;
+  @override
+  bool canResolveOnThisDevice(MediaItem item) => true;
+  @override
+  Future<MediaSourceData> resolve(MediaItem item) async =>
+      const UnavailableData(kind: UnavailableKind.notFound);
+  @override
+  Future<MediaSourceData> resolveThumbnail(
+    MediaItem item, {
+    required Size target,
+  }) => resolve(item);
+  @override
+  Future<MediaSourceMetadata?> extractMetadata(MediaItem item) async => null;
+  @override
+  Future<VerifyResult> verify(MediaItem item) async => VerifyResult.available;
+}
+
+MediaItem _item(String id, {String? diveId, MediaEnrichment? enrichment}) =>
+    MediaItem(
+      id: id,
+      diveId: diveId,
+      mediaType: MediaType.photo,
+      sourceType: MediaSourceType.platformGallery,
+      takenAt: DateTime.utc(2026, 7, 1, 10),
+      createdAt: DateTime.utc(2026, 7, 1),
+      updatedAt: DateTime.utc(2026, 7, 1),
+      enrichment: enrichment,
+    );
+
+MediaEnrichment _enrichment(String mediaId) => MediaEnrichment(
+  id: 'e-$mediaId',
+  mediaId: mediaId,
+  diveId: 'd1',
+  elapsedSeconds: 180,
+  depthMeters: 15.0,
+  matchConfidence: MatchConfidence.exact,
+  createdAt: DateTime.utc(2026, 7, 1),
+);
+
+final _dive = domain.Dive(
+  id: 'd1',
+  dateTime: DateTime.utc(2026, 7, 1, 9, 30),
+  profile: const [
+    domain.DiveProfilePoint(timestamp: 0, depth: 0.0),
+    domain.DiveProfilePoint(timestamp: 60, depth: 10.0),
+    domain.DiveProfilePoint(timestamp: 120, depth: 20.0),
+    domain.DiveProfilePoint(timestamp: 180, depth: 15.0),
+    domain.DiveProfilePoint(timestamp: 240, depth: 5.0),
+  ],
+);
+
+void main() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({'perdix_overlay_enabled': true});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(tearDownTestDatabase);
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required List<MediaItem> mediaList,
+    required String initialMediaId,
+    // Riverpod 3 does not export its Override type, so the list cannot be
+    // named; the spread below casts it back from context.
+    List<dynamic> overrides = const [],
+  }) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            mediaSourceResolverRegistryProvider.overrideWithValue(
+              MediaSourceResolverRegistry({
+                MediaSourceType.platformGallery: _UnavailableResolver(
+                  MediaSourceType.platformGallery,
+                ),
+              }),
+            ),
+            diveProvider('d1').overrideWith((ref) async => _dive),
+            ...overrides.cast(),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MediaViewerPage(
+              mediaList: mediaList,
+              initialMediaId: initialMediaId,
+              showGoToDive: true,
+            ),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+    });
+  }
+
+  testWidgets('a lean library item shows the mini dive profile chart', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1', diveId: 'd1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith(
+          (ref) async =>
+              _item('m1', diveId: 'd1', enrichment: _enrichment('m1')),
+        ),
+      ],
+    );
+
+    expect(find.byType(MiniDiveProfileOverlay), findsOneWidget);
+  });
+
+  testWidgets('a lean library item shows the dive computer face', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1', diveId: 'd1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith(
+          (ref) async =>
+              _item('m1', diveId: 'd1', enrichment: _enrichment('m1')),
+        ),
+      ],
+    );
+
+    expect(find.byType(PerdixFace), findsOneWidget);
+  });
+
+  testWidgets('a lean library item shows photo depth and elapsed time', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1', diveId: 'd1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith(
+          (ref) async =>
+              _item('m1', diveId: 'd1', enrichment: _enrichment('m1')),
+        ),
+      ],
+    );
+
+    expect(find.byIcon(Icons.arrow_downward), findsOneWidget);
+    expect(find.byIcon(Icons.timer_outlined), findsOneWidget);
+  });
+
+  testWidgets('an item unlinked in both the snapshot and the database shows '
+      'no dive context', (tester) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith((ref) async => _item('m1')),
+      ],
+    );
+
+    expect(find.byType(MiniDiveProfileOverlay), findsNothing);
+    expect(find.byType(PerdixFace), findsNothing);
+    expect(find.byIcon(Icons.scuba_diving), findsNothing);
+  });
+
+  // The list handed to the viewer is an immutable snapshot taken when the grid
+  // pushed the route. Re-linking updates the media row, but a snapshot
+  // captured before that still says diveId == null, and reading the dive link
+  // off the snapshot meant a freshly re-linked photo opened with no
+  // Go-to-dive action, no depth chips, no mini profile and no dive computer:
+  // indistinguishable from an item that really is unlinked.
+  testWidgets('a re-linked item whose snapshot still says unlinked takes its '
+      'dive from the database', (tester) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith(
+          (ref) async =>
+              _item('m1', diveId: 'd1', enrichment: _enrichment('m1')),
+        ),
+      ],
+    );
+
+    expect(find.byIcon(Icons.scuba_diving), findsOneWidget);
+    expect(find.byType(MiniDiveProfileOverlay), findsOneWidget);
+    expect(find.byType(PerdixFace), findsOneWidget);
+  });
+
+  testWidgets('a re-linked item with no enrichment yet backfills the dive the '
+      'database reports', (tester) async {
+    final enrichedDives = <String>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (diveId) async {
+        enrichedDives.add(diveId);
+        return _dive;
+      },
+      loadMediaForDive: (diveId) async => const [],
+      saveEnrichment: (enrichment) async {},
+    );
+
+    await pump(
+      tester,
+      mediaList: [_item('m1')],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider(
+          'm1',
+        ).overrideWith((ref) async => _item('m1', diveId: 'd1')),
+        diveMediaEnricherProvider.overrideWithValue(enricher),
+      ],
+    );
+
+    expect(enrichedDives, ['d1']);
+  });
+
+  testWidgets('an item whose enrichment row is missing backfills the dive '
+      'once', (tester) async {
+    final enrichedDives = <String>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (diveId) async {
+        enrichedDives.add(diveId);
+        return _dive;
+      },
+      loadMediaForDive: (diveId) async => const [],
+      saveEnrichment: (enrichment) async {},
+    );
+
+    await pump(
+      tester,
+      mediaList: [
+        _item('m1', diveId: 'd1'),
+        _item('m2', diveId: 'd1'),
+      ],
+      initialMediaId: 'm1',
+      overrides: [
+        // The row exists but carries no enrichment: the backfill is the only
+        // thing that can produce one.
+        mediaByIdProvider(
+          'm1',
+        ).overrideWith((ref) async => _item('m1', diveId: 'd1')),
+        mediaByIdProvider(
+          'm2',
+        ).overrideWith((ref) async => _item('m2', diveId: 'd1')),
+        diveMediaEnricherProvider.overrideWithValue(enricher),
+      ],
+    );
+
+    expect(enrichedDives, ['d1']);
+  });
+}

--- a/test/features/media/presentation/providers/media_by_id_enrichment_reactivity_test.dart
+++ b/test/features/media/presentation/providers/media_by_id_enrichment_reactivity_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart'
+    hide MediaEnrichment;
+import 'package:submersion/features/media/domain/entities/media_item.dart'
+    as domain
+    show MediaEnrichment;
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// The link the "newly linked media shows nothing" bug actually broke.
+///
+/// The viewer reads the item on screen through [mediaByIdProvider], and the
+/// enrichment backfill writes the depth/elapsed row a moment later, from a
+/// post-frame callback. Nothing re-reads the provider explicitly, so the
+/// overlays appear only if the provider notices the write by itself. It did
+/// not: its tick watched `media` while its query left-joins `media_enrichment`,
+/// so the row landed and the UI kept rendering the pre-backfill answer until
+/// the viewer was closed and reopened.
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  final epoch = DateTime.utc(2026, 6, 1).millisecondsSinceEpoch;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  test('mediaByIdProvider picks up an enrichment written after the first '
+      'read, with no manual invalidate', () async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'd1',
+            diveDateTime: epoch,
+            createdAt: epoch,
+            updatedAt: epoch,
+          ),
+        );
+    final media = await repo.createMedia(
+      MediaItem(
+        id: 'm1',
+        diveId: 'd1',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        filePath: '/photos/m1.jpg',
+        localPath: '/photos/m1.jpg',
+        takenAt: DateTime.utc(2026, 6, 1, 12),
+        createdAt: DateTime.utc(2026, 6, 1),
+        updatedAt: DateTime.utc(2026, 6, 1),
+      ),
+    );
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // Keep the provider alive the way the open viewer does; without a listener
+    // it would simply recompute on the next read and prove nothing.
+    final sub = container.listen(
+      mediaByIdProvider(media.id),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(sub.close);
+
+    expect(
+      (await container.read(mediaByIdProvider(media.id).future))?.enrichment,
+      isNull,
+      reason: 'no enrichment exists yet, exactly as after a fresh link',
+    );
+
+    await repo.saveEnrichment(
+      domain.MediaEnrichment(
+        id: 'e1',
+        mediaId: media.id,
+        diveId: 'd1',
+        elapsedSeconds: 2520,
+        depthMeters: 20,
+        matchConfidence: MatchConfidence.exact,
+        createdAt: DateTime.utc(2026, 6, 1),
+      ),
+    );
+
+    // The tick is debounced, so poll rather than assume a single turn is
+    // enough. Same shape as the repository tick-stream guards.
+    domain.MediaEnrichment? seen;
+    for (var i = 0; i < 150 && seen == null; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      seen = (await container.read(
+        mediaByIdProvider(media.id).future,
+      ))?.enrichment;
+    }
+
+    expect(
+      seen,
+      isNotNull,
+      reason:
+          'the enrichment write must invalidate mediaByIdProvider on its own; '
+          'the viewer has no other way to learn the backfill finished',
+    );
+    expect(seen!.depthMeters, 20.0);
+    expect(seen.elapsedSeconds, 2520);
+  });
+}


### PR DESCRIPTION
Viewing a photo or video from the **Media** section now shows the same dive context as viewing it from dive detail: the mini dive profile chart, the draggable dive computer face with its toolbar toggle, and the depth / temperature / elapsed-time chips in the bottom metadata bar.

Both surfaces already shared `MediaViewerPage` (dive detail reaches it through a thin `PhotoViewerPage` wrapper). Three independent defects kept the Media section's copy blank, each hiding the next.

## 1. The library hydrates lean, so every overlay gated itself off

`MediaLibraryRepository` deliberately omits the enrichment join, because grids never render photo-time depth. Items arriving from it carry `enrichment == null`, and the mini profile, the Perdix gate, `hasEnrichment` and the bottom chips all key off exactly that.

The viewer now resolves the live record for the item on screen through the existing `mediaByIdProvider`. The library keeps its lean, keyset-paginated grid; the viewer gets the same record dive detail already receives. Substituting the whole item rather than threading an enrichment variable fixes every consumer at one point.

## 2. Dive context was read from an immutable snapshot

`MediaViewerPage.mediaList` is captured when the route is pushed, and `currentDiveId` was read off it *before* hydration. A photo linked or re-linked since then still reported `diveId == null`, so it opened with no Go-to-dive action and no overlays: indistinguishable from media that really is unlinked.

Dive context is now derived from the hydrated record. Because `mediaByIdProvider` self-invalidates on media changes, a re-link performed while the viewer is open also lands.

## 3. The change tick watched a table the query does not read

`getMediaById` LEFT JOINs `media_enrichment`, but `watchMediaChanges()` ticked only on the `media` table. The enrichment backfill therefore computed and wrote its row and nothing re-read it, so the overlays appeared only after closing and reopening the viewer. **Newly linked media hit this every time**, since linking is precisely when the enrichment does not exist yet.

The tick now covers both tables. It is still built on `tableUpdates`, not a watched query, so the #1175 emit-on-subscribe guard still holds. This also removed the manual `ref.invalidate` the viewer was carrying, which was the tell that the provider was watching the wrong table in the first place.

## Related repairs on the way through

- **`DiveMediaEnricher` skipped anything that merely had a row.** Rows skewed by the old `taken_at` wall-clock-UTC bug (elapsed off by the host offset, depth clamped to the surface) and rows left pointing at a previous dive could never heal; the only remedy was unlinking and re-adding the photo. It now recomputes every item and writes only on a difference. Matching rows are left untouched, which matters because `media_enrichment` is HLC-synced and a no-op write would ship a clock bump to every device.
- **`saveEnrichment`'s update path never wrote `diveId`**, without which the cross-dive repair above could not persist.
- **The enrichment backfill dive detail runs on open is now wired into the viewer**, so media linked from a local file (a row with no enrichment) gets one in the Media section instead of only after a trip through dive detail.

## Testing

New `media_viewer_library_overlays_test.dart` (7 cases) covers the lean-item overlays, the depth/elapsed chips, the stale-snapshot re-link case, the unlinked-item negative guard, and the once-only backfill. New `media_by_id_enrichment_reactivity_test.dart` drives a real database to pin the exact link that was broken: an enrichment written after the first read must reach the provider with no manual invalidate. New tick guard in `repository_tick_stream_test.dart`, in the file whose stated contract is that a tick must fire for every table its callers read.

Each was watched fail first for the intended reason. The reactivity test was written after its fix, so the fix was reverted to confirm it actually goes red without it.

Existing coverage extended: the reassign test now pins the recompute half of `reassignMediaToDive`'s documented contract (it only asserted the deletion before), and `media_repository_test` gains the `diveId`-on-update guard.

Full suite green. No schema migration, no new settings, no new user-facing strings.
