### PR TITLE
test(dive-log): cover re-picking a present buddy's role in bulk edit (#700)

### DIFF
--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -406,6 +406,96 @@ void main() {
       expect(await BuddyRepository().getBuddiesForDive(d2.id), isEmpty);
     });
 
+    testWidgets('re-picking an already-present buddy with a new role rewrites '
+        'that role (#700)', (tester) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final buddy = await BuddyRepository().createBuddy(
+        Buddy(
+          id: '',
+          name: 'Casey Diver',
+          createdAt: DateTime(2026, 1, 1),
+          updatedAt: DateTime(2026, 1, 1),
+        ),
+      );
+      final d1 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'repick-role-1'),
+      );
+      final d2 = await repository.createDive(
+        createTestDiveWithBottomTime().copyWith(id: 'repick-role-2'),
+      );
+      // Both dives already carry the buddy as a plain Buddy.
+      await BuddyRepository().bulkAddBuddies(
+        [d1.id, d2.id],
+        [BuddyWithRole(buddy: buddy, role: DiveRole.builtInBuddy())],
+      );
+
+      final overrides = await getBaseOverrides();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: buildOverrides(overrides).cast(),
+          child: MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: DiveEditPage(bulkDiveIds: [d1.id, d2.id], embedded: true),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Go through Add and re-pick the buddy who is already on both dives,
+      // this time as Instructor.
+      final buddiesSection = find.ancestor(
+        of: find.text('Buddies'),
+        matching: find.byType(BulkMembershipEditor),
+      );
+      final addToBuddies = find.descendant(
+        of: buddiesSection,
+        matching: find.byIcon(Icons.add),
+      );
+      await tester.ensureVisible(addToBuddies);
+      await tester.tap(addToBuddies);
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.byIcon(Icons.add),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(buddy.name).last);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Instructor'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Add').last);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save'));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Apply'));
+      await tester.pumpAndSettle();
+
+      // The existing links are re-roled in place, not duplicated.
+      for (final id in [d1.id, d2.id]) {
+        final saved = await BuddyRepository().getBuddiesForDive(id);
+        expect(saved, hasLength(1));
+        expect(saved.single.role.id, DiveRole.instructorId);
+      }
+    });
+
     testWidgets('toggling a gate enables its checkbox', (tester) async {
       await pumpBulk(tester);
 


### PR DESCRIPTION
## Summary

Issue #700 reported that re-picking an already-present buddy through the bulk
editor's Add picker with a different role left the old role unchanged. That is
no longer reproducible: the three-way split of the buddy ops introduced by
#1220 fixed it, and the fix shipped in v1.7.5 (commit b54b725 is contained in
tag v1.7.5.6772). The reporter was on v1.6.0.114.

`_bulkOps` in `dive_edit_page.dart` now routes buddy work down three separate
paths instead of one:

| Stream | Condition | Op |
| --- | --- | --- |
| `membershipOnlyAdds` | ticked on, no role picked | `add` with `overwriteRole: false` (#893) |
| `pickedRoleAdds` | role picked and in `addIds` | `add`, role rides the new links |
| `roleOnlyUpdates` | role picked, no membership change | `update`, rewrites existing links and creates none |

A re-picked buddy who is already on the selection falls into that third bucket,
which is exactly the case #700 said was unreachable.

What was missing was coverage. The suite tests the inline per-row role button
that #1220 added, but never the picker re-pick flow #700 actually describes, so
nothing guards that path against a future regression. This PR adds that test.
It passes against current `main` with no production change, which is the
evidence for closing the issue.

## Changes

- Add a regression test to `bulk_dive_edit_form_test.dart` driving issue #700's
  literal steps: two dives that already share a buddy with the Buddy role, then
  Buddies > Add > re-pick that buddy > Instructor > Save > Apply.
- Assert both existing links are re-roled in place and that neither dive gains a
  duplicate link.

## Test Plan

- [x] `flutter test test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart` passes (19/19)
- [x] `flutter analyze` passes on the changed file, `dart format` clean
- [x] Pre-push hook's ranked affected-test selection passed
- [ ] Manual testing: not applicable, no production code changed

Closes #700
