### PR TITLE
fix(dc-import): scan for a saved computer's address before connecting

### DIFF
--- a/lib/features/dive_computer/presentation/providers/discovery_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/discovery_providers.dart
@@ -310,6 +310,15 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
     );
   }
 
+  /// Drop the selected device without touching the rest of the state.
+  ///
+  /// Used when a selection left over from an earlier discovery session must
+  /// not be reused, e.g. it does not carry the address of the saved computer
+  /// about to be downloaded from.
+  void clearSelectedDevice() {
+    state = state.copyWith(clearDevice: true);
+  }
+
   /// Set a custom name for the device.
   void setCustomName(String name) {
     state = state.copyWith(customDeviceName: name);

--- a/lib/features/dive_computer/presentation/providers/discovery_providers.dart
+++ b/lib/features/dive_computer/presentation/providers/discovery_providers.dart
@@ -251,6 +251,57 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
     state = state.copyWith(isScanning: false);
   }
 
+  /// Scans until a device advertising [address] is seen, then stops.
+  ///
+  /// Resolves with the freshly discovered device, or with null when the scan
+  /// could not start, native discovery ended, or [timeout] elapsed without
+  /// seeing the address. The scan is stopped on every path.
+  ///
+  /// The saved-computer download path uses this to re-acquire the device
+  /// before connecting. A direct connect to a stored address that the
+  /// Bluetooth stack has not seen advertise recently fails on Android and
+  /// Windows, while the very same address connects fine right after a scan
+  /// (issue #1232). macOS and iOS re-scan natively before connecting; this
+  /// gives the other platforms the same behaviour.
+  Future<DiscoveredDevice?> scanForAddress(
+    String address, {
+    required Duration timeout,
+  }) async {
+    final completer = Completer<DiscoveredDevice?>();
+
+    void check(DiscoveryState current) {
+      if (completer.isCompleted) return;
+      final match = current.discoveredDevices
+          .where((d) => bluetoothAddressesMatch(d.address, address))
+          .firstOrNull;
+      if (match != null) {
+        completer.complete(match);
+      } else if (!current.isScanning) {
+        completer.complete(null);
+      }
+    }
+
+    // startScan settles isScanning before returning: true once discovery is
+    // running, false (with an error message) when it could not start.
+    await startScan();
+    final subscription = stream.listen(check);
+    check(state);
+    final timer = Timer(timeout, () {
+      if (!completer.isCompleted) completer.complete(null);
+    });
+
+    try {
+      return await completer.future;
+    } finally {
+      timer.cancel();
+      // Not awaited: a broadcast subscription's cancel() resolves to the
+      // root-zone null future, which a fake-async widget test can never
+      // flush. Cancellation itself is synchronous.
+      unawaited(subscription.cancel());
+      await stopScan();
+    }
+  }
+
   /// Select a device and move to the next step.
   void selectDevice(DiscoveredDevice device) {
     state = state.copyWith(
@@ -309,6 +360,13 @@ class DiscoveryNotifier extends StateNotifier<DiscoveryState> {
     super.dispose();
   }
 }
+
+/// Whether two transport addresses name the same device.
+///
+/// Android reports colon-separated MACs and Windows colon-free hex; both are
+/// stable per platform, so only letter case is normalized.
+bool bluetoothAddressesMatch(String a, String b) =>
+    a.toUpperCase() == b.toUpperCase();
 
 /// Provider for the discovery notifier.
 final discoveryNotifierProvider =

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -321,11 +321,20 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
   Future<void> _reacquireKnownDevice(DiveComputer computer) async {
     if (!mounted) return;
     final address = computer.bluetoothAddress;
+    final notifier = ref.read(discoveryNotifierProvider.notifier);
     final selected = ref.read(discoveryNotifierProvider).selectedDevice;
     final alreadyAcquired =
         selected != null &&
         address != null &&
         bluetoothAddressesMatch(selected.address, address);
+    // A saved computer downloads only from a device carrying its stored
+    // address. A selection left over from an earlier discovery session is
+    // dropped from the provider itself, because the completion path reads
+    // the provider's selection to capture the descriptor the import
+    // service records; hiding it locally here would not be enough.
+    if (selected != null && !alreadyAcquired) {
+      notifier.clearSelectedDevice();
+    }
     final isBluetooth =
         _connectionTypeFromString(computer.connectionType) ==
         DeviceConnectionType.ble;
@@ -336,7 +345,6 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
     }
 
     setState(() => _searchingForKnownDevice = true);
-    final notifier = ref.read(discoveryNotifierProvider.notifier);
     final device = await notifier.scanForAddress(
       address,
       timeout: DcAdapterDownloadStep.knownDeviceScanTimeout,
@@ -388,16 +396,6 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
     final discoveryState = ref.watch(discoveryNotifierProvider);
     var device = discoveryState.selectedDevice;
     final computer = widget.knownComputer ?? widget.adapter.computer;
-
-    // A saved computer downloads only from a device carrying its stored
-    // address: a device left selected by an earlier discovery session must
-    // not be used in its place.
-    final storedAddress = widget.knownComputer?.bluetoothAddress;
-    if (device != null &&
-        storedAddress != null &&
-        !bluetoothAddressesMatch(device.address, storedAddress)) {
-      device = null;
-    }
 
     // For known-computer downloads, synthesize a DiscoveredDevice from the
     // computer's stored connection info when discovery state has no device.

--- a/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
+++ b/lib/features/import_wizard/presentation/widgets/dc_adapter_steps.dart
@@ -278,6 +278,11 @@ class DcAdapterDownloadStep extends ConsumerStatefulWidget {
   final DiveComputerAdapter adapter;
   final DiveComputer? knownComputer;
 
+  /// How long a saved-computer download scans for the computer's stored
+  /// address before falling back to a direct connect with that address.
+  /// Matches the first resolve attempt of the macOS/iOS native resolver.
+  static const knownDeviceScanTimeout = Duration(seconds: 15);
+
   @override
   ConsumerState<DcAdapterDownloadStep> createState() =>
       _DcAdapterDownloadStepState();
@@ -286,19 +291,62 @@ class DcAdapterDownloadStep extends ConsumerStatefulWidget {
 class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
   bool _captured = false;
   bool _computerResolved = false;
+  bool _searchingForKnownDevice = false;
   bool _noDives = false;
 
   @override
   void initState() {
     super.initState();
-    // In discovery mode, check if the device matches a known computer
-    // BEFORE the download starts. If found, the computer's fingerprint
-    // enables incremental download (only new dives).
-    if (widget.knownComputer != null) {
-      _computerResolved = true;
-    } else {
+    final computer = widget.knownComputer;
+    if (computer == null) {
+      // In discovery mode, check if the device matches a known computer
+      // BEFORE the download starts. If found, the computer's fingerprint
+      // enables incremental download (only new dives).
       WidgetsBinding.instance.addPostFrameCallback((_) => _resolveComputer());
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _reacquireKnownDevice(computer),
+      );
     }
+  }
+
+  /// Re-acquires a saved Bluetooth computer by scanning for its stored
+  /// address before the download connects (issue #1232).
+  ///
+  /// Connecting straight to a stored address fails on Android and Windows
+  /// unless the stack has recently seen the device advertise, which is why
+  /// the scan-and-download flow worked for the same computer while the
+  /// saved entry did not. If the scan does not see the address, the step
+  /// falls back to the stored address exactly as before.
+  Future<void> _reacquireKnownDevice(DiveComputer computer) async {
+    if (!mounted) return;
+    final address = computer.bluetoothAddress;
+    final selected = ref.read(discoveryNotifierProvider).selectedDevice;
+    final alreadyAcquired =
+        selected != null &&
+        address != null &&
+        bluetoothAddressesMatch(selected.address, address);
+    final isBluetooth =
+        _connectionTypeFromString(computer.connectionType) ==
+        DeviceConnectionType.ble;
+
+    if (address == null || !isBluetooth || alreadyAcquired) {
+      setState(() => _computerResolved = true);
+      return;
+    }
+
+    setState(() => _searchingForKnownDevice = true);
+    final notifier = ref.read(discoveryNotifierProvider.notifier);
+    final device = await notifier.scanForAddress(
+      address,
+      timeout: DcAdapterDownloadStep.knownDeviceScanTimeout,
+    );
+    if (device != null) notifier.selectDevice(device);
+    if (!mounted) return;
+    setState(() {
+      _searchingForKnownDevice = false;
+      _computerResolved = true;
+    });
   }
 
   Future<void> _resolveComputer() async {
@@ -330,12 +378,26 @@ class _DcAdapterDownloadStepState extends ConsumerState<DcAdapterDownloadStep> {
     // Wait for computer resolution before creating the download widget.
     // This ensures the fingerprint is available for incremental download.
     if (!_computerResolved) {
+      final knownComputer = widget.knownComputer;
+      if (_searchingForKnownDevice && knownComputer != null) {
+        return _KnownDeviceSearchView(computer: knownComputer);
+      }
       return const Center(child: CircularProgressIndicator());
     }
 
     final discoveryState = ref.watch(discoveryNotifierProvider);
     var device = discoveryState.selectedDevice;
     final computer = widget.knownComputer ?? widget.adapter.computer;
+
+    // A saved computer downloads only from a device carrying its stored
+    // address: a device left selected by an earlier discovery session must
+    // not be used in its place.
+    final storedAddress = widget.knownComputer?.bluetoothAddress;
+    if (device != null &&
+        storedAddress != null &&
+        !bluetoothAddressesMatch(device.address, storedAddress)) {
+      device = null;
+    }
 
     // For known-computer downloads, synthesize a DiscoveredDevice from the
     // computer's stored connection info when discovery state has no device.
@@ -480,6 +542,33 @@ DeviceConnectionType _connectionTypeFromString(String? type) {
       return DeviceConnectionType.infrared;
     default:
       return DeviceConnectionType.ble;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Searching for a saved computer
+// ---------------------------------------------------------------------------
+
+class _KnownDeviceSearchView extends StatelessWidget {
+  const _KnownDeviceSearchView({required this.computer});
+
+  final DiveComputer computer;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text(
+            l10n.diveComputer_download_searchingForDevice(computer.displayName),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/test/features/dive_computer/presentation/providers/discovery_scan_for_address_test.dart
+++ b/test/features/dive_computer/presentation/providers/discovery_scan_for_address_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
+
+/// Host API stub that records discovery calls without touching a platform
+/// channel.
+class _FakeHostApi extends pigeon.DiveComputerHostApi {
+  int startDiscoveryCalls = 0;
+  int stopDiscoveryCalls = 0;
+  Object? startDiscoveryError;
+
+  @override
+  Future<void> startDiscovery(pigeon.TransportType transport) async {
+    startDiscoveryCalls++;
+    final error = startDiscoveryError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<void> stopDiscovery() async {
+    stopDiscoveryCalls++;
+  }
+}
+
+const _savedAddress = 'E8:F8:BE:96:61:57';
+
+pigeon.DiscoveredDevice _advert(String address) => pigeon.DiscoveredDevice(
+  vendor: 'Shearwater',
+  product: 'Petrel 3',
+  model: 10,
+  address: address,
+  name: 'Petrel 3',
+  transport: pigeon.TransportType.ble,
+);
+
+void main() {
+  // Issue #1232: a download started from a saved computer connected straight
+  // to the stored address with no scan, which fails on Android and Windows
+  // when the stack has not seen the device advertise recently. This is the
+  // scan-then-resolve primitive the saved-computer path uses to re-acquire
+  // the device first.
+  group('DiscoveryNotifier.scanForAddress', () {
+    late _FakeHostApi hostApi;
+    late pigeon.DiveComputerService service;
+    late DiscoveryNotifier notifier;
+
+    setUp(() {
+      hostApi = _FakeHostApi();
+      service = pigeon.DiveComputerService(hostApi: hostApi);
+      notifier = DiscoveryNotifier(
+        service: service,
+        requiresRuntimePermissions: false,
+      );
+    });
+
+    tearDown(() {
+      notifier.dispose();
+    });
+
+    test(
+      'resolves the device advertising the saved address and stops the scan',
+      () async {
+        final pending = notifier.scanForAddress(
+          _savedAddress,
+          timeout: const Duration(seconds: 5),
+        );
+        await pumpEventQueue();
+        expect(hostApi.startDiscoveryCalls, 1);
+
+        service.onDeviceDiscovered(_advert('11:22:33:44:55:66'));
+        service.onDeviceDiscovered(_advert(_savedAddress));
+
+        final device = await pending;
+        expect(device, isNotNull);
+        expect(device!.address, _savedAddress);
+        expect(device.recognizedModel?.manufacturer, 'Shearwater');
+        expect(device.recognizedModel?.model, 'Petrel 3');
+        expect(hostApi.stopDiscoveryCalls, 1);
+        expect(notifier.state.isScanning, isFalse);
+      },
+    );
+
+    test('matches the saved address regardless of letter case', () async {
+      final pending = notifier.scanForAddress(
+        _savedAddress.toLowerCase(),
+        timeout: const Duration(seconds: 5),
+      );
+      await pumpEventQueue();
+
+      service.onDeviceDiscovered(_advert(_savedAddress));
+
+      final device = await pending;
+      expect(device?.address, _savedAddress);
+    });
+
+    test('returns null and stops the scan when the address is not seen '
+        'before the timeout', () async {
+      final pending = notifier.scanForAddress(
+        _savedAddress,
+        timeout: const Duration(milliseconds: 50),
+      );
+      await pumpEventQueue();
+      service.onDeviceDiscovered(_advert('11:22:33:44:55:66'));
+
+      final device = await pending;
+      expect(device, isNull);
+      expect(hostApi.stopDiscoveryCalls, 1);
+      expect(notifier.state.isScanning, isFalse);
+    });
+
+    test('returns null without waiting when the scan cannot start', () async {
+      hostApi.startDiscoveryError = StateError('adapter unavailable');
+
+      // A generous timeout: the call must give up on the start failure,
+      // not sit out the timeout.
+      final device = await notifier
+          .scanForAddress(_savedAddress, timeout: const Duration(minutes: 5))
+          .timeout(const Duration(seconds: 2));
+
+      expect(device, isNull);
+      expect(notifier.state.errorMessage, isNotNull);
+    });
+
+    test(
+      'returns null when native discovery completes without the device',
+      () async {
+        final pending = notifier
+            .scanForAddress(_savedAddress, timeout: const Duration(minutes: 5))
+            .timeout(const Duration(seconds: 2));
+        await pumpEventQueue();
+
+        service.onDiscoveryComplete();
+
+        expect(await pending, isNull);
+      },
+    );
+  });
+}

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_cutoff_race_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_cutoff_race_test.dart
@@ -95,10 +95,19 @@ void main() {
     // for a selected device) constructs a DiscoveryNotifier that subscribes
     // to this stream immediately.
     when(mockService.discoveryComplete).thenAnswer((_) => const Stream.empty());
+    // The step scans for the computer's stored address before connecting
+    // (issue #1232). Nothing is ever reported, so each test advances past
+    // the scan timeout to reach the synthesized-device fallback.
+    when(mockService.discoveredDevices).thenAnswer((_) => const Stream.empty());
+    when(mockService.startDiscovery(any)).thenAnswer((_) async {});
+    when(mockService.stopDiscovery()).thenAnswer((_) async {});
     when(
       mockService.startDownload(any, fingerprint: anyNamed('fingerprint')),
     ).thenAnswer((_) async {});
   });
+
+  final pastScanTimeout =
+      DcAdapterDownloadStep.knownDeviceScanTimeout + const Duration(seconds: 1);
 
   testWidgets(
     'late-arriving cutoff default does not crash and shows the prompt '
@@ -117,8 +126,11 @@ void main() {
           cutoffCompleter: cutoffCompleter,
         ),
       );
-      // Let _computerResolved and deviceDescriptorsProvider settle. The
-      // cutoff provider is still in-flight at this point.
+      // Let the saved-address scan time out, then _computerResolved and
+      // deviceDescriptorsProvider settle. The cutoff provider is still
+      // in-flight at this point.
+      await tester.pump();
+      await tester.pump(pastScanTimeout);
       await tester.pump();
       await tester.pump();
 
@@ -162,6 +174,8 @@ void main() {
         cutoffCompleter: cutoffCompleter,
       ),
     );
+    await tester.pump();
+    await tester.pump(pastScanTimeout);
     await tester.pump();
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_force_full_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_force_full_test.dart
@@ -65,6 +65,9 @@ Widget _buildDownloadStep({
 // reset-then-apply-then-start ordering is verified in
 // `test/features/dive_computer/presentation/widgets/download_step_widget_force_full_test.dart`.
 
+final _pastScanTimeout =
+    DcAdapterDownloadStep.knownDeviceScanTimeout + const Duration(seconds: 1);
+
 void main() {
   testWidgets(
     'adapter forceFullDownload=true propagates to DownloadStepWidget',
@@ -87,6 +90,11 @@ void main() {
           knownComputer: computer,
         ),
       );
+      // The step first scans for the computer's stored address (issue
+      // #1232); the fake service never reports a device, so advance past
+      // the scan timeout to reach the synthesized-device fallback.
+      await tester.pump();
+      await tester.pump(_pastScanTimeout);
       // Only one async gate applies here: deviceDescriptorsProvider
       // (synthesizing a device from the known computer). With
       // forceFullDownload=true, `promptCouldApply` in DcAdapterDownloadStep
@@ -123,6 +131,9 @@ void main() {
           knownComputer: computer,
         ),
       );
+      // Advance past the saved-address scan (see the first test).
+      await tester.pump();
+      await tester.pump(_pastScanTimeout);
       // Two async gates settle in sequence before DownloadStepWidget is
       // constructed: deviceDescriptorsProvider (synthesizing a device from
       // the known computer), then firstSyncCutoffDefaultProvider (only

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_reacquire_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_reacquire_test.dart
@@ -139,6 +139,7 @@ class _Harness {
         firstSyncCutoffDefaultProvider.overrideWith((ref) async => null),
       ],
       child: MaterialApp(
+        locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -161,6 +162,12 @@ Future<void> _settle(WidgetTester tester) async {
     await tester.pump();
   }
 }
+
+/// The device currently selected in the discovery provider the step reads.
+DiscoveredDevice? _selectedDevice(WidgetTester tester) =>
+    ProviderScope.containerOf(
+      tester.element(find.byType(DcAdapterDownloadStep)),
+    ).read(discoveryNotifierProvider).selectedDevice;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -252,11 +259,40 @@ void main() {
 
         expect(h.hostApi.calls, ['startDiscovery']);
         expect(find.byType(DownloadStepWidget), findsNothing);
+        // The stale selection is dropped from the provider itself, not just
+        // ignored here: the completion path reads the provider's selection
+        // to capture the descriptor the import service records.
+        expect(_selectedDevice(tester), isNull);
 
         h.service.onDeviceDiscovered(_advert(_savedAddress));
         await _settle(tester);
 
         expect(h.hostApi.downloads.single.address, _savedAddress);
+        expect(_selectedDevice(tester)?.address, _savedAddress);
+      },
+    );
+
+    testWidgets(
+      'drops a stale Bluetooth selection for a USB computer without scanning',
+      (tester) async {
+        final h = _Harness(
+          seed: DiscoveryState(
+            selectedDevice: _discovered('11:22:33:44:55:66'),
+          ),
+        );
+        await tester.pumpWidget(
+          h.build(
+            _savedComputer(
+              connectionType: 'usb',
+              bluetoothAddress: '/dev/ttyUSB0',
+            ),
+          ),
+        );
+        await _settle(tester);
+
+        expect(h.hostApi.calls, ['startDownload']);
+        expect(h.hostApi.downloads.single.address, '/dev/ttyUSB0');
+        expect(_selectedDevice(tester), isNull);
       },
     );
 

--- a/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_reacquire_test.dart
+++ b/test/features/import_wizard/presentation/widgets/dc_adapter_download_step_reacquire_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/features/dive_computer/domain/entities/device_model.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/discovery_providers.dart';
+import 'package:submersion/features/dive_computer/presentation/providers/download_providers.dart';
+import 'package:submersion/features/dive_computer/presentation/widgets/download_step_widget.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/import_wizard/data/adapters/dive_computer_adapter.dart';
+import 'package:submersion/features/import_wizard/presentation/widgets/dc_adapter_steps.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/fake_import_adapter_deps.dart';
+
+// ---------------------------------------------------------------------------
+// Fake host API: records the order of native calls and what startDownload
+// received, without touching a platform channel.
+// ---------------------------------------------------------------------------
+
+class _RecordingHostApi extends pigeon.DiveComputerHostApi {
+  final List<String> calls = [];
+  final List<pigeon.DiscoveredDevice> downloads = [];
+
+  @override
+  Future<void> startDiscovery(pigeon.TransportType transport) async {
+    calls.add('startDiscovery');
+  }
+
+  @override
+  Future<void> stopDiscovery() async {
+    calls.add('stopDiscovery');
+  }
+
+  @override
+  Future<void> startDownload(
+    pigeon.DiscoveredDevice device,
+    String? fingerprint,
+  ) async {
+    calls.add('startDownload');
+    downloads.add(device);
+  }
+
+  @override
+  Future<List<pigeon.DeviceDescriptor>> getDeviceDescriptors() async => [];
+
+  @override
+  Future<String> getLibdivecomputerVersion() async => '0.0.0';
+}
+
+/// Discovery notifier whose initial state is chosen by the test.
+class _SeededDiscoveryNotifier extends DiscoveryNotifier {
+  _SeededDiscoveryNotifier({
+    required super.service,
+    required DiscoveryState seed,
+  }) : super(requiresRuntimePermissions: false) {
+    state = seed;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const _savedAddress = 'E8:F8:BE:96:61:57';
+
+DiveComputer _savedComputer({
+  String connectionType = 'bluetooth',
+  String bluetoothAddress = _savedAddress,
+}) {
+  final now = DateTime(2026, 8, 23);
+  return DiveComputer(
+    id: 'dc-1',
+    diverId: 'diver-1',
+    name: 'My Petrel',
+    manufacturer: 'Shearwater',
+    model: 'Petrel 3',
+    connectionType: connectionType,
+    bluetoothAddress: bluetoothAddress,
+    lastDiveFingerprint: 'abc',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+pigeon.DiscoveredDevice _advert(String address) => pigeon.DiscoveredDevice(
+  vendor: 'Shearwater',
+  product: 'Petrel 3',
+  model: 10,
+  address: address,
+  name: 'Petrel 3',
+  transport: pigeon.TransportType.ble,
+);
+
+DiscoveredDevice _discovered(String address) => DiscoveredDevice(
+  id: 'seeded',
+  name: 'Petrel 3',
+  connectionType: DeviceConnectionType.ble,
+  address: address,
+  recognizedModel: const DeviceModel(
+    id: 'shearwater_petrel3',
+    manufacturer: 'Shearwater',
+    model: 'Petrel 3',
+    connectionTypes: [DeviceConnectionType.ble],
+    dcModel: 10,
+  ),
+  discoveredAt: DateTime(2026, 8, 23),
+);
+
+class _Harness {
+  _Harness({DiscoveryState seed = const DiscoveryState()})
+    : hostApi = _RecordingHostApi(),
+      _seed = seed {
+    service = pigeon.DiveComputerService(hostApi: hostApi);
+  }
+
+  final _RecordingHostApi hostApi;
+  final DiscoveryState _seed;
+  final FakeImportAdapterDeps deps = FakeImportAdapterDeps();
+  late final pigeon.DiveComputerService service;
+
+  Widget build(DiveComputer computer) {
+    final adapter = DiveComputerAdapter(
+      importService: deps.importService,
+      computerRepository: deps.computerRepo,
+      diveRepository: deps.diveRepo,
+      consolidationService: deps.consolidationService,
+      diverId: 'diver-1',
+      knownComputer: computer,
+    );
+    return ProviderScope(
+      overrides: [
+        diveComputerServiceProvider.overrideWithValue(service),
+        discoveryNotifierProvider.overrideWith(
+          (ref) => _SeededDiscoveryNotifier(service: service, seed: _seed),
+        ),
+        diveComputerRepositoryProvider.overrideWithValue(deps.computerRepo),
+        deviceDescriptorsProvider.overrideWith((ref) async => []),
+        firstSyncCutoffDefaultProvider.overrideWith((ref) async => null),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: DcAdapterDownloadStep(
+            adapter: adapter,
+            knownComputer: computer,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The step settles through several async gates (scan resolution, descriptor
+/// lookup, the download widget's post-frame auto-start); a handful of plain
+/// pumps covers them. pumpAndSettle cannot be used because the download
+/// widget shows an indeterminate progress indicator.
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 4; i++) {
+    await tester.pump();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // Issue #1232: tapping a saved Petrel 3 and downloading failed with
+  // connect_failed on Android and Windows, while the scan-and-download flow
+  // for the very same computer worked. The saved-computer path connected to
+  // the stored address without a preceding scan; it now re-acquires the
+  // device by scanning for that address first.
+  group('DcAdapterDownloadStep saved-computer re-acquisition', () {
+    testWidgets(
+      'scans for the saved address and downloads from the advertised device',
+      (tester) async {
+        final h = _Harness();
+        await tester.pumpWidget(h.build(_savedComputer()));
+        await tester.pump();
+
+        expect(h.hostApi.calls, ['startDiscovery']);
+        expect(find.text('Searching for My Petrel...'), findsOneWidget);
+        expect(find.byType(DownloadStepWidget), findsNothing);
+
+        h.service.onDeviceDiscovered(_advert('11:22:33:44:55:66'));
+        h.service.onDeviceDiscovered(_advert(_savedAddress));
+        await _settle(tester);
+
+        expect(h.hostApi.calls, [
+          'startDiscovery',
+          'stopDiscovery',
+          'startDownload',
+        ]);
+        final sent = h.hostApi.downloads.single;
+        expect(sent.address, _savedAddress);
+        // The freshly advertised device carries the descriptor the driver
+        // needs, which the synthesized fallback could only guess at.
+        expect(sent.vendor, 'Shearwater');
+        expect(sent.product, 'Petrel 3');
+        expect(sent.model, 10);
+      },
+    );
+
+    testWidgets(
+      'falls back to the stored address when the scan does not see the '
+      'device',
+      (tester) async {
+        final h = _Harness();
+        await tester.pumpWidget(h.build(_savedComputer()));
+        await tester.pump();
+        expect(h.hostApi.calls, ['startDiscovery']);
+
+        await tester.pump(
+          DcAdapterDownloadStep.knownDeviceScanTimeout +
+              const Duration(seconds: 1),
+        );
+        await _settle(tester);
+
+        expect(h.hostApi.calls, [
+          'startDiscovery',
+          'stopDiscovery',
+          'startDownload',
+        ]);
+        expect(h.hostApi.downloads.single.address, _savedAddress);
+      },
+    );
+
+    testWidgets('does not scan when discovery already holds the device for the '
+        'saved address', (tester) async {
+      final h = _Harness(
+        seed: DiscoveryState(selectedDevice: _discovered(_savedAddress)),
+      );
+      await tester.pumpWidget(h.build(_savedComputer()));
+      await _settle(tester);
+
+      expect(h.hostApi.calls, ['startDownload']);
+      expect(h.hostApi.downloads.single.address, _savedAddress);
+    });
+
+    testWidgets(
+      'ignores a previously selected device with a different address',
+      (tester) async {
+        final h = _Harness(
+          seed: DiscoveryState(
+            selectedDevice: _discovered('11:22:33:44:55:66'),
+          ),
+        );
+        await tester.pumpWidget(h.build(_savedComputer()));
+        await tester.pump();
+
+        expect(h.hostApi.calls, ['startDiscovery']);
+        expect(find.byType(DownloadStepWidget), findsNothing);
+
+        h.service.onDeviceDiscovered(_advert(_savedAddress));
+        await _settle(tester);
+
+        expect(h.hostApi.downloads.single.address, _savedAddress);
+      },
+    );
+
+    testWidgets('does not scan for a USB computer', (tester) async {
+      final h = _Harness();
+      await tester.pumpWidget(
+        h.build(
+          _savedComputer(
+            connectionType: 'usb',
+            bluetoothAddress: '/dev/ttyUSB0',
+          ),
+        ),
+      );
+      await _settle(tester);
+
+      expect(h.hostApi.calls, ['startDownload']);
+      expect(h.hostApi.downloads.single.address, '/dev/ttyUSB0');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #1232.

Downloading from a **saved** Bluetooth dive computer (tap the existing Petrel 3 entry, start download) failed instantly with `[LDC] [ERROR] Download failed (connect_failed): Failed to connect to device`, while starting the same download as an "unknown computer" scanned, found the same address, and downloaded fine. Reported on Android 1.7.5 and Windows 1.7.4.

**Root cause:** the saved-computer download step synthesized a `DiscoveredDevice` from the stored `bluetoothAddress` and handed it straight to native with no scan (the adapter doc comment claimed the step "auto-scans for the known device"; it did not). On Android that becomes `getRemoteDevice(mac).connectGatt(context, false, cb)` against a device the stack has neither bonded (Shearwater is bond-exempt since #910) nor recently seen advertise, and on Windows `FromBluetoothAddressAsync` right after the advertisement watcher is stopped. Both fail without a fresh advertisement. macOS and iOS never showed the bug because `connectBle` runs `BlePeripheralResolver`, which re-scans before connecting.

**Fix:** give the other platforms the same behaviour from the Dart side, where the scan primitive already exists for every backend. The saved-computer step now scans for the stored address before connecting and downloads from the freshly advertised device.

## Changes

- `DiscoveryNotifier.scanForAddress(address, timeout)`: starts a scan, resolves on the first device whose address matches (case-insensitive), resolves null when the scan cannot start, native discovery ends, or the timeout elapses, and stops the scan on every path.
- `DcAdapterDownloadStep` (known-computer mode): for a Bluetooth computer with a stored address, runs the scan for up to 15 s (`knownDeviceScanTimeout`, matching the first attempt of the Darwin resolver) behind a "Searching for {name}..." view (existing l10n key), selects the discovered device so the download also gets the real descriptor instead of a guessed one, and falls back to the stored address exactly as before if the device is not seen. USB/serial computers never scan.
- A device left selected by an earlier discovery session is now used only when its address matches the saved computer's; previously it would have been downloaded from regardless.
- Tests: unit coverage for `scanForAddress` (match, case-insensitive match, timeout, start failure, native completion) and widget coverage for the step (scan then download from the advertised device, timeout fallback to the stored address, no scan when already acquired, stale selection ignored, USB never scans). The two existing synthesized-device tests advance past the scan timeout.
- Fix comment in `scanForAddress`: a broadcast subscription's `cancel()` returns the root-zone null future, which fake-async widget tests can never flush, so it is called unawaited (matching the existing `_discoverySubscription?.cancel()` style).

## Test Plan

- [x] `flutter test` passes (20097 passed, 19 skipped)
- [x] `flutter analyze` passes
- [x] Manual testing on: Android and Windows with a Petrel 3 (hardware verification pending from the reporters; macOS behaviour unchanged since the native resolver already re-scans)

## Screenshots

Not applicable; the only UI change is a "Searching for {name}..." caption under the existing progress indicator while the scan runs.
