### PR TITLE
fix(3d): two-finger zoom, unobscured zoom buttons, closable settings sheet

### DIFF
--- a/lib/features/dive_3d/presentation/pages/spatial_site_page.dart
+++ b/lib/features/dive_3d/presentation/pages/spatial_site_page.dart
@@ -155,13 +155,16 @@ class _SpatialSitePageState extends ConsumerState<SpatialSitePage>
                       child: _captions(result!),
                     ),
                     // The legend describes the depth ramp; a photographed
-                    // surface has no ramp to explain.
+                    // surface has no ramp to explain. It sits LEFT because the
+                    // viewport's zoom column owns the right edge, and on a
+                    // phone-sized pane a right-hand legend covers the +/-
+                    // buttons outright (issue #1188).
                     if (result.grid != null &&
                         result.axisInputs != null &&
                         appearance.surfaceMode != SeascapeSurfaceMode.imagery)
                       Positioned(
                         top: 40,
-                        right: 8,
+                        left: 8,
                         child: SeascapeDepthLegend(
                           maxDepthMeters: result.axisInputs!.maxDepth,
                           hasLand: result.grid!.depthsMeters.any(

--- a/lib/features/dive_3d/presentation/widgets/dive_3d_interactive_viewport.dart
+++ b/lib/features/dive_3d/presentation/widgets/dive_3d_interactive_viewport.dart
@@ -93,6 +93,8 @@ class Dive3dInteractiveViewport extends StatefulWidget {
 class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
   static const double _initialYaw = -32;
   static const double _initialPitch = 22;
+  static const double _minZoom = 0.4;
+  static const double _maxZoom = 8.0;
   double _yaw = _initialYaw;
   double _pitch = _initialPitch;
   double _zoom = 1.0;
@@ -100,6 +102,9 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
   // as a Transform on the painted output; picks subtract it from the cursor.
   Offset _pan = Offset.zero;
   double _panZoomBaseZoom = 1.0;
+  // Zoom at the moment the active touch pinch began; ScaleUpdateDetails.scale
+  // is cumulative against the gesture start, not the previous tick.
+  double _scaleGestureBaseZoom = 1.0;
   // Last laid-out size, captured in build so camera-change handlers (which lack
   // the LayoutBuilder constraints) can re-project the hover pick.
   Size? _lastLayoutSize;
@@ -133,24 +138,68 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
     }
   }
 
-  void _onPanUpdate(DragUpdateDetails details) {
+  void _onScaleStart(ScaleStartDetails _) {
+    _scaleGestureBaseZoom = _zoom;
+  }
+
+  /// One recognizer serves both touch gestures, because Flutter cannot run a
+  /// pan and a scale recognizer in the same arena without one starving the
+  /// other. Pointer count decides the meaning: one finger orbits (or pans the
+  /// locked plan view in chart mode), two fingers pinch-zoom and pan. That is
+  /// the mapping issue #1188 asked for, and it is the only zoom a touchscreen
+  /// can reach -- pan/zoom pointer events are trackpad-only.
+  void _onScaleUpdate(Size size, ScaleUpdateDetails details) {
+    final delta = details.focalPointDelta;
+    if (details.pointerCount < 2) {
+      setState(() {
+        if (widget.chartMode) {
+          _pan += delta;
+        } else {
+          // Drag follows the object: dragging right spins it clockwise (yaw
+          // up), dragging down tilts it toward the viewer.
+          _yaw += delta.dx * 0.4;
+          _pitch = (_pitch + delta.dy * 0.4).clamp(-80.0, 80.0);
+        }
+      });
+      _refreshHoverAfterCameraChange();
+      return;
+    }
     setState(() {
-      if (widget.chartMode) {
-        // Chart mode is a locked plan view: one-finger drag pans the map.
-        _pan += details.delta;
-      } else {
-        // Drag follows the object: dragging right spins it clockwise (yaw
-        // up), dragging down tilts it toward the viewer.
-        _yaw += details.delta.dx * 0.4;
-        _pitch = (_pitch + details.delta.dy * 0.4).clamp(-80.0, 80.0);
-      }
+      _setZoomAnchored(
+        size,
+        (_scaleGestureBaseZoom * details.scale).clamp(_minZoom, _maxZoom),
+        focalPoint: details.localFocalPoint,
+        focalDelta: delta,
+      );
     });
     _refreshHoverAfterCameraChange();
   }
 
+  /// Scales the camera to [next] while keeping the scene point that sat under
+  /// the pinch's PREVIOUS focal point ([focalPoint] - [focalDelta]) welded to
+  /// the fingers, then carries the focal point's own travel as a pan.
+  ///
+  /// [SceneProjector] scales the scene about the canvas center, and the pan
+  /// Transform is applied on top, so a projected point lands at
+  /// `center + zoom * v + pan`. Solving that for the pan that pins one point
+  /// across a zoom change gives the single expression below; with
+  /// `next == _zoom` it degenerates to a plain `_pan += focalDelta`.
+  void _setZoomAnchored(
+    Size size,
+    double next, {
+    required Offset focalPoint,
+    Offset focalDelta = Offset.zero,
+  }) {
+    final ratio = next / _zoom;
+    final center = Offset(size.width / 2, size.height / 2);
+    _pan =
+        focalPoint - center - (focalPoint - focalDelta - center - _pan) * ratio;
+    _zoom = next;
+  }
+
   void _zoomBy(double factor) {
     setState(() {
-      _zoom = (_zoom * factor).clamp(0.4, 8.0);
+      _zoom = (_zoom * factor).clamp(_minZoom, _maxZoom);
     });
     _refreshHoverAfterCameraChange();
   }
@@ -164,7 +213,7 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
   void _onPanZoomUpdate(PointerPanZoomUpdateEvent event) {
     setState(() {
       _pan += event.panDelta;
-      _zoom = (_panZoomBaseZoom * event.scale).clamp(0.4, 8.0);
+      _zoom = (_panZoomBaseZoom * event.scale).clamp(_minZoom, _maxZoom);
     });
     _refreshHoverAfterCameraChange();
   }
@@ -413,12 +462,14 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
         final gestures = RawGestureDetector(
           behavior: HitTestBehavior.opaque,
           gestures: <Type, GestureRecognizerFactory>{
-            // Rotate: one-finger drag from mouse/touch/stylus. Trackpad
-            // two-finger pans are handled as pan by the Listener below, so we
-            // exclude trackpad here to avoid rotating while panning.
-            PanGestureRecognizer:
-                GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
-                  () => PanGestureRecognizer(
+            // Rotate (one finger) and pinch-zoom + pan (two fingers) from
+            // mouse/touch/stylus. Trackpad pan-zoom pointers stay with the
+            // Listener below.
+            _TouchScaleGestureRecognizer:
+                GestureRecognizerFactoryWithHandlers<
+                  _TouchScaleGestureRecognizer
+                >(
+                  () => _TouchScaleGestureRecognizer(
                     supportedDevices: const {
                       PointerDeviceKind.touch,
                       PointerDeviceKind.mouse,
@@ -427,7 +478,9 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
                       PointerDeviceKind.unknown,
                     },
                   ),
-                  (r) => r.onUpdate = _onPanUpdate,
+                  (r) => r
+                    ..onStart = _onScaleStart
+                    ..onUpdate = (details) => _onScaleUpdate(size, details),
                 ),
             TapGestureRecognizer:
                 GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
@@ -488,6 +541,7 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
 
   Widget _zoomControls(BuildContext context) {
     return Column(
+      key: const ValueKey('dive3dZoomControls'),
       mainAxisSize: MainAxisSize.min,
       children: [
         _zoomButton(
@@ -535,6 +589,21 @@ class _Dive3dInteractiveViewportState extends State<Dive3dInteractiveViewport> {
       ),
     );
   }
+}
+
+/// A scale recognizer that ignores trackpad pan/zoom pointers.
+///
+/// `supportedDevices` filters pointer-DOWN events only:
+/// [GestureRecognizer.isPointerPanZoomAllowed] returns true unconditionally,
+/// so a trackpad gesture reaches every recognizer no matter what devices it
+/// declares. The viewport handles trackpads on a [Listener], and without this
+/// refusal both paths would fire and every trackpad pan would move the camera
+/// twice.
+class _TouchScaleGestureRecognizer extends ScaleGestureRecognizer {
+  _TouchScaleGestureRecognizer({super.supportedDevices});
+
+  @override
+  bool isPointerPanZoomAllowed(PointerPanZoomStartEvent event) => false;
 }
 
 /// Foreground layer: only the scrub cursor. Repaints on every scrub tick

--- a/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
+++ b/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
@@ -29,6 +29,12 @@ void showTerrainAppearanceSheet(BuildContext context) {
     // The custom-level rows open a keypad. Without a viewInsets pad the sheet
     // keeps its full height, so the lower rows and the add button sit behind
     // the keyboard with no scroll extent left to bring them up (issue #1094).
+    // Not redundant with useSafeArea: that inserts SafeArea(bottom: false),
+    // so the sheet deliberately runs to the bottom edge of the screen. This
+    // one supplies the bottom inset the outer one skips, keeping the last
+    // control clear of the home indicator. Nothing is applied twice -- a
+    // SafeArea strips the padding it consumes out of the MediaQuery, so the
+    // horizontal insets are already zero by the time this one reads them.
     builder: (sheetContext) => SafeArea(
       child: Padding(
         key: const ValueKey('terrainAppearanceSheetInsets'),

--- a/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
+++ b/lib/features/dive_3d/presentation/widgets/terrain_appearance_sheet.dart
@@ -14,7 +14,18 @@ void showTerrainAppearanceSheet(BuildContext context) {
   showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
+    // A scroll-controlled sheet grows to whatever its content asks for, and
+    // this content is taller than a phone. Left alone it reached y=0, putting
+    // the drag handle inside Android's notification-shade swipe zone -- so
+    // pulling the sheet down opened the system shade instead of closing it,
+    // and the sheet could not be dismissed at all (issue #1188). The safe
+    // area keeps it clear of the status bar; the height cap leaves a strip of
+    // scrim above it so tapping outside stays an obvious way out.
+    useSafeArea: true,
     showDragHandle: true,
+    constraints: BoxConstraints(
+      maxHeight: MediaQuery.of(context).size.height * _maxHeightFraction,
+    ),
     // The custom-level rows open a keypad. Without a viewInsets pad the sheet
     // keeps its full height, so the lower rows and the add button sit behind
     // the keyboard with no scroll extent left to bring them up (issue #1094).
@@ -24,10 +35,54 @@ void showTerrainAppearanceSheet(BuildContext context) {
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(sheetContext).viewInsets.bottom,
         ),
-        child: const SingleChildScrollView(child: TerrainAppearanceSheet()),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _SheetHeader(onClose: () => Navigator.of(sheetContext).pop()),
+            // Loose fit: the sheet still hugs short content, but a body
+            // taller than the cap scrolls under the pinned header instead of
+            // pushing it (and the close action) off the screen.
+            const Flexible(
+              child: SingleChildScrollView(child: TerrainAppearanceSheet()),
+            ),
+          ],
+        ),
       ),
     ),
   );
+}
+
+/// Share of the screen the sheet may occupy at most.
+const double _maxHeightFraction = 0.85;
+
+/// Title plus an explicit way out. The drag handle alone is not enough on
+/// Android, where a downward drag near the top edge belongs to the system.
+class _SheetHeader extends StatelessWidget {
+  final VoidCallback onClose;
+
+  const _SheetHeader({required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 8, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              context.l10n.dive3d_seascape_appearance,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          TextButton(
+            key: const ValueKey('terrainAppearanceCloseButton'),
+            onPressed: onClose,
+            child: Text(context.l10n.common_action_close),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 /// Issue #1065 knobs: ramp depth range, banded gradient, contour mode with
@@ -82,11 +137,6 @@ class TerrainAppearanceSheet extends ConsumerWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            l10n.dive3d_seascape_appearance,
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          _controlGap,
           Text(l10n.dive3d_seascape_appearance_surface),
           _labelGap,
           SegmentedButton<SeascapeSurfaceMode>(

--- a/lib/features/site_scape/presentation/site_terrain_pane.dart
+++ b/lib/features/site_scape/presentation/site_terrain_pane.dart
@@ -201,11 +201,14 @@ class _SiteTerrainPaneState extends ConsumerState<SiteTerrainPane> {
                       child: _sourceChip(sourceId, resolutionMeters),
                     ),
                     // The legend describes the depth ramp; a photographed
-                    // surface has no ramp to explain.
+                    // surface has no ramp to explain. It sits LEFT because the
+                    // viewport's zoom column owns the right edge, and on a
+                    // phone-sized pane a right-hand legend covers the +/-
+                    // buttons outright (issue #1188).
                     if (appearance.surfaceMode != SeascapeSurfaceMode.imagery)
                       Positioned(
                         top: 96,
-                        right: 8,
+                        left: 8,
                         child: SeascapeDepthLegend(
                           maxDepthMeters: axisInputs.maxDepth,
                           hasLand: grid.depthsMeters.any(

--- a/test/features/dive_3d/presentation/widgets/dive_3d_interactive_viewport_test.dart
+++ b/test/features/dive_3d/presentation/widgets/dive_3d_interactive_viewport_test.dart
@@ -267,6 +267,79 @@ void main() {
     expect(scenePainterOf(tester).zoom, 1.0);
   });
 
+  // Issue #1188: on a touchscreen there are no pan/zoom pointers at all, so
+  // the trackpad path below can never fire. Two fingers must pinch-zoom and
+  // pan, while one finger keeps orbiting.
+  testWidgets('two-finger pinch zooms about the focal point', (tester) async {
+    await pumpViewport(tester, scene: buildScene());
+    expect(scenePainterOf(tester).zoom, 1.0);
+    final before = scenePainterOf(tester);
+    final center = tester.getCenter(find.byType(Dive3dInteractiveViewport));
+
+    final f1 = await tester.startGesture(center - const Offset(20, 0));
+    final f2 = await tester.startGesture(center + const Offset(20, 0));
+    await tester.pump();
+    for (var i = 0; i < 4; i++) {
+      await f1.moveBy(const Offset(-15, 0));
+      await f2.moveBy(const Offset(15, 0));
+      await tester.pump();
+    }
+
+    final after = scenePainterOf(tester);
+    expect(after.zoom, greaterThan(1.0));
+    // A pinch must not double as a rotation.
+    expect(after.yawDegrees, before.yawDegrees);
+    expect(after.pitchDegrees, before.pitchDegrees);
+
+    await f1.up();
+    await f2.up();
+    // Let the double-tap recognizer's countdown expire before teardown.
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
+  testWidgets('two fingers moving together pan without rotating', (
+    tester,
+  ) async {
+    await pumpViewport(tester, scene: buildScene());
+    Offset panOffset() {
+      final t = tester
+          .widget<Transform>(find.byKey(const ValueKey('dive3dViewportPan')))
+          .transform
+          .getTranslation();
+      return Offset(t.x, t.y);
+    }
+
+    final before = scenePainterOf(tester);
+    final center = tester.getCenter(find.byType(Dive3dInteractiveViewport));
+    final f1 = await tester.startGesture(center - const Offset(20, 0));
+    final f2 = await tester.startGesture(center + const Offset(20, 0));
+    await tester.pump();
+    for (var i = 0; i < 3; i++) {
+      await f1.moveBy(const Offset(10, 6));
+      await f2.moveBy(const Offset(10, 6));
+      await tester.pump();
+    }
+
+    expect(panOffset().dx, greaterThan(0));
+    expect(panOffset().dy, greaterThan(0));
+    final after = scenePainterOf(tester);
+    expect(after.yawDegrees, before.yawDegrees);
+    expect(after.pitchDegrees, before.pitchDegrees);
+    expect(after.zoom, closeTo(1.0, 0.05));
+
+    await f1.up();
+    await f2.up();
+    // Let the double-tap recognizer's countdown expire before teardown.
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
+  testWidgets('zoom controls carry a stable key for host layout checks', (
+    tester,
+  ) async {
+    await pumpViewport(tester, scene: buildScene());
+    expect(find.byKey(const ValueKey('dive3dZoomControls')), findsOneWidget);
+  });
+
   testWidgets('trackpad pan translates the view and pinch zooms', (
     tester,
   ) async {

--- a/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
+++ b/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
@@ -114,6 +114,48 @@ void main() {
     return container;
   }
 
+  // Issue #1188: the scroll-controlled sheet grew until it touched the top
+  // edge of the screen. Its drag handle then sat inside Android's
+  // notification-shade swipe zone, and with no close action the sheet became
+  // impossible to dismiss.
+  testWidgets('the sheet stops short of the top edge on a phone', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 560));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await pumpSheetRoute(tester);
+    final sheet = tester.getRect(find.byType(BottomSheet));
+    expect(sheet.top, greaterThan(0));
+  });
+
+  testWidgets('the Close action dismisses the sheet', (tester) async {
+    await pumpSheetRoute(tester);
+    expect(find.byType(TerrainAppearanceSheet), findsOneWidget);
+    await tester.tap(
+      find.byKey(const ValueKey('terrainAppearanceCloseButton')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(TerrainAppearanceSheet), findsNothing);
+  });
+
+  testWidgets('the Close action stays reachable when the body scrolls', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 560));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await pumpSheetRoute(tester);
+    final closeButton = find.byKey(
+      const ValueKey('terrainAppearanceCloseButton'),
+    );
+    final before = tester.getRect(closeButton);
+    await tester.drag(
+      find.byKey(const ValueKey('seascapeBandedSwitch')),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getRect(closeButton), before);
+  });
+
   testWidgets('banded switch writes through to settings', (tester) async {
     final container = await pumpSheet(tester);
     expect(

--- a/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
+++ b/test/features/dive_3d/presentation/widgets/terrain_appearance_sheet_test.dart
@@ -81,6 +81,7 @@ void main() {
   Future<ProviderContainer> pumpSheetRoute(
     WidgetTester tester, {
     AppSettings initial = const AppSettings(),
+    EdgeInsets systemPadding = EdgeInsets.zero,
   }) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
@@ -98,6 +99,12 @@ void main() {
           locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          // MaterialApp.builder wraps the Navigator, so padding stated here is
+          // what the modal route's own SafeArea sees.
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(padding: systemPadding),
+            child: child!,
+          ),
           home: Scaffold(
             body: Builder(
               builder: (context) => TextButton(
@@ -154,6 +161,34 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(tester.getRect(closeButton), before);
+  });
+
+  // `useSafeArea: true` inserts `SafeArea(bottom: false)`, so it covers top,
+  // left and right and deliberately lets the sheet run to the bottom edge --
+  // the SDK doc says so outright. The SafeArea in the builder is what applies
+  // the bottom inset, and it is not a double application: SafeArea strips the
+  // padding it consumes out of the MediaQuery, so each inset lands once.
+  testWidgets('every system inset is applied exactly once', (tester) async {
+    const insets = EdgeInsets.only(top: 44, left: 30, right: 30, bottom: 34);
+    await tester.binding.setSurfaceSize(const Size(400, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await pumpSheetRoute(tester, systemPadding: insets);
+
+    final screen = tester.getRect(find.byType(MaterialApp));
+    final sheet = tester.getRect(find.byType(BottomSheet));
+    final body = tester.getRect(
+      find.byKey(const ValueKey('terrainAppearanceSheetInsets')),
+    );
+
+    // Outer SafeArea: horizontal insets once, and no bottom inset at all.
+    expect(sheet.left, insets.left);
+    expect(sheet.right, screen.right - insets.right);
+    expect(sheet.bottom, screen.bottom);
+    // Inner SafeArea: the bottom inset the outer one skipped, and nothing
+    // horizontal on top of what the outer one already applied.
+    expect(body.bottom, screen.bottom - insets.bottom);
+    expect(body.left, sheet.left);
+    expect(body.right, sheet.right);
   });
 
   testWidgets('banded switch writes through to settings', (tester) async {

--- a/test/features/site_scape/presentation/site_terrain_pane_test.dart
+++ b/test/features/site_scape/presentation/site_terrain_pane_test.dart
@@ -182,6 +182,30 @@ void main() {
     );
   });
 
+  // Issue #1188: on a phone-sized pane the legend and the viewport's zoom
+  // column both hugged the right edge, and the legend covered the +/-
+  // buttons outright.
+  testWidgets('the legend never overlaps the zoom controls', (tester) async {
+    for (final surface in const [Size(360, 640), Size(360, 380)]) {
+      await tester.binding.setSurfaceSize(surface);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(page(readyState()));
+      await tester.pump();
+      await tester.pump();
+      final legend = tester.getRect(
+        find.byKey(const ValueKey('seascapeDepthLegend')),
+      );
+      final zoom = tester.getRect(
+        find.byKey(const ValueKey('dive3dZoomControls')),
+      );
+      expect(
+        legend.overlaps(zoom),
+        isFalse,
+        reason: 'legend $legend overlaps zoom controls $zoom at $surface',
+      );
+    }
+  });
+
   testWidgets('imagery reaches the viewport and shows attribution', (
     tester,
   ) async {


### PR DESCRIPTION
Fixes #1188.

Three separate defects reported together against the dive site 3D map on Android 1.7.5.6566.

## 1. Zooming was impossible on a touchscreen

`Dive3dInteractiveViewport` had two zoom paths and neither one could reach a touch device:

- a `PanGestureRecognizer` that only ever orbited the camera, and
- a `Listener` on `onPointerPanZoom*`, which only fires for `PointerDeviceKind.trackpad`.

A touchscreen emits neither, so the `+` / `-` buttons were the only zoom affordance in the app.

One `ScaleGestureRecognizer` now serves both touch gestures, branching on `details.pointerCount`: one finger rotates and tilts, two fingers pinch-zoom and pan. That is the mapping the reporter asked for, and it is the conventional one. A single recognizer is required here because a pan and a scale recognizer in the same arena starve each other.

The pinch is anchored to its focal point. `SceneProjector` scales about the canvas center and the pan `Transform` is applied on top, so a projected point lands at `center + zoom * v + pan`; solving that for the pan which pins one point across a zoom step yields a single expression that degenerates to `_pan += focalDelta` when the zoom does not change, so pinch and two-finger drag share one code path.

**Trap worth knowing:** `supportedDevices` gates `isPointerAllowed`, which sees pointer-*down* events only. `GestureRecognizer.isPointerPanZoomAllowed` returns `true` unconditionally, so excluding `PointerDeviceKind.trackpad` from `supportedDevices` did nothing for trackpad gestures and every trackpad pan was applied twice. The pre-existing trackpad test caught it (`Offset(80, 40)` where `Offset(40, 20)` was expected). `_TouchScaleGestureRecognizer` overrides that predicate to `false` so the `Listener` remains the single trackpad path.

## 2. The legend covered the +/- buttons

`SeascapeDepthLegend` sat at `Positioned(top: 96, right: 8)` while the viewport's zoom column sat at `Positioned(top: 0, bottom: 0, right: 8, child: Center(...))`. Both hugged the right edge, and on a plain 360x640 phone they intersected: legend `272..352 x 96..208`, zoom column `312.. x 154..`.

The legend moves to the left edge in both seascape hosts (`SiteTerrainPane` and `SpatialSitePage`). Left is free there: the source chip and captions are top-anchored single-line rows, and the chart-mode axis chrome anchors at the SW corner.

## 3. The terrain appearance sheet could not be closed

`showTerrainAppearanceSheet` passed `isScrollControlled: true` with no `useSafeArea` and no `constraints`. That removes the sheet's height ceiling entirely rather than making it scroll, and this content is taller than a phone, so the sheet expanded to `y = 0`. Its drag handle then sat inside Android's notification-shade swipe zone, so pulling down opened the system shade instead of closing the sheet, and there was no other dismissal affordance.

The fix:

- `useSafeArea: true`, so the sheet cannot run under the status bar;
- `maxHeight` capped at 85% of the screen, so a strip of scrim is always tappable;
- a pinned header carrying the title and a **Close** button, in the house `Column(mainAxisSize: min) -> [header, Flexible(scrollView)]` shape used by the filter sheets. `Flexible`'s loose fit lets the sheet still hug short content, while a body taller than the cap scrolls under the header instead of pushing the close action off screen.

The `viewInsets.bottom` keyboard padding from #1094 wraps the whole column and is unchanged, so the custom-level keypad behaviour is preserved.

## Tests

Nine new tests:

- two-finger pinch zooms and does not rotate;
- two fingers moving together pan and do not rotate or zoom;
- the zoom controls carry a stable key;
- the legend rect never overlaps the zoom-control rect, checked at a tall and a short pane height;
- the sheet stops short of the top edge on a 360x560 phone;
- the Close action dismisses the sheet;
- the Close action stays in place when the body scrolls.

Full suite: 20094 passed, 19 skipped, 0 failed. `flutter analyze` clean.

## Not verified

Multi-touch is simulated through the gesture arena in widget tests, not exercised on physical Android hardware. The real feel of the pinch is unconfirmed.
