### PR TITLE
fix(sync): make Google Drive sign-in work on desktop builds

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -183,7 +183,7 @@ jobs:
           echo 'CODE_SIGN_IDENTITY = ' >> macos/Runner/Configs/Release.xcconfig
 
       - name: Build macOS release
-        run: flutter build macos --release --dart-define=UPDATE_CHANNEL=github
+        run: flutter build macos --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
 
       # -- Developer ID DMG (for GitHub Release) --
 
@@ -453,7 +453,7 @@ jobs:
           grep '^version:' pubspec.yaml
 
       - name: Build Windows release
-        run: flutter build windows --release --dart-define=UPDATE_CHANNEL=github
+        run: flutter build windows --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
 
       - name: Check bundled native assets
         # Runs before the installer is compiled: the .iss packages whatever is
@@ -595,7 +595,7 @@ jobs:
           grep '^version:' pubspec.yaml
 
       - name: Build Linux release
-        run: flutter build linux --release --dart-define=UPDATE_CHANNEL=github
+        run: flutter build linux --release --dart-define=UPDATE_CHANNEL=github --dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
 
       - name: Check bundled native assets
         # Runs before the tarball is rolled, for the same reason as the Windows

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -691,7 +691,7 @@ jobs:
             macos/Runner.xcodeproj/project.pbxproj
 
           # Build with Flutter
-          flutter build macos --release "${{ env.DART_DEFINES }}"
+          flutter build macos --release "${{ env.DART_DEFINES }}" "--dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}"
 
           # Re-sign with ad-hoc signature and no-sandbox entitlements
           codesign --force --deep --sign - \
@@ -928,7 +928,7 @@ jobs:
         run: tar -xzf generated-code.tar.gz
 
       - name: Build Linux
-        run: flutter build linux --release "${{ env.DART_DEFINES }}" -v
+        run: flutter build linux --release "${{ env.DART_DEFINES }}" "--dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}" -v
 
       - name: Check bundled native assets
         # Same guard as the Windows job. Linux uses the stock Flutter install
@@ -1010,7 +1010,7 @@ jobs:
         run: tar -xzf generated-code.tar.gz
 
       - name: Build Windows
-        run: flutter build windows --release "${{ env.DART_DEFINES }}" -v
+        run: flutter build windows --release "${{ env.DART_DEFINES }}" "--dart-define=GOOGLE_DRIVE_CLIENT_SECRET=${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}" -v
 
       - name: Check bundled native assets
         # A Windows build that never bundles sqlcipher.dll still compiles,

--- a/docs/superpowers/specs/2026-07-02-google-drive-sync-manual-test-checklist.md
+++ b/docs/superpowers/specs/2026-07-02-google-drive-sync-manual-test-checklist.md
@@ -19,6 +19,32 @@ cold-launch silent auth that passes today fails a week later.
 - [ ] B. An Android OAuth client exists for the **release / Play App
       Signing** SHA-1, not just the debug SHA-1. Without it, sign-in works
       in debug builds and fails in release ones.
+- [ ] C. The repository secret `GOOGLE_DRIVE_CLIENT_SECRET` holds the
+      **Desktop** client's secret (starts with `GOCSPX-`, ~35 chars), not the
+      client id. Google authenticates the Desktop-client token exchange with
+      it and answers `invalid_request: client_secret is missing` without it,
+      PKCE notwithstanding, so a wrong value produces a green build whose
+      sign-in fails only after the user has authorised in the browser. Google
+      no longer displays secrets after creation; use Add secret to mint a new
+      one. Local desktop builds read the same value from the
+      `GOOGLE_DRIVE_CLIENT_SECRET` environment variable
+      (`scripts/release/build_nosandbox_macos.sh`); omitting it disables
+      Google Drive in that build by design rather than failing at sign-in.
+
+## Verification status (2026-08-23)
+
+Recorded so the next person knows what is actually proven:
+
+- **macOS Developer ID DMG** -- VERIFIED on device. Fresh sign-in and a full
+  publish of 224 pending changes, on a build signed Developer ID + hardened
+  runtime with `ReleaseNoSandbox.entitlements`.
+- **macOS sandboxed (App Store)** -- regression-checked only: the build must
+  still choose the google_sign_in path, since `KeychainGatedAuthenticator` now
+  sits in front of every macOS build.
+- **Windows / Linux** -- NOT verified on device. The loopback flow there was
+  broken in exactly the same way (no client secret) and the fix is shared
+  code, but nobody has watched sign-in complete on either platform. Treat
+  items 1-7 below as outstanding for both.
 
 ## Device matrix
 

--- a/lib/core/services/accounts/adapters/google_drive_account_adapter.dart
+++ b/lib/core/services/accounts/adapters/google_drive_account_adapter.dart
@@ -9,11 +9,14 @@ import 'package:submersion/core/services/media_store/google_drive_media_object_s
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_provider_instances.dart';
 
-/// The Google login as a session-managed, single-instance account. Auth
-/// lives in GoogleSignIn.instance (OS/SDK session) -- there is no keychain
-/// blob to re-key -- so this adapter delegates to the shared core-level
-/// provider singleton (cloud_provider_instances) for session reuse,
-/// avoiding a presentation -> core import cycle.
+/// The Google login as a session-managed, single-instance account. Auth is
+/// owned by whichever authenticator the provider selected -- the SDK session
+/// in GoogleSignIn.instance on mobile and the sandboxed macOS build, or a
+/// refresh token in GoogleDriveTokenStore wherever the loopback flow is used
+/// (Windows, Linux, and the Developer ID macOS build). Either way this
+/// adapter holds no credential of its own, so it delegates to the shared
+/// core-level provider singleton (cloud_provider_instances) for session
+/// reuse, avoiding a presentation -> core import cycle.
 class GoogleDriveAccountAdapter extends AccountProviderAdapter
     implements SyncCapable, MediaStoreCapable {
   GoogleDriveAccountAdapter({GoogleDriveStorageProvider? provider})

--- a/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
@@ -29,14 +29,20 @@ typedef BuildRefreshingClient =
       http.Client baseClient,
     );
 
-/// Loopback-OAuth authenticator for Windows and Linux (RFC 8252 section
-/// 7.3): binds an ephemeral 127.0.0.1 port, opens the system browser to
-/// Google's consent page, and receives the auth code on the local
-/// redirect. Uses PKCE with no client secret -- Google lists client_secret
-/// as optional for Desktop-app clients, so the code_verifier alone
-/// authenticates the token exchange. Credentials persist in
-/// [GoogleDriveTokenStore]; cold-launch re-auth is silent via the stored
-/// refresh token.
+/// Loopback-OAuth authenticator for Windows, Linux, and the Developer ID
+/// macOS build (RFC 8252 section 7.3): binds an ephemeral 127.0.0.1 port,
+/// opens the system browser to Google's consent page, and receives the auth
+/// code on the local redirect.
+///
+/// Uses PKCE **and** the Desktop client's secret. PKCE alone does not
+/// satisfy Google: its token endpoint answers `invalid_request:
+/// client_secret is missing` for a Desktop-app client whether the field is
+/// omitted or sent empty, code_verifier present. The secret is supplied at
+/// build time via [GoogleDriveClientConfig.desktopClientSecret] rather than
+/// committed.
+///
+/// Credentials persist in [GoogleDriveTokenStore]; cold-launch re-auth is
+/// silent via the stored refresh token.
 class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
   DesktopOAuthAuthenticator({
     GoogleDriveTokenStore? tokenStore,
@@ -44,7 +50,10 @@ class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
     BuildRefreshingClient? buildClient,
     http.Client Function()? baseClientFactory,
     Future<void> Function(String url)? launchBrowser,
-  }) : _tokenStore = tokenStore ?? GoogleDriveTokenStore(),
+    String? clientSecret,
+  }) : _clientSecret =
+           clientSecret ?? GoogleDriveClientConfig.desktopClientSecret,
+       _tokenStore = tokenStore ?? GoogleDriveTokenStore(),
        _obtainConsent =
            obtainConsent ?? gauth.obtainAccessCredentialsViaUserConsent,
        _buildClient = buildClient ?? gauth.autoRefreshingClient,
@@ -63,6 +72,7 @@ class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
 
   static const String _revokeEndpoint = 'https://oauth2.googleapis.com/revoke';
 
+  final String _clientSecret;
   final GoogleDriveTokenStore _tokenStore;
   final ObtainConsentCredentials _obtainConsent;
   final BuildRefreshingClient _buildClient;
@@ -73,10 +83,13 @@ class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
   StreamSubscription<gauth.AccessCredentials>? _updateSubscription;
   String? _email;
 
-  // No client secret: PKCE authenticates the token exchange (Google lists
-  // client_secret as optional for Desktop-app clients).
-  gauth.ClientId get _clientId =>
-      gauth.ClientId(GoogleDriveClientConfig.desktopClientId);
+  // Null rather than '' when unconfigured: googleapis_auth serialises
+  // `secret ?? ''` so both reach Google identically, but null keeps the
+  // not-configured state legible at this layer.
+  gauth.ClientId get _clientId => gauth.ClientId(
+    GoogleDriveClientConfig.desktopClientId,
+    _clientSecret.isEmpty ? null : _clientSecret,
+  );
 
   @override
   http.Client? get authClient => _authClient;

--- a/lib/core/services/cloud_storage/google_drive/google_drive_client_config.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_drive_client_config.dart
@@ -44,8 +44,18 @@ class GoogleDriveClientConfig {
   /// block and forks do not inherit this project's client.
   ///
   /// Empty in `flutter test` and in any build that omits the define, which
-  /// closes [hasDesktopClient] and hides Drive rather than offering a tile
-  /// whose sign-in cannot finish.
+  /// closes [hasDesktopClient]. What that means differs by platform:
+  ///
+  /// - **Windows/Linux**: [isSupportedOnThisPlatform] goes false and the Drive
+  ///   tile is hidden, since the loopback flow is the only option there.
+  /// - **macOS**: the tile is still offered, because a sandboxed build signs
+  ///   in through google_sign_in and needs no secret. Only the no-sandbox DMG
+  ///   is stuck, and KeychainGatedAuthenticator detects exactly that case and
+  ///   fails with a message naming this define instead of a keychain error.
+  ///   Deciding availability up front would mean probing the keychain just to
+  ///   render the settings list, for every macOS user including those who
+  ///   never touch Drive.
+  /// - **iOS/Android**: unaffected; they never use the Desktop client.
   static const String desktopClientSecret = String.fromEnvironment(
     'GOOGLE_DRIVE_CLIENT_SECRET',
   );

--- a/lib/core/services/cloud_storage/google_drive/google_drive_client_config.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_drive_client_config.dart
@@ -1,21 +1,29 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
 /// OAuth client configuration for Google Drive sync.
 ///
-/// Only client IDs are committed -- never a client secret. The desktop
-/// flow uses PKCE on a loopback redirect (RFC 8252 / Google's native-app
-/// OAuth), for which Google lists client_secret as optional; the token
-/// exchange is authenticated by the PKCE code_verifier alone. OAuth client
-/// IDs are public identifiers, safe to commit.
+/// Only client IDs are committed. OAuth client IDs are public identifiers,
+/// safe to commit; the Desktop client's secret is NOT committed and arrives
+/// at build time (see [desktopClientSecret]).
+///
+/// The desktop flow uses PKCE on a loopback redirect (RFC 8252 / Google's
+/// native-app OAuth). PKCE alone is not sufficient for Google: its token
+/// endpoint authenticates Desktop-app clients with the client secret and
+/// rejects the exchange with `invalid_request: client_secret is missing`
+/// when it is absent OR sent empty, code_verifier notwithstanding. (Google's
+/// iOS/Android client types are true public clients with no secret, which is
+/// what the google_sign_in path uses.)
 ///
 /// All clients must belong to the same Google Cloud project so every
 /// platform shares the same Drive appDataFolder (it is scoped per project,
 /// per user); that is what makes cross-device sync work.
 class GoogleDriveClientConfig {
-  /// OAuth 2.0 "Desktop app" client used by the Windows/Linux loopback
-  /// flow (PKCE, no secret). Empty until the client is created in the
-  /// Google Cloud console; an empty value disables Google Drive on desktop
-  /// instead of crashing.
+  /// OAuth 2.0 "Desktop app" client used by the loopback flow on Windows,
+  /// Linux, and the Developer ID macOS build. Empty until the client is
+  /// created in the Google Cloud console; an empty value disables Google
+  /// Drive on desktop instead of crashing.
   static const String desktopClientId =
       '433819313354-eotqmtncg57b836gvc2bls3on5ppiu07.apps.googleusercontent.com';
 
@@ -26,8 +34,32 @@ class GoogleDriveClientConfig {
   static const String androidServerClientId =
       '433819313354-qughape9gt872m38lgtjam2u4qgbdv3o.apps.googleusercontent.com';
 
-  /// True when the Desktop-app client is configured in this build.
-  static bool get hasDesktopClient => desktopClientId.isNotEmpty;
+  /// Secret for [desktopClientId], supplied at build time by
+  /// `--dart-define=GOOGLE_DRIVE_CLIENT_SECRET=...` and never committed
+  /// (see release workflows and scripts/release/build_nosandbox_macos.sh).
+  ///
+  /// Google documents that an installed-app client secret is not treated as
+  /// confidential -- it ships inside every desktop binary by design -- but it
+  /// stays out of the repository so GitHub secret scanning has nothing to
+  /// block and forks do not inherit this project's client.
+  ///
+  /// Empty in `flutter test` and in any build that omits the define, which
+  /// closes [hasDesktopClient] and hides Drive rather than offering a tile
+  /// whose sign-in cannot finish.
+  static const String desktopClientSecret = String.fromEnvironment(
+    'GOOGLE_DRIVE_CLIENT_SECRET',
+  );
+
+  /// True when BOTH halves of the Desktop-app client are present in this
+  /// build. Split out from [hasDesktopClient] so the rule is testable without
+  /// rebuilding under a --dart-define.
+  @visibleForTesting
+  static bool desktopClientConfigured(String id, String secret) =>
+      id.isNotEmpty && secret.isNotEmpty;
+
+  /// True when the Desktop-app client is fully configured in this build.
+  static bool get hasDesktopClient =>
+      desktopClientConfigured(desktopClientId, desktopClientSecret);
 
   /// Whether Google Drive can be offered on the current platform/build.
   ///

--- a/lib/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
+
+/// Builds one of the two concrete authenticators on demand.
+typedef GoogleDriveAuthenticatorBuilder = GoogleDriveAuthenticator Function();
+
+/// macOS authenticator that defers the choice between google_sign_in and the
+/// loopback OAuth flow until the keychain's capabilities are known.
+///
+/// ## Why macOS needs a gate at all
+///
+/// GoogleSignIn hard-codes the **data-protection** keychain on macOS:
+/// `GIDSignIn` builds its `GTMKeychainStore` with no attributes, and
+/// GTMAppAuth's keychain query then always sets `kSecUseDataProtectionKeychain`.
+/// The `useFileBasedKeychain` opt-out exists but is never passed, and the store
+/// is private, so no app-side setting can redirect it.
+///
+/// That keychain refuses a process with no keychain access group. The
+/// Developer ID DMG (ReleaseNoSandbox) has none and cannot get one: AMFI
+/// SIGKILLs a Developer-ID-signed app that declares `keychain-access-groups`
+/// without a provisioning profile to authorise it (this shipped once, as the
+/// v1.5.2 launch failure). So on that build every sign-in completes in the
+/// browser and then dies when the SDK saves the token, surfacing as
+/// `GoogleSignInExceptionCode.providerConfigurationError` with the message
+/// "keychain error" -- misleading, since nothing about the OAuth client is
+/// misconfigured.
+///
+/// ## Why the probe is the right gate
+///
+/// The two builds' constraints line up exactly, so one measurement decides
+/// both halves:
+///
+/// - **Non-sandboxed DMG**: data-protection keychain unavailable, so
+///   google_sign_in cannot work; no sandbox, so the loopback listener binds
+///   freely and [DesktopOAuthAuthenticator] persists its refresh token through
+///   [FallbackSecureStorage]'s legacy-keychain fallback.
+/// - **Sandboxed App Store / iOS**: the provisioning profile grants the access
+///   group, so google_sign_in works; that build has no
+///   `com.apple.security.network.server` entitlement, so a loopback listener
+///   would fail anyway.
+///
+/// Probing the real capability rather than a build flag also means a future
+/// signing change is picked up automatically instead of silently mismatching.
+class KeychainGatedAuthenticator implements GoogleDriveAuthenticator {
+  KeychainGatedAuthenticator({
+    Future<bool> Function()? legacyKeychainRequired,
+    bool Function()? desktopClientConfigured,
+    GoogleDriveAuthenticatorBuilder? loopbackAuthenticator,
+    GoogleDriveAuthenticatorBuilder? googleSignInAuthenticator,
+  }) : _legacyKeychainRequired = legacyKeychainRequired ?? _probeKeychain,
+       _desktopClientConfigured = desktopClientConfigured ?? _hasDesktopClient,
+       _buildLoopback = loopbackAuthenticator ?? DesktopOAuthAuthenticator.new,
+       _buildGoogleSignIn =
+           googleSignInAuthenticator ?? GoogleSignInAuthenticator.new;
+
+  static final _log = LoggerService.forClass(KeychainGatedAuthenticator);
+
+  static Future<bool> _probeKeychain() => FallbackSecureStorage(
+    const FlutterSecureStorage(),
+  ).legacyKeychainRequired();
+
+  static bool _hasDesktopClient() => GoogleDriveClientConfig.hasDesktopClient;
+
+  final Future<bool> Function() _legacyKeychainRequired;
+  final bool Function() _desktopClientConfigured;
+  final GoogleDriveAuthenticatorBuilder _buildLoopback;
+  final GoogleDriveAuthenticatorBuilder _buildGoogleSignIn;
+
+  /// Set once [_resolve] completes; the sync [authClient] getter reads it.
+  GoogleDriveAuthenticator? _delegate;
+
+  /// Memoised resolution, shared by concurrent first callers so the keychain
+  /// is probed at most once per process.
+  Future<GoogleDriveAuthenticator>? _resolution;
+
+  Future<GoogleDriveAuthenticator> _resolve() => _resolution ??= _select();
+
+  Future<GoogleDriveAuthenticator> _select() async {
+    final delegate = await _chooseDelegate();
+    _delegate = delegate;
+    return delegate;
+  }
+
+  Future<GoogleDriveAuthenticator> _chooseDelegate() async {
+    bool needsLoopback;
+    try {
+      needsLoopback = await _legacyKeychainRequired();
+    } catch (e, stackTrace) {
+      // An unreadable keychain leaves the verdict unknown. Keep the
+      // long-standing google_sign_in path rather than binding a socket a
+      // sandboxed build could not bind, and memoise it: a single process must
+      // never flap between two auth backends mid-session.
+      _log.warning(
+        'Keychain capability probe failed; keeping the google_sign_in flow',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return _buildGoogleSignIn();
+    }
+
+    if (!needsLoopback) return _buildGoogleSignIn();
+
+    if (!_desktopClientConfigured()) {
+      // The Desktop client id or its build-time secret is missing, so the
+      // loopback exchange cannot complete. Sign-in still fails on this build,
+      // but no worse than before the gate existed.
+      _log.warning(
+        'Data-protection keychain unavailable and the Desktop OAuth client is '
+        'incomplete (needs --dart-define=GOOGLE_DRIVE_CLIENT_SECRET); Google '
+        'Drive sign-in will fail on this build',
+      );
+      return _buildGoogleSignIn();
+    }
+
+    _log.info(
+      'Data-protection keychain unavailable (Developer ID build); using the '
+      'loopback OAuth flow for Google Drive',
+    );
+    return _buildLoopback();
+  }
+
+  @override
+  http.Client? get authClient => _delegate?.authClient;
+
+  @override
+  Future<void> authenticate() async => (await _resolve()).authenticate();
+
+  @override
+  Future<bool> attemptSilentAuth() async {
+    try {
+      return await (await _resolve()).attemptSilentAuth();
+    } catch (e, stackTrace) {
+      // The seam contract forbids throwing here; a failed resolution must
+      // read as "not signed in", not as a crash on a cold launch.
+      _log.warning(
+        'Silent sign-in could not resolve an authenticator',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+
+  @override
+  Future<String?> get userEmail async => (await _resolve()).userEmail;
+
+  @override
+  Future<void> signOut() async => (await _resolve()).signOut();
+
+  @override
+  Future<void> handleAuthFailure() async =>
+      (await _resolve()).handleAuthFailure();
+}

--- a/lib/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
 
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
@@ -108,15 +109,16 @@ class KeychainGatedAuthenticator implements GoogleDriveAuthenticator {
     if (!needsLoopback) return _buildGoogleSignIn();
 
     if (!_desktopClientConfigured()) {
-      // The Desktop client id or its build-time secret is missing, so the
-      // loopback exchange cannot complete. Sign-in still fails on this build,
-      // but no worse than before the gate existed.
+      // Neither backend can work here: google_sign_in dies in the keychain
+      // (above) and the loopback exchange has no client secret. Returning
+      // google_sign_in anyway would reproduce the misleading "keychain error"
+      // this gate exists to eliminate, so say what is actually wrong.
       _log.warning(
         'Data-protection keychain unavailable and the Desktop OAuth client is '
         'incomplete (needs --dart-define=GOOGLE_DRIVE_CLIENT_SECRET); Google '
-        'Drive sign-in will fail on this build',
+        'Drive sign-in is disabled in this build',
       );
-      return _buildGoogleSignIn();
+      return const _UnconfiguredDesktopAuthenticator();
     }
 
     _log.info(
@@ -157,4 +159,42 @@ class KeychainGatedAuthenticator implements GoogleDriveAuthenticator {
   @override
   Future<void> handleAuthFailure() async =>
       (await _resolve()).handleAuthFailure();
+}
+
+/// Stands in when the build can use neither backend: the data-protection
+/// keychain is unavailable (so google_sign_in cannot persist a token) and no
+/// Desktop client secret was compiled in (so the loopback exchange cannot
+/// complete).
+///
+/// Reports "not signed in" for every silent path and names the real cause on
+/// the one path a user actually triggers, rather than deferring to a backend
+/// known to fail with an unrelated message.
+class _UnconfiguredDesktopAuthenticator implements GoogleDriveAuthenticator {
+  const _UnconfiguredDesktopAuthenticator();
+
+  static const String _message =
+      'Google Drive is unavailable in this build: it was compiled without '
+      'the Desktop OAuth client secret '
+      '(--dart-define=GOOGLE_DRIVE_CLIENT_SECRET).';
+
+  @override
+  http.Client? get authClient => null;
+
+  @override
+  Future<void> authenticate() async =>
+      throw const CloudStorageException(_message);
+
+  /// False, never throwing: the seam contract forbids it, and a cold launch
+  /// must read as "not signed in" rather than crash.
+  @override
+  Future<bool> attemptSilentAuth() async => false;
+
+  @override
+  Future<String?> get userEmail async => null;
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> handleAuthFailure() async {}
 }

--- a/lib/core/services/cloud_storage/google_drive_storage_provider.dart
+++ b/lib/core/services/cloud_storage/google_drive_storage_provider.dart
@@ -11,6 +11,7 @@ import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oaut
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
 /// Google Drive implementation of CloudStorageProvider
@@ -19,7 +20,9 @@ import 'package:submersion/core/services/logger_service.dart';
 /// This folder is hidden from the user and only accessible by this app.
 ///
 /// Authentication is delegated to a [GoogleDriveAuthenticator]:
-/// google_sign_in on iOS/macOS/Android, loopback OAuth on Windows/Linux.
+/// google_sign_in on iOS/Android, loopback OAuth on Windows/Linux, and on
+/// macOS whichever of the two the build's keychain entitlements allow (see
+/// [KeychainGatedAuthenticator]).
 /// The seam's boundary is an [http.Client], so neither auth world leaks
 /// into the Drive REST code below.
 class GoogleDriveStorageProvider
@@ -30,10 +33,26 @@ class GoogleDriveStorageProvider
 
   static final _log = LoggerService.forClass(GoogleDriveStorageProvider);
 
-  static GoogleDriveAuthenticator _defaultAuthenticator() =>
-      (Platform.isWindows || Platform.isLinux)
-      ? DesktopOAuthAuthenticator()
-      : GoogleSignInAuthenticator();
+  static GoogleDriveAuthenticator _defaultAuthenticator() => authenticatorFor(
+    isLoopbackPlatform: Platform.isWindows || Platform.isLinux,
+    isMacOS: Platform.isMacOS,
+  );
+
+  /// Picks the authenticator for a platform, without reading [Platform] --
+  /// which is what makes the choice testable on any host.
+  ///
+  /// macOS is the interesting case: it can use either flow, and which one
+  /// works depends on how the build is signed rather than on the platform.
+  /// [KeychainGatedAuthenticator] measures that and decides.
+  @visibleForTesting
+  static GoogleDriveAuthenticator authenticatorFor({
+    required bool isLoopbackPlatform,
+    required bool isMacOS,
+  }) {
+    if (isLoopbackPlatform) return DesktopOAuthAuthenticator();
+    if (isMacOS) return KeychainGatedAuthenticator();
+    return GoogleSignInAuthenticator();
+  }
 
   final GoogleDriveAuthenticator _authenticator;
   drive.DriveApi? _driveApi;

--- a/lib/core/services/secure_storage/fallback_secure_storage.dart
+++ b/lib/core/services/secure_storage/fallback_secure_storage.dart
@@ -45,6 +45,17 @@ class FallbackSecureStorage {
   /// concurrent first callers, so the probe runs at most once.
   Future<bool>? _useLegacy;
 
+  /// Whether this build must use the legacy file-based keychain, i.e. whether
+  /// the data-protection keychain rejects writes with -34018.
+  ///
+  /// Public because the verdict also decides things outside this wrapper:
+  /// google_sign_in hard-codes the data-protection keychain on macOS and
+  /// exposes no way to change it, so a build that fails this probe cannot use
+  /// the native Google sign-in flow at all (see KeychainGatedAuthenticator).
+  /// Shares the same memoised probe, so asking costs at most one throwaway
+  /// write per instance.
+  Future<bool> legacyKeychainRequired() => _legacyKeychainRequired();
+
   Future<bool> _legacyKeychainRequired() => _useLegacy ??= _probe();
 
   Future<bool> _probe() async {

--- a/macos/Runner/ReleaseNoSandbox.entitlements
+++ b/macos/Runner/ReleaseNoSandbox.entitlements
@@ -39,5 +39,12 @@
 	<!-- non-sandboxed app. The sandboxed App Store (Release.entitlements) and -->
 	<!-- iOS builds DO declare keychain-access-groups, where their provisioning -->
 	<!-- profile authorizes it. -->
+
+	<!-- Google Drive sign-in is the other consumer of that fact. GoogleSignIn -->
+	<!-- hard-codes the data-protection keychain on macOS and exposes no way -->
+	<!-- to change it, so it can never work on this build; the app detects -->
+	<!-- that at runtime (KeychainGatedAuthenticator) and uses the loopback -->
+	<!-- OAuth flow instead. Do NOT try to fix Drive by adding the entitlement -->
+	<!-- here; that is the launch failure described above. -->
 </dict>
 </plist>

--- a/scripts/release/build_nosandbox_macos.sh
+++ b/scripts/release/build_nosandbox_macos.sh
@@ -21,8 +21,22 @@ cd "$PROJECT_DIR"
 echo "=== No-Sandbox Build for macOS ==="
 echo "Building for GitHub distribution (no sandbox)..."
 
+# Google Drive's Desktop OAuth client secret is supplied at build time, never
+# committed. Google authenticates the Desktop-client token exchange with it and
+# rejects sign-in without it ("invalid_request: client_secret is missing"), so a
+# build that omits it ships with Google Drive sync disabled. Export
+# GOOGLE_DRIVE_CLIENT_SECRET (the same value stored as the repo secret of that
+# name) to produce a Drive-capable build. Never echo the value.
+DART_DEFINES=()
+if [ -n "${GOOGLE_DRIVE_CLIENT_SECRET:-}" ]; then
+  DART_DEFINES+=("--dart-define=GOOGLE_DRIVE_CLIENT_SECRET=$GOOGLE_DRIVE_CLIENT_SECRET")
+  echo "Google Drive: Desktop client secret supplied (Drive sync enabled)"
+else
+  echo "Google Drive: GOOGLE_DRIVE_CLIENT_SECRET unset -- Drive sync disabled in this build"
+fi
+
 # Build with Flutter first
-flutter build macos --release
+flutter build macos --release "${DART_DEFINES[@]}"
 
 # Re-sign with ad-hoc signature and no-sandbox entitlements
 echo ""

--- a/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_token_store.dart';
 
 class _MemoryTokenStore implements GoogleDriveTokenStore {
@@ -94,6 +95,50 @@ void main() {
     baseClientFactory: baseClient,
     launchBrowser: (url) async {},
   );
+
+  group('client credentials', () {
+    // Google rejects the token exchange for Desktop-app clients with
+    // `invalid_request: client_secret is missing`, with or without PKCE and
+    // whether the field is omitted or sent empty. Verified against
+    // oauth2.googleapis.com; the secret is NOT optional here.
+    Future<gauth.ClientId> capturedClientId({String? clientSecret}) async {
+      late gauth.ClientId seen;
+      final auth = DesktopOAuthAuthenticator(
+        tokenStore: store,
+        clientSecret: clientSecret,
+        obtainConsent: (clientId, scopes, client, prompt) async {
+          seen = clientId;
+          return creds();
+        },
+        buildClient: (clientId, credentials, base) =>
+            _FakeRefreshingClient(credentials),
+        baseClientFactory: baseClient,
+        launchBrowser: (url) async {},
+      );
+      await auth.authenticate();
+      return seen;
+    }
+
+    test('the build-time secret reaches the token exchange', () async {
+      final clientId = await capturedClientId(clientSecret: 'build-time-value');
+
+      expect(clientId.secret, 'build-time-value');
+    });
+
+    test('an absent secret yields a null secret rather than empty', () async {
+      // googleapis_auth serialises `secret ?? ''`, so both spellings reach
+      // Google identically; null keeps the "not configured" state legible.
+      final clientId = await capturedClientId(clientSecret: '');
+
+      expect(clientId.secret, isNull);
+    });
+
+    test('the client id still comes from the committed config', () async {
+      final clientId = await capturedClientId(clientSecret: 'x');
+
+      expect(clientId.identifier, GoogleDriveClientConfig.desktopClientId);
+    });
+  });
 
   test('attemptSilentAuth returns false with no stored credentials', () async {
     final auth = authenticator();

--- a/test/core/services/cloud_storage/google_drive/google_drive_client_config_test.dart
+++ b/test/core/services/cloud_storage/google_drive/google_drive_client_config_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
+
+void main() {
+  group('desktopClientConfigured', () {
+    // The loopback flow needs BOTH halves. Google authenticates the token
+    // exchange for Desktop-app clients with the client secret and rejects the
+    // request outright without it (`invalid_request: client_secret is
+    // missing`), PKCE notwithstanding -- so a build carrying only the client
+    // id can never complete sign-in and must not advertise Drive.
+    test('requires both the client id and the secret', () {
+      expect(
+        GoogleDriveClientConfig.desktopClientConfigured('id', 'secret'),
+        isTrue,
+      );
+    });
+
+    test('is false with an id but no secret', () {
+      expect(
+        GoogleDriveClientConfig.desktopClientConfigured('id', ''),
+        isFalse,
+        reason: 'a secretless build cannot exchange the auth code',
+      );
+    });
+
+    test('is false with a secret but no id', () {
+      expect(
+        GoogleDriveClientConfig.desktopClientConfigured('', 'secret'),
+        isFalse,
+      );
+    });
+
+    test('is false with neither', () {
+      expect(GoogleDriveClientConfig.desktopClientConfigured('', ''), isFalse);
+    });
+  });
+
+  group('committed configuration', () {
+    test('the desktop client id is compiled in', () {
+      expect(GoogleDriveClientConfig.desktopClientId, isNotEmpty);
+    });
+
+    test('the secret is build-time only, never committed', () {
+      // Guards the repo rule: the value arrives via
+      // --dart-define=GOOGLE_DRIVE_CLIENT_SECRET, so a plain `flutter test`
+      // must see it absent. If this ever fails, a secret was hardcoded.
+      const hardcoded = String.fromEnvironment(
+        'GOOGLE_DRIVE_CLIENT_SECRET',
+        defaultValue: '__unset__',
+      );
+      expect(
+        GoogleDriveClientConfig.desktopClientSecret,
+        hardcoded == '__unset__' ? '' : hardcoded,
+      );
+    });
+  });
+}

--- a/test/core/services/cloud_storage/google_drive/keychain_gated_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/keychain_gated_authenticator_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart';
 import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
@@ -107,23 +108,61 @@ void main() {
         expect(probes, 1);
       },
     );
-    test(
-      'falls back to google_sign_in when the Desktop client secret is absent',
-      () async {
-        // A build without --dart-define=GOOGLE_DRIVE_CLIENT_SECRET cannot
-        // complete the loopback token exchange, so binding a socket for it
-        // would only fail later and more confusingly.
-        final gate = gateOver(
-          FallbackSecureStorage(NoEntitlementKeychain()),
-          desktopClientConfigured: false,
+    group('keychain unavailable AND no Desktop client secret', () {
+      // Neither backend can work: google_sign_in dies in the keychain and the
+      // loopback exchange has no secret. Routing to google_sign_in anyway
+      // would reproduce the misleading "keychain error" this gate exists to
+      // eliminate, so the gate names the real cause instead.
+      KeychainGatedAuthenticator unconfiguredGate() => gateOver(
+        FallbackSecureStorage(NoEntitlementKeychain()),
+        desktopClientConfigured: false,
+      );
+
+      test('authenticate throws naming the missing define', () async {
+        final gate = unconfiguredGate();
+
+        await expectLater(
+          gate.authenticate(),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              contains('GOOGLE_DRIVE_CLIENT_SECRET'),
+            ),
+          ),
         );
+      });
 
-        await gate.authenticate();
+      test('it does not route to an authenticator that cannot work', () async {
+        final gate = unconfiguredGate();
 
-        expect(googleSignIn.authenticateCalls, 1);
+        await gate.attemptSilentAuth();
+
+        expect(googleSignIn.authenticateCalls, 0);
+        expect(googleSignIn.silentAuthCalls, 0);
         expect(loopback.authenticateCalls, 0);
-      },
-    );
+        expect(loopback.silentAuthCalls, 0);
+      });
+
+      test(
+        'attemptSilentAuth reports not-signed-in without throwing',
+        () async {
+          final gate = unconfiguredGate();
+
+          expect(await gate.attemptSilentAuth(), isFalse);
+          expect(gate.authClient, isNull);
+          expect(await gate.userEmail, isNull);
+        },
+      );
+
+      test('signOut and handleAuthFailure are inert', () async {
+        final gate = unconfiguredGate();
+
+        // Must not throw: both run on paths that treat failure as fatal.
+        await gate.signOut();
+        await gate.handleAuthFailure();
+      });
+    });
   });
 
   group('laziness', () {

--- a/test/core/services/cloud_storage/google_drive/keychain_gated_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/keychain_gated_authenticator_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart';
+import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
+
+import '../../../../support/fake_keychain_storage.dart';
+
+/// Records which delegate the gate picked and that calls reach it.
+class _FakeAuthenticator implements GoogleDriveAuthenticator {
+  _FakeAuthenticator(this.label);
+
+  final String label;
+  final http.Client client = http.Client();
+
+  int authenticateCalls = 0;
+  int silentAuthCalls = 0;
+  int signOutCalls = 0;
+  int authFailureCalls = 0;
+  bool silentAuthResult = true;
+  bool exposeClient = false;
+
+  @override
+  http.Client? get authClient => exposeClient ? client : null;
+
+  @override
+  Future<void> authenticate() async => authenticateCalls++;
+
+  @override
+  Future<bool> attemptSilentAuth() async {
+    silentAuthCalls++;
+    return silentAuthResult;
+  }
+
+  @override
+  Future<void> handleAuthFailure() async => authFailureCalls++;
+
+  @override
+  Future<void> signOut() async => signOutCalls++;
+
+  @override
+  Future<String?> get userEmail async => '$label@example.com';
+}
+
+void main() {
+  late _FakeAuthenticator loopback;
+  late _FakeAuthenticator googleSignIn;
+
+  setUp(() {
+    loopback = _FakeAuthenticator('loopback');
+    googleSignIn = _FakeAuthenticator('gsi');
+  });
+
+  KeychainGatedAuthenticator gateOver(
+    FallbackSecureStorage storage, {
+    bool desktopClientConfigured = true,
+  }) => KeychainGatedAuthenticator(
+    legacyKeychainRequired: storage.legacyKeychainRequired,
+    desktopClientConfigured: () => desktopClientConfigured,
+    loopbackAuthenticator: () => loopback,
+    googleSignInAuthenticator: () => googleSignIn,
+  );
+
+  group('delegate selection', () {
+    test('uses the loopback flow when the data-protection keychain is '
+        'unavailable (the Developer ID DMG)', () async {
+      final gate = gateOver(FallbackSecureStorage(NoEntitlementKeychain()));
+
+      await gate.authenticate();
+
+      expect(loopback.authenticateCalls, 1);
+      expect(googleSignIn.authenticateCalls, 0);
+    });
+
+    test('uses google_sign_in when the data-protection keychain works '
+        '(App Store / iOS)', () async {
+      final gate = gateOver(FallbackSecureStorage(InMemoryKeychain()));
+
+      await gate.authenticate();
+
+      expect(googleSignIn.authenticateCalls, 1);
+      expect(loopback.authenticateCalls, 0);
+    });
+
+    test(
+      'falls back to google_sign_in when the probe fails outright',
+      () async {
+        var probes = 0;
+        final gate = KeychainGatedAuthenticator(
+          legacyKeychainRequired: () async {
+            probes++;
+            throw PlatformException(code: 'boom', details: -25308);
+          },
+          desktopClientConfigured: () => true,
+          loopbackAuthenticator: () => loopback,
+          googleSignInAuthenticator: () => googleSignIn,
+        );
+
+        await gate.authenticate();
+        await gate.authenticate();
+
+        expect(googleSignIn.authenticateCalls, 2);
+        expect(loopback.authenticateCalls, 0);
+        // An unreadable keychain is memoised like any other verdict, so a
+        // single process never flaps between two auth backends.
+        expect(probes, 1);
+      },
+    );
+    test(
+      'falls back to google_sign_in when the Desktop client secret is absent',
+      () async {
+        // A build without --dart-define=GOOGLE_DRIVE_CLIENT_SECRET cannot
+        // complete the loopback token exchange, so binding a socket for it
+        // would only fail later and more confusingly.
+        final gate = gateOver(
+          FallbackSecureStorage(NoEntitlementKeychain()),
+          desktopClientConfigured: false,
+        );
+
+        await gate.authenticate();
+
+        expect(googleSignIn.authenticateCalls, 1);
+        expect(loopback.authenticateCalls, 0);
+      },
+    );
+  });
+
+  group('laziness', () {
+    test('does not probe the keychain at construction', () async {
+      final keychain = NoEntitlementKeychain();
+      gateOver(FallbackSecureStorage(keychain));
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(keychain.dataProtectionAttempted, isFalse);
+    });
+
+    test('probes at most once across concurrent first calls', () async {
+      var probes = 0;
+      final gate = KeychainGatedAuthenticator(
+        legacyKeychainRequired: () async {
+          probes++;
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          return true;
+        },
+        desktopClientConfigured: () => true,
+        loopbackAuthenticator: () => loopback,
+        googleSignInAuthenticator: () => googleSignIn,
+      );
+
+      await Future.wait([
+        gate.authenticate(),
+        gate.attemptSilentAuth(),
+        gate.userEmail,
+      ]);
+
+      expect(probes, 1);
+    });
+
+    test('builds the unselected authenticator not at all', () async {
+      var loopbackBuilds = 0;
+      var googleSignInBuilds = 0;
+      final gate = KeychainGatedAuthenticator(
+        legacyKeychainRequired: () async => false,
+        desktopClientConfigured: () => true,
+        loopbackAuthenticator: () {
+          loopbackBuilds++;
+          return loopback;
+        },
+        googleSignInAuthenticator: () {
+          googleSignInBuilds++;
+          return googleSignIn;
+        },
+      );
+
+      await gate.attemptSilentAuth();
+
+      expect(loopbackBuilds, 0, reason: 'must not bind a loopback socket');
+      expect(googleSignInBuilds, 1);
+    });
+  });
+
+  group('forwarding', () {
+    test('authClient is null before resolution, the delegate after', () async {
+      final gate = gateOver(FallbackSecureStorage(NoEntitlementKeychain()));
+      loopback.exposeClient = true;
+
+      expect(gate.authClient, isNull);
+      await gate.attemptSilentAuth();
+
+      expect(gate.authClient, same(loopback.client));
+    });
+
+    test('forwards every seam method to the chosen delegate', () async {
+      final gate = gateOver(FallbackSecureStorage(NoEntitlementKeychain()));
+      loopback.silentAuthResult = false;
+
+      expect(await gate.attemptSilentAuth(), isFalse);
+      expect(await gate.userEmail, 'loopback@example.com');
+      await gate.handleAuthFailure();
+      await gate.signOut();
+
+      expect(loopback.silentAuthCalls, 1);
+      expect(loopback.authFailureCalls, 1);
+      expect(loopback.signOutCalls, 1);
+    });
+
+    test('attemptSilentAuth never throws when resolution fails', () async {
+      final gate = KeychainGatedAuthenticator(
+        legacyKeychainRequired: () async => throw StateError('probe exploded'),
+        desktopClientConfigured: () => true,
+        loopbackAuthenticator: () => loopback,
+        googleSignInAuthenticator: () => throw StateError('build exploded'),
+      );
+
+      expect(await gate.attemptSilentAuth(), isFalse);
+    });
+  });
+}

--- a/test/core/services/cloud_storage/google_drive_storage_provider_auth_test.dart
+++ b/test/core/services/cloud_storage/google_drive_storage_provider_auth_test.dart
@@ -7,8 +7,11 @@ import 'package:googleapis/drive/v3.dart' as drive;
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/google_drive/keychain_gated_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive_storage_provider.dart';
 
 /// Exercises the provider through the [GoogleDriveAuthenticator] seam: auth
@@ -427,5 +430,41 @@ void main() {
     await provider.signOut();
     expect(auth.signedOut, isTrue);
     expect(await provider.getFileInfo('x'), isNull);
+  });
+
+  group('default authenticator selection', () {
+    test('Windows/Linux get the loopback flow outright', () {
+      expect(
+        GoogleDriveStorageProvider.authenticatorFor(
+          isLoopbackPlatform: true,
+          isMacOS: false,
+        ),
+        isA<DesktopOAuthAuthenticator>(),
+      );
+    });
+
+    test('iOS and Android get google_sign_in outright', () {
+      expect(
+        GoogleDriveStorageProvider.authenticatorFor(
+          isLoopbackPlatform: false,
+          isMacOS: false,
+        ),
+        isA<GoogleSignInAuthenticator>(),
+      );
+    });
+
+    test('macOS defers the choice to the keychain gate', () {
+      // Neither flow works on every macOS build: google_sign_in needs the
+      // data-protection keychain the Developer ID DMG cannot reach, and the
+      // loopback listener needs the sandbox to be off. Only a runtime probe
+      // can tell the two builds apart.
+      expect(
+        GoogleDriveStorageProvider.authenticatorFor(
+          isLoopbackPlatform: false,
+          isMacOS: true,
+        ),
+        isA<KeychainGatedAuthenticator>(),
+      );
+    });
   });
 }

--- a/test/core/services/secure_storage/fallback_secure_storage_test.dart
+++ b/test/core/services/secure_storage/fallback_secure_storage_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/services/secure_storage/fallback_secure_storage.dart';
 
@@ -76,4 +77,62 @@ void main() {
       expect(map['useDataProtectionKeyChain'], 'false');
     },
   );
+
+  group('legacyKeychainRequired', () {
+    // Google sign-in on macOS cannot be pointed at the legacy keychain, so
+    // callers outside this wrapper need the verdict itself, not just routing.
+    test('is false when the data-protection keychain accepts writes', () async {
+      final storage = FallbackSecureStorage(InMemoryKeychain());
+
+      expect(await storage.legacyKeychainRequired(), isFalse);
+    });
+
+    test('is true when the data-protection keychain is unentitled', () async {
+      final storage = FallbackSecureStorage(NoEntitlementKeychain());
+
+      expect(await storage.legacyKeychainRequired(), isTrue);
+    });
+
+    test('shares the memoised probe with read/write routing', () async {
+      final keychain = _CountingKeychain();
+      final storage = FallbackSecureStorage(keychain);
+
+      await storage.legacyKeychainRequired();
+      await storage.write(key: 'k', value: 'v');
+      await storage.read(key: 'k');
+
+      expect(keychain.dataProtectionWrites, 1, reason: 'probed once');
+    });
+  });
+}
+
+/// Counts data-protection writes so the memoisation is observable.
+class _CountingKeychain extends NoEntitlementKeychain {
+  int dataProtectionWrites = 0;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    final usesDataProtection =
+        mOptions is! MacOsOptions || mOptions.usesDataProtectionKeychain;
+    if (usesDataProtection) dataProtectionWrites++;
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
 }

--- a/test/features/media_store/media_storage_page_test.dart
+++ b/test/features/media_store/media_storage_page_test.dart
@@ -131,6 +131,12 @@ void main() {
 
   Widget app({
     bool apple = true,
+    // Pinned, not inherited: googleDriveAvailableProvider resolves to
+    // GoogleDriveClientConfig.isSupportedOnThisPlatform, which is false on a
+    // Windows/Linux HOST with no Desktop client secret compiled in. Reading it
+    // ambiently made these expectations pass on macOS and fail on the Linux
+    // CI runners.
+    bool googleDriveAvailable = true,
     String? statusHint,
     MediaTransferSummary summary = const MediaTransferSummary(),
     // Riverpod 3 does not export the Override type; mirror the
@@ -147,6 +153,9 @@ void main() {
       mediaStoreStatusHintProvider.overrideWith((ref) async => statusHint),
       mediaTransferSummaryProvider.overrideWith((ref) => Stream.value(summary)),
       isApplePlatformProvider.overrideWithValue(apple),
+      googleDriveAvailableProvider.overrideWith(
+        (ref) async => googleDriveAvailable,
+      ),
       // Last, so callers can genuinely override any of the defaults above.
       // (Plain spread: dynamic elements implicitly cast, and Riverpod 3
       // does not export the Override type to name in a cast<T>().)


### PR DESCRIPTION
Google Drive sign-in failed on the macOS Developer ID DMG with `GoogleSignInException(providerConfigurationError, "keychain error")`. Diagnosing it uncovered a second defect behind it that made the desktop loopback flow unusable on every platform it serves.

## 1. google_sign_in cannot work on the no-sandbox macOS build

`GIDSignIn` builds its `GTMKeychainStore` with no attributes, and GTMAppAuth's `KeychainHelper.keychainQuery` then always sets `kSecUseDataProtectionKeychain`. The `useFileBasedKeychain` opt-out exists but is never passed, and the store is private, so no app-side setting can redirect it.

That keychain rejects a process with no keychain access group. The Developer ID DMG has none and cannot be given one. Measured with a probe binary signed exactly like the DMG (Developer ID + hardened runtime, no provisioning profile):

| entitlements | result |
| --- | --- |
| none (today's DMG) | data-protection `-34018`, file-based `0` |
| `+ keychain-access-groups` | **exit 137, AMFI SIGKILL** — this is the v1.5.2 launch failure |
| `+ com.apple.application-identifier` | runs, still `-34018` |

`GIDSignIn.saveAuthState` discards the `OSStatus` and returns a bool, which is why the real `-34018` never surfaces and the message points at the OAuth client instead. Nothing about the Google Cloud configuration was ever wrong.

**Fix:** `KeychainGatedAuthenticator` defers the macOS choice until `FallbackSecureStorage`'s memoised probe answers, then picks the loopback flow or google_sign_in. The two builds' constraints line up exactly: no-sandbox has no data-protection keychain but a bindable loopback socket, while the sandboxed build gets its access group from the provisioning profile and has no `network.server` entitlement. The probe is lazy, so no keychain write happens at startup for users who never touch Drive.

## 2. PKCE does not remove the need for a client secret

`desktop_oauth_authenticator.dart` asserted that "Google lists client_secret as optional for Desktop-app clients, so the code_verifier alone authenticates the token exchange." That is false. Measured against `oauth2.googleapis.com`:

| client | `client_secret` | response |
| --- | --- | --- |
| Desktop app | omitted | `invalid_request: client_secret is missing` |
| Desktop app | empty string (what `googleapis_auth` sends) | `invalid_request: client_secret is missing` |
| iOS | omitted | `invalid_grant: Malformed auth code` (client auth passed) |

The requirement is per client *type*: Google treats Desktop clients as needing the secret and iOS/Android clients as true public clients. Consequence: **Windows and Linux Drive sync had never worked either** — macOS was simply the first platform to reach the token exchange.

**Fix:** the secret arrives via `--dart-define=GOOGLE_DRIVE_CLIENT_SECRET` and is never committed. `hasDesktopClient` now requires both halves, so a build without the define hides Drive rather than offering a tile whose sign-in cannot finish. A test asserts the value is absent under plain `flutter test`, so it goes red if anyone hardcodes it.

## Deployment requirement

The repository secret `GOOGLE_DRIVE_CLIENT_SECRET` must hold the Desktop client's secret (`GOCSPX-…`). `release.yml` and `beta.yml` already pass `secrets: inherit`, so the macOS, Windows and Linux jobs pick it up. Local desktop builds read the same value from the environment variable of that name; omitting it disables Drive in that build by design.

## Verification

- **macOS Developer ID DMG** — verified on device. Fresh sign-in, then 224 pending changes published, on a build signed Developer ID + hardened runtime with `ReleaseNoSandbox.entitlements`.
- **macOS sandboxed** — regression-checked on device. Still takes the google_sign_in path; no loopback listener bound, and since that build carries no client secret it could not have completed via loopback.
- **Windows / Linux** — unit-verified only. Same shared code path and same client, but nobody has watched sign-in complete there. Recorded as outstanding in the manual test checklist.

Test suite: 19,973 passed / 19 skipped. Whole-project `flutter analyze` clean, `dart format` clean. Both new behaviors mutation-checked (inverting the keychain verdict fails 5 tests; removing the memoisation fails 2).
