### PR TITLE
fix(cloud): give the Dropbox and Google Drive transports request deadlines

### DIFF
--- a/docs/superpowers/specs/2026-08-25-cloud-http-request-deadlines-design.md
+++ b/docs/superpowers/specs/2026-08-25-cloud-http-request-deadlines-design.md
@@ -1,0 +1,203 @@
+# Cloud HTTP Request Deadlines: Design
+
+**Status:** approved 2026-08-25
+**Issue:** #1279
+**Branch:** `worktree-1279-cloud-http-timeouts`
+**Supersedes nothing.** Generalises the deadlines `S3ApiClient` gained in
+#1175/#942 to the other two cloud transports.
+
+## Problem
+
+`S3ApiClient` is the only cloud transport in the app with request deadlines.
+The Dropbox and Google Drive clients both fall back to a bare `http.Client()`,
+which on Dart IO means `HttpClient.connectionTimeout == null` and no response
+or idle deadline at all. A socket that connects and then wedges, or one that
+never connects, waits on the OS default.
+
+Found while investigating #1270 (media uploads stuck on desktop). Not the root
+cause of that issue, but the underlying gap is real and worth closing on its
+own.
+
+## Findings
+
+Every claim below was verified against `origin/main` at 716d2c597fc.
+
+**F1. The S3 client gets this right and documents why.**
+`s3_api_client.dart:93` wraps `IOClient(HttpClient()..connectionTimeout =
+defaultConnectTimeout)`. `:117`, `:121`, `:132` and `:140` define
+`defaultConnectTimeout` (15s), `defaultResponseTimeout` (30s),
+`defaultUploadTimeout` (10m) and `defaultIdleTimeout` (30s), each with its own
+rationale traced back to #942, and `:729` applies the response/upload split on
+the send path.
+
+**F2. Dropbox has none.** `dropbox_api_client.dart:64` is
+`_http = httpClient ?? http.Client()`. `grep -n "timeout"` over the file
+returns nothing.
+
+**F3. Dropbox's auth manager has none either, and it is on the same critical
+path.** `dropbox_auth_manager.dart:25` is the same fallback. This matters more
+than it looks: `dropbox_api_client.dart:307` awaits `_getAccessToken()`
+*inside* the send loop, before every request. A wedged token refresh stalls
+every Dropbox request behind it exactly like a wedged request would, so fixing
+only the API client would leave the hole open.
+
+**F4. Google Drive has none, on either auth path.**
+`google_drive_media_object_store.dart:17` takes an injected `http.Client`.
+Both construction sites (`media_store_service.dart:60`,
+`google_drive_account_adapter.dart:51`) get it from
+`google_drive_storage_provider.dart:108`'s `mediaHttpClient()`, which returns
+the authenticator's `authClient`. That is a `googleapis_auth` refreshing
+client over a plain `http.Client()` in both implementations
+(`desktop_oauth_authenticator.dart:60`, `google_sign_in_authenticator.dart:113`).
+`grep -n "timeout" lib/core/services/media_store/*.dart` returns nothing.
+
+**F5. The same client backs Drive *sync*, not just media.**
+`google_drive_storage_provider.dart:130` builds `drive.DriveApi(client)` from
+the same `authClient`. One wrapper at the authenticator therefore covers sync,
+media transfers, and the store marker read below.
+
+**F6. The store marker read runs before every queue entry, on the same
+transport.** `media_store_providers.dart:311` calls
+`StoreMarkerStore(store: store).read()` (one GET of `smv1/store.json`,
+`store_marker.dart:46`) from the worker's preflight, and
+`media_store_worker.dart:78` re-runs that preflight per entry, not once per
+drain.
+
+**F7. There is no containment for a wedged request on `main` today.**
+`media_store_worker.dart:66-111` is a sequential `while (true)` loop guarded
+by a `_running` single-flight flag, and `await _pipeline.process(entry)` has
+no per-entry deadline. A request that never returns therefore blocks the loop
+forever *and* leaves `_running` true, so every later `drain()` call returns
+immediately. #1279's text refers to a per-entry drain budget from #1270 as
+already containing the blast radius; #1270 is still open and that budget is
+not on `main`, so the freeze is currently unbounded.
+
+**F8. googleapis never declares a body length.**
+`_discoveryapis_commons-1.0.7/lib/src/request_impl.dart:11-32`: `RequestImpl`
+extends `http.BaseRequest`, supplies the body from a `Stream<List<int>>` in
+`finalize()`, and never assigns `contentLength`. It is null for every call the
+Drive API makes, upload or not. Any deadline rule keyed purely on declared
+body size would put every Drive upload on the short response deadline.
+
+## Design
+
+One shared decorator, installed at four seams. No transport re-implements the
+policy.
+
+### Part 1: `TimeoutHttpClient`
+
+New file `lib/core/services/cloud_storage/http_timeouts.dart`.
+
+`TimeoutHttpClient` is an `http.BaseClient` decorator over any inner client.
+`send` applies a deadline to `_inner.send(request)` (status and headers) and a
+second, independent idle deadline to the response body stream, then rebuilds
+the `StreamedResponse` around the wrapped stream. `close()` forwards to the
+inner client.
+
+`TimeoutHttpClient.overSockets()` additionally owns its transport:
+`IOClient(HttpClient()..connectionTimeout = ...)`. The two halves are
+complementary and both are needed. The `send` deadlines bound a socket that
+connects and then stalls; `connectionTimeout` bounds one that never connects.
+
+The four constants are deliberately F1's constants, with F1's reasoning:
+
+| Deadline | Value | Bounds |
+| --- | --- | --- |
+| connect | 15s | TCP connect to an unreachable endpoint |
+| response | 30s | status + headers on a request with no meaningful body |
+| upload | 10m | the same, on a request whose body must be written first |
+| idle | 30s | longest gap the response body may go without a byte |
+
+The idle deadline is a gap, not a total budget: a legitimate 8 MiB download
+over a weak link takes minutes and must not be killed, while a connection that
+has stopped delivering is dead regardless of how little it had left to send.
+
+### Part 2: which deadline a request gets
+
+`Client.send` does not complete until the request body has been written, so
+for a PUT the "wait for a response" window contains the whole upload. That is
+why the upload deadline exists at all, and why it cannot simply be applied to
+everything: a wedged Dropbox RPC would then take ten minutes to fail.
+
+The classifier is size first, method second:
+
+1. A declared `contentLength` above `uploadBodyThresholdBytes` (64 KiB) is an
+   upload. Below it, the request is a control-plane call whose body is written
+   in one go, so the response deadline is the right one. A Dropbox RPC carries
+   a few dozen bytes of JSON; the smallest thing the app actually uploads is
+   an 8 MiB chunk, so 64 KiB separates them with room to spare.
+2. When `contentLength` is null the method decides: `GET`, `HEAD` and `DELETE`
+   get the response deadline, anything else gets the upload deadline.
+
+Step 2 exists entirely because of F8. Without it every Drive upload would be
+cut off at 30s and healthy transfers would start failing.
+
+### Part 3: the four installation seams
+
+**Dropbox API client.** `httpClient ?? TimeoutHttpClient.overSockets()`. No
+change to `_send`: its existing `on Exception` wrapper already maps the
+resulting `TimeoutException` to `CloudStorageException('Could not reach
+Dropbox')`, and `DropboxMediaObjectStore` already classifies that message as
+transient. This one seam covers Dropbox sync and Dropbox media.
+
+**Dropbox auth manager.** The same fallback, for F3.
+
+**Desktop OAuth authenticator.** The default `baseClientFactory` becomes a
+timed client. The wrapper goes *underneath* `gauth.autoRefreshingClient`
+(`desktop_oauth_authenticator.dart:139`), so it covers every Drive call the
+refreshing client makes, its own token refreshes, the consent-flow token
+exchange, and revocation.
+
+**google_sign_in authenticator.** The opposite: the plugin builds the
+authorized client over a socket layer the app never sees, so the wrapper goes
+on the *outside* of `authorization.authClient(scopes:)`. The field's type
+relaxes from `gapis_auth.AuthClient?` to `http.Client?`, which is what the
+`GoogleDriveAuthenticator.authClient` contract already exposes and all
+downstream consumers already use.
+
+By F4 and F5 those two authenticator seams are sufficient for Google Drive:
+`GoogleDriveMediaObjectStore` needs no change, because its transport is the
+authenticator's client at both construction sites. Wrapping it again inside
+the store would stack a second idle deadline on the same stream for no gain.
+
+### Part 4: testability
+
+Each transport that builds its own default exposes a `@visibleForTesting`
+`transport` getter, so a test can assert the fact the issue is actually about
+("this client did not fall back to a bare `http.Client()`") rather than
+asserting it indirectly through a stall. `TimeoutHttpClient` carries the
+`connectTimeout` it configured as a field, null when the inner client came
+from the caller, so the same assertion covers the connect half.
+
+## Out of scope
+
+**`S3ApiClient` is not routed through the wrapper.** It applies the same four
+deadlines inline, interleaved with its SigV4 retry loop, which classifies
+`TimeoutException` as a retryable transport fault and replays the request
+(possibly against a server-corrected region). Unpicking that is a change to a
+well-covered path with no behaviour to gain. The duplication is one `.timeout`
+pair, and this design deliberately adopts its constants rather than inventing
+new ones.
+
+**Other bare `http.Client()` users stay as they are:** weather, tides, reef,
+bathymetry, the GitHub updater, and the Lightroom client. None sit on the sync
+or media transfer paths, so none can wedge a queue. The wrapper is now
+available to them.
+
+**Retry policy is unchanged.** A deadline that fires surfaces through each
+client's existing error mapping. Nothing here adds attempts, backoff, or a new
+`UnavailableKind`; per the media fetch-budget work, a new unavailability kind
+must never reach an orphan path, so introducing one was avoided outright.
+
+## Product decisions (do not relitigate)
+
+- **Ten minutes, not one, for uploads.** Killing a transfer that was making
+  progress is the failure mode that left large first syncs failing nine times
+  in ten (#942). The deadline exists to bound a genuinely wedged socket, not
+  to enforce throughput.
+- **A 64 KiB threshold, not "any body".** Chosen so control-plane POSTs fail
+  fast while real chunks get the long clock. It is a classifier, not a limit:
+  nothing rejects a body for its size.
+- **Deadlines live in the transport, not in each call site.** Every call site
+  that would otherwise need its own `.timeout` is a place a future call site
+  can forget one. That is exactly how #1279 happened.

--- a/lib/core/services/cloud_storage/dropbox/dropbox_api_client.dart
+++ b/lib/core/services/cloud_storage/dropbox/dropbox_api_client.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 
 /// Account labels from /users/get_current_account.
 class DropboxAccount {
@@ -51,6 +53,11 @@ class DropboxFileMetadata {
 ///                  (getMetadata, delete); download throws.
 /// - insufficient_space -> distinct user-facing message.
 /// - anything else non-2xx, and transport errors -> wrapped generic.
+///
+/// Every request runs under [TimeoutHttpClient]'s deadlines unless the caller
+/// injects its own transport: a bare `http.Client()` has none, so a wedged
+/// socket used to park a request forever, freezing the sequential media
+/// transfer drain that runs through DropboxMediaObjectStore (#1279).
 class DropboxApiClient {
   DropboxApiClient({
     required Future<String> Function() getAccessToken,
@@ -61,7 +68,7 @@ class DropboxApiClient {
     Future<void> Function(Duration)? wait,
   }) : _getAccessToken = getAccessToken,
        _onAccessTokenRejected = onAccessTokenRejected,
-       _http = httpClient ?? http.Client(),
+       _http = httpClient ?? TimeoutHttpClient.overSockets(),
        _wait = wait ?? ((d) => Future<void>.delayed(d));
 
   static final Uri _apiBase = Uri.parse('https://api.dropboxapi.com');
@@ -79,6 +86,11 @@ class DropboxApiClient {
   final void Function() _onAccessTokenRejected;
   final http.Client _http;
   final Future<void> Function(Duration) _wait;
+
+  /// The transport actually in use, so a test can assert that a client nobody
+  /// handed one to did not fall back to a deadline-free `http.Client()`.
+  @visibleForTesting
+  http.Client get transport => _http;
 
   Future<DropboxFileMetadata> upload(String path, Uint8List data) async {
     if (data.length > chunkedUploadThresholdBytes) {

--- a/lib/core/services/cloud_storage/dropbox/dropbox_auth_manager.dart
+++ b/lib/core/services/cloud_storage/dropbox/dropbox_auth_manager.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:http/http.dart' as http;
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_app.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_store.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 import 'package:submersion/core/services/oauth/oauth_pkce.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
@@ -14,6 +16,10 @@ import 'package:submersion/core/services/logger_service.dart';
 ///
 /// The refresh token is the only persisted credential (DropboxAuthStore);
 /// access tokens (~4 h lifetime) live in memory only.
+///
+/// The transport carries [TimeoutHttpClient]'s deadlines: token refresh is
+/// awaited inside DropboxApiClient's send loop, so a wedged refresh stalls
+/// every Dropbox request behind it just as a wedged request would (#1279).
 class DropboxAuthManager {
   DropboxAuthManager({
     this.appKey = dropboxAppKey,
@@ -22,7 +28,7 @@ class DropboxAuthManager {
     DateTime Function()? now,
     String Function()? verifierGenerator,
   }) : _store = store ?? DropboxAuthStore(),
-       _http = httpClient ?? http.Client(),
+       _http = httpClient ?? TimeoutHttpClient.overSockets(),
        _now = now ?? DateTime.now,
        _generateVerifier = verifierGenerator ?? generateCodeVerifier;
 
@@ -50,6 +56,12 @@ class DropboxAuthManager {
   final http.Client _http;
   final DateTime Function() _now;
   final String Function() _generateVerifier;
+
+  /// The transport actually in use, so a test can assert that a manager
+  /// nobody handed one to did not fall back to a deadline-free
+  /// `http.Client()`.
+  @visibleForTesting
+  http.Client get transport => _http;
 
   String? _pendingVerifier;
   String? _accessToken;

--- a/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_token_store.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
 /// Runs the user-consent step of the loopback flow and returns credentials.
@@ -57,10 +58,19 @@ class DesktopOAuthAuthenticator implements GoogleDriveAuthenticator {
        _obtainConsent =
            obtainConsent ?? gauth.obtainAccessCredentialsViaUserConsent,
        _buildClient = buildClient ?? gauth.autoRefreshingClient,
-       _baseClientFactory = baseClientFactory ?? http.Client.new,
+       _baseClientFactory = baseClientFactory ?? _timedClient,
        _launchBrowser = launchBrowser ?? launchUrlString;
 
   static final _log = LoggerService.forClass(DesktopOAuthAuthenticator);
+
+  /// Base transport for the refreshing client, the consent-flow token
+  /// exchange, and revocation.
+  ///
+  /// A bare `http.Client()` has no connect, response or read deadline, so a
+  /// wedged socket parked every Drive call made through the refreshing client
+  /// on top of it -- on sync and, via `mediaHttpClient()`, on the media
+  /// transfer queue (#1279).
+  static http.Client _timedClient() => TimeoutHttpClient.overSockets();
 
   /// openid + email are included so the id_token carries the account email
   /// for the settings tile subtitle; drive.appdata is the only Drive scope.

--- a/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
+++ b/lib/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:extension_google_sign_in_as_googleapis_auth/extension_google_sign_in_as_googleapis_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:googleapis/drive/v3.dart' as drive;
-import 'package:googleapis_auth/googleapis_auth.dart' as gapis_auth;
 import 'package:http/http.dart' as http;
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 import 'package:submersion/core/services/logger_service.dart';
 
 /// google_sign_in-backed authenticator for iOS, macOS, and Android.
@@ -29,7 +29,12 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
   // hints.
   final GoogleSignIn _googleSignIn = GoogleSignIn.instance;
   bool _initialized = false;
-  gapis_auth.AuthClient? _authClient;
+
+  /// The authorized client, wrapped in [TimeoutHttpClient]. Held as a plain
+  /// [http.Client] because that wrapper is what everything downstream uses:
+  /// the provider builds its DriveApi from it and the media store sends raw
+  /// REST over it, and neither needs the AuthClient surface.
+  http.Client? _authClient;
   GoogleSignInAccount? _currentUser;
 
   @override
@@ -110,7 +115,10 @@ class GoogleSignInAuthenticator implements GoogleDriveAuthenticator {
     GoogleSignInClientAuthorization authorization,
   ) {
     _authClient?.close();
-    _authClient = authorization.authClient(scopes: _scopes);
+    // google_sign_in builds the authorized client over a transport this app
+    // never gets to configure, so the deadlines go on the outside. Closing
+    // the wrapper closes the client underneath it (#1279).
+    _authClient = TimeoutHttpClient(authorization.authClient(scopes: _scopes));
     _currentUser = account;
   }
 

--- a/lib/core/services/cloud_storage/http_timeouts.dart
+++ b/lib/core/services/cloud_storage/http_timeouts.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+/// An [http.Client] decorator that gives every request a deadline (#1279).
+///
+/// A bare `http.Client()` has none. On Dart IO it leaves
+/// `HttpClient.connectionTimeout` null, so a TCP connect to an unreachable
+/// endpoint waits on the OS default -- minutes on some Windows configurations
+/// -- and it adds no response or read deadline at all, so a socket that
+/// connects and then wedges parks its request forever. The media transfer
+/// queue is sequential and single-flight, so one such request used to freeze
+/// the whole drain (#1270).
+///
+/// Wrap a transport in this and both halves are covered: [overSockets] bounds
+/// a connection that never establishes, and [send] bounds one that establishes
+/// and then goes quiet.
+///
+/// `S3ApiClient` applies the same four deadlines inline rather than through
+/// this wrapper. It interleaves them with its own SigV4 retry loop, which
+/// classifies `TimeoutException` as a retryable transport fault and replays
+/// the request; unpicking that is a change to a well-covered path with no
+/// behaviour to gain. The constants here are deliberately its constants.
+class TimeoutHttpClient extends http.BaseClient {
+  TimeoutHttpClient(
+    this._inner, {
+    this.responseTimeout = defaultResponseTimeout,
+    this.uploadTimeout = defaultUploadTimeout,
+    this.idleTimeout = defaultIdleTimeout,
+    this.connectTimeout,
+  });
+
+  /// A wrapper over a fresh IO transport whose TCP connect is bounded too.
+  ///
+  /// This is the constructor callers want unless they are decorating a client
+  /// somebody else built (an OAuth refreshing client, say), which cannot have
+  /// its socket layer reconfigured after the fact.
+  factory TimeoutHttpClient.overSockets({
+    Duration connectTimeout = defaultConnectTimeout,
+    Duration responseTimeout = defaultResponseTimeout,
+    Duration uploadTimeout = defaultUploadTimeout,
+    Duration idleTimeout = defaultIdleTimeout,
+  }) => TimeoutHttpClient(
+    IOClient(HttpClient()..connectionTimeout = connectTimeout),
+    responseTimeout: responseTimeout,
+    uploadTimeout: uploadTimeout,
+    idleTimeout: idleTimeout,
+    connectTimeout: connectTimeout,
+  );
+
+  /// How long to wait for the TCP connection itself.
+  static const Duration defaultConnectTimeout = Duration(seconds: 15);
+
+  /// How long to wait for a response's status and headers on a request that
+  /// carries no meaningful body. Covers TLS setup and the server's own think
+  /// time.
+  static const Duration defaultResponseTimeout = Duration(seconds: 30);
+
+  /// The same deadline for a request that CARRIES a body.
+  ///
+  /// Separate and far more generous, because `Client.send` does not complete
+  /// until the body has been written: for a PUT the "wait for a response"
+  /// window contains the whole upload. A media chunk is 8 MiB, which at
+  /// 110 kbps takes ten minutes, and killing a transfer that was making
+  /// progress is exactly the failure mode that left large first syncs failing
+  /// nine times in ten (#942). Ten minutes still bounds a socket that has
+  /// genuinely wedged, which is all this needs to do.
+  static const Duration defaultUploadTimeout = Duration(minutes: 10);
+
+  /// How long a response body may go without delivering a single byte.
+  ///
+  /// Deliberately an IDLE gap rather than a total budget: a legitimate 8 MiB
+  /// download over a weak mobile link takes minutes and must not be killed,
+  /// while a connection that has stopped delivering is dead regardless of how
+  /// little it had left to send.
+  static const Duration defaultIdleTimeout = Duration(seconds: 30);
+
+  /// Above this many declared body bytes a request is treated as an upload.
+  ///
+  /// A Dropbox RPC POSTs a few dozen bytes of JSON; writing that is not a
+  /// transfer, and a wedged one should fail on the seconds-scale response
+  /// deadline rather than sit for the ten minutes a real multi-megabyte
+  /// upload is allowed. 64 KiB is comfortably above every control-plane body
+  /// the app sends and far below the smallest chunk it uploads.
+  static const int uploadBodyThresholdBytes = 64 * 1024;
+
+  /// Methods that do not carry a body, used to classify a request whose
+  /// length is unknown until it is written.
+  static const Set<String> _bodilessMethods = {'GET', 'HEAD', 'DELETE'};
+
+  final http.Client _inner;
+
+  /// Deadline for a response's status and headers, on a request with no
+  /// meaningful body.
+  final Duration responseTimeout;
+
+  /// The same deadline for a request whose body has to be written first.
+  final Duration uploadTimeout;
+
+  /// Longest gap the response body may go without delivering a byte.
+  final Duration idleTimeout;
+
+  /// Connect deadline configured on the transport this wrapper owns, or null
+  /// when the inner client came from the caller and its socket layer is not
+  /// ours to configure.
+  final Duration? connectTimeout;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await _inner
+        .send(request)
+        .timeout(_carriesUpload(request) ? uploadTimeout : responseTimeout);
+    return http.StreamedResponse(
+      response.stream.timeout(idleTimeout),
+      response.statusCode,
+      contentLength: response.contentLength,
+      request: response.request,
+      headers: response.headers,
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+
+  @override
+  void close() => _inner.close();
+
+  /// Whether [request] should get the generous body-carrying deadline.
+  ///
+  /// A declared length settles it. When there is none the method decides,
+  /// because googleapis' own `RequestImpl` never sets `contentLength` --
+  /// upload or not -- so a length-only rule would put every Drive upload on
+  /// the short response deadline and start killing healthy transfers.
+  static bool _carriesUpload(http.BaseRequest request) {
+    final length = request.contentLength;
+    if (length != null) return length > uploadBodyThresholdBytes;
+    return !_bodilessMethods.contains(request.method.toUpperCase());
+  }
+}

--- a/test/core/services/cloud_storage/dropbox/dropbox_api_client_timeout_test.dart
+++ b/test/core/services/cloud_storage/dropbox/dropbox_api_client_timeout_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_api_client.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
+
+/// Request deadlines on the Dropbox transport (#1279).
+///
+/// The client used to default to a bare `http.Client()`, so a wedged socket
+/// parked its request forever -- on the sync path and, through
+/// `DropboxMediaObjectStore`, on the media transfer queue, where a single
+/// stuck entry froze the sequential drain (#1270).
+
+/// A client that accepts the request and then never answers, or answers its
+/// headers and then never sends a body byte.
+class _StallingClient extends http.BaseClient {
+  _StallingClient({required this.stallBeforeHeaders});
+
+  final bool stallBeforeHeaders;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (stallBeforeHeaders) {
+      return Completer<http.StreamedResponse>().future;
+    }
+    return http.StreamedResponse(
+      StreamController<List<int>>().stream,
+      200,
+      contentLength: 1024,
+    );
+  }
+}
+
+void main() {
+  DropboxApiClient clientOver(http.Client transport) => DropboxApiClient(
+    getAccessToken: () async => 'token',
+    onAccessTokenRejected: () {},
+    httpClient: transport,
+  );
+
+  DropboxApiClient stalling({required bool beforeHeaders}) => clientOver(
+    TimeoutHttpClient(
+      _StallingClient(stallBeforeHeaders: beforeHeaders),
+      responseTimeout: const Duration(milliseconds: 60),
+      uploadTimeout: const Duration(milliseconds: 60),
+      idleTimeout: const Duration(milliseconds: 60),
+    ),
+  );
+
+  test(
+    'a response that never arrives surfaces as a reachability error',
+    () async {
+      await expectLater(
+        stalling(beforeHeaders: true).getMetadata('/db.sqlite'),
+        throwsA(
+          isA<CloudStorageException>().having(
+            (e) => e.message,
+            'message',
+            'Could not reach Dropbox',
+          ),
+        ),
+      );
+    },
+  );
+
+  test('a body that stops mid-stream surfaces the same way', () async {
+    await expectLater(
+      stalling(beforeHeaders: false).download('/db.sqlite'),
+      throwsA(isA<CloudStorageException>()),
+    );
+  });
+
+  test('an upload that stalls gives up instead of hanging', () async {
+    await expectLater(
+      stalling(beforeHeaders: true).upload('/db.sqlite', Uint8List(8)),
+      throwsA(isA<CloudStorageException>()),
+    );
+  });
+
+  test('the default transport carries deadlines', () {
+    // The whole point of #1279: a client nobody handed a transport to must
+    // not fall back to a bare http.Client().
+    final client = DropboxApiClient(
+      getAccessToken: () async => 'token',
+      onAccessTokenRejected: () {},
+    );
+    addTearDown(client.close);
+
+    final transport = client.transport;
+    expect(transport, isA<TimeoutHttpClient>());
+    expect(
+      (transport as TimeoutHttpClient).connectTimeout,
+      TimeoutHttpClient.defaultConnectTimeout,
+    );
+  });
+
+  test('an injected transport is left exactly as the caller built it', () {
+    final injected = _StallingClient(stallBeforeHeaders: true);
+    final client = clientOver(injected);
+
+    expect(client.transport, same(injected));
+  });
+}

--- a/test/core/services/cloud_storage/dropbox/dropbox_auth_manager_test.dart
+++ b/test/core/services/cloud_storage/dropbox/dropbox_auth_manager_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_manager.dart';
 import 'package:submersion/core/services/cloud_storage/dropbox/dropbox_auth_store.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 import 'package:submersion/core/services/oauth/oauth_pkce.dart';
 
 import '../../../../support/fake_keychain_storage.dart';
@@ -265,6 +266,22 @@ void main() {
         throwsA(isA<CloudStorageException>()),
       );
       expect(await m.getAccessToken(), 'at-recovered');
+    });
+  });
+
+  group('transport', () {
+    test('defaults to a client with request deadlines', () {
+      // Token refresh is awaited inside DropboxApiClient's send loop, so a
+      // wedged refresh on a deadline-free client stalls every Dropbox
+      // request behind it (#1279).
+      final m = DropboxAuthManager(store: store);
+      addTearDown(() => m.transport.close());
+
+      expect(m.transport, isA<TimeoutHttpClient>());
+      expect(
+        (m.transport as TimeoutHttpClient).connectTimeout,
+        TimeoutHttpClient.defaultConnectTimeout,
+      );
     });
   });
 

--- a/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/desktop_oauth_authenticator_test.dart
@@ -9,6 +9,7 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/cloud_storage/google_drive/desktop_oauth_authenticator.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_client_config.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_drive_token_store.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 
 class _MemoryTokenStore implements GoogleDriveTokenStore {
   gauth.AccessCredentials? stored;
@@ -138,6 +139,34 @@ void main() {
 
       expect(clientId.identifier, GoogleDriveClientConfig.desktopClientId);
     });
+  });
+
+  test('the default base transport carries request deadlines', () async {
+    // The refreshing client sends every Drive call, and its own token
+    // refreshes, over this base. A bare http.Client() has no connect,
+    // response or read deadline, so a wedged socket parked the request
+    // forever -- on sync and, via mediaHttpClient(), on the media transfer
+    // queue (#1279).
+    store.stored = creds(refreshToken: 'rt-1');
+    late http.Client capturedBase;
+    final auth = DesktopOAuthAuthenticator(
+      tokenStore: store,
+      obtainConsent: (clientId, scopes, client, prompt) async => creds(),
+      buildClient: (clientId, credentials, base) {
+        capturedBase = base;
+        return _FakeRefreshingClient(credentials);
+      },
+      launchBrowser: (url) async {},
+    );
+
+    expect(await auth.attemptSilentAuth(), isTrue);
+
+    addTearDown(capturedBase.close);
+    expect(capturedBase, isA<TimeoutHttpClient>());
+    expect(
+      (capturedBase as TimeoutHttpClient).connectTimeout,
+      TimeoutHttpClient.defaultConnectTimeout,
+    );
   });
 
   test('attemptSilentAuth returns false with no stored credentials', () async {

--- a/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
+++ b/test/core/services/cloud_storage/google_drive/google_sign_in_authenticator_test.dart
@@ -8,6 +8,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/cloud_storage/google_drive/google_sign_in_authenticator.dart';
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
 
 /// Drives [GoogleSignInAuthenticator] through a fake [GoogleSignInPlatform]
 /// rather than the real plugin, so the mobile/macOS auth path is exercisable
@@ -104,6 +105,19 @@ void main() {
       expect(await auth.attemptSilentAuth(), isTrue);
       expect(auth.authClient, isNotNull);
       expect(await auth.userEmail, 'diver@example.com');
+    });
+
+    test('installs a client with request deadlines', () async {
+      // google_sign_in builds the authorized client itself, over a transport
+      // this app never sees, so the deadlines have to go on the outside. A
+      // bare client parked a wedged Drive request forever -- on sync and, via
+      // mediaHttpClient(), on the media transfer queue (#1279).
+      platform.lightweightResult = _FakePlatform.resultsFor(
+        'diver@example.com',
+      );
+
+      expect(await auth.attemptSilentAuth(), isTrue);
+      expect(auth.authClient, isA<TimeoutHttpClient>());
     });
 
     test('returns false when there is no cached session', () async {

--- a/test/core/services/cloud_storage/http_timeouts_test.dart
+++ b/test/core/services/cloud_storage/http_timeouts_test.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:submersion/core/services/cloud_storage/http_timeouts.dart';
+
+/// Request deadlines for the non-S3 cloud transports (#1279).
+///
+/// `S3ApiClient` was the only transport in the app with deadlines. Dropbox and
+/// Google Drive both fell back to a bare `http.Client()`, which on Dart IO
+/// leaves `HttpClient.connectionTimeout` null and adds no response or read
+/// deadline at all, so a socket that connected and then wedged parked its
+/// request forever. In the media pipeline that showed up as a queue entry
+/// stuck in `transferring` (#1270).
+///
+/// [TimeoutHttpClient] is the shared piece: a decorator any client can be
+/// wrapped in, so the deadline policy lives in one place rather than being
+/// re-derived per transport.
+
+/// A client that accepts the request and then never answers, or answers its
+/// headers and then never sends a body byte.
+class _StallingClient extends http.BaseClient {
+  _StallingClient({required this.stallBeforeHeaders});
+
+  final bool stallBeforeHeaders;
+  final List<http.BaseRequest> requests = [];
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    requests.add(request);
+    if (stallBeforeHeaders) {
+      // Never completes: a half-open socket after the request was written.
+      return Completer<http.StreamedResponse>().future;
+    }
+    // Headers arrive, then the body stream goes quiet forever.
+    return http.StreamedResponse(
+      StreamController<List<int>>().stream,
+      200,
+      contentLength: 1024,
+    );
+  }
+}
+
+class _EchoClient extends http.BaseClient {
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      http.StreamedResponse(
+        Stream<List<int>>.value(const [7]),
+        200,
+        contentLength: 1,
+        headers: const {'x-echo': 'yes'},
+        reasonPhrase: 'OK',
+      );
+
+  @override
+  void close() => closed = true;
+}
+
+/// A request whose length is unknown until it is written, which is what
+/// googleapis' own `RequestImpl` produces for every call it makes.
+class _UnsizedRequest extends http.BaseRequest {
+  _UnsizedRequest(super.method, super.url);
+
+  @override
+  http.ByteStream finalize() {
+    super.finalize();
+    return const http.ByteStream(Stream<List<int>>.empty());
+  }
+}
+
+void main() {
+  TimeoutHttpClient wrap(
+    http.Client inner, {
+    Duration response = const Duration(milliseconds: 60),
+    Duration upload = const Duration(milliseconds: 400),
+    Duration idle = const Duration(milliseconds: 60),
+  }) => TimeoutHttpClient(
+    inner,
+    responseTimeout: response,
+    uploadTimeout: upload,
+    idleTimeout: idle,
+  );
+
+  http.Request get(String url) => http.Request('GET', Uri.parse(url));
+
+  test('a response that never arrives gives up instead of hanging', () async {
+    final client = wrap(_StallingClient(stallBeforeHeaders: true));
+
+    await expectLater(
+      client.send(get('https://example.test/a')),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('a body that stops mid-stream gives up instead of hanging', () async {
+    final client = wrap(_StallingClient(stallBeforeHeaders: false));
+
+    final streamed = await client.send(get('https://example.test/a'));
+
+    await expectLater(
+      streamed.stream.toBytes(),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('an upload gets its own, far longer deadline', () async {
+    // `Client.send` does not complete until the body has been written, so for
+    // a PUT the "wait for a response" window contains the whole upload. An
+    // 8 MiB chunk on a weak link legitimately takes minutes, and killing one
+    // that was making progress is the failure mode the S3 client's own
+    // deadlines were tuned to avoid (#942).
+    final client = wrap(
+      _StallingClient(stallBeforeHeaders: true),
+      response: const Duration(milliseconds: 1),
+      upload: const Duration(milliseconds: 300),
+    );
+    final request = http.Request('PUT', Uri.parse('https://example.test/a'))
+      ..bodyBytes = Uint8List(TimeoutHttpClient.uploadBodyThresholdBytes + 1);
+
+    final started = DateTime.now();
+    await expectLater(client.send(request), throwsA(isA<TimeoutException>()));
+
+    expect(
+      DateTime.now().difference(started),
+      greaterThan(const Duration(milliseconds: 150)),
+      reason: 'the upload must not be cut off by the read deadline',
+    );
+  });
+
+  test('a small POST body stays on the short response deadline', () async {
+    // A Dropbox RPC carries a few dozen bytes of JSON. Writing that is not an
+    // upload, so a wedged one must fail in seconds, not in the ten minutes a
+    // real multi-megabyte transfer is allowed.
+    final client = wrap(
+      _StallingClient(stallBeforeHeaders: true),
+      response: const Duration(milliseconds: 60),
+      upload: const Duration(seconds: 30),
+    );
+    final request = http.Request('POST', Uri.parse('https://example.test/a'))
+      ..body = '{"path":"/x"}';
+
+    await expectLater(client.send(request), throwsA(isA<TimeoutException>()));
+  });
+
+  test('an unsized non-GET request is treated as an upload', () async {
+    // googleapis' RequestImpl never sets contentLength, upload or not, so a
+    // length-only rule would put a multi-megabyte Drive upload on the 30s
+    // response deadline and start killing healthy transfers.
+    final client = wrap(
+      _StallingClient(stallBeforeHeaders: true),
+      response: const Duration(milliseconds: 1),
+      upload: const Duration(milliseconds: 300),
+    );
+
+    final started = DateTime.now();
+    await expectLater(
+      client.send(_UnsizedRequest('POST', Uri.parse('https://example.test/a'))),
+      throwsA(isA<TimeoutException>()),
+    );
+
+    expect(
+      DateTime.now().difference(started),
+      greaterThan(const Duration(milliseconds: 150)),
+    );
+  });
+
+  test('an unsized GET stays on the short response deadline', () async {
+    final client = wrap(
+      _StallingClient(stallBeforeHeaders: true),
+      response: const Duration(milliseconds: 60),
+      upload: const Duration(seconds: 30),
+    );
+
+    await expectLater(
+      client.send(_UnsizedRequest('GET', Uri.parse('https://example.test/a'))),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
+
+  test('a prompt response passes through untouched', () async {
+    final client = wrap(_EchoClient());
+
+    final streamed = await client.send(get('https://example.test/a'));
+
+    expect(streamed.statusCode, 200);
+    expect(streamed.contentLength, 1);
+    expect(streamed.headers['x-echo'], 'yes');
+    expect(streamed.reasonPhrase, 'OK');
+    expect(await streamed.stream.toBytes(), Uint8List.fromList([7]));
+  });
+
+  test('closing the wrapper closes the client underneath it', () {
+    final inner = _EchoClient();
+
+    wrap(inner).close();
+
+    expect(inner.closed, isTrue);
+  });
+
+  test('the socket-backed factory bounds the TCP connect itself', () {
+    // The deadlines above bound a socket that connects and then stalls. A
+    // bare http.Client() leaves HttpClient.connectionTimeout null, so one
+    // that never connects waits on the OS default -- minutes on some Windows
+    // configurations.
+    final client = TimeoutHttpClient.overSockets(
+      connectTimeout: const Duration(seconds: 3),
+    );
+    addTearDown(client.close);
+
+    expect(client.connectTimeout, const Duration(seconds: 3));
+  });
+
+  test('the defaults match the deadlines the S3 client settled on', () {
+    expect(
+      TimeoutHttpClient.defaultConnectTimeout,
+      const Duration(seconds: 15),
+    );
+    expect(
+      TimeoutHttpClient.defaultResponseTimeout,
+      const Duration(seconds: 30),
+    );
+    expect(TimeoutHttpClient.defaultUploadTimeout, const Duration(minutes: 10));
+    expect(TimeoutHttpClient.defaultIdleTimeout, const Duration(seconds: 30));
+  });
+}


### PR DESCRIPTION
Fixes #1279.

`S3ApiClient` was the only cloud transport in the app with request deadlines.
Dropbox and Google Drive both fell back to a bare `http.Client()`, which on
Dart IO leaves `HttpClient.connectionTimeout` null and adds no response or
read deadline at all: a socket that never connects waits on the OS default
(minutes on some Windows configurations), and one that connects and then
wedges parks its request forever.

That affects both data sync and media transfers. In the media pipeline the
symptom is a queue entry stuck in `transferring`.

One correction to the issue text, verified against `main`: it says #1270's
per-entry drain budget already contains the blast radius. #1270 is still open
and that budget is not on `main`. `MediaStoreWorker.drain` is a bare
sequential `while (true)` whose `await _pipeline.process(entry)` has no
deadline, guarded by a `_running` single-flight flag that stays true while it
is stuck, so every later `drain()` call returns immediately. Today the freeze
is unbounded, which makes this fix load-bearing rather than merely tidy.

## What changed

New `lib/core/services/cloud_storage/http_timeouts.dart` holds the policy in
one place. `TimeoutHttpClient` is an `http.Client` decorator that bounds the
response and the body-idle gap; its `overSockets` constructor also bounds the
TCP connect. The four deadlines are deliberately the ones `S3ApiClient`
settled on in #942: 15s connect, 30s response, 10m upload, 30s body idle.

Two details worth flagging:

- **A request's deadline is picked by size, then by method.** A body over
  64 KiB gets the generous upload deadline, because `Client.send` does not
  complete until the body has been written, so for a PUT the "wait for a
  response" window contains the whole transfer. Below that (a Dropbox RPC is
  a few dozen bytes of JSON) the short response deadline applies. When the
  length is unknown the method decides: googleapis' own `RequestImpl` never
  sets `contentLength`, upload or not, so a length-only rule would have put
  every Drive upload on the 30s deadline and started killing healthy
  transfers.
- **The two Google paths need opposite treatments.** On desktop the app owns
  the base transport, so the wrapper goes *underneath* the refreshing client
  and covers its token refreshes too. With google_sign_in the plugin builds
  the authorized client over a socket layer the app never sees, so the
  wrapper goes on the *outside*.

Wired in at four places:

- `DropboxApiClient` (sync, and media via `DropboxMediaObjectStore`)
- `DropboxAuthManager`, which the issue does not name but belongs here:
  `getAccessToken` is awaited *inside* `DropboxApiClient._send`'s loop, so a
  wedged token refresh stalls every Dropbox request behind it exactly like a
  wedged request would
- `DesktopOAuthAuthenticator` (Windows, Linux, Developer ID macOS)
- `GoogleSignInAuthenticator` (iOS, Android, App Store macOS)

Both Google Drive paths are covered by the authenticator seam alone, which is
why `GoogleDriveMediaObjectStore` needs no change: its transport comes from
`GoogleDriveStorageProvider.mediaHttpClient()` at both construction sites, and
that returns the authenticator's client. The same client backs the `DriveApi`
the sync path uses, so one wrapper covers sync, media transfers, and the store
marker read in `MediaStoreWorker`'s preflight.

`S3ApiClient` is untouched. It applies the same four deadlines inline,
interleaved with its SigV4 retry loop, which classifies `TimeoutException` as
a retryable transport fault and replays the request. Routing it through the
wrapper would be a change to a well-covered path with no behaviour to gain.

## Tests

- `http_timeouts_test.dart`: a stalled response, a body that stops
  mid-stream, the upload deadline outliving the response deadline, a small
  POST staying on the short one, an unsized POST vs an unsized GET, pass-through
  of a prompt response, close forwarding, and the constant values.
- `dropbox_api_client_timeout_test.dart`: a stall on each of the metadata,
  download, and upload paths surfaces as `CloudStorageException`, plus the
  default transport carrying deadlines and an injected one being left alone.
- Additions to the Dropbox auth manager and both Google Drive authenticator
  suites asserting the default transport is timed.

A timeout is recoverable rather than fatal on the media path:
`DropboxMediaObjectStore._map` classifies any `Could not reach` message as
`MediaStoreErrorKind.transient`, so a fired deadline retries instead of
burning the row.

Full suite: 20104 passed, 19 skipped. The one failure was
`backup_encryption_service_test.dart` ("enable persists key + mirror and
returns a recovery code"), a known yo-yo flake in a file this diff does not
touch; it passes when run alone. Design notes are in
`docs/superpowers/specs/2026-08-25-cloud-http-request-deadlines-design.md`.

## Out of scope

Other bare `http.Client()` users remain: weather, tides, reef, bathymetry,
the GitHub updater, and the Lightroom client. None are on the sync or media
transfer paths, and the wrapper is now there for them when someone wants it.
