### PR TITLE
fix(certifications): keep the certification visible when a custom name owns the title

### DIFF
--- a/lib/features/buddies/presentation/pages/buddy_detail_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_detail_page.dart
@@ -505,7 +505,7 @@ class _BuddyDetailContent extends ConsumerWidget {
                             contentPadding: EdgeInsets.zero,
                             leading: const Icon(Icons.card_membership),
                             title: Text(certificationTitle(cert)),
-                            subtitle: Text(cert.agency.displayName),
+                            subtitle: Text(certificationAgencyAndLevel(cert)),
                           ),
                       ],
                     ),

--- a/lib/features/buddies/presentation/pages/buddy_edit_page.dart
+++ b/lib/features/buddies/presentation/pages/buddy_edit_page.dart
@@ -431,7 +431,7 @@ class _BuddyEditPageState extends ConsumerState<BuddyEditPage> {
                   contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.card_membership),
                   title: Text(certificationTitle(cert)),
-                  subtitle: Text(cert.agency.displayName),
+                  subtitle: Text(certificationAgencyAndLevel(cert)),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/features/certifications/domain/certification_title.dart
+++ b/lib/features/certifications/domain/certification_title.dart
@@ -63,3 +63,16 @@ String certificationTitle(Certification cert) =>
 /// remove.
 String? certificationSubtitle(Certification cert) =>
     customNameOrNull(cert) == null ? null : cert.level?.displayName;
+
+/// The agency line that list surfaces put beneath [certificationTitle],
+/// carrying the level as well whenever the title is a custom name.
+///
+/// A card stored as "Bill Ansell" takes the whole title, so without this the
+/// level it was actually issued for (Divemaster) would appear nowhere on the
+/// tile. [certificationSubtitle] returns null for a derived title, which
+/// already names the level, so this never says it twice.
+String certificationAgencyAndLevel(Certification cert) {
+  final level = certificationSubtitle(cert);
+  final agency = cert.agency.displayName;
+  return level == null ? agency : '$agency - $level';
+}

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -745,9 +745,8 @@ class CertificationListTile extends StatelessWidget {
         : '';
     // Only non-null when a custom name owns the title, so the level is spoken
     // exactly once either way.
-    final levelLabel = certificationSubtitle(certification) != null
-        ? ', ${certificationSubtitle(certification)}'
-        : '';
+    final level = certificationSubtitle(certification);
+    final levelLabel = level != null ? ', $level' : '';
 
     return Semantics(
       // Keep the agency: this label stands in for the whole tile, so dropping

--- a/lib/features/certifications/presentation/widgets/certification_list_content.dart
+++ b/lib/features/certifications/presentation/widgets/certification_list_content.dart
@@ -743,6 +743,11 @@ class CertificationListTile extends StatelessWidget {
     final issueDateLabel = certification.issueDate != null
         ? ', issued ${DateFormat.yMMMd().format(certification.issueDate!)}'
         : '';
+    // Only non-null when a custom name owns the title, so the level is spoken
+    // exactly once either way.
+    final levelLabel = certificationSubtitle(certification) != null
+        ? ', ${certificationSubtitle(certification)}'
+        : '';
 
     return Semantics(
       // Keep the agency: this label stands in for the whole tile, so dropping
@@ -750,7 +755,8 @@ class CertificationListTile extends StatelessWidget {
       // derived rather than raw so the agency is not said twice.
       label:
           '${certification.agency.displayName} '
-          '${certificationTitle(certification)}$issueDateLabel$statusLabel',
+          '${certificationTitle(certification)}'
+          '$levelLabel$issueDateLabel$statusLabel',
       child: Card(
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         color: isSelected
@@ -800,7 +806,9 @@ class CertificationListTile extends StatelessWidget {
 
   Widget? _buildSubtitle(BuildContext context) {
     final parts = <String>[];
-    parts.add(certification.agency.displayName);
+    // Carries the level too when the title is a custom name, which is the
+    // only place the level can show on this tile.
+    parts.add(certificationAgencyAndLevel(certification));
     if (certification.issueDate != null) {
       parts.add(DateFormat.yMMMd().format(certification.issueDate!));
     }

--- a/lib/features/certifications/presentation/widgets/certification_picker.dart
+++ b/lib/features/certifications/presentation/widgets/certification_picker.dart
@@ -204,6 +204,15 @@ class CertificationPickerSheet extends ConsumerWidget {
 
                   return Semantics(
                     label: certLabel,
+                    // Without excludeSemantics the label MERGES with the
+                    // tile's own text rather than standing in for it, so a
+                    // screen reader hears the name, agency and level twice.
+                    // Excluding the subtree drops the tile's tap action along
+                    // with its text, so restate it here or the row stops being
+                    // activatable.
+                    excludeSemantics: true,
+                    button: true,
+                    onTap: () => onCertificationSelected(cert),
                     child: ListTile(
                       leading: CircleAvatar(
                         backgroundColor: isSelected

--- a/lib/features/certifications/presentation/widgets/certification_picker.dart
+++ b/lib/features/certifications/presentation/widgets/certification_picker.dart
@@ -190,9 +190,8 @@ class CertificationPickerSheet extends ConsumerWidget {
 
                   // Only non-null when a custom name owns the title, so the
                   // level is spoken exactly once either way.
-                  final levelLabel = certificationSubtitle(cert) != null
-                      ? ', ${certificationSubtitle(cert)}'
-                      : '';
+                  final level = certificationSubtitle(cert);
+                  final levelLabel = level != null ? ', $level' : '';
                   // Keep the agency: this label replaces the tile's own
                   // semantics, including the subtitle that shows the agency
                   // visually. The title is derived so it is not said twice.

--- a/lib/features/certifications/presentation/widgets/certification_picker.dart
+++ b/lib/features/certifications/presentation/widgets/certification_picker.dart
@@ -43,7 +43,7 @@ class CertificationPicker extends ConsumerWidget {
             context.l10n.certifications_picker_noSelection,
       ),
       subtitle: selectedCertification != null
-          ? Text(selectedCertification!.agency.displayName)
+          ? Text(certificationAgencyAndLevel(selectedCertification!))
           : Text(context.l10n.certifications_picker_hint),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
@@ -188,11 +188,17 @@ class CertificationPickerSheet extends ConsumerWidget {
                   final isSelected = selectedCertification?.id == cert.id;
                   final dateFormat = DateFormat.yMMMd();
 
+                  // Only non-null when a custom name owns the title, so the
+                  // level is spoken exactly once either way.
+                  final levelLabel = certificationSubtitle(cert) != null
+                      ? ', ${certificationSubtitle(cert)}'
+                      : '';
                   // Keep the agency: this label replaces the tile's own
                   // semantics, including the subtitle that shows the agency
                   // visually. The title is derived so it is not said twice.
                   final certName =
-                      '${cert.agency.displayName} ${certificationTitle(cert)}';
+                      '${cert.agency.displayName} '
+                      '${certificationTitle(cert)}$levelLabel';
                   final certLabel = cert.issueDate != null
                       ? '$certName, issued ${dateFormat.format(cert.issueDate!)}${isSelected ? ', selected' : ''}${cert.isExpired ? ', expired' : ''}'
                       : '$certName${isSelected ? ', selected' : ''}${cert.isExpired ? ', expired' : ''}';
@@ -214,8 +220,8 @@ class CertificationPickerSheet extends ConsumerWidget {
                       title: Text(certificationTitle(cert)),
                       subtitle: Text(
                         cert.issueDate != null
-                            ? '${cert.agency.displayName} - ${dateFormat.format(cert.issueDate!)}'
-                            : cert.agency.displayName,
+                            ? '${certificationAgencyAndLevel(cert)} - ${dateFormat.format(cert.issueDate!)}'
+                            : certificationAgencyAndLevel(cert),
                       ),
                       trailing: isSelected
                           ? Icon(Icons.check_circle, color: colorScheme.primary)

--- a/lib/features/certifications/presentation/widgets/certification_summary_widget.dart
+++ b/lib/features/certifications/presentation/widgets/certification_summary_widget.dart
@@ -222,7 +222,7 @@ class CertificationSummaryWidget extends ConsumerWidget {
                   ),
                 ),
                 title: Text(certificationTitle(cert)),
-                subtitle: Text(cert.agency.displayName),
+                subtitle: Text(certificationAgencyAndLevel(cert)),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () {
                   final state = GoRouterState.of(context);

--- a/test/features/buddies/presentation/pages/buddy_detail_cert_subtitle_test.dart
+++ b/test/features/buddies/presentation/pages/buddy_detail_cert_subtitle_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/pages/buddy_detail_page.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+final _buddy = Buddy(
+  id: 'buddy-1',
+  name: 'Jane Doe',
+  notes: '',
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+);
+
+Certification _makeCert({
+  required String name,
+  CertificationLevel? level,
+  CertificationAgency agency = CertificationAgency.padi,
+}) {
+  return Certification(
+    id: 'c1',
+    name: name,
+    agency: agency,
+    level: level,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Certification cert) async {
+  final overrides = await getBaseOverrides();
+
+  final router = GoRouter(
+    initialLocation: '/buddies/buddy-1',
+    routes: [
+      GoRoute(
+        path: '/buddies/:id',
+        builder: (context, state) =>
+            BuddyDetailPage(buddyId: state.pathParameters['id']!),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        ...overrides,
+        buddyByIdProvider(_buddy.id).overrideWith((ref) async => _buddy),
+        buddyCertificationsProvider(
+          _buddy.id,
+        ).overrideWith((ref) async => [cert]),
+      ],
+      child: MaterialApp.router(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The certification tile's subtitle, read off the [ListTile] so it cannot be
+/// confused with the identically-worded text elsewhere on the page.
+String _certSubtitle(WidgetTester tester) {
+  final tile = tester.widget<ListTile>(
+    find.ancestor(
+      of: find.byIcon(Icons.card_membership),
+      matching: find.byType(ListTile),
+    ),
+  );
+  return (tile.subtitle! as Text).data!;
+}
+
+void main() {
+  group('buddy certification list', () {
+    testWidgets('a custom name keeps the certification in the subtitle', (
+      tester,
+    ) async {
+      // Issue #1265: the title is the custom name, so the subtitle is the only
+      // place left for the level.
+      await _pump(
+        tester,
+        _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
+      );
+
+      expect(find.text('Bill Ansell'), findsOneWidget);
+      expect(_certSubtitle(tester), 'PADI - Divemaster');
+    });
+
+    testWidgets('a derived title does not repeat the level in the subtitle', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        _makeCert(name: '', level: CertificationLevel.diveMaster),
+      );
+
+      expect(find.text('Divemaster'), findsOneWidget);
+      expect(_certSubtitle(tester), 'PADI');
+    });
+  });
+}

--- a/test/features/certifications/domain/certification_title_test.dart
+++ b/test/features/certifications/domain/certification_title_test.dart
@@ -123,4 +123,28 @@ void main() {
       expect(certificationSubtitle(cert(name: 'Bali OW', level: null)), isNull);
     });
   });
+
+  group('certificationAgencyAndLevel', () {
+    test('is the agency alone when the title already names the level', () {
+      expect(
+        certificationAgencyAndLevel(cert(name: 'PADI : Open Water')),
+        'PADI',
+      );
+    });
+
+    test('adds the level when a custom name owns the title', () {
+      // Issue #1265: without this the level appears nowhere on the tile.
+      expect(
+        certificationAgencyAndLevel(cert(name: 'Bill Ansell')),
+        'PADI - Open Water',
+      );
+    });
+
+    test('is the agency alone when a custom name has no level', () {
+      expect(
+        certificationAgencyAndLevel(cert(name: 'Bali OW', level: null)),
+        'PADI',
+      );
+    });
+  });
 }

--- a/test/features/certifications/presentation/widgets/certification_list_content_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_list_content_test.dart
@@ -707,5 +707,98 @@ void main() {
       // carries "PADI" on its own, so the title must not repeat it.
       expect(find.text('Open Water'), findsWidgets);
     });
+
+    // A custom name takes the title, which leaves the level with nowhere to go
+    // unless the subtitle carries it. See issue #1265: a card entered as
+    // "Bill Ansell" / PADI / Divemaster showed no trace of "Divemaster".
+    testWidgets('a custom name keeps the certification in the subtitle', (
+      tester,
+    ) async {
+      final overrides = await _buildPhoneOverrides(
+        certs: [
+          _makeCert(
+            id: 'c1',
+            name: 'Bill Ansell',
+            level: CertificationLevel.diveMaster,
+            issueDate: DateTime(2026, 8, 24),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: overrides,
+          child: const CertificationListContent(showAppBar: true),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Bill Ansell'), findsOneWidget);
+      expect(find.text('PADI - Divemaster - Aug 24, 2026'), findsOneWidget);
+    });
+
+    testWidgets('a derived title does not repeat the level in the subtitle', (
+      tester,
+    ) async {
+      final overrides = await _buildPhoneOverrides(
+        certs: [
+          _makeCert(
+            id: 'c2',
+            name: '',
+            level: CertificationLevel.diveMaster,
+            issueDate: DateTime(2026, 8, 24),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: overrides,
+          child: const CertificationListContent(showAppBar: true),
+        ),
+      );
+      await tester.pump();
+
+      // The title already says "Divemaster"; the subtitle must not say it
+      // again, which is the duplication the title helper exists to remove.
+      expect(find.text('Divemaster'), findsOneWidget);
+      expect(find.text('PADI - Aug 24, 2026'), findsOneWidget);
+    });
+
+    testWidgets('accessibility label names the certification too', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+
+      final overrides = await _buildPhoneOverrides(
+        certs: [
+          _makeCert(
+            id: 'c3',
+            name: 'Bill Ansell',
+            level: CertificationLevel.diveMaster,
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: overrides,
+          child: const CertificationListContent(showAppBar: true),
+        ),
+      );
+      await tester.pump();
+
+      // The label stands in for the whole tile, so a screen reader must hear
+      // the level even when a custom name owns the title.
+      expect(
+        find.bySemanticsLabel('PADI Bill Ansell, Divemaster'),
+        findsOneWidget,
+      );
+
+      handle.dispose();
+    });
   });
 }

--- a/test/features/certifications/presentation/widgets/certification_list_content_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_list_content_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/list_view_mode.dart';
@@ -630,6 +631,20 @@ void main() {
   });
 
   group('title derivation', () {
+    // The subtitle dates itself with DateFormat.yMMMd(), which resolves
+    // against Intl.defaultLocale (a process global that app.dart sets from the
+    // app locale), NOT the MaterialApp.locale the harness passes. Pin it so
+    // the "Aug 24, 2026" assertions below state their real dependency instead
+    // of riding on intl's implicit en_US fallback, and restore it so the
+    // global stays contained. No initializeDateFormatting is needed: these are
+    // widget tests, so GlobalMaterialLocalizations loads the symbol data.
+    String? previousLocale;
+    setUp(() {
+      previousLocale = Intl.defaultLocale;
+      Intl.defaultLocale = 'en';
+    });
+    tearDown(() => Intl.defaultLocale = previousLocale);
+
     testWidgets('a cert with no stored name still shows a title', (
       tester,
     ) async {

--- a/test/features/certifications/presentation/widgets/certification_picker_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_picker_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -82,23 +83,13 @@ Future<void> _pumpSheet(WidgetTester tester, List<Certification> certs) async {
 String _subtitleOf(WidgetTester tester, Finder tile) =>
     ((tester.widget<ListTile>(tile)).subtitle! as Text).data!;
 
-/// The label the sheet's [Semantics] wrapper declares for a tile.
+/// The label a tile's own [ListTile] contributes when it is NOT excluded from
+/// the semantics tree: its visible title and subtitle, newline-joined.
 ///
-/// Read off the widget rather than queried with `find.bySemanticsLabel`,
-/// following the precedent in certification_ecard_test.dart: this wrapper
-/// merges with the tile's own text instead of replacing it, so the rendered
-/// node is the declared label followed by the visible title and subtitle.
-String _tileSemanticsLabel(WidgetTester tester) {
-  final candidates = find.ancestor(
-    of: find.byType(ListTile),
-    matching: find.byType(Semantics),
-  );
-  for (final element in candidates.evaluate()) {
-    final label = (element.widget as Semantics).properties.label;
-    if (label != null && label.isNotEmpty) return label;
-  }
-  return '';
-}
+/// Asserting this is absent is what distinguishes a label that stands in for
+/// the tile from one that merely sits alongside it. Only the rendered tree
+/// shows the difference, so a check on the [Semantics] widget cannot see it.
+String _visibleTextNode(String title, String subtitle) => '$title\n$subtitle';
 
 void main() {
   // The sheet subtitle dates itself with DateFormat.yMMMd(), which resolves
@@ -170,23 +161,88 @@ void main() {
     testWidgets('the accessibility label names the certification too', (
       tester,
     ) async {
+      final handle = tester.ensureSemantics();
+
       await _pumpSheet(tester, [
         _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
       ]);
 
       // A screen reader must hear the level even when a custom name owns the
       // title, since the title alone no longer carries it.
-      expect(_tileSemanticsLabel(tester), 'PADI Bill Ansell, Divemaster');
+      expect(
+        find.bySemanticsLabel('PADI Bill Ansell, Divemaster'),
+        findsOneWidget,
+      );
+      // And exactly once: without excludeSemantics the tile keeps a second
+      // node carrying its visible text, so the row is announced twice.
+      expect(
+        find.bySemanticsLabel(
+          _visibleTextNode('Bill Ansell', 'PADI - Divemaster'),
+        ),
+        findsNothing,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('the tile stays activatable through the semantics label', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      Certification? picked;
+
+      await tester.pumpWidget(
+        testApp(
+          locale: const Locale('en'),
+          overrides: [
+            certificationListNotifierProvider.overrideWith(
+              (ref) => _MockCertListNotifier([
+                _makeCert(
+                  name: 'Bill Ansell',
+                  level: CertificationLevel.diveMaster,
+                ),
+              ]),
+            ),
+          ],
+          child: CertificationPickerSheet(
+            scrollController: ScrollController(),
+            selectedCertification: null,
+            onCertificationSelected: (cert) => picked = cert,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Excluding the subtree drops the ListTile's own tap action, so the
+      // wrapper must carry one or the row becomes unreachable by a screen
+      // reader even though it still looks tappable.
+      tester.semantics.performAction(
+        find.semantics.byLabel('PADI Bill Ansell, Divemaster'),
+        SemanticsAction.tap,
+      );
+      await tester.pump();
+
+      expect(picked?.name, 'Bill Ansell');
+
+      handle.dispose();
     });
 
     testWidgets('a derived title does not repeat the level', (tester) async {
+      final handle = tester.ensureSemantics();
+
       await _pumpSheet(tester, [
         _makeCert(name: '', level: CertificationLevel.diveMaster),
       ]);
 
       expect(_subtitleOf(tester, find.byType(ListTile)), 'PADI');
       // The title is already the level, so the label says it once, not twice.
-      expect(_tileSemanticsLabel(tester), 'PADI Divemaster');
+      expect(find.bySemanticsLabel('PADI Divemaster'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(_visibleTextNode('Divemaster', 'PADI')),
+        findsNothing,
+      );
+
+      handle.dispose();
     });
   });
 }

--- a/test/features/certifications/presentation/widgets/certification_picker_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_picker_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
+import 'package:submersion/features/certifications/presentation/widgets/certification_picker.dart';
+
+import '../../../../helpers/test_app.dart';
+
+class _MockCertListNotifier
+    extends StateNotifier<AsyncValue<List<Certification>>>
+    implements CertificationListNotifier {
+  _MockCertListNotifier(List<Certification> certs)
+    : super(AsyncValue.data(certs));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+final _now = DateTime(2026, 8, 24);
+
+Certification _makeCert({
+  required String name,
+  CertificationLevel? level,
+  DateTime? issueDate,
+  CertificationAgency agency = CertificationAgency.padi,
+}) {
+  return Certification(
+    id: 'c1',
+    name: name,
+    agency: agency,
+    level: level,
+    issueDate: issueDate,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+/// The collapsed picker field, which shows the current selection.
+Future<void> _pumpField(WidgetTester tester, Certification? selected) async {
+  await tester.pumpWidget(
+    testApp(
+      locale: const Locale('en'),
+      overrides: [
+        certificationListNotifierProvider.overrideWith(
+          (ref) => _MockCertListNotifier(const []),
+        ),
+      ],
+      child: CertificationPicker(
+        selectedCertification: selected,
+        onCertificationSelected: (_) {},
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// The sheet body directly, rather than through showModalBottomSheet: it is a
+/// public widget, so rendering it avoids driving a modal route just to read
+/// two lines of text off a tile.
+Future<void> _pumpSheet(WidgetTester tester, List<Certification> certs) async {
+  await tester.pumpWidget(
+    testApp(
+      locale: const Locale('en'),
+      overrides: [
+        certificationListNotifierProvider.overrideWith(
+          (ref) => _MockCertListNotifier(certs),
+        ),
+      ],
+      child: CertificationPickerSheet(
+        scrollController: ScrollController(),
+        selectedCertification: null,
+        onCertificationSelected: (_) {},
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+String _subtitleOf(WidgetTester tester, Finder tile) =>
+    ((tester.widget<ListTile>(tile)).subtitle! as Text).data!;
+
+/// The label the sheet's [Semantics] wrapper declares for a tile.
+///
+/// Read off the widget rather than queried with `find.bySemanticsLabel`,
+/// following the precedent in certification_ecard_test.dart: this wrapper
+/// merges with the tile's own text instead of replacing it, so the rendered
+/// node is the declared label followed by the visible title and subtitle.
+String _tileSemanticsLabel(WidgetTester tester) {
+  final candidates = find.ancestor(
+    of: find.byType(ListTile),
+    matching: find.byType(Semantics),
+  );
+  for (final element in candidates.evaluate()) {
+    final label = (element.widget as Semantics).properties.label;
+    if (label != null && label.isNotEmpty) return label;
+  }
+  return '';
+}
+
+void main() {
+  // The sheet subtitle dates itself with DateFormat.yMMMd(), which resolves
+  // against Intl.defaultLocale (a process global) rather than the
+  // MaterialApp.locale the harness passes. Pin it so the "Aug 24, 2026"
+  // assertion states its real dependency, and restore it afterwards because
+  // the global leaks across tests in the same isolate.
+  String? previousLocale;
+  setUp(() {
+    previousLocale = Intl.defaultLocale;
+    Intl.defaultLocale = 'en';
+  });
+  tearDown(() => Intl.defaultLocale = previousLocale);
+
+  group('collapsed picker field', () {
+    testWidgets('a custom name keeps the certification in the subtitle', (
+      tester,
+    ) async {
+      // Issue #1265: the title is the custom name, so the subtitle is the only
+      // place left for the level.
+      await _pumpField(
+        tester,
+        _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
+      );
+
+      expect(find.text('Bill Ansell'), findsOneWidget);
+      expect(_subtitleOf(tester, find.byType(ListTile)), 'PADI - Divemaster');
+    });
+
+    testWidgets('a derived title does not repeat the level', (tester) async {
+      await _pumpField(
+        tester,
+        _makeCert(name: '', level: CertificationLevel.diveMaster),
+      );
+
+      expect(find.text('Divemaster'), findsOneWidget);
+      expect(_subtitleOf(tester, find.byType(ListTile)), 'PADI');
+    });
+  });
+
+  group('picker sheet', () {
+    testWidgets('a custom name keeps the certification in the subtitle', (
+      tester,
+    ) async {
+      await _pumpSheet(tester, [
+        _makeCert(
+          name: 'Bill Ansell',
+          level: CertificationLevel.diveMaster,
+          issueDate: DateTime(2026, 8, 24),
+        ),
+      ]);
+
+      expect(
+        _subtitleOf(tester, find.byType(ListTile)),
+        'PADI - Divemaster - Aug 24, 2026',
+      );
+    });
+
+    testWidgets('a certification with no issue date omits the date', (
+      tester,
+    ) async {
+      await _pumpSheet(tester, [
+        _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
+      ]);
+
+      expect(_subtitleOf(tester, find.byType(ListTile)), 'PADI - Divemaster');
+    });
+
+    testWidgets('the accessibility label names the certification too', (
+      tester,
+    ) async {
+      await _pumpSheet(tester, [
+        _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
+      ]);
+
+      // A screen reader must hear the level even when a custom name owns the
+      // title, since the title alone no longer carries it.
+      expect(_tileSemanticsLabel(tester), 'PADI Bill Ansell, Divemaster');
+    });
+
+    testWidgets('a derived title does not repeat the level', (tester) async {
+      await _pumpSheet(tester, [
+        _makeCert(name: '', level: CertificationLevel.diveMaster),
+      ]);
+
+      expect(_subtitleOf(tester, find.byType(ListTile)), 'PADI');
+      // The title is already the level, so the label says it once, not twice.
+      expect(_tileSemanticsLabel(tester), 'PADI Divemaster');
+    });
+  });
+}

--- a/test/features/certifications/presentation/widgets/certification_summary_widget_test.dart
+++ b/test/features/certifications/presentation/widgets/certification_summary_widget_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/certifications/domain/entities/certification.dart';
+import 'package:submersion/features/certifications/presentation/providers/certification_providers.dart';
+import 'package:submersion/features/certifications/presentation/widgets/certification_summary_widget.dart';
+
+import '../../../../helpers/test_app.dart';
+
+class _MockCertListNotifier
+    extends StateNotifier<AsyncValue<List<Certification>>>
+    implements CertificationListNotifier {
+  _MockCertListNotifier(List<Certification> certs)
+    : super(AsyncValue.data(certs));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+final _now = DateTime(2026, 8, 24);
+
+Certification _makeCert({
+  required String name,
+  CertificationLevel? level,
+  CertificationAgency agency = CertificationAgency.padi,
+}) {
+  return Certification(
+    id: 'c1',
+    name: name,
+    agency: agency,
+    level: level,
+    createdAt: _now,
+    updatedAt: _now,
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Certification cert) async {
+  await tester.pumpWidget(
+    testApp(
+      locale: const Locale('en'),
+      overrides: [
+        certificationListNotifierProvider.overrideWith(
+          (ref) => _MockCertListNotifier([cert]),
+        ),
+      ],
+      child: const CertificationSummaryWidget(),
+    ),
+  );
+  await tester.pump();
+}
+
+/// The preview tile's two lines. Read off the [ListTile] rather than via
+/// `find.text` because the leading avatar also renders the agency, so a bare
+/// text match on "PADI" cannot tell the subtitle from the badge.
+({String title, String subtitle}) _tileLines(WidgetTester tester) {
+  final tile = tester.widget<ListTile>(find.byType(ListTile));
+  return (
+    title: (tile.title! as Text).data!,
+    subtitle: (tile.subtitle! as Text).data!,
+  );
+}
+
+void main() {
+  group('recent certification preview', () {
+    testWidgets('a custom name keeps the certification in the subtitle', (
+      tester,
+    ) async {
+      // Issue #1265: the title is the custom name, so the subtitle is the only
+      // place left for the level.
+      await _pump(
+        tester,
+        _makeCert(name: 'Bill Ansell', level: CertificationLevel.diveMaster),
+      );
+
+      expect(_tileLines(tester), (
+        title: 'Bill Ansell',
+        subtitle: 'PADI - Divemaster',
+      ));
+    });
+
+    testWidgets('a derived title does not repeat the level in the subtitle', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        _makeCert(name: '', level: CertificationLevel.diveMaster),
+      );
+
+      // The title already says "Divemaster"; the subtitle must not say it
+      // again, which is the duplication the title helper exists to remove.
+      expect(_tileLines(tester), (title: 'Divemaster', subtitle: 'PADI'));
+    });
+
+    testWidgets('a custom name with no level shows the agency alone', (
+      tester,
+    ) async {
+      await _pump(tester, _makeCert(name: 'DAN Insurance'));
+
+      expect(_tileLines(tester), (title: 'DAN Insurance', subtitle: 'PADI'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1265

## The report

A newly added certification showed only its agency on the list card, never the certification itself. In the reporter's screenshot the card was entered as **Bill Ansell** / PADI / **Divemaster**, and rendered:

```
Bill Ansell
PADI - Aug 24, 2026
```

"Divemaster" appeared nowhere on the tile.

## Root cause

`certificationTitle()` deliberately prefers a custom stored `name` over the structured `level`, on a documented contract: the surface's *secondary* line carries the level, via `certificationSubtitle()` (which returns `null` for a derived title so the level is never said twice).

Six list and summary surfaces never honoured that contract. They took the title from the helper but hand-assembled their subtitle from the agency (plus a date) alone, leaving the level with nowhere to go.

The gap has existed since the title helper landed, but was invisible while the edit form still auto-filled `name` as `"PADI : Divemaster"`: the title itself carried the level. Removing that auto-fill is what exposed it, which matches the reporter's "in the past it did properly display both".

## The fix

Adds `certificationAgencyAndLevel()` to `certification_title.dart`, the module that already owns naming decisions, so the anti-duplication rule is enforced once by construction rather than re-argued at every call site. Routed into:

- certification list tile (the reported surface)
- certification summary preview
- certification picker tile and picker sheet
- buddy detail and buddy edit cert lists

The two screen-reader labels gain the level on the same condition, so it is spoken exactly once either way.

The card now reads:

```
Bill Ansell
PADI - Divemaster - Aug 24, 2026
```

A cert with a derived title is unchanged: `certificationSubtitle()` returns `null` there and the title already names the level, so the subtitle stays `PADI - Aug 24, 2026`.

Deliberately **not** changed: the detail page header. It shows agency alone on purpose, because the Details card directly beneath it already has a `Certification: Divemaster` row (visible in the reporter's screenshot). Adding it to the header would trade one duplication for another, which is exactly what this module exists to prevent.

## Tests

Written before the fix, and confirmed failing for the right reason first.

- `certification_title_test.dart`: three cases pinning `certificationAgencyAndLevel` (agency alone for a derived title, agency + level for a custom name, agency alone when a custom name has no level).
- `certification_list_content_test.dart`: a custom name keeps the certification in the subtitle; a derived title does not repeat the level; the accessibility label names the certification too.

The pre-existing "accessibility label names the agency exactly once" guard stays green, which is the regression this could most plausibly have reintroduced.

`flutter analyze` clean. Full suite: 20083 passed, 19 skipped.