### PR TITLE
feat(media): show a thumbnail for every pre-import review row

### DIFF
--- a/lib/features/media/data/services/network_import_targets.dart
+++ b/lib/features/media/data/services/network_import_targets.dart
@@ -1,6 +1,7 @@
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/data/services/dive_link_matcher.dart';
 import 'package:submersion/features/media/data/services/network_fetch_pipeline.dart';
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
 import 'package:submersion/features/media/domain/entities/import_candidate.dart';
 import 'package:submersion/features/media/domain/services/dive_photo_matcher.dart';
 import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
@@ -51,6 +52,10 @@ List<ImportCandidate> candidatesFor(
                 m.uri.toString()),
         takenAt: m.takenAt,
         error: m.failure,
+        // Set even for a failed probe: the art and the metadata resolve
+        // independently, so a row that could not be examined may still
+        // paint.
+        preview: UrlImportPreview(m.uri.toString()),
       ),
   ];
 }

--- a/lib/features/media/domain/entities/import_candidate.dart
+++ b/lib/features/media/domain/entities/import_candidate.dart
@@ -1,3 +1,5 @@
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
+
 /// One thing the user is about to import, before any row exists for it.
 class ImportCandidate {
   const ImportCandidate({
@@ -5,6 +7,7 @@ class ImportCandidate {
     required this.title,
     this.takenAt,
     this.error,
+    this.preview,
   });
 
   /// Caller-defined identity (asset id, URL, manifest entry key).
@@ -17,6 +20,10 @@ class ImportCandidate {
   /// Why the candidate could not be examined (a failed fetch). Such a
   /// candidate can still be imported against an explicit target.
   final String? error;
+
+  /// Where to find this candidate's thumbnail, or null when the caller has
+  /// no art for it and the row should render text-only.
+  final ImportPreview? preview;
 }
 
 /// What confirming did, for the result snackbar.

--- a/lib/features/media/domain/value_objects/import_preview.dart
+++ b/lib/features/media/domain/value_objects/import_preview.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+
+/// Where the pre-import review finds the art for one candidate row.
+///
+/// The review page is shared by three import paths that resolve bytes
+/// through two entirely different stacks: the device gallery goes through
+/// photo_manager by asset id, while pasted URLs and manifest entries go
+/// through the HTTP cache by URL. Without this the page would have to know
+/// both, so the candidate carries a handle and the thumbnail widget does
+/// the resolving.
+///
+/// A sealed hierarchy rather than two nullable strings, matching
+/// [MediaAttachTarget]: a candidate is a gallery asset or a remote URL,
+/// never both, and `switch` over it is exhaustive so a third import path
+/// cannot quietly render a blank row.
+sealed class ImportPreview extends Equatable {
+  const ImportPreview();
+
+  @override
+  bool get stringify => true;
+}
+
+/// An asset in the device photo library, addressed by its platform id.
+final class AssetImportPreview extends ImportPreview {
+  const AssetImportPreview(this.assetId);
+
+  final String assetId;
+
+  @override
+  List<Object?> get props => [assetId];
+}
+
+/// A remote image, addressed by its URL. Covers both pasted URLs and
+/// manifest entries, which resolve identically.
+final class UrlImportPreview extends ImportPreview {
+  const UrlImportPreview(this.url);
+
+  final String url;
+
+  @override
+  List<Object?> get props => [url];
+}

--- a/lib/features/media/domain/value_objects/import_preview.dart
+++ b/lib/features/media/domain/value_objects/import_preview.dart
@@ -10,9 +10,16 @@ import 'package:equatable/equatable.dart';
 /// the resolving.
 ///
 /// A sealed hierarchy rather than two nullable strings, matching
-/// [MediaAttachTarget]: a candidate is a gallery asset or a remote URL,
-/// never both, and `switch` over it is exhaustive so a third import path
-/// cannot quietly render a blank row.
+/// `MediaAttachTarget`: a candidate's art lives in the gallery or behind a
+/// URL, never both, and `switch` over it is exhaustive, so adding a third
+/// kind fails to compile at every site that renders one instead of falling
+/// through to a blank box.
+///
+/// That constrains the *kinds* of art, not whether a row has any.
+/// `ImportCandidate.preview` is deliberately nullable: a caller with no art
+/// for a row wants it rendered text-only, and `ListTile` indents its title
+/// for any non-null leading widget, so an explicit "no preview" variant
+/// would still have to be special-cased back into rendering nothing.
 sealed class ImportPreview extends Equatable {
   const ImportPreview();
 

--- a/lib/features/media/presentation/pages/media_import_review_page.dart
+++ b/lib/features/media/presentation/pages/media_import_review_page.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/media/domain/value_objects/media_attach_targ
 import 'package:submersion/features/media/presentation/providers/media_import_suggestion_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/ambiguous_dive_sheet.dart';
 import 'package:submersion/features/media/presentation/widgets/dive_picker_sheet.dart';
+import 'package:submersion/features/media/presentation/widgets/import_preview_thumbnail.dart';
 import 'package:submersion/features/media/presentation/widgets/site_picker_sheet.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
@@ -154,9 +155,26 @@ class _MediaImportReviewPageState extends ConsumerState<MediaImportReviewPage> {
               itemBuilder: (context, index) {
                 final (c, s, target) = rows[index];
                 final subtitle = _subtitle(context, c, s, target);
-                return CheckboxListTile(
-                  value: target != null,
-                  onChanged: _busy ? null : (_) => _toggle(c, s),
+                final preview = c.preview;
+                // A plain ListTile rather than CheckboxListTile: that widget
+                // has two slots (control and `secondary`) and the row needs
+                // three, since the art sits between the checkbox and the
+                // title.
+                return ListTile(
+                  onTap: _busy ? null : () => _toggle(c, s),
+                  leading: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Checkbox(
+                        value: target != null,
+                        onChanged: _busy ? null : (_) => _toggle(c, s),
+                      ),
+                      if (preview != null) ...[
+                        const SizedBox(width: 4),
+                        ImportPreviewThumbnail(preview: preview),
+                      ],
+                    ],
+                  ),
                   title: Text(
                     c.title,
                     maxLines: 1,
@@ -168,7 +186,7 @@ class _MediaImportReviewPageState extends ConsumerState<MediaImportReviewPage> {
                         ? TextStyle(color: Theme.of(context).colorScheme.error)
                         : null,
                   ),
-                  secondary: PopupMenuButton<String>(
+                  trailing: PopupMenuButton<String>(
                     enabled: !_busy,
                     onSelected: (action) {
                       if (action == 'dive') {

--- a/lib/features/media/presentation/pages/media_import_view.dart
+++ b/lib/features/media/presentation/pages/media_import_view.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/media/data/services/media_import_service.dar
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/data/services/trip_media_scanner.dart';
 import 'package:submersion/features/media/domain/entities/import_candidate.dart';
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
 import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/pages/media_import_review_page.dart';
 import 'package:submersion/features/media/presentation/pages/photo_picker_page.dart';
@@ -128,6 +129,7 @@ class MediaImportView extends ConsumerWidget {
           // The same value the import persists as takenAt, so the match
           // shown here is the match the row would get.
           takenAt: TripMediaScanner.toWallClockUtc(a.createDateTime),
+          preview: AssetImportPreview(a.id),
         ),
     ];
     await Navigator.of(context).push(

--- a/lib/features/media/presentation/widgets/import_preview_thumbnail.dart
+++ b/lib/features/media/presentation/widgets/import_preview_thumbnail.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/network_thumbnail.dart';
+
+/// The leading art for one pre-import review row.
+///
+/// The only place the gallery and network byte stacks meet: it switches on
+/// [ImportPreview] so `MediaImportReviewPage` imports neither. A candidate
+/// with no preview gets nothing at all rather than an empty box, because
+/// `ListTile` indents its title for any non-null leading widget.
+class ImportPreviewThumbnail extends ConsumerWidget {
+  const ImportPreviewThumbnail({
+    super.key,
+    required this.preview,
+    this.size = 48,
+  });
+
+  final ImportPreview preview;
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: switch (preview) {
+        AssetImportPreview(:final assetId) => _AssetThumbnail(
+          assetId: assetId,
+          size: size,
+        ),
+        UrlImportPreview(:final url) => NetworkThumbnail(url: url, size: size),
+      },
+    );
+  }
+}
+
+/// Bytes for a device-library asset. The provider is the same one the picker
+/// grid uses, so a thumbnail the user already scrolled past is a cache hit
+/// rather than a second PhotoKit round trip.
+class _AssetThumbnail extends ConsumerWidget {
+  const _AssetThumbnail({required this.assetId, required this.size});
+
+  final String assetId;
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bytes = ref.watch(assetThumbnailProvider(assetId));
+    return bytes.when(
+      data: (data) => data == null
+          ? _Placeholder(size: size, icon: Icons.broken_image_outlined)
+          : Image.memory(
+              data,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              errorBuilder: (_, _, _) =>
+                  _Placeholder(size: size, icon: Icons.broken_image_outlined),
+            ),
+      loading: () => _Placeholder(size: size),
+      error: (_, _) =>
+          _Placeholder(size: size, icon: Icons.broken_image_outlined),
+    );
+  }
+}
+
+/// A neutral box while bytes are in flight, or with an icon once they are
+/// known not to be coming.
+class _Placeholder extends StatelessWidget {
+  const _Placeholder({required this.size, this.icon});
+
+  final double size;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = this.icon;
+    return Container(
+      width: size,
+      height: size,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: icon == null ? null : Icon(icon, size: size * 0.6),
+    );
+  }
+}

--- a/test/features/media/data/services/network_import_targets_test.dart
+++ b/test/features/media/data/services/network_import_targets_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/media/data/services/dive_link_matcher.dart';
 import 'package:submersion/features/media/data/services/network_fetch_pipeline.dart';
 import 'package:submersion/features/media/data/services/network_import_targets.dart';
 import 'package:submersion/features/media/data/services/url_metadata_extractor.dart';
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
 import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 
 class _FakeDiveRepo implements DiveRepository {
@@ -87,6 +88,17 @@ void main() {
     expect(candidates[0].title, 'a.jpg');
     expect(candidates[1].error, 'HTTP 404');
     expect(candidates[1].takenAt, isNull);
+  });
+
+  test('candidatesFor gives every row a url preview, failures included', () {
+    final candidates = candidatesFor([a, broken]);
+    expect(
+      candidates[0].preview,
+      const UrlImportPreview('https://e.com/a.jpg'),
+    );
+    // A failed fetch still has a URL, and the art may well load even when
+    // the metadata probe did not.
+    expect(candidates[1].preview, isA<UrlImportPreview>());
   });
 
   test('candidatesFor prefers a manifest caption, then a custom title', () {

--- a/test/features/media/presentation/media_import_review_test.dart
+++ b/test/features/media/presentation/media_import_review_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -16,6 +19,7 @@ import 'package:submersion/features/media/domain/value_objects/import_preview.da
 import 'package:submersion/features/media/presentation/providers/media_import_suggestion_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/import_preview_thumbnail.dart';
 import 'package:submersion/features/media/presentation/widgets/network_thumbnail.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
@@ -322,6 +326,68 @@ void main() {
     await tester.pump();
 
     expect(find.byType(NetworkThumbnail), findsOneWidget);
+  });
+
+  testWidgets('an asset whose bytes are gone shows a centred placeholder', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        [candidate('a', t1, preview: const AssetImportPreview('asset-a'))],
+        {t1: none},
+        extraOverrides: [
+          assetThumbnailProvider('asset-a').overrideWith((ref) async => null),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final icon = find.byIcon(Icons.broken_image_outlined);
+    expect(icon, findsOneWidget);
+    expect(
+      tester.getCenter(icon),
+      tester.getCenter(find.byType(ImportPreviewThumbnail)),
+    );
+  });
+
+  testWidgets('a thumbnail that fails to resolve falls back to the icon', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        [candidate('a', t1, preview: const AssetImportPreview('asset-a'))],
+        {t1: none},
+        extraOverrides: [
+          assetThumbnailProvider(
+            'asset-a',
+          ).overrideWith((ref) async => throw StateError('gallery gone')),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.broken_image_outlined), findsOneWidget);
+  });
+
+  testWidgets('a thumbnail still loading paints neither art nor an icon', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        [candidate('a', t1, preview: const AssetImportPreview('asset-a'))],
+        {t1: none},
+        extraOverrides: [
+          assetThumbnailProvider(
+            'asset-a',
+          ).overrideWith((ref) => Completer<Uint8List?>().future),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(ImportPreviewThumbnail), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+    expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
   });
 
   testWidgets('a candidate with no preview paints no thumbnail', (

--- a/test/features/media/presentation/media_import_review_test.dart
+++ b/test/features/media/presentation/media_import_review_test.dart
@@ -7,16 +7,22 @@ import 'package:submersion/features/dive_log/presentation/providers/dive_provide
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/media/data/services/network_credentials_service.dart';
 import 'package:submersion/features/media/domain/entities/import_candidate.dart';
 import 'package:submersion/features/media/domain/services/dive_photo_matcher.dart';
 import 'package:submersion/features/media/domain/value_objects/media_attach_target.dart';
 import 'package:submersion/features/media/presentation/pages/media_import_review_page.dart';
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
 import 'package:submersion/features/media/presentation/providers/media_import_suggestion_providers.dart';
+import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
+import 'package:submersion/features/media/presentation/providers/url_tab_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/network_thumbnail.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 // `Override` is not exported from flutter_riverpod's public barrel; the
 // shared test helper re-types it for widget tests.
 import '../../../helpers/mock_providers.dart' show Override;
+import 'support/media_widget_harness.dart' show onePixelPng;
 
 final t1 = DateTime.utc(2026, 6, 12, 10);
 final t2 = DateTime.utc(2026, 6, 12, 11);
@@ -71,13 +77,18 @@ void main() {
     );
   }
 
-  ImportCandidate candidate(String key, DateTime? takenAt, {String? error}) =>
-      ImportCandidate(
-        key: key,
-        title: '$key.jpg',
-        takenAt: takenAt,
-        error: error,
-      );
+  ImportCandidate candidate(
+    String key,
+    DateTime? takenAt, {
+    String? error,
+    ImportPreview? preview,
+  }) => ImportCandidate(
+    key: key,
+    title: '$key.jpg',
+    takenAt: takenAt,
+    error: error,
+    preview: preview,
+  );
 
   testWidgets('confident matches are pre-checked; the rest are not', (
     tester,
@@ -271,6 +282,69 @@ void main() {
     expect(confirmed, {'a': const DiveAttachTarget('d5')});
     await tester.pumpAndSettle();
   });
+
+  testWidgets('an asset candidate paints the gallery thumbnail bytes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(
+        [candidate('a', t1, preview: const AssetImportPreview('asset-a'))],
+        {t1: none},
+        extraOverrides: [
+          assetThumbnailProvider(
+            'asset-a',
+          ).overrideWith((ref) async => onePixelPng()),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(tester.widget<Image>(find.byType(Image)).image, isA<MemoryImage>());
+  });
+
+  testWidgets('a url candidate paints a network thumbnail', (tester) async {
+    await tester.pumpWidget(
+      host(
+        [
+          candidate(
+            'a',
+            t1,
+            preview: const UrlImportPreview('https://example.com/a.jpg'),
+          ),
+        ],
+        {t1: none},
+        extraOverrides: [
+          networkCredentialsServiceProvider.overrideWithValue(_FakeCreds()),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(NetworkThumbnail), findsOneWidget);
+  });
+
+  testWidgets('a candidate with no preview paints no thumbnail', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host([candidate('a', t1)], {t1: none}));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.byType(NetworkThumbnail), findsNothing);
+  });
+}
+
+/// [NetworkThumbnail] asks for an `Authorization` header before it paints,
+/// and the real service reaches for the database.
+class _FakeCreds implements NetworkCredentialsService {
+  @override
+  Future<Map<String, String>?> headersFor(Uri uri) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+    '${invocation.memberName} not stubbed in _FakeCreds',
+  );
 }
 
 class _FakeDiveRepo implements DiveRepository {

--- a/test/features/media/presentation/media_import_view_test.dart
+++ b/test/features/media/presentation/media_import_view_test.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/media/domain/value_objects/import_preview.dart';
 import 'package:submersion/features/media/data/services/media_import_service.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
@@ -73,6 +74,10 @@ void main() {
       expect(page.candidates.map((c) => c.key), ['a1', 'a2']);
       expect(page.candidates.first.title, 'a1.jpg');
       expect(page.candidates.first.takenAt, DateTime.utc(2026, 6, 12, 10));
+      expect(page.candidates.map((c) => c.preview), [
+        const AssetImportPreview('a1'),
+        const AssetImportPreview('a2'),
+      ]);
     },
   );
 

--- a/test/features/media/presentation/widgets/manifest_mode_panel_import_test.dart
+++ b/test/features/media/presentation/widgets/manifest_mode_panel_import_test.dart
@@ -6,6 +6,7 @@ import 'package:submersion/features/media/data/parsers/manifest_format.dart';
 import 'package:submersion/features/media/data/parsers/manifest_parse_result.dart';
 import 'package:submersion/features/media/data/repositories/manifest_subscription_repository.dart';
 import 'package:submersion/features/media/data/services/manifest_fetch_service.dart';
+import 'package:submersion/features/media/data/services/network_credentials_service.dart';
 import 'package:submersion/features/media/data/services/network_fetch_pipeline.dart';
 import 'package:submersion/features/media/domain/services/dive_photo_matcher.dart';
 import 'package:submersion/features/media/presentation/pages/media_import_review_page.dart';
@@ -142,6 +143,10 @@ void main() {
       overrides: [
         manifestFetchServiceProvider.overrideWithValue(stub),
         networkFetchPipelineProvider.overrideWithValue(pipeline),
+        // The review page renders [NetworkThumbnail] for each entry, which
+        // reads the credentials provider; the real one reaches into the
+        // not-initialized [DatabaseService] in tests.
+        networkCredentialsServiceProvider.overrideWithValue(_FakeCreds()),
         manifestTabProvider.overrideWith(
           (ref) => _SeededManifestTabNotifier(
             ManifestTabShowingPreview(
@@ -238,4 +243,14 @@ void main() {
     expect(subRepo.deleted, ['sub-1']);
     await tester.pumpAndSettle();
   });
+}
+
+class _FakeCreds implements NetworkCredentialsService {
+  @override
+  Future<Map<String, String>?> headersFor(Uri uri) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+    '${invocation.memberName} not stubbed in _FakeCreds',
+  );
 }


### PR DESCRIPTION
## Problem

The media import preview showed no thumbnails.

`MediaImportReviewPage` is the shared pre-import review that all three import paths funnel into (device gallery, pasted URLs, manifest subscriptions), and it rendered text only. Every other staging surface in the feature paints 48px leading art:

| Surface | Thumbnail |
| --- | --- |
| `FileReviewCard` (Files tab) | `Image.file`, 48x48 |
| `UrlReviewPane` (URL paste) | `NetworkThumbnail(size: 48)` |
| `PhotoPickerPage` grid | `assetThumbnailProvider` |
| **`MediaImportReviewPage`** | **none** |

So the user saw thumbnails while picking and then lost them at the one screen where they have to give each file a dive or a site.

Not a regression: the page was added whole in b32cb9e730c as a text-only `CheckboxListTile`, and `ImportCandidate` carried no image handle, so it had nothing to paint.

## Change

`ImportCandidate` now carries an `ImportPreview`: a sealed pair of `AssetImportPreview` (device library, by asset id) and `UrlImportPreview` (remote, by URL), mirroring the existing `MediaAttachTarget`. Sealed rather than two nullable strings so a fourth import path cannot quietly render a blank row; the switch in `ImportPreviewThumbnail` is exhaustive and would fail to compile.

`ImportPreviewThumbnail` is the only place the two byte-resolution stacks meet, which keeps both out of the page. It reuses `assetThumbnailProvider` rather than calling `getThumbnail` directly, so a thumbnail the user just scrolled past in the picker is a cache hit instead of a second PhotoKit round trip.

The tile becomes a plain `ListTile`. `CheckboxListTile` exposes only a control slot and `secondary`, both already taken by the checkbox and the dive/site menu, and the row needs three slots since the art sits between the checkbox and the title. `onTap` still toggles, so the nine existing tests hold unchanged.

A URL candidate is given a preview even when its metadata probe failed: art and metadata resolve independently, so a row that could not be examined may still paint.

## Incidental

Stubs `networkCredentialsServiceProvider` in `manifest_mode_panel_import_test`. `NetworkThumbnail` reads it and the real one reaches into the not-initialized `DatabaseService`, so pulling that widget into the shared page reached a consumer tree that had never needed it. `url_tab_test` already carried the same stub. Test-harness gap, not a production defect.

## Known cost

`NetworkThumbnail` fetches the full image rather than a server-side thumbnail, so a large manifest costs bandwidth. `ListView.builder` keeps it lazy and scroll-bounded, and the URL review pane already behaves this way, so this is consistent rather than new. If it bites, the fix is thumbnail-size negotiation inside `NetworkThumbnail`, which would improve the URL pane at the same time.

## Testing

- 3 new tests in `media_import_review_test.dart`, each written failing first: asset bytes render as `MemoryImage`, a URL candidate renders `NetworkThumbnail`, a candidate with no preview renders no art
- Both caller tests assert the preview is populated, both watched failing with `null` first
- Full suite: 20047 passed, 19 skipped
- `flutter analyze` clean, `dart format` clean

Not yet verified visually in the running app. The layout evidence is that the widget tests render the thumbnail row without a `RenderFlex` overflow.
