### PR TITLE
Move Site Features section below the depth stats

### DIFF
--- a/lib/features/dive_sites/presentation/pages/site_detail_page.dart
+++ b/lib/features/dive_sites/presentation/pages/site_detail_page.dart
@@ -177,14 +177,6 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
           if (site.hasCoordinates) ...[
             _buildMapSection(context, ref, site),
             const SizedBox(height: 16),
-            // Diver-placed annotations; placement happens on the map, so
-            // the add action opens the fullscreen scape armed to place.
-            SiteFeaturesSection(
-              siteId: site.id,
-              onAddFeature: () =>
-                  _showFullscreenMap(context, ref, site, startPlacing: true),
-            ),
-            const SizedBox(height: 16),
           ],
 
           // Basic Info Section (Name + Location String)
@@ -210,6 +202,18 @@ class _SiteDetailContentState extends ConsumerState<_SiteDetailContent> {
           // Altitude Section (only if altitude is set)
           if (site.altitude != null) ...[
             _buildAltitudeSection(context, ref, site),
+            const SizedBox(height: 16),
+          ],
+
+          // Site Features Section (diver-placed annotations; placement happens
+          // on the map, so the add action opens the fullscreen scape armed to
+          // place)
+          if (site.hasCoordinates) ...[
+            SiteFeaturesSection(
+              siteId: site.id,
+              onAddFeature: () =>
+                  _showFullscreenMap(context, ref, site, startPlacing: true),
+            ),
             const SizedBox(height: 16),
           ],
 


### PR DESCRIPTION
## Summary

The Site Features section rendered directly under the map, above Basic Info. That put diver-placed annotations ahead of the site's own identity and core stats, pushing name, location, dive count, description, and depth below the fold on a site with coordinates.

It now sits after the Depth and Altitude sections and before Tide.

New section order on the site detail page:

Map, Basic Info, Dive Count, Description, Location Details, Depth, Altitude, **Site Features**, Tide, Reef, Marine Life, Media, Difficulty, Rating, Hazards, Access, Notes.

## Implementation note

The section had been nested inside the map's `if (site.hasCoordinates) ...[ ]` spread, sharing the map's guard. Moving it out required giving it its own `hasCoordinates` check. It still needs one: `onAddFeature` calls `_showFullscreenMap`, which has nothing to render without a `site.location`.

## Testing

- `dart format`: no changes
- `flutter analyze`: no issues found across the project
- `flutter test test/features/dive_sites/presentation/pages/ test/features/site_scape/presentation/`: 170 tests, all passing
- Pre-push hook: 55 affected tests, all passing

No test asserts the page's section order, so nothing needed updating. `site_features_section_test.dart` mounts the widget standalone, which is the convention for section widgets here.