### PR TITLE
fix(media): address review comments from #1229

### DIFF
--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -32,20 +32,19 @@ class MediaRepository {
   /// straight to the database and so bypass the notifier paths that invalidate
   /// per-dive media providers.
   ///
-  /// Scoped to `media` alone: consumers render the media rows themselves, not
-  /// the joined `media_enrichment` values, and enrichment is backfilled on
-  /// every dive-detail open (see `DiveMediaEnricher`), which would otherwise
-  /// churn listeners for data they do not display.
-  /// Fires on writes to `media` AND `media_enrichment`.
+  /// Covers `media_enrichment` as well as `media`.
   ///
-  /// Every read behind this tick left-outer-joins the enrichment table, so a
-  /// row written there changes what consumers would return just as much as a
-  /// write to `media` itself. Watching only `media` made the enrichment
-  /// backfill invisible: it computed and saved the depth/elapsed values, no
-  /// provider re-read them, and the depth chips, mini profile and dive
-  /// computer stayed absent until the viewer was closed and reopened. Newly
-  /// linked media hit that every time, since linking is precisely when the
-  /// enrichment does not exist yet.
+  /// This tick was scoped to `media` alone on the reasoning that consumers
+  /// render the media rows themselves and not the joined enrichment values.
+  /// That is not true of the fullscreen viewer, and the reads behind the tick
+  /// left-outer-join the enrichment table regardless, so a row written there
+  /// changes what they return just as much as a write to `media` does.
+  ///
+  /// The narrower scope made the enrichment backfill invisible: it computed
+  /// and saved the depth and elapsed values, no provider re-read them, and
+  /// the depth chips, mini profile and dive computer stayed absent until the
+  /// viewer was closed and reopened. Newly linked media hit that every time,
+  /// since linking is precisely when the enrichment does not exist yet.
   Stream<void> watchMediaChanges() => _db
       .tableUpdates(
         TableUpdateQuery.onAllTables([_db.media, _db.mediaEnrichment]),

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -93,8 +93,13 @@ class DiveMediaEnricher {
   }
 
   /// Whether [existing] already records exactly what [result] computes for
-  /// [diveId]. Every persisted field is compared: a partial match still means
-  /// the stored row is wrong and has to be rewritten.
+  /// [diveId].
+  ///
+  /// Compares the computed values and the dive they belong to, not the row's
+  /// own identity or bookkeeping: `id` and `createdAt` are persisted but say
+  /// nothing about whether the enrichment is correct, and the repository's
+  /// update path does not rewrite them either. A partial match still counts
+  /// as a mismatch, since a stored row disagreeing on any value is wrong.
   bool _matches(
     MediaEnrichment existing,
     EnrichmentResult result,

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -129,15 +129,19 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
   ///
   /// Reading the one item actually on screen straight from the database
   /// settles both: the library keeps its lean grid, and the viewer keeps
-  /// showing the truth. [mediaByIdProvider] self-invalidates on media
-  /// changes, so a re-link performed while the viewer is open lands too.
+  /// showing the truth. [mediaByIdProvider] self-invalidates on media and
+  /// enrichment changes, so a re-link or a backfill that happens while the
+  /// viewer is open lands too.
   ///
-  /// The early return keeps the dive-detail path free of a second read: its
-  /// list already arrives enriched and reactive.
-  MediaItem _hydrate(MediaItem item) {
-    if (item.enrichment != null) return item;
-    return ref.watch(mediaByIdProvider(item.id)).value ?? item;
-  }
+  /// Deliberately unconditional. Skipping the read for a snapshot that
+  /// already carries an enrichment would save one keyed lookup on the
+  /// dive-detail path, but a snapshot holding an enrichment is no more
+  /// current than one holding none: both were captured when the route was
+  /// pushed. Trusting it is what produced this class of bug twice already,
+  /// so the rule is that the on-screen item always comes from the database.
+  /// The passed item stands in only while the read is in flight.
+  MediaItem _hydrate(MediaItem item) =>
+      ref.watch(mediaByIdProvider(item.id)).value ?? item;
 
   /// Computes and saves the missing [MediaEnrichment] rows for [diveId], the
   /// same idempotent backfill dive detail runs on open.

--- a/test/architecture/repository_tick_stream_test.dart
+++ b/test/architecture/repository_tick_stream_test.dart
@@ -641,7 +641,7 @@ void main() {
         isTrue,
         reason:
             'a media read joins media_enrichment, so an enrichment write '
-            'changes what the tick s consumers would return',
+            'changes what the consumers of this tick would return',
       );
     });
 

--- a/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
@@ -236,6 +236,30 @@ void main() {
     expect(find.byType(PerdixFace), findsOneWidget);
   });
 
+  // The snapshot already carrying an enrichment is not a reason to trust it.
+  // It is still a route-time capture, so a re-link (or a backfill) since then
+  // leaves it describing the wrong dive, and skipping the read would render
+  // that stale context for as long as the viewer stayed open.
+  testWidgets('an item that arrived already enriched still follows the '
+      'database', (tester) async {
+    await pump(
+      tester,
+      mediaList: [_item('m1', diveId: 'd-old', enrichment: _enrichment('m1'))],
+      initialMediaId: 'm1',
+      overrides: [
+        mediaByIdProvider('m1').overrideWith(
+          (ref) async =>
+              _item('m1', diveId: 'd1', enrichment: _enrichment('m1')),
+        ),
+      ],
+    );
+
+    // d1 is the dive the database reports; only it has a profile here, so
+    // the overlays render exactly when the stale d-old was NOT used.
+    expect(find.byType(MiniDiveProfileOverlay), findsOneWidget);
+    expect(find.byType(PerdixFace), findsOneWidget);
+  });
+
   testWidgets('a re-linked item with no enrichment yet backfills the dive the '
       'database reports', (tester) async {
     final enrichedDives = <String>[];


### PR DESCRIPTION
Follow-up to #1229, which merged before its review comments were addressed. Four Copilot findings, all accepted.

## Hydrate the on-screen item unconditionally

`_hydrate` short-circuited when the passed item already carried an enrichment, to spare the dive-detail path a second read. The reviewer's point is sharper than my optimisation: **a snapshot holding an enrichment is no more current than one holding none.** Both were captured when the route was pushed, so a re-link or a backfill since then leaves either of them describing the wrong dive.

That early return quietly re-introduced the assumption #1229 exists to remove. The rule is now uniform: the on-screen item always comes from the database, and the passed item stands in only while the read is in flight. The dive-detail path pays one keyed lookup per viewed item, which is worth a rule with no exceptions.

New test pins it. The snapshot claims `d-old` (no profile) while the database says `d1` (the dive that has one), so the overlays render only when the stale link is *not* used. It fails without the change.

## Contradictory `watchMediaChanges` doc

#1229 added a paragraph explaining that the tick now covers `media_enrichment`, and left the previous "Scoped to `media` alone" paragraph directly above it. The comment contradicted itself and the implementation. Rewritten as one doc that names the old scoping as the thing that was wrong, and why: consumers were assumed not to render the joined enrichment values, which is untrue of the fullscreen viewer, and every read behind the tick left-outer-joins that table regardless.

## `_matches` doc overclaimed

It said "every persisted field is compared", but `id` and `createdAt` are persisted and deliberately not compared (the repository's update path does not rewrite them either). Reworded to say it compares the computed values and the owning dive, not row identity or bookkeeping. The "a partial match is still a mismatch" point is kept, since that is what makes a half-populated row heal.

## Typo

`tick s` in a tick-test failure message, from dodging an apostrophe inside a single-quoted Dart string. Reworded rather than escaped.

## Testing

Full suite green (19811 passed, 0 failures). Analyze and format clean. No behaviour change beyond the hydration rule; the other three are documentation and a test string.
