### PR TITLE
fix(icloud): upload backups to Submersion Backups, not the sync folder

### DIFF
--- a/lib/core/services/cloud_storage/icloud_storage_provider.dart
+++ b/lib/core/services/cloud_storage/icloud_storage_provider.dart
@@ -40,6 +40,11 @@ typedef ICloudContainerPathLookup = Future<String?> Function();
 typedef ICloudContainerFileMove =
     Future<bool> Function(String sourcePath, String destinationPath);
 
+/// Writes bytes into the container with file coordination; throws when the
+/// write could not be performed.
+typedef ICloudContainerFileWrite =
+    Future<void> Function(String path, Uint8List data);
+
 /// Materializes an iCloud container file locally before it is read; false
 /// when the file could not be downloaded.
 typedef ICloudFileDownload = Future<bool> Function(String path);
@@ -66,20 +71,24 @@ class ICloudStorageProvider
   /// reaching the channel on other hosts — so on a Linux CI runner a mocked
   /// channel is never consulted, and a test would reach its assertion via a
   /// short circuit rather than via the branch it means to exercise.
-  /// [containerFileMove] and [ensureDownloaded] default to the native channel
-  /// calls and are injectable for the same reason as [containerPathLookup]:
-  /// both carry their own Apple-platform guard and short-circuit without
-  /// reaching the channel on other hosts, so a mocked channel would go
-  /// unconsulted on the Linux CI runner.
+  /// [containerFileMove], [containerFileWrite] and [ensureDownloaded] default
+  /// to the native channel calls and are injectable for the same reason as
+  /// [containerPathLookup]: each carries its own Apple-platform guard and
+  /// short-circuits (or, for the write, throws) without reaching the channel on
+  /// other hosts, so a mocked channel would go unconsulted on the Linux CI
+  /// runner.
   ICloudStorageProvider({
     ICloudHostPlatform? platform,
     ICloudContainerPathLookup? containerPathLookup,
     ICloudContainerFileMove? containerFileMove,
+    ICloudContainerFileWrite? containerFileWrite,
     ICloudFileDownload? ensureDownloaded,
   }) : _platform = platform ?? ICloudHostPlatform.current(),
        _lookupContainerPath =
            containerPathLookup ?? ICloudNativeService.getContainerPath,
        _moveIntoContainer = containerFileMove ?? ICloudNativeService.moveFile,
+       _writeIntoContainer =
+           containerFileWrite ?? ICloudNativeService.writeFile,
        _ensureDownloaded =
            ensureDownloaded ?? ICloudNativeService.downloadIfNeeded;
 
@@ -88,6 +97,7 @@ class ICloudStorageProvider
   final ICloudHostPlatform _platform;
   final ICloudContainerPathLookup _lookupContainerPath;
   final ICloudContainerFileMove _moveIntoContainer;
+  final ICloudContainerFileWrite _writeIntoContainer;
   final ICloudFileDownload _ensureDownloaded;
 
   Directory? _icloudContainer;
@@ -193,6 +203,23 @@ class ICloudStorageProvider
     }
   }
 
+  /// The container path an upload should land in.
+  ///
+  /// On iCloud a folder id IS a container path (that is what [createFolder]
+  /// returns), so honouring [folderId] is a plain substitution. Dropping it
+  /// instead filed database backups among the sync files, where the backup
+  /// UI (which lists by that same folder id) could never see them again
+  /// (issue #653).
+  Future<String> _resolveUploadFolder(String? folderId) async {
+    if (folderId != null) return folderId;
+    return getOrCreateSyncFolder().timeout(
+      const Duration(seconds: 15),
+      onTimeout: () {
+        throw const CloudStorageException('Timeout getting sync folder (15s)');
+      },
+    );
+  }
+
   @override
   Future<UploadResult> uploadFile(
     Uint8List data,
@@ -202,24 +229,17 @@ class ICloudStorageProvider
     try {
       _log.info('uploadFile: START for $filename (${data.length} bytes)');
 
-      // Step 1: Get sync folder with timeout
-      _log.info('uploadFile: Step 1 - getting sync folder...');
-      final syncFolder = await getOrCreateSyncFolder().timeout(
-        const Duration(seconds: 15),
-        onTimeout: () {
-          throw const CloudStorageException(
-            'Timeout getting sync folder (15s)',
-          );
-        },
-      );
-      _log.info('uploadFile: Step 1 DONE - sync folder: $syncFolder');
+      // Step 1: Resolve the destination folder with timeout
+      _log.info('uploadFile: Step 1 - resolving destination folder...');
+      final targetFolder = await _resolveUploadFolder(folderId);
+      _log.info('uploadFile: Step 1 DONE - destination: $targetFolder');
 
-      final filePath = path.join(syncFolder, filename);
+      final filePath = path.join(targetFolder, filename);
 
       // Step 2: Write directly to iCloud using native file coordination
       // Native code handles direct file write with timeout
       _log.info('uploadFile: Step 2 - writing to iCloud via native: $filePath');
-      await ICloudNativeService.writeFile(filePath, data).timeout(
+      await _writeIntoContainer(filePath, data).timeout(
         const Duration(seconds: 30),
         onTimeout: () {
           throw const CloudStorageException('Timeout writing to iCloud (30s)');
@@ -274,15 +294,8 @@ class ICloudStorageProvider
     String? folderId,
   }) async {
     try {
-      final syncFolder = await getOrCreateSyncFolder().timeout(
-        const Duration(seconds: 15),
-        onTimeout: () {
-          throw const CloudStorageException(
-            'Timeout getting sync folder (15s)',
-          );
-        },
-      );
-      final filePath = path.join(syncFolder, filename);
+      final targetFolder = await _resolveUploadFolder(folderId);
+      final filePath = path.join(targetFolder, filename);
 
       // Copy next to the destination so the coordinated move is same-volume,
       // mirroring ICloudMediaObjectStore.putFile. The copy itself sits inside

--- a/test/core/services/cloud_storage/icloud_storage_provider_test.dart
+++ b/test/core/services/cloud_storage/icloud_storage_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -267,6 +268,112 @@ void main() {
         expect(File(dest).existsSync(), isFalse);
       },
     );
+  });
+
+  group('upload target folder', () {
+    // BackupService resolves 'Submersion Backups' via createFolder and hands
+    // it to the upload as folderId. Every other provider honours that
+    // parameter; iCloud silently dropped it and filed every backup among the
+    // sync files (issue #653).
+    late String containerPath;
+    late List<String> writtenPaths;
+
+    setUp(() {
+      containerPath = p.join(tempDir.path, 'container');
+      Directory(containerPath).createSync(recursive: true);
+      writtenPaths = [];
+    });
+
+    String syncFolderPath() =>
+        p.join(containerPath, CloudStorageProviderMixin.syncFolderName);
+
+    String backupFolderPath() => p.join(containerPath, 'Submersion Backups');
+
+    ICloudStorageProvider uploadProvider() {
+      return ICloudStorageProvider(
+        platform: ICloudHostPlatform.ios,
+        containerPathLookup: () async => containerPath,
+        containerFileMove: (source, destination) async {
+          File(source).renameSync(destination);
+          return true;
+        },
+        containerFileWrite: (path, data) async {
+          writtenPaths.add(path);
+          await File(path).writeAsBytes(data);
+        },
+      );
+    }
+
+    test(
+      'uploadFileFromPath writes into the folder the caller named',
+      () async {
+        Directory(backupFolderPath()).createSync();
+        final src = File(p.join(tempDir.path, 'backup.db'))
+          ..writeAsStringSync('payload');
+
+        final result = await uploadProvider().uploadFileFromPath(
+          src.path,
+          'submersion_backup_x.db',
+          folderId: backupFolderPath(),
+        );
+
+        expect(
+          result.fileId,
+          p.join(backupFolderPath(), 'submersion_backup_x.db'),
+        );
+        expect(File(result.fileId).readAsStringSync(), 'payload');
+        expect(
+          Directory(syncFolderPath()).existsSync(),
+          isFalse,
+          reason: 'a backup upload must not even reach the sync folder',
+        );
+      },
+    );
+
+    test('uploadFileFromPath falls back to the sync folder when the caller '
+        'names none', () async {
+      final src = File(p.join(tempDir.path, 'sync.json'))
+        ..writeAsStringSync('{}');
+
+      final result = await uploadProvider().uploadFileFromPath(
+        src.path,
+        'submersion_sync.json',
+      );
+
+      expect(result.fileId, p.join(syncFolderPath(), 'submersion_sync.json'));
+    });
+
+    test('uploadFile writes into the folder the caller named', () async {
+      Directory(backupFolderPath()).createSync();
+
+      final result = await uploadProvider().uploadFile(
+        Uint8List.fromList([1, 2, 3]),
+        'submersion_backup_x.db',
+        folderId: backupFolderPath(),
+      );
+
+      expect(
+        result.fileId,
+        p.join(backupFolderPath(), 'submersion_backup_x.db'),
+      );
+      expect(writtenPaths, [result.fileId]);
+      expect(
+        Directory(syncFolderPath()).existsSync(),
+        isFalse,
+        reason: 'a backup upload must not even reach the sync folder',
+      );
+    });
+
+    test('uploadFile falls back to the sync folder when the caller names '
+        'none', () async {
+      final result = await uploadProvider().uploadFile(
+        Uint8List.fromList([1, 2, 3]),
+        'submersion_sync.json',
+      );
+
+      expect(result.fileId, p.join(syncFolderPath(), 'submersion_sync.json'));
+      expect(writtenPaths, [result.fileId]);
+    });
   });
 
   group('ICloudHostPlatform', () {


### PR DESCRIPTION
Fixes #653.

## Problem

`ICloudStorageProvider` declares `String? folderId` on both `uploadFile` and
`uploadFileFromPath` and then never reads it. Both methods unconditionally
joined the filename onto `getOrCreateSyncFolder()`.

`BackupService._uploadToCloud` was doing everything correctly:

```dart
final folderId = await _getOrCreateCloudBackupFolder();   // "Submersion Backups"
...
await _cloudProvider.uploadFileFromPath(uploadPath, uploadName, folderId: folderId);
```

iCloud threw that argument away, so every cloud backup landed in
`Submersion Sync` alongside the sync JSON. Every other provider honours the
parameter: Drive uses `folderId ?? await getOrCreateSyncFolder()`, S3 uses
`folderId ?? session.config.prefix`, Dropbox uses `_join(folderId, filename)`.

The asymmetry that kept this invisible: iCloud's `listFiles` **does** honour
`folderId`. So `getCloudBackups()` was reading the (empty) `Submersion Backups`
folder while writes went to `Submersion Sync`. Reads and writes disagreed, and
neither raised an error, which is exactly the reported symptom: the backup
completes, the integrity check passes, and the file is nowhere to be found.

## Change

`lib/core/services/cloud_storage/icloud_storage_provider.dart`

- New `_resolveUploadFolder(folderId)`: returns `folderId` when the caller names
  one, otherwise the sync folder with the existing 15s timeout. Both upload
  methods route through it. On iCloud a folder id **is** a container path (that
  is what `createFolder` returns), so honouring it is a plain substitution.
- That extraction also collapses the duplicated 15s timeout block the two upload
  methods had drifted into separate copies of, which is how they came to share
  the same bug.
- New `ICloudContainerFileWrite` injection seam. `ICloudNativeService.writeFile`
  *throws* on a non-Apple host, so `uploadFile` previously had no test reach at
  all. This mirrors the existing `containerFileMove` / `ensureDownloaded` seams
  and the rationale already documented on the constructor.

## Blast radius

Only backups move. Every sync-side `folderId` originates from
`getOrCreateSyncFolder()` itself (`sync_service.dart:483, 896, 2792, 3075, 3515,
3567` and `sync_encryption_service.dart:264`), so honouring the parameter
resolves to the same path string for sync and is a no-op there. `BackupService`
is the only caller that passes a different folder.

## No migration needed for backups already in the wrong place

`BackupRecord.cloudFileId` stores the absolute container path, and both
`deleteBackup` and `_downloadFromCloud` use it directly. Backups already sitting
in `Submersion Sync` therefore still restore from history and are still pruned
normally as retention rolls over, so they clean themselves up over time.

## Known residue, not addressed here

`deletePlaintextCloudBackups()` (offered when a user enables backup encryption)
lists by `folderId`, so on iCloud it has been finding nothing. Unencrypted `.db`
backups written before this fix are still in the sync folder and that sweep will
not reach them. That is a separate hygiene gap from the upload destination and
is worth its own issue.

## Testing

- Written test-first. The new tests fail on `main` with the literal bug:
  `Expected: .../Submersion Backups/submersion_backup_x.db`,
  `Actual: .../Submersion Sync/submersion_backup_x.db`.
- Four new cases in `icloud_storage_provider_test.dart`: both upload methods
  write into the folder the caller named (and never even create the sync
  folder), and both still fall back to the sync folder when none is named.
- `flutter analyze lib test`: no issues.
- Full suite: 20091 passed, 19 skipped, 0 failed.
