### PR TITLE
fix(media): stop the app-wide 5-30s freeze after viewing media

### DIFF
--- a/lib/features/dive_3d/application/providers.dart
+++ b/lib/features/dive_3d/application/providers.dart
@@ -15,10 +15,11 @@ import 'package:submersion/features/dive_3d/domain/scene_geometry_service.dart';
 
 /// Assembles scene data from the primary/active source. Returns null when
 /// the dive has no usable profile (manual logs) so the UI can hide all 3D
-/// entry points. Reactivity comes from the upstream providers, which all
-/// self-invalidate on watchDiveDetailChanges. A null active source id
-/// means "the primary source"; sourceProfilesProvider orders primary
-/// first.
+/// entry points. Reactivity comes from the upstream providers: the
+/// profile/pressure/gas/event ones self-invalidate on
+/// watchAnalysisInputChanges, and mediaForDiveProvider on the broad
+/// watchDiveDetailChanges. A null active source id means "the primary
+/// source"; sourceProfilesProvider orders primary first.
 final dive3dSceneDataProvider = FutureProvider.family<Dive3dSceneData?, String>(
   (ref, diveId) async {
     final sourceProfiles = await ref.watch(

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -177,6 +177,42 @@ class DiveRepository {
       )
       .debounce(changeTickDebounce);
 
+  /// Change tick for the Buhlmann analysis chain and its input providers:
+  /// exactly the tables the pipeline reads, nothing else.
+  ///
+  /// The analysis providers used to subscribe to [watchDiveDetailChanges],
+  /// which includes `media`. Viewing a photo writes media rows (orphan
+  /// reconciliation, enrichment backfill), so every cached analysis in the
+  /// app was discarded and recomputed on the UI isolate -- the recursive
+  /// residual-CNS/tissue lookback across a whole trip included. That
+  /// recompute wave is the "20-30s of UI stutter" [changeTickDebounce]
+  /// documents, and it fired for writes the analysis never reads.
+  ///
+  /// Table set = the reads of [getDiveForAnalysis] (dives, dive_profiles,
+  /// dive_tanks, plus dive_data_sources/dive_computers for primary-source
+  /// resolution in [getMergedProfile]), the pipeline's direct queries
+  /// (gas_switches, tank_pressure_profiles), and dive_profile_events --
+  /// which the detail tick never covered at all, leaving
+  /// `diveComputerEventsProvider` blind to writes of its own table.
+  ///
+  /// `dives` also covers FK cascades: SQLite performs a cascade delete of
+  /// child rows without Drift seeing a write on the child tables, so the
+  /// parent tick is what keeps child readers from going stale.
+  Stream<void> watchAnalysisInputChanges() => _db
+      .tableUpdates(
+        TableUpdateQuery.allOf([
+          TableUpdateQuery.onTable(_db.dives),
+          TableUpdateQuery.onTable(_db.diveProfiles),
+          TableUpdateQuery.onTable(_db.diveTanks),
+          TableUpdateQuery.onTable(_db.tankPressureProfiles),
+          TableUpdateQuery.onTable(_db.gasSwitches),
+          TableUpdateQuery.onTable(_db.diveDataSources),
+          TableUpdateQuery.onTable(_db.diveComputers),
+          TableUpdateQuery.onTable(_db.diveProfileEvents),
+        ]),
+      )
+      .debounce(changeTickDebounce);
+
   /// Get all dives, ordered by date (newest first)
   /// This method is optimized to avoid N+1 queries by batch loading related data
   /// Optionally filter by [diverId] for multi-diver support

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -232,7 +232,10 @@ final sourceProfilesProvider =
       diveId,
     ) async {
       final repository = ref.watch(diveRepositoryProvider);
-      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
+      // Analysis-input tick: this hydration feeds sourceProfileAnalysisProvider
+      // and reads only profile/source tables, so the broad detail tick (which
+      // includes media) re-ran the per-source analysis after viewing a photo.
+      ref.invalidateSelfWhen(repository.watchAnalysisInputChanges());
       return repository.getProfilesByDataSource(diveId);
     });
 
@@ -1031,8 +1034,11 @@ final tankPressuresProvider =
       diveId,
     ) async {
       final repository = ref.watch(tankPressureRepositoryProvider);
+      // Analysis-input tick covers tank_pressure_profiles (and the dives
+      // cascade); the broad detail tick made every pressure curve re-query
+      // on unrelated writes such as media.
       ref.invalidateSelfWhen(
-        ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+        ref.watch(diveRepositoryProvider).watchAnalysisInputChanges(),
       );
       return repository.getTankPressuresForDive(diveId);
     });
@@ -1072,7 +1078,10 @@ final estimatedTankPressuresProvider =
 final diveDataSourcesProvider =
     FutureProvider.family<List<DiveDataSource>, String>((ref, diveId) async {
       final repository = ref.watch(diveRepositoryProvider);
-      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
+      // Analysis-input tick: reads dive_data_sources/dive_computers only, and
+      // sourceProfileAnalysisProvider watches this, so the broad detail tick
+      // re-ran the per-source analysis on unrelated writes such as media.
+      ref.invalidateSelfWhen(repository.watchAnalysisInputChanges());
       return repository.getDataSources(diveId);
     });
 

--- a/lib/features/dive_log/presentation/providers/gas_switch_providers.dart
+++ b/lib/features/dive_log/presentation/providers/gas_switch_providers.dart
@@ -9,7 +9,10 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_reposit
 final gasSwitchesProvider =
     FutureProvider.family<List<GasSwitchWithTank>, String>((ref, diveId) async {
       final repository = ref.watch(diveRepositoryProvider);
-      ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
+      // Analysis-input tick: gas_switches and dive_tanks are both in it, and
+      // the viewer/analysis chain watches this provider, so the broad detail
+      // tick (which includes media) re-ran analyses on photo-viewing writes.
+      ref.invalidateSelfWhen(repository.watchAnalysisInputChanges());
       return repository.getGasSwitchesForDive(diveId);
     });
 

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -38,8 +38,14 @@ final metricSourceInfoProvider = StateProvider<MetricSourceInfo?>(
 final diveComputerEventsProvider =
     FutureProvider.family<List<ProfileEvent>, String>((ref, diveId) async {
       final repository = ref.watch(diveComputerRepositoryProvider);
+      // The analysis-input tick, not the broad detail tick: every
+      // profileAnalysisProvider watches this provider, so its invalidation
+      // re-runs the whole Buhlmann chain. The detail tick fired for media
+      // and 15 other tables this query never reads -- and, being built
+      // before dive_profile_events existed, never fired for the one table
+      // it DOES read.
       ref.invalidateSelfWhen(
-        ref.watch(diveRepositoryProvider).watchDiveDetailChanges(),
+        ref.watch(diveRepositoryProvider).watchAnalysisInputChanges(),
       );
       final dbEvents = await repository.getEventsForDive(diveId);
       return dbEvents.map(mapDiveProfileEventToProfileEvent).toList();
@@ -823,15 +829,18 @@ ProfileAnalysis _runProfileAnalysis(_ProfileAnalysisInput input) {
 /// performance). keepAlive family, so a residual-chain walk over a
 /// repetitive dive week hydrates each prior dive once per session instead
 /// of fully re-hydrating on every detail open. Self-invalidates on the
-/// detail-table tick exactly like diveProvider, preserving the analysis
-/// refresh behavior that previously arrived transitively through
-/// diveProvider.
+/// analysis-input tick (the tables this hydration actually reads), so the
+/// residual-chain cache survives writes to unrelated detail tables such as
+/// media.
 final analysisDiveProvider = FutureProvider.family<Dive?, String>((
   ref,
   diveId,
 ) async {
   final repository = ref.watch(diveRepositoryProvider);
-  ref.invalidateSelfWhen(repository.watchDiveDetailChanges());
+  // Analysis-input tick only: this provider feeds profileAnalysisProvider,
+  // so invalidating it on the broad detail tick (which includes media)
+  // re-ran the full analysis cascade after merely viewing a photo.
+  ref.invalidateSelfWhen(repository.watchAnalysisInputChanges());
   return repository.getDiveForAnalysis(diveId);
 });
 

--- a/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_analysis_provider.dart
@@ -1422,10 +1422,12 @@ final weeklyOtuProvider = FutureProvider.family<double, String>((
 ) async {
   final repository = ref.watch(diveRepositoryProvider);
   // Sums OTU across every dive in the surrounding week, so it goes stale when
-  // ANY of those dives is added or removed -- not just this one. The rest of
-  // the file subscribes to watchDiveDetailChanges; this needs the wider dives
-  // tick, or the "Prior" figure keeps counting a merged-away same-week dive
-  // after the rest of the page has refreshed (issue #974).
+  // ANY of those dives is added or removed -- not just this one. The dives
+  // tick covers exactly that, or the "Prior" figure keeps counting a
+  // merged-away same-week dive after the rest of the page has refreshed
+  // (issue #974). watchAnalysisInputChanges, which the rest of the file now
+  // subscribes to, would also fire (it includes dives); the plain dives tick
+  // simply names the one table this query reads.
   ref.invalidateSelfWhen(repository.watchDivesChanges());
   try {
     final currentDive = await repository.getDiveTimes(diveId);

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -770,63 +770,7 @@ class MediaRepository {
   Future<void> saveEnrichment(domain.MediaEnrichment enrichment) async {
     try {
       _log.info('Saving enrichment for media: ${enrichment.mediaId}');
-      final now = DateTime.now();
-      final id = enrichment.id.isEmpty ? _uuid.v4() : enrichment.id;
-
-      // Check if enrichment already exists for this media
-      final existing = await (_db.select(
-        _db.mediaEnrichment,
-      )..where((t) => t.mediaId.equals(enrichment.mediaId))).getSingleOrNull();
-
-      if (existing != null) {
-        // Update existing enrichment
-        await (_db.update(
-          _db.mediaEnrichment,
-        )..where((t) => t.mediaId.equals(enrichment.mediaId))).write(
-          MediaEnrichmentCompanion(
-            // The dive is part of the value, not just a back-pointer: an
-            // enrichment is the join product of this media and ONE dive's
-            // profile. Leaving it behind would let a row repaired against a
-            // different dive keep claiming the old one.
-            diveId: Value(enrichment.diveId),
-            depthMeters: Value(enrichment.depthMeters),
-            temperatureCelsius: Value(enrichment.temperatureCelsius),
-            elapsedSeconds: Value(enrichment.elapsedSeconds),
-            matchConfidence: Value(enrichment.matchConfidence.name),
-            timestampOffsetSeconds: Value(enrichment.timestampOffsetSeconds),
-          ),
-        );
-        await _syncRepository.markRecordPending(
-          entityType: 'mediaEnrichment',
-          recordId: existing.id,
-          localUpdatedAt: now.millisecondsSinceEpoch,
-        );
-      } else {
-        // Insert new enrichment
-        await _db
-            .into(_db.mediaEnrichment)
-            .insert(
-              MediaEnrichmentCompanion(
-                id: Value(id),
-                mediaId: Value(enrichment.mediaId),
-                diveId: Value(enrichment.diveId),
-                depthMeters: Value(enrichment.depthMeters),
-                temperatureCelsius: Value(enrichment.temperatureCelsius),
-                elapsedSeconds: Value(enrichment.elapsedSeconds),
-                matchConfidence: Value(enrichment.matchConfidence.name),
-                timestampOffsetSeconds: Value(
-                  enrichment.timestampOffsetSeconds,
-                ),
-                createdAt: Value(now.millisecondsSinceEpoch),
-              ),
-            );
-        await _syncRepository.markRecordPending(
-          entityType: 'mediaEnrichment',
-          recordId: id,
-          localUpdatedAt: now.millisecondsSinceEpoch,
-        );
-      }
-
+      await _writeEnrichmentRow(enrichment);
       SyncEventBus.notifyLocalChange();
       _log.info('Saved enrichment for media: ${enrichment.mediaId}');
     } catch (e, stackTrace) {
@@ -836,6 +780,100 @@ class MediaRepository {
         stackTrace: stackTrace,
       );
       rethrow;
+    }
+  }
+
+  /// Saves a batch of enrichments in one transaction.
+  ///
+  /// One transaction means ONE mediaEnrichment table tick when it commits,
+  /// where per-row [saveEnrichment] calls tick once each. The dive-media
+  /// backfill runs from the open media viewer and can write a row per photo
+  /// of a dive; per-row ticks re-ran every provider on `watchMediaChanges`
+  /// (the library re-query included) once per 300ms debounce window for the
+  /// whole burst. An empty batch returns without touching the database, so
+  /// the common "everything already enriched" pass costs no tick at all.
+  Future<void> saveEnrichments(List<domain.MediaEnrichment> enrichments) async {
+    if (enrichments.isEmpty) return;
+    try {
+      _log.info('Saving ${enrichments.length} enrichments');
+      // markRecordPending opens its own transaction; Drift nests it as a
+      // savepoint because both repositories share the one database instance.
+      await _db.transaction(() async {
+        for (final enrichment in enrichments) {
+          await _writeEnrichmentRow(enrichment);
+        }
+      });
+      SyncEventBus.notifyLocalChange();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to save enrichment batch of ${enrichments.length}',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Upserts one enrichment row and marks it pending for sync.
+  ///
+  /// Shared by [saveEnrichment] (single write, then notify) and
+  /// [saveEnrichments] (many writes in one transaction, then one notify);
+  /// deliberately does NOT call [SyncEventBus.notifyLocalChange] so the
+  /// batch path can notify once.
+  Future<void> _writeEnrichmentRow(domain.MediaEnrichment enrichment) async {
+    final now = DateTime.now();
+    final id = enrichment.id.isEmpty ? _uuid.v4() : enrichment.id;
+
+    // Check if enrichment already exists for this media
+    final existing = await (_db.select(
+      _db.mediaEnrichment,
+    )..where((t) => t.mediaId.equals(enrichment.mediaId))).getSingleOrNull();
+
+    if (existing != null) {
+      // Update existing enrichment
+      await (_db.update(
+        _db.mediaEnrichment,
+      )..where((t) => t.mediaId.equals(enrichment.mediaId))).write(
+        MediaEnrichmentCompanion(
+          // The dive is part of the value, not just a back-pointer: an
+          // enrichment is the join product of this media and ONE dive's
+          // profile. Leaving it behind would let a row repaired against a
+          // different dive keep claiming the old one.
+          diveId: Value(enrichment.diveId),
+          depthMeters: Value(enrichment.depthMeters),
+          temperatureCelsius: Value(enrichment.temperatureCelsius),
+          elapsedSeconds: Value(enrichment.elapsedSeconds),
+          matchConfidence: Value(enrichment.matchConfidence.name),
+          timestampOffsetSeconds: Value(enrichment.timestampOffsetSeconds),
+        ),
+      );
+      await _syncRepository.markRecordPending(
+        entityType: 'mediaEnrichment',
+        recordId: existing.id,
+        localUpdatedAt: now.millisecondsSinceEpoch,
+      );
+    } else {
+      // Insert new enrichment
+      await _db
+          .into(_db.mediaEnrichment)
+          .insert(
+            MediaEnrichmentCompanion(
+              id: Value(id),
+              mediaId: Value(enrichment.mediaId),
+              diveId: Value(enrichment.diveId),
+              depthMeters: Value(enrichment.depthMeters),
+              temperatureCelsius: Value(enrichment.temperatureCelsius),
+              elapsedSeconds: Value(enrichment.elapsedSeconds),
+              matchConfidence: Value(enrichment.matchConfidence.name),
+              timestampOffsetSeconds: Value(enrichment.timestampOffsetSeconds),
+              createdAt: Value(now.millisecondsSinceEpoch),
+            ),
+          );
+      await _syncRepository.markRecordPending(
+        entityType: 'mediaEnrichment',
+        recordId: id,
+        localUpdatedAt: now.millisecondsSinceEpoch,
+      );
     }
   }
 

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -785,13 +785,15 @@ class MediaRepository {
 
   /// Saves a batch of enrichments in one transaction.
   ///
-  /// One transaction means ONE mediaEnrichment table tick when it commits,
-  /// where per-row [saveEnrichment] calls tick once each. The dive-media
-  /// backfill runs from the open media viewer and can write a row per photo
-  /// of a dive; per-row ticks re-ran every provider on `watchMediaChanges`
-  /// (the library re-query included) once per 300ms debounce window for the
-  /// whole burst. An empty batch returns without touching the database, so
-  /// the common "everything already enriched" pass costs no tick at all.
+  /// One transaction means one commit, all-or-nothing persistence, and ONE
+  /// mediaEnrichment table tick, where per-row [saveEnrichment] calls each
+  /// tick separately. `watchMediaChanges` trailing-debounces at 300ms, so a
+  /// fast per-row burst already coalesced -- but a burst SLOWER than the
+  /// window (the dive-media backfill runs from the open media viewer and
+  /// can write a row per photo of a dive) re-ran every subscribed provider
+  /// (the library re-query included) once per quiet gap. An empty batch
+  /// returns without touching the database, so the common "everything
+  /// already enriched" pass costs no tick at all.
   Future<void> saveEnrichments(List<domain.MediaEnrichment> enrichments) async {
     if (enrichments.isEmpty) return;
     try {

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -27,9 +27,10 @@ class DiveMediaEnricher {
 
   /// Persists a whole dive's new/changed rows in one call
   /// (`MediaRepository.saveEnrichments`: one transaction, one table tick).
-  /// A per-row save here ticked `watchMediaChanges` once per photo, and the
-  /// backfill runs from the OPEN media viewer: each tick re-ran the library
-  /// query and the other media providers while the user was mid-swipe.
+  /// Per-row saves here committed once per photo, and the backfill runs
+  /// from the OPEN media viewer: whenever the burst outlasted the 300ms
+  /// tick debounce, the library query and the other media providers re-ran
+  /// while the user was mid-swipe.
   final Future<void> Function(List<MediaEnrichment> enrichments)
   saveEnrichments;
   final EnrichmentService enrichmentService;

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -16,7 +16,7 @@ class DiveMediaEnricher {
   DiveMediaEnricher({
     required this.loadDive,
     required this.loadMediaForDive,
-    required this.saveEnrichment,
+    required this.saveEnrichments,
     this.enrichmentService = const EnrichmentService(),
   });
 
@@ -24,7 +24,14 @@ class DiveMediaEnricher {
   /// which populates `profile`; list queries do not).
   final Future<Dive?> Function(String diveId) loadDive;
   final Future<List<MediaItem>> Function(String diveId) loadMediaForDive;
-  final Future<void> Function(MediaEnrichment enrichment) saveEnrichment;
+
+  /// Persists a whole dive's new/changed rows in one call
+  /// (`MediaRepository.saveEnrichments`: one transaction, one table tick).
+  /// A per-row save here ticked `watchMediaChanges` once per photo, and the
+  /// backfill runs from the OPEN media viewer: each tick re-ran the library
+  /// query and the other media providers while the user was mid-swipe.
+  final Future<void> Function(List<MediaEnrichment> enrichments)
+  saveEnrichments;
   final EnrichmentService enrichmentService;
 
   /// Enriches every media item linked to [diveId] whose stored enrichment is
@@ -49,7 +56,7 @@ class DiveMediaEnricher {
     if (dive == null || dive.profile.isEmpty) return 0;
 
     final media = await loadMediaForDive(diveId);
-    var enriched = 0;
+    final toSave = <MediaEnrichment>[];
     for (final item in media) {
       // Signatures are attached to a dive but not moments within it, and the
       // chart excludes them regardless — don't fabricate a depth/time for one.
@@ -72,7 +79,7 @@ class DiveMediaEnricher {
       final existing = item.enrichment;
       if (existing != null && _matches(existing, result, diveId)) continue;
 
-      await saveEnrichment(
+      toSave.add(
         MediaEnrichment(
           // Keep the row's identity so the repository updates in place
           // instead of minting a second row for the same media.
@@ -87,9 +94,13 @@ class DiveMediaEnricher {
           createdAt: DateTime.now(),
         ),
       );
-      enriched++;
     }
-    return enriched;
+    // One batched save for the whole dive; skipped entirely when nothing
+    // changed, so the idempotent re-run costs no write and no tick.
+    if (toSave.isNotEmpty) {
+      await saveEnrichments(toSave);
+    }
+    return toSave.length;
   }
 
   /// Whether [existing] already records exactly what [result] computes for

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -377,17 +377,18 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
               tankPressures: tankPressures,
             );
           }
-          // With the overlay on, availability is the resolver's own answer.
-          // With it off, no resolver exists (that is the point: no analysis
-          // runs), so the toolbar toggle is offered from what is known
-          // cheaply: a synced item and a non-empty profile. For a
-          // multi-computer dive the source-scoped profile can differ from
-          // the merged one, so this can rarely offer a toggle the resolver
-          // would then decline; the cost is an inert toggle, not a wrongly
-          // hidden one.
-          final perdixAvailable = perdixResolver != null
-              ? perdixResolver.isAvailable
-              : perdixPrecondition && (diveProfile?.isNotEmpty ?? false);
+          // Toolbar-toggle visibility, decided the same cheap way in BOTH
+          // toggle states: a synced item and a non-empty merged profile.
+          // Deliberately NOT the resolver's answer. On a multi-computer dive
+          // whose ACTIVE source is metadata-only, the resolver scopes to an
+          // empty bucket and reports unavailable; a toggle that followed it
+          // would vanish the moment the user turned it on, stranding the
+          // setting with no control on this page to turn it back off. The
+          // cheap test's cost is an inert toggle in that case, never a
+          // vanished one. The resolver's own availability still gates the
+          // face mount below.
+          final perdixToggleAvailable =
+              perdixPrecondition && (diveProfile?.isNotEmpty ?? false);
 
           final viewer = GestureDetector(
             // Swipe down to close (common pattern for fullscreen viewers)
@@ -452,7 +453,7 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                         ? () => context.pushOrReturnTo('/dives/$currentDiveId')
                         : null,
                     hasEnrichment: enrichment?.depthMeters != null,
-                    showPerdixToggle: perdixAvailable,
+                    showPerdixToggle: perdixToggleAvailable,
                     perdixEnabled: settings.perdixOverlayEnabled,
                     onTogglePerdix: () => ref
                         .read(settingsProvider.notifier)
@@ -517,9 +518,9 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                 // The face absorbs pointer events over its own bounds (drags
                 // move it, taps do nothing); chrome-toggle and video
                 // play/pause taps work anywhere outside it.
-                if (perdixAvailable &&
-                    settings.perdixOverlayEnabled &&
-                    perdixResolver != null)
+                if (settings.perdixOverlayEnabled &&
+                    perdixResolver != null &&
+                    perdixResolver.isAvailable)
                   DraggablePerdixOverlay(
                     // Re-key when the persisted seed first arrives so a late
                     // settings load re-seeds the position (same trick as the
@@ -529,8 +530,8 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                       '${settings.perdixOverlayX}-${settings.perdixOverlayY}',
                     ),
                     resolver: perdixResolver,
-                    // Non-null under perdixAvailable: the resolver is only
-                    // ever built for items passing perdixPrecondition.
+                    // Non-null here: the resolver is only ever built for
+                    // items passing perdixPrecondition.
                     baseElapsedSeconds: enrichment!.elapsedSeconds!,
                     settings: settings,
                     topReserve:

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -301,21 +301,33 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
           );
 
           final dive = diveAsync.value;
+          // Whether this item is synced to a moment in the profile, decided
+          // from the enrichment alone. Media that is not synced can never
+          // show the Perdix face, whatever the analysis would say.
+          final perdixPrecondition =
+              enrichment?.elapsedSeconds != null &&
+              enrichment!.matchConfidence != MatchConfidence.noProfile;
+
           // Same source-aware profile/analysis pairing as the fullscreen
           // profile page: analysis curves are read by index, so the profile
           // passed to the resolver must be the one the analysis was computed
-          // over (multi-computer dives). Skipped entirely for items with no
-          // dive link — there is no profile to resolve against.
-          final PerdixFaceResolver perdixResolver;
-          if (currentDiveId == null) {
-            perdixResolver = PerdixFaceResolver(
-              profile: const [],
-              analysis: null,
-              tanks: const [],
-              gasSwitches: const [],
-              tankPressures: null,
-            );
-          } else {
+          // over (multi-computer dives).
+          //
+          // Built ONLY when the face can actually render: a dive-linked,
+          // profile-synced item with the overlay turned on. The watches
+          // below start the per-source profile analysis, and through it the
+          // full Buhlmann pipeline with its recursive residual-CNS/tissue
+          // lookback across the surrounding dives. Watching that
+          // unconditionally ran the whole cascade on the UI isolate for
+          // every dive-linked item the viewer showed, with the result
+          // discarded whenever the overlay was off -- the first ingredient
+          // of the app-wide freeze after viewing media (2026-08 hang
+          // reports). Toggling the overlay on simply rebuilds and starts the
+          // watches then.
+          PerdixFaceResolver? perdixResolver;
+          if (currentDiveId != null &&
+              perdixPrecondition &&
+              settings.perdixOverlayEnabled) {
             final activeSourceId = ref.watch(
               activeDiveSourceProvider(currentDiveId),
             );
@@ -365,10 +377,17 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
               tankPressures: tankPressures,
             );
           }
-          final perdixAvailable =
-              enrichment?.elapsedSeconds != null &&
-              enrichment!.matchConfidence != MatchConfidence.noProfile &&
-              perdixResolver.isAvailable;
+          // With the overlay on, availability is the resolver's own answer.
+          // With it off, no resolver exists (that is the point: no analysis
+          // runs), so the toolbar toggle is offered from what is known
+          // cheaply: a synced item and a non-empty profile. For a
+          // multi-computer dive the source-scoped profile can differ from
+          // the merged one, so this can rarely offer a toggle the resolver
+          // would then decline; the cost is an inert toggle, not a wrongly
+          // hidden one.
+          final perdixAvailable = perdixResolver != null
+              ? perdixResolver.isAvailable
+              : perdixPrecondition && (diveProfile?.isNotEmpty ?? false);
 
           final viewer = GestureDetector(
             // Swipe down to close (common pattern for fullscreen viewers)
@@ -498,7 +517,9 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                 // The face absorbs pointer events over its own bounds (drags
                 // move it, taps do nothing); chrome-toggle and video
                 // play/pause taps work anywhere outside it.
-                if (perdixAvailable && settings.perdixOverlayEnabled)
+                if (perdixAvailable &&
+                    settings.perdixOverlayEnabled &&
+                    perdixResolver != null)
                   DraggablePerdixOverlay(
                     // Re-key when the persisted seed first arrives so a late
                     // settings load re-seeds the position (same trick as the
@@ -508,7 +529,9 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                       '${settings.perdixOverlayX}-${settings.perdixOverlayY}',
                     ),
                     resolver: perdixResolver,
-                    baseElapsedSeconds: enrichment.elapsedSeconds!,
+                    // Non-null under perdixAvailable: the resolver is only
+                    // ever built for items passing perdixPrecondition.
+                    baseElapsedSeconds: enrichment!.elapsedSeconds!,
                     settings: settings,
                     topReserve:
                         MediaQuery.paddingOf(context).top + _topChromeHeight,

--- a/lib/features/media/presentation/providers/media_providers.dart
+++ b/lib/features/media/presentation/providers/media_providers.dart
@@ -32,7 +32,7 @@ final diveMediaEnricherProvider = Provider<DiveMediaEnricher>((ref) {
   return DiveMediaEnricher(
     loadDive: diveRepo.getDiveById,
     loadMediaForDive: mediaRepo.getMediaForDive,
-    saveEnrichment: mediaRepo.saveEnrichment,
+    saveEnrichments: mediaRepo.saveEnrichments,
   );
 });
 

--- a/test/architecture/repository_tick_stream_test.dart
+++ b/test/architecture/repository_tick_stream_test.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/data/repositories/connected_accounts_repository.
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/cylinder_configs/data/repositories/cylinder_config_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_custom_field_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
 import 'package:submersion/features/equipment/data/repositories/service_kind_repository.dart';
@@ -193,6 +194,8 @@ void main() {
           WeightHistoryRepository().watchGearLeadChanges,
       'CsvPresetRepository.watchPresetsChanges':
           CsvPresetRepository().watchPresetsChanges,
+      'DiveRepository.watchAnalysisInputChanges':
+          DiveRepository().watchAnalysisInputChanges,
     };
 
     for (final entry in ticks.entries) {
@@ -704,6 +707,72 @@ void main() {
               ),
         ),
         isTrue,
+      );
+    });
+  });
+
+  group('analysis inputs', () {
+    Future<void> seedDive(String id) => db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: id,
+            diveDateTime: now,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+    test(
+      'watchAnalysisInputChanges fires on a dive_profile_events write',
+      () async {
+        // The coupling watchDiveDetailChanges never had: dive_profile_events is
+        // read by diveComputerEventsProvider and merged into every analysis,
+        // but the broad detail tick does not include the table at all.
+        await seedDive('d1');
+        expect(
+          await fires(
+            DiveRepository().watchAnalysisInputChanges(),
+            () => db
+                .into(db.diveProfileEvents)
+                .insert(
+                  DiveProfileEventsCompanion.insert(
+                    id: 'ev1',
+                    diveId: 'd1',
+                    timestamp: 120,
+                    eventType: 'gasSwitch',
+                    createdAt: now,
+                  ),
+                ),
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('watchAnalysisInputChanges stays silent on a media write', () async {
+      // The other half of the contract, and the reason this tick exists.
+      // media IS in watchDiveDetailChanges, so the analysis chain used to be
+      // discarded by every media write (orphan reconcile, enrichment
+      // backfill) -- re-running the Buhlmann cascade after merely viewing a
+      // photo. The analysis reads nothing from media; its tick must not
+      // fire for it.
+      await seedDive('d1');
+      expect(
+        await fires(
+          DiveRepository().watchAnalysisInputChanges(),
+          () => db
+              .into(db.media)
+              .insert(
+                MediaCompanion.insert(
+                  id: 'm1',
+                  filePath: '/tmp/m1.jpg',
+                  createdAt: now,
+                  updatedAt: now,
+                ),
+              ),
+        ),
+        isFalse,
       );
     });
   });

--- a/test/features/dive_log/profile_analysis_tick_reactivity_test.dart
+++ b/test/features/dive_log/profile_analysis_tick_reactivity_test.dart
@@ -1,0 +1,270 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../helpers/mock_providers.dart';
+import '../../helpers/test_database.dart';
+
+/// Guards which writes may re-run the Buhlmann analysis chain.
+///
+/// The analysis providers used to self-invalidate on
+/// `watchDiveDetailChanges()`, a 23-table aggregate that includes `media`.
+/// Viewing a photo in the Media section writes media rows (orphan
+/// reconciliation, enrichment backfill), so every cached analysis in the app
+/// was discarded and recomputed -- the recursive residual-CNS/tissue lookback
+/// chain included -- pinning the UI isolate for 5-30s per wave (the freeze
+/// diagnosed from the 2026-08-18/20 macOS hang reports).
+///
+/// The same broad stream also NEVER included `dive_profile_events`, so
+/// [diveComputerEventsProvider] could not see its own table change: an event
+/// written after first read was invisible until an unrelated detail-table
+/// write happened to evict it.
+///
+/// These tests pin the corrected contract: analysis recomputes on its actual
+/// inputs (profile samples, events), and does NOT recompute on media writes.
+void main() {
+  late AppDatabase db;
+
+  final now = DateTime.utc(2026, 3, 28).millisecondsSinceEpoch;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ProviderContainer makeContainer() => ProviderContainer(
+    overrides: [
+      currentDiverIdProvider.overrideWith(
+        (ref) => MockCurrentDiverIdNotifier(),
+      ),
+      // The analysis pipeline reads a dozen settings-derived providers
+      // (GF, ppO2 thresholds, CNS method, ...). Pin the notifier so the
+      // real SharedPreferences-backed load never runs in this test.
+      settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+    ],
+  );
+
+  /// A dive with three profile samples, enough for the pipeline to produce a
+  /// non-null analysis.
+  Future<void> seedDiveWithProfile(String diveId) async {
+    final repository = DiveRepository();
+    await repository.createDive(
+      createTestDiveWithBottomTime(id: diveId, diveNumber: 1),
+    );
+    for (final (i, depth) in const [(0, 0.0), (1, 18.0), (2, 0.0)]) {
+      await db
+          .into(db.diveProfiles)
+          .insert(
+            DiveProfilesCompanion.insert(
+              id: '$diveId-p$i',
+              diveId: diveId,
+              timestamp: i * 600,
+              depth: depth,
+            ),
+          );
+    }
+  }
+
+  Future<void> insertMediaRow(String id, {String? diveId}) async {
+    await db
+        .into(db.media)
+        .insert(
+          MediaCompanion.insert(
+            id: id,
+            filePath: '/tmp/$id.jpg',
+            createdAt: now,
+            updatedAt: now,
+            diveId: Value(diveId),
+          ),
+        );
+  }
+
+  Future<void> insertProfileEvent(String diveId, String id) async {
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          DiveProfileEventsCompanion.insert(
+            id: id,
+            diveId: diveId,
+            timestamp: 300,
+            eventType: 'gasSwitch',
+            createdAt: now,
+          ),
+        );
+  }
+
+  /// Waits until [read] satisfies [done], or gives up. Ticks are
+  /// [DiveRepository.changeTickDebounce]-debounced (300ms), so a refresh is
+  /// never immediate.
+  Future<void> settle(bool Function() done, {int attempts = 100}) async {
+    for (var i = 0; i < attempts; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      if (done()) return;
+    }
+  }
+
+  test(
+    'diveComputerEventsProvider sees an event written after its first read',
+    () async {
+      await seedDiveWithProfile('d1');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final onScreen = container.listen(
+        diveComputerEventsProvider('d1'),
+        (_, _) {},
+      );
+      addTearDown(onScreen.close);
+
+      final initial = await container.read(
+        diveComputerEventsProvider('d1').future,
+      );
+      expect(initial, isEmpty, reason: 'no events seeded yet');
+
+      // A dive-computer import or a sync pull writing straight to the DB.
+      await insertProfileEvent('d1', 'ev1');
+
+      List<Object?> events = const [];
+      await settle(() {
+        final value = container.read(diveComputerEventsProvider('d1'));
+        events = value.valueOrNull ?? const [];
+        return events.length == 1;
+      });
+
+      expect(
+        events.length,
+        1,
+        reason:
+            'An event insert must tick the provider. The old subscription '
+            'watched watchDiveDetailChanges(), which does not include '
+            'dive_profile_events, so the new event stayed invisible until an '
+            'unrelated table write evicted the cache.',
+      );
+    },
+  );
+
+  test('a media write does not recompute the profile analysis', () async {
+    await seedDiveWithProfile('d1');
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+
+    var rebuilds = 0;
+    final onScreen = container.listen(profileAnalysisProvider('d1'), (
+      previous,
+      next,
+    ) {
+      if (next.isLoading) rebuilds++;
+    });
+    addTearDown(onScreen.close);
+
+    // The media viewer watches these alongside the analysis (Perdix face,
+    // pressure curves); if they stay on the broad tick, a media write still
+    // rebuilds the per-source analysis through them.
+    var inputRebuilds = 0;
+    void countLoading(AsyncValue<Object?>? previous, AsyncValue<Object?> next) {
+      if (next.isLoading) inputRebuilds++;
+    }
+
+    final inputSubs = [
+      container.listen(sourceProfilesProvider('d1'), countLoading),
+      container.listen(diveDataSourcesProvider('d1'), countLoading),
+      container.listen(gasSwitchesProvider('d1'), countLoading),
+      container.listen(tankPressuresProvider('d1'), countLoading),
+    ];
+    for (final sub in inputSubs) {
+      addTearDown(sub.close);
+    }
+
+    final initial = await container.read(profileAnalysisProvider('d1').future);
+    expect(initial, isNotNull, reason: 'seeded profile must analyze');
+    await container.read(sourceProfilesProvider('d1').future);
+    await container.read(diveDataSourcesProvider('d1').future);
+    await container.read(gasSwitchesProvider('d1').future);
+    await container.read(tankPressuresProvider('d1').future);
+    final baseline = rebuilds;
+    final inputBaseline = inputRebuilds;
+
+    // What viewing a photo in the Media section does: orphan reconciliation
+    // and enrichment backfill write media rows.
+    await insertMediaRow('m1', diveId: 'd1');
+
+    // Wait past the 300ms tick debounce plus margin. settle() cannot wait for
+    // an absence, so give the tick ample time to fire if it (wrongly) would.
+    await Future<void>.delayed(const Duration(milliseconds: 900));
+
+    expect(
+      rebuilds,
+      baseline,
+      reason:
+          'A media write must not discard the cached analysis. Re-running '
+          'the Buhlmann chain (with its recursive residual lookback across '
+          'the trip) on every media write is the app-wide 5-30s input freeze '
+          'after viewing media.',
+    );
+    expect(
+      inputRebuilds,
+      inputBaseline,
+      reason:
+          'The analysis-input providers (source profiles, data sources, gas '
+          'switches, tank pressures) must not re-hydrate on media writes '
+          'either: the viewer watches them, and their rebuild re-runs the '
+          'per-source analysis even when the dive-level cache survives.',
+    );
+  });
+
+  test('a profile-sample write still recomputes the analysis', () async {
+    await seedDiveWithProfile('d1');
+
+    final container = makeContainer();
+    addTearDown(container.dispose);
+
+    var rebuilds = 0;
+    final onScreen = container.listen(profileAnalysisProvider('d1'), (
+      previous,
+      next,
+    ) {
+      if (next.isLoading) rebuilds++;
+    });
+    addTearDown(onScreen.close);
+
+    final initial = await container.read(profileAnalysisProvider('d1').future);
+    expect(initial, isNotNull);
+    final baseline = rebuilds;
+
+    // A profile edit, import, or sync pull rewriting samples.
+    await db
+        .into(db.diveProfiles)
+        .insert(
+          DiveProfilesCompanion.insert(
+            id: 'd1-p9',
+            diveId: 'd1',
+            timestamp: 1500,
+            depth: 10.0,
+          ),
+        );
+
+    await settle(() => rebuilds > baseline);
+
+    expect(
+      rebuilds,
+      greaterThan(baseline),
+      reason:
+          'Narrowing the analysis tick away from media must not lose '
+          'reactivity to the tables the analysis actually reads.',
+    );
+  });
+}

--- a/test/features/media/data/media_reassign_test.dart
+++ b/test/features/media/data/media_reassign_test.dart
@@ -134,7 +134,7 @@ void main() {
           ],
         ),
         loadMediaForDive: repo.getMediaForDive,
-        saveEnrichment: repo.saveEnrichment,
+        saveEnrichments: repo.saveEnrichments,
       );
 
       expect(await enricher.enrichMissingForDive('d2'), 1);

--- a/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
+++ b/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
@@ -129,4 +129,36 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 300));
     expect(ticks, 0);
   });
+
+  test('a failing row rolls back the whole batch and rethrows', () async {
+    await seedDiveAndMedia(['m1']);
+
+    // 'm-missing' violates mediaEnrichment's media FK (enforced at open),
+    // so the second insert throws mid-transaction. All-or-nothing is the
+    // point of the batch: a partial backfill would leave some photos
+    // enriched and some not, with no pending-sync rows to say which.
+    await expectLater(
+      repository.saveEnrichments([
+        enrichmentFor('m1'),
+        enrichmentFor('m-missing'),
+      ]),
+      throwsA(anything),
+    );
+
+    expect(
+      await repository.getEnrichmentForMedia('m1'),
+      isNull,
+      reason:
+          'the transaction must roll back the rows written before the '
+          'failure, not persist a partial batch',
+    );
+    final pending = await db.select(db.syncRecords).get();
+    expect(
+      pending.where((r) => r.entityType == 'mediaEnrichment'),
+      isEmpty,
+      reason:
+          'pending-sync marks ride the same transaction and must roll '
+          'back with it',
+    );
+  });
 }

--- a/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
+++ b/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
@@ -12,13 +12,13 @@ import '../../../../helpers/test_database.dart';
 /// Guards the batched write path the enrichment backfill uses.
 ///
 /// The viewer's backfill used to save each enrichment row with its own
-/// [MediaRepository.saveEnrichment] call. Every save is a separate top-level
-/// write, so a dive with N un-enriched photos produced N mediaEnrichment
-/// table ticks in a burst, each one (after the 300ms debounce window
-/// re-opened) re-running every media provider that watches
-/// `watchMediaChanges` -- the library re-query included. [saveEnrichments]
-/// exists so the whole backfill commits as ONE transaction and lands as ONE
-/// tick.
+/// [MediaRepository.saveEnrichment] call: N separate top-level writes and
+/// commits. `watchMediaChanges` trailing-debounces at 300ms, so a fast burst
+/// coalesced -- but a backfill spanning longer than the window re-ran every
+/// media provider (the library re-query included) once per quiet gap, from
+/// inside the open viewer. [saveEnrichments] exists so the whole backfill
+/// commits as ONE atomic transaction and lands as ONE tick regardless of
+/// how long the writes take.
 void main() {
   late db_schema.AppDatabase db;
   late MediaRepository repository;

--- a/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
+++ b/test/features/media/data/repositories/media_repository_enrichment_batch_test.dart
@@ -1,0 +1,132 @@
+import 'package:drift/drift.dart' show TableUpdateQuery;
+import 'package:submersion/core/database/database.dart' as db_schema;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Guards the batched write path the enrichment backfill uses.
+///
+/// The viewer's backfill used to save each enrichment row with its own
+/// [MediaRepository.saveEnrichment] call. Every save is a separate top-level
+/// write, so a dive with N un-enriched photos produced N mediaEnrichment
+/// table ticks in a burst, each one (after the 300ms debounce window
+/// re-opened) re-running every media provider that watches
+/// `watchMediaChanges` -- the library re-query included. [saveEnrichments]
+/// exists so the whole backfill commits as ONE transaction and lands as ONE
+/// tick.
+void main() {
+  late db_schema.AppDatabase db;
+  late MediaRepository repository;
+  late DiveRepository diveRepository;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = MediaRepository();
+    diveRepository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  MediaEnrichment enrichmentFor(String mediaId) => MediaEnrichment(
+    id: '',
+    mediaId: mediaId,
+    diveId: 'd1',
+    depthMeters: 18.0,
+    temperatureCelsius: 24.0,
+    elapsedSeconds: 600,
+    matchConfidence: MatchConfidence.exact,
+    timestampOffsetSeconds: 0,
+    createdAt: DateTime.utc(2026, 3, 28),
+  );
+
+  Future<void> seedDiveAndMedia(List<String> mediaIds) async {
+    await diveRepository.createDive(
+      Dive(id: 'd1', diveNumber: 1, dateTime: DateTime.utc(2026, 3, 28)),
+    );
+    for (final id in mediaIds) {
+      await repository.createMedia(
+        MediaItem(
+          id: id,
+          diveId: 'd1',
+          mediaType: MediaType.photo,
+          sourceType: MediaSourceType.localFile,
+          takenAt: DateTime.utc(2026, 3, 28, 10),
+          createdAt: DateTime.utc(2026, 3, 28),
+          updatedAt: DateTime.utc(2026, 3, 28),
+        ),
+      );
+    }
+  }
+
+  test('saveEnrichments persists every row and marks each pending', () async {
+    await seedDiveAndMedia(['m1', 'm2', 'm3']);
+
+    await repository.saveEnrichments([
+      enrichmentFor('m1'),
+      enrichmentFor('m2'),
+      enrichmentFor('m3'),
+    ]);
+
+    for (final mediaId in ['m1', 'm2', 'm3']) {
+      final stored = await repository.getEnrichmentForMedia(mediaId);
+      expect(stored, isNotNull, reason: '$mediaId enrichment must persist');
+      expect(stored!.elapsedSeconds, 600);
+    }
+
+    final pending = await db.select(db.syncRecords).get();
+    expect(
+      pending.where((r) => r.entityType == 'mediaEnrichment').length,
+      3,
+      reason: 'each batched row still syncs like an individual save',
+    );
+  });
+
+  test('a batch of enrichments lands as a single table tick', () async {
+    await seedDiveAndMedia(['m1', 'm2', 'm3']);
+
+    var ticks = 0;
+    final sub = db
+        .tableUpdates(TableUpdateQuery.onTable(db.mediaEnrichment))
+        .listen((_) => ticks++);
+    addTearDown(sub.cancel);
+
+    await repository.saveEnrichments([
+      enrichmentFor('m1'),
+      enrichmentFor('m2'),
+      enrichmentFor('m3'),
+    ]);
+
+    // Drift dispatches table notifications per top-level statement; give any
+    // extra (wrong) emissions ample time to arrive before counting.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    expect(
+      ticks,
+      1,
+      reason:
+          'The whole batch must commit as one transaction and therefore one '
+          'tick. One tick per row is what turned the enrichment backfill '
+          'into a media-provider invalidation storm after viewing a photo.',
+    );
+  });
+
+  test('an empty batch writes nothing and ticks nothing', () async {
+    var ticks = 0;
+    final sub = db
+        .tableUpdates(TableUpdateQuery.onTable(db.mediaEnrichment))
+        .listen((_) => ticks++);
+    addTearDown(sub.cancel);
+
+    await repository.saveEnrichments(const []);
+
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    expect(ticks, 0);
+  });
+}

--- a/test/features/media/data/services/dive_media_enricher_test.dart
+++ b/test/features/media/data/services/dive_media_enricher_test.dart
@@ -39,7 +39,7 @@ void main() {
         // Shutter at 12:08 == 2520s (42 min) after the 11:26 entry.
         _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
       ],
-      saveEnrichment: (e) async => saved.add(e),
+      saveEnrichments: (rows) async => saved.addAll(rows),
     );
 
     final count = await enricher.enrichMissingForDive('d1');
@@ -79,7 +79,7 @@ void main() {
             ),
           ),
         ],
-        saveEnrichment: (e) async => saved.add(e),
+        saveEnrichments: (rows) async => saved.addAll(rows),
       );
 
       expect(await enricher.enrichMissingForDive('d1'), 0);
@@ -113,7 +113,7 @@ void main() {
             ),
           ),
         ],
-        saveEnrichment: (e) async => saved.add(e),
+        saveEnrichments: (rows) async => saved.addAll(rows),
       );
 
       expect(await enricher.enrichMissingForDive('d1'), 1);
@@ -149,7 +149,7 @@ void main() {
           ),
         ),
       ],
-      saveEnrichment: (e) async => saved.add(e),
+      saveEnrichments: (rows) async => saved.addAll(rows),
     );
 
     expect(await enricher.enrichMissingForDive('d1'), 1);
@@ -163,7 +163,7 @@ void main() {
       loadMediaForDive: (_) async => [
         _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
       ],
-      saveEnrichment: (e) async => saved.add(e),
+      saveEnrichments: (rows) async => saved.addAll(rows),
     );
 
     expect(await enricher.enrichMissingForDive('d1'), 0);
@@ -184,7 +184,7 @@ void main() {
     final enricher = DiveMediaEnricher(
       loadDive: (_) async => _diveWithProfile(),
       loadMediaForDive: (_) async => [signature],
-      saveEnrichment: (e) async => saved.add(e),
+      saveEnrichments: (rows) async => saved.addAll(rows),
     );
 
     expect(await enricher.enrichMissingForDive('d1'), 0);
@@ -198,10 +198,66 @@ void main() {
       loadMediaForDive: (_) async => [
         _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
       ],
-      saveEnrichment: (e) async => saved.add(e),
+      saveEnrichments: (rows) async => saved.addAll(rows),
     );
 
     expect(await enricher.enrichMissingForDive('d1'), 0);
     expect(saved, isEmpty);
+  });
+
+  /// The backfill fires from the media viewer, where each write used to tick
+  /// watchMediaChanges and re-run every media provider. All of a dive's
+  /// missing rows must therefore leave in ONE batched save (one transaction,
+  /// one tick), not one save per item.
+  test('saves all missing enrichments in a single batched call', () async {
+    final batches = <List<MediaEnrichment>>[];
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => _diveWithProfile(),
+      loadMediaForDive: (_) async => [
+        _media('m1', takenAt: DateTime.utc(2025, 12, 27, 12, 8)),
+        _media('m2', takenAt: DateTime.utc(2025, 12, 27, 12, 9)),
+      ],
+      saveEnrichments: (rows) async => batches.add(rows),
+    );
+
+    final count = await enricher.enrichMissingForDive('d1');
+
+    expect(count, 2);
+    expect(batches, hasLength(1), reason: 'one save call for the whole dive');
+    expect(batches.single.map((e) => e.mediaId), ['m1', 'm2']);
+  });
+
+  test('a dive with nothing to enrich never calls the save at all', () async {
+    var calls = 0;
+    final enricher = DiveMediaEnricher(
+      loadDive: (_) async => _diveWithProfile(),
+      loadMediaForDive: (_) async => [
+        _media(
+          'm1',
+          takenAt: DateTime.utc(2025, 12, 27, 12, 8),
+          enrichment: MediaEnrichment(
+            id: 'e1',
+            mediaId: 'm1',
+            diveId: 'd1',
+            elapsedSeconds: 2520,
+            depthMeters: 20,
+            temperatureCelsius: 26,
+            timestampOffsetSeconds: 0,
+            matchConfidence: MatchConfidence.exact,
+            createdAt: DateTime.utc(2025),
+          ),
+        ),
+      ],
+      saveEnrichments: (rows) async => calls++,
+    );
+
+    expect(await enricher.enrichMissingForDive('d1'), 0);
+    expect(
+      calls,
+      0,
+      reason:
+          'an empty batch must not reach the repository: even a no-op save '
+          'would tick watchMediaChanges and invalidate the media providers',
+    );
   });
 }

--- a/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_library_overlays_test.dart
@@ -269,7 +269,7 @@ void main() {
         return _dive;
       },
       loadMediaForDive: (diveId) async => const [],
-      saveEnrichment: (enrichment) async {},
+      saveEnrichments: (enrichments) async {},
     );
 
     await pump(
@@ -296,7 +296,7 @@ void main() {
         return _dive;
       },
       loadMediaForDive: (diveId) async => const [],
-      saveEnrichment: (enrichment) async {},
+      saveEnrichments: (enrichments) async {},
     );
 
     await pump(

--- a/test/features/media/presentation/pages/media_viewer_perdix_gating_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_perdix_gating_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/pages/media_viewer_page.dart';
+import 'package:submersion/features/media/presentation/widgets/perdix_overlay/perdix_face.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Guards that the viewer starts the profile-analysis chain ONLY when the
+/// Perdix overlay can actually be shown.
+///
+/// The build used to watch sourceProfileAnalysisProvider (and the source /
+/// gas-switch / tank-pressure providers feeding it) for EVERY dive-linked
+/// item, purely to construct the Perdix face resolver -- with the overlay
+/// toggled off in settings, the analysis ran and its result was thrown away.
+/// Opening any dive-linked photo from the Media section therefore kicked the
+/// full Buhlmann cascade (recursive residual lookback included) on the UI
+/// isolate: the first ingredient of the 5-30s app-wide freeze.
+void main() {
+  late SharedPreferences prefs;
+
+  Future<void> setUpWithPerdixEnabled(bool enabled) async {
+    await setUpTestDatabase();
+    SharedPreferences.setMockInitialValues({'perdix_overlay_enabled': enabled});
+    prefs = await SharedPreferences.getInstance();
+  }
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final media = MediaItem(
+    id: 'm1',
+    diveId: 'd1',
+    mediaType: MediaType.photo,
+    sourceType: MediaSourceType.platformGallery,
+    platformAssetId: 'g1',
+    takenAt: DateTime.utc(2026, 7, 1, 10),
+    createdAt: DateTime.utc(2026, 7, 1),
+    updatedAt: DateTime.utc(2026, 7, 1),
+    enrichment: MediaEnrichment(
+      id: 'e1',
+      mediaId: 'm1',
+      diveId: 'd1',
+      elapsedSeconds: 180,
+      depthMeters: 15.0,
+      matchConfidence: MatchConfidence.exact,
+      createdAt: DateTime.utc(2026, 7, 1),
+    ),
+  );
+
+  final dive = domain.Dive(
+    id: 'd1',
+    dateTime: DateTime.utc(2026, 7, 1, 9, 30),
+    profile: const [
+      domain.DiveProfilePoint(timestamp: 0, depth: 0.0),
+      domain.DiveProfilePoint(timestamp: 120, depth: 20.0),
+      domain.DiveProfilePoint(timestamp: 240, depth: 5.0),
+    ],
+  );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required void Function() onAnalysisTouched,
+  }) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            diveProvider('d1').overrideWith((ref) async => dive),
+            sourceProfileAnalysisProvider.overrideWith((ref, key) async {
+              onAnalysisTouched();
+              return null;
+            }),
+          ],
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MediaViewerPage(mediaList: [media], initialMediaId: 'm1'),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+    });
+  }
+
+  testWidgets(
+    'with the overlay disabled, viewing a photo never starts the analysis',
+    (tester) async {
+      await setUpWithPerdixEnabled(false);
+
+      var analysisTouched = 0;
+      await pump(tester, onAnalysisTouched: () => analysisTouched++);
+
+      expect(
+        analysisTouched,
+        0,
+        reason:
+            'The Perdix face is the only consumer of the analysis in the '
+            'viewer. With the overlay off, watching '
+            'sourceProfileAnalysisProvider runs the whole Buhlmann cascade '
+            'for a result nothing renders.',
+      );
+      expect(find.byType(PerdixFace), findsNothing);
+      expect(
+        find.byIcon(Icons.watch),
+        findsOneWidget,
+        reason:
+            'the toggle stays offered for synced media so the user can still '
+            'turn the face on from the viewer',
+      );
+    },
+  );
+
+  testWidgets(
+    'with the overlay enabled, the analysis runs and the face shows',
+    (tester) async {
+      await setUpWithPerdixEnabled(true);
+
+      var analysisTouched = 0;
+      await pump(tester, onAnalysisTouched: () => analysisTouched++);
+
+      expect(analysisTouched, greaterThan(0));
+      expect(find.byType(PerdixFace), findsOneWidget);
+    },
+  );
+
+  testWidgets('tapping the toggle starts the analysis on demand', (
+    tester,
+  ) async {
+    await setUpWithPerdixEnabled(false);
+
+    var analysisTouched = 0;
+    await pump(tester, onAnalysisTouched: () => analysisTouched++);
+    expect(analysisTouched, 0);
+
+    await tester.runAsync(() async {
+      await tester.tap(find.byIcon(Icons.watch));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await tester.pump();
+    });
+
+    expect(
+      analysisTouched,
+      greaterThan(0),
+      reason: 'enabling the overlay is what starts paying for the analysis',
+    );
+    expect(find.byType(PerdixFace), findsOneWidget);
+  });
+}

--- a/test/features/media/presentation/pages/media_viewer_perdix_gating_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_perdix_gating_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
+import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/source_profile.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/profile_analysis_provider.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
@@ -163,4 +165,90 @@ void main() {
     );
     expect(find.byType(PerdixFace), findsOneWidget);
   });
+
+  testWidgets(
+    'the toggle survives enabling on a multi-computer dive whose active '
+    'source has no samples',
+    (tester) async {
+      // A metadata-only primary source: getProfilesByDataSource represents
+      // every source, even one with no profile points, and the resolver
+      // scopes to the ACTIVE source's bucket on multi-source dives. If the
+      // toolbar toggle follows the resolver's availability, tapping it on
+      // such a dive builds a resolver with an empty profile and the toggle
+      // vanishes with the setting stuck on -- no control left on the page
+      // to turn it back off.
+      await setUpWithPerdixEnabled(true);
+
+      final sources = <DiveDataSource>[
+        DiveDataSource(
+          id: 's1',
+          diveId: 'd1',
+          isPrimary: true,
+          importedAt: DateTime.utc(2026, 7, 1),
+          createdAt: DateTime.utc(2026, 7, 1),
+        ),
+        DiveDataSource(
+          id: 's2',
+          diveId: 'd1',
+          isPrimary: false,
+          importedAt: DateTime.utc(2026, 7, 1),
+          createdAt: DateTime.utc(2026, 7, 1),
+        ),
+      ];
+      final sourceProfiles = {
+        's1': const SourceProfile(
+          sourceId: 's1',
+          computerId: null,
+          isEdited: false,
+          points: [],
+        ),
+        's2': SourceProfile(
+          sourceId: 's2',
+          computerId: null,
+          isEdited: false,
+          points: dive.profile,
+        ),
+      };
+
+      await tester.runAsync(() async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
+              diveProvider('d1').overrideWith((ref) async => dive),
+              diveDataSourcesProvider(
+                'd1',
+              ).overrideWith((ref) async => sources),
+              sourceProfilesProvider(
+                'd1',
+              ).overrideWith((ref) async => sourceProfiles),
+              sourceProfileAnalysisProvider.overrideWith(
+                (ref, key) async => null,
+              ),
+            ],
+            child: MaterialApp(
+              locale: const Locale('en'),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: MediaViewerPage(mediaList: [media], initialMediaId: 'm1'),
+            ),
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await tester.pump();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await tester.pump();
+      });
+
+      expect(
+        find.byIcon(Icons.watch),
+        findsOneWidget,
+        reason:
+            'the toggle must stay reachable while the setting is on, even '
+            'when the active source cannot render a face',
+      );
+      // No face: the active source has no samples to drive one.
+      expect(find.byType(PerdixFace), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Viewing a dive-linked item in the Media section could freeze every button and link in the app for 5-30 seconds. macOS hang reports from the installed app (2026-08-18/20) show the Dart UI isolate CPU-pegged in a tight allocation-heavy loop while the freeze lasts (one report: 90s of CPU over 167s, footprint 540 MB -> 1.2 GB).

Three compounding causes, each fixed with a failing test first:

### 1. Media writes discarded every cached dive analysis
The whole analysis chain (`analysisDiveProvider`, `diveComputerEventsProvider`, `sourceProfilesProvider`, `diveDataSourcesProvider`, `gasSwitchesProvider`, `tankPressuresProvider`) self-invalidated on `watchDiveDetailChanges()`, a 23-table tick that includes `media`. Viewing a photo writes media rows (orphan reconciliation, enrichment backfill), so every cached Buhlmann analysis was thrown away and recomputed, including the recursive residual-CNS/tissue lookback across a whole trip's dive chain.

New `DiveRepository.watchAnalysisInputChanges()` ticks on exactly the tables the pipeline reads (dives, dive_profiles, dive_tanks, tank_pressure_profiles, gas_switches, dive_data_sources, dive_computers, dive_profile_events), and the chain now subscribes to it. This also fixes a latent staleness bug: the broad tick never included `dive_profile_events`, so the events provider was blind to writes of its own table.

### 2. The enrichment backfill ticked once per photo
`DiveMediaEnricher` saved each row via its own `saveEnrichment` call from inside the open viewer, producing a burst of N table ticks that re-ran every `watchMediaChanges` provider (library re-query included). New `MediaRepository.saveEnrichments` commits the whole batch in one transaction (one tick, one sync notification, per-row sync marking preserved); the enricher collects and saves once per dive, and skips the repository entirely when nothing changed.

### 3. The viewer ran the analysis even with the Perdix overlay off
`MediaViewerPage` watched `sourceProfileAnalysisProvider` (and its input providers) for every dive-linked item just to build the Perdix face resolver, discarding the result when the overlay was disabled. The resolver and its watches now exist only for a profile-synced item with the overlay enabled; the toolbar toggle is still offered from the enrichment and already-loaded dive profile, and tapping it starts the analysis on demand.

## Testing
- New: `profile_analysis_tick_reactivity_test.dart` (media writes no longer recompute analyses; profile writes still do; events writes now reach the events provider), `media_repository_enrichment_batch_test.dart` (one tick per batch, empty batch no-op, per-row sync marking), `media_viewer_perdix_gating_test.dart` (no analysis when disabled, toggle works, enabled path unchanged), plus two `repository_tick_stream_test` contract cases for the new tick.
- Full suite: 19,962 passed / 19 skipped / 0 failures. `flutter analyze` clean, `dart format` clean.