### PR TITLE
fix(statistics): scope personal records to the active filter

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2681,21 +2681,48 @@ class DiveRepository {
   }
 
   /// Get dive records (superlatives)
-  /// Optionally filter by [diverId] for per-diver records
-  Future<DiveRecords> getRecords({String? diverId}) async {
+  ///
+  /// Optionally filter by [diverId] for per-diver records, and by [filter] for
+  /// a narrowed scope. Issue #1028: the Statistics tab shows these superlatives
+  /// beside totals that already honour its filter, so a deepest dive drawn from
+  /// the whole logbook contradicted the panel right above it.
+  Future<DiveRecords> getRecords({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+  }) async {
     try {
-      final vars = diverId != null
-          ? [Variable<String>(diverId)]
-          : <Variable<Object>>[];
+      // Explicitly typed List<Variable<Object>>: a bare `[Variable<String>(...)]`
+      // literal would reify as List<Variable<String>>, and the later addAll of
+      // the filter binds would then throw (mirrors getStatistics).
+      final List<Variable<Object>> vars = [
+        if (diverId != null) Variable<String>(diverId),
+      ];
+      final df = buildFilteredDiveIdSubquery(filter);
+      // params are always non-null so `p!` is safe.
+      vars.addAll(df.params.map((p) => Variable<Object>(p!)));
+
+      // Every statement below binds the same `vars` list, so the diver `?` must
+      // always precede the filter `?`s -- hence the fixed clause order.
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final diverFilterFirst = diverId != null ? 'WHERE d.diver_id = ?' : '';
+      final filterClause = df.subquery.isEmpty
+          ? ''
+          : 'AND d.id IN (${df.subquery})';
+      // The first/last statements have no WHERE of their own, so their scope
+      // clauses have to open one.
+      final scopeConditions = [
+        if (diverId != null) 'd.diver_id = ?',
+        if (df.subquery.isNotEmpty) 'd.id IN (${df.subquery})',
+      ];
+      final diverFilterFirst = scopeConditions.isEmpty
+          ? ''
+          : 'WHERE ${scopeConditions.join(' AND ')}';
 
       // Deepest dive
       final deepestResult = await _db.customSelect('''
       SELECT d.*, s.name as site_name
       FROM dives d
       LEFT JOIN dive_sites s ON d.site_id = s.id
-      WHERE d.max_depth IS NOT NULL $diverFilter
+      WHERE d.max_depth IS NOT NULL $diverFilter $filterClause
       ORDER BY d.max_depth DESC
       LIMIT 1
     ''', variables: vars).getSingleOrNull();
@@ -2706,7 +2733,7 @@ class DiveRepository {
         COALESCE(d.runtime, d.bottom_time) as effective_runtime
       FROM dives d
       LEFT JOIN dive_sites s ON d.site_id = s.id
-      WHERE COALESCE(d.runtime, d.bottom_time) IS NOT NULL $diverFilter
+      WHERE COALESCE(d.runtime, d.bottom_time) IS NOT NULL $diverFilter $filterClause
       ORDER BY effective_runtime DESC
       LIMIT 1
     ''', variables: vars).getSingleOrNull();
@@ -2716,7 +2743,7 @@ class DiveRepository {
       SELECT d.*, s.name as site_name
       FROM dives d
       LEFT JOIN dive_sites s ON d.site_id = s.id
-      WHERE d.water_temp IS NOT NULL $diverFilter
+      WHERE d.water_temp IS NOT NULL $diverFilter $filterClause
       ORDER BY d.water_temp ASC
       LIMIT 1
     ''', variables: vars).getSingleOrNull();
@@ -2726,7 +2753,7 @@ class DiveRepository {
       SELECT d.*, s.name as site_name
       FROM dives d
       LEFT JOIN dive_sites s ON d.site_id = s.id
-      WHERE d.water_temp IS NOT NULL $diverFilter
+      WHERE d.water_temp IS NOT NULL $diverFilter $filterClause
       ORDER BY d.water_temp DESC
       LIMIT 1
     ''', variables: vars).getSingleOrNull();
@@ -2756,7 +2783,7 @@ class DiveRepository {
       SELECT d.*, s.name as site_name
       FROM dives d
       LEFT JOIN dive_sites s ON d.site_id = s.id
-      WHERE d.max_depth IS NOT NULL AND d.max_depth > 0 $diverFilter
+      WHERE d.max_depth IS NOT NULL AND d.max_depth > 0 $diverFilter $filterClause
       ORDER BY d.max_depth ASC
       LIMIT 1
     ''', variables: vars).getSingleOrNull();

--- a/lib/features/statistics/presentation/pages/records_page.dart
+++ b/lib/features/statistics/presentation/pages/records_page.dart
@@ -4,16 +4,22 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
+import 'package:submersion/features/statistics/presentation/widgets/statistics_filter_bar.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Full-page personal records, reached from the Statistics tab's trophy
+/// action. Scoped by the Statistics filter (issue #1028) so it agrees with the
+/// records card on the overview page one tap behind it; the filter bar keeps
+/// the narrowed scope visible and clearable here too.
 class RecordsPage extends ConsumerWidget {
   const RecordsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final recordsAsync = ref.watch(diveRecordsProvider);
+    final recordsAsync = ref.watch(filteredDiveRecordsProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -22,32 +28,40 @@ class RecordsPage extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: context.l10n.statistics_tooltip_refreshRecords,
-            onPressed: () => ref.invalidate(diveRecordsProvider),
+            onPressed: () => ref.invalidate(filteredDiveRecordsProvider),
           ),
         ],
       ),
-      body: recordsAsync.when(
-        data: (records) => _buildContent(context, ref, records),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                Icons.error_outline,
-                size: 64,
-                color: Theme.of(context).colorScheme.error,
+      body: Column(
+        children: [
+          const StatisticsFilterBar(),
+          Expanded(
+            child: recordsAsync.when(
+              data: (records) => _buildContent(context, ref, records),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, stack) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 64,
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(context.l10n.statistics_records_error),
+                    const SizedBox(height: 8),
+                    FilledButton(
+                      onPressed: () =>
+                          ref.invalidate(filteredDiveRecordsProvider),
+                      child: Text(context.l10n.statistics_records_retry),
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 16),
-              Text(context.l10n.statistics_records_error),
-              const SizedBox(height: 8),
-              FilledButton(
-                onPressed: () => ref.invalidate(diveRecordsProvider),
-                child: Text(context.l10n.statistics_records_retry),
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
     );
   }
@@ -67,12 +81,18 @@ class RecordsPage extends ConsumerWidget {
         records.warmestDive != null;
 
     if (!hasRecords) {
+      // "Start logging dives" is wrong advice when the logbook is full and the
+      // filter is simply too narrow, so the filtered case gets the dive list's
+      // wording instead.
+      final filtered = ref.watch(
+        statisticsFilterProvider.select((f) => f.hasActiveFilters),
+      );
       return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
-              Icons.emoji_events_outlined,
+              filtered ? Icons.filter_list_off : Icons.emoji_events_outlined,
               size: 80,
               color: Theme.of(
                 context,
@@ -80,15 +100,21 @@ class RecordsPage extends ConsumerWidget {
             ),
             const SizedBox(height: 16),
             Text(
-              context.l10n.statistics_records_emptyTitle,
+              filtered
+                  ? context.l10n.diveLog_emptyFiltered_title
+                  : context.l10n.statistics_records_emptyTitle,
               style: Theme.of(context).textTheme.headlineSmall,
+              textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
-              context.l10n.statistics_records_emptySubtitle,
+              filtered
+                  ? context.l10n.diveLog_emptyFiltered_subtitle
+                  : context.l10n.statistics_records_emptySubtitle,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
+              textAlign: TextAlign.center,
             ),
           ],
         ),

--- a/lib/features/statistics/presentation/pages/records_page.dart
+++ b/lib/features/statistics/presentation/pages/records_page.dart
@@ -74,11 +74,19 @@ class RecordsPage extends ConsumerWidget {
     final settings = ref.watch(settingsProvider);
     final units = UnitFormatter(settings);
 
-    final hasRecords =
-        records.deepestDive != null ||
-        records.longestDive != null ||
-        records.coldestDive != null ||
-        records.warmestDive != null;
+    // Every slot the page can render, not just the four superlative cards:
+    // firstDive/lastDive carry no field predicate, so dives logged with only a
+    // date populate the milestones while all four superlatives stay null.
+    // Gating on the four alone hid milestone cards that had content.
+    final hasRecords = [
+      records.deepestDive,
+      records.longestDive,
+      records.coldestDive,
+      records.warmestDive,
+      records.shallowestDive,
+      records.firstDive,
+      records.lastDive,
+    ].any((record) => record != null);
 
     if (!hasRecords) {
       // "Start logging dives" is wrong advice when the logbook is full and the

--- a/lib/features/statistics/presentation/pages/statistics_overview_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_overview_page.dart
@@ -5,7 +5,6 @@ import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/add_dive_bottom_sheet.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
@@ -81,7 +80,7 @@ class _OverviewBody extends ConsumerWidget {
 
     final settings = ref.watch(settingsProvider);
     final fmt = UnitFormatter(settings);
-    final recordsAsync = ref.watch(diveRecordsProvider);
+    final recordsAsync = ref.watch(filteredDiveRecordsProvider);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),

--- a/lib/features/statistics/presentation/providers/statistics_providers.dart
+++ b/lib/features/statistics/presentation/providers/statistics_providers.dart
@@ -33,6 +33,26 @@ final filteredDiveStatisticsProvider = FutureProvider<DiveStatistics>((
   return repository.getStatistics(diverId: currentDiverId, filter: filter);
 });
 
+/// Personal records (superlatives) scoped by the Statistics filter.
+///
+/// Split from diveRecordsProvider for the same reason
+/// [filteredDiveStatisticsProvider] is split from diveStatisticsProvider: the
+/// dive-log summary widget reads the unfiltered one and has no filter UI, so
+/// the Statistics tab's scope must not reach it. Issue #1028: before this
+/// split, the Statistics tab's records were the only panel on the page that
+/// ignored the filter.
+///
+/// Takes the same dives tick as its unfiltered sibling (issue #217): a merge,
+/// a bulk delete, or a sync pull rewrites the superlatives without going
+/// through any notifier.
+final filteredDiveRecordsProvider = FutureProvider<DiveRecords>((ref) async {
+  final repository = ref.watch(diveRepositoryProvider);
+  final currentDiverId = ref.watch(currentDiverIdProvider);
+  final filter = ref.watch(statisticsFilterProvider);
+  ref.invalidateSelfWhen(repository.watchDivesChanges());
+  return repository.getRecords(diverId: currentDiverId, filter: filter);
+});
+
 /// Adds keepAlive with a 5-minute expiry and subscribes to the statistics
 /// change tick, so all stats providers stay cached across navigations but
 /// refresh whenever any table they read is written.

--- a/test/architecture/provider_tick_build_smoke_test.dart
+++ b/test/architecture/provider_tick_build_smoke_test.dart
@@ -767,6 +767,10 @@ void main() {
       name: 'filteredDiveStatisticsProvider',
       read: (c) => c.read(filteredDiveStatisticsProvider.future),
     ),
+    (
+      name: 'filteredDiveRecordsProvider',
+      read: (c) => c.read(filteredDiveRecordsProvider.future),
+    ),
   ]);
 
   _tickGroup('tags', [

--- a/test/features/dive_log/data/repositories/dive_records_filter_test.dart
+++ b/test/features/dive_log/data/repositories/dive_records_filter_test.dart
@@ -1,0 +1,291 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1028: the Statistics tab's personal records ignored the active
+/// Statistics filter while every other panel on the page honoured it.
+void main() {
+  late AppDatabase db;
+  late DiveRepository repository;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> insertSite(String id) async {
+    await db
+        .into(db.diveSites)
+        .insert(
+          DiveSitesCompanion(
+            id: Value(id),
+            name: Value('Site $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertDiver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value('Diver $id'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  Future<void> insertDive(
+    String id, {
+    required DateTime date,
+    String? diverId,
+    String? siteId,
+    double? maxDepth,
+    double? waterTemp,
+    int? bottomTimeSeconds,
+    bool favorite = false,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            diveDateTime: Value(date.millisecondsSinceEpoch),
+            siteId: Value(siteId),
+            maxDepth: Value(maxDepth),
+            waterTemp: Value(waterTemp),
+            bottomTime: Value(bottomTimeSeconds),
+            isFavorite: Value(favorite),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  group('getRecords with a filter', () {
+    test('an empty filter still considers every dive', () async {
+      await insertDive(
+        'shallow',
+        date: DateTime(2024, 1, 10),
+        maxDepth: 12,
+        waterTemp: 26,
+        bottomTimeSeconds: 1800,
+      );
+      await insertDive(
+        'deep',
+        date: DateTime(2026, 5, 10),
+        maxDepth: 44,
+        waterTemp: 9,
+        bottomTimeSeconds: 3600,
+      );
+
+      final records = await repository.getRecords();
+
+      expect(records.deepestDive!.diveId, 'deep');
+      expect(records.shallowestDive!.diveId, 'shallow');
+      expect(records.longestDive!.diveId, 'deep');
+      expect(records.coldestDive!.diveId, 'deep');
+      expect(records.warmestDive!.diveId, 'shallow');
+      expect(records.firstDive!.diveId, 'shallow');
+      expect(records.lastDive!.diveId, 'deep');
+    });
+
+    test('a date-range filter narrows every superlative', () async {
+      await insertDive(
+        'old',
+        date: DateTime(2024, 1, 10),
+        maxDepth: 60,
+        waterTemp: 4,
+        bottomTimeSeconds: 7200,
+      );
+      await insertDive(
+        'inRange',
+        date: DateTime(2026, 6, 15),
+        maxDepth: 30,
+        waterTemp: 20,
+        bottomTimeSeconds: 2400,
+      );
+      await insertDive(
+        'newer',
+        date: DateTime(2026, 9, 1),
+        maxDepth: 50,
+        waterTemp: 8,
+        bottomTimeSeconds: 5400,
+      );
+
+      final records = await repository.getRecords(
+        filter: DiveFilterState(
+          startDate: DateTime(2026, 6, 1),
+          endDate: DateTime(2026, 6, 30),
+        ),
+      );
+
+      expect(records.deepestDive!.diveId, 'inRange');
+      expect(records.shallowestDive!.diveId, 'inRange');
+      expect(records.longestDive!.diveId, 'inRange');
+      expect(records.coldestDive!.diveId, 'inRange');
+      expect(records.warmestDive!.diveId, 'inRange');
+      expect(records.firstDive!.diveId, 'inRange');
+      expect(records.lastDive!.diveId, 'inRange');
+    });
+
+    test('a site filter narrows the records to that site', () async {
+      await insertSite('reef');
+      await insertSite('wreck');
+      await insertDive(
+        'atReef',
+        date: DateTime(2026, 3, 1),
+        siteId: 'reef',
+        maxDepth: 18,
+        waterTemp: 24,
+      );
+      await insertDive(
+        'atWreck',
+        date: DateTime(2026, 4, 1),
+        siteId: 'wreck',
+        maxDepth: 42,
+        waterTemp: 12,
+      );
+
+      final records = await repository.getRecords(
+        filter: const DiveFilterState(siteId: 'wreck'),
+      );
+
+      expect(records.deepestDive!.diveId, 'atWreck');
+      expect(records.warmestDive!.diveId, 'atWreck');
+      expect(records.firstDive!.diveId, 'atWreck');
+      expect(records.lastDive!.diveId, 'atWreck');
+    });
+
+    test('a filter that matches nothing yields no records', () async {
+      await insertDive(
+        'only',
+        date: DateTime(2026, 3, 1),
+        maxDepth: 18,
+        waterTemp: 24,
+        bottomTimeSeconds: 1800,
+      );
+
+      final records = await repository.getRecords(
+        filter: const DiveFilterState(favoritesOnly: true),
+      );
+
+      expect(records.deepestDive, isNull);
+      expect(records.shallowestDive, isNull);
+      expect(records.longestDive, isNull);
+      expect(records.coldestDive, isNull);
+      expect(records.warmestDive, isNull);
+      expect(records.firstDive, isNull);
+      expect(records.lastDive, isNull);
+    });
+
+    test('the diver scope and the filter compose', () async {
+      await insertDiver('me');
+      await insertDiver('other');
+      await insertDive(
+        'mineFavorite',
+        date: DateTime(2026, 3, 1),
+        diverId: 'me',
+        maxDepth: 20,
+        waterTemp: 22,
+        bottomTimeSeconds: 1800,
+        favorite: true,
+      );
+      await insertDive(
+        'minePlain',
+        date: DateTime(2026, 3, 2),
+        diverId: 'me',
+        maxDepth: 55,
+        waterTemp: 6,
+        bottomTimeSeconds: 3600,
+      );
+      await insertDive(
+        'theirsFavorite',
+        date: DateTime(2026, 3, 3),
+        diverId: 'other',
+        maxDepth: 70,
+        waterTemp: 3,
+        bottomTimeSeconds: 5400,
+        favorite: true,
+      );
+
+      final records = await repository.getRecords(
+        diverId: 'me',
+        filter: const DiveFilterState(favoritesOnly: true),
+      );
+
+      expect(records.deepestDive!.diveId, 'mineFavorite');
+      expect(records.shallowestDive!.diveId, 'mineFavorite');
+      expect(records.longestDive!.diveId, 'mineFavorite');
+      expect(records.coldestDive!.diveId, 'mineFavorite');
+      expect(records.warmestDive!.diveId, 'mineFavorite');
+      expect(records.firstDive!.diveId, 'mineFavorite');
+      expect(records.lastDive!.diveId, 'mineFavorite');
+    });
+
+    // The no-buddy axis is the one clause that names `dives` explicitly inside
+    // its own correlated subquery; getRecords aliases the outer table as `d`,
+    // so this guards against the alias resolving the wrong way.
+    test(
+      'a no-buddy filter resolves inside the aliased records query',
+      () async {
+        await insertDive(
+          'solo',
+          date: DateTime(2026, 3, 1),
+          maxDepth: 20,
+          waterTemp: 22,
+          bottomTimeSeconds: 1800,
+        );
+        await insertDive(
+          'paired',
+          date: DateTime(2026, 3, 2),
+          maxDepth: 40,
+          waterTemp: 10,
+          bottomTimeSeconds: 3600,
+        );
+        await db
+            .into(db.buddies)
+            .insert(
+              BuddiesCompanion(
+                id: const Value('b1'),
+                name: const Value('Buddy One'),
+                createdAt: Value(now),
+                updatedAt: Value(now),
+              ),
+            );
+        await db
+            .into(db.diveBuddies)
+            .insert(
+              DiveBuddiesCompanion(
+                id: const Value('paired-b1'),
+                diveId: const Value('paired'),
+                buddyId: const Value('b1'),
+                createdAt: Value(now),
+              ),
+            );
+
+        final records = await repository.getRecords(
+          filter: const DiveFilterState(noBuddyOnly: true),
+        );
+
+        expect(records.deepestDive!.diveId, 'solo');
+        expect(records.lastDive!.diveId, 'solo');
+      },
+    );
+  });
+}

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -11,7 +11,6 @@ import 'package:submersion/core/constants/list_view_mode.dart';
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/deco/entities/cns_calculation_method.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
-import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/core/constants/card_color.dart';
 import 'package:submersion/core/constants/map_style.dart';
@@ -24,6 +23,10 @@ import 'package:submersion/core/utils/coordinates/coordinate_format.dart';
 import 'package:submersion/features/dive_3d/domain/spatial/seascape_appearance.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/statistics/presentation/pages/records_page.dart';
+import 'package:submersion/features/statistics/presentation/widgets/statistics_filter_bar.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 typedef Override = riverpod.Override;
@@ -497,13 +500,28 @@ void main() {
       prefs = await SharedPreferences.getInstance();
     });
 
-    /// Helper to create common provider overrides
+    /// Helper to create common provider overrides.
+    ///
+    /// [filter] drives the Statistics scope the page now follows (issue
+    /// #1028); an active one also makes StatisticsFilterBar read the filtered
+    /// statistics, hence the paired override.
     List<Override> getOverrides({
       Future<DiveRecords> Function(Ref)? diveRecordsOverride,
+      DiveFilterState filter = const DiveFilterState(),
     }) {
       return [
-        diveRecordsProvider.overrideWith(
+        filteredDiveRecordsProvider.overrideWith(
           diveRecordsOverride ?? (ref) async => DiveRecords(),
+        ),
+        statisticsFilterProvider.overrideWith((ref) => filter),
+        filteredDiveStatisticsProvider.overrideWith(
+          (ref) async => DiveStatistics(
+            totalDives: 0,
+            totalTimeSeconds: 0,
+            maxDepth: 0,
+            avgMaxDepth: 0,
+            totalSites: 0,
+          ),
         ),
         sharedPreferencesProvider.overrideWithValue(prefs),
         // Mock the settingsProvider to avoid database access
@@ -550,6 +568,68 @@ void main() {
         find.text('Start logging dives to see your records here'),
         findsOneWidget,
       );
+    });
+
+    // Issue #1028: the page follows the Statistics filter, so an empty result
+    // can mean "the filter is too narrow" rather than "no dives logged".
+    testWidgets('shows the filtered empty state when a filter is active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(
+            filter: const DiveFilterState(favoritesOnly: true),
+          ),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: RecordsPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No dives match your filters'), findsOneWidget);
+      expect(find.text('No Records Yet'), findsNothing);
+    });
+
+    testWidgets('hosts the filter bar, collapsed while no filter is active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: RecordsPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StatisticsFilterBar), findsOneWidget);
+      expect(find.byIcon(Icons.filter_list), findsNothing);
+    });
+
+    testWidgets('shows the filter bar summary while a filter is active', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(
+            filter: const DiveFilterState(favoritesOnly: true),
+          ),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: RecordsPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.filter_list), findsOneWidget);
     });
 
     testWidgets('should display refresh button in app bar', (tester) async {

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -538,6 +538,7 @@ void main() {
         ProviderScope(
           overrides: getOverrides(),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -555,6 +556,7 @@ void main() {
         ProviderScope(
           overrides: getOverrides(),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -581,6 +583,7 @@ void main() {
             filter: const DiveFilterState(favoritesOnly: true),
           ),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -600,6 +603,7 @@ void main() {
         ProviderScope(
           overrides: getOverrides(),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -621,6 +625,7 @@ void main() {
             filter: const DiveFilterState(favoritesOnly: true),
           ),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -637,6 +642,7 @@ void main() {
         ProviderScope(
           overrides: getOverrides(),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -672,6 +678,7 @@ void main() {
         ProviderScope(
           overrides: getOverrides(diveRecordsOverride: (ref) async => records),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),
@@ -685,6 +692,72 @@ void main() {
       expect(find.text('Longest Dive'), findsOneWidget);
     });
 
+    // firstDive/lastDive carry no field predicate, so a dive logged with only
+    // a date populates the milestones while every superlative stays null. The
+    // page must not call that "no records".
+    testWidgets('shows milestones when only first and last dive are known', (
+      tester,
+    ) async {
+      final records = DiveRecords(
+        firstDive: DiveRecord(
+          diveId: '1',
+          diveNumber: 1,
+          dateTime: DateTime(2024, 6, 15),
+        ),
+        lastDive: DiveRecord(
+          diveId: '2',
+          diveNumber: 2,
+          dateTime: DateTime(2024, 7, 20),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(diveRecordsOverride: (ref) async => records),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: RecordsPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No Records Yet'), findsNothing);
+      expect(find.text('First Dive'), findsOneWidget);
+      expect(find.text('Most Recent Dive'), findsOneWidget);
+    });
+
+    testWidgets('shows the shallowest dive card when it is the only record', (
+      tester,
+    ) async {
+      final records = DiveRecords(
+        shallowestDive: DiveRecord(
+          diveId: '1',
+          diveNumber: 1,
+          dateTime: DateTime(2024, 6, 15),
+          maxDepth: 6.0,
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: getOverrides(diveRecordsOverride: (ref) async => records),
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: RecordsPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No Records Yet'), findsNothing);
+      expect(find.text('Shallowest Dive'), findsOneWidget);
+    });
+
     testWidgets('should display error state with retry button', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -694,6 +767,7 @@ void main() {
             },
           ),
           child: const MaterialApp(
+            locale: Locale('en'),
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: RecordsPage(),

--- a/test/features/statistics/presentation/pages/statistics_overview_page_test.dart
+++ b/test/features/statistics/presentation/pages/statistics_overview_page_test.dart
@@ -62,7 +62,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => fixture),
             filteredDiveStatisticsProvider.overrideWith((ref) async => fixture),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -126,7 +128,7 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => records),
+            filteredDiveRecordsProvider.overrideWith((ref) async => records),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -179,7 +181,7 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => records),
+            filteredDiveRecordsProvider.overrideWith((ref) async => records),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -252,7 +254,7 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => records),
+            filteredDiveRecordsProvider.overrideWith((ref) async => records),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -304,7 +306,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -342,7 +346,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -401,7 +407,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -467,7 +475,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -521,7 +531,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -579,7 +591,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => diveTypes),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
@@ -615,7 +629,9 @@ void main() {
           overrides: [
             diveStatisticsProvider.overrideWith((ref) async => stats),
             filteredDiveStatisticsProvider.overrideWith((ref) async => stats),
-            diveRecordsProvider.overrideWith((ref) async => DiveRecords()),
+            filteredDiveRecordsProvider.overrideWith(
+              (ref) async => DiveRecords(),
+            ),
             diveTypeDistributionProvider.overrideWith((ref) async => []),
             sharedPreferencesProvider.overrideWithValue(prefs),
             settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),

--- a/test/features/statistics/presentation/providers/filtered_dive_records_provider_test.dart
+++ b/test/features/statistics/presentation/providers/filtered_dive_records_provider_test.dart
@@ -1,0 +1,111 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/gas_model.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_filter_provider.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1028: personal records on the Statistics tab must follow the tab's
+/// filter, the way every other panel on that page already does. The unfiltered
+/// [diveRecordsProvider] stays as-is for the dive-log summary widget, which is
+/// not a Statistics-tab surface.
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+  Future<void> insertDive(String id, {required double maxDepth}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(now),
+            maxDepth: Value(maxDepth),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  }
+
+  ProviderContainer makeContainer(DiveFilterState filter) => ProviderContainer(
+    overrides: [
+      currentDiverIdProvider.overrideWith(
+        (ref) => MockCurrentDiverIdNotifier(),
+      ),
+      gasModelProvider.overrideWith((ref) => GasModel.real),
+      statisticsFilterProvider.overrideWith((ref) => filter),
+    ],
+  );
+
+  test('filteredDiveRecordsProvider narrows the records to the active '
+      'Statistics filter', () async {
+    await insertDive('shallow', maxDepth: 10);
+    await insertDive('deep', maxDepth: 40);
+
+    final unfilteredContainer = makeContainer(const DiveFilterState());
+    addTearDown(unfilteredContainer.dispose);
+    final unfiltered = await unfilteredContainer.read(
+      filteredDiveRecordsProvider.future,
+    );
+
+    // Sanity check: without a filter the deep dive wins, so a filter that
+    // excludes it has something real to change.
+    expect(unfiltered.deepestDive!.diveId, 'deep');
+
+    final filteredContainer = makeContainer(
+      const DiveFilterState(maxDepth: 20),
+    );
+    addTearDown(filteredContainer.dispose);
+    final filtered = await filteredContainer.read(
+      filteredDiveRecordsProvider.future,
+    );
+
+    expect(
+      filtered.deepestDive!.diveId,
+      'shallow',
+      reason:
+          'the deepest dive must come from the filtered subset, otherwise it '
+          'contradicts the totals shown directly above it',
+    );
+    expect(filtered.shallowestDive!.diveId, 'shallow');
+    expect(filtered.firstDive!.diveId, 'shallow');
+    expect(filtered.lastDive!.diveId, 'shallow');
+  });
+
+  test(
+    'diveRecordsProvider stays unfiltered for non-Statistics surfaces',
+    () async {
+      await insertDive('shallow', maxDepth: 10);
+      await insertDive('deep', maxDepth: 40);
+
+      final container = makeContainer(const DiveFilterState(maxDepth: 20));
+      addTearDown(container.dispose);
+
+      final records = await container.read(diveRecordsProvider.future);
+
+      expect(
+        records.deepestDive!.diveId,
+        'deep',
+        reason:
+            'the dive-log summary widget reads diveRecordsProvider and has no '
+            'filter UI of its own; the Statistics filter must not reach it',
+      );
+    },
+  );
+}

--- a/test/features/statistics/presentation/providers/statistics_providers_all_test.dart
+++ b/test/features/statistics/presentation/providers/statistics_providers_all_test.dart
@@ -50,6 +50,10 @@ void main() {
       (await container.read(filteredDiveStatisticsProvider.future)).totalDives,
       0,
     );
+    expect(
+      (await container.read(filteredDiveRecordsProvider.future)).deepestDive,
+      isNull,
+    );
     expect(await container.read(gasMixDistributionProvider.future), isEmpty);
     expect(await container.read(diveTypeDistributionProvider.future), isEmpty);
     expect(await container.read(depthProgressionTrendProvider.future), isEmpty);
@@ -131,6 +135,10 @@ void main() {
     expect(
       (await container.read(filteredDiveStatisticsProvider.future)).totalDives,
       0,
+    );
+    expect(
+      (await container.read(filteredDiveRecordsProvider.future)).deepestDive,
+      isNull,
     );
     expect(await container.read(topBuddiesProvider.future), isEmpty);
     expect(await container.read(divesPerYearProvider.future), isEmpty);


### PR DESCRIPTION
Fixes #1028.

## The problem

On the Statistics tab, the aggregate panels and Most Visited Sites both narrow
when a filter is applied, because they read `filteredDiveStatisticsProvider`.
Personal Records read `diveRecordsProvider`, whose `getRecords()` had no filter
parameter at all, so the superlatives stayed lifetime-wide and contradicted the
totals directly above them.

## The fix

`DiveRepository.getRecords` now takes the same optional `DiveFilterState`
that `getStatistics` already takes, threading `buildFilteredDiveIdSubquery`
into all seven superlative statements. Two clause shapes are needed: five of
them already open with a `WHERE`, while `firstDive`/`lastDive` have none, so
their scope clause has to open one. All seven bind the same `vars` list, so
the diver placeholder is always emitted ahead of the filter placeholders.

A new `filteredDiveRecordsProvider` watches `statisticsFilterProvider` and
passes it through. It is split from `diveRecordsProvider` for the same reason
`filteredDiveStatisticsProvider` is split from `diveStatisticsProvider`: the
dive-log summary widget reads the unfiltered one and has no filter UI of its
own, so the Statistics scope must not reach it.

Both Statistics-side surfaces now use it:

- the Personal Records card on the overview page
- the full-page `/records` view, reached from the Statistics tab's trophy
  action, which would otherwise have shown lifetime records one tap behind a
  filtered page

`/records` also hosts `StatisticsFilterBar` so the narrowed scope stays visible
and clearable there, and its empty state now distinguishes "no dives logged"
from "no dives match your filters", reusing the existing
`diveLog_emptyFiltered_*` strings rather than adding translations.

## Tests

- `test/features/dive_log/data/repositories/dive_records_filter_test.dart`
  (new): date range, site, no-match, diver-scope composition, and a
  `noBuddyOnly` case covering the correlated subquery resolving correctly
  inside the alias-`d` records query.
- `test/features/statistics/presentation/providers/filtered_dive_records_provider_test.dart`
  (new): the filtered provider narrows; `diveRecordsProvider` stays unfiltered.
- `records_page_test.dart`: filtered empty state, plus the filter bar collapsed
  vs. active.
- Existing overview/records page overrides repointed at the new provider, and
  `filteredDiveRecordsProvider` added to the tick-build smoke list and the
  all-providers filter smoke test.

Full suite: 20097 passing. Two unrelated files (`resumable_base_publish_test`,
`media_item_view_store_fallback_test`) failed under concurrent local runs from
other worktrees and pass in isolation; neither touches this change.

## Noted, not changed

`_RecordsSection`'s single-dive collapse branch labels its one row "First
Dive" regardless of which record collapsed. It is pre-existing, but filtering
down to a single dive makes that path much easier to reach, so it is worth a
follow-up.
