### PR TITLE
Add persisted default for CCR O2 cell visibility

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1807,6 +1807,9 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(true))();
   BoolColumn get defaultShowGasTimeline =>
       boolean().withDefault(const Constant(false))();
+  // v161: default visibility for the per-cell O2 mV traces (issue #1235).
+  BoolColumn get defaultShowO2CellMv =>
+      boolean().withDefault(const Constant(false))();
   // Drift column declarations are codegen inputs shadowed by the generated
   // table at runtime, so this line is never executed (every sibling column
   // getter is likewise uncovered). The default is verified via the migration
@@ -3162,7 +3165,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 160;
+  static const int currentSchemaVersion = 161;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3444,6 +3447,9 @@ class AppDatabase extends _$AppDatabase {
     // service_records.service_type -> service_category rename. Renumbered
     // from 158 and then 159, which #1149 and #1177 claimed first on main.
     160,
+    // v161: diver_settings.default_show_o2_cell_mv, a persisted default for
+    // the per-cell O2 mV toggle on the profile chart (issue #1235).
+    161,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4893,6 +4899,24 @@ class AppDatabase extends _$AppDatabase {
           'ALTER TABLE dive_profiles ADD COLUMN o2_sensor_mv$n INTEGER',
         );
       }
+    }
+  }
+
+  /// v161: default_show_o2_cell_mv on diver_settings (issue #1235). The
+  /// per-cell O2 mV toggle previously had no persisted default; this lets a
+  /// diver make it visible by default on the profile chart.
+  Future<void> _assertO2CellMvDefaultColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('diver_settings')",
+    ).get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('default_show_o2_cell_mv')) {
+      await customStatement(
+        'ALTER TABLE diver_settings ADD COLUMN default_show_o2_cell_mv '
+        'INTEGER NOT NULL DEFAULT 0 '
+        'CHECK (default_show_o2_cell_mv IN (0, 1))',
+      );
     }
   }
 
@@ -8506,6 +8530,11 @@ class AppDatabase extends _$AppDatabase {
           await _assertServiceCategoryRename();
         }
         if (from < 160) await reportProgress();
+        // v161: default_show_o2_cell_mv on diver_settings (issue #1235).
+        if (from < 161) {
+          await _assertO2CellMvDefaultColumn();
+        }
+        if (from < 161) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -8695,6 +8724,10 @@ class AppDatabase extends _$AppDatabase {
         // database that arrives by restore or sync-adopt never runs
         // onUpgrade, and every read of a service record would throw.
         await _assertServiceCategoryRename();
+
+        // v161 backstop: re-assert diver_settings.default_show_o2_cell_mv
+        // (issue #1235; same parallel-branch version-collision self-heal).
+        await _assertO2CellMvDefaultColumn();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5660,6 +5660,9 @@ class SyncDataSerializer {
       'defaultShowOtu': false,
       'defaultShowGasSwitchMarkers': true,
       'defaultShowGasTimeline': false,
+      // v161: seed it so payloads predating the column hydrate instead of
+      // throwing in DiverSetting.fromJson.
+      'defaultShowO2CellMv': false,
       // Dive profile default-visible metrics. Non-nullable bool added in v91;
       // seed it so payloads predating the column hydrate instead of throwing in
       // DiverSetting.fromJson.

--- a/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
+++ b/lib/features/dive_log/presentation/providers/profile_legend_provider.dart
@@ -54,8 +54,8 @@ class ProfileLegendState {
   final bool showCns;
   final bool showOtu;
 
-  /// Raw O2 cell output lines (issue #810). Session-only: no persisted
-  /// default backs it, following the showMod precedent.
+  /// Raw O2 cell output lines (issue #810). Seeds from the persisted
+  /// [AppSettings.defaultShowO2CellMv] default (issue #1235).
   final bool showO2CellMv;
 
   // Per-metric data source preferences (session overrides).
@@ -364,6 +364,7 @@ class ProfileLegend extends _$ProfileLegend {
           defaultShowGasSwitchMarkers: s.defaultShowGasSwitchMarkers,
           defaultShowPhotoMarkers: s.defaultShowPhotoMarkers,
           defaultShowGasTimeline: s.defaultShowGasTimeline,
+          defaultShowO2CellMv: s.defaultShowO2CellMv,
           showNdlOnProfile: s.showNdlOnProfile,
           defaultShowPpO2: s.defaultShowPpO2,
           defaultShowPpN2: s.defaultShowPpN2,
@@ -399,6 +400,7 @@ class ProfileLegend extends _$ProfileLegend {
       showGasSwitchMarkers: settings.defaultShowGasSwitchMarkers,
       showPhotoMarkers: settings.defaultShowPhotoMarkers,
       showGas: settings.defaultShowGasTimeline,
+      showO2CellMv: settings.defaultShowO2CellMv,
       showNdl: settings.showNdlOnProfile,
       showPpO2: settings.defaultShowPpO2,
       showPpN2: settings.defaultShowPpN2,

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -177,6 +177,7 @@ class DiverSettingsRepository {
               defaultShowGasSwitchMarkers: Value(s.defaultShowGasSwitchMarkers),
               defaultShowPhotoMarkers: Value(s.defaultShowPhotoMarkers),
               defaultShowGasTimeline: Value(s.defaultShowGasTimeline),
+              defaultShowO2CellMv: Value(s.defaultShowO2CellMv),
               defaultShowAscentRateLine: Value(s.defaultShowAscentRateLine),
               notificationsEnabled: Value(s.notificationsEnabled),
               serviceReminderDays: Value(
@@ -340,6 +341,7 @@ class DiverSettingsRepository {
           ),
           defaultShowPhotoMarkers: Value(settings.defaultShowPhotoMarkers),
           defaultShowGasTimeline: Value(settings.defaultShowGasTimeline),
+          defaultShowO2CellMv: Value(settings.defaultShowO2CellMv),
           defaultShowAscentRateLine: Value(settings.defaultShowAscentRateLine),
           notificationsEnabled: Value(settings.notificationsEnabled),
           serviceReminderDays: Value(
@@ -541,6 +543,7 @@ class DiverSettingsRepository {
       defaultShowGasSwitchMarkers: row.defaultShowGasSwitchMarkers,
       defaultShowPhotoMarkers: row.defaultShowPhotoMarkers,
       defaultShowGasTimeline: row.defaultShowGasTimeline,
+      defaultShowO2CellMv: row.defaultShowO2CellMv,
       defaultShowAscentRateLine: row.defaultShowAscentRateLine,
       notificationsEnabled: row.notificationsEnabled,
       serviceReminderDays: _parseReminderDays(row.serviceReminderDays),

--- a/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
+++ b/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
@@ -128,6 +128,11 @@ class DefaultVisibleMetricsPage extends ConsumerWidget {
             value: settings.defaultShowGasDensity,
             onChanged: notifier.setDefaultShowGasDensity,
           ),
+          SwitchListTile(
+            title: Text(context.l10n.diveLog_legend_label_o2Cells),
+            value: settings.defaultShowO2CellMv,
+            onChanged: notifier.setDefaultShowO2CellMv,
+          ),
           const Divider(),
           _buildSectionHeader(
             context,

--- a/lib/features/settings/presentation/pages/section_appearance_page.dart
+++ b/lib/features/settings/presentation/pages/section_appearance_page.dart
@@ -576,7 +576,7 @@ class SectionAppearancePage extends ConsumerWidget {
         subtitle: Text(
           context.l10n.settings_appearance_metricsEnabledCount(
             _countEnabledMetrics(settings),
-            18,
+            19,
           ),
         ),
         trailing: const Icon(Icons.chevron_right),
@@ -732,6 +732,7 @@ class SectionAppearancePage extends ConsumerWidget {
       settings.defaultShowGf,
       settings.defaultShowSurfaceGf,
       settings.defaultShowMeanDepth,
+      settings.defaultShowO2CellMv,
     ];
     return values.where((v) => v).length;
   }

--- a/lib/features/settings/presentation/pages/section_appearance_page.dart
+++ b/lib/features/settings/presentation/pages/section_appearance_page.dart
@@ -576,7 +576,7 @@ class SectionAppearancePage extends ConsumerWidget {
         subtitle: Text(
           context.l10n.settings_appearance_metricsEnabledCount(
             _countEnabledMetrics(settings),
-            19,
+            _visibleMetricToggles(settings).length,
           ),
         ),
         trailing: const Icon(Icons.chevron_right),
@@ -710,30 +710,34 @@ class SectionAppearancePage extends ConsumerWidget {
     };
   }
 
-  int _countEnabledMetrics(AppSettings settings) {
-    final values = [
-      settings.defaultShowTemperature,
-      settings.defaultShowPressure,
-      settings.defaultShowHeartRate,
-      settings.defaultShowSac,
-      settings.defaultShowEvents,
-      settings.defaultShowPhotoMarkers,
-      settings.showCeilingOnProfile,
-      settings.showAscentRateColors,
-      settings.defaultShowAscentRateLine,
-      settings.showNdlOnProfile,
-      settings.defaultShowTts,
-      settings.defaultShowCns,
-      settings.defaultShowOtu,
-      settings.defaultShowPpO2,
-      settings.defaultShowPpN2,
-      settings.defaultShowPpHe,
-      settings.defaultShowGasDensity,
-      settings.defaultShowGf,
-      settings.defaultShowSurfaceGf,
-      settings.defaultShowMeanDepth,
-      settings.defaultShowO2CellMv,
-    ];
-    return values.where((v) => v).length;
-  }
+  /// One entry per SwitchListTile on [DefaultVisibleMetricsPage], in the same
+  /// order, so the enabled/total counts shown in the summary subtitle can
+  /// never drift out of sync with what that page actually renders.
+  List<bool> _visibleMetricToggles(AppSettings settings) => [
+    settings.defaultShowTemperature,
+    settings.defaultShowPressure,
+    settings.defaultShowHeartRate,
+    settings.defaultShowSac,
+    settings.defaultShowEvents,
+    settings.defaultShowPhotoMarkers,
+    settings.showCeilingOnProfile,
+    settings.showDecoStopsOnProfile,
+    settings.showAscentRateColors,
+    settings.defaultShowAscentRateLine,
+    settings.showNdlOnProfile,
+    settings.defaultShowTts,
+    settings.defaultShowCns,
+    settings.defaultShowOtu,
+    settings.defaultShowPpO2,
+    settings.defaultShowPpN2,
+    settings.defaultShowPpHe,
+    settings.defaultShowGasDensity,
+    settings.defaultShowO2CellMv,
+    settings.defaultShowGf,
+    settings.defaultShowSurfaceGf,
+    settings.defaultShowMeanDepth,
+  ];
+
+  int _countEnabledMetrics(AppSettings settings) =>
+      _visibleMetricToggles(settings).where((v) => v).length;
 }

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -391,6 +391,9 @@ class AppSettings {
   /// Default visibility for the gas-usage timeline strip on the dive profile
   final bool defaultShowGasTimeline;
 
+  /// Default visibility for the per-cell O2 mV traces on the dive profile
+  final bool defaultShowO2CellMv;
+
   /// Default visibility for the separate ascent-rate magnitude line on the
   /// dive profile (distinct from [showAscentRateColors], which tints the depth
   /// line by velocity band).
@@ -557,6 +560,7 @@ class AppSettings {
     this.defaultShowGasSwitchMarkers = true,
     this.defaultShowPhotoMarkers = true,
     this.defaultShowGasTimeline = false,
+    this.defaultShowO2CellMv = false,
     this.defaultShowAscentRateLine = false,
     // Notification defaults
     this.notificationsEnabled = true,
@@ -716,6 +720,7 @@ class AppSettings {
     bool? defaultShowGasSwitchMarkers,
     bool? defaultShowPhotoMarkers,
     bool? defaultShowGasTimeline,
+    bool? defaultShowO2CellMv,
     bool? defaultShowAscentRateLine,
     bool? notificationsEnabled,
     List<int>? serviceReminderDays,
@@ -864,6 +869,7 @@ class AppSettings {
           defaultShowPhotoMarkers ?? this.defaultShowPhotoMarkers,
       defaultShowGasTimeline:
           defaultShowGasTimeline ?? this.defaultShowGasTimeline,
+      defaultShowO2CellMv: defaultShowO2CellMv ?? this.defaultShowO2CellMv,
       defaultShowAscentRateLine:
           defaultShowAscentRateLine ?? this.defaultShowAscentRateLine,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -1785,6 +1791,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> setDefaultShowGasTimeline(bool value) async {
     state = state.copyWith(defaultShowGasTimeline: value);
+    await _saveSettings();
+  }
+
+  Future<void> setDefaultShowO2CellMv(bool value) async {
+    state = state.copyWith(defaultShowO2CellMv: value);
     await _saveSettings();
   }
 

--- a/test/core/database/migration_v161_o2_cell_mv_default_test.dart
+++ b/test/core/database/migration_v161_o2_cell_mv_default_test.dart
@@ -1,0 +1,62 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Minimal pre-v161 shape: a diver_settings table without the O2 cell mV
+/// default-visibility column, stamped at v160 so the 160->161 upgrade runs.
+NativeDatabase _dbAt160() {
+  return NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = 160');
+      rawDb.execute('''
+        CREATE TABLE diver_settings (
+          id TEXT NOT NULL PRIMARY KEY
+        )
+      ''');
+      rawDb.execute("INSERT INTO diver_settings (id) VALUES ('settings')");
+    },
+  );
+}
+
+void main() {
+  test('v161 adds default_show_o2_cell_mv defaulting to 0', () async {
+    final db = AppDatabase(_dbAt160());
+    addTearDown(() => db.close());
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('default_show_o2_cell_mv'));
+
+    final row = await db
+        .customSelect('SELECT default_show_o2_cell_mv FROM diver_settings')
+        .getSingle();
+    expect(row.read<int>('default_show_o2_cell_mv'), 0);
+  });
+
+  test('fresh databases get the default_show_o2_cell_mv column', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    expect(names, contains('default_show_o2_cell_mv'));
+  });
+
+  test('the helper no-ops when diver_settings is absent', () async {
+    final native = NativeDatabase.memory(
+      setup: (rawDb) => rawDb.execute('PRAGMA user_version = 160'),
+    );
+    final db = AppDatabase(native);
+    addTearDown(db.close);
+
+    await expectLater(db.customSelect('SELECT 1').get(), completes);
+  });
+
+  test('v161 is present in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(161));
+    expect(AppDatabase.migrationVersions, contains(161));
+  });
+}

--- a/test/core/services/sync/sync_diver_settings_fallback_test.dart
+++ b/test/core/services/sync/sync_diver_settings_fallback_test.dart
@@ -277,4 +277,41 @@ void main() {
     expect(exported, isNotNull);
     expect(exported!['gasModel'], 'ideal');
   });
+
+  test(
+    'applies a pre-v161 diver_settings payload missing defaultShowO2CellMv',
+    () async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.diverSettings)
+          .insert(
+            DiverSettingsCompanion.insert(
+              id: 'ds8',
+              diverId: 'diver-8',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      final exported = await serializer.fetchRecord('diverSettings', 'ds8');
+      expect(exported, isNotNull);
+
+      // A peer still on v160 exports no defaultShowO2CellMv. The column is
+      // NOT NULL, so an unseeded import would throw in DiverSetting.fromJson.
+      final legacy = Map<String, dynamic>.from(exported!)
+        ..remove('defaultShowO2CellMv');
+
+      await (db.delete(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds8'))).go();
+
+      await serializer.upsertRecord('diverSettings', legacy);
+
+      final row = await (db.select(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds8'))).getSingle();
+      expect(row.defaultShowO2CellMv, isFalse);
+    },
+  );
 }

--- a/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/profile_legend_provider_test.dart
@@ -488,7 +488,7 @@ void main() {
       expect(on.hashCode, isNot(equals(off.hashCode)));
     });
 
-    test('toggleO2CellMv flips the state, session-only', () {
+    test('toggleO2CellMv flips the state', () {
       final container = ProviderContainer(
         overrides: [
           settingsProvider.overrideWith(
@@ -497,10 +497,37 @@ void main() {
         ],
       );
       addTearDown(container.dispose);
-      // No persisted default setting backs this one, so it always starts off.
       expect(container.read(profileLegendProvider).showO2CellMv, isFalse);
       container.read(profileLegendProvider.notifier).toggleO2CellMv();
       expect(container.read(profileLegendProvider).showO2CellMv, isTrue);
+    });
+
+    test('showO2CellMv seeds from defaultShowO2CellMv when true', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => _StubSettingsNotifier(
+              const AppSettings(defaultShowO2CellMv: true),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(profileLegendProvider).showO2CellMv, isTrue);
+    });
+
+    test('showO2CellMv seeds from defaultShowO2CellMv when false', () {
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => _StubSettingsNotifier(
+              const AppSettings(defaultShowO2CellMv: false),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(profileLegendProvider).showO2CellMv, isFalse);
     });
   });
 }

--- a/test/features/settings/data/repositories/diver_settings_repository_o2_cell_mv_test.dart
+++ b/test/features/settings/data/repositories/diver_settings_repository_o2_cell_mv_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  group('DiverSettingsRepository defaultShowO2CellMv persistence', () {
+    late AppDatabase db;
+    late DiverSettingsRepository repository;
+
+    setUp(() async {
+      db = await setUpTestDatabase();
+      repository = DiverSettingsRepository();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion.insert(
+              id: 'd1',
+              name: 'Test Diver',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    test('new settings default defaultShowO2CellMv to false', () async {
+      await repository.createSettingsForDiver('d1');
+      final loaded = await repository.getSettingsForDiver('d1');
+      expect(loaded, isNotNull);
+      expect(loaded!.defaultShowO2CellMv, isFalse);
+    });
+
+    test('round-trips defaultShowO2CellMv = true through update', () async {
+      await repository.createSettingsForDiver('d1');
+      await repository.updateSettingsForDiver(
+        'd1',
+        const AppSettings(defaultShowO2CellMv: true),
+      );
+      final loaded = await repository.getSettingsForDiver('d1');
+      expect(loaded, isNotNull);
+      expect(loaded!.defaultShowO2CellMv, isTrue);
+    });
+  });
+}

--- a/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
+++ b/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
@@ -26,6 +26,10 @@ class _StubSettingsNotifier extends StateNotifier<AppSettings>
       state = state.copyWith(defaultShowPhotoMarkers: value);
 
   @override
+  Future<void> setDefaultShowO2CellMv(bool value) async =>
+      state = state.copyWith(defaultShowO2CellMv: value);
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
@@ -132,5 +136,23 @@ void main() {
     await tester.tap(tile);
     await tester.pumpAndSettle();
     expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+  });
+
+  testWidgets('toggles O2 cells default', (tester) async {
+    await tester.pumpWidget(buildPage(_StubSettingsNotifier()));
+    await tester.pumpAndSettle();
+
+    final tile = find.widgetWithText(SwitchListTile, 'O2 cells');
+    await tester.dragUntilVisible(
+      tile,
+      find.byType(Scrollable),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.widget<SwitchListTile>(tile).value, isFalse);
+
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+    expect(tester.widget<SwitchListTile>(tile).value, isTrue);
   });
 }

--- a/test/features/settings/presentation/pages/section_appearance_page_test.dart
+++ b/test/features/settings/presentation/pages/section_appearance_page_test.dart
@@ -712,8 +712,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Default settings have some metrics enabled. The exact count depends
-      // on default AppSettings. Find the pattern "X of 18"
-      expect(find.textContaining('of 18'), findsOneWidget);
+      // on default AppSettings. Find the pattern "X of 19"
+      expect(find.textContaining('of 19'), findsOneWidget);
     });
   });
 

--- a/test/features/settings/presentation/pages/section_appearance_page_test.dart
+++ b/test/features/settings/presentation/pages/section_appearance_page_test.dart
@@ -712,8 +712,9 @@ void main() {
       await tester.pumpAndSettle();
 
       // Default settings have some metrics enabled. The exact count depends
-      // on default AppSettings. Find the pattern "X of 19"
-      expect(find.textContaining('of 19'), findsOneWidget);
+      // on default AppSettings. Find the pattern "X of 22" -- one entry per
+      // SwitchListTile on DefaultVisibleMetricsPage.
+      expect(find.textContaining('of 22'), findsOneWidget);
     });
   });
 

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -528,6 +528,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowOtu(bool value) async =>
       state = state.copyWith(defaultShowOtu: value);
   @override
+  Future<void> setDefaultShowO2CellMv(bool value) async =>
+      state = state.copyWith(defaultShowO2CellMv: value);
+  @override
   Future<void> setShowDataSourceBadges(bool value) async =>
       state = state.copyWith(showDataSourceBadges: value);
   @override

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -89,6 +89,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override
+  Future<void> setDefaultShowO2CellMv(bool value) async =>
+      state = state.copyWith(defaultShowO2CellMv: value);
+  @override
   Future<void> setDefaultShowAscentRateLine(bool value) async =>
       state = state.copyWith(defaultShowAscentRateLine: value);
   @override

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -431,6 +431,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowOtu(bool value) async =>
       state = state.copyWith(defaultShowOtu: value);
   @override
+  Future<void> setDefaultShowO2CellMv(bool value) async =>
+      state = state.copyWith(defaultShowO2CellMv: value);
+  @override
   Future<void> setShowDataSourceBadges(bool value) async =>
       state = state.copyWith(showDataSourceBadges: value);
   @override

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -381,6 +381,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowPhotoMarkers(bool value) async =>
       state = state.copyWith(defaultShowPhotoMarkers: value);
   @override
+  Future<void> setDefaultShowO2CellMv(bool value) async =>
+      state = state.copyWith(defaultShowO2CellMv: value);
+  @override
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override


### PR DESCRIPTION
## Summary
- The per-cell O2 mV toggle added for #810 had no persisted default, unlike every other dive profile chart metric, so it always started off each session.
- Adds `defaultShowO2CellMv` (schema v161) following the same pattern as the other default-visible metrics: guarded migration, repository round-trip, sync-fallback default for legacy payloads, and legend-provider seeding.
- Surfaces the new toggle in the Gas Analysis Metrics group of Settings > Appearance > Dives > Default Visible Metrics, reusing the existing "O2 cells" legend label so no new translations are needed.

Closes #1235

<img width="1584" height="892" alt="image" src="https://github.com/user-attachments/assets/1a8db1aa-29b8-4b65-90e8-4a716291ec88" />


## Test plan
- [x] New migration test: column added, defaults to off, idempotent, present in the migration ladder
- [x] New repository round-trip test
- [x] Updated legend-provider tests to cover seeding from the persisted default
- [x] New sync-fallback test for a pre-v161 legacy payload
- [x] New/updated settings-page widget tests for the toggle and the updated enabled-metrics count
- [x] `flutter analyze` and `dart format` clean