### PR TITLE
fix(release): resubmit after a rejection instead of skipping

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -52,6 +52,21 @@ ALREADY_SUBMITTED_STATES = [
   "ACCEPTED",
 ].freeze
 
+# Apple's name for "we reviewed this and found problems", ie a rejection. It is
+# a REVIEW SUBMISSION state, not a version state, and the distinction is the
+# whole point of the handling below: App Store Connect shows the version as
+# Rejected while the submission that carried it stays OPEN in this state until
+# someone clears it.
+REJECTED_REVIEW_STATE = "UNRESOLVED_ISSUES"
+
+# How long to wait for App Store Connect to retire a cancelled submission.
+# Cancelling moves it to CANCELING, which is not a state the in-progress
+# lookup matches, but the transition is not documented as synchronous, and
+# submitting into a half-cancelled submission is exactly the kind of ambiguity
+# this guard exists to avoid.
+CANCELLED_SUBMISSION_POLL_ATTEMPTS = 10
+CANCELLED_SUBMISSION_POLL_INTERVAL = 3
+
 platform :ios do
   # ============================================================================
   # Screenshot Lanes
@@ -213,10 +228,20 @@ platform :ios do
   # Note what is deliberately NOT blocking: an editable version carrying an
   # older version string. Renaming that forward is legitimate, and is how the
   # recovery from that incident worked.
+  #
+  # Nor is a REJECTION blocking, which promote run 32779335838 showed the hard
+  # way. Apple rejected iOS 1.7.4, but a rejected submission does not close: it
+  # sits in UNRESOLVED_ISSUES, which the in-progress lookup matches, so the
+  # version-agnostic check above skipped 1.7.5 and reported 1.7.4 as "already
+  # in review" while App Store Connect showed it as Rejected. Resubmitting
+  # after a rejection is precisely what this lane is for, and
+  # ALREADY_SUBMITTED_STATES already says so; the short-circuit above simply
+  # never let that decision run. Only an EXPLICIT UNRESOLVED_ISSUES lowers the
+  # block - an unreadable or unrecognised state keeps the old behaviour.
   def submission_skip_reason(app_version:, review_in_progress:,
-                             review_version: nil, edit_version: nil,
-                             edit_state: nil)
-    if review_in_progress
+                             review_version: nil, review_state: nil,
+                             edit_version: nil, edit_state: nil)
+    if review_in_progress && review_state != REJECTED_REVIEW_STATE
       held_by = review_version ? "#{review_version} is" : "another version is"
       return "#{held_by} already in review; skipping submission of " \
              "#{app_version}. App Store Connect allows one submission at a " \
@@ -247,7 +272,8 @@ platform :ios do
   # app_store_connect_api_key action, whose set_spaceship_token defaults to
   # true, so Spaceship::ConnectAPI.token is already set by the time a lane
   # calls this.
-  def submission_blocker(app_version, platform)
+  def submission_blocker(app_version, platform,
+                         poll_interval: CANCELLED_SUBMISSION_POLL_INTERVAL)
     app = Spaceship::ConnectAPI::App.find(
       CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
     )
@@ -265,18 +291,38 @@ platform :ios do
       includes: "appStoreVersionForReview",
     )
 
-    # Short-circuit. An in-progress submission is already a block, so the
-    # editable version cannot change the answer. Skipping the second lookup is
-    # partly about latency, but mostly about failure surface: this method
-    # deliberately lets App Store Connect errors propagate, so a call made
-    # after the answer is known could fail the lane at the moment we already
-    # knew the safe outcome. Blocking beats erroring.
+    # Short-circuit. A submission Apple is actually working on is already a
+    # block, so the editable version cannot change the answer. Skipping the
+    # second lookup is partly about latency, but mostly about failure surface:
+    # this method deliberately lets App Store Connect errors propagate, so a
+    # call made after the answer is known could fail the lane at the moment we
+    # already knew the safe outcome. Blocking beats erroring.
     unless submission.nil?
-      return submission_skip_reason(
+      reason = submission_skip_reason(
         app_version: app_version,
         review_in_progress: true,
+        review_state: review_submission_state(submission),
         review_version: review_submission_version(submission),
       )
+      return reason unless reason.nil?
+
+      # Only a rejection gets past that, and a rejected submission has to be
+      # retired before anything else can be submitted: deliver runs the same
+      # in-progress lookup in create_review_submission and hard-errors on it,
+      # but only AFTER it has renamed the editable version and uploaded
+      # metadata. Clearing it here keeps that half-finished state from ever
+      # existing. Nothing is withdrawn from Apple by this: the review is over,
+      # which is what UNRESOLVED_ISSUES means.
+      cleared = clear_rejected_submission(
+        app, mapped, submission, poll_interval: poll_interval
+      )
+
+      unless cleared
+        return "the rejected review submission was cancelled but App Store " \
+               "Connect still reports it in progress; skipping submission of " \
+               "#{app_version}. Re-run once it clears, or remove it from " \
+               "review in App Store Connect."
+      end
     end
 
     version = app.get_edit_app_store_version(platform: mapped)
@@ -301,6 +347,47 @@ platform :ios do
     submission.app_store_version_for_review&.version_string
   rescue StandardError
     nil
+  end
+
+  # The state of a review submission, or nil when it cannot be read.
+  #
+  # Read defensively for the same reason as the version above, but note the
+  # consequence is inverted: an unknown version only costs a vaguer message,
+  # while an unknown state decides whether CI may cancel a submission. nil is
+  # therefore the SAFE answer here, because only an explicit
+  # REJECTED_REVIEW_STATE lowers the block or triggers a cancel.
+  def review_submission_state(submission)
+    return nil if submission.nil?
+
+    submission.state
+  rescue StandardError
+    nil
+  end
+
+  # Cancels a rejected review submission and waits for App Store Connect to
+  # stop reporting it. True when the road is clear.
+  #
+  # A cancel that raises is deliberately NOT rescued, matching the rest of this
+  # guard: an unexpected App Store Connect error must stop the lane, not be
+  # read as permission to carry on.
+  def clear_rejected_submission(app, mapped, submission,
+                                poll_interval: CANCELLED_SUBMISSION_POLL_INTERVAL)
+    held = review_submission_version(submission)
+    UI.important(
+      "#{held || 'A previous version'} was rejected and its review submission " \
+      "is still open; cancelling it so this version can be submitted."
+    )
+
+    submission.cancel_submission
+
+    CANCELLED_SUBMISSION_POLL_ATTEMPTS.times do |attempt|
+      return true if app.get_in_progress_review_submission(platform: mapped).nil?
+
+      last = attempt == CANCELLED_SUBMISSION_POLL_ATTEMPTS - 1
+      sleep(poll_interval) if poll_interval.positive? && !last
+    end
+
+    false
   end
 
   # Loads API key from environment variables or falls back to api_key.json
@@ -572,7 +659,10 @@ platform :ios do
 
     # Makes the lane a no-op once Apple has this version, or any other version,
     # so a re-dispatched promotion does not fail on the leg that already
-    # succeeded and cannot rename a submission that is already under review.
+    # succeeded and cannot rename a submission that is already under review. A
+    # REJECTED version is not "Apple has it": rejection leaves the submission
+    # open in UNRESOLVED_ISSUES, and the blocker retires that so this run can
+    # resubmit, which is what the lane is for.
     if (reason = submission_blocker(app_version, "ios"))
       UI.important("ios: #{reason}")
       next

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -52,6 +52,21 @@ ALREADY_SUBMITTED_STATES = [
   "ACCEPTED",
 ].freeze
 
+# Apple's name for "we reviewed this and found problems", ie a rejection. It is
+# a REVIEW SUBMISSION state, not a version state, and the distinction is the
+# whole point of the handling below: App Store Connect shows the version as
+# Rejected while the submission that carried it stays OPEN in this state until
+# someone clears it.
+REJECTED_REVIEW_STATE = "UNRESOLVED_ISSUES"
+
+# How long to wait for App Store Connect to retire a cancelled submission.
+# Cancelling moves it to CANCELING, which is not a state the in-progress
+# lookup matches, but the transition is not documented as synchronous, and
+# submitting into a half-cancelled submission is exactly the kind of ambiguity
+# this guard exists to avoid.
+CANCELLED_SUBMISSION_POLL_ATTEMPTS = 10
+CANCELLED_SUBMISSION_POLL_INTERVAL = 3
+
 platform :mac do
   # ============================================================================
   # Helper Methods
@@ -168,10 +183,20 @@ platform :mac do
   # Note what is deliberately NOT blocking: an editable version carrying an
   # older version string. Renaming that forward is legitimate, and is how the
   # recovery from that incident worked.
+  #
+  # Nor is a REJECTION blocking, which promote run 32779335838 showed the hard
+  # way. Apple rejected iOS 1.7.4, but a rejected submission does not close: it
+  # sits in UNRESOLVED_ISSUES, which the in-progress lookup matches, so the
+  # version-agnostic check above skipped 1.7.5 and reported 1.7.4 as "already
+  # in review" while App Store Connect showed it as Rejected. Resubmitting
+  # after a rejection is precisely what this lane is for, and
+  # ALREADY_SUBMITTED_STATES already says so; the short-circuit above simply
+  # never let that decision run. Only an EXPLICIT UNRESOLVED_ISSUES lowers the
+  # block - an unreadable or unrecognised state keeps the old behaviour.
   def submission_skip_reason(app_version:, review_in_progress:,
-                             review_version: nil, edit_version: nil,
-                             edit_state: nil)
-    if review_in_progress
+                             review_version: nil, review_state: nil,
+                             edit_version: nil, edit_state: nil)
+    if review_in_progress && review_state != REJECTED_REVIEW_STATE
       held_by = review_version ? "#{review_version} is" : "another version is"
       return "#{held_by} already in review; skipping submission of " \
              "#{app_version}. App Store Connect allows one submission at a " \
@@ -202,7 +227,8 @@ platform :mac do
   # app_store_connect_api_key action, whose set_spaceship_token defaults to
   # true, so Spaceship::ConnectAPI.token is already set by the time a lane
   # calls this.
-  def submission_blocker(app_version, platform)
+  def submission_blocker(app_version, platform,
+                         poll_interval: CANCELLED_SUBMISSION_POLL_INTERVAL)
     app = Spaceship::ConnectAPI::App.find(
       CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
     )
@@ -220,18 +246,38 @@ platform :mac do
       includes: "appStoreVersionForReview",
     )
 
-    # Short-circuit. An in-progress submission is already a block, so the
-    # editable version cannot change the answer. Skipping the second lookup is
-    # partly about latency, but mostly about failure surface: this method
-    # deliberately lets App Store Connect errors propagate, so a call made
-    # after the answer is known could fail the lane at the moment we already
-    # knew the safe outcome. Blocking beats erroring.
+    # Short-circuit. A submission Apple is actually working on is already a
+    # block, so the editable version cannot change the answer. Skipping the
+    # second lookup is partly about latency, but mostly about failure surface:
+    # this method deliberately lets App Store Connect errors propagate, so a
+    # call made after the answer is known could fail the lane at the moment we
+    # already knew the safe outcome. Blocking beats erroring.
     unless submission.nil?
-      return submission_skip_reason(
+      reason = submission_skip_reason(
         app_version: app_version,
         review_in_progress: true,
+        review_state: review_submission_state(submission),
         review_version: review_submission_version(submission),
       )
+      return reason unless reason.nil?
+
+      # Only a rejection gets past that, and a rejected submission has to be
+      # retired before anything else can be submitted: deliver runs the same
+      # in-progress lookup in create_review_submission and hard-errors on it,
+      # but only AFTER it has renamed the editable version and uploaded
+      # metadata. Clearing it here keeps that half-finished state from ever
+      # existing. Nothing is withdrawn from Apple by this: the review is over,
+      # which is what UNRESOLVED_ISSUES means.
+      cleared = clear_rejected_submission(
+        app, mapped, submission, poll_interval: poll_interval
+      )
+
+      unless cleared
+        return "the rejected review submission was cancelled but App Store " \
+               "Connect still reports it in progress; skipping submission of " \
+               "#{app_version}. Re-run once it clears, or remove it from " \
+               "review in App Store Connect."
+      end
     end
 
     version = app.get_edit_app_store_version(platform: mapped)
@@ -256,6 +302,47 @@ platform :mac do
     submission.app_store_version_for_review&.version_string
   rescue StandardError
     nil
+  end
+
+  # The state of a review submission, or nil when it cannot be read.
+  #
+  # Read defensively for the same reason as the version above, but note the
+  # consequence is inverted: an unknown version only costs a vaguer message,
+  # while an unknown state decides whether CI may cancel a submission. nil is
+  # therefore the SAFE answer here, because only an explicit
+  # REJECTED_REVIEW_STATE lowers the block or triggers a cancel.
+  def review_submission_state(submission)
+    return nil if submission.nil?
+
+    submission.state
+  rescue StandardError
+    nil
+  end
+
+  # Cancels a rejected review submission and waits for App Store Connect to
+  # stop reporting it. True when the road is clear.
+  #
+  # A cancel that raises is deliberately NOT rescued, matching the rest of this
+  # guard: an unexpected App Store Connect error must stop the lane, not be
+  # read as permission to carry on.
+  def clear_rejected_submission(app, mapped, submission,
+                                poll_interval: CANCELLED_SUBMISSION_POLL_INTERVAL)
+    held = review_submission_version(submission)
+    UI.important(
+      "#{held || 'A previous version'} was rejected and its review submission " \
+      "is still open; cancelling it so this version can be submitted."
+    )
+
+    submission.cancel_submission
+
+    CANCELLED_SUBMISSION_POLL_ATTEMPTS.times do |attempt|
+      return true if app.get_in_progress_review_submission(platform: mapped).nil?
+
+      last = attempt == CANCELLED_SUBMISSION_POLL_ATTEMPTS - 1
+      sleep(poll_interval) if poll_interval.positive? && !last
+    end
+
+    false
   end
 
   def load_api_key
@@ -654,7 +741,10 @@ platform :mac do
 
     # Makes the lane a no-op once Apple has this version, or any other version,
     # so a re-dispatched promotion does not fail on the leg that already
-    # succeeded and cannot rename a submission that is already under review.
+    # succeeded and cannot rename a submission that is already under review. A
+    # REJECTED version is not "Apple has it": rejection leaves the submission
+    # open in UNRESOLVED_ISSUES, and the blocker retires that so this run can
+    # resubmit, which is what the lane is for.
     if (reason = submission_blocker(app_version, "osx"))
       UI.important("osx: #{reason}")
       next

--- a/scripts/release/fastlane_submit_guard_test.rb
+++ b/scripts/release/fastlane_submit_guard_test.rb
@@ -92,28 +92,69 @@ module Spaceship
 end
 
 FakeVersion = Struct.new(:version_string, :app_version_state, :app_store_state)
-FakeSubmission = Struct.new(:app_store_version_for_review)
+
+# A review submission as the guard sees it: a state, the version it covers, and
+# a cancel that the guard is allowed to call on exactly one of those states.
+class FakeSubmission
+  attr_reader :cancel_calls
+
+  def initialize(state: 'IN_REVIEW', version: nil)
+    @state = state
+    @version = version
+    @cancel_calls = 0
+  end
+
+  def state
+    @state
+  end
+
+  def app_store_version_for_review
+    @version
+  end
+
+  def cancel_submission
+    @cancel_calls += 1
+    self
+  end
+end
 
 # Stands in for a submission fetched without the relationship included, which
 # is what makes the version unreadable in the first place.
-class UnreadableSubmission
+class UnreadableSubmission < FakeSubmission
   def app_store_version_for_review
     raise StandardError, 'relationship not included'
   end
 end
 
-class FakeApp
-  attr_reader :review_calls, :edit_calls
+# A submission whose STATE cannot be read. Deliberately distinct from the
+# above: an unreadable version only costs a vaguer message, while an unreadable
+# state is the difference between "Apple is holding this build" and "Apple
+# already rejected it", so it must fail closed and must never be cancelled.
+class UnreadableStateSubmission < FakeSubmission
+  def state
+    raise StandardError, 'state not returned'
+  end
+end
 
-  def initialize(submission: nil, edit_version: nil)
+class FakeApp
+  attr_reader :review_calls, :edit_calls, :submission
+
+  # clears_after_cancel models App Store Connect retiring a cancelled
+  # submission, which is what lets the guard go on to submit. false models it
+  # lingering, which must not be mistaken for a clear road.
+  def initialize(submission: nil, edit_version: nil, clears_after_cancel: true)
     @submission = submission
     @edit_version = edit_version
+    @clears_after_cancel = clears_after_cancel
     @review_calls = []
     @edit_calls = []
   end
 
   def get_in_progress_review_submission(platform:, includes: nil)
     @review_calls << { platform: platform, includes: includes }
+    return nil if @submission.nil?
+    return nil if @clears_after_cancel && @submission.cancel_calls.positive?
+
     @submission
   end
 
@@ -210,6 +251,67 @@ def assert_guard_behaviour(label)
           "#{label}: the live version state #{live} was treated as blocking " \
           "(got #{reason.inspect}); that would stop every future release")
   end
+
+  # 8. The rejection this guard used to trap, from promote run 32779335838.
+  #    Apple reviewed 1.7.4 and rejected it, but the REVIEW SUBMISSION stays
+  #    open in UNRESOLVED_ISSUES, so the version-agnostic check above read it
+  #    as "a review is in progress" and skipped 1.7.5. Nobody is holding the
+  #    build; a dead submission is. Resubmitting after a rejection is this
+  #    lane's whole job, so it must proceed.
+  reason = submission_skip_reason(
+    app_version: '1.7.5',
+    review_in_progress: true,
+    review_state: 'UNRESOLVED_ISSUES',
+    review_version: '1.7.4',
+    edit_version: '1.7.4',
+    edit_state: 'REJECTED',
+  )
+  check(reason.nil?,
+        "#{label}: a rejected (UNRESOLVED_ISSUES) submission blocked the " \
+        "resubmission it exists to allow (got #{reason.inspect})")
+
+  # 9. The states where Apple genuinely holds the build still block. This is
+  #    the protection from run 31903095751 and it must survive case 8.
+  %w[WAITING_FOR_REVIEW IN_REVIEW].each do |held|
+    reason = submission_skip_reason(
+      app_version: '1.7.5',
+      review_in_progress: true,
+      review_state: held,
+      review_version: '1.7.4',
+    )
+    check(!reason.nil?,
+          "#{label}: a submission in #{held} stopped blocking; that is the " \
+          'exact hole that renamed an in-review version')
+  end
+
+  # 10. Fail CLOSED on a state we cannot read or do not recognise. Only an
+  #     explicit UNRESOLVED_ISSUES may lower the block: if Apple adds a state
+  #     or the field goes unread, the safe answer is the old behaviour.
+  [nil, '', 'SOME_NEW_APPLE_STATE'].each do |unknown|
+    reason = submission_skip_reason(
+      app_version: '1.7.5',
+      review_in_progress: true,
+      review_state: unknown,
+      review_version: '1.7.4',
+    )
+    check(!reason.nil?,
+          "#{label}: an unrecognised review state #{unknown.inspect} did not " \
+          'block; unknown must never weaken the guard')
+  end
+
+  # 11. A rejection lowers the FIRST check only. If the editable version is
+  #     somehow already handed over, the second check still stops the lane.
+  reason = submission_skip_reason(
+    app_version: '1.7.5',
+    review_in_progress: true,
+    review_state: 'UNRESOLVED_ISSUES',
+    review_version: '1.7.4',
+    edit_version: '1.7.5',
+    edit_state: 'WAITING_FOR_REVIEW',
+  )
+  check(!reason.nil?,
+        "#{label}: UNRESOLVED_ISSUES let a version that is already " \
+        'WAITING_FOR_REVIEW be submitted again')
 end
 
 # --- The App Store Connect wrapper ------------------------------------------
@@ -223,7 +325,10 @@ def assert_wrapper_behaviour(label, platform_arg)
   # A review under way for a different version blocks, and the version it
   # covers is read through the relationship the request asked for.
   $stub_app = FakeApp.new(
-    submission: FakeSubmission.new(FakeVersion.new('1.7.3', 'WAITING_FOR_REVIEW', nil)),
+    submission: FakeSubmission.new(
+      state: 'WAITING_FOR_REVIEW',
+      version: FakeVersion.new('1.7.3', 'WAITING_FOR_REVIEW', nil),
+    ),
     edit_version: FakeVersion.new('1.7.3', 'WAITING_FOR_REVIEW', nil),
   )
   reason = submission_blocker('1.7.4', platform_arg)
@@ -249,7 +354,7 @@ def assert_wrapper_behaviour(label, platform_arg)
         'already in progress; that is an avoidable way to fail the lane')
 
   # An unreadable relationship must not weaken the block.
-  $stub_app = FakeApp.new(submission: UnreadableSubmission.new)
+  $stub_app = FakeApp.new(submission: UnreadableSubmission.new(state: 'IN_REVIEW'))
   reason = submission_blocker('1.7.4', platform_arg)
   check(!reason.nil?,
         "#{label}: a submission whose version could not be read stopped blocking")
@@ -283,6 +388,73 @@ def assert_wrapper_behaviour(label, platform_arg)
   $stub_app = nil
   check(submission_blocker('1.7.4', platform_arg).nil?,
         "#{label}: a missing app record did not fall through")
+
+  # A rejection left open: the dead submission is cancelled and the lane goes
+  # on to read the editable version, which is REJECTED and therefore
+  # submittable. Both halves matter - cancelling without proceeding leaves the
+  # release stuck, and proceeding without cancelling hits deliver's own
+  # in-progress check (deliver/submit_for_review.rb) AFTER it has renamed the
+  # version and uploaded metadata.
+  rejected = FakeSubmission.new(
+    state: 'UNRESOLVED_ISSUES',
+    version: FakeVersion.new('1.7.4', 'REJECTED', nil),
+  )
+  $stub_app = FakeApp.new(
+    submission: rejected,
+    edit_version: FakeVersion.new('1.7.4', 'REJECTED', nil),
+  )
+  reason = submission_blocker('1.7.5', platform_arg)
+  check(reason.nil?,
+        "#{label}: a rejected submission still blocked (got #{reason.inspect})")
+  check(rejected.cancel_calls == 1,
+        "#{label}: expected the rejected submission to be cancelled exactly " \
+        "once, got #{rejected.cancel_calls} cancels")
+  check($stub_app.edit_calls.length == 1,
+        "#{label}: the editable version was not consulted after the cancel; " \
+        'the second check is what allows the rename-forward')
+
+  # The cancel is confined to rejections. A build actually with Apple must
+  # never be withdrawn by CI.
+  %w[WAITING_FOR_REVIEW IN_REVIEW].each do |held|
+    live = FakeSubmission.new(
+      state: held,
+      version: FakeVersion.new('1.7.4', held, nil),
+    )
+    $stub_app = FakeApp.new(submission: live)
+    check(!submission_blocker('1.7.5', platform_arg).nil?,
+          "#{label}: a submission in #{held} did not block the wrapper")
+    check(live.cancel_calls.zero?,
+          "#{label}: CI cancelled a live #{held} submission; that pulls a " \
+          'build out of Apple review')
+  end
+
+  # An unreadable state fails closed AND keeps its hands off the submission.
+  opaque = UnreadableStateSubmission.new(state: 'UNRESOLVED_ISSUES')
+  $stub_app = FakeApp.new(submission: opaque)
+  check(!submission_blocker('1.7.5', platform_arg).nil?,
+        "#{label}: a submission whose state could not be read stopped blocking")
+  check(opaque.cancel_calls.zero?,
+        "#{label}: a submission whose state could not be read was cancelled")
+
+  # A cancel that does not take effect must block rather than fall through.
+  # poll_interval 0 keeps the retry loop instant here.
+  stuck = FakeSubmission.new(
+    state: 'UNRESOLVED_ISSUES',
+    version: FakeVersion.new('1.7.4', 'REJECTED', nil),
+  )
+  $stub_app = FakeApp.new(
+    submission: stuck,
+    edit_version: FakeVersion.new('1.7.4', 'REJECTED', nil),
+    clears_after_cancel: false,
+  )
+  reason = submission_blocker('1.7.5', platform_arg, poll_interval: 0)
+  check(!reason.nil?,
+        "#{label}: a cancel that never took effect was treated as a clear road")
+  check(stuck.cancel_calls == 1,
+        "#{label}: expected a single cancel attempt, got #{stuck.cancel_calls}")
+  check($stub_app.edit_calls.empty?,
+        "#{label}: the lane carried on to the editable version after the " \
+        'cancel failed to clear the submission')
 end
 
 # --- Both platform Fastfiles ------------------------------------------------


### PR DESCRIPTION
## Summary

Promote run [32779335838](https://github.com/submersion-app/submersion/actions/runs/32779335838) published 1.7.5 and submitted it on macOS, but the iOS submit job exited green in 17 seconds having submitted nothing:

```
[21:26:32]: ios: 1.7.4 is already in review; skipping submission of 1.7.5.
```

App Store Connect showed 1.7.4 as **Rejected**, not in review. Both readings were correct, and that is the bug.

A rejection closes the review but not the review *submission*. The submission stays open in `UNRESOLVED_ISSUES`, which is one of the three states fastlane's `get_in_progress_review_submission` matches (`spaceship/.../app.rb`). The guard's version-agnostic first check read that as "Apple is holding a build" and short-circuited, so `ALREADY_SUBMITTED_STATES`, which deliberately omits every rejected state on the grounds that they "all need a fresh submission, which is exactly what this lane is for", never got to run. The two halves of the guard disagreed about rejection and the half that never sees a version string won.

Relaxing that check alone would not have been enough. `deliver` runs the identical lookup in `create_review_submission` and calls `user_error!` on any hit, but only *after* it has renamed the editable version and uploaded metadata. That would have traded a clean skip for a red run plus a half-written version. The rejected submission has to be retired first.

## Changes

- `submission_skip_reason` takes `review_state:` and blocks only when a review is in progress **and** the state is not `UNRESOLVED_ISSUES`. A rejection now falls through to the editable-version check, which already handles `REJECTED` correctly.
- `submission_blocker` cancels the dead submission and polls until App Store Connect stops reporting it, then continues to that second check. `WAITING_FOR_REVIEW` and `IN_REVIEW` still block exactly as before; the protection bought by run 31903095751 is untouched.
- New `review_submission_state` helper, defensive like `review_submission_version`, but note the fail-safe direction is inverted: an unreadable *version* only costs a vaguer log message, while an unreadable *state* decides whether CI may cancel something at Apple. Only a literal `UNRESOLVED_ISSUES` lowers the guard or triggers a cancel, so `nil`, `''`, and any state Apple adds later all keep the old blocking behaviour. A cancel that does not take effect blocks too, rather than falling through into deliver's error.
- Same patch applied to both `ios/fastlane/Fastfile` and `macos/fastlane/Fastfile`; the guard test enforces that they stay in lockstep.
- `scripts/release/fastlane_submit_guard_test.rb`: fakes gain submission state and `cancel_submission`, plus five decision cases and four wrapper cases.

## Operational change worth calling out

A rejection used to force a human to look before anything was resubmitted. The promote job now resubmits on its own, which brings the App Store into line with how Play and the appcast already behave, and puts the "did we actually fix the rejection?" judgement entirely on the release owner.

## Test Plan

- [x] `ruby scripts/release/fastlane_submit_guard_test.rb` passes (the check CI runs at `ci.yaml:417`)
- [x] Reverting only the new `review_state != REJECTED_REVIEW_STATE` condition reproduces run 32779335838's message verbatim, on both platforms, so the new cases fail for the real reason rather than passing vacuously
- [x] `ruby -c` clean on both Fastfiles
- [x] No Dart changed, so `flutter analyze` and `flutter test` are unaffected (the pre-push hook resolved 0 changed Dart files and 0 affected tests)

Not verifiable without acting on the live account, so both are built to fail safe rather than assumed: that Apple retires a cancelled submission promptly (hence the bounded poll), and that nothing other than a rejection is ever parked in `UNRESOLVED_ISSUES`.

## Getting 1.7.5 submitted

Re-running the old job replays the old code, so either clear 1.7.4 in App Store Connect by hand and re-run, or land this and dispatch a fresh promote. The lane will then cancel the 1.7.4 submission, rename the rejected 1.7.4 edit version forward to 1.7.5, attach build 6772, and submit.
