### PR TITLE
Route every version string through formatAppVersion

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -37,6 +37,7 @@ import 'package:submersion/core/services/security/database_security_sidecar.dart
 import 'package:submersion/core/services/security/locked_database_escape.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/notification_service.dart';
+import 'package:submersion/core/utils/app_version.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/data/services/backup_target.dart';
@@ -730,7 +731,7 @@ class _StartupWrapperState extends State<StartupWrapper>
       appVersion = '0.0.0.0';
     } else {
       final info = await PackageInfo.fromPlatform();
-      appVersion = '${info.version}.${info.buildNumber}';
+      appVersion = formatAppVersion(info);
       service = PreMigrationBackupService(
         livePathProvider: () async => dbPath,
         // Resolve LAZILY, inside the provider. Resolution arms any

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
-import 'package:submersion/core/providers/provider.dart';
-import 'package:submersion/core/utils/app_version.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/app_version.dart';
 import 'package:submersion/features/auto_update/data/repositories/update_preferences.dart';
 import 'package:submersion/features/auto_update/data/services/github_update_service.dart';
 import 'package:submersion/features/auto_update/data/services/sparkle_update_service.dart';

--- a/lib/features/auto_update/presentation/providers/update_providers.dart
+++ b/lib/features/auto_update/presentation/providers/update_providers.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/app_version.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:submersion/features/auto_update/data/repositories/update_preferences.dart';
@@ -67,10 +68,7 @@ final updateServiceProvider = FutureProvider<UpdateService?>((ref) async {
   // Release tags are 4-segment (vX.Y.Z.N) while packageInfo.version is the
   // 3-segment marketing version; without the build number appended, a
   // current install always compares as older than its own release tag.
-  final currentVersion =
-      packageInfo.version.endsWith('.${packageInfo.buildNumber}')
-      ? packageInfo.version
-      : '${packageInfo.version}.${packageInfo.buildNumber}';
+  final currentVersion = formatAppVersion(packageInfo);
 
   if (_useSparkleEngine) {
     return SparkleUpdateService(feedUrl: appcastUrlFor(channel));

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/icons/mdi_icons.dart';
+import 'package:submersion/core/utils/app_version.dart';
 import 'package:submersion/core/utils/currency.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
@@ -2998,9 +2999,7 @@ class _AboutSectionContentState extends ConsumerState<_AboutSectionContent> {
         ref.watch(releaseChannelProvider) == ReleaseChannel.beta;
     final versionString = packageInfoAsync.when(
       data: (info) {
-        final version = info.version.endsWith('.${info.buildNumber}')
-            ? info.version
-            : '${info.version}.${info.buildNumber}';
+        final version = formatAppVersion(info);
         final base = context.l10n.settings_about_version(version);
         return isBetaChannel
             ? context.l10n.settings_updates_channelBadgeBeta(base)

--- a/test/core/utils/app_version_test.dart
+++ b/test/core/utils/app_version_test.dart
@@ -1,5 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:submersion/core/utils/app_version.dart';
+
+PackageInfo _info({required String version, required String buildNumber}) =>
+    PackageInfo(
+      appName: 'Submersion',
+      packageName: 'app.submersion',
+      version: version,
+      buildNumber: buildNumber,
+    );
 
 void main() {
   group('formatVersionWithBuild', () {
@@ -21,6 +30,34 @@ void main() {
       // "1.7.23" does not end with ".3" as a segment even though it ends with
       // the characters; endsWith('.3') is false here, so nothing is swallowed.
       expect(formatVersionWithBuild('1.7.23', '3'), '1.7.23.3');
+    });
+  });
+
+  group('formatAppVersion', () {
+    test('appends the build number to a three-segment marketing version', () {
+      expect(
+        formatAppVersion(_info(version: '1.7.6', buildNumber: '123')),
+        '1.7.6.123',
+      );
+    });
+
+    test('does not double a build number the platform already reported', () {
+      // The case every caller has to survive: PackageInfo.version is not
+      // guaranteed to be the three-segment marketing version. Open-coding
+      // "$version.$buildNumber" here yields the five-segment "1.7.6.123.123",
+      // which reaches the user in the restore confirmation dialog as the
+      // version that produced a backup.
+      expect(
+        formatAppVersion(_info(version: '1.7.6.123', buildNumber: '123')),
+        '1.7.6.123',
+      );
+    });
+
+    test('leaves the version alone when the platform reports no build', () {
+      expect(
+        formatAppVersion(_info(version: '1.7.6', buildNumber: '')),
+        '1.7.6',
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #1285.

Stacked on #1282, which introduced `formatAppVersion` / `formatVersionWithBuild`
in `lib/core/utils/app_version.dart` and deliberately used them only from the
new `LogEnvironment` code. **Base this PR's review on the top commit only;**
retarget to `main` once #1282 lands.

## What changed

Three call sites still open-coded the same "append the build number as a fourth
segment" idiom. All three now call the helper:

| Call site | Was | Guarded before? |
| --- | --- | --- |
| `lib/core/presentation/pages/startup_page.dart` | unconditional interpolation | no |
| `lib/features/settings/presentation/pages/settings_page.dart` | 3-line ternary | yes |
| `lib/features/auto_update/presentation/providers/update_providers.dart` | 4-line ternary | yes |

## The behaviour fix

`startup_page` built the version as `'${info.version}.${info.buildNumber}'` with
no guard. `PackageInfo.version` is not always the three-segment marketing
version; where the platform already reports four segments, this produced a
five-segment string such as `1.7.6.123.123`.

That value is not internal. It is passed to `PreMigrationBackupService`, stored
as `BackupRecord.appVersion`, and rendered verbatim in every branch of
`restore_confirmation_dialog.dart` (safe, newer-app, and incomplete-metadata),
where it tells someone which app version produced the backup they are about to
restore. A malformed version there is misleading at exactly the moment a user is
making a destructive decision.

The other two sites already guarded correctly, so adopting the helper there is
deduplication. `update_providers` keeps its comment explaining that a version
which does not match its release tag compares as older than its own release, so
the guard is not merely cosmetic in general.

## Tests

`formatAppVersion` now has `PackageInfo`-level coverage, including the
already-four-segment input that no existing test covered.

The pin lives on the helper rather than at `startup_page`'s own call site
because that branch is unreachable from a widget test by construction: tests
supply `preMigrationBackupFactory` (which short-circuits `appVersion` to
`0.0.0.0`), and taking the real branch would build a `PreMigrationBackupService`
against the production database path. Adding a test-only `PackageInfo` field to
`StartupWrapper` purely to observe one format call did not seem worth the
production surface, but say the word if you would rather have it.

That asymmetry is also why the bug survived here and not at the other two sites:
`startup_page` writes a value that is only read much later, on a path most users
never reach.

## Verification

- `dart format .`: 0 changed
- `flutter analyze`: no issues found
- `flutter test`: 20109 passed, 19 skipped, exit 0