### PR TITLE
Name the build in debug log exports, and label an OSTC Sport correctly

### DIFF
--- a/lib/core/services/log_environment.dart
+++ b/lib/core/services/log_environment.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart'
+    show kDebugMode, kProfileMode, visibleForTesting;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/utils/app_version.dart';
+
+/// Value shown wherever a field could not be determined.
+const _unknown = 'unknown';
+
+/// A snapshot of the build and device that produced a debug log.
+///
+/// Bug reports arrive as pasted log excerpts, and every triage starts with the
+/// same question: which build wrote these lines? Issue #1246 is the worked
+/// example: an OSTC Sport download failure that had already been fixed
+/// months earlier, but the report carried no version, so establishing that the
+/// reporter was simply on an older build meant inferring it from a numeric
+/// score in a BLE selection log line and from the *absence* of a log statement
+/// that newer builds emit. Attaching this to the logs makes that a read
+/// instead of an inference.
+class LogEnvironment {
+  /// Four-segment app version, e.g. `1.7.6.123`.
+  final String appVersion;
+
+  /// Operating system identifier, e.g. `ios`, `android`, `macos`.
+  final String platform;
+
+  /// Full OS version string, e.g. `Version 26.6 (Build 23G93)`.
+  final String osVersion;
+
+  /// Host locale, e.g. `de_DE.UTF-8`.
+  final String locale;
+
+  /// Flutter build mode: `release`, `profile` or `debug`.
+  final String buildMode;
+
+  /// When this snapshot was taken.
+  ///
+  /// A field rather than a `DateTime.now()` inside [toExportHeader] so the
+  /// header is a pure function of the value: rendering it twice must produce
+  /// the same string. Capture happens at export time, so this is also the
+  /// moment the export was produced.
+  final DateTime capturedAt;
+
+  const LogEnvironment({
+    required this.appVersion,
+    required this.platform,
+    required this.osVersion,
+    required this.locale,
+    required this.buildMode,
+    required this.capturedAt,
+  });
+
+  /// How long [capture] waits for the app version before giving up.
+  ///
+  /// A platform channel that never answers is just as damaging as one that
+  /// throws: the caller is a user pressing Copy or Share, and an unbounded
+  /// wait would hang the export outright rather than degrade it. That is not
+  /// hypothetical, because `PackageInfo.fromPlatform` never completes under
+  /// `testWidgets`, and a headless isolate has no plugin registrant either.
+  static const versionLookupTimeout = Duration(seconds: 2);
+
+  /// Seam for the version lookup, so tests can drive its failure modes.
+  @visibleForTesting
+  static Future<PackageInfo> Function() packageInfoLoader =
+      PackageInfo.fromPlatform;
+
+  /// Read the environment from the platform.
+  ///
+  /// Never throws and always completes. Anything that cannot be determined
+  /// degrades to [_unknown] rather than failing the caller: this only ever
+  /// decorates a log export or a log line, so losing the app version must not
+  /// cost the user the logs themselves.
+  static Future<LogEnvironment> capture({Duration? versionTimeout}) async {
+    var appVersion = _unknown;
+    try {
+      final info = await packageInfoLoader().timeout(
+        versionTimeout ?? versionLookupTimeout,
+      );
+      appVersion = formatAppVersion(info);
+    } on Object {
+      // A throw or a timeout both land here; see the doc comment.
+    }
+
+    var platform = _unknown;
+    var osVersion = _unknown;
+    var locale = _unknown;
+    try {
+      platform = Platform.operatingSystem;
+      osVersion = Platform.operatingSystemVersion;
+      locale = Platform.localeName;
+    } on Object {
+      // Platform getters throw on unsupported hosts (e.g. web).
+    }
+
+    return LogEnvironment(
+      appVersion: appVersion,
+      platform: platform,
+      osVersion: osVersion,
+      locale: locale,
+      buildMode: kDebugMode
+          ? 'debug'
+          : kProfileMode
+          ? 'profile'
+          : 'release',
+      capturedAt: DateTime.now(),
+    );
+  }
+
+  /// One-line form, used for the session marker written into the log file.
+  ///
+  /// Deliberately a single line so it survives [LogEntry.tryParse] and shows
+  /// up in the log viewer like any other entry.
+  String toSummaryLine() =>
+      'Session start: Submersion $appVersion'
+      ' | $platform $osVersion'
+      ' | locale $locale'
+      ' | $buildMode build';
+
+  /// Multi-line header prepended to an exported or copied log.
+  ///
+  /// Regenerated at export time rather than read back from the file, because
+  /// the file's head is what log rotation discards and what the viewer's
+  /// category/severity filters exclude.
+  String toExportHeader() {
+    final exportedAt = capturedAt.toIso8601String();
+    return '''
+=== Submersion debug log ===
+app:      Submersion $appVersion
+platform: $platform $osVersion
+locale:   $locale
+build:    $buildMode
+exported: $exportedAt
+============================
+''';
+  }
+}
+
+/// Record the current build and device at the top of a logging session.
+///
+/// Called wherever file logging is switched on, so a log file that spans
+/// several app versions attributes each run to the build that wrote it.
+Future<void> logSessionEnvironment() async {
+  final environment = await LogEnvironment.capture();
+  const LoggerService(
+    'Submersion',
+  ).info(environment.toSummaryLine(), category: LogCategory.app);
+}

--- a/lib/core/utils/app_version.dart
+++ b/lib/core/utils/app_version.dart
@@ -1,0 +1,20 @@
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Format the app version the way the project displays it everywhere: the
+/// three-segment marketing version with the build number appended as a fourth
+/// segment (`1.7.6.123`).
+///
+/// Release tags are four-segment (`vX.Y.Z.N`) while `PackageInfo.version` is
+/// the three-segment marketing version, so the build number has to be appended
+/// for a version string to be comparable with a tag. Some platforms already
+/// report a four-segment version, hence the guard against doubling it.
+String formatAppVersion(PackageInfo info) =>
+    formatVersionWithBuild(info.version, info.buildNumber);
+
+/// [formatAppVersion] without the PackageInfo dependency, for callers that
+/// already hold the two parts separately.
+String formatVersionWithBuild(String version, String buildNumber) {
+  if (buildNumber.isEmpty) return version;
+  if (version.endsWith('.$buildNumber')) return version;
+  return '$version.$buildNumber';
+}

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -1,10 +1,13 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/log_environment.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
@@ -122,41 +125,91 @@ final filteredLogEntriesProvider = Provider<AsyncValue<List<LogEntry>>>((ref) {
   });
 });
 
+/// Name the exported copy carries in the share sheet and the save dialog.
+const _exportFileName = 'submersion-debug-logs.txt';
+
+/// Resolve the header prepended to every export.
+///
+/// Callers may pass a captured [LogEnvironment]; otherwise it is read here.
+/// Attaching the build and device to the logs is what turns a pasted excerpt
+/// into something triageable (issue #1246).
+Future<String> _exportHeader(LogEnvironment? environment) async {
+  final resolved = environment ?? await LogEnvironment.capture();
+  return resolved.toExportHeader();
+}
+
+/// The log file's bytes behind the export header.
+///
+/// Concatenated as BYTES rather than decoded to a string first: the log
+/// carries whatever a device name or a native log message put in it, and
+/// `readAsString` throws on a malformed UTF-8 sequence. Losing the whole
+/// export to one bad byte is a worse outcome than passing it through.
+Future<Uint8List> _exportBytes(File file, String header) async {
+  return Uint8List.fromList([
+    ...utf8.encode(header),
+    ...await file.readAsBytes(),
+  ]);
+}
+
 /// Share the full log file via system share sheet.
-Future<void> shareLogFile(LogFileService service, AppLocalizations l10n) async {
-  final path = service.logFilePath;
-  final file = File(path);
+///
+/// Shares a header-prefixed copy rather than the log file itself, so the
+/// recipient sees which build and device produced the lines.
+Future<void> shareLogFile(
+  LogFileService service,
+  AppLocalizations l10n, {
+  LogEnvironment? environment,
+}) async {
+  final file = File(service.logFilePath);
   if (!file.existsSync()) return;
+
+  final header = await _exportHeader(environment);
+
+  // Written to the temp directory rather than shared in place: the log file
+  // has to stay untouched (it is still being appended to), and the copy is
+  // disposable once the share sheet has read it. Sharing a *copy* is also what
+  // lets the export carry the header at all. Reusing one name bounds the temp
+  // directory to a single file across repeated shares.
+  final tempDir = await getTemporaryDirectory();
+  final export = File('${tempDir.path}/$_exportFileName');
+  await export.writeAsBytes(await _exportBytes(file, header));
 
   await SharePlus.instance.share(
     ShareParams(
-      files: [XFile(path, mimeType: 'text/plain')],
+      files: [XFile(export.path, mimeType: 'text/plain')],
       subject: l10n.settings_debugLog_shareSubject,
     ),
   );
 }
 
 /// Copy the filtered log entries to clipboard.
-Future<void> copyFilteredLogs(List<LogEntry> entries) async {
+///
+/// The header is prepended even when the filters exclude everything: an empty
+/// excerpt that still names the build is more useful than a bare empty string.
+Future<void> copyFilteredLogs(
+  List<LogEntry> entries, {
+  LogEnvironment? environment,
+}) async {
+  final header = await _exportHeader(environment);
   final text = entries.map((e) => e.toLogLine()).join('\n');
-  await Clipboard.setData(ClipboardData(text: text));
+  await Clipboard.setData(ClipboardData(text: '$header$text'));
 }
 
 /// Save the full log file to a user-chosen location.
 Future<String?> saveLogFile(
   LogFileService service,
-  AppLocalizations l10n,
-) async {
-  final path = service.logFilePath;
-  final file = File(path);
+  AppLocalizations l10n, {
+  LogEnvironment? environment,
+}) async {
+  final file = File(service.logFilePath);
   if (!file.existsSync()) return null;
 
-  final bytes = await file.readAsBytes();
+  final header = await _exportHeader(environment);
   final result = await FilePicker.saveFile(
     dialogTitle: l10n.settings_debugLog_saveDialogTitle,
-    fileName: 'submersion-debug-logs.txt',
+    fileName: _exportFileName,
     type: FileType.custom,
-    bytes: bytes,
+    bytes: await _exportBytes(file, header),
     mimeType: 'text/plain',
   );
 

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -182,10 +182,13 @@ Future<void> shareLogFile(
   );
 }
 
-/// Copy the filtered log entries to clipboard.
+/// Copy the filtered log entries to clipboard, behind the export header.
 ///
-/// The header is prepended even when the filters exclude everything: an empty
-/// excerpt that still names the build is more useful than a bare empty string.
+/// The header is unconditional, so even a one-line excerpt names the build it
+/// came from. That is deliberately not special-cased for an empty list, but it
+/// is also not reachable that way today: the Copy button in
+/// [DebugLogViewerPage] guards on a non-empty list, so an empty filter result
+/// copies nothing at all rather than a bare header.
 Future<void> copyFilteredLogs(
   List<LogEntry> entries, {
   LogEnvironment? environment,

--- a/lib/features/settings/presentation/providers/debug_mode_provider.dart
+++ b/lib/features/settings/presentation/providers/debug_mode_provider.dart
@@ -21,6 +21,13 @@ class DebugModeNotifier extends StateNotifier<bool> {
     state = true;
     await _prefs.setBool(_kDebugModeKey, true);
     LoggerService.setFileService(_logFileService);
+    // Deliberately no session-environment line here, unlike main.dart. It
+    // would have to be fire-and-forget (a settings toggle must not wait on a
+    // platform channel), and a background version lookup plus a file write
+    // outliving the toggle is a timer and a real-IO future escaping whatever
+    // widget test flipped it. The export header in debug_log_providers.dart
+    // already names the build on every copy, share and save, which is the
+    // path a bug report actually travels (issue #1246).
   }
 
   Future<void> disable() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/providers/root_overrides.dart';
 import 'package:submersion/core/services/global_error_handler.dart';
 import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/core/services/log_environment.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
 import 'package:submersion/app.dart';
@@ -73,6 +74,11 @@ Future<void> _bootstrap() async {
   final debugEnabled = prefs.getBool('debug_mode_enabled') ?? false;
   if (debugEnabled) {
     LoggerService.setFileService(logFileService);
+    // Stamp the build and device at the top of the session so a log file that
+    // spans several app versions attributes each run to the build that wrote
+    // it (issue #1246). Not awaited: startup must not block on a platform
+    // channel, and the write is serialized behind LoggerService's queue.
+    unawaited(logSessionEnvironment());
   }
 
   // Create location service and get storage config

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -175,6 +175,43 @@ static unsigned int uwatec_ble_alias_model(const char *name) {
     return 0;
 }
 
+// Some dive computers advertise an ABBREVIATED BLE name that is neither the
+// libdivecomputer product string nor a prefix of it, so neither the exact-name
+// nor the longest-prefix tiebreaker below can reach the right descriptor. The
+// Uwatec aliases above solve the same problem by model code, but that only
+// works where the models differ: every hw_ostc3 descriptor except OSTC 4 and
+// OSTC 5 carries model 0, so a Heinrichs Weikamp alias has to name its PRODUCT
+// instead.
+//
+// Issue #1246: an OSTC Sport advertises "OSTCs" followed by its serial
+// ("OSTCs 21211"). dc_filter_hw accepts any "OSTC*" name for every hw_ostc3
+// row, and "OSTCs" is not a prefix of "OSTC Sport", so the matcher fell back
+// to the first family row and reported the device as an "OSTC 2". The model is
+// the same either way, so this is a labelling fix, not a download fix.
+//
+// Aliases are compared with product_prefix_len, so an entry also covers the
+// serial-suffixed form and will not match a longer word ("OSTCsomething").
+// Only add an alias with a real advertised name behind it: a wrong guess here
+// silently mislabels hardware. Returns NULL when the name is not a known
+// alias.
+static const char *ble_alias_product(const char *name) {
+    static const struct {
+        const char *alias;
+        const char *product;
+    } aliases[] = {
+        {"OSTCs", "OSTC Sport"}, // issue #1246
+    };
+    if (name == NULL) {
+        return NULL;
+    }
+    for (size_t i = 0; i < sizeof(aliases) / sizeof(aliases[0]); i++) {
+        if (product_prefix_len(name, aliases[i].alias) > 0) {
+            return aliases[i].product;
+        }
+    }
+    return NULL;
+}
+
 int libdc_descriptor_match(const char *name, unsigned int transport,
                            libdc_descriptor_info_t *info) {
     if (name == NULL || info == NULL) {
@@ -229,6 +266,15 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
         }
     }
 
+    // Advertised names that abbreviate their product rather than prefixing it
+    // (see ble_alias_product). Resolved to a product string because the
+    // hw_ostc3 family shares one model code, which the exact-model preference
+    // above cannot tell apart. Issue #1246.
+    const char *alias_product = NULL;
+    if (!has_name_model && (transport & LIBDC_TRANSPORT_BLE)) {
+        alias_product = ble_alias_product(name);
+    }
+
     dc_descriptor_t *desc = NULL;
     int found = 0;
     size_t best_prefix_len = 0;
@@ -259,6 +305,19 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
             if (!has_name_model) {
                 const char *product = dc_descriptor_get_product(desc);
                 if (product && strcasecmp_nospace(name, product) == 0) {
+                    info->vendor = dc_descriptor_get_vendor(desc);
+                    info->product = product;
+                    info->model = dc_descriptor_get_model(desc);
+                    info->transports = dc_descriptor_get_transports(desc);
+                    dc_descriptor_free(desc);
+                    break;
+                }
+
+                // An abbreviated advertised name reaches its product through
+                // the alias table; that beats the prefix tiebreaker below,
+                // which by definition cannot match an abbreviation.
+                if (alias_product && product &&
+                    strcasecmp_nospace(alias_product, product) == 0) {
                     info->vendor = dc_descriptor_get_vendor(desc);
                     info->product = product;
                     info->model = dc_descriptor_get_model(desc);

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -114,6 +114,32 @@ static void test_hw_ostc_suffixed_names_resolve(void) {
     printf("PASS: test_hw_ostc_suffixed_names_resolve\n");
 }
 
+// Issue #1246: an OSTC Sport advertises "OSTCs" plus its serial. That is an
+// ABBREVIATION, not a prefix of "OSTC Sport", so neither the exact-name nor
+// the longest-prefix tiebreaker could reach the right row and the device was
+// reported as an "OSTC 2". The alias table resolves it by product name,
+// because the whole hw_ostc3 family below OSTC 4 shares model 0 and so cannot
+// be told apart by model code.
+static void test_hw_ostc_sport_alias_resolves(void) {
+    expect_ble_match("OSTCs 21211", "OSTC Sport", 0);
+    expect_ble_match("OSTCs", "OSTC Sport", 0);
+    expect_ble_match("ostcs 21211", "OSTC Sport", 0);
+    // The spelled-out product must keep resolving through the ordinary
+    // exact/prefix path rather than depending on the alias.
+    expect_ble_match("OSTC Sport", "OSTC Sport", 0);
+    expect_ble_match("OSTC Sport 4711", "OSTC Sport", 0);
+    printf("PASS: test_hw_ostc_sport_alias_resolves\n");
+}
+
+// The alias must not swallow a longer word that merely starts with it:
+// product_prefix_len rejects a match that ends mid-word, so a hypothetical
+// "OSTCsomething" falls back to the family row instead of claiming to be a
+// Sport.
+static void test_hw_ostc_alias_does_not_match_longer_word(void) {
+    expect_ble_match("OSTCsomething", "OSTC 2", 0);
+    printf("PASS: test_hw_ostc_alias_does_not_match_longer_word\n");
+}
+
 // Issue #483 regression guard: dc_filter_shearwater passes a whitelisted name
 // for EVERY Shearwater row, so resolution relies on the wrapper preferring the
 // row whose product exactly equals the BLE name. The new "Perdix 3" row must
@@ -149,6 +175,8 @@ int main(void) {
     test_non_uwatec_device_unaffected();
     test_perdix_3_resolves();
     test_hw_ostc_suffixed_names_resolve();
+    test_hw_ostc_sport_alias_resolves();
+    test_hw_ostc_alias_does_not_match_longer_word();
     test_other_perdix_models_unchanged();
     test_symbios_handset_resolves_to_handset();
     test_symbios_hud_resolves_to_hud();

--- a/test/core/services/log_environment_test.dart
+++ b/test/core/services/log_environment_test.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/log_environment.dart';
+import 'package:submersion/core/services/log_file_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
+
+void main() {
+  final environment = LogEnvironment(
+    appVersion: '1.7.6.123',
+    platform: 'ios',
+    osVersion: 'Version 26.6 (Build 23G93)',
+    locale: 'de_DE.UTF-8',
+    buildMode: 'release',
+    capturedAt: DateTime(2026, 8, 25, 20, 25, 19),
+  );
+
+  group('toSummaryLine', () {
+    test('names the build, platform, locale and build mode', () {
+      final line = environment.toSummaryLine();
+
+      expect(line, contains('1.7.6.123'));
+      expect(line, contains('ios'));
+      expect(line, contains('Version 26.6 (Build 23G93)'));
+      expect(line, contains('de_DE.UTF-8'));
+      expect(line, contains('release'));
+    });
+
+    test('is a single line so it survives the log-line parser', () {
+      // LogFileService.readEntries drops anything LogEntry.tryParse rejects,
+      // and the parser is line-oriented: a multi-line summary would be
+      // silently discarded from the log viewer.
+      expect(environment.toSummaryLine(), isNot(contains('\n')));
+    });
+  });
+
+  group('toExportHeader', () {
+    test('carries every field an incoming bug report needs', () {
+      final header = environment.toExportHeader();
+
+      expect(header, contains('1.7.6.123'));
+      expect(header, contains('ios'));
+      expect(header, contains('Version 26.6 (Build 23G93)'));
+      expect(header, contains('de_DE.UTF-8'));
+      expect(header, contains('release'));
+      expect(header, contains('exported:'));
+    });
+
+    test('ends with a newline so log lines start on their own line', () {
+      expect(environment.toExportHeader(), endsWith('\n'));
+    });
+
+    test('renders identically twice', () {
+      // The exported timestamp is a captured field, not a DateTime.now()
+      // inside the getter, so callers can compare two renderings.
+      expect(environment.toExportHeader(), environment.toExportHeader());
+      expect(environment.toExportHeader(), contains('2026-08-25T20:25:19'));
+    });
+  });
+
+  group('logSessionEnvironment', () {
+    late Directory tempDir;
+    late LogFileService service;
+
+    setUp(() async {
+      tempDir = Directory.systemTemp.createTempSync('log_environment_test_');
+      service = LogFileService(logDirectory: tempDir.path);
+      await service.initialize();
+      LoggerService.setFileService(service);
+    });
+
+    tearDown(() {
+      LoggerService.setFileService(null);
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('writes an entry the log file parser accepts', () async {
+      // LogFileService.readEntries silently drops anything tryParse rejects,
+      // so a session marker that does not round-trip would never reach the
+      // log viewer at all.
+      await logSessionEnvironment();
+      await LoggerService.flushPendingWrites();
+
+      final entries = await service.readEntries();
+
+      expect(entries, hasLength(1));
+      expect(entries.single.message, startsWith('Session start: Submersion'));
+      expect(entries.single.category, LogCategory.app);
+      expect(entries.single.level, LogLevel.info);
+    });
+
+    test('records the platform the run happened on', () async {
+      await logSessionEnvironment();
+      await LoggerService.flushPendingWrites();
+
+      final entries = await service.readEntries();
+
+      expect(entries.single.message, contains(Platform.operatingSystem));
+    });
+  });
+
+  group('capture', () {
+    test('never throws when the platform channel is unavailable', () async {
+      // PackageInfo.fromPlatform needs a platform channel that does not exist
+      // under flutter test. Losing the version must not cost the caller the
+      // logs, so capture degrades instead of failing.
+      final captured = await LogEnvironment.capture();
+
+      expect(captured.appVersion, 'unknown');
+    });
+
+    test('reads the real platform identity', () async {
+      final captured = await LogEnvironment.capture();
+
+      expect(captured.platform, Platform.operatingSystem);
+      expect(captured.osVersion, Platform.operatingSystemVersion);
+      expect(captured.locale, Platform.localeName);
+    });
+
+    test('degrades when the version lookup never answers', () async {
+      // An unbounded wait would hang a Copy or Share outright. Proven
+      // reachable: PackageInfo.fromPlatform never completes under testWidgets.
+      LogEnvironment.packageInfoLoader = () => Completer<PackageInfo>().future;
+      addTearDown(() {
+        LogEnvironment.packageInfoLoader = PackageInfo.fromPlatform;
+      });
+
+      final captured = await LogEnvironment.capture(
+        versionTimeout: const Duration(milliseconds: 20),
+      );
+
+      expect(captured.appVersion, 'unknown');
+      expect(captured.platform, Platform.operatingSystem);
+    });
+
+    test('uses the version when the lookup answers', () async {
+      LogEnvironment.packageInfoLoader = () async => PackageInfo(
+        appName: 'Submersion',
+        packageName: 'app.submersion',
+        version: '1.7.6',
+        buildNumber: '123',
+        buildSignature: '',
+      );
+      addTearDown(() {
+        LogEnvironment.packageInfoLoader = PackageInfo.fromPlatform;
+      });
+
+      final captured = await LogEnvironment.capture();
+
+      expect(captured.appVersion, '1.7.6.123');
+    });
+
+    test('reports the build mode flutter test runs in', () async {
+      final captured = await LogEnvironment.capture();
+
+      expect(captured.buildMode, anyOf('debug', 'profile', 'release'));
+    });
+
+    test(
+      'still produces a usable header when the version is unknown',
+      () async {
+        final captured = await LogEnvironment.capture();
+
+        expect(captured.toExportHeader(), contains('Submersion debug log'));
+        expect(captured.toExportHeader(), contains(Platform.operatingSystem));
+      },
+    );
+  });
+}

--- a/test/core/utils/app_version_test.dart
+++ b/test/core/utils/app_version_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/app_version.dart';
+
+void main() {
+  group('formatVersionWithBuild', () {
+    test('appends the build number as a fourth segment', () {
+      expect(formatVersionWithBuild('1.7.6', '123'), '1.7.6.123');
+    });
+
+    test('does not double a build number the version already carries', () {
+      // Some platforms report a four-segment version. Without this guard a
+      // release comparison would see "1.7.6.123.123" and never match its tag.
+      expect(formatVersionWithBuild('1.7.6.123', '123'), '1.7.6.123');
+    });
+
+    test('leaves the version alone when there is no build number', () {
+      expect(formatVersionWithBuild('1.7.6', ''), '1.7.6');
+    });
+
+    test('appends a build number that merely repeats a digit run', () {
+      // "1.7.23" does not end with ".3" as a segment even though it ends with
+      // the characters; endsWith('.3') is false here, so nothing is swallowed.
+      expect(formatVersionWithBuild('1.7.23', '3'), '1.7.23.3');
+    });
+  });
+}

--- a/test/features/settings/presentation/pages/debug_log_viewer_page_test.dart
+++ b/test/features/settings/presentation/pages/debug_log_viewer_page_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -369,6 +370,19 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+
+      // copyFilteredLogs prefixes the export header, which reads the app
+      // version (issue #1246). PackageInfo.fromPlatform NEVER completes under
+      // testWidgets, so without this mock the handler stays suspended and the
+      // snackbar is never scheduled. Production is covered by the timeout in
+      // LogEnvironment.capture; here the normal path is what we want to test.
+      PackageInfo.setMockInitialValues(
+        appName: 'Submersion',
+        packageName: 'app.submersion',
+        version: '1.7.6',
+        buildNumber: '123',
+        buildSignature: '',
+      );
 
       // Tap the Copy button
       await tester.tap(find.text('Copy'));

--- a/test/features/settings/presentation/providers/debug_log_providers_test.dart
+++ b/test/features/settings/presentation/providers/debug_log_providers_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:submersion/core/models/log_entry.dart';
+import 'package:submersion/core/services/log_environment.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
@@ -16,6 +17,16 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// English localizations for the share/save helpers, which now take their
 /// subject and dialog title from the app's translations.
 final _l10n = l10nForLocaleTag('en');
+
+/// Fixed environment so the export header is byte-comparable across renders.
+final _environment = LogEnvironment(
+  appVersion: '1.7.6.123',
+  platform: 'ios',
+  osVersion: 'Version 26.6 (Build 23G93)',
+  locale: 'de_DE.UTF-8',
+  buildMode: 'release',
+  capturedAt: DateTime(2026, 8, 25, 20, 25, 19),
+);
 
 LogEntry _entry({
   required String message,
@@ -702,7 +713,7 @@ void main() {
         ),
       ];
 
-      await copyFilteredLogs(entries);
+      await copyFilteredLogs(entries, environment: _environment);
 
       final setDataCall = clipboardCalls.firstWhere(
         (c) => c.method == 'Clipboard.setData',
@@ -712,22 +723,57 @@ void main() {
 
       expect(text, contains(entries[0].toLogLine()));
       expect(text, contains(entries[1].toLogLine()));
-      // Lines joined by newline.
+      // Header, then the lines joined by newline.
       expect(
         text,
-        equals('${entries[0].toLogLine()}\n${entries[1].toLogLine()}'),
+        equals(
+          '${_environment.toExportHeader()}'
+          '${entries[0].toLogLine()}\n${entries[1].toLogLine()}',
+        ),
       );
     });
 
-    test('copies empty string when entries list is empty', () async {
-      await copyFilteredLogs([]);
+    test('prefixes the header naming the build that wrote the logs', () async {
+      // Issue #1246: a pasted log excerpt with no version behind it cost a
+      // full investigation to attribute to a build.
+      await copyFilteredLogs([
+        _entry(message: 'alpha'),
+      ], environment: _environment);
 
       final setDataCall = clipboardCalls.firstWhere(
         (c) => c.method == 'Clipboard.setData',
       );
       final text =
           (setDataCall.arguments as Map<dynamic, dynamic>)['text'] as String;
-      expect(text, isEmpty);
+
+      expect(text, startsWith('=== Submersion debug log ==='));
+      expect(text, contains('1.7.6.123'));
+      expect(text, contains('ios'));
+    });
+
+    test('copies the header alone when entries list is empty', () async {
+      // An excerpt filtered down to nothing still names the build, which is
+      // more useful than the bare empty string this used to produce.
+      await copyFilteredLogs([], environment: _environment);
+
+      final setDataCall = clipboardCalls.firstWhere(
+        (c) => c.method == 'Clipboard.setData',
+      );
+      final text =
+          (setDataCall.arguments as Map<dynamic, dynamic>)['text'] as String;
+      expect(text, equals(_environment.toExportHeader()));
+    });
+
+    test('captures the environment itself when none is supplied', () async {
+      await copyFilteredLogs([_entry(message: 'alpha')]);
+
+      final setDataCall = clipboardCalls.firstWhere(
+        (c) => c.method == 'Clipboard.setData',
+      );
+      final text =
+          (setDataCall.arguments as Map<dynamic, dynamic>)['text'] as String;
+
+      expect(text, startsWith('=== Submersion debug log ==='));
     });
   });
 
@@ -740,7 +786,7 @@ void main() {
       await service.initialize();
 
       // No entries written, so log file doesn't exist
-      await shareLogFile(service, _l10n);
+      await shareLogFile(service, _l10n, environment: _environment);
       // Should complete without error
     });
 
@@ -756,7 +802,7 @@ void main() {
       // SharePlus may throw MissingPluginException in test env.
       // The key is that we reach the share call (covering those lines).
       try {
-        await shareLogFile(service, _l10n);
+        await shareLogFile(service, _l10n, environment: _environment);
       } catch (_) {
         // Expected in test environment
       }
@@ -771,7 +817,11 @@ void main() {
       final service = LogFileService(logDirectory: tempDir.path);
       await service.initialize();
 
-      final result = await saveLogFile(service, _l10n);
+      final result = await saveLogFile(
+        service,
+        _l10n,
+        environment: _environment,
+      );
       expect(result, isNull);
     });
 
@@ -787,7 +837,11 @@ void main() {
       // FilePicker may throw MissingPluginException in test env.
       // The key is that we reach the FilePicker call (covering those lines).
       try {
-        final result = await saveLogFile(service, _l10n);
+        final result = await saveLogFile(
+          service,
+          _l10n,
+          environment: _environment,
+        );
         // If it somehow succeeds (returns null from picker), that's fine
         expect(result, anything);
       } catch (_) {

--- a/test/features/settings/presentation/providers/debug_log_providers_test.dart
+++ b/test/features/settings/presentation/providers/debug_log_providers_test.dart
@@ -752,8 +752,9 @@ void main() {
     });
 
     test('copies the header alone when entries list is empty', () async {
-      // An excerpt filtered down to nothing still names the build, which is
-      // more useful than the bare empty string this used to produce.
+      // This is the function's contract, not a UI path: the Copy button
+      // guards on a non-empty list, so DebugLogViewerPage never reaches it.
+      // Pinned so the header stays unconditional if that guard is relaxed.
       await copyFilteredLogs([], environment: _environment);
 
       final setDataCall = clipboardCalls.firstWhere(


### PR DESCRIPTION
Addresses #1246.

## What the report actually was

The OSTC Sport download failure in #1246 is **not a live defect on `main`**. The
reporter's log shows a Telit/Stollmann BlueMod+SR module on service `0xFEFB`
whose credit characteristics are discovered and then never used: `00000003`
(UART Credits RX) is never written and `00000004` (UART Credits TX) is never
subscribed. The bridge therefore stays closed, the `0xBB` init byte gets no
answer, and the 3000 ms timeout becomes `result=-7`.

That handshake landed in #946 (issue #923) and shipped in **v1.7.3**:

```
$ git merge-base --is-ancestor 0ad7a88f271 v1.7.2.4977  ->  NOT-SHIPPED
$ git merge-base --is-ancestor 0ad7a88f271 v1.7.3.6027  ->  SHIPPED
```

Two independent signals date the reporter's build to v1.7.2 or older:

- the selection scores `8` (the bare property heuristic), where a build with
  the fix scores `2008` because `BleCharacteristicSelector` biases the Telit
  service and its Data RX/TX characteristics by `+1000` each;
- builds with the fix log `Credit flow control detected (Telit, required)`
  immediately before `Selected write=...`, and that line is absent.

So the download half needs a release, not a patch. This PR fixes the two real
gaps the triage exposed.

## 1. Debug log exports name the build that produced them

Establishing which binary wrote that log took an entire investigation, because
`copyFilteredLogs` was `entries.map((e) => e.toLogLine()).join('\n')` and
neither `LoggerService` nor `LogFileService` recorded a version anywhere.

- New `LogEnvironment` (`lib/core/services/log_environment.dart`) captures app
  version + build, platform, OS version, locale and build mode. `capture()`
  never throws: anything unavailable degrades to `unknown` rather than costing
  the user their logs.
- `copyFilteredLogs`, `shareLogFile` and `saveLogFile` all prepend a header
  block. It is generated **at export time**, not read back from the file,
  because the file's head is exactly what `_rotateIfNeeded` discards and what
  the viewer's category/severity filters exclude. #1246 arrived as a
  filtered copy.
- A one-line `Session start: ...` marker is written at startup (`main.dart`,
  fire-and-forget) when debug logging is already on, so a log file spanning
  several app versions attributes each run to its build. It is deliberately
  single-line so `LogEntry.tryParse` accepts it and it reaches the log viewer;
  `readEntries` silently drops anything that does not parse.
- `DebugModeNotifier.enable` deliberately does **not** emit that marker, with a
  comment saying why: it would have to be fire-and-forget, and a background
  version lookup plus a file write outliving a settings toggle is a timer and a
  real-IO future escaping whatever widget test flipped it. The export header
  already covers that flow, which is the path a bug report actually travels.
- `LogEnvironment.capture` bounds the version lookup with a 2 s timeout. A
  channel that never answers is as damaging as one that throws, and this is not
  hypothetical: `PackageInfo.fromPlatform` **never completes at all** under
  `testWidgets` (verified with a probe), and a headless isolate has no plugin
  registrant either. Without the bound, pressing Copy would hang rather than
  degrade. A `packageInfoLoader` seam makes both failure modes testable.
- `shareLogFile` and `saveLogFile` now concatenate **bytes**, not decoded
  strings: `readAsString` throws on a malformed UTF-8 sequence, and losing a
  whole export to one bad byte is worse than passing it through.
- New `formatAppVersion` / `formatVersionWithBuild`
  (`lib/core/utils/app_version.dart`) so this does not become a fourth copy of
  the `version.endsWith('.$buildNumber') ? ... : ...` idiom. The three existing
  copies (`settings_page.dart`, `update_providers.dart`, `startup_page.dart`)
  are deliberately left alone here; adopting them is a separate change.

## 2. An OSTC Sport is no longer labelled "OSTC 2"

The reporter's device advertises `OSTCs 21211` and the app called it
"Heinrichs Weikamp OSTC 2". `dc_filter_hw` accepts any `OSTC*` name for every
`hw_ostc3` descriptor, and `"OSTCs"` is an **abbreviation**, not a prefix of
`"OSTC Sport"`, so both tiebreakers in `libdc_descriptor_match` scored zero
and the first family row won.

The existing `uwatec_ble_alias_model` table cannot solve this: it disambiguates
by model code, and `descriptor.c` gives OSTC 2 / 2 TR / 3 / cR / Plus / Sport /
Nano all model `0`. Only OSTC 4 (`0x43`) and OSTC 5 (`0x44`) differ, which is
why those two already resolved correctly. The new `ble_alias_product` table
therefore maps an advertised name to a **product string**.

Aliases are compared with the existing `product_prefix_len`, so one entry
covers `OSTCs`, `OSTCs 21211` and `ostcs-21211` while still refusing
`OSTCsomething` (that helper already rejects a match ending mid-word).

`libdc_wrapper.c` is one shared source across darwin/Windows/Linux/Android
(iOS is a symlink), so this lands on every platform at once.

**Behaviour note:** every affected descriptor carries the same model code, so
downloads are unchanged; this is purely the displayed name. One consequence
worth stating: `findByHardwareIdentity` matches on manufacturer + model +
serial, so an OSTC Sport already registered as "OSTC 2" on another device would
not match the new name and could register twice. In practice the affected
population is users whose Sport could not download at all, and the local path
keys on the BLE address first.

## Verification

- Native suite green, including the two new cases. Red state confirmed first:
  without the fix, `FAIL: "OSTCs 21211" resolved to OSTC 2/0x00, expected OSTC
  Sport/0x00`.
- `libdc_wrapper.c` compiles clean under `-Wall -Wextra -std=c99`.
- `flutter analyze`: no issues.
- Full `flutter test` suite run locally.

The first full-suite run caught two real regressions from this change, both
fixed above rather than papered over: `debug_log_viewer_page_test` hung because
the copy handler now awaits a lookup that never completes under `testWidgets`
(fixed with `PackageInfo.setMockInitialValues` plus the production timeout), and
`settings_page_test` failed `A Timer is still pending` because
`DebugModeNotifier.enable` had started background work that outlived the widget
tree (fixed by not starting it there).
