### PR TITLE
ci: ship standing App Review notes with every store submission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -416,6 +416,14 @@ jobs:
         # creating a new one and left it carrying the wrong build.
         run: ruby scripts/release/fastlane_submit_guard_test.rb
 
+      - name: Run App Review notes test
+        # Guards the committed App Review notes deliver uploads with every
+        # submission: present on both platforms, identical, within Apple's
+        # length limit, and free of other-platform names (2.3.10). iOS 1.7.4
+        # and 1.7.5 were rejected under 5.1.1(v) because nothing told the
+        # reviewer the app has no accounts.
+        run: ./scripts/release/app_review_notes_test.sh
+
       - name: Run pre-push hook test
         # Guards two hook bugs that both rejected pushes for reasons unrelated
         # to the change being pushed: running the checks against the main

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -289,7 +289,8 @@ jobs:
           set -euo pipefail
           # Apple requires whatsNew on a new App Store version; deliver reads
           # it from metadata/en-US/release_notes.txt (the only metadata file
-          # we provide, so nothing else is touched).
+          # generated here; the committed review_information/notes.txt beside
+          # it is uploaded as-is and must not be touched).
           #
           # The GitHub release body is written for every platform at once, and
           # App Review guideline 2.3.10 forbids naming other platforms in App

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -85,7 +85,16 @@ and the next merge to `main` starts the next beta train.
 Two things still want a human:
 
 - **A rejection.** Auto-release only covers the approved path. A rejected
-  version sits in App Store Connect until someone addresses it.
+  version sits in App Store Connect until someone addresses it. If the
+  rejection is a misunderstanding rather than a defect (1.7.4 and 1.7.5 were
+  both flagged under 5.1.1(v) because the first-launch "Create Your Profile"
+  step reads as account creation), reply in the Resolution Center thread and
+  do **not** re-run promote: the submission is still open, Apple approves
+  from the reply, and promote would cancel that submission and start over.
+  The standing explanation Apple reads before every review lives in
+  `ios/fastlane/metadata/review_information/notes.txt` (macOS has an
+  identical copy; `scripts/release/app_review_notes_test.sh` enforces
+  that). Update it whenever a reviewer needs context a reply had to supply.
 - **A bad build.** There is no staged rollout to halt and no rollback once a
   version is live. Recovering means pulling it and shipping a fix through
   another review cycle. If that risk ever outweighs the convenience, set

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -677,8 +677,13 @@ platform :ios do
       skip_screenshots: true,
       # skip_metadata false so deliver uploads metadata/en-US/release_notes.txt
       # (written by promote.yml from the GitHub release notes) - Apple requires
-      # whatsNew on a new version. Only files present are uploaded, and that is
-      # the only metadata file provided.
+      # whatsNew on a new version. Only files present are uploaded. The other
+      # file provided is the committed metadata/review_information/notes.txt,
+      # which lands in App Review Information > Notes on every submission: it
+      # explains that the app has no accounts, after 1.7.4 and 1.7.5 were both
+      # rejected under 5.1.1(v) for the first-launch "Create Your Profile"
+      # step. scripts/release/app_review_notes_test.sh keeps it in lockstep
+      # with the macOS copy.
       skip_metadata: false,
       # Required BECAUSE skip_metadata is false. deliver renders the metadata
       # it is about to upload to fastlane/Preview.html and blocks on "Does the

--- a/ios/fastlane/metadata/review_information/notes.txt
+++ b/ios/fastlane/metadata/review_information/notes.txt
@@ -4,6 +4,6 @@ Submersion has no user accounts: no sign-up, no login, no demo account, and no b
 
 "SIGN IN": these options connect to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive it. Connections are removed at Settings > Photos & Media > Connected Accounts.
 
-App Lock (Settings > Security) and backup encryption are optional device-local passwords, not accounts, and can be turned off from the same screens.
+App Lock (Settings > Security, a password or biometric unlock for the app) and backup encryption (a password on exported backup files) are optional device-local protections, not accounts, and can be turned off from the same screens.
 
 No demo credentials are needed; entering any name in the profile step reaches every feature.

--- a/ios/fastlane/metadata/review_information/notes.txt
+++ b/ios/fastlane/metadata/review_information/notes.txt
@@ -1,0 +1,22 @@
+Submersion is a scuba dive logging app. It has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. Every dive log, profile, setting and photo link is stored locally on the device.
+
+ABOUT "CREATE YOUR PROFILE" (guideline 5.1.1(v))
+The first-launch step titled "Create Your Profile" creates a local diver profile: a name used to label dive logs when more than one person shares a device. It is not an account. The name is never transmitted to us and there is nothing to register with.
+
+Diver profiles are deleted in-app: Settings > Diver Profile > Manage Divers, choose the diver, then Delete. The confirmation asks the user to type "Delete <name>". Deletion permanently removes the profile and every dive log, dive computer, equipment item, certification and site attached to it. This works for the only profile on the device as well. A screen recording of this flow, captured on a physical device, was attached to the review reply for version 1.7.5 (submission ce6d5c46-26d8-4c48-851c-4654ff4e60f5).
+
+ABOUT "SIGN IN" WORDING
+Where the app offers to sign in, it connects to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive that data. Those connections are removed at Settings > Photos & Media > Connected Accounts ("Remove from library"), which also discards the stored credentials.
+
+OPTIONAL LOCAL PROTECTIONS THAT ARE NOT ACCOUNTS
+- App Lock sets a device-local password or Face ID unlock for the app. It can be turned off from Settings > Security.
+- Backup encryption protects exported backup files with a user-chosen password. It can be turned off from the backup settings.
+
+PERMISSIONS REQUESTED AND WHY (all optional; the app is fully usable without any of them)
+- Bluetooth: download dives from a dive computer.
+- Location: record dive site coordinates and find nearby sites.
+- Photos and camera: attach photos to a dive.
+- Contacts: import dive buddies.
+- Health: import dives recorded by Apple Watch.
+
+No demo credentials are needed. A fresh install with any name entered in the profile step reaches every feature.

--- a/ios/fastlane/metadata/review_information/notes.txt
+++ b/ios/fastlane/metadata/review_information/notes.txt
@@ -1,22 +1,9 @@
-Submersion is a scuba dive logging app. It has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. Every dive log, profile, setting and photo link is stored locally on the device.
+Submersion has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. All data is stored locally on the device.
 
-ABOUT "CREATE YOUR PROFILE" (guideline 5.1.1(v))
-The first-launch step titled "Create Your Profile" creates a local diver profile: a name used to label dive logs when more than one person shares a device. It is not an account. The name is never transmitted to us and there is nothing to register with.
+"CREATE YOUR PROFILE" (guideline 5.1.1(v)): the first-launch step creates a local diver profile, a name used to label dive logs when several people share a device. It is not an account and is never transmitted. Profiles are deleted in-app at Settings > Diver Profile > Manage Divers > select the diver > Delete (type "Delete <name>" to confirm). This permanently removes the profile and all of its dive logs, equipment, certifications and sites, and works for the only profile on the device.
 
-Diver profiles are deleted in-app: Settings > Diver Profile > Manage Divers, choose the diver, then Delete. The confirmation asks the user to type "Delete <name>". Deletion permanently removes the profile and every dive log, dive computer, equipment item, certification and site attached to it. This works for the only profile on the device as well. A screen recording of this flow, captured on a physical device, was attached to the review reply for version 1.7.5 (submission ce6d5c46-26d8-4c48-851c-4654ff4e60f5).
+"SIGN IN": these options connect to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive it. Connections are removed at Settings > Photos & Media > Connected Accounts.
 
-ABOUT "SIGN IN" WORDING
-Where the app offers to sign in, it connects to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive that data. Those connections are removed at Settings > Photos & Media > Connected Accounts ("Remove from library"), which also discards the stored credentials.
+App Lock (Settings > Security) and backup encryption are optional device-local passwords, not accounts, and can be turned off from the same screens.
 
-OPTIONAL LOCAL PROTECTIONS THAT ARE NOT ACCOUNTS
-- App Lock sets a device-local password or Face ID unlock for the app. It can be turned off from Settings > Security.
-- Backup encryption protects exported backup files with a user-chosen password. It can be turned off from the backup settings.
-
-PERMISSIONS REQUESTED AND WHY (all optional; the app is fully usable without any of them)
-- Bluetooth: download dives from a dive computer.
-- Location: record dive site coordinates and find nearby sites.
-- Photos and camera: attach photos to a dive.
-- Contacts: import dive buddies.
-- Health: import dives recorded by Apple Watch.
-
-No demo credentials are needed. A fresh install with any name entered in the profile step reaches every feature.
+No demo credentials are needed; entering any name in the profile step reaches every feature.

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -769,8 +769,13 @@ platform :mac do
       skip_screenshots: true,
       # skip_metadata false so deliver uploads metadata/en-US/release_notes.txt
       # (written by promote.yml from the GitHub release notes) - Apple requires
-      # whatsNew on a new version. Only files present are uploaded, and that is
-      # the only metadata file provided.
+      # whatsNew on a new version. Only files present are uploaded. The other
+      # file provided is the committed metadata/review_information/notes.txt,
+      # which lands in App Review Information > Notes on every submission: it
+      # explains that the app has no accounts, after 1.7.4 and 1.7.5 were both
+      # rejected under 5.1.1(v) for the first-launch "Create Your Profile"
+      # step. scripts/release/app_review_notes_test.sh keeps it in lockstep
+      # with the iOS copy.
       skip_metadata: false,
       # Required BECAUSE skip_metadata is false. deliver renders the metadata
       # it is about to upload to fastlane/Preview.html and blocks on "Does the

--- a/macos/fastlane/metadata/review_information/notes.txt
+++ b/macos/fastlane/metadata/review_information/notes.txt
@@ -4,6 +4,6 @@ Submersion has no user accounts: no sign-up, no login, no demo account, and no b
 
 "SIGN IN": these options connect to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive it. Connections are removed at Settings > Photos & Media > Connected Accounts.
 
-App Lock (Settings > Security) and backup encryption are optional device-local passwords, not accounts, and can be turned off from the same screens.
+App Lock (Settings > Security, a password or biometric unlock for the app) and backup encryption (a password on exported backup files) are optional device-local protections, not accounts, and can be turned off from the same screens.
 
 No demo credentials are needed; entering any name in the profile step reaches every feature.

--- a/macos/fastlane/metadata/review_information/notes.txt
+++ b/macos/fastlane/metadata/review_information/notes.txt
@@ -1,0 +1,22 @@
+Submersion is a scuba dive logging app. It has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. Every dive log, profile, setting and photo link is stored locally on the device.
+
+ABOUT "CREATE YOUR PROFILE" (guideline 5.1.1(v))
+The first-launch step titled "Create Your Profile" creates a local diver profile: a name used to label dive logs when more than one person shares a device. It is not an account. The name is never transmitted to us and there is nothing to register with.
+
+Diver profiles are deleted in-app: Settings > Diver Profile > Manage Divers, choose the diver, then Delete. The confirmation asks the user to type "Delete <name>". Deletion permanently removes the profile and every dive log, dive computer, equipment item, certification and site attached to it. This works for the only profile on the device as well. A screen recording of this flow, captured on a physical device, was attached to the review reply for version 1.7.5 (submission ce6d5c46-26d8-4c48-851c-4654ff4e60f5).
+
+ABOUT "SIGN IN" WORDING
+Where the app offers to sign in, it connects to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive that data. Those connections are removed at Settings > Photos & Media > Connected Accounts ("Remove from library"), which also discards the stored credentials.
+
+OPTIONAL LOCAL PROTECTIONS THAT ARE NOT ACCOUNTS
+- App Lock sets a device-local password or Face ID unlock for the app. It can be turned off from Settings > Security.
+- Backup encryption protects exported backup files with a user-chosen password. It can be turned off from the backup settings.
+
+PERMISSIONS REQUESTED AND WHY (all optional; the app is fully usable without any of them)
+- Bluetooth: download dives from a dive computer.
+- Location: record dive site coordinates and find nearby sites.
+- Photos and camera: attach photos to a dive.
+- Contacts: import dive buddies.
+- Health: import dives recorded by Apple Watch.
+
+No demo credentials are needed. A fresh install with any name entered in the profile step reaches every feature.

--- a/macos/fastlane/metadata/review_information/notes.txt
+++ b/macos/fastlane/metadata/review_information/notes.txt
@@ -1,22 +1,9 @@
-Submersion is a scuba dive logging app. It has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. Every dive log, profile, setting and photo link is stored locally on the device.
+Submersion has no user accounts: no sign-up, no login, no demo account, and no backend service operated by us. All data is stored locally on the device.
 
-ABOUT "CREATE YOUR PROFILE" (guideline 5.1.1(v))
-The first-launch step titled "Create Your Profile" creates a local diver profile: a name used to label dive logs when more than one person shares a device. It is not an account. The name is never transmitted to us and there is nothing to register with.
+"CREATE YOUR PROFILE" (guideline 5.1.1(v)): the first-launch step creates a local diver profile, a name used to label dive logs when several people share a device. It is not an account and is never transmitted. Profiles are deleted in-app at Settings > Diver Profile > Manage Divers > select the diver > Delete (type "Delete <name>" to confirm). This permanently removes the profile and all of its dive logs, equipment, certifications and sites, and works for the only profile on the device.
 
-Diver profiles are deleted in-app: Settings > Diver Profile > Manage Divers, choose the diver, then Delete. The confirmation asks the user to type "Delete <name>". Deletion permanently removes the profile and every dive log, dive computer, equipment item, certification and site attached to it. This works for the only profile on the device as well. A screen recording of this flow, captured on a physical device, was attached to the review reply for version 1.7.5 (submission ce6d5c46-26d8-4c48-851c-4654ff4e60f5).
+"SIGN IN": these options connect to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive it. Connections are removed at Settings > Photos & Media > Connected Accounts.
 
-ABOUT "SIGN IN" WORDING
-Where the app offers to sign in, it connects to a third-party storage account the user already owns (iCloud, Dropbox, Google Drive, or a user-supplied S3 bucket) so the user can sync or back up their own data to their own storage. We never receive that data. Those connections are removed at Settings > Photos & Media > Connected Accounts ("Remove from library"), which also discards the stored credentials.
+App Lock (Settings > Security) and backup encryption are optional device-local passwords, not accounts, and can be turned off from the same screens.
 
-OPTIONAL LOCAL PROTECTIONS THAT ARE NOT ACCOUNTS
-- App Lock sets a device-local password or Face ID unlock for the app. It can be turned off from Settings > Security.
-- Backup encryption protects exported backup files with a user-chosen password. It can be turned off from the backup settings.
-
-PERMISSIONS REQUESTED AND WHY (all optional; the app is fully usable without any of them)
-- Bluetooth: download dives from a dive computer.
-- Location: record dive site coordinates and find nearby sites.
-- Photos and camera: attach photos to a dive.
-- Contacts: import dive buddies.
-- Health: import dives recorded by Apple Watch.
-
-No demo credentials are needed. A fresh install with any name entered in the profile step reaches every feature.
+No demo credentials are needed; entering any name in the profile step reaches every feature.

--- a/scripts/release/app_review_notes_test.sh
+++ b/scripts/release/app_review_notes_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Guards the App Review notes that deliver uploads with every store
+# submission from fastlane/metadata/review_information/notes.txt.
+#
+# Why they exist: iOS 1.7.4 and 1.7.5 were both rejected under guideline
+# 5.1.1(v) ("account deletion") because a reviewer took the first-launch
+# "Create Your Profile" step for account creation, and nothing told them
+# otherwise. Apple reads these notes before touching the build, so keeping
+# them accurate and present is the durable fix.
+#
+# What is checked:
+# - Both platform copies exist and are non-empty, so a submission never goes
+#   up silent on one platform. deliver uploads only the files present, so a
+#   missing file is a missing field, not an error.
+# - The two copies are byte-identical. There is one app and one explanation.
+# - The text fits Apple's 4000-character limit for the field.
+# - The 2.3.10 sanitizer passes the text through unchanged, so no other
+#   platform name can reach Apple through this field. Release notes are
+#   sanitized in CI; this file is hand-written and committed, so the check
+#   has to run here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SANITIZE="$SCRIPT_DIR/sanitize_apple_store_notes.py"
+IOS="$ROOT/ios/fastlane/metadata/review_information/notes.txt"
+MACOS="$ROOT/macos/fastlane/metadata/review_information/notes.txt"
+APPLE_LIMIT=4000
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+for f in "$IOS" "$MACOS"; do
+  [ -s "$f" ] || fail "missing or empty: ${f#"$ROOT"/}"
+done
+
+cmp -s "$IOS" "$MACOS" \
+  || fail "ios and macos review notes differ; keep them identical"
+
+# Characters, not bytes: the limit is on text, and a multi-byte character
+# still counts once.
+chars=$(python3 -c 'import sys; print(len(sys.stdin.read()))' < "$IOS")
+[ "$chars" -le "$APPLE_LIMIT" ] \
+  || fail "review notes are $chars characters; Apple's limit is $APPLE_LIMIT"
+
+sanitized=$("$SANITIZE" < "$IOS")
+original=$(cat "$IOS")
+[ "$sanitized" = "$original" ] \
+  || fail "review notes name another platform or store (guideline 2.3.10); run: $SANITIZE --report < ${IOS#"$ROOT"/}"
+
+echo "app_review_notes_test: OK ($chars characters)"


### PR DESCRIPTION
## Summary

iOS 1.7.4 and 1.7.5 were both rejected under guideline 5.1.1(v) ("account deletion") because a reviewer took the first-launch **Create Your Profile** step for account creation. Submersion has no accounts, but nothing told the reviewer that: the repo shipped no App Review notes, and promote auto-resubmits after a rejection (#1255), so the 1.7.4 flag carried into 1.7.5 unanswered.

This PR makes the explanation part of every submission.

- **`ios/` and `macos/fastlane/metadata/review_information/notes.txt`** (identical, 1290 chars). deliver reads `review_information/` from the metadata root and uploads it into App Review Information > Notes. Every sentence is there to pre-empt a guideline: no accounts; the profile is a local label with an in-app delete (exact path, works for the only profile); what every "Sign in" connects to and where it is removed; App Lock and backup encryption as local passwords, not accounts; no demo login needed. A reviewer skims this field in seconds, so it is deliberately short. Verified against fastlane 2.232.0 source that only present non-empty files are sent and no contact fields are required alongside notes.
- **`scripts/release/app_review_notes_test.sh`**, wired into the CI Script Tests job: both copies present, byte-identical, within Apple's 4000-character limit, and passed through `sanitize_apple_store_notes.py` unchanged so no other-platform name (2.3.10) can reach Apple through this field.
- Comment fixes in both Fastfiles and `promote.yml`, which called `release_notes.txt` the only metadata file.
- `docs/developer/release-process.md`: for a misunderstanding-type rejection, reply in the thread and do not re-run promote (it would cancel the open submission).

## Verification

- `./scripts/release/app_review_notes_test.sh` passes: `OK (1290 characters)`.
- Both failure paths confirmed to fire: diverged copies, and a platform name appended to the text.
- `ruby scripts/release/fastlane_submit_guard_test.rb` still passes after the Fastfile comment edits.
- shellcheck clean.

## Notes

- `settings_profileHub_cannotDeleteOnly` ("Cannot delete the only diver profile") has no callers; `deleteDiverWithReassignment` deletes everything when no survivor exists, so the notes' claim that the sole profile can be deleted is true. Worth removing that dead string in a follow-up so it is never re-wired.
- The recording attached to the 1.7.5 review reply is not referenced (a submission ID goes stale); a hosted link can be added to the notes file if a reviewer ever asks for it again.
