### PR TITLE
fix(android): give sideloaded APKs an update path

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+        Cloud sync, media upload, and the GitHub update check (#1258).
+        Release builds already carry this permission: the manifest merger
+        unions it in from a library manifest, and apkanalyzer confirms it in
+        the shipped v1.7.5.6772 APK. Declared here so it stops depending on
+        which plugins happen to be in the tree, since the only pub package
+        supplying it is google_sign_in_android, a transitive dependency.
+    -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- Biometric unlock for App Lock (local_auth) -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <!-- Photo library access for attaching dive photos -->

--- a/lib/features/auto_update/domain/beta_program_links.dart
+++ b/lib/features/auto_update/domain/beta_program_links.dart
@@ -1,5 +1,42 @@
+import 'dart:io' show Platform;
+
+import 'package:submersion/features/auto_update/domain/entities/update_channel.dart';
+
 /// Public enrollment links for the beta program. An empty link hides the
 /// corresponding Join-the-Beta tile.
 ///
 const kTestFlightBetaUrl = 'https://testflight.apple.com/join/aMD393sB';
 const kPlayBetaOptInUrl = 'https://play.google.com/apps/testing/app.submersion';
+
+/// The store beta-enrollment link to offer on this build, or null when there
+/// is none.
+String? get betaEnrollUrl => betaEnrollUrlFor(
+  isIOS: Platform.isIOS,
+  isMacOS: Platform.isMacOS,
+  isAndroid: Platform.isAndroid,
+  autoUpdateEnabled: UpdateChannelConfig.isAutoUpdateEnabled,
+);
+
+/// The rule behind [betaEnrollUrl], with the host platform and the updater
+/// state passed in rather than read from the environment.
+///
+/// Only store builds are offered a link. A build with its own updater picks
+/// its channel in Settings > Updates > Update channel, so pointing it at a
+/// store testing program would be a dead end: that is what the sideloaded
+/// Android APK did, offering the Play opt-in page for an app that is not
+/// listed on Play (#1258).
+String? betaEnrollUrlFor({
+  required bool isIOS,
+  required bool isMacOS,
+  required bool isAndroid,
+  required bool autoUpdateEnabled,
+}) {
+  if (autoUpdateEnabled) return null;
+  if (isIOS || isMacOS) return _orNull(kTestFlightBetaUrl);
+  if (isAndroid) return _orNull(kPlayBetaOptInUrl);
+  return null;
+}
+
+/// An empty constant means the program is not live yet, which reads as "no
+/// link" rather than as a link to nowhere.
+String? _orNull(String url) => url.isEmpty ? null : url;

--- a/lib/features/auto_update/domain/entities/update_channel.dart
+++ b/lib/features/auto_update/domain/entities/update_channel.dart
@@ -25,12 +25,32 @@ class UpdateChannelConfig {
     return UpdateChannel.github;
   }
 
-  /// Whether in-app auto-update is enabled.
-  /// Always false on iOS and Android (store-only platforms).
-  /// Store-distributed builds rely on the store's own update mechanism.
-  static bool get isAutoUpdateEnabled {
-    if (Platform.isIOS || Platform.isAndroid) return false;
-    return !isStoreChannel(current);
+  /// Whether in-app update checking is enabled.
+  ///
+  /// iOS is the one genuinely store-only platform: every iOS build reaches a
+  /// device through the App Store or TestFlight, both of which deliver
+  /// updates themselves, so no compile-time channel can turn the updater on
+  /// there. Every other platform follows [current], which store builds set
+  /// via the UPDATE_CHANNEL dart-define.
+  ///
+  /// Android is deliberately not special-cased (#1258). The sideloaded APK is
+  /// built with UPDATE_CHANNEL=github and polls GitHub Releases exactly as
+  /// Linux does; the Play bundle is built with UPDATE_CHANNEL=playstore and
+  /// turns the updater off. Treating Android as store-only left every APK
+  /// install with no update path at all while Submersion is not on Play.
+  static bool get isAutoUpdateEnabled =>
+      isAutoUpdateEnabledFor(isIOS: Platform.isIOS, channel: current);
+
+  /// The rule behind [isAutoUpdateEnabled], with the host platform and the
+  /// distribution channel passed in rather than read from the environment.
+  /// [isAutoUpdateEnabled] binds them to the running build; tests use this
+  /// form to reach combinations the host platform cannot produce.
+  static bool isAutoUpdateEnabledFor({
+    required bool isIOS,
+    required UpdateChannel channel,
+  }) {
+    if (isIOS) return false;
+    return !isStoreChannel(channel);
   }
 
   /// Returns true for every channel except [UpdateChannel.github].

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -3039,9 +3039,9 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
                 ),
                 // Beta enrollment signpost for store builds: the app cannot
                 // switch channels itself there, so link to the store's beta
-                // program. Hidden until the enrollment links exist.
-                if (!UpdateChannelConfig.isAutoUpdateEnabled &&
-                    _betaEnrollUrl.isNotEmpty) ...[
+                // program. Null on every build that has its own updater, and
+                // on platforms whose program is not live.
+                if (betaEnrollUrl case final enrollUrl?) ...[
                   const Divider(height: 1),
                   ListTile(
                     leading: const Icon(Icons.science_outlined),
@@ -3050,7 +3050,7 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
                       context.l10n.settings_updates_joinBetaSubtitle,
                     ),
                     onTap: () => launchUrl(
-                      Uri.parse(_betaEnrollUrl),
+                      Uri.parse(enrollUrl),
                       mode: LaunchMode.externalApplication,
                     ),
                   ),
@@ -3202,13 +3202,6 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
         ],
       ),
     );
-  }
-
-  /// The store beta-program URL for this platform ('' hides the signpost).
-  String get _betaEnrollUrl {
-    if (Platform.isIOS || Platform.isMacOS) return kTestFlightBetaUrl;
-    if (Platform.isAndroid) return kPlayBetaOptInUrl;
-    return '';
   }
 
   Future<void> _showChannelPicker(BuildContext context) async {

--- a/test/features/auto_update/data/services/github_update_service_test.dart
+++ b/test/features/auto_update/data/services/github_update_service_test.dart
@@ -137,6 +137,60 @@ void main() {
       );
     });
 
+    // The scenario from #1258: a phone sitting on v1.7.4.6062 while
+    // v1.7.5.6772 was published. currentVersion is assembled in
+    // update_providers.dart from PackageInfo, whose Android values are the
+    // APK's versionName and versionCode. Promoted stable APKs carry the
+    // tag's build number as their versionCode (promote.yml copies the beta
+    // artifacts, and beta APKs are built with build-number = commit count),
+    // so the assembled string is directly comparable to the 4-segment tag.
+    test(
+      'an Android install is offered the APK asset for a newer tag',
+      () async {
+        final client = MockClient((request) async {
+          return http.Response(
+            jsonEncode(makeRelease(tagName: 'v1.7.5.6772')),
+            200,
+          );
+        });
+
+        final service = GithubUpdateService(
+          owner: owner,
+          repo: repo,
+          currentVersion: '1.7.4.6062',
+          platformSuffix: 'Android.apk',
+          httpClient: client,
+        );
+
+        final status = await service.checkForUpdate();
+        expect(status, isA<UpdateAvailable>());
+        expect((status as UpdateAvailable).version, '1.7.5.6772');
+        expect(status.downloadUrl, endsWith('Android.apk'));
+      },
+    );
+
+    test('an Android install on the published build stays quiet', () async {
+      // The other half of the same wiring: if versionCode did not line up
+      // with the tag's build number, every check would report the version
+      // the device is already running as an available update, forever.
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode(makeRelease(tagName: 'v1.7.5.6772')),
+          200,
+        );
+      });
+
+      final service = GithubUpdateService(
+        owner: owner,
+        repo: repo,
+        currentVersion: '1.7.5.6772',
+        platformSuffix: 'Android.apk',
+        httpClient: client,
+      );
+
+      expect(await service.checkForUpdate(), isA<UpToDate>());
+    });
+
     test('returns UpToDate when current is newer than remote', () async {
       final client = MockClient((request) async {
         return http.Response(jsonEncode(makeRelease(tagName: 'v0.9.0')), 200);

--- a/test/features/auto_update/domain/beta_program_links_test.dart
+++ b/test/features/auto_update/domain/beta_program_links_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/auto_update/domain/beta_program_links.dart';
+
+void main() {
+  group('betaEnrollUrlFor', () {
+    test('offers nothing when the build has its own updater', () {
+      // A build that polls GitHub Releases switches channels in Settings >
+      // Updates > Update channel, so sending it to a store testing program
+      // would be a dead end. This is the sideloaded Android APK (#1258): it
+      // was offering the Play opt-in page for an app not listed on Play.
+      expect(
+        betaEnrollUrlFor(
+          isIOS: false,
+          isMacOS: false,
+          isAndroid: true,
+          autoUpdateEnabled: true,
+        ),
+        isNull,
+      );
+    });
+
+    test('offers the Play opt-in page to a Play-channel Android build', () {
+      expect(
+        betaEnrollUrlFor(
+          isIOS: false,
+          isMacOS: false,
+          isAndroid: true,
+          autoUpdateEnabled: false,
+        ),
+        kPlayBetaOptInUrl,
+      );
+    });
+
+    test('offers TestFlight to iOS and to Mac App Store builds', () {
+      expect(
+        betaEnrollUrlFor(
+          isIOS: true,
+          isMacOS: false,
+          isAndroid: false,
+          autoUpdateEnabled: false,
+        ),
+        kTestFlightBetaUrl,
+      );
+      expect(
+        betaEnrollUrlFor(
+          isIOS: false,
+          isMacOS: true,
+          isAndroid: false,
+          autoUpdateEnabled: false,
+        ),
+        kTestFlightBetaUrl,
+      );
+    });
+
+    test('offers nothing on platforms with no store program', () {
+      // Linux and Windows store builds have no public testing programme to
+      // enroll in, so there is no link to show even with updates disabled.
+      expect(
+        betaEnrollUrlFor(
+          isIOS: false,
+          isMacOS: false,
+          isAndroid: false,
+          autoUpdateEnabled: false,
+        ),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/auto_update/domain/entities/update_channel_test.dart
+++ b/test/features/auto_update/domain/entities/update_channel_test.dart
@@ -55,5 +55,64 @@ void main() {
       // Default channel is github, which is not a store channel
       expect(UpdateChannelConfig.isAutoUpdateEnabled, true);
     });
+
+    // The host platform under flutter test is never iOS, so the getter above
+    // can only ever exercise one branch. These cases drive the pure form
+    // directly to cover the platform/channel matrix (#1258).
+    group('isAutoUpdateEnabledFor', () {
+      test('is false on iOS even on the github channel', () {
+        // iOS ships only through the App Store and TestFlight, both of which
+        // deliver updates themselves. No dart-define can turn this on.
+        expect(
+          UpdateChannelConfig.isAutoUpdateEnabledFor(
+            isIOS: true,
+            channel: UpdateChannel.github,
+          ),
+          false,
+        );
+      });
+
+      test('is true off iOS on the github channel', () {
+        // This is the Android sideloaded APK, which build-all.yml builds with
+        // UPDATE_CHANNEL=github, alongside Linux and the direct desktop
+        // builds. Re-adding a Platform.isAndroid guard here fails this test.
+        expect(
+          UpdateChannelConfig.isAutoUpdateEnabledFor(
+            isIOS: false,
+            channel: UpdateChannel.github,
+          ),
+          true,
+        );
+      });
+
+      test('is false off iOS on the playstore channel', () {
+        // The Play bundle is built with UPDATE_CHANNEL=playstore, so the
+        // switch-over when Play lands is a build flag, not a code change.
+        expect(
+          UpdateChannelConfig.isAutoUpdateEnabledFor(
+            isIOS: false,
+            channel: UpdateChannel.playstore,
+          ),
+          false,
+        );
+      });
+
+      test('is false off iOS on every other store channel', () {
+        for (final channel in [
+          UpdateChannel.appstore,
+          UpdateChannel.msstore,
+          UpdateChannel.snapstore,
+        ]) {
+          expect(
+            UpdateChannelConfig.isAutoUpdateEnabledFor(
+              isIOS: false,
+              channel: channel,
+            ),
+            false,
+            reason: '$channel is a store channel',
+          );
+        }
+      });
+    });
   });
 }


### PR DESCRIPTION
Fixes #1258.

## The problem

`UpdateChannelConfig.isAutoUpdateEnabled` returned false on Android on the
grounds that Android is a store-only platform, but Submersion is not on Google
Play. A diver who sideloads the APK got no banner, no check button, no channel
display and no version comparison, so they sat on whatever build they first
installed until they happened to visit the releases page.

That is how the "database is locked" launch failure fixed in 1.7.5.6772 could
not reach the phone in #1256. The artifact was fine: grepping
`lib/arm64-v8a/libapp.so` inside `Submersion-v1.7.5.6772-Android.apk` finds
`PRAGMA busy_timeout` and `Your dive log was busy`. A shipped fix and a
delivered fix are different claims, and on Android only the first was true.

## The change

The guard conflated two questions: can this platform self-install a binary, and
does a store already deliver updates here. iOS answers yes to the second and
keeps its guard, because every iOS build reaches a device through the App Store
or TestFlight. Android answers no to both, exactly like Linux, and now follows
the compile-time `UPDATE_CHANNEL` like every other platform.

```dart
static bool get isAutoUpdateEnabled =>
    isAutoUpdateEnabledFor(isIOS: Platform.isIOS, channel: current);
```

Both new rules are pure functions taking the platform as an argument.
`Platform.isIOS` is a host fact under `flutter test`, so a getter reading it
directly can only ever exercise one branch and any test of the other side would
pass vacuously.

## Why nothing else was needed

- **No build change.** `build-all.yml:729` already builds the APK with
  `--dart-define=UPDATE_CHANNEL=github` and the App Bundle with
  `UPDATE_CHANNEL=playstore`, so the sideloaded build opts in and a future Play
  build opts out on its own. The switch-over when Play lands is a build flag,
  not another code change.
- **No new updater.** The Android branch of the GitHub updater was already
  written and unreachable behind the guard (`update_providers.dart:43` returns
  the `Android.apk` suffix), and every release already publishes a matching
  asset.
- **No self-install machinery, no `REQUEST_INSTALL_PACKAGES`.**
  `GithubUpdateService` installs nothing; the banner's Download action is
  `launchUrl(..., LaunchMode.externalApplication)`. Android's own download
  manager and package installer take it from there, which is the same flow the
  diver used to install the app in the first place.
- **No new UI.** `UpdateBanner` is already mounted in `main_scaffold.dart:271`
  and `:289`; it was watching a status that stayed `UpToDate()` forever.

This also restores the original design rather than reversing it. The table in
`docs/plans/2026-02-14-auto-update-design.md:136` has always listed the Android
APK as GitHub-updated; the platform guard contradicted it in the very first
commit that introduced the file (`de837cedf84`).

## The three open questions in the issue

**Beta channel: enabled, deliberately.** `beta.yml` uploads
`artifacts/Submersion*` to `beta-builds`, which includes
`Submersion-<tag>-Android.apk`, and those releases are not marked prerelease, so
`/releases/latest` resolves them. The channel switcher works end to end on
Android with no extra code.

**Updates card wording: unchanged.** The subtitle is already "Check for updates
periodically", which promises a check and not an installation. Linux shares this
card and behaves identically today (a `tar.gz` opened in a browser, no
self-install), so an Android-specific string would describe a difference that
does not exist.

**Version comparison: verified.** Stable releases are promoted beta artifacts:
`promote.yml` copies rather than rebuilds, and beta APKs are built with
`build-number` = commit count. So a shipped APK's `versionCode` is the tag's
fourth segment, and the `currentVersion` assembly in `update_providers.dart:70`
yields `1.7.5.6772` against tag `v1.7.5.6772`. Both directions are now pinned by
tests, because getting this wrong in the other direction would report the
version the device is already running as an available update, forever.

## Secondary defect

The dead "Join the Beta" tile is fixed by the same split. It renders only when
auto-update is off, so the sideloaded APK no longer offers
`play.google.com/apps/testing/app.submersion` for an app that is not listed on
Play. The tile's platform mapping moves out of a private getter on the
3,000-line settings page into `betaEnrollUrlFor()`, next to the constants it
reads, so the condition is covered by a test; it now returns null for any build
that has its own updater, and an empty constant still means "this program is not
live" rather than a link to nowhere.

## Testing

12 new cases, all green:

- `update_channel_test.dart`: the platform/channel matrix. The github-off-iOS
  case is the Android APK, and re-adding a `Platform.isAndroid` guard fails it.
- `beta_program_links_test.dart`: the enrollment-link matrix, including that a
  build with its own updater is offered nothing.
- `github_update_service_test.dart`: the reported scenario end to end. A phone
  on `1.7.4.6062` is offered the `Android.apk` asset for `v1.7.5.6772`, and the
  same phone on `1.7.5.6772` stays quiet.

`flutter analyze` clean (no issues), `dart format` clean, and the full suite is
20,077 passed / 19 skipped / 0 failed.

## Verification left to a device

Everything above is verified by tests and by reading the shipped workflows. What
they cannot cover is the last hop: installing a pre-1.7.6 APK on a real phone,
watching the banner appear, and confirming the browser hands the download to the
package installer.
