### PR TITLE
Make the master-detail pane divider user-resizable

### DIFF
--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "لوحة قائمة {title}",
   "accessibility_label_mapPane": "لوحة خريطة {title}",
   "accessibility_label_mapViewTitle": "عرض خريطة {title}",
+  "accessibility_label_resizeMasterPane": "تغيير حجم اللوحة الرئيسية",
   "accessibility_label_showList": "عرض القائمة",
   "accessibility_label_showMapView": "عرض الخريطة",
   "accessibility_label_viewDetails": "عرض التفاصيل",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "{title} Listenbereich",
   "accessibility_label_mapPane": "{title} Kartenbereich",
   "accessibility_label_mapViewTitle": "{title} Kartenansicht",
+  "accessibility_label_resizeMasterPane": "Hauptbereich in der Groesse aendern",
   "accessibility_label_showList": "Liste anzeigen",
   "accessibility_label_showMapView": "Kartenansicht anzeigen",
   "accessibility_label_viewDetails": "Details anzeigen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -472,6 +472,10 @@
   "accessibility_label_listPane": "{title} list pane",
   "accessibility_label_mapPane": "{title} map pane",
   "accessibility_label_mapViewTitle": "{title} map view",
+  "accessibility_label_resizeMasterPane": "Resize master pane",
+  "@accessibility_label_resizeMasterPane": {
+    "description": "Semantics label for the draggable divider between the master and detail panes in master-detail scaffold"
+  },
   "accessibility_label_sharedWithAllProfiles": "Shared with all dive profiles",
   "@accessibility_label_sharedWithAllProfiles": {
     "description": "Screen-reader / tooltip label for the people icon shown on trip and site list tiles when a record is shared across dive profiles. Descriptive form (state), distinct from the imperative form used on the edit-page switch."

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "Panel de lista de {title}",
   "accessibility_label_mapPane": "Panel de mapa de {title}",
   "accessibility_label_mapViewTitle": "Vista de mapa de {title}",
+  "accessibility_label_resizeMasterPane": "Cambiar el tamano del panel principal",
   "accessibility_label_showList": "Mostrar lista",
   "accessibility_label_showMapView": "Mostrar vista de mapa",
   "accessibility_label_viewDetails": "Ver detalles",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "Volet liste {title}",
   "accessibility_label_mapPane": "Volet carte {title}",
   "accessibility_label_mapViewTitle": "Vue carte {title}",
+  "accessibility_label_resizeMasterPane": "Redimensionner le panneau principal",
   "accessibility_label_showList": "Afficher la liste",
   "accessibility_label_showMapView": "Afficher la vue carte",
   "accessibility_label_viewDetails": "Voir les details",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "חלונית רשימת {title}",
   "accessibility_label_mapPane": "חלונית מפת {title}",
   "accessibility_label_mapViewTitle": "תצוגת מפה של {title}",
+  "accessibility_label_resizeMasterPane": "שינוי גודל החלונית הראשית",
   "accessibility_label_showList": "הצגת רשימה",
   "accessibility_label_showMapView": "הצגת תצוגת מפה",
   "accessibility_label_viewDetails": "הצגת פרטים",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "{title} lista panel",
   "accessibility_label_mapPane": "{title} terkep panel",
   "accessibility_label_mapViewTitle": "{title} terkepi nezet",
+  "accessibility_label_resizeMasterPane": "Fo panel atmeretezese",
   "accessibility_label_showList": "Lista megjelenitese",
   "accessibility_label_showMapView": "Terkepi nezet megjelenitese",
   "accessibility_label_viewDetails": "Reszletek megtekintese",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "Pannello elenco {title}",
   "accessibility_label_mapPane": "Pannello mappa {title}",
   "accessibility_label_mapViewTitle": "Vista mappa {title}",
+  "accessibility_label_resizeMasterPane": "Ridimensiona riquadro principale",
   "accessibility_label_showList": "Mostra elenco",
   "accessibility_label_showMapView": "Mostra vista mappa",
   "accessibility_label_viewDetails": "Visualizza dettagli",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -1357,6 +1357,12 @@ abstract class AppLocalizations {
   /// **'{title} map view'**
   String accessibility_label_mapViewTitle(Object title);
 
+  /// Semantics label for the draggable divider between the master and detail panes in master-detail scaffold
+  ///
+  /// In en, this message translates to:
+  /// **'Resize master pane'**
+  String get accessibility_label_resizeMasterPane;
+
   /// Screen-reader / tooltip label for the people icon shown on trip and site list tiles when a record is shared across dive profiles. Descriptive form (state), distinct from the imperative form used on the edit-page switch.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -792,6 +792,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'تغيير حجم اللوحة الرئيسية';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'مشترك مع جميع ملفات الغوص';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -799,6 +799,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Hauptbereich in der Groesse aendern';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Mit allen Taucherprofilen geteilt';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -788,6 +788,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane => 'Resize master pane';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Shared with all dive profiles';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -801,6 +801,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Cambiar el tamano del panel principal';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Compartido con todos los perfiles de buceo';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -804,6 +804,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Redimensionner le panneau principal';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Partagé avec tous les profils de plongée';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -782,6 +782,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'שינוי גודל החלונית הראשית';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'משותף עם כל פרופילי הצלילה';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -797,6 +797,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane => 'Fo panel atmeretezese';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Megosztva az összes búvárprofillal';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -800,6 +800,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Ridimensiona riquadro principale';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Condiviso con tutti i profili subacquei';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -797,6 +797,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Hoofdvenster formaat aanpassen';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Gedeeld met alle duikersprofielen';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -798,6 +798,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane =>
+      'Redimensionar painel principal';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles =>
       'Partilhado com todos os perfis de mergulho';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -744,6 +744,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get accessibility_label_resizeMasterPane => '调整主窗格大小';
+
+  @override
   String get accessibility_label_sharedWithAllProfiles => '已与所有潜水员资料共享';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "{title} lijstpaneel",
   "accessibility_label_mapPane": "{title} kaartpaneel",
   "accessibility_label_mapViewTitle": "{title} kaartweergave",
+  "accessibility_label_resizeMasterPane": "Hoofdvenster formaat aanpassen",
   "accessibility_label_showList": "Lijst tonen",
   "accessibility_label_showMapView": "Kaartweergave tonen",
   "accessibility_label_viewDetails": "Details bekijken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -429,6 +429,7 @@
   "accessibility_label_listPane": "Painel de lista {title}",
   "accessibility_label_mapPane": "Painel do mapa {title}",
   "accessibility_label_mapViewTitle": "Visualizacao do mapa {title}",
+  "accessibility_label_resizeMasterPane": "Redimensionar painel principal",
   "accessibility_label_showList": "Mostrar Lista",
   "accessibility_label_showMapView": "Mostrar Visualizacao do Mapa",
   "accessibility_label_viewDetails": "Ver detalhes",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -523,6 +523,7 @@
   "accessibility_label_listPane": "{title}列表面板",
   "accessibility_label_mapPane": "{title}地图面板",
   "accessibility_label_mapViewTitle": "{title}地图视图",
+  "accessibility_label_resizeMasterPane": "调整主窗格大小",
   "accessibility_label_showList": "显示列表",
   "accessibility_label_showMapView": "显示地图视图",
   "accessibility_label_viewDetails": "查看详情",

--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -25,6 +25,9 @@ const double _kMasterPaneMaxWidth = 700;
 /// always keeps a usable minimum width.
 const double _kDetailPaneReservedWidth = 400;
 
+/// Width of the draggable divider between the master and detail panes.
+const double _kResizeHandleWidth = 8;
+
 /// Master pane width, user-resizable via the divider and shared across every
 /// [MasterDetailScaffold] instance for the lifetime of the app session (not
 /// persisted to disk, so it resets on restart).
@@ -333,8 +336,11 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
     return Scaffold(
       body: LayoutBuilder(
         builder: (context, constraints) {
-          final maxWidth = (constraints.maxWidth - _kDetailPaneReservedWidth)
-              .clamp(_kMasterPaneMinWidth, _kMasterPaneMaxWidth);
+          final maxWidth =
+              (constraints.maxWidth -
+                      _kDetailPaneReservedWidth -
+                      _kResizeHandleWidth)
+                  .clamp(_kMasterPaneMinWidth, _kMasterPaneMaxWidth);
           final width = ref
               .watch(masterPaneWidthProvider)
               .clamp(_kMasterPaneMinWidth, maxWidth);
@@ -429,15 +435,18 @@ class _ResizeHandle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.resizeColumn,
-      child: GestureDetector(
-        key: const Key('master-detail-resize-handle'),
-        behavior: HitTestBehavior.opaque,
-        onHorizontalDragUpdate: (details) => onDrag(details.delta.dx),
-        child: const SizedBox(
-          width: 8,
-          child: Center(child: VerticalDivider(width: 1, thickness: 1)),
+    return Semantics(
+      label: context.l10n.accessibility_label_resizeMasterPane,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.resizeColumn,
+        child: GestureDetector(
+          key: const Key('master-detail-resize-handle'),
+          behavior: HitTestBehavior.opaque,
+          onHorizontalDragUpdate: (details) => onDrag(details.delta.dx),
+          child: const SizedBox(
+            width: _kResizeHandleWidth,
+            child: Center(child: VerticalDivider(width: 1, thickness: 1)),
+          ),
         ),
       ),
     );

--- a/lib/shared/widgets/master_detail/master_detail_scaffold.dart
+++ b/lib/shared/widgets/master_detail/master_detail_scaffold.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -12,6 +13,24 @@ import 'package:submersion/shared/widgets/master_detail/responsive_breakpoints.d
 /// same list rows outside a split view (the dashboard's recent dives, for
 /// one) has to match it or the same card appears at two different widths.
 const double kMasterPaneWidth = 440;
+
+/// Minimum width the master pane can be resized to.
+const double _kMasterPaneMinWidth = 280;
+
+/// Maximum width the master pane can be resized to.
+const double _kMasterPaneMaxWidth = 700;
+
+/// Width of the space reserved for the detail pane, subtracted from the
+/// available width when computing the resize maximum so the detail pane
+/// always keeps a usable minimum width.
+const double _kDetailPaneReservedWidth = 400;
+
+/// Master pane width, user-resizable via the divider and shared across every
+/// [MasterDetailScaffold] instance for the lifetime of the app session (not
+/// persisted to disk, so it resets on restart).
+final masterPaneWidthProvider = StateProvider<double>(
+  (ref) => kMasterPaneWidth,
+);
 
 /// Mode for the detail pane in master-detail layout.
 enum DetailPaneMode {
@@ -310,49 +329,68 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
       );
     }
 
-    // Desktop: Split view with fixed-width master pane
+    // Desktop: Split view with a user-resizable master pane
     return Scaffold(
-      body: Row(
-        children: [
-          // Master pane (list) with fixed width
-          SizedBox(
-            width: widget.masterWidth,
-            child: ExcludeFocusTraversal(
-              excluding: isEditingDetail,
-              child: _MasterPane(
-                floatingActionButton: widget.floatingActionButton != null
-                    ? _wrapFabForCreate(widget.floatingActionButton!)
-                    : null,
-                child: widget.masterBuilder(
-                  context,
-                  _onItemSelected,
-                  selectedId,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth = (constraints.maxWidth - _kDetailPaneReservedWidth)
+              .clamp(_kMasterPaneMinWidth, _kMasterPaneMaxWidth);
+          final width = ref
+              .watch(masterPaneWidthProvider)
+              .clamp(_kMasterPaneMinWidth, maxWidth);
+
+          return Row(
+            children: [
+              // Master pane (list), user-resizable
+              SizedBox(
+                key: const Key('master-detail-master-pane'),
+                width: width,
+                child: ExcludeFocusTraversal(
+                  excluding: isEditingDetail,
+                  child: _MasterPane(
+                    floatingActionButton: widget.floatingActionButton != null
+                        ? _wrapFabForCreate(widget.floatingActionButton!)
+                        : null,
+                    child: widget.masterBuilder(
+                      context,
+                      _onItemSelected,
+                      selectedId,
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
-          // Vertical divider
-          const VerticalDivider(width: 1, thickness: 1),
-          // Detail pane (or map view)
-          Expanded(
-            child: widget.mapBuilder != null && _isMapView
-                ? widget.mapBuilder!(context, selectedId, _onItemSelected)
-                : _DetailPane(
-                    selectedId: selectedId,
-                    mode: mode,
-                    detailBuilder: widget.detailBuilder,
-                    summaryBuilder: widget.summaryBuilder,
-                    editBuilder: widget.editBuilder,
-                    createBuilder: widget.createBuilder,
-                    onClose: () => _onItemSelected(null),
-                    onSaved: _onSaved,
-                    onCancel: _onCancel,
-                    detailScrollOffset: _detailScrollOffset,
-                    onDetailScrollOffsetChanged: (offset) =>
-                        _detailScrollOffset = offset,
-                  ),
-          ),
-        ],
+              // Draggable divider
+              _ResizeHandle(
+                onDrag: (delta) {
+                  final notifier = ref.read(masterPaneWidthProvider.notifier);
+                  notifier.state = (notifier.state + delta).clamp(
+                    _kMasterPaneMinWidth,
+                    maxWidth,
+                  );
+                },
+              ),
+              // Detail pane (or map view)
+              Expanded(
+                child: widget.mapBuilder != null && _isMapView
+                    ? widget.mapBuilder!(context, selectedId, _onItemSelected)
+                    : _DetailPane(
+                        selectedId: selectedId,
+                        mode: mode,
+                        detailBuilder: widget.detailBuilder,
+                        summaryBuilder: widget.summaryBuilder,
+                        editBuilder: widget.editBuilder,
+                        createBuilder: widget.createBuilder,
+                        onClose: () => _onItemSelected(null),
+                        onSaved: _onSaved,
+                        onCancel: _onCancel,
+                        detailScrollOffset: _detailScrollOffset,
+                        onDetailScrollOffsetChanged: (offset) =>
+                            _detailScrollOffset = offset,
+                      ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
@@ -378,6 +416,29 @@ class _MasterDetailScaffoldState extends ConsumerState<MasterDetailScaffold> {
       child: GestureDetector(
         onTap: handler,
         child: AbsorbPointer(child: fab),
+      ),
+    );
+  }
+}
+
+/// Draggable divider between the master and detail panes.
+class _ResizeHandle extends StatelessWidget {
+  final ValueChanged<double> onDrag;
+
+  const _ResizeHandle({required this.onDrag});
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeColumn,
+      child: GestureDetector(
+        key: const Key('master-detail-resize-handle'),
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragUpdate: (details) => onDrag(details.delta.dx),
+        child: const SizedBox(
+          width: 8,
+          child: Center(child: VerticalDivider(width: 1, thickness: 1)),
+        ),
       ),
     );
   }

--- a/test/shared/widgets/master_detail/master_detail_scaffold_resize_test.dart
+++ b/test/shared/widgets/master_detail/master_detail_scaffold_resize_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/master_detail/master_detail_scaffold.dart';
+
+/// Builds a [MasterDetailScaffold] at desktop width with a single item.
+Widget _app() {
+  final router = GoRouter(
+    initialLocation: '/test',
+    routes: [
+      GoRoute(
+        path: '/test',
+        builder: (context, state) => MasterDetailScaffold(
+          sectionId: 'test',
+          masterBuilder: (context, onSelect, selectedId) =>
+              const Text('Master'),
+          detailBuilder: (_, id) => Text('Detail $id'),
+          summaryBuilder: (_) => const Text('Summary'),
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+/// Builds an app with two routes, each a [MasterDetailScaffold] for a
+/// different section, sharing one [GoRouter] so navigation between them can
+/// be driven from the test.
+(Widget, GoRouter) _twoSectionApp() {
+  final router = GoRouter(
+    initialLocation: '/a',
+    routes: [
+      GoRoute(
+        path: '/a',
+        builder: (context, state) => MasterDetailScaffold(
+          sectionId: 'a',
+          masterBuilder: (context, onSelect, selectedId) =>
+              const Text('Master A'),
+          detailBuilder: (_, id) => Text('Detail $id'),
+          summaryBuilder: (_) => const Text('Summary A'),
+        ),
+      ),
+      GoRoute(
+        path: '/b',
+        builder: (context, state) => MasterDetailScaffold(
+          sectionId: 'b',
+          masterBuilder: (context, onSelect, selectedId) =>
+              const Text('Master B'),
+          detailBuilder: (_, id) => Text('Detail $id'),
+          summaryBuilder: (_) => const Text('Summary B'),
+        ),
+      ),
+    ],
+  );
+
+  final app = ProviderScope(
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+  return (app, router);
+}
+
+double _masterPaneWidth(WidgetTester tester) {
+  return tester
+      .widget<SizedBox>(find.byKey(const Key('master-detail-master-pane')))
+      .width!;
+}
+
+/// Sets a real 1200x800 desktop viewport (not just a MediaQuery override) so
+/// the master pane's LayoutBuilder sees the width this test expects.
+void _setDesktopViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1200, 800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  group('MasterDetailScaffold resize', () {
+    testWidgets('dragging the divider right widens the master pane', (
+      tester,
+    ) async {
+      _setDesktopViewport(tester);
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      final initialWidth = _masterPaneWidth(tester);
+
+      await tester.drag(
+        find.byKey(const Key('master-detail-resize-handle')),
+        const Offset(80, 0),
+      );
+      await tester.pump();
+
+      // tester.drag() can split the movement into several update events with
+      // touch-slop compensation that isn't pixel-exact, so allow a small
+      // tolerance rather than asserting the delta precisely.
+      expect(_masterPaneWidth(tester), closeTo(initialWidth + 80, 5));
+    });
+
+    testWidgets('dragging the divider left narrows the master pane', (
+      tester,
+    ) async {
+      _setDesktopViewport(tester);
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      final initialWidth = _masterPaneWidth(tester);
+
+      await tester.drag(
+        find.byKey(const Key('master-detail-resize-handle')),
+        const Offset(-80, 0),
+      );
+      await tester.pump();
+
+      expect(_masterPaneWidth(tester), closeTo(initialWidth - 80, 5));
+    });
+
+    testWidgets('drag past the minimum clamps the master pane width', (
+      tester,
+    ) async {
+      _setDesktopViewport(tester);
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      await tester.drag(
+        find.byKey(const Key('master-detail-resize-handle')),
+        const Offset(-1000, 0),
+      );
+      await tester.pump();
+
+      expect(_masterPaneWidth(tester), 280);
+    });
+
+    testWidgets('drag past the maximum clamps the master pane width', (
+      tester,
+    ) async {
+      _setDesktopViewport(tester);
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      await tester.drag(
+        find.byKey(const Key('master-detail-resize-handle')),
+        const Offset(1000, 0),
+      );
+      await tester.pump();
+
+      // Window is 1200 wide; max is min(700, 1200 - 400) = 700.
+      expect(_masterPaneWidth(tester), 700);
+    });
+
+    testWidgets(
+      'resized width carries over when navigating to another section',
+      (tester) async {
+        _setDesktopViewport(tester);
+        final (app, router) = _twoSectionApp();
+        await tester.pumpWidget(app);
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byKey(const Key('master-detail-resize-handle')),
+          const Offset(80, 0),
+        );
+        await tester.pump();
+        final resizedWidth = _masterPaneWidth(tester);
+        expect(resizedWidth, isNot(kMasterPaneWidth));
+
+        router.go('/b');
+        await tester.pumpAndSettle();
+
+        expect(find.text('Summary B'), findsOneWidget);
+        expect(_masterPaneWidth(tester), resizedWidth);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a drag handle to the divider between the list (master) pane and the detail pane in the desktop split view, so the list pane can be widened or narrowed by dragging, per #1268.
- Width is shared across every section (Dives, Sites, Gear, Trips, etc.) for the app session via a Riverpod StateProvider, since they all use the same MasterDetailScaffold. Not persisted to disk yet, so it resets on restart.
- Clamped to a 280-700px range, with the max further limited so the detail pane always keeps at least ~400px.

<img width="3560" height="1686" alt="image" src="https://github.com/user-attachments/assets/d9176c09-0082-48cf-9113-a4bc72c6fdc2" />


## Test plan
- [x] `flutter test test/shared/widgets/master_detail/` (all pass, including 5 new resize tests)
- [x] `flutter analyze` / `dart format` clean on changed files
- [x] Manually verified in the running app: dragging resizes the Dives list pane, and the resized width carries over when switching to Sites

Closes #1268