### PR TITLE
fix(media): report Live Photos as unsupported instead of raising PHPhotos 3302

### DIFF
--- a/ios/Runner/MetadataWriteHandler.swift
+++ b/ios/Runner/MetadataWriteHandler.swift
@@ -92,6 +92,17 @@ class MetadataWriteHandler: NSObject {
 
         if isVideo {
             writeVideoMetadata(asset: asset, metadata: metadata, description: description, keepOriginal: keepOriginal, result: result)
+        } else if asset.mediaSubtypes.contains(.photoLive) {
+            // A Live Photo is a still paired with a short video. Photos' content
+            // editing session expects the output to represent both resources, so
+            // the plain-image round-trip in writePhotoMetadata is rejected with
+            // PHPhotosErrorDomain error 3302. Refuse up front with a code the
+            // Dart layer can translate rather than surfacing that raw error.
+            result(FlutterError(
+                code: "LIVE_PHOTO_UNSUPPORTED",
+                message: "Live Photos cannot be edited in place without breaking the paired video.",
+                details: nil
+            ))
         } else {
             writePhotoMetadata(asset: asset, metadata: metadata, description: description, result: result)
         }

--- a/lib/features/media/data/services/metadata_write_service.dart
+++ b/lib/features/media/data/services/metadata_write_service.dart
@@ -5,12 +5,29 @@ import 'package:flutter/services.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 
+/// Native error code for an asset the platform cannot edit in place because
+/// it is a Live Photo (a still paired with a short video).
+///
+/// PhotoKit's content-editing round-trip expects the output to represent both
+/// resources, so writing back a bare modified still is rejected with
+/// `PHPhotosErrorDomain error 3302`. The iOS and macOS handlers detect the
+/// case up front and return this code instead of that raw error.
+const metadataWriteLivePhotoUnsupportedCode = 'LIVE_PHOTO_UNSUPPORTED';
+
 /// Exception thrown when metadata writing fails.
 class MetadataWriteException implements Exception {
   final String message;
+
+  /// The originating native error code, when the failure came from the
+  /// platform channel. Null for failures raised on the Dart side.
+  ///
+  /// Callers in the presentation layer use this to substitute a localized
+  /// message for [message], which is English-only.
+  final String? code;
+
   final Object? cause;
 
-  const MetadataWriteException(this.message, {this.cause});
+  const MetadataWriteException(this.message, {this.code, this.cause});
 
   @override
   String toString() => message;
@@ -115,6 +132,9 @@ class DiveMediaMetadata {
 /// - JPEG photos (EXIF)
 /// - HEIC/HEIF photos (EXIF via CGImageDestination)
 /// - MOV/MP4 videos (QuickTime metadata)
+///
+/// Does not support Live Photos on iOS or macOS: see
+/// [metadataWriteLivePhotoUnsupportedCode].
 class MetadataWriteService {
   static const _channel = MethodChannel('com.submersion.app/metadata');
   final _log = LoggerService.forClass(MetadataWriteService);
@@ -176,7 +196,11 @@ class MetadataWriteService {
       }
     } on PlatformException catch (e) {
       _log.error('Platform exception writing metadata', error: e);
-      throw MetadataWriteException(_parseErrorMessage(e), cause: e);
+      throw MetadataWriteException(
+        _parseErrorMessage(e),
+        code: e.code,
+        cause: e,
+      );
     } catch (e) {
       _log.error('Unexpected error writing metadata', error: e);
       throw MetadataWriteException(
@@ -202,6 +226,12 @@ class MetadataWriteService {
             'Cannot modify iCloud-only or shared album items.';
       case 'UNSUPPORTED_FORMAT':
         return 'This file format does not support metadata writing.';
+      case metadataWriteLivePhotoUnsupportedCode:
+        // Deliberately discards the native message: PhotoKit's own text for
+        // this case is an untranslated error-domain string.
+        return 'Live Photos are not supported yet. '
+            'Duplicate this as a still photo, '
+            'then write the dive data to the copy.';
       case 'WRITE_FAILED':
         return message.isNotEmpty ? message : 'Failed to write metadata.';
       default:

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -717,7 +717,13 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
     } on MetadataWriteException catch (e) {
       debugPrint('[MediaViewerPage] MetadataWriteException: ${e.message}');
       dismissLoadingDialog();
-      _showError(e.message);
+      // The service's messages are English-only; substitute a translation for
+      // the codes we have one for and fall back to its text otherwise.
+      _showError(
+        e.code == metadataWriteLivePhotoUnsupportedCode
+            ? l10n.media_writeMetadata_livePhotoUnsupported
+            : e.message,
+      );
     } catch (e) {
       debugPrint('[MediaViewerPage] Exception: $e');
       dismissLoadingDialog();

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4130,6 +4130,7 @@
   "media_writeMetadata_diveTimeLabel": "وقت الغوصة",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "الاحتفاظ بالفيديو الأصلي",
+  "media_writeMetadata_livePhotoUnsupported": "صور Live Photos غير مدعومة بعد. كرّر هذه الصورة كصورة ثابتة، ثم اكتب بيانات الغوص في النسخة.",
   "media_writeMetadata_noDataAvailable": "لا توجد بيانات غوص متاحة للكتابة.",
   "media_writeMetadata_siteLabel": "الموقع",
   "media_writeMetadata_temperatureLabel": "درجة الحرارة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4130,6 +4130,7 @@
   "media_writeMetadata_diveTimeLabel": "Tauchzeit",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Originalvideo beibehalten",
+  "media_writeMetadata_livePhotoUnsupported": "Live Photos werden noch nicht unterstützt. Dupliziere dieses Foto als Standbild und schreibe die Tauchdaten dann in die Kopie.",
   "media_writeMetadata_noDataAvailable": "Keine Tauchdaten zum Schreiben verfügbar.",
   "media_writeMetadata_siteLabel": "Tauchplatz",
   "media_writeMetadata_temperatureLabel": "Temperatur",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7238,6 +7238,7 @@
   "media_writeMetadata_diveTimeLabel": "Dive time",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Keep original video",
+  "media_writeMetadata_livePhotoUnsupported": "Live Photos are not supported yet. Duplicate this as a still photo, then write the dive data to the copy.",
   "media_writeMetadata_noDataAvailable": "No dive data available to write.",
   "media_writeMetadata_siteLabel": "Site",
   "media_writeMetadata_temperatureLabel": "Temperature",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4130,6 +4130,7 @@
   "media_writeMetadata_diveTimeLabel": "Hora de inmersion",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Conservar video original",
+  "media_writeMetadata_livePhotoUnsupported": "Las Live Photos aún no son compatibles. Duplica esta foto como imagen fija y luego escribe los datos de buceo en la copia.",
   "media_writeMetadata_noDataAvailable": "No hay datos de inmersion disponibles para escribir.",
   "media_writeMetadata_siteLabel": "Punto",
   "media_writeMetadata_temperatureLabel": "Temperatura",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4057,6 +4057,7 @@
   "media_writeMetadata_diveTimeLabel": "Heure de plongee",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Conserver la video originale",
+  "media_writeMetadata_livePhotoUnsupported": "Les Live Photos ne sont pas encore prises en charge. Dupliquez cette photo en image fixe, puis écrivez les données de plongée sur la copie.",
   "media_writeMetadata_noDataAvailable": "Aucune donnee de plongee disponible a ecrire.",
   "media_writeMetadata_siteLabel": "Site",
   "media_writeMetadata_temperatureLabel": "Temperature",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4057,6 +4057,7 @@
   "media_writeMetadata_diveTimeLabel": "זמן צלילה",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "שמור סרטון מקורי",
+  "media_writeMetadata_livePhotoUnsupported": "‏Live Photos עדיין אינן נתמכות. שכפל תמונה זו כתמונת סטילס, ולאחר מכן כתוב את נתוני הצלילה בעותק.",
   "media_writeMetadata_noDataAvailable": "אין נתוני צלילה זמינים לכתיבה.",
   "media_writeMetadata_siteLabel": "אתר",
   "media_writeMetadata_temperatureLabel": "טמפרטורה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4057,6 +4057,7 @@
   "media_writeMetadata_diveTimeLabel": "Merülesi ido",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Eredeti video megtartasa",
+  "media_writeMetadata_livePhotoUnsupported": "A Live Photo még nem támogatott. Készíts róla állóképes másolatot, majd a merülési adatokat a másolatba írd.",
   "media_writeMetadata_noDataAvailable": "Nincs elerheto merülesi adat az irashoz.",
   "media_writeMetadata_siteLabel": "Merülohely",
   "media_writeMetadata_temperatureLabel": "Homerseklet",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4057,6 +4057,7 @@
   "media_writeMetadata_diveTimeLabel": "Tempo di immersione",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Mantieni video originale",
+  "media_writeMetadata_livePhotoUnsupported": "Le Live Photo non sono ancora supportate. Duplica questa foto come immagine statica, poi scrivi i dati dell'immersione sulla copia.",
   "media_writeMetadata_noDataAvailable": "Nessun dato immersione disponibile da scrivere.",
   "media_writeMetadata_siteLabel": "Sito",
   "media_writeMetadata_temperatureLabel": "Temperatura",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -21946,6 +21946,12 @@ abstract class AppLocalizations {
   /// **'Keep original video'**
   String get media_writeMetadata_keepOriginalVideo;
 
+  /// No description provided for @media_writeMetadata_livePhotoUnsupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Live Photos are not supported yet. Duplicate this as a still photo, then write the dive data to the copy.'**
+  String get media_writeMetadata_livePhotoUnsupported;
+
   /// No description provided for @media_writeMetadata_noDataAvailable.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -12771,6 +12771,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'الاحتفاظ بالفيديو الأصلي';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'صور Live Photos غير مدعومة بعد. كرّر هذه الصورة كصورة ثابتة، ثم اكتب بيانات الغوص في النسخة.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'لا توجد بيانات غوص متاحة للكتابة.';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -13000,6 +13000,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Originalvideo beibehalten';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Live Photos werden noch nicht unterstützt. Dupliziere dieses Foto als Standbild und schreibe die Tauchdaten dann in die Kopie.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Keine Tauchdaten zum Schreiben verfügbar.';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -12794,6 +12794,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get media_writeMetadata_keepOriginalVideo => 'Keep original video';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Live Photos are not supported yet. Duplicate this as a still photo, then write the dive data to the copy.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'No dive data available to write.';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -12995,6 +12995,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Conservar video original';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Las Live Photos aún no son compatibles. Duplica esta foto como imagen fija y luego escribe los datos de buceo en la copia.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'No hay datos de inmersion disponibles para escribir.';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -13047,6 +13047,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Conserver la video originale';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Les Live Photos ne sont pas encore prises en charge. Dupliquez cette photo en image fixe, puis écrivez les données de plongée sur la copie.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Aucune donnee de plongee disponible a ecrire.';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -12686,6 +12686,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get media_writeMetadata_keepOriginalVideo => 'שמור סרטון מקורי';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      '‏Live Photos עדיין אינן נתמכות. שכפל תמונה זו כתמונת סטילס, ולאחר מכן כתוב את נתוני הצלילה בעותק.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'אין נתוני צלילה זמינים לכתיבה.';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -12968,6 +12968,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Eredeti video megtartasa';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'A Live Photo még nem támogatott. Készíts róla állóképes másolatot, majd a merülési adatokat a másolatba írd.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Nincs elerheto merülesi adat az irashoz.';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -13010,6 +13010,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mantieni video originale';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Le Live Photo non sono ancora supportate. Duplica questa foto come immagine statica, poi scrivi i dati dell\'immersione sulla copia.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Nessun dato immersione disponibile da scrivere.';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -12910,6 +12910,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get media_writeMetadata_keepOriginalVideo => 'Originele video bewaren';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'Live Photos worden nog niet ondersteund. Dupliceer deze als stilstaande foto en schrijf de duikgegevens vervolgens naar de kopie.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Geen duikgegevens beschikbaar om te schrijven.';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -13007,6 +13007,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get media_writeMetadata_keepOriginalVideo => 'Manter video original';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      'As Live Photos ainda não são suportadas. Duplique esta como fotografia estática e escreva os dados do mergulho na cópia.';
+
+  @override
   String get media_writeMetadata_noDataAvailable =>
       'Nenhum dado de mergulho disponivel para gravar.';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -12409,6 +12409,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get media_writeMetadata_keepOriginalVideo => '保留原始视频';
 
   @override
+  String get media_writeMetadata_livePhotoUnsupported =>
+      '尚不支持实况照片。请将其复制为静态照片，然后将潜水数据写入副本。';
+
+  @override
   String get media_writeMetadata_noDataAvailable => '没有可写入的潜水数据。';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4130,6 +4130,7 @@
   "media_writeMetadata_diveTimeLabel": "Duiktijd",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Originele video bewaren",
+  "media_writeMetadata_livePhotoUnsupported": "Live Photos worden nog niet ondersteund. Dupliceer deze als stilstaande foto en schrijf de duikgegevens vervolgens naar de kopie.",
   "media_writeMetadata_noDataAvailable": "Geen duikgegevens beschikbaar om te schrijven.",
   "media_writeMetadata_siteLabel": "Duikstek",
   "media_writeMetadata_temperatureLabel": "Temperatuur",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4130,6 +4130,7 @@
   "media_writeMetadata_diveTimeLabel": "Horario do mergulho",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "Manter video original",
+  "media_writeMetadata_livePhotoUnsupported": "As Live Photos ainda não são suportadas. Duplique esta como fotografia estática e escreva os dados do mergulho na cópia.",
   "media_writeMetadata_noDataAvailable": "Nenhum dado de mergulho disponivel para gravar.",
   "media_writeMetadata_siteLabel": "Ponto",
   "media_writeMetadata_temperatureLabel": "Temperatura",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4285,6 +4285,7 @@
   "media_writeMetadata_diveTimeLabel": "潜水时间",
   "media_writeMetadata_gpsLabel": "GPS",
   "media_writeMetadata_keepOriginalVideo": "保留原始视频",
+  "media_writeMetadata_livePhotoUnsupported": "尚不支持实况照片。请将其复制为静态照片，然后将潜水数据写入副本。",
   "media_writeMetadata_noDataAvailable": "没有可写入的潜水数据。",
   "media_writeMetadata_siteLabel": "潜水点",
   "media_writeMetadata_temperatureLabel": "温度",

--- a/macos/Runner/MetadataWriteHandler.swift
+++ b/macos/Runner/MetadataWriteHandler.swift
@@ -97,6 +97,18 @@ class MetadataWriteHandler: NSObject {
 
         if isVideo {
             writeVideoMetadata(asset: asset, metadata: metadata, description: description, keepOriginal: keepOriginal, result: result)
+        } else if asset.mediaSubtypes.contains(.photoLive) {
+            // A Live Photo is a still paired with a short video. Photos' content
+            // editing session expects the output to represent both resources, so
+            // the plain-image round-trip in writePhotoMetadata is rejected with
+            // PHPhotosErrorDomain error 3302. Refuse up front with a code the
+            // Dart layer can translate rather than surfacing that raw error.
+            NSLog("[MetadataWriteHandler] Asset is a Live Photo; metadata writing is not supported")
+            result(FlutterError(
+                code: "LIVE_PHOTO_UNSUPPORTED",
+                message: "Live Photos cannot be edited in place without breaking the paired video.",
+                details: nil
+            ))
         } else {
             writePhotoMetadata(asset: asset, metadata: metadata, description: description, result: result)
         }

--- a/test/features/media/data/services/metadata_write_service_test.dart
+++ b/test/features/media/data/services/metadata_write_service_test.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/services/metadata_write_service.dart';
+
+/// Mirrors `MetadataWriteService.isSupported`, which is checked BEFORE the
+/// platform channel: on an unsupported host the service throws outright and
+/// the mocked channel is never reached, so every case that asserts on a
+/// channel response has to be skipped there.
+final bool _metadataWriteSupported =
+    Platform.isIOS || Platform.isMacOS || Platform.isAndroid;
+
+/// Enough dive data to clear the service's `hasData` guard.
+const _metadata = DiveMediaMetadata(
+  depthMeters: 18.3,
+  temperatureCelsius: 21.5,
+  latitude: 36.9,
+  longitude: -25.1,
+  siteName: 'Dom Pedro',
+  elapsedSeconds: 600,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.submersion.app/metadata');
+  late Future<Object?> Function(MethodCall) handler;
+
+  setUp(() {
+    handler = (_) async => true;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) => handler(call));
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  Future<void> write() => MetadataWriteService().writeMetadata(
+    platformAssetId: 'asset-1',
+    metadata: _metadata,
+    isVideo: false,
+  );
+
+  group('live photos', () {
+    test('the native refusal is carried through as a distinct code', () async {
+      handler = (_) async => throw PlatformException(
+        code: metadataWriteLivePhotoUnsupportedCode,
+        message: 'Live Photos are not supported.',
+      );
+
+      await expectLater(
+        write(),
+        throwsA(
+          isA<MetadataWriteException>().having(
+            (e) => e.code,
+            'code',
+            metadataWriteLivePhotoUnsupportedCode,
+          ),
+        ),
+      );
+    }, skip: !_metadataWriteSupported);
+
+    test('the raw PhotoKit error never reaches the message', () async {
+      // Before the native Live Photo check existed, PhotoKit rejected the
+      // rewritten still and its untranslated error text was shown verbatim.
+      handler = (_) async => throw PlatformException(
+        code: metadataWriteLivePhotoUnsupportedCode,
+        message:
+            "The operation couldn't be completed. "
+            '(PHPhotosErrorDomain error 3302.)',
+      );
+
+      await expectLater(
+        write(),
+        throwsA(
+          isA<MetadataWriteException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('Live Photo'),
+              isNot(contains('PHPhotosErrorDomain')),
+            ),
+          ),
+        ),
+      );
+    }, skip: !_metadataWriteSupported);
+  });
+
+  group('other platform failures', () {
+    test('a known code keeps its curated message and its code', () async {
+      handler = (_) async =>
+          throw PlatformException(code: 'READ_ONLY', message: 'raw native');
+
+      await expectLater(
+        write(),
+        throwsA(
+          isA<MetadataWriteException>()
+              .having((e) => e.code, 'code', 'READ_ONLY')
+              .having((e) => e.message, 'message', contains('read-only')),
+        ),
+      );
+    }, skip: !_metadataWriteSupported);
+
+    test('WRITE_FAILED still passes the native message through', () async {
+      handler = (_) async =>
+          throw PlatformException(code: 'WRITE_FAILED', message: 'disk full');
+
+      await expectLater(
+        write(),
+        throwsA(
+          isA<MetadataWriteException>()
+              .having((e) => e.code, 'code', 'WRITE_FAILED')
+              .having((e) => e.message, 'message', 'disk full'),
+        ),
+      );
+    }, skip: !_metadataWriteSupported);
+
+    test('a failure raised on the Dart side carries no code', () async {
+      // A `false` result is rejected by a throw inside the service's own try,
+      // so it reaches the untyped catch rather than the PlatformException one
+      // and no native code is available to attach. Callers keying off `code`
+      // must therefore tolerate null and fall back to the message.
+      handler = (_) async => false;
+
+      await expectLater(
+        write(),
+        throwsA(
+          isA<MetadataWriteException>().having((e) => e.code, 'code', isNull),
+        ),
+      );
+    }, skip: !_metadataWriteSupported);
+
+    test('a thrown non-platform error is still surfaced', () async {
+      // The mock messenger re-wraps anything that is not a PlatformException
+      // into `PlatformException(code: 'error')`, so this arrives typed.
+      handler = (_) async => throw StateError('boom');
+
+      await expectLater(write(), throwsA(isA<MetadataWriteException>()));
+    }, skip: !_metadataWriteSupported);
+  });
+}

--- a/test/features/media/presentation/pages/media_viewer_write_metadata_test.dart
+++ b/test/features/media/presentation/pages/media_viewer_write_metadata_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/data/services/metadata_write_service.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 import 'package:submersion/features/media/domain/services/media_source_resolver.dart';
@@ -231,4 +232,26 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(find.byType(SnackBar), findsOneWidget);
   });
+
+  testWidgets('a Live Photo refusal is translated, not shown raw', (
+    tester,
+  ) async {
+    // The native handlers now reject Live Photos up front; before that,
+    // PhotoKit rejected the rewritten still and this untranslated string
+    // reached the user verbatim (issue #795).
+    handler = (_) async => throw PlatformException(
+      code: metadataWriteLivePhotoUnsupportedCode,
+      message:
+          "The operation couldn't be completed. "
+          '(PHPhotosErrorDomain error 3302.)',
+    );
+    await pump(tester, item());
+    await openDialog(tester);
+    await confirmWrite(tester);
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.textContaining('PHPhotosErrorDomain'), findsNothing);
+    expect(find.textContaining('Live Photos'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  }, skip: !_metadataWriteSupported);
 }


### PR DESCRIPTION
Refs #795 (deliberately not a closing keyword)

## The bug

"Write dive data to photo" on a Live Photo failed with the raw native error:

> The operation couldn't be completed. (PHPhotosErrorDomain error 3302.)

A Live Photo is a still paired with a short video. Photos' content editing
session expects the output to represent both resources, but `writePhotoMetadata`
fed it a bare rewritten still, so Photos rejected the resource. Neither the iOS
nor the macOS handler checked `asset.mediaSubtypes`, so every Live Photo took
the plain-image `PHContentEditingInput` -> `CGImageDestination` ->
`PHContentEditingOutput` path.

The raw text reached the user because `WRITE_FAILED` is a passthrough:
`MetadataWriteService._parseErrorMessage` returns the native message verbatim
for that code, unlike every other code, which gets a curated string.

## The fix

Both handlers now check `mediaSubtypes.contains(.photoLive)` at the point where
they choose a write strategy, and return a new `LIVE_PHOTO_UNSUPPORTED` code
before opening a content editing session. `MetadataWriteException` gained a
`code` field so the viewer can substitute a localized message; the service
keeps an English fallback for callers without a context and deliberately
discards PhotoKit's own text.

macOS was the reported platform, but iOS shares the same code path and the same
missing check, so both are fixed. The check sits beside the `isVideo` branch
rather than inside `writePhotoMetadata` so the "which strategy does this asset
need" decision stays in one place, and so it returns before any async PhotoKit
session is opened.

## Why not actually write the metadata

The issue floated `PHLivePhotoEditingContext` as a full fix. That route
re-encodes the pairing, and per
[Apple Developer Forums thread 769154](https://developer.apple.com/forums/thread/769154)
and [immich-app/immich#26124](https://github.com/immich-app/immich/issues/26124)
the metadata still does not stick. This PR reports the limitation instead of
pretending to work. The message tells users what does work: duplicate the shot
as a still photo and write the dive data to the copy.

#795 therefore stays open after this merges, to track actually writing the
metadata to a Live Photo.

## Localization

`media_writeMetadata_livePhotoUnsupported` added to all 11 locales; the
generated `app_localizations*.dart` files are regenerated (additive only).

## Testing

- New `test/features/media/data/services/metadata_write_service_test.dart`:
  covers the new code reaching the exception, the raw `PHPhotosErrorDomain`
  text never reaching the message, the existing curated and passthrough codes
  still behaving, and the Dart-side path that carries no code.
- `media_viewer_write_metadata_test.dart` gains a case asserting the SnackBar
  shows the translation and never the `PHPhotosErrorDomain` string.
- 15/15 pass. `dart format .` clean, `flutter analyze` clean.
- `flutter build macos --debug` succeeds, confirming the Swift compiles.

The native `.photoLive` branch itself has no automated coverage: it needs a real
Live Photo in a real photo library, so it was reasoned about rather than
executed. Worth a manual check on macOS against the asset from the issue.
