### PR TITLE
Stop estimating tank pressure on gauge dives, and let estimates be turned off (#731)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1812,9 +1812,13 @@ class DiverSettings extends Table {
       boolean().withDefault(const Constant(false))();
   // v163: whether synthesized ("(est.)") tank pressure lines are drawn on the
   // profile chart at all (issue #731). Defaults to true, preserving the
-  // behavior estimates shipped with.
+  // behavior estimates shipped with. Ignored for coverage for the reason
+  // given below: the declaration is a codegen input, never executed. Its
+  // default is pinned by migration_v163_estimated_tank_pressure_default_test.
+  // coverage:ignore-start
   BoolColumn get defaultShowEstimatedTankPressure =>
       boolean().withDefault(const Constant(true))();
+  // coverage:ignore-end
   // Drift column declarations are codegen inputs shadowed by the generated
   // table at runtime, so this line is never executed (every sibling column
   // getter is likewise uncovered). The default is verified via the migration

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3461,7 +3461,10 @@ class AppDatabase extends _$AppDatabase {
     161,
     // v163: diver_settings.default_show_estimated_tank_pressure, the switch
     // that suppresses synthesized "(est.)" tank pressure lines on the profile
-    // chart (issue #731). v162 was claimed first on main by #1090.
+    // chart (issue #731). v162 is skipped rather than missing: main was at
+    // v161 when this branch was cut, and the open PR #1287 (issue #1090) had
+    // already written 162 on its own branch. Two branches writing the same
+    // scalar auto-merge with no conflict marker, so 163 was taken instead.
     163,
   ];
 

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1810,6 +1810,11 @@ class DiverSettings extends Table {
   // v161: default visibility for the per-cell O2 mV traces (issue #1235).
   BoolColumn get defaultShowO2CellMv =>
       boolean().withDefault(const Constant(false))();
+  // v163: whether synthesized ("(est.)") tank pressure lines are drawn on the
+  // profile chart at all (issue #731). Defaults to true, preserving the
+  // behavior estimates shipped with.
+  BoolColumn get defaultShowEstimatedTankPressure =>
+      boolean().withDefault(const Constant(true))();
   // Drift column declarations are codegen inputs shadowed by the generated
   // table at runtime, so this line is never executed (every sibling column
   // getter is likewise uncovered). The default is verified via the migration
@@ -3165,7 +3170,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 161;
+  static const int currentSchemaVersion = 163;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3450,6 +3455,10 @@ class AppDatabase extends _$AppDatabase {
     // v161: diver_settings.default_show_o2_cell_mv, a persisted default for
     // the per-cell O2 mV toggle on the profile chart (issue #1235).
     161,
+    // v163: diver_settings.default_show_estimated_tank_pressure, the switch
+    // that suppresses synthesized "(est.)" tank pressure lines on the profile
+    // chart (issue #731). v162 was claimed first on main by #1090.
+    163,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -4916,6 +4925,25 @@ class AppDatabase extends _$AppDatabase {
         'ALTER TABLE diver_settings ADD COLUMN default_show_o2_cell_mv '
         'INTEGER NOT NULL DEFAULT 0 '
         'CHECK (default_show_o2_cell_mv IN (0, 1))',
+      );
+    }
+  }
+
+  /// v163: default_show_estimated_tank_pressure on diver_settings (issue
+  /// #731). Synthesized "(est.)" pressure lines previously had no off switch.
+  /// Defaults to 1 so existing databases keep drawing them.
+  Future<void> _assertEstimatedTankPressureDefaultColumn() async {
+    final cols = await customSelect(
+      "PRAGMA table_info('diver_settings')",
+    ).get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('default_show_estimated_tank_pressure')) {
+      await customStatement(
+        'ALTER TABLE diver_settings ADD COLUMN '
+        'default_show_estimated_tank_pressure '
+        'INTEGER NOT NULL DEFAULT 1 '
+        'CHECK (default_show_estimated_tank_pressure IN (0, 1))',
       );
     }
   }
@@ -8535,6 +8563,12 @@ class AppDatabase extends _$AppDatabase {
           await _assertO2CellMvDefaultColumn();
         }
         if (from < 161) await reportProgress();
+        // v163: default_show_estimated_tank_pressure on diver_settings
+        // (issue #731).
+        if (from < 163) {
+          await _assertEstimatedTankPressureDefaultColumn();
+        }
+        if (from < 163) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -8728,6 +8762,11 @@ class AppDatabase extends _$AppDatabase {
         // v161 backstop: re-assert diver_settings.default_show_o2_cell_mv
         // (issue #1235; same parallel-branch version-collision self-heal).
         await _assertO2CellMvDefaultColumn();
+
+        // v163 backstop: re-assert
+        // diver_settings.default_show_estimated_tank_pressure (issue #731;
+        // same parallel-branch version-collision self-heal).
+        await _assertEstimatedTankPressureDefaultColumn();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5663,8 +5663,6 @@ class SyncDataSerializer {
       // v161: seed it so payloads predating the column hydrate instead of
       // throwing in DiverSetting.fromJson.
       'defaultShowO2CellMv': false,
-      // v163: seed it so payloads predating the column hydrate instead of
-      // throwing in DiverSetting.fromJson (issue #731).
       // Dive profile default-visible metrics. Non-nullable bool added in v91;
       // seed it so payloads predating the column hydrate instead of throwing in
       // DiverSetting.fromJson.

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -5663,6 +5663,8 @@ class SyncDataSerializer {
       // v161: seed it so payloads predating the column hydrate instead of
       // throwing in DiverSetting.fromJson.
       'defaultShowO2CellMv': false,
+      // v163: seed it so payloads predating the column hydrate instead of
+      // throwing in DiverSetting.fromJson (issue #731).
       // Dive profile default-visible metrics. Non-nullable bool added in v91;
       // seed it so payloads predating the column hydrate instead of throwing in
       // DiverSetting.fromJson.

--- a/lib/features/dive_log/presentation/providers/dive_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_providers.dart
@@ -1054,9 +1054,26 @@ final estimatedTankPressuresProvider =
       final realFuture = ref.watch(tankPressuresProvider(diveId).future);
       final diveFuture = ref.watch(diveProvider(diveId).future);
       final switchesFuture = ref.watch(gasSwitchesProvider(diveId).future);
+      // Read synchronously, before the first await, so the dependency is
+      // registered while the provider is certainly still alive.
+      final showEstimates = ref.watch(
+        settingsProvider.select((s) => s.defaultShowEstimatedTankPressure),
+      );
       final real = await realFuture;
       final dive = await diveFuture;
       if (dive == null) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      // A gauge (bottom-timer) dive models no gas at all, so a synthesized
+      // pressure trace would be fabricated rather than measured (issue #731).
+      // Real transmitter samples, if the dive has any, still pass through.
+      if (dive.isGauge) {
+        return EstimatedTankPressures(real, const <String>{});
+      }
+      // The diver can switch estimates off entirely (issue #731). Gating here
+      // rather than at the chart means the series never exists, so no legend
+      // chip, tooltip row, or "(est.)" label survives anywhere.
+      if (!showEstimates) {
         return EstimatedTankPressures(real, const <String>{});
       }
       final switches = await switchesFuture;

--- a/lib/features/settings/data/repositories/diver_settings_repository.dart
+++ b/lib/features/settings/data/repositories/diver_settings_repository.dart
@@ -178,6 +178,9 @@ class DiverSettingsRepository {
               defaultShowPhotoMarkers: Value(s.defaultShowPhotoMarkers),
               defaultShowGasTimeline: Value(s.defaultShowGasTimeline),
               defaultShowO2CellMv: Value(s.defaultShowO2CellMv),
+              defaultShowEstimatedTankPressure: Value(
+                s.defaultShowEstimatedTankPressure,
+              ),
               defaultShowAscentRateLine: Value(s.defaultShowAscentRateLine),
               notificationsEnabled: Value(s.notificationsEnabled),
               serviceReminderDays: Value(
@@ -342,6 +345,9 @@ class DiverSettingsRepository {
           defaultShowPhotoMarkers: Value(settings.defaultShowPhotoMarkers),
           defaultShowGasTimeline: Value(settings.defaultShowGasTimeline),
           defaultShowO2CellMv: Value(settings.defaultShowO2CellMv),
+          defaultShowEstimatedTankPressure: Value(
+            settings.defaultShowEstimatedTankPressure,
+          ),
           defaultShowAscentRateLine: Value(settings.defaultShowAscentRateLine),
           notificationsEnabled: Value(settings.notificationsEnabled),
           serviceReminderDays: Value(
@@ -544,6 +550,7 @@ class DiverSettingsRepository {
       defaultShowPhotoMarkers: row.defaultShowPhotoMarkers,
       defaultShowGasTimeline: row.defaultShowGasTimeline,
       defaultShowO2CellMv: row.defaultShowO2CellMv,
+      defaultShowEstimatedTankPressure: row.defaultShowEstimatedTankPressure,
       defaultShowAscentRateLine: row.defaultShowAscentRateLine,
       notificationsEnabled: row.notificationsEnabled,
       serviceReminderDays: _parseReminderDays(row.serviceReminderDays),

--- a/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
+++ b/lib/features/settings/presentation/pages/default_visible_metrics_page.dart
@@ -39,6 +39,13 @@ class DefaultVisibleMetricsPage extends ConsumerWidget {
             onChanged: notifier.setDefaultShowPressure,
           ),
           SwitchListTile(
+            title: Text(
+              context.l10n.settings_appearance_metric_estimatedTankPressure,
+            ),
+            value: settings.defaultShowEstimatedTankPressure,
+            onChanged: notifier.setDefaultShowEstimatedTankPressure,
+          ),
+          SwitchListTile(
             title: Text(context.l10n.settings_appearance_metric_heartRate),
             value: settings.defaultShowHeartRate,
             onChanged: notifier.setDefaultShowHeartRate,

--- a/lib/features/settings/presentation/providers/settings_providers.dart
+++ b/lib/features/settings/presentation/providers/settings_providers.dart
@@ -394,6 +394,11 @@ class AppSettings {
   /// Default visibility for the per-cell O2 mV traces on the dive profile
   final bool defaultShowO2CellMv;
 
+  /// Whether synthesized ("(est.)") tank pressure lines are drawn on the dive
+  /// profile at all. Off means the estimate is never built, so no legend chip,
+  /// tooltip row, or chart-options entry appears for it (issue #731).
+  final bool defaultShowEstimatedTankPressure;
+
   /// Default visibility for the separate ascent-rate magnitude line on the
   /// dive profile (distinct from [showAscentRateColors], which tints the depth
   /// line by velocity band).
@@ -561,6 +566,7 @@ class AppSettings {
     this.defaultShowPhotoMarkers = true,
     this.defaultShowGasTimeline = false,
     this.defaultShowO2CellMv = false,
+    this.defaultShowEstimatedTankPressure = true,
     this.defaultShowAscentRateLine = false,
     // Notification defaults
     this.notificationsEnabled = true,
@@ -721,6 +727,7 @@ class AppSettings {
     bool? defaultShowPhotoMarkers,
     bool? defaultShowGasTimeline,
     bool? defaultShowO2CellMv,
+    bool? defaultShowEstimatedTankPressure,
     bool? defaultShowAscentRateLine,
     bool? notificationsEnabled,
     List<int>? serviceReminderDays,
@@ -870,6 +877,9 @@ class AppSettings {
       defaultShowGasTimeline:
           defaultShowGasTimeline ?? this.defaultShowGasTimeline,
       defaultShowO2CellMv: defaultShowO2CellMv ?? this.defaultShowO2CellMv,
+      defaultShowEstimatedTankPressure:
+          defaultShowEstimatedTankPressure ??
+          this.defaultShowEstimatedTankPressure,
       defaultShowAscentRateLine:
           defaultShowAscentRateLine ?? this.defaultShowAscentRateLine,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -1796,6 +1806,11 @@ class SettingsNotifier extends StateNotifier<AppSettings> {
 
   Future<void> setDefaultShowO2CellMv(bool value) async {
     state = state.copyWith(defaultShowO2CellMv: value);
+    await _saveSettings();
+  }
+
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async {
+    state = state.copyWith(defaultShowEstimatedTankPressure: value);
     await _saveSettings();
   }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4430,6 +4430,7 @@
   "settings_appearance_metric_ceiling": "السقف",
   "settings_appearance_metric_cns": "CNS% (سمية الأكسجين)",
   "settings_appearance_metric_events": "الأحداث",
+  "settings_appearance_metric_estimatedTankPressure": "ضغط الأسطوانة المقدر",
   "settings_appearance_metric_gasDensity": "كثافة الغاز",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "معدل ضربات القلب",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4430,6 +4430,7 @@
   "settings_appearance_metric_ceiling": "Ceiling",
   "settings_appearance_metric_cns": "CNS% (O2-Toxizität)",
   "settings_appearance_metric_events": "Ereignisse",
+  "settings_appearance_metric_estimatedTankPressure": "Geschätzter Flaschendruck",
   "settings_appearance_metric_gasDensity": "Gasdichte",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Herzfrequenz",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -8671,6 +8671,10 @@
   "settings_appearance_metric_ascentRateColors": "Ascent Rate Colors",
   "settings_appearance_metric_ceiling": "Ceiling",
   "settings_appearance_metric_events": "Events",
+  "settings_appearance_metric_estimatedTankPressure": "Estimated Tank Pressure",
+  "@settings_appearance_metric_estimatedTankPressure": {
+    "description": "Settings switch that turns off the synthesized (estimated) tank pressure line on the dive profile chart."
+  },
   "settings_appearance_metric_gasDensity": "Gas Density",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Heart Rate",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4430,6 +4430,7 @@
   "settings_appearance_metric_ceiling": "Techo",
   "settings_appearance_metric_cns": "CNS% (Toxicidad de O2)",
   "settings_appearance_metric_events": "Eventos",
+  "settings_appearance_metric_estimatedTankPressure": "Presión estimada del tanque",
   "settings_appearance_metric_gasDensity": "Densidad del gas",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Frecuencia cardiaca",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -4357,6 +4357,7 @@
   "settings_appearance_metric_ceiling": "Plafond",
   "settings_appearance_metric_cns": "CNS% (Toxicite O2)",
   "settings_appearance_metric_events": "Evenements",
+  "settings_appearance_metric_estimatedTankPressure": "Pression estimée du bloc",
   "settings_appearance_metric_gasDensity": "Densite du gaz",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Frequence cardiaque",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -4434,6 +4434,7 @@
   "settings_appearance_metric_ceiling": "תקרה",
   "settings_appearance_metric_cns": "CNS% (רעילות חמצן)",
   "settings_appearance_metric_events": "אירועים",
+  "settings_appearance_metric_estimatedTankPressure": "לחץ בלון משוער",
   "settings_appearance_metric_gasDensity": "צפיפות גז",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "קצב לב",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -4357,6 +4357,7 @@
   "settings_appearance_metric_ceiling": "Plafon",
   "settings_appearance_metric_cns": "CNS% (O2 toxicitás)",
   "settings_appearance_metric_events": "Esemenyek",
+  "settings_appearance_metric_estimatedTankPressure": "Becsült palacknyomás",
   "settings_appearance_metric_gasDensity": "Gaz suruseg",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Szivfrekvencia",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -4357,6 +4357,7 @@
   "settings_appearance_metric_ceiling": "Ceiling",
   "settings_appearance_metric_cns": "CNS% (Tossicita O2)",
   "settings_appearance_metric_events": "Eventi",
+  "settings_appearance_metric_estimatedTankPressure": "Pressione stimata della bombola",
   "settings_appearance_metric_gasDensity": "Densità gas",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Frequenza cardiaca",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -24502,6 +24502,12 @@ abstract class AppLocalizations {
   /// **'Events'**
   String get settings_appearance_metric_events;
 
+  /// Settings switch that turns off the synthesized (estimated) tank pressure line on the dive profile chart.
+  ///
+  /// In en, this message translates to:
+  /// **'Estimated Tank Pressure'**
+  String get settings_appearance_metric_estimatedTankPressure;
+
   /// No description provided for @settings_appearance_metric_gasDensity.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -14274,6 +14274,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_appearance_metric_events => 'الأحداث';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'ضغط الأسطوانة المقدر';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'كثافة الغاز';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -14510,6 +14510,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_appearance_metric_events => 'Ereignisse';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Geschätzter Flaschendruck';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Gasdichte';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -14293,6 +14293,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_appearance_metric_events => 'Events';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Estimated Tank Pressure';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Gas Density';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -14521,6 +14521,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_appearance_metric_events => 'Eventos';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Presión estimada del tanque';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Densidad del gas';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14570,6 +14570,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_appearance_metric_events => 'Evenements';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Pression estimée du bloc';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Densite du gaz';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -14178,6 +14178,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_appearance_metric_events => 'אירועים';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'לחץ בלון משוער';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'צפיפות גז';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -14480,6 +14480,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_appearance_metric_events => 'Esemenyek';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Becsült palacknyomás';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Gaz suruseg';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -14527,6 +14527,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_appearance_metric_events => 'Eventi';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Pressione stimata della bombola';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Densità gas';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -14419,6 +14419,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_appearance_metric_events => 'Gebeurtenissen';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Geschatte flesdruk';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Gasdichtheid';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -14526,6 +14526,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_appearance_metric_events => 'Eventos';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure =>
+      'Pressão estimada do cilindro';
+
+  @override
   String get settings_appearance_metric_gasDensity => 'Densidade do Gas';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13845,6 +13845,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_appearance_metric_events => '事件';
 
   @override
+  String get settings_appearance_metric_estimatedTankPressure => '估算气瓶压力';
+
+  @override
   String get settings_appearance_metric_gasDensity => '气体密度';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4430,6 +4430,7 @@
   "settings_appearance_metric_ceiling": "Plafond",
   "settings_appearance_metric_cns": "CNS% (O2-toxiciteit)",
   "settings_appearance_metric_events": "Gebeurtenissen",
+  "settings_appearance_metric_estimatedTankPressure": "Geschatte flesdruk",
   "settings_appearance_metric_gasDensity": "Gasdichtheid",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Hartslag",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4430,6 +4430,7 @@
   "settings_appearance_metric_ceiling": "Teto",
   "settings_appearance_metric_cns": "CNS% (Toxicidade de O2)",
   "settings_appearance_metric_events": "Eventos",
+  "settings_appearance_metric_estimatedTankPressure": "Pressão estimada do cilindro",
   "settings_appearance_metric_gasDensity": "Densidade do Gas",
   "settings_appearance_metric_gfPercent": "GF%",
   "settings_appearance_metric_heartRate": "Frequencia Cardiaca",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4586,6 +4586,7 @@
   "settings_appearance_metric_ceiling": "上升限制",
   "settings_appearance_metric_cns": "中枢神经系统% (O2 毒性)",
   "settings_appearance_metric_events": "事件",
+  "settings_appearance_metric_estimatedTankPressure": "估算气瓶压力",
   "settings_appearance_metric_gasDensity": "气体密度",
   "settings_appearance_metric_gfPercent": "梯度因子%",
   "settings_appearance_metric_heartRate": "心率",

--- a/test/core/database/migration_v163_estimated_tank_pressure_default_test.dart
+++ b/test/core/database/migration_v163_estimated_tank_pressure_default_test.dart
@@ -1,0 +1,127 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+
+/// Minimal pre-v163 diver_settings stamped at v161, so opening it runs the
+/// 161 -> 163 rung of the ladder rather than only the beforeOpen backstop.
+NativeDatabase _dbAt161() {
+  return NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = 161');
+      rawDb.execute('''
+        CREATE TABLE diver_settings (
+          id TEXT NOT NULL PRIMARY KEY,
+          created_at INTEGER,
+          updated_at INTEGER
+        )
+      ''');
+      rawDb.execute(
+        "INSERT INTO diver_settings (id, created_at, updated_at) "
+        "VALUES ('ds1', 0, 0)",
+      );
+    },
+  );
+}
+
+/// v163 adds the switch that suppresses synthesized "(est.)" tank pressure
+/// lines on the profile chart (issue #731). v162 was claimed first on main by
+/// #1090.
+void main() {
+  test('v163 is in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(163));
+    expect(AppDatabase.migrationVersions, contains(163));
+  });
+
+  test(
+    'a fresh database has diver_settings.default_show_estimated_tank_pressure',
+    () async {
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('diver_settings')")
+          .get();
+      final names = cols.map((c) => c.read<String>('name')).toSet();
+      expect(names, contains('default_show_estimated_tank_pressure'));
+    },
+  );
+
+  test('the column defaults to showing estimates', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final cols = await db
+        .customSelect("PRAGMA table_info('diver_settings')")
+        .get();
+    final column = cols.firstWhere(
+      (c) => c.read<String>('name') == 'default_show_estimated_tank_pressure',
+    );
+    // Estimates shipped always-on, so defaulting to 1 means upgrading does not
+    // silently remove a line a diver was already reading.
+    expect(column.read<String?>('dflt_value'), '1');
+  });
+
+  test(
+    'a database stranded before v163 gains the column via beforeOpen',
+    () async {
+      final nativeDb = NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('''
+          CREATE TABLE diver_settings (
+            id TEXT NOT NULL PRIMARY KEY,
+            created_at INTEGER,
+            updated_at INTEGER
+          )
+        ''');
+        },
+      );
+      final db = AppDatabase(nativeDb);
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('diver_settings')")
+          .get();
+      final names = cols.map((c) => c.read<String>('name')).toSet();
+      expect(names, contains('default_show_estimated_tank_pressure'));
+    },
+  );
+
+  test('the assert is a no-op when the table is absent', () async {
+    final nativeDb = NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('CREATE TABLE unrelated (id TEXT)');
+      },
+    );
+    final db = AppDatabase(nativeDb);
+    addTearDown(db.close);
+
+    await db.customSelect('SELECT 1').get();
+  });
+
+  test(
+    'the 161 -> 163 upgrade keeps estimates on for an existing row',
+    () async {
+      final db = AppDatabase(_dbAt161());
+      addTearDown(db.close);
+
+      final cols = await db
+          .customSelect("PRAGMA table_info('diver_settings')")
+          .get();
+      expect(
+        cols.map((c) => c.read<String>('name')),
+        contains('default_show_estimated_tank_pressure'),
+      );
+
+      // This open runs both the ladder rung and the beforeOpen backstop, so it
+      // also proves the assert does not try to re-add a column the migration
+      // just created.
+      final row = await db
+          .customSelect(
+            'SELECT default_show_estimated_tank_pressure FROM diver_settings',
+          )
+          .getSingle();
+      expect(row.read<bool>('default_show_estimated_tank_pressure'), isTrue);
+    },
+  );
+}

--- a/test/core/database/migration_v163_estimated_tank_pressure_default_test.dart
+++ b/test/core/database/migration_v163_estimated_tank_pressure_default_test.dart
@@ -25,8 +25,9 @@ NativeDatabase _dbAt161() {
 }
 
 /// v163 adds the switch that suppresses synthesized "(est.)" tank pressure
-/// lines on the profile chart (issue #731). v162 was claimed first on main by
-/// #1090.
+/// lines on the profile chart (issue #731). v162 is skipped rather than
+/// missing: main was at v161 when this branch was cut, and the open PR #1287
+/// (issue #1090) had already written 162 on its own branch.
 void main() {
   test('v163 is in the migration ladder', () {
     expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(163));

--- a/test/core/services/sync/sync_diver_settings_fallback_test.dart
+++ b/test/core/services/sync/sync_diver_settings_fallback_test.dart
@@ -314,4 +314,43 @@ void main() {
       expect(row.defaultShowO2CellMv, isFalse);
     },
   );
+
+  test(
+    'applies a pre-v163 diver_settings payload missing the estimate default',
+    () async {
+      await db.customStatement('PRAGMA foreign_keys = OFF');
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.diverSettings)
+          .insert(
+            DiverSettingsCompanion.insert(
+              id: 'ds9',
+              diverId: 'diver-9',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      final exported = await serializer.fetchRecord('diverSettings', 'ds9');
+      expect(exported, isNotNull);
+
+      // A peer still on v161 exports no defaultShowEstimatedTankPressure.
+      // _withSchemaDefaults fills it from the column's declared default, so a
+      // mixed-version sync must leave the estimate ON rather than silently
+      // switching it off (issue #731).
+      final legacy = Map<String, dynamic>.from(exported!)
+        ..remove('defaultShowEstimatedTankPressure');
+
+      await (db.delete(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds9'))).go();
+
+      await serializer.upsertRecord('diverSettings', legacy);
+
+      final row = await (db.select(
+        db.diverSettings,
+      )..where((t) => t.id.equals('ds9'))).getSingle();
+      expect(row.defaultShowEstimatedTankPressure, isTrue);
+    },
+  );
 }

--- a/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
+++ b/test/features/dive_log/presentation/providers/estimated_tank_pressures_provider_test.dart
@@ -1,9 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/gas_switch_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
 
 void main() {
   test('augments real map with an estimated line for a manual tank', () async {
@@ -26,6 +30,7 @@ void main() {
 
     final container = ProviderContainer(
       overrides: [
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
         tankPressuresProvider(
           'd1',
         ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
@@ -44,5 +49,197 @@ void main() {
     expect(result.estimatedTankIds, {'t1'});
     expect(result.pressures['t1']!.first.pressure, 200);
     expect(result.pressures['t1']!.last.pressure, 60);
+  });
+
+  test('does not estimate pressures for a gauge dive', () async {
+    // Issue #731: a gauge (bottom-timer) dive models no gas, so a synthesized
+    // pressure trace would be fabricated data rather than a measurement.
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1),
+      diveMode: DiveMode.gauge,
+      tanks: const [
+        DiveTank(
+          id: 't1',
+          gasMix: GasMix(o2: 21),
+          startPressure: 200,
+          endPressure: 60,
+        ),
+      ],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 1800, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        tankPressuresProvider(
+          'd1',
+        ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, isEmpty);
+    expect(result.pressures, isEmpty);
+  });
+
+  test('keeps real transmitter pressures on a gauge dive', () async {
+    // Only the synthesized line is suppressed; measured air-integrated data
+    // is real and still plots.
+    const real = <String, List<TankPressurePoint>>{
+      't1': [
+        TankPressurePoint(id: 'p1', tankId: 't1', timestamp: 0, pressure: 200),
+        TankPressurePoint(
+          id: 'p2',
+          tankId: 't1',
+          timestamp: 1800,
+          pressure: 60,
+        ),
+      ],
+    };
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1),
+      diveMode: DiveMode.gauge,
+      tanks: const [
+        DiveTank(
+          id: 't1',
+          gasMix: GasMix(o2: 21),
+          startPressure: 200,
+          endPressure: 60,
+        ),
+      ],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 1800, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+        tankPressuresProvider('d1').overrideWith((ref) async => real),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, isEmpty);
+    expect(result.pressures['t1'], hasLength(2));
+  });
+
+  test(
+    'does not estimate pressures when the diver turned estimates off',
+    () async {
+      // Issue #731: the estimated line had no off switch. With the preference
+      // off the series is never synthesized, so no legend chip, tooltip row, or
+      // "(est.)" label appears anywhere.
+      final dive = Dive(
+        id: 'd1',
+        dateTime: DateTime(2026, 1, 1),
+        tanks: const [
+          DiveTank(
+            id: 't1',
+            gasMix: GasMix(o2: 21),
+            startPressure: 200,
+            endPressure: 60,
+          ),
+        ],
+        profile: const [
+          DiveProfilePoint(timestamp: 0, depth: 0),
+          DiveProfilePoint(timestamp: 1800, depth: 0),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => MockSettingsNotifier(
+              const AppSettings(defaultShowEstimatedTankPressure: false),
+            ),
+          ),
+          tankPressuresProvider(
+            'd1',
+          ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+          diveProvider('d1').overrideWith((ref) async => dive),
+          gasSwitchesProvider(
+            'd1',
+          ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        estimatedTankPressuresProvider('d1').future,
+      );
+
+      expect(result.estimatedTankIds, isEmpty);
+      expect(result.pressures, isEmpty);
+    },
+  );
+
+  test('estimates pressures when the preference is left on', () async {
+    final dive = Dive(
+      id: 'd1',
+      dateTime: DateTime(2026, 1, 1),
+      tanks: const [
+        DiveTank(
+          id: 't1',
+          gasMix: GasMix(o2: 21),
+          startPressure: 200,
+          endPressure: 60,
+        ),
+      ],
+      profile: const [
+        DiveProfilePoint(timestamp: 0, depth: 0),
+        DiveProfilePoint(timestamp: 1800, depth: 0),
+      ],
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsProvider.overrideWith(
+          (ref) => MockSettingsNotifier(
+            const AppSettings(defaultShowEstimatedTankPressure: true),
+          ),
+        ),
+        tankPressuresProvider(
+          'd1',
+        ).overrideWith((ref) async => <String, List<TankPressurePoint>>{}),
+        diveProvider('d1').overrideWith((ref) async => dive),
+        gasSwitchesProvider(
+          'd1',
+        ).overrideWith((ref) async => <GasSwitchWithTank>[]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final result = await container.read(
+      estimatedTankPressuresProvider('d1').future,
+    );
+
+    expect(result.estimatedTankIds, {'t1'});
+  });
+
+  test('estimates pressures by default', () async {
+    expect(const AppSettings().defaultShowEstimatedTankPressure, isTrue);
   });
 }

--- a/test/features/settings/data/repositories/diver_settings_repository_estimated_tank_pressure_test.dart
+++ b/test/features/settings/data/repositories/diver_settings_repository_estimated_tank_pressure_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/settings/data/repositories/diver_settings_repository.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  group('DiverSettingsRepository defaultShowEstimatedTankPressure', () {
+    late AppDatabase db;
+    late DiverSettingsRepository repository;
+
+    setUp(() async {
+      db = await setUpTestDatabase();
+      repository = DiverSettingsRepository();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion.insert(
+              id: 'd1',
+              name: 'Test Diver',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+    });
+
+    tearDown(() {
+      DatabaseService.instance.resetForTesting();
+    });
+
+    test('new settings default the estimate to on', () async {
+      // Issue #731: estimates shipped always-on, so the new preference has to
+      // default to true or an upgrade would silently drop the line.
+      await repository.createSettingsForDiver('d1');
+      final loaded = await repository.getSettingsForDiver('d1');
+      expect(loaded, isNotNull);
+      expect(loaded!.defaultShowEstimatedTankPressure, isTrue);
+    });
+
+    test('round-trips the estimate turned off through update', () async {
+      await repository.createSettingsForDiver('d1');
+      await repository.updateSettingsForDiver(
+        'd1',
+        const AppSettings(defaultShowEstimatedTankPressure: false),
+      );
+      final loaded = await repository.getSettingsForDiver('d1');
+      expect(loaded, isNotNull);
+      expect(loaded!.defaultShowEstimatedTankPressure, isFalse);
+    });
+  });
+}

--- a/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
+++ b/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
@@ -44,6 +44,10 @@ void main() {
       child: const MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        // Every finder below matches an English label, so pin the locale
+        // rather than depend on the host machine's, which flutter_test
+        // forwards.
+        locale: Locale('en'),
         home: DefaultVisibleMetricsPage(),
       ),
     );

--- a/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
+++ b/test/features/settings/presentation/pages/default_visible_metrics_page_test.dart
@@ -30,6 +30,10 @@ class _StubSettingsNotifier extends StateNotifier<AppSettings>
       state = state.copyWith(defaultShowO2CellMv: value);
 
   @override
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async =>
+      state = state.copyWith(defaultShowEstimatedTankPressure: value);
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
@@ -154,5 +158,47 @@ void main() {
     await tester.tap(tile);
     await tester.pumpAndSettle();
     expect(tester.widget<SwitchListTile>(tile).value, isTrue);
+  });
+
+  testWidgets('estimated tank pressure starts on', (tester) async {
+    // Issue #731: the estimate shipped always-on, so the preference preserves
+    // that as its default.
+    await tester.pumpWidget(buildPage(_StubSettingsNotifier()));
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.text('Estimated Tank Pressure'),
+      find.byType(Scrollable),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+
+    final tile = tester.widget<SwitchListTile>(
+      find.ancestor(
+        of: find.text('Estimated Tank Pressure'),
+        matching: find.byType(SwitchListTile),
+      ),
+    );
+    expect(tile.value, isTrue);
+  });
+
+  testWidgets('tapping Estimated Tank Pressure turns the estimate off', (
+    tester,
+  ) async {
+    final notifier = _StubSettingsNotifier();
+    await tester.pumpWidget(buildPage(notifier));
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.text('Estimated Tank Pressure'),
+      find.byType(Scrollable),
+      const Offset(0, -200),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Estimated Tank Pressure'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.state.defaultShowEstimatedTankPressure, isFalse);
   });
 }

--- a/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_shared_data_test.dart
@@ -531,6 +531,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowO2CellMv(bool value) async =>
       state = state.copyWith(defaultShowO2CellMv: value);
   @override
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async =>
+      state = state.copyWith(defaultShowEstimatedTankPressure: value);
+  @override
   Future<void> setShowDataSourceBadges(bool value) async =>
       state = state.copyWith(showDataSourceBadges: value);
   @override

--- a/test/features/settings/presentation/pages/settings_page_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_test.dart
@@ -92,6 +92,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowO2CellMv(bool value) async =>
       state = state.copyWith(defaultShowO2CellMv: value);
   @override
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async =>
+      state = state.copyWith(defaultShowEstimatedTankPressure: value);
+  @override
   Future<void> setDefaultShowAscentRateLine(bool value) async =>
       state = state.copyWith(defaultShowAscentRateLine: value);
   @override

--- a/test/features/statistics/presentation/pages/records_page_test.dart
+++ b/test/features/statistics/presentation/pages/records_page_test.dart
@@ -434,6 +434,9 @@ class _MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowO2CellMv(bool value) async =>
       state = state.copyWith(defaultShowO2CellMv: value);
   @override
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async =>
+      state = state.copyWith(defaultShowEstimatedTankPressure: value);
+  @override
   Future<void> setShowDataSourceBadges(bool value) async =>
       state = state.copyWith(showDataSourceBadges: value);
   @override

--- a/test/helpers/mock_providers.dart
+++ b/test/helpers/mock_providers.dart
@@ -384,6 +384,9 @@ class MockSettingsNotifier extends StateNotifier<AppSettings>
   Future<void> setDefaultShowO2CellMv(bool value) async =>
       state = state.copyWith(defaultShowO2CellMv: value);
   @override
+  Future<void> setDefaultShowEstimatedTankPressure(bool value) async =>
+      state = state.copyWith(defaultShowEstimatedTankPressure: value);
+  @override
   Future<void> setDefaultShowGasTimeline(bool value) async =>
       state = state.copyWith(defaultShowGasTimeline: value);
   @override


### PR DESCRIPTION
Fixes #731.

## The report

On a dive switched to gauge mode, the profile chart grew a `Tank 1 (Air) (est.)`
line: an automatic estimate, for a gas that was not air, with no way to remove
it.

## What was happening

Gauge mode already suppresses gas and decompression analysis (#569 / PR #570):
the analysis providers return profile-only results and the detail page hides the
`tanks`, `decoO2`, and `sacSegments` sections. `estimatedTankPressuresProvider`
is a separate path that feeds the chart directly, and it had no dive-mode check,
so it kept synthesizing a linear start-to-end pressure trace from the retained
tank row. Gauge dives keep their tank rows on purpose, so switching to gauge
could not clear it.

The `(Air)` half of the label is the domain default rather than a reading:
`DiveTank.gasMix` defaults to `const GasMix()` (21/0), which `GasMix.name`
renders as "Air".

There was also no global way to turn estimates off. The per-tank toggle in the
chart options dialog hides one line for one dive, and does not persist.

## Changes

**Gauge dives never get a synthesized line.** `estimatedTankPressuresProvider`
returns the real pressure map untouched when `dive.isGauge`. Measured
air-integrated samples, if a gauge dive has any, still plot; only the fabricated
series is suppressed.

**A persisted preference to turn estimates off.** New
`defaultShowEstimatedTankPressure`, defaulting to **true** so nothing changes for
existing divers, wired the same way as `defaultShowO2CellMv` (#1235): schema
column, settings provider and repository, and a switch under Settings ->
Appearance -> Default visible metrics, next to Pressure.

Both gates live in the provider rather than in the chart, so when they fire the
series does not exist at all: no legend chip, no tooltip row, no chart-options
entry, no `(est.)` label anywhere. The settings read is registered synchronously,
before the provider's first `await`.

## Schema

Claims **v163**, skipping v162 deliberately. Main was at v161 when this branch
was cut, and the open PR #1287 (issue #1090) had already written 162 on its own
branch. Two branches writing the same scalar auto-merge with no conflict marker,
so 163 was taken instead. Note v162 is claimed but not yet landed, so the gap is
intentional rather than a missing rung.

The column follows the house pattern: a PRAGMA-guarded idempotent helper called from both
the `onUpgrade` rung and the `beforeOpen` backstop, so a database arriving by
restore or sync-adopt (which never runs `onUpgrade`) still gets the column.

`minimumCompatibleSchemaVersion` stays at 160: a new defaulted column is
additive, which that constant's own rules exclude from raising the floor.

## Tests

- Provider: a gauge dive yields no estimates while real transmitter pressures
  pass through; the preference off yields no estimates; on, and by default,
  estimates behave as before.
- Migration v163: ladder membership, fresh-database column, the `1` default, the
  161 -> 163 rung, the `beforeOpen` backstop, and the no-op when the table is
  absent.
- Settings repository round-trip, settings page switch, and a mixed-version sync
  payload from a v161 peer hydrating the estimate to on rather than silently off.

The migration and repository tests were mutation-checked: removing the ladder
rung and backstop, and breaking the repository read, each make them fail.

Localized across all 11 locales.

## Note for the reporter

The issue also asks whether gauge dives are classified automatically. They are:
`libdc_dive_mode.dart` maps libdivecomputer's gauge mode to `DiveMode.gauge`, and
both the live download and reparse paths carry it. Manual switching is only
needed for dives that predate that support, or that came from an import format
which does not report the mode.
