### PR TITLE
fix(media_store): resume a stalled transfer queue instead of freezing it

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -19,6 +20,7 @@ import 'package:submersion/features/auto_update/presentation/providers/update_me
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
 import 'package:submersion/features/settings/presentation/widgets/adopt_replaced_library_dialog.dart';
@@ -107,6 +109,7 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeSyncOnLaunch();
+      _resumeMediaTransfers();
       _fileShareHandler.initialize();
     });
   }
@@ -150,7 +153,27 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     if (state == AppLifecycleState.resumed) {
       ref.read(appLockNotifierProvider.notifier).noteResumed();
       _maybeSyncOnResume();
+      _resumeMediaTransfers();
     }
+  }
+
+  /// Restarts an outstanding media transfer queue (issue #1270).
+  ///
+  /// On launch and on every resume, because the queue's own triggers all live
+  /// downstream of a runtime this process may never have built: a desktop app
+  /// sits in one process for days, and a queue that stopped mid-import stayed
+  /// stopped through every restart. The provider does the deciding - it
+  /// short-circuits on an unattached device or an empty queue before anything
+  /// expensive - and contains its own failures, which is what makes this call
+  /// safe to leave unawaited.
+  ///
+  /// Safe to reach the local cache database from here: StartupWrapper mounts
+  /// SubmersionRestart (and so this widget) only once `_state` is ready, which
+  /// it sets after `_initializeServices()` returns - and that awaits
+  /// `LocalCacheDatabaseService.instance.initialize`. This runs a post-frame
+  /// callback later still.
+  void _resumeMediaTransfers() {
+    unawaited(ref.read(mediaTransferResumeProvider)());
   }
 
   Future<void> _maybeSyncOnLaunch() async {

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -21,11 +21,15 @@ class MediaStoreWorker {
     MediaDeleteProcessor? deleteProcessor,
     Future<bool> Function()? preflight,
     Future<WorkerGate> Function(MediaTransferQueueEntry entry)? gate,
+    Duration entryBudget = defaultEntryBudget,
+    Duration preflightBudget = defaultPreflightBudget,
   }) : _queue = queue,
        _pipeline = pipeline,
        _deleteProcessor = deleteProcessor,
        _preflight = preflight,
-       _gate = gate;
+       _gate = gate,
+       _entryBudget = entryBudget,
+       _preflightBudget = preflightBudget;
 
   final MediaTransferQueueRepository _queue;
   final MediaUploadPipeline _pipeline;
@@ -44,6 +48,26 @@ class MediaStoreWorker {
 
   /// Deferral window for policy/connectivity-blocked entries.
   static const Duration deferWindow = Duration(minutes: 10);
+
+  /// How long the drain waits on one entry before moving to the next.
+  ///
+  /// Generous on purpose. This is not a policy on how fast a transfer ought
+  /// to be - an original-quality video over a slow uplink legitimately takes
+  /// a long time, and the adapters that do carry request timeouts (only S3,
+  /// at S3ApiClient.defaultUploadTimeout) already police that layer. Its one
+  /// job is to keep a transfer that will never come back from freezing the
+  /// whole queue, which is what happened in issue #1270.
+  static const Duration defaultEntryBudget = Duration(minutes: 30);
+
+  /// How long the drain waits on the preflight before giving up on it.
+  ///
+  /// Much shorter than [defaultEntryBudget] because the work is much
+  /// smaller: one GET of smv1/store.json. It runs before EVERY entry, so a
+  /// stall here wedges the drain without a single row being touched.
+  static const Duration defaultPreflightBudget = Duration(seconds: 30);
+
+  final Duration _entryBudget;
+  final Duration _preflightBudget;
 
   final _log = LoggerService.forClass(MediaStoreWorker);
   bool _running = false;
@@ -100,14 +124,50 @@ class MediaStoreWorker {
             await _queue.defer(entry.id, DateTime.now().add(deferWindow));
             continue;
           }
-          await deleteProcessor.process(entry);
+          await _withinBudget(entry, () => deleteProcessor.process(entry));
           continue;
         }
-        await _pipeline.process(entry);
+        await _withinBudget(entry, () async {
+          await _pipeline.process(entry);
+        });
       }
     } finally {
       _running = false;
       await _armWakeup(drainedToEmpty: drainedToEmpty);
+    }
+  }
+
+  /// Runs one entry's processing under [_entryBudget], moving on rather than
+  /// waiting forever (issue #1270).
+  ///
+  /// The budget stops the drain WAITING; it does not stop the transfer. Dart
+  /// cannot cancel a Future, so [work] keeps running and still owns its queue
+  /// row - which is what makes moving on safe. The row it left in
+  /// 'transferring' is invisible to [MediaTransferQueueRepository.nextPending]
+  /// until that call finally settles it, and every staging path is minted per
+  /// call ([MediaCacheStore.stagingFile]), so the entries that follow cannot
+  /// collide with the one still in flight.
+  ///
+  /// The deferral is load-bearing in exactly one case: a hang BEFORE
+  /// markTransferring (a stalled queue write, or a processor that never
+  /// reaches it) leaves the row 'pending' and re-selectable, and without a
+  /// future nextAttemptAt the loop would pick it straight back up and spin.
+  /// On the ordinary 'transferring' row the write is inert. [defer] is the
+  /// right verb either way: a budget expiry is a postponement, not a failed
+  /// attempt - the transfer may yet succeed, so it must not burn one of the
+  /// five attempts markFailed counts.
+  Future<void> _withinBudget(
+    MediaTransferQueueEntry entry,
+    Future<void> Function() work,
+  ) async {
+    try {
+      await work().timeout(_entryBudget);
+    } on TimeoutException {
+      _log.warning(
+        'Transfer entry ${entry.id} (media ${entry.mediaId}) exceeded its '
+        '${_entryBudget.inMinutes}m budget; deferring it and draining on',
+      );
+      await _queue.defer(entry.id, DateTime.now().add(deferWindow));
     }
   }
 
@@ -123,6 +183,12 @@ class MediaStoreWorker {
   /// stop transfers against a store this device may no longer be attached to,
   /// so "could not verify" must never be treated as "verified".
   ///
+  /// A preflight that never answers is the same case, and reaches the same
+  /// handler: [_preflightBudget] turns the stall into a TimeoutException.
+  /// Only the S3 adapter carries request timeouts of its own, so on the
+  /// others this is the sole thing standing between a stalled marker read
+  /// and a drain that hangs before touching a single row (issue #1270).
+  ///
   /// The throw is logged with its error and stack trace, not interpolated into
   /// the message: catching it is what stops the crash, so the log is now the
   /// only record of a preflight that keeps failing, and a bare string would
@@ -131,7 +197,7 @@ class MediaStoreWorker {
     final preflight = _preflight;
     if (preflight == null) return true;
     try {
-      if (await preflight()) return true;
+      if (await preflight().timeout(_preflightBudget)) return true;
       _log.warning('Media store preflight failed; drain suspended');
     } on Object catch (e, stackTrace) {
       _log.warning(

--- a/lib/features/media_store/data/media_upload_pipeline.dart
+++ b/lib/features/media_store/data/media_upload_pipeline.dart
@@ -286,7 +286,18 @@ class MediaUploadPipeline {
       return (isOverride || existing == null)
           ? UploadOutcome.uploaded
           : UploadOutcome.deduplicated;
-    } on Exception catch (e, stackTrace) {
+    } on Object catch (e, stackTrace) {
+      // Untyped on purpose (issue #1270). process() marks the row
+      // 'transferring' before it does anything, and nextPending never selects
+      // that state, so anything that escapes this catch leaves the row
+      // invisible to the drainer - unretryable and unclearable from the
+      // Transfers UI - until the next launch's reclaim pass hands it straight
+      // back to whatever raised it. Errors are not hypothetical on this path:
+      // an uninitialized singleton raises StateError (the same reasoning
+      // MediaDeletionCoordinator._delete documents), and staging a large
+      // original can raise OutOfMemoryError. Neither is an Exception, and
+      // markFailed's backoff is a far better answer to both than a row that
+      // wedges the queue head.
       _log.error(
         'Upload failed for media ${entry.mediaId}',
         error: e,

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
@@ -32,6 +34,26 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
 
   bool get _isSelectionMode => _selection.value.isActive;
   Set<String> get _selectedIds => _selection.value.checkedIds;
+
+  @override
+  void initState() {
+    super.initState();
+    // Opening this page resumes the queue (issue #1270).
+    //
+    // The dashboard's "N uploads pending" chip pushes straight here, and this
+    // route is a plain `builder` nested under media-storage, so
+    // MediaStoragePage - whose build resolves the runtime, and which is
+    // therefore the app's only reliable drain trigger - never runs on the way
+    // in. Someone arriving to ask why nothing is uploading was shown the
+    // stuck rows and nothing else.
+    //
+    // Resolving the runtime IS the kick: see the unawaited worker.drain() at
+    // the end of mediaStoreRuntimeProvider. Deliberately a read from
+    // initState rather than a watch in build whose value is thrown away - the
+    // list's rebuilds have nothing to do with the store's lifecycle, and the
+    // intent should not have to be inferred from an unused expression.
+    unawaited(ref.read(mediaStoreRuntimeProvider.future));
+  }
 
   /// Retry is safe only for a terminally failed entry. A `transferring` row
   /// must never be retried: the worker still holds it and a requeue would

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -158,6 +158,51 @@ final mediaVerifyRunnerProvider =
       };
     });
 
+/// Resumes an outstanding transfer queue at app launch and on app resume
+/// (issue #1270).
+///
+/// Every other drain trigger is downstream of [mediaStoreRuntimeProvider]
+/// already existing: the runtime is what kicks the first drain, subscribes to
+/// connectivity changes, and lets the worker arm its retry wakeup. Nothing in
+/// the launch path ever built it, and the display surfaces cannot stand in for
+/// one - the media grid only reaches the store for a row that is already
+/// backed up (`MediaItemView`'s storeConfirmed gate), which on a device that
+/// has never finished an upload is never true. So a queue that stopped for any
+/// reason - the app quit mid-import, a moment offline, a policy hold - had no
+/// way back, and the reporter's 196 rows survived every restart untouched.
+///
+/// Two cheap guards run before anything expensive, because building the
+/// runtime opens the keychain and reads the store marker out of the bucket:
+/// [mediaStoreAttachedProvider] is one SharedPreferences read (and is
+/// documented never to error, which is exactly why it exists), and
+/// [MediaTransferQueueRepository.nextPending] is one indexed local read that
+/// means precisely "there is work a drain could take right now". A queue
+/// holding only deferred rows is left to the worker's own wakeup timer.
+///
+/// Contains its own failures rather than propagating them: both call sites are
+/// fire-and-forget, so an escaping throw would land in the zone handler with
+/// nothing to catch it - the shape of #942.
+// no-tick: the value is a CLOSURE, not a query result. Every read happens
+// inside it at call time via ref.read, so there is no cached row to go stale.
+final mediaTransferResumeProvider = Provider<Future<void> Function()>((ref) {
+  return () async {
+    try {
+      if (!await ref.read(mediaStoreAttachedProvider.future)) return;
+      final queue = ref.read(mediaTransferQueueRepositoryProvider);
+      if (await queue.nextPending(DateTime.now()) == null) return;
+      // Building the runtime is the kick: see the unawaited drain at the end
+      // of mediaStoreRuntimeProvider.
+      await ref.read(mediaStoreRuntimeProvider.future);
+    } on Object catch (e, stackTrace) {
+      LoggerService.forClass(MediaStoreWorker).warning(
+        'Could not resume media transfers',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  };
+});
+
 final mediaBackfillServiceProvider = Provider<MediaBackfillService>(
   (ref) => MediaBackfillService(
     mediaRepository: ref.watch(mediaRepositoryProvider),

--- a/test/features/media_store/media_store_worker_budget_test.dart
+++ b/test/features/media_store/media_store_worker_budget_test.dart
@@ -1,0 +1,231 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_delete_processor.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+/// Processes every entry except the ones named in [hangOn], which are left
+/// unresolved for the life of the test - the shape of a transfer that never
+/// comes back rather than one that fails.
+class _HangingPipeline extends MediaUploadPipeline {
+  _HangingPipeline({
+    required this.queueRef,
+    required this.hangOn,
+    required super.mediaRepository,
+    required super.queue,
+    required super.store,
+    required super.registry,
+    required super.cache,
+    this.markTransferringFirst = true,
+  });
+
+  final MediaTransferQueueRepository queueRef;
+  final Set<String> hangOn;
+
+  /// Whether a hanging entry gets as far as `markTransferring`. The real
+  /// pipeline always does; false models a hang in the queue write itself,
+  /// which leaves the row 'pending' and therefore re-selectable.
+  final bool markTransferringFirst;
+
+  final processed = <String>[];
+  final _stuck = <Completer<UploadOutcome>>[];
+
+  /// Releases every parked call so the test ends with nothing in flight.
+  void releaseAll() {
+    for (final completer in _stuck) {
+      if (!completer.isCompleted) completer.complete(UploadOutcome.failed);
+    }
+  }
+
+  @override
+  Future<UploadOutcome> process(MediaTransferQueueEntry entry) async {
+    if (hangOn.contains(entry.mediaId)) {
+      if (markTransferringFirst) await queueRef.markTransferring(entry.id);
+      final completer = Completer<UploadOutcome>();
+      _stuck.add(completer);
+      return completer.future;
+    }
+    processed.add(entry.mediaId);
+    await queueRef.markDone(entry.id);
+    return UploadOutcome.uploaded;
+  }
+}
+
+class _HangingDeleteProcessor extends MediaDeleteProcessor {
+  _HangingDeleteProcessor({
+    required super.queue,
+    required super.store,
+    required super.mediaRepository,
+  });
+
+  final _stuck = <Completer<void>>[];
+
+  void releaseAll() {
+    for (final completer in _stuck) {
+      if (!completer.isCompleted) completer.complete();
+    }
+  }
+
+  @override
+  Future<void> process(MediaTransferQueueEntry entry) {
+    final completer = Completer<void>();
+    _stuck.add(completer);
+    return completer.future;
+  }
+}
+
+void main() {
+  late MediaRepository mediaRepository;
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late MediaTransferQueueRepository queue;
+
+  /// Short enough that a test waits it out in real time. The worker's default
+  /// is minutes; the seam exists so the budget is assertable at all.
+  const budget = Duration(milliseconds: 30);
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    mediaRepository = MediaRepository();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('worker_budget');
+    queue = MediaTransferQueueRepository(database: cacheDb);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    if (root.existsSync()) await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  _HangingPipeline buildPipeline({
+    required Set<String> hangOn,
+    bool markTransferringFirst = true,
+  }) {
+    return _HangingPipeline(
+      queueRef: queue,
+      hangOn: hangOn,
+      markTransferringFirst: markTransferringFirst,
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: InMemoryMediaObjectStore(),
+      registry: MediaSourceResolverRegistry({}),
+      cache: MediaCacheStore(database: cacheDb, root: root),
+    );
+  }
+
+  // Issue #1270: the drain is sequential and single-flight, so an upload that
+  // never returns holds _running forever and every later kick - connectivity,
+  // enqueue, the retry wakeup - becomes a no-op. One unreachable item froze
+  // the whole queue, and the next launch's reclaim handed the same row back to
+  // the same wedge.
+  test('an entry that never completes does not freeze the rest of the '
+      'queue', () async {
+    await queue.enqueueUpload(mediaId: 'stuck');
+    await queue.enqueueUpload(mediaId: 'healthy');
+    final pipeline = buildPipeline(hangOn: {'stuck'});
+    addTearDown(pipeline.releaseAll);
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      entryBudget: budget,
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+
+    expect(pipeline.processed, ['healthy']);
+  });
+
+  // The budget stops the drain WAITING; it cannot stop the upload, because
+  // Dart cannot cancel a Future. A hang before markTransferring therefore
+  // leaves the row 'pending' and re-selectable, and without the deferral the
+  // loop would pick it straight back up and spin.
+  test('a budgeted-out entry is deferred so the drain cannot spin on '
+      'it', () async {
+    await queue.enqueueUpload(mediaId: 'stuck');
+    final pipeline = buildPipeline(
+      hangOn: {'stuck'},
+      markTransferringFirst: false,
+    );
+    addTearDown(pipeline.releaseAll);
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      entryBudget: budget,
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+
+    final rows = await queue.allForTesting();
+    expect(rows.single.state, 'pending');
+    expect(rows.single.nextAttemptAt, isNotNull);
+    // A budget expiry is a postponement, not a failed attempt: the entry may
+    // still be uploading, and burning one of its five attempts would retire a
+    // healthy-but-slow item.
+    expect(rows.single.attempts, 0);
+  });
+
+  // The preflight runs before every entry and reads smv1/store.json out of the
+  // bucket. Only the S3 adapter carries HTTP timeouts of its own, so on the
+  // others a stalled read wedges the drain before any row is touched.
+  test('a preflight that never answers suspends the drain instead of '
+      'hanging it', () async {
+    await queue.enqueueUpload(mediaId: 'healthy');
+    final pipeline = buildPipeline(hangOn: const {});
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () => Completer<bool>().future,
+      preflightBudget: budget,
+    );
+    addTearDown(worker.dispose);
+
+    await expectLater(worker.drain(), completes);
+    expect(pipeline.processed, isEmpty);
+  });
+
+  // Deletes share the drain, so they wedge it the same way an upload does.
+  test('a delete entry that never completes does not freeze the '
+      'queue', () async {
+    await queue.enqueueDelete(
+      mediaId: 'gone',
+      contentHash: 'abc',
+      originalExt: 'jpg',
+      renditionExt: 'jpg',
+    );
+    await queue.enqueueUpload(mediaId: 'healthy');
+    final pipeline = buildPipeline(hangOn: const {});
+    final deleteProcessor = _HangingDeleteProcessor(
+      queue: queue,
+      store: InMemoryMediaObjectStore(),
+      mediaRepository: mediaRepository,
+    );
+    addTearDown(deleteProcessor.releaseAll);
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      deleteProcessor: deleteProcessor,
+      entryBudget: budget,
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+
+    expect(pipeline.processed, ['healthy']);
+  });
+}

--- a/test/features/media_store/media_transfer_resume_provider_test.dart
+++ b/test/features/media_store/media_transfer_resume_provider_test.dart
@@ -1,0 +1,109 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+void main() {
+  late LocalCacheDatabase db;
+  late MediaTransferQueueRepository queue;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: db);
+  });
+
+  tearDown(() => db.close());
+
+  /// Counts runtime builds without constructing a real store. Building the
+  /// real runtime is what kicks the drain, attaches the connectivity
+  /// subscription, and arms the retry wakeup, so "was it built?" is the whole
+  /// question this provider answers.
+  ({ProviderContainer container, List<int> builds}) buildContainer({
+    required bool attached,
+  }) {
+    final builds = <int>[];
+    final container = ProviderContainer(
+      overrides: [
+        mediaTransferQueueRepositoryProvider.overrideWithValue(queue),
+        mediaStoreAttachedProvider.overrideWith((ref) async => attached),
+        mediaStoreRuntimeProvider.overrideWith((ref) async {
+          builds.add(builds.length);
+          return null;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    return (container: container, builds: builds);
+  }
+
+  // Issue #1270: nothing in main.dart, app.dart, or startup_page.dart ever
+  // reads mediaStoreRuntimeProvider, so a queue left over from a previous
+  // session had no trigger at all - the reporter's 196 rows survived every
+  // restart untouched.
+  test('a device with due work builds the runtime, which drains it', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final harness = buildContainer(attached: true);
+
+    await harness.container.read(mediaTransferResumeProvider)();
+
+    expect(harness.builds, hasLength(1));
+  });
+
+  // Building the runtime opens the keychain and reads the store marker out of
+  // the bucket. That is far too expensive to pay on every launch and resume of
+  // a device that has nothing to transfer.
+  test('an empty queue does not build the runtime', () async {
+    final harness = buildContainer(attached: true);
+
+    await harness.container.read(mediaTransferResumeProvider)();
+
+    expect(harness.builds, isEmpty);
+  });
+
+  // The attach check is one SharedPreferences read and short-circuits before
+  // the queue is even opened, which is why mediaStoreAttachedProvider exists.
+  test('a device with no store attached does not build the runtime', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final harness = buildContainer(attached: false);
+
+    await harness.container.read(mediaTransferResumeProvider)();
+
+    expect(harness.builds, isEmpty);
+  });
+
+  // A row parked behind markFailed's backoff (up to 25 hours) is not due, so
+  // there is nothing for a drain to take. The worker's own wakeup timer owns
+  // that case once the runtime exists.
+  test('a queue holding only deferred rows does not build the '
+      'runtime', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final entry = (await queue.nextPending(DateTime.now()))!;
+    await queue.defer(entry.id, DateTime.now().add(const Duration(hours: 25)));
+    final harness = buildContainer(attached: true);
+
+    await harness.container.read(mediaTransferResumeProvider)();
+
+    expect(harness.builds, isEmpty);
+  });
+
+  // Both call sites are fire-and-forget, so an unusable local cache database
+  // (StateError, an Error rather than an Exception) must not escape into the
+  // zone handler the way the preflight throw did in #942.
+  test('a failure resuming transfers is contained, not thrown', () async {
+    final container = ProviderContainer(
+      overrides: [
+        mediaStoreAttachedProvider.overrideWith((ref) async => true),
+        mediaTransferQueueRepositoryProvider.overrideWith(
+          (ref) => MediaTransferQueueRepository(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(container.read(mediaTransferResumeProvider)(), completes);
+  });
+}

--- a/test/features/media_store/media_upload_pipeline_test.dart
+++ b/test/features/media_store/media_upload_pipeline_test.dart
@@ -46,6 +46,24 @@ class _PutThrowsStore extends InMemoryMediaObjectStore {
   }
 }
 
+/// A store whose uploads fail with an Error rather than an Exception.
+/// StateError is what an uninitialized singleton throws (the pattern
+/// MediaDeletionCoordinator already documents), and a staging read of a large
+/// original can raise OutOfMemoryError; neither is an Exception.
+class _PutThrowsErrorStore extends InMemoryMediaObjectStore {
+  @override
+  Future<void> putFile(
+    String key,
+    File source, {
+    required String contentType,
+    TransferProgressCallback? onProgress,
+    String? resumeStateJson,
+    void Function(String resumeStateJson)? onResumeStateChanged,
+  }) async {
+    throw StateError('LocalCacheDatabaseService is not initialized');
+  }
+}
+
 class _FakeLocalFileResolver implements MediaSourceResolver {
   _FakeLocalFileResolver(this.data);
 
@@ -439,6 +457,38 @@ void main() {
     expect(row.attempts, 1);
     expect(row.errorMessage, isNotNull);
     expect(failingStore.objects, isEmpty);
+  });
+
+  // Issue #1270: process() marks the row 'transferring' before it does any
+  // work, and nextPending deliberately never selects that state. An Error
+  // escaping the catch therefore left the row invisible to the drainer for
+  // the rest of the process - unretryable (failed-only) and unclearable
+  // (done-only) from the Transfers UI - until the next launch's reclaim pass
+  // handed it back to whatever raised the Error in the first place.
+  test('an upload Error fails the row rather than stranding it in '
+      'transferring', () async {
+    final erroringStore = _PutThrowsErrorStore();
+    final registry = MediaSourceResolverRegistry({
+      MediaSourceType.localFile: resolver,
+    });
+    final erroringPipeline = MediaUploadPipeline(
+      mediaRepository: mediaRepository,
+      queue: queue,
+      store: erroringStore,
+      registry: registry,
+      cache: cache,
+      thumbnails: ThumbnailGenerator(registry: registry, cache: cache),
+      now: () => DateTime(2026, 7, 10, 12),
+    );
+
+    await enqueueLocalFileItem(bytes: [1, 2, 3], name: 'error.jpg');
+    final entry = (await queue.nextPending(DateTime.now()))!;
+
+    expect(await erroringPipeline.process(entry), UploadOutcome.failed);
+    final row = (await queue.allForTesting()).single;
+    expect(row.state, 'pending', reason: 'the drainer must see it again');
+    expect(row.attempts, 1);
+    expect(row.errorMessage, contains('not initialized'));
   });
 
   group('serviceConnector rows', () {

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -419,4 +419,42 @@ void main() {
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
+
+  // Issue #1270: the dashboard's "N uploads pending" chip pushes straight
+  // here, and go_router builds this route with a plain `builder` nested under
+  // media-storage, so MediaStoragePage - the one screen whose build resolves
+  // the runtime, and therefore the app's only reliable drain trigger - never
+  // runs on the way in. Opening Transfers showed the stuck rows without doing
+  // anything about them, which is precisely what the reporter expected it to
+  // fix. Resolving the runtime here kicks the drain (see the unawaited
+  // worker.drain() at the end of mediaStoreRuntimeProvider).
+  testWidgets('opening the page resolves the runtime, which drains the queue', (
+    tester,
+  ) async {
+    var builds = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mediaTransferQueueRepositoryProvider.overrideWithValue(repo),
+          localAssetCacheRepositoryProvider.overrideWithValue(assetCache),
+          mediaTransferEntriesProvider.overrideWith(
+            (ref) => Stream.value(const <MediaTransferQueueEntry>[]),
+          ),
+          mediaStoreRuntimeProvider.overrideWith((ref) async {
+            builds++;
+            return null;
+          }),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: TransfersPage(),
+        ),
+      ),
+    );
+    await pumpRoute(tester);
+
+    expect(builds, 1);
+  });
 }


### PR DESCRIPTION
Closes #1270.

## Root cause

A media transfer queue that stopped for any reason had no way back.

Every drain trigger lives downstream of `mediaStoreRuntimeProvider` already existing in the current process: building it is what fires the first `worker.drain()` (`media_store_providers.dart:354`), attaches the connectivity subscription (`:347`), and lets the worker arm its retry wakeup. That provider is lazily built, and nothing in `main.dart`, `app.dart`, or `startup_page.dart` ever read it. `didChangeAppLifecycleState` handled only app-lock and data sync.

The display surfaces cannot stand in for a real trigger. `MediaItemView` only reaches the store for a row that is **already backed up** (`media_item_view.dart:330-335`: `contentHash` plus one of the three remote-upload stamps). On a device that has never finished an upload, no row qualifies, so browsing the library never builds the runtime, so nothing drains, so nothing ever becomes `storeConfirmed`. Mobile hides this because lifecycle churn and constant media viewing build the runtime anyway; a desktop app sits in one process for days.

Both screens a stuck user visits were dead ends. The home "N uploads pending" chip only did `context.push('/settings/media-storage/transfers')` (`gauge_strip.dart:319`), and `TransfersPage.build` watched just `mediaTransferEntriesProvider`, a plain stream over the queue table. Because that route is a plain go_router `builder` nested under `media-storage` (`app_router.dart:1108-1118`), pushing the child never builds `MediaStoragePage`, whose `mediaStoreStatusHintProvider` watch was the app's only reliable drain trigger.

## Changes

**1. Launch and resume drain** (`media_store_providers.dart`, `app.dart`)

New `mediaTransferResumeProvider`, called from `initState`'s post-frame callback and on `AppLifecycleState.resumed`. Two cheap guards run before anything expensive, because building the runtime opens the keychain and reads the store marker out of the bucket: `mediaStoreAttachedProvider` is one SharedPreferences read (documented never to error, which is exactly why it exists), and `nextPending` is one indexed local read meaning precisely "there is work a drain could take right now". A queue holding only deferred rows is left to the worker's own wakeup timer.

Reaching the local cache database from there is safe, and the comment records why: `StartupWrapper` mounts `SubmersionRestart` only once `_state` is ready (`startup_page.dart:1128`, set at `:328`), which it sets after `_initializeServices()` returns, and that awaits `LocalCacheDatabaseService.instance.initialize` at `:647`.

**2. Transfers page kicks a drain** (`transfers_page.dart`)

`initState` resolves `mediaStoreRuntimeProvider`, which makes the home chip's push actually do something. Deliberately a `read` from `initState` rather than a `watch` in `build` whose value is discarded: the list's rebuilds have nothing to do with the store's lifecycle, and the intent should not have to be inferred from an unused expression.

**3. An escaping `Error` no longer strands a row** (`media_upload_pipeline.dart`)

`process()` marks the row `transferring` before doing any work, and `nextPending` never selects that state, so anything escaping the catch left the row invisible to the drainer: unretryable (failed-only) and unclearable (done-only) from the Transfers UI, until the next launch's reclaim pass handed it straight back to whatever raised it. The catch was `on Exception`; `StateError` from an uninitialized singleton and `OutOfMemoryError` from staging a large original are both `Error`s. Now `on Object`, the same reasoning `MediaDeletionCoordinator._delete` already documents.

**4. Per-entry time budget in the drain loop** (`media_store_worker.dart`)

The drain is sequential and single-flight, so one entry that never returns held `_running` forever and every later kick (connectivity, enqueue, the retry wakeup) became a no-op. `_withinBudget` wraps pipeline and delete processing (30 minutes, injectable), and the preflight gets its own much shorter budget (30 seconds) because it runs before **every** entry and does an untimed marker GET.

The honest caveat, written into the code: **`.timeout()` does not cancel anything.** Dart cannot cancel a `Future`, so the work keeps running and still owns its queue row, which is what makes moving on safe: the row it left in `transferring` is invisible to `nextPending` until that call settles it, and `MediaCacheStore.stagingFile()` mints a unique path per call. The `defer` on expiry is load-bearing in exactly one case, a hang *before* `markTransferring`, which leaves the row `pending` and re-selectable; `defer` rather than `markFailed` because a budget expiry is a postponement and must not burn one of the five attempts.

## Scope

This fixes the **persistence** of the reported bug, not necessarily the original trigger for that first stalled drain, which is not determinable from the report. What is proven is that whatever stopped it, the queue had no way back.

The macOS Photos path is not at fault. Traced end to end: macOS routes to `PhotoPickerServiceMobile` (`photo_picker_providers.dart:18-23`), `media_import_service.dart:268-288` writes `sourceType: platformGallery` with a non-null `platformAssetId`, that type is in `kUploadableSources`, and `photo_manager`'s `originBytes` reaches macOS through `originFile`/`getFullFile` rather than the `getOriginBytes` channel the darwin plugin does not implement. `_materialize` gets real bytes.

Filed #1279 separately: `DropboxApiClient` and the Google Drive media client both fall back to a bare `http.Client()` with no timeouts, unlike `S3ApiClient`. The new entry budget contains the blast radius but does not close that gap.

## Testing

11 new tests, each watched failing first. The four drain-budget tests are the sharpest: before the fix all four hung until the 30-second test timeout, which is the reported bug reproduced.

- `media_store_worker_budget_test.dart` (new): a hanging entry does not freeze the rest of the queue; a budgeted-out entry is deferred without consuming an attempt; a hanging preflight suspends rather than freezes; a hanging delete entry does not freeze the queue.
- `media_transfer_resume_provider_test.dart` (new): builds the runtime only when a store is attached and there is due work; not for an empty queue, not when unattached, not for deferred-only rows; a failure is contained rather than thrown into the zone handler.
- `media_upload_pipeline_test.dart`: an upload `Error` fails the row rather than stranding it in `transferring`.
- `transfers_page_test.dart`: opening the page resolves the runtime.

`dart format` clean, `flutter analyze` clean across the project, and the full suite green: **20,098 passed, 19 skipped**.
