### PR TITLE
fix(import): register dive computers for file-imported dives (#1288)

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 
 import 'package:drift/drift.dart';
 
+import 'package:submersion/core/database/imported_computer_backfill.dart';
 import 'package:submersion/core/database/performance_indexes.dart';
 import 'package:submersion/core/database/tag_uniqueness.dart';
 import 'package:submersion/core/constants/enums.dart';
@@ -4485,6 +4486,15 @@ class AppDatabase extends _$AppDatabase {
   /// Test-only hook exercising the #1064 attribution self-heal directly.
   Future<void> backfillDiveComputerIdsForTest() => _backfillDiveComputerIds();
 
+  /// Register the dive computers that file-imported dives name (issue
+  /// #1288). Body lives in `imported_computer_backfill.dart`.
+  Future<void> _backfillImportedDiveComputers() =>
+      backfillImportedDiveComputers(this);
+
+  /// Test-only hook exercising the #1288 registration self-heal directly.
+  Future<void> backfillImportedDiveComputersForTest() =>
+      _backfillImportedDiveComputers();
+
   /// Copy each buddy's inline certification into a certifications row owned by
   /// that buddy (issue #553). Invoked from the onUpgrade blocks only (v109
   /// expand + the v110 contract safety-net), NEVER the beforeOpen backstop --
@@ -8899,6 +8909,12 @@ class AppDatabase extends _$AppDatabase {
         // bump). Also AFTER ensurePerformanceIndexes, for the same reason as
         // the backfill above.
         await _backfillDiveComputerIds();
+
+        // Data self-heal (issue #1288): register the computers that
+        // file-imported dives name, so they reach the filter at all. AFTER
+        // the #1064 heal above, which resolves the same column from the
+        // stronger download-derived signal.
+        await _backfillImportedDiveComputers();
       },
     );
   }

--- a/lib/core/database/imported_computer_backfill.dart
+++ b/lib/core/database/imported_computer_backfill.dart
@@ -1,0 +1,194 @@
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/database/imported_computer_identity.dart';
+
+/// Register the dive computers that file-imported dives name, and attribute
+/// those dives to them (issue #1288).
+///
+/// A file import writes only the `dive_computer_model`/`_serial` display
+/// snapshots; before #1288 it created no `dive_computers` row and never
+/// stamped `computer_id`. The filter, the statistics SQL, and "View dives
+/// from this computer" all read the registry, so a logbook built from files
+/// named a computer on every dive and still reported "No dive computers
+/// registered".
+///
+/// The #1064 self-heal cannot reach these dives: it adopts `computer_id` from
+/// `dive_data_sources`, which a file import also left null. Hence a second
+/// pass keyed on the snapshots instead.
+///
+/// Local-only and idempotent: no HLC bump, nothing marked pending. New rows
+/// land on a deterministic id ([importedDiveComputerId]), so every device in a
+/// synced fleet derives the same primary key independently and converges
+/// without any of them pushing duplicates. An existing row for the same
+/// hardware is adopted rather than shadowed, using the same rule the import
+/// path applies ([matchImportedComputer]).
+///
+/// Must run after the #1064 heal, so a dive that can be attributed from its
+/// data source (the stronger, download-derived signal) is already resolved
+/// and skipped here.
+///
+/// Only `dives.computer_id` is stamped, not `dive_data_sources.computer_id`:
+/// a dive can carry several sources, and no snapshot on the source row is
+/// reliable enough to say which of them this device produced.
+Future<void> backfillImportedDiveComputers(DatabaseConnectionUser db) async {
+  // PRAGMA-guarded like every other self-heal helper: beforeOpen runs for
+  // every open, including minimal old-schema fixtures and databases caught
+  // mid-upgrade. PRAGMA table_info returns empty for a missing table, so
+  // probing the columns covers both cases.
+  Future<Set<String>> columnsOf(String table) async {
+    final rows = await db.customSelect("PRAGMA table_info('$table')").get();
+    return rows.map((c) => c.read<String>('name')).toSet();
+  }
+
+  final diveCols = await columnsOf('dives');
+  if (!diveCols.containsAll({
+    'computer_id',
+    'dive_computer_model',
+    'dive_computer_serial',
+    'diver_id',
+  })) {
+    return;
+  }
+  final computerCols = await columnsOf('dive_computers');
+  if (!computerCols.containsAll({
+    'id',
+    'diver_id',
+    'name',
+    'manufacturer',
+    'model',
+    'serial_number',
+    'dive_count',
+    'is_favorite',
+    'notes',
+    'created_at',
+    'updated_at',
+  })) {
+    return;
+  }
+  final sourceCols = await columnsOf('dive_data_sources');
+  if (!sourceCols.containsAll({'dive_id', 'source_format'})) return;
+
+  // Downloaded dives carry the same model/serial snapshots, written by
+  // importProfile. Excluding them is what stops a deleted device from coming
+  // back as a phantom: deleteComputer nulls dives.computer_id but leaves the
+  // snapshots, and its _backfillProvenanceSnapshots pass guarantees every
+  // orphaned dive keeps a `dive_computer` source row to recognize it by.
+  const notADownload =
+      "NOT EXISTS (SELECT 1 FROM dive_data_sources s "
+      "WHERE s.dive_id = dives.id AND s.source_format = 'dive_computer')";
+
+  final identities = await db.customSelect('''
+    SELECT DISTINCT diver_id, dive_computer_model, dive_computer_serial
+    FROM dives
+    WHERE computer_id IS NULL
+      AND TRIM(COALESCE(dive_computer_model, '')) <> ''
+      AND $notADownload
+  ''').get();
+  if (identities.isEmpty) return;
+
+  // A file-imported computer the user deleted keeps its snapshots too, and
+  // its row was registered at the deterministic id, so re-minting would
+  // resurrect a tombstoned primary key: the peer that applied the delete
+  // would delete it again on the next sync, forever.
+  final tombstoned = await _tombstonedComputerIds(db);
+
+  // The registry is small (a handful of devices per library), so it is read
+  // once into memory: the model comparison collapses internal whitespace,
+  // which SQLite cannot express.
+  var candidates = await _candidates(db);
+
+  for (final identity in identities) {
+    final model = identity.read<String>('dive_computer_model');
+    final serial = identity.read<String?>('dive_computer_serial');
+    final diverId = identity.read<String?>('diver_id');
+
+    var computerId = matchImportedComputer(
+      model: model,
+      serialNumber: serial,
+      diverId: diverId,
+      candidates: candidates,
+    )?.id;
+
+    if (computerId == null) {
+      final derivedId = importedDiveComputerId(
+        model: model,
+        serialNumber: serial,
+        diverId: diverId,
+      );
+      if (tombstoned.contains(derivedId)) continue;
+
+      computerId = derivedId;
+      final trimmedModel = model.trim();
+      final trimmedSerial = serial?.trim();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await db.customStatement(
+        'INSERT OR IGNORE INTO dive_computers '
+        '(id, diver_id, name, model, serial_number, dive_count, '
+        'is_favorite, notes, created_at, updated_at) '
+        "VALUES (?, ?, ?, ?, ?, 0, 0, '', ?, ?)",
+        [
+          computerId,
+          diverId,
+          trimmedModel,
+          trimmedModel,
+          (trimmedSerial?.isEmpty ?? true) ? null : trimmedSerial,
+          now,
+          now,
+        ],
+      );
+      // Re-read so a later identity that normalizes onto this same device
+      // adopts it instead of racing to insert it again.
+      candidates = await _candidates(db);
+    }
+
+    // `IS` rather than `=` so the NULL diver/serial groups match too. The
+    // download exclusion is repeated here: without it this would claim the
+    // downloaded dives that share the identity but were filtered out above.
+    await db.customStatement(
+      'UPDATE dives SET computer_id = ? '
+      'WHERE computer_id IS NULL AND diver_id IS ? '
+      'AND dive_computer_model IS ? AND dive_computer_serial IS ? '
+      'AND $notADownload',
+      [computerId, diverId, model, serial],
+    );
+  }
+}
+
+/// Ids of dive computers this library has deleted.
+///
+/// Empty when the schema predates the deletion log, which also predates any
+/// delete it could have recorded.
+Future<Set<String>> _tombstonedComputerIds(DatabaseConnectionUser db) async {
+  final cols = await db.customSelect("PRAGMA table_info('deletion_log')").get();
+  final names = cols.map((c) => c.read<String>('name')).toSet();
+  if (!names.containsAll({'entity_type', 'record_id'})) return const {};
+
+  final rows = await db
+      .customSelect(
+        "SELECT record_id FROM deletion_log WHERE entity_type = 'diveComputers'",
+      )
+      .get();
+  return rows.map((r) => r.read<String>('record_id')).toSet();
+}
+
+Future<List<ImportedComputerCandidate>> _candidates(
+  DatabaseConnectionUser db,
+) async {
+  final rows = await db
+      .customSelect(
+        'SELECT id, diver_id, manufacturer, model, serial_number '
+        'FROM dive_computers ORDER BY updated_at DESC, id',
+      )
+      .get();
+  return rows
+      .map(
+        (row) => ImportedComputerCandidate(
+          id: row.read<String>('id'),
+          diverId: row.read<String?>('diver_id'),
+          manufacturer: row.read<String?>('manufacturer'),
+          model: row.read<String?>('model'),
+          serialNumber: row.read<String?>('serial_number'),
+        ),
+      )
+      .toList();
+}

--- a/lib/core/database/imported_computer_identity.dart
+++ b/lib/core/database/imported_computer_identity.dart
@@ -1,0 +1,124 @@
+import 'package:uuid/uuid.dart';
+
+/// Namespace for deterministic dive computer ids derived from file imports.
+/// Frozen: every device must derive the same id from the same device
+/// identity, so changing this would fork the registry across the fleet.
+const String kImportedDiveComputerNamespace =
+    '70658227-40eb-49bf-b86f-66dc22323d4b';
+
+/// Normalize a computer identity fragment for comparison and id derivation.
+///
+/// Trims, collapses runs of internal whitespace, and lowercases, so
+/// `'  PERDIX   2 '` and `'Perdix 2'` are one device rather than two.
+String normalizeComputerIdentityPart(String? value) {
+  if (value == null) return '';
+  return value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+}
+
+/// A registered dive computer, reduced to the fields the import match needs.
+///
+/// Lets the matching rule live in one place: the repository builds these from
+/// domain entities, the `beforeOpen` self-heal from raw rows.
+class ImportedComputerCandidate {
+  const ImportedComputerCandidate({
+    required this.id,
+    this.diverId,
+    this.manufacturer,
+    this.model,
+    this.serialNumber,
+  });
+
+  final String id;
+  final String? diverId;
+  final String? manufacturer;
+  final String? model;
+  final String? serialNumber;
+}
+
+/// The already-registered computer a file-imported dive belongs to, if any.
+///
+/// A file offers a weaker identity than a download does, so the rule has two
+/// tiers:
+///
+/// - With a serial, match on the serial alone. The file's model spelling must
+///   not defeat it, exactly as on the download path.
+/// - Without one, match a candidate that also has no serial and whose model,
+///   or whose manufacturer + model, normalizes to the same string. Comparing
+///   the combined form is what lets a file's `'Shearwater Perdix'` find a
+///   downloaded row stored as manufacturer `'Shearwater'`, model `'Perdix'`.
+///
+/// A serial-bearing candidate is deliberately never adopted by a serial-less
+/// import: two units of one model are common, and collapsing them would
+/// misattribute dives with no way to undo it.
+///
+/// [candidates] must already be ordered by preference (most recently updated
+/// first) so every device resolves a tie the same way.
+ImportedComputerCandidate? matchImportedComputer({
+  required String model,
+  String? serialNumber,
+  String? diverId,
+  required Iterable<ImportedComputerCandidate> candidates,
+}) {
+  final normalizedModel = normalizeComputerIdentityPart(model);
+  if (normalizedModel.isEmpty) return null;
+  final normalizedSerial = normalizeComputerIdentityPart(serialNumber);
+  final normalizedDiver = normalizeComputerIdentityPart(diverId);
+
+  for (final candidate in candidates) {
+    if (normalizedDiver.isNotEmpty &&
+        normalizeComputerIdentityPart(candidate.diverId) != normalizedDiver) {
+      continue;
+    }
+    final candidateSerial = normalizeComputerIdentityPart(
+      candidate.serialNumber,
+    );
+    if (normalizedSerial.isNotEmpty) {
+      if (candidateSerial == normalizedSerial) return candidate;
+      continue;
+    }
+    if (candidateSerial.isNotEmpty) continue;
+
+    final candidateModel = normalizeComputerIdentityPart(candidate.model);
+    final candidateManufacturer = normalizeComputerIdentityPart(
+      candidate.manufacturer,
+    );
+    final candidateFullName = candidateManufacturer.isEmpty
+        ? candidateModel
+        : '$candidateManufacturer $candidateModel';
+    if (candidateModel == normalizedModel ||
+        candidateFullName == normalizedModel) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/// The deterministic id for a dive computer named by a file import.
+///
+/// File imports register computers from two places that never see each
+/// other: the import itself, and the `beforeOpen` self-heal that adopts
+/// logbooks imported before registration existed. Both must land on the same
+/// primary key, or a synced fleet ends up with one row per device for a
+/// single physical computer; there is no merge action to clean that up.
+///
+/// Deriving the id from the identity rather than minting a v4 makes sync's
+/// upsert-by-id merge the rows instead of unioning them. This is also why
+/// `dive_computers` needs no unique index: a unique constraint on a
+/// replicated table would make an inbound sync insert throw rather than
+/// merge.
+///
+/// The serial is the strong key when the file supplies one. When it does
+/// not, the model string carries the identity on its own, which is weaker
+/// but is all most UDDF/MacDive/CSV exports offer.
+String importedDiveComputerId({
+  required String model,
+  String? serialNumber,
+  String? diverId,
+}) {
+  final normalizedSerial = normalizeComputerIdentityPart(serialNumber);
+  final normalizedDiver = normalizeComputerIdentityPart(diverId);
+  final key = normalizedSerial.isNotEmpty
+      ? 'serial:$normalizedDiver|$normalizedSerial'
+      : 'model:$normalizedDiver|${normalizeComputerIdentityPart(model)}';
+  return const Uuid().v5(kImportedDiveComputerNamespace, key);
+}

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -156,6 +156,9 @@ class UddfFullImportService {
                 'model': model ?? '',
                 'serial': serial ?? '',
                 'firmware': firmware ?? '',
+                'manufacturer':
+                    UddfImportParsers.getManufacturerName(computerElement) ??
+                    '',
               };
             }
           }
@@ -1290,6 +1293,9 @@ class UddfFullImportService {
             if (computer['firmware']?.isNotEmpty == true) {
               diveData['diveComputerFirmware'] = computer['firmware'];
             }
+            if (computer['manufacturer']?.isNotEmpty == true) {
+              diveData['diveComputerManufacturer'] = computer['manufacturer'];
+            }
           }
         }
       }
@@ -1308,6 +1314,9 @@ class UddfFullImportService {
             }
             if (computer['firmware']?.isNotEmpty == true) {
               diveData['diveComputerFirmware'] = computer['firmware'];
+            }
+            if (computer['manufacturer']?.isNotEmpty == true) {
+              diveData['diveComputerManufacturer'] = computer['manufacturer'];
             }
           }
         }

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -138,6 +138,28 @@ class UddfImportParsers {
         : element?.innerText.trim();
   }
 
+  /// Reads a dive computer's vendor from a `<divecomputer>` element.
+  ///
+  /// UDDF nests the vendor as `<manufacturer><name>`, alongside optional
+  /// address and contact children, so the nested `<name>` is read first.
+  ///
+  /// The bare-text fallback keeps exporters that write
+  /// `<manufacturer>Shearwater</manufacturer>` working, but applies only when
+  /// the element has no child elements at all: `innerText` walks the whole
+  /// subtree, so a `<manufacturer>` carrying only an address would otherwise
+  /// yield a vendor of "VancouverCanada".
+  static String? getManufacturerName(XmlElement computerElement) {
+    final manufacturer = computerElement
+        .findElements('manufacturer')
+        .firstOrNull;
+    if (manufacturer == null) return null;
+    final named = getElementText(manufacturer, 'name');
+    if (named != null) return named;
+    if (manufacturer.childElements.isNotEmpty) return null;
+    final text = manufacturer.innerText.trim();
+    return text.isEmpty ? null : text;
+  }
+
   /// Maximum O2 cells the profile schema can hold (o2Sensor1..o2Sensor6).
   static const int maxO2Sensors = 6;
 

--- a/lib/core/services/export/uddf/uddf_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_import_service.dart
@@ -130,6 +130,9 @@ class UddfImportService {
                 'model': model ?? '',
                 'serial': serial ?? '',
                 'firmware': firmware ?? '',
+                'manufacturer':
+                    UddfImportParsers.getManufacturerName(computerElement) ??
+                    '',
               };
             }
           }
@@ -332,6 +335,9 @@ class UddfImportService {
             if (computer['firmware']?.isNotEmpty == true) {
               diveData['diveComputerFirmware'] = computer['firmware'];
             }
+            if (computer['manufacturer']?.isNotEmpty == true) {
+              diveData['diveComputerManufacturer'] = computer['manufacturer'];
+            }
           }
         }
       }
@@ -350,6 +356,9 @@ class UddfImportService {
             }
             if (computer['firmware']?.isNotEmpty == true) {
               diveData['diveComputerFirmware'] = computer['firmware'];
+            }
+            if (computer['manufacturer']?.isNotEmpty == true) {
+              diveData['diveComputerManufacturer'] = computer['manufacturer'];
             }
           }
         }

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/imported_computer_identity.dart';
 import 'package:submersion/core/database/database.dart'
     show DiveDataSourcesCompanion, DiveSitesCompanion, DivesCompanion;
 import 'package:submersion/core/services/export/export_service.dart';
@@ -19,6 +20,7 @@ import 'package:submersion/features/courses/data/repositories/course_repository.
 import 'package:submersion/features/courses/domain/entities/course.dart';
 import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
 import 'package:submersion/features/dive_centers/domain/entities/dive_center.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
@@ -72,6 +74,12 @@ class ImportRepositories {
   final TankPressureRepository tankPressureRepository;
   final CourseRepository courseRepository;
 
+  /// Optional for the same reason; when null, the dives keep their
+  /// `dive_computer_model`/`_serial` display snapshots but no
+  /// `dive_computers` row is registered and no attribution is stamped
+  /// (#1288).
+  final DiveComputerRepository? diveComputerRepository;
+
   const ImportRepositories({
     required this.tripRepository,
     required this.equipmentRepository,
@@ -87,6 +95,7 @@ class ImportRepositories {
     required this.diveRepository,
     required this.tankPressureRepository,
     required this.courseRepository,
+    this.diveComputerRepository,
   });
 }
 
@@ -1283,6 +1292,69 @@ class UddfEntityImporter {
 
   // -- Dive import --
 
+  /// Group key for the computer a parsed dive names, matching the identity
+  /// [DiveComputerRepository.findOrRegisterImportedComputer] dedupes on, so
+  /// two spellings of one device share a single registration.
+  ///
+  /// Null when the source names no model, which is the signal to leave the
+  /// dive unattributed rather than register a placeholder device.
+  String? _importedComputerKey(Map<String, dynamic> diveData) {
+    final model = normalizeComputerIdentityPart(
+      diveData['diveComputerModel'] as String?,
+    );
+    if (model.isEmpty) return null;
+    final serial = normalizeComputerIdentityPart(
+      diveData['diveComputerSerial'] as String?,
+    );
+    return serial.isNotEmpty ? 'serial:$serial' : 'model:$model';
+  }
+
+  /// Register every distinct computer the selected dives name, returning the
+  /// registry id for each [_importedComputerKey].
+  ///
+  /// Runs once per import rather than per dive so a hundred dives off one
+  /// computer cost one registration lookup, not a hundred.
+  ///
+  /// Best-effort per device, mirroring `_relinkOrphanedRows`: attribution is
+  /// cosmetic next to the dives themselves, so a registry failure degrades
+  /// that one device to unattributed instead of costing the user the whole
+  /// import. The dive still keeps its `dive_computer_model` snapshot, which
+  /// is what the Details card renders.
+  Future<Map<String, String>> _registerImportedComputers(
+    List<Map<String, dynamic>> items,
+    List<int> selected,
+    String diverId,
+    DiveComputerRepository? repository,
+  ) async {
+    if (repository == null) return const {};
+
+    final idByKey = <String, String>{};
+    for (final i in selected) {
+      final diveData = items[i];
+      final key = _importedComputerKey(diveData);
+      if (key == null || idByKey.containsKey(key)) continue;
+
+      try {
+        final computer = await repository.findOrRegisterImportedComputer(
+          model: diveData['diveComputerModel'] as String,
+          manufacturer: diveData['diveComputerManufacturer'] as String?,
+          serialNumber: diveData['diveComputerSerial'] as String?,
+          firmwareVersion: diveData['diveComputerFirmware'] as String?,
+          diverId: diverId,
+        );
+        if (computer != null) idByKey[key] = computer.id;
+      } catch (e, stackTrace) {
+        _log.error(
+          'Failed to register imported dive computer for "$key"; '
+          'its dives stay unattributed',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    return idByKey;
+  }
+
   Future<_DiveImportResult> _importDives(
     List<Map<String, dynamic>> items,
     Set<int> selected,
@@ -1325,6 +1397,19 @@ class UddfEntityImporter {
     // One instance for the run: its lookup cache collapses a batch of dives
     // at the same location into a single elevation request.
     final altitudeEnricher = DiveAltitudeEnricher();
+
+    // Register the computers this batch names, once per distinct device,
+    // before any dive is written. The filter, the statistics SQL, and "View
+    // dives from this computer" all read the `dive_computers` registry
+    // rather than the per-dive display snapshots, so without this a
+    // file-only logbook shows a computer on every dive and still reports
+    // "No dive computers registered" (#1288).
+    final computerIdByKey = await _registerImportedComputers(
+      items,
+      sortedSelected,
+      diverId,
+      repos.diveComputerRepository,
+    );
 
     for (final i in sortedSelected) {
       if (cancelToken?.isCancelled ?? false) break;
@@ -1599,6 +1684,32 @@ class UddfEntityImporter {
       }
 
       await repos.diveRepository.createDive(dive);
+
+      // createDive's companion deliberately omits computer_id, so attribution
+      // has to be an explicit second write (#1288).
+      final computerKey = _importedComputerKey(diveData);
+      final computerId = computerKey == null
+          ? null
+          : computerIdByKey[computerKey];
+      if (computerId != null) {
+        // Best-effort for the same reason as the registration above, and more
+        // pressingly: the dive is already committed, so throwing here would
+        // abort the loop and leave a half-imported logbook behind.
+        try {
+          await repos.diveComputerRepository?.attributeDiveToComputer(
+            diveId: diveId,
+            computerId: computerId,
+          );
+        } catch (e, stackTrace) {
+          _log.error(
+            'Failed to attribute imported dive $diveId to computer '
+            '$computerId; the dive keeps its model snapshot only',
+            error: e,
+            stackTrace: stackTrace,
+          );
+        }
+      }
+
       await DiveEquipmentDefaulter().applyForImportedDive(dive);
       await ChecklistDiveLinker().applyForImportedDive(dive);
       await altitudeEnricher.applyForImportedDive(dive);
@@ -1910,6 +2021,7 @@ class UddfEntityImporter {
           id: Value(_uuid.v4()),
           diveId: Value(diveId),
           isPrimary: const Value(true),
+          computerId: Value(computerId),
           computerModel: Value(diveData['diveComputerModel'] as String?),
           computerSerial: Value(diveData['diveComputerSerial'] as String?),
           sourceFileName: Value(sourceFileName),

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1695,6 +1695,11 @@ class UddfEntityImporter {
         // Best-effort for the same reason as the registration above, and more
         // pressingly: the dive is already committed, so throwing here would
         // abort the loop and leave a half-imported logbook behind.
+        //
+        // The provenance row below is still stamped on failure, deliberately.
+        // The #1064 beforeOpen heal adopts dives.computer_id from exactly that
+        // column, so leaving it is what recovers the attribution on the next
+        // open; clearing it for symmetry would discard the recovery.
         try {
           await repos.diveComputerRepository?.attributeDiveToComputer(
             diveId: diveId,
@@ -1703,7 +1708,8 @@ class UddfEntityImporter {
         } catch (e, stackTrace) {
           _log.error(
             'Failed to attribute imported dive $diveId to computer '
-            '$computerId; the dive keeps its model snapshot only',
+            '$computerId; the data source keeps the link, so the beforeOpen '
+            'self-heal will adopt it on the next open',
             error: e,
             stackTrace: stackTrace,
           );

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -17,6 +17,7 @@ import 'package:submersion/core/database/database.dart'
         DiveProfile,
         DiveProfileEvent,
         TankPressureProfilesCompanion;
+import 'package:submersion/core/database/imported_computer_identity.dart';
 import 'package:submersion/core/matching/match_scorer.dart';
 import 'package:submersion/core/utils/stream_debounce.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
@@ -1594,6 +1595,161 @@ class DiveComputerRepository {
       return diveId;
     } catch (e, stackTrace) {
       _log.error('Failed to import profile', error: e, stackTrace: stackTrace);
+      rethrow;
+    }
+  }
+
+  /// Attribute a dive to a computer, with explicit intent.
+  ///
+  /// `Dive.computerId` is a read-only projection: the insert/update
+  /// companions deliberately omit the column so saving a dive never rewrites
+  /// attribution. Setting it therefore needs a deliberate write, which is
+  /// what the download, consolidation, split, and reparse paths do; file
+  /// import (#1288) joins them through here.
+  ///
+  /// Marks the dive pending so the restored link syncs, matching
+  /// [_relinkOrphanedRows].
+  Future<void> attributeDiveToComputer({
+    required String diveId,
+    required String computerId,
+  }) async {
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await _db.customStatement(
+        'UPDATE dives SET computer_id = ?, updated_at = ? WHERE id = ?',
+        [computerId, now, diveId],
+      );
+      await _syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: diveId,
+        localUpdatedAt: now,
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to attribute dive $diveId to computer $computerId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Register the dive computer a file import names, reusing an existing row
+  /// when one already stands for the same physical device (#1288).
+  ///
+  /// File imports only ever wrote the `dive_computer_model`/`_serial`
+  /// display snapshots onto each dive, so a logbook built entirely from
+  /// files showed a computer on every dive and still reported "No dive
+  /// computers registered" in the filter, which reads `dive_computers`.
+  ///
+  /// The match key is weaker than the download path's, because a file offers
+  /// less to go on:
+  ///
+  /// - With a serial, match on the serial alone (scoped to the diver), the
+  ///   same strong key [findOrCreateComputer] uses. A file's model spelling
+  ///   must not defeat it.
+  /// - Without one, match a row that also has no serial and whose model, or
+  ///   whose manufacturer + model, normalizes to the same string. Matching
+  ///   the full name too is what lets a file's `'Shearwater Perdix'` find a
+  ///   downloaded row stored as manufacturer `'Shearwater'`, model
+  ///   `'Perdix'`.
+  ///
+  /// A serial-bearing row is deliberately never adopted by a serial-less
+  /// import: two units of one model are common, and collapsing them would
+  /// misattribute dives with no way to undo it.
+  ///
+  /// Returns null when the file names no model, which is the signal to leave
+  /// the dive unattributed rather than register a placeholder device.
+  Future<domain.DiveComputer?> findOrRegisterImportedComputer({
+    required String model,
+    String? manufacturer,
+    String? serialNumber,
+    String? firmwareVersion,
+    String? diverId,
+  }) async {
+    try {
+      final normalizedModel = normalizeComputerIdentityPart(model);
+      if (normalizedModel.isEmpty) return null;
+
+      final query = _db.select(_db.diveComputers)
+        ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]);
+      final normalizedDiverId = diverId?.trim();
+      if (normalizedDiverId != null && normalizedDiverId.isNotEmpty) {
+        query.where((t) => t.diverId.equals(normalizedDiverId));
+      }
+
+      // Matched in Dart, like findByHardwareIdentity: a stored serial or
+      // model may itself carry whitespace from an older import, so trimming
+      // only the input would miss that row. The rule itself lives in
+      // [matchImportedComputer] because the beforeOpen self-heal has to apply
+      // exactly the same one.
+      final rows = await query.get();
+      final match = matchImportedComputer(
+        model: model,
+        serialNumber: serialNumber,
+        diverId: diverId,
+        candidates: rows.map(
+          (row) => ImportedComputerCandidate(
+            id: row.id,
+            diverId: row.diverId,
+            manufacturer: row.manufacturer,
+            model: row.model,
+            serialNumber: row.serialNumber,
+          ),
+        ),
+      );
+      if (match != null) {
+        return _mapRowToComputer(rows.firstWhere((r) => r.id == match.id));
+      }
+
+      // Deterministic, so the import and the beforeOpen self-heal agree and a
+      // synced fleet converges on one row per device.
+      final id = importedDiveComputerId(
+        model: model,
+        serialNumber: serialNumber,
+        diverId: diverId,
+      );
+
+      // The identity match above reads the row's CURRENT text while the id is
+      // derived from the FILE's text, so renaming a registered computer makes
+      // them disagree: the match misses and the id still collides. Adopt the
+      // row holding it rather than letting the insert throw and abort the
+      // import.
+      final byDerivedId = await (_db.select(
+        _db.diveComputers,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      if (byDerivedId != null) return _mapRowToComputer(byDerivedId);
+
+      final trimmedModel = model.trim();
+      final trimmedManufacturer = manufacturer?.trim();
+      final now = DateTime.now();
+      return await createComputer(
+        domain.DiveComputer(
+          id: id,
+          diverId: diverId,
+          name: trimmedManufacturer != null && trimmedManufacturer.isNotEmpty
+              ? '$trimmedManufacturer $trimmedModel'
+              : trimmedModel,
+          manufacturer: trimmedManufacturer?.isNotEmpty ?? false
+              ? trimmedManufacturer
+              : null,
+          model: trimmedModel,
+          serialNumber: serialNumber?.trim().isNotEmpty ?? false
+              ? serialNumber!.trim()
+              : null,
+          firmwareVersion: firmwareVersion?.trim().isNotEmpty ?? false
+              ? firmwareVersion!.trim()
+              : null,
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to register imported dive computer',
+        error: e,
+        stackTrace: stackTrace,
+      );
       rethrow;
     }
   }

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1671,8 +1671,15 @@ class DiveComputerRepository {
       final normalizedModel = normalizeComputerIdentityPart(model);
       if (normalizedModel.isEmpty) return null;
 
+      // Most recently updated first, ties broken on id: matchImportedComputer
+      // takes the first candidate that matches, so an unstable order would let
+      // two devices attribute the same dives to different rows. Mirrors the
+      // backfill's `ORDER BY updated_at DESC, id`.
       final query = _db.select(_db.diveComputers)
-        ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)]);
+        ..orderBy([
+          (t) => OrderingTerm.desc(t.updatedAt),
+          (t) => OrderingTerm.asc(t.id),
+        ]);
       final normalizedDiverId = diverId?.trim();
       if (normalizedDiverId != null && normalizedDiverId.isNotEmpty) {
         query.where((t) => t.diverId.equals(normalizedDiverId));

--- a/lib/features/import_wizard/data/adapters/universal_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/universal_adapter.dart
@@ -15,6 +15,7 @@ import 'package:submersion/features/courses/presentation/providers/course_provid
 import 'package:submersion/features/dive_centers/presentation/providers/dive_center_providers.dart';
 import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
 import 'package:submersion/features/dive_import/domain/services/dive_matcher.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
 import 'package:submersion/features/data_quality/data/services/quality_scan_service.dart';
@@ -513,6 +514,7 @@ class UniversalAdapter implements ImportSourceAdapter {
       tankPressureRepository: _ref.read(tankPressureRepositoryProvider),
       courseRepository: _ref.read(courseRepositoryProvider),
       serviceRecordRepository: _ref.read(serviceRecordRepositoryProvider),
+      diveComputerRepository: _ref.read(diveComputerRepositoryProvider),
     );
 
     final settings = _ref.read(settingsProvider);

--- a/test/core/database/imported_dive_computer_backfill_test.dart
+++ b/test/core/database/imported_dive_computer_backfill_test.dart
@@ -1,0 +1,396 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/imported_computer_identity.dart';
+
+import '../../helpers/test_database.dart';
+
+/// Issue #1288: dives created by a file import carry only the
+/// `dive_computer_model`/`_serial` display snapshots. Nothing ever registered
+/// a `dive_computers` row for them, so a logbook built entirely from files
+/// named a computer on every dive and still reported "No dive computers
+/// registered" in the filter, which reads the registry.
+///
+/// The #1064 self-heal cannot reach these: it adopts `computer_id` from
+/// `dive_data_sources`, and a file import leaves that null too. This one
+/// registers the device from the snapshots instead.
+void main() {
+  late AppDatabase db;
+
+  const nowMs = 1750000000000;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> insertDiver(String id) async {
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: Value(id),
+            name: Value('Diver $id'),
+            createdAt: const Value(nowMs),
+            updatedAt: const Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertDive(
+    String id, {
+    String? computerId,
+    String? model,
+    String? serial,
+    String? diverId,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            diveDateTime: const Value(nowMs),
+            computerId: Value(computerId),
+            diveComputerModel: Value(model),
+            diveComputerSerial: Value(serial),
+            createdAt: const Value(nowMs),
+            updatedAt: const Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertComputer(
+    String id, {
+    String? diverId,
+    String? manufacturer,
+    String? model,
+    String? serial,
+  }) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            name: Value('Computer $id'),
+            manufacturer: Value(manufacturer),
+            model: Value(model),
+            serialNumber: Value(serial),
+            createdAt: const Value(nowMs),
+            updatedAt: const Value(nowMs),
+          ),
+        );
+  }
+
+  Future<void> insertDataSource(
+    String id, {
+    required String diveId,
+    String? computerId,
+    String? sourceFormat,
+    String? sourceFileFormat,
+  }) async {
+    final now = DateTime.fromMillisecondsSinceEpoch(nowMs);
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion.insert(
+            id: id,
+            diveId: diveId,
+            computerId: Value(computerId),
+            isPrimary: const Value(true),
+            sourceFormat: Value(sourceFormat),
+            sourceFileFormat: Value(sourceFileFormat),
+            importedAt: now,
+            createdAt: now,
+          ),
+        );
+  }
+
+  Future<void> logDeletion(String recordId) async {
+    await db
+        .into(db.deletionLog)
+        .insert(
+          DeletionLogCompanion.insert(
+            id: 'del-$recordId',
+            entityType: 'diveComputers',
+            recordId: recordId,
+            deletedAt: nowMs,
+          ),
+        );
+  }
+
+  Future<String?> computerIdOf(String diveId) async {
+    final row = await (db.select(
+      db.dives,
+    )..where((d) => d.id.equals(diveId))).getSingle();
+    return row.computerId;
+  }
+
+  test(
+    'registers a computer for a file-imported dive and attributes it',
+    () async {
+      await insertDiver('diver-1');
+      await insertDive(
+        'dive-1',
+        model: 'Perdix 2',
+        serial: 'SN-1',
+        diverId: 'diver-1',
+      );
+
+      await db.backfillImportedDiveComputersForTest();
+
+      final computer = (await db.select(db.diveComputers).get()).single;
+      expect(computer.model, 'Perdix 2');
+      expect(computer.serialNumber, 'SN-1');
+      expect(computer.diverId, 'diver-1');
+      expect(computer.name, 'Perdix 2');
+      expect(await computerIdOf('dive-1'), computer.id);
+    },
+  );
+
+  test(
+    'registers one computer for many dives naming the same device',
+    () async {
+      await insertDive('dive-1', model: 'Perdix 2', serial: 'SN-1');
+      await insertDive('dive-2', model: 'Perdix 2', serial: 'SN-1');
+      await insertDive('dive-3', model: 'Perdix 2', serial: 'SN-1');
+
+      await db.backfillImportedDiveComputersForTest();
+
+      final computers = await db.select(db.diveComputers).get();
+      expect(computers, hasLength(1));
+      for (final id in ['dive-1', 'dive-2', 'dive-3']) {
+        expect(await computerIdOf(id), computers.single.id);
+      }
+    },
+  );
+
+  test('registers a computer per distinct device', () async {
+    await insertDive('dive-1', model: 'Perdix 2', serial: 'SN-1');
+    await insertDive('dive-2', model: 'Teric', serial: 'SN-2');
+
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await db.select(db.diveComputers).get(), hasLength(2));
+  });
+
+  test('leaves a dive that names no computer alone', () async {
+    await insertDive('dive-manual');
+
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await db.select(db.diveComputers).get(), isEmpty);
+    expect(await computerIdOf('dive-manual'), isNull);
+  });
+
+  test('ignores a blank model string', () async {
+    await insertDive('dive-blank', model: '   ');
+
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await db.select(db.diveComputers).get(), isEmpty);
+    expect(await computerIdOf('dive-blank'), isNull);
+  });
+
+  test('leaves an already attributed dive alone', () async {
+    await insertComputer('dc-a', model: 'Something Else');
+    await insertDive(
+      'dive-attributed',
+      computerId: 'dc-a',
+      model: 'Perdix 2',
+      serial: 'SN-1',
+    );
+
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await computerIdOf('dive-attributed'), 'dc-a');
+    expect(await db.select(db.diveComputers).get(), hasLength(1));
+  });
+
+  test('adopts a computer already registered by a download', () async {
+    // The device was downloaded over BLE and later the same dives arrived in
+    // a file. Minting a second row would split one physical computer in two,
+    // and there is no merge action to undo that.
+    await insertDiver('diver-1');
+    await insertComputer(
+      'downloaded',
+      diverId: 'diver-1',
+      manufacturer: 'Shearwater',
+      model: 'Perdix 2',
+      serial: 'SN-1',
+    );
+    await insertDive(
+      'dive-1',
+      model: 'Shearwater Perdix 2',
+      serial: 'SN-1',
+      diverId: 'diver-1',
+    );
+
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await db.select(db.diveComputers).get(), hasLength(1));
+    expect(await computerIdOf('dive-1'), 'downloaded');
+  });
+
+  test(
+    'registers at the deterministic id so a synced fleet converges',
+    () async {
+      await insertDiver('diver-1');
+      await insertDive(
+        'dive-1',
+        model: 'Perdix 2',
+        serial: 'SN-1',
+        diverId: 'diver-1',
+      );
+
+      await db.backfillImportedDiveComputersForTest();
+
+      expect(
+        (await db.select(db.diveComputers).get()).single.id,
+        importedDiveComputerId(
+          diverId: 'diver-1',
+          model: 'Perdix 2',
+          serialNumber: 'SN-1',
+        ),
+      );
+    },
+  );
+
+  test('does not queue sync work: every device heals independently', () async {
+    await insertDive('dive-1', model: 'Perdix 2', serial: 'SN-1');
+
+    await db.backfillImportedDiveComputersForTest();
+
+    // Deterministic ids mean each device derives the same row locally, so
+    // pushing them would be pure duplicate traffic (and a rename made on one
+    // device must not be clobbered by another device's backfill).
+    expect(await db.select(db.syncRecords).get(), isEmpty);
+  });
+
+  test('is idempotent across repeated opens', () async {
+    await insertDive('dive-1', model: 'Perdix 2', serial: 'SN-1');
+
+    await db.backfillImportedDiveComputersForTest();
+    final firstId = await computerIdOf('dive-1');
+    await db.backfillImportedDiveComputersForTest();
+
+    expect(await db.select(db.diveComputers).get(), hasLength(1));
+    expect(await computerIdOf('dive-1'), firstId);
+  });
+
+  test('collapses spelling noise onto one registration', () async {
+    await insertDive('dive-1', model: 'Perdix 2', serial: 'SN-1');
+    await insertDive('dive-2', model: '  PERDIX   2 ', serial: ' sn-1 ');
+
+    await db.backfillImportedDiveComputersForTest();
+
+    final computers = await db.select(db.diveComputers).get();
+    expect(computers, hasLength(1));
+    expect(await computerIdOf('dive-2'), computers.single.id);
+  });
+
+  // beforeOpen runs against minimal old-schema fixtures too. The PRAGMA guard
+  // must skip rather than raise "no such column".
+  test('skips a legacy schema that lacks the snapshot columns', () async {
+    final legacy = AppDatabase(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute(
+            'PRAGMA user_version = ${AppDatabase.currentSchemaVersion}',
+          );
+          rawDb.execute('CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY)');
+          rawDb.execute("INSERT INTO dives (id) VALUES ('legacy-dive')");
+        },
+      ),
+    );
+    addTearDown(legacy.close);
+
+    final rows = await legacy.customSelect('SELECT id FROM dives').get();
+
+    expect(rows.single.read<String>('id'), 'legacy-dive');
+  });
+
+  // deleteComputer nulls dives.computer_id and writes a tombstone, but leaves
+  // the dive_computer_model/_serial snapshots in place by design. Those are
+  // exactly the rows this backfill claims, so without a guard a deliberate
+  // delete would not survive the next app open.
+  group('respects a deliberate delete', () {
+    test('does not resurrect a tombstoned computer', () async {
+      await insertDiver('diver-1');
+      await insertDive(
+        'dive-1',
+        model: 'Perdix 2',
+        serial: 'SN-1',
+        diverId: 'diver-1',
+      );
+      // The row the user deleted was registered at the deterministic id, so
+      // re-minting it would resurrect a tombstoned primary key: the peer that
+      // applied the delete would just delete it again, forever.
+      await logDeletion(
+        importedDiveComputerId(
+          diverId: 'diver-1',
+          model: 'Perdix 2',
+          serialNumber: 'SN-1',
+        ),
+      );
+
+      await db.backfillImportedDiveComputersForTest();
+
+      expect(await db.select(db.diveComputers).get(), isEmpty);
+      expect(await computerIdOf('dive-1'), isNull);
+    });
+
+    test('does not invent a computer for a downloaded dive', () async {
+      // The download path stamps the same model/serial snapshots onto every
+      // dive it writes. After its computer is deleted, those snapshots must
+      // not conjure a phantom device, which would also be a corrupted copy:
+      // the snapshot is the combined full name, with no manufacturer.
+      await insertDive(
+        'dive-downloaded',
+        model: 'Shearwater Perdix',
+        serial: 'SN-123',
+      );
+      await insertDataSource(
+        'src-1',
+        diveId: 'dive-downloaded',
+        sourceFormat: 'dive_computer',
+      );
+
+      await db.backfillImportedDiveComputersForTest();
+
+      expect(await db.select(db.diveComputers).get(), isEmpty);
+      expect(await computerIdOf('dive-downloaded'), isNull);
+    });
+
+    test('still registers a file-imported dive alongside a download', () async {
+      await insertDive(
+        'dive-downloaded',
+        model: 'Shearwater Perdix',
+        serial: 'SN-123',
+      );
+      await insertDataSource(
+        'src-1',
+        diveId: 'dive-downloaded',
+        sourceFormat: 'dive_computer',
+      );
+      await insertDive('dive-imported', model: 'Suunto D5');
+      await insertDataSource(
+        'src-2',
+        diveId: 'dive-imported',
+        sourceFileFormat: 'uddf',
+      );
+
+      await db.backfillImportedDiveComputersForTest();
+
+      final computers = await db.select(db.diveComputers).get();
+      expect(computers, hasLength(1));
+      expect(computers.single.model, 'Suunto D5');
+      expect(await computerIdOf('dive-imported'), computers.single.id);
+      expect(await computerIdOf('dive-downloaded'), isNull);
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_computer_manufacturer_test.dart
+++ b/test/core/services/export/uddf/uddf_computer_manufacturer_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_service.dart';
+
+/// UDDF names the vendor in `<manufacturer><name>`, but the dive-attribution
+/// map only ever carried model/serial/firmware, so an imported computer was
+/// registered with a null manufacturer and could not match a downloaded row
+/// that stores vendor and product separately (#1288).
+const _uddf = '''<?xml version="1.0" encoding="UTF-8" ?>
+<uddf xmlns="http://www.streit.cc/uddf/3.2/" version="3.2.1">
+  <diver>
+    <owner id="owner-1">
+      <personal>
+        <firstname>Test</firstname>
+        <lastname>Diver</lastname>
+      </personal>
+      <equipment>
+        <divecomputer id="dc-1">
+          <name>Shearwater Perdix 2</name>
+          <manufacturer>
+            <name>Shearwater</name>
+          </manufacturer>
+          <model>Perdix 2</model>
+          <serialnumber>2013766D</serialnumber>
+        </divecomputer>
+      </equipment>
+    </owner>
+  </diver>
+  <profiledata>
+    <repetitiongroup id="repgrp-1">
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2024-03-01T10:00:00</datetime>
+          <link ref="dc-1" />
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>10.0</depth>
+            <divetime>0</divetime>
+          </waypoint>
+          <waypoint>
+            <depth>20.0</depth>
+            <divetime>600</divetime>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>20.0</greatestdepth>
+          <diveduration>1800</diveduration>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+/// UDDF's `<manufacturer>` legitimately carries `<address>`/`<contact>`
+/// siblings of `<name>`. Reading the element's whole subtree would splice
+/// those into the vendor string.
+const _uddfManufacturerWithoutName = '''<?xml version="1.0" encoding="UTF-8" ?>
+<uddf xmlns="http://www.streit.cc/uddf/3.2/" version="3.2.1">
+  <diver>
+    <owner id="owner-1">
+      <personal>
+        <firstname>Test</firstname>
+        <lastname>Diver</lastname>
+      </personal>
+      <equipment>
+        <divecomputer id="dc-1">
+          <name>Perdix 2</name>
+          <manufacturer>
+            <address>
+              <city>Vancouver</city>
+              <country>Canada</country>
+            </address>
+            <contact>
+              <email>support@example.com</email>
+            </contact>
+          </manufacturer>
+          <model>Perdix 2</model>
+        </divecomputer>
+      </equipment>
+    </owner>
+  </diver>
+  <profiledata>
+    <repetitiongroup id="repgrp-1">
+      <dive id="dive-1">
+        <informationbeforedive>
+          <datetime>2024-03-01T10:00:00</datetime>
+          <link ref="dc-1" />
+        </informationbeforedive>
+        <samples>
+          <waypoint>
+            <depth>10.0</depth>
+            <divetime>0</divetime>
+          </waypoint>
+        </samples>
+        <informationafterdive>
+          <greatestdepth>20.0</greatestdepth>
+          <diveduration>1800</diveduration>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>
+''';
+
+void main() {
+  test('UddfImportService carries the dive computer manufacturer', () async {
+    final result = await UddfImportService().importDivesFromUddf(_uddf);
+    final dive = result['dives']!.single;
+
+    expect(dive['diveComputerModel'], 'Perdix 2');
+    expect(dive['diveComputerManufacturer'], 'Shearwater');
+  });
+
+  test(
+    'UddfFullImportService carries the dive computer manufacturer',
+    () async {
+      final result = await UddfFullImportService().importAllDataFromUddf(_uddf);
+      final dive = result.dives.single;
+
+      expect(dive['diveComputerModel'], 'Perdix 2');
+      expect(dive['diveComputerManufacturer'], 'Shearwater');
+    },
+  );
+
+  test('ignores a manufacturer element that carries no name', () async {
+    final result = await UddfImportService().importDivesFromUddf(
+      _uddfManufacturerWithoutName,
+    );
+    final dive = result['dives']!.single;
+
+    // Never 'VancouverCanada': the address and contact subtrees are not the
+    // vendor name.
+    expect(dive['diveComputerManufacturer'], isNull);
+  });
+}

--- a/test/features/dive_import/data/services/uddf_entity_importer_computer_registration_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_computer_registration_test.dart
@@ -267,6 +267,52 @@ void main() {
     expect(dives.single.diveComputerModel, 'Perdix 2');
   });
 
+  test(
+    'a failed attribution leaves the provenance link for the self-heal',
+    () async {
+      // Deliberately NOT symmetric: when the dive-level write fails, the
+      // dive_data_sources.computer_id stamp is kept on purpose. The #1064
+      // beforeOpen heal adopts dives.computer_id from exactly that column, so
+      // the breadcrumb is what recovers the attribution on the next open.
+      // Clearing it for tidiness would throw the recovery away.
+      final result = await importer.import(
+        data: UddfImportResult(
+          dives: [diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')],
+        ),
+        selections: const UddfImportSelections(dives: {0}),
+        repositories: ImportRepositories(
+          tripRepository: TripRepository(),
+          equipmentRepository: EquipmentRepository(),
+          equipmentSetRepository: EquipmentSetRepository(),
+          buddyRepository: BuddyRepository(),
+          diveCenterRepository: DiveCenterRepository(),
+          certificationRepository: CertificationRepository(),
+          tagRepository: TagRepository(),
+          diveTypeRepository: DiveTypeRepository(),
+          siteRepository: SiteRepository(),
+          diveRepository: DiveRepository(),
+          tankPressureRepository: TankPressureRepository(),
+          courseRepository: CourseRepository(),
+          diveComputerRepository: _AttributionFailingComputerRepository(),
+        ),
+        diverId: diverId,
+      );
+
+      expect(result.dives, 1);
+      final computer = (await db.select(db.diveComputers).get()).single;
+      expect((await db.select(db.dives).get()).single.computerId, isNull);
+      expect(
+        (await db.select(db.diveDataSources).get()).single.computerId,
+        computer.id,
+      );
+
+      // The next app open recovers it.
+      await db.backfillDiveComputerIdsForTest();
+
+      expect((await db.select(db.dives).get()).single.computerId, computer.id);
+    },
+  );
+
   test('adopts a computer already registered by a download', () async {
     // The download path stores vendor and product separately; the file
     // carries them as one string. The dive must join the existing device,
@@ -307,4 +353,14 @@ class _FailingComputerRepository extends DiveComputerRepository {
     String? firmwareVersion,
     String? diverId,
   }) async => throw StateError('registry unavailable');
+}
+
+/// Registers normally but cannot write the dive-level attribution, to pin
+/// that the provenance link survives for the #1064 self-heal.
+class _AttributionFailingComputerRepository extends DiveComputerRepository {
+  @override
+  Future<void> attributeDiveToComputer({
+    required String diveId,
+    required String computerId,
+  }) async => throw StateError('dives table unavailable');
 }

--- a/test/features/dive_import/data/services/uddf_entity_importer_computer_registration_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_computer_registration_test.dart
@@ -1,0 +1,310 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/imported_computer_identity.dart';
+import 'package:submersion/core/services/export/models/uddf_import_result.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/certifications/data/repositories/certification_repository.dart';
+import 'package:submersion/features/courses/data/repositories/course_repository.dart';
+import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
+import 'package:submersion/features/dive_import/data/services/uddf_entity_importer.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
+    as domain;
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_repository.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_types/data/repositories/dive_type_repository.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_repository_impl.dart';
+import 'package:submersion/features/equipment/data/repositories/equipment_set_repository_impl.dart';
+import 'package:submersion/features/tags/data/repositories/tag_repository.dart';
+import 'package:submersion/features/trips/data/repositories/trip_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1288: a logbook built from a file import named a dive computer on
+/// every dive's Details card, yet Dives > Filter still read "No dive
+/// computers registered" and offered nothing to filter by. The importer wrote
+/// only the `dive_computer_model`/`_serial` display snapshots and never
+/// registered a `dive_computers` row, which is what the filter reads.
+///
+/// These run against a real in-memory database rather than mocks: the bug was
+/// the absence of a write, so only the persisted rows prove the fix.
+void main() {
+  late AppDatabase db;
+  late UddfEntityImporter importer;
+  late ImportRepositories repos;
+  const diverId = 'diver-1';
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    importer = UddfEntityImporter();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: const Value(diverId),
+            name: const Value('Test Diver'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    repos = ImportRepositories(
+      tripRepository: TripRepository(),
+      equipmentRepository: EquipmentRepository(),
+      equipmentSetRepository: EquipmentSetRepository(),
+      buddyRepository: BuddyRepository(),
+      diveCenterRepository: DiveCenterRepository(),
+      certificationRepository: CertificationRepository(),
+      tagRepository: TagRepository(),
+      diveTypeRepository: DiveTypeRepository(),
+      siteRepository: SiteRepository(),
+      diveRepository: DiveRepository(),
+      tankPressureRepository: TankPressureRepository(),
+      courseRepository: CourseRepository(),
+      diveComputerRepository: DiveComputerRepository(),
+    );
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Map<String, dynamic> diveEntry({
+    required int day,
+    String? model,
+    String? serial,
+    String? firmware,
+    String? manufacturer,
+  }) => {
+    'dateTime': DateTime(2024, 3, day, 10),
+    'maxDepth': 30.0,
+    'diveComputerModel': model,
+    'diveComputerSerial': serial,
+    'diveComputerFirmware': firmware,
+    'diveComputerManufacturer': manufacturer,
+  };
+
+  Future<UddfEntityImportResult> runImport(List<Map<String, dynamic>> dives) =>
+      importer.import(
+        data: UddfImportResult(dives: dives),
+        selections: UddfImportSelections(
+          dives: {for (var i = 0; i < dives.length; i++) i},
+        ),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+  test('registers one computer for dives naming the same device', () async {
+    final result = await runImport([
+      diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1'),
+      diveEntry(day: 2, model: 'Perdix 2', serial: 'SN-1'),
+    ]);
+
+    expect(result.dives, 2);
+
+    final computers = await db.select(db.diveComputers).get();
+    expect(computers, hasLength(1));
+    expect(computers.single.model, 'Perdix 2');
+    expect(computers.single.serialNumber, 'SN-1');
+    expect(computers.single.diverId, diverId);
+  });
+
+  test('stamps computer_id on every imported dive', () async {
+    await runImport([
+      diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1'),
+      diveEntry(day: 2, model: 'Perdix 2', serial: 'SN-1'),
+    ]);
+
+    final computer = (await db.select(db.diveComputers).get()).single;
+    final dives = await db.select(db.dives).get();
+    expect(dives, hasLength(2));
+    expect(dives.every((d) => d.computerId == computer.id), isTrue);
+    // The display snapshots stay: they are what the Details card renders
+    // when no computer is registered, and what exports carry.
+    expect(dives.every((d) => d.diveComputerModel == 'Perdix 2'), isTrue);
+  });
+
+  test('stamps computer_id on the provenance row', () async {
+    await runImport([diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')]);
+
+    final computer = (await db.select(db.diveComputers).get()).single;
+    final source = (await db.select(db.diveDataSources).get()).single;
+    expect(source.computerId, computer.id);
+  });
+
+  test('registers a computer per distinct device in one file', () async {
+    await runImport([
+      diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1'),
+      diveEntry(day: 2, model: 'Teric', serial: 'SN-2'),
+    ]);
+
+    final computers = await db.select(db.diveComputers).get();
+    expect(computers, hasLength(2));
+    expect(computers.map((c) => c.model).toSet(), {'Perdix 2', 'Teric'});
+  });
+
+  test(
+    'registers a computer when the file gives a model but no serial',
+    () async {
+      await runImport([diveEntry(day: 1, model: 'Suunto D5')]);
+
+      final computer = (await db.select(db.diveComputers).get()).single;
+      expect(computer.serialNumber, isNull);
+      expect(computer.model, 'Suunto D5');
+      expect((await db.select(db.dives).get()).single.computerId, computer.id);
+    },
+  );
+
+  test('records the manufacturer when the file supplies one', () async {
+    await runImport([
+      diveEntry(day: 1, model: 'Perdix 2', manufacturer: 'Shearwater'),
+    ]);
+
+    final computer = (await db.select(db.diveComputers).get()).single;
+    expect(computer.manufacturer, 'Shearwater');
+    expect(computer.name, 'Shearwater Perdix 2');
+  });
+
+  test('records the firmware the file reports', () async {
+    await runImport([
+      diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1', firmware: '92'),
+    ]);
+
+    expect(
+      (await db.select(db.diveComputers).get()).single.firmwareVersion,
+      '92',
+    );
+  });
+
+  test('leaves dives unattributed when the file names no computer', () async {
+    await runImport([diveEntry(day: 1)]);
+
+    expect(await db.select(db.diveComputers).get(), isEmpty);
+    expect((await db.select(db.dives).get()).single.computerId, isNull);
+  });
+
+  test(
+    'reuses an already registered computer instead of duplicating it',
+    () async {
+      await runImport([diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')]);
+      await runImport([diveEntry(day: 5, model: 'Perdix 2', serial: 'SN-1')]);
+
+      final computers = await db.select(db.diveComputers).get();
+      expect(computers, hasLength(1));
+      final dives = await db.select(db.dives).get();
+      expect(dives, hasLength(2));
+      expect(dives.every((d) => d.computerId == computers.single.id), isTrue);
+    },
+  );
+
+  test(
+    'registers at the deterministic id so a synced fleet converges',
+    () async {
+      await runImport([diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')]);
+
+      expect(
+        (await db.select(db.diveComputers).get()).single.id,
+        importedDiveComputerId(
+          diverId: diverId,
+          model: 'Perdix 2',
+          serialNumber: 'SN-1',
+        ),
+      );
+    },
+  );
+
+  test(
+    'the query behind the filter dropdown finds the imported computer',
+    () async {
+      await runImport([diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')]);
+
+      // allDiveComputersProvider, which the Dives > Filter dropdown builds its
+      // list from, is exactly this call. Coming back empty is what rendered
+      // "No dive computers registered" while every dive showed a computer.
+      final computers = await DiveComputerRepository().getAllComputers(
+        diverId: diverId,
+      );
+
+      expect(computers, hasLength(1));
+      expect(computers.single.model, 'Perdix 2');
+    },
+  );
+
+  test('a registration failure does not abort the import', () async {
+    // Attribution is cosmetic next to the dives themselves: a registry
+    // problem must degrade to "unattributed", never cost the user the
+    // logbook they were importing.
+    final result = await importer.import(
+      data: UddfImportResult(
+        dives: [diveEntry(day: 1, model: 'Perdix 2', serial: 'SN-1')],
+      ),
+      selections: const UddfImportSelections(dives: {0}),
+      repositories: ImportRepositories(
+        tripRepository: TripRepository(),
+        equipmentRepository: EquipmentRepository(),
+        equipmentSetRepository: EquipmentSetRepository(),
+        buddyRepository: BuddyRepository(),
+        diveCenterRepository: DiveCenterRepository(),
+        certificationRepository: CertificationRepository(),
+        tagRepository: TagRepository(),
+        diveTypeRepository: DiveTypeRepository(),
+        siteRepository: SiteRepository(),
+        diveRepository: DiveRepository(),
+        tankPressureRepository: TankPressureRepository(),
+        courseRepository: CourseRepository(),
+        diveComputerRepository: _FailingComputerRepository(),
+      ),
+      diverId: diverId,
+    );
+
+    expect(result.dives, 1);
+    final dives = await db.select(db.dives).get();
+    expect(dives, hasLength(1));
+    expect(dives.single.computerId, isNull);
+    // The display snapshot still lands, so the Details card is unaffected.
+    expect(dives.single.diveComputerModel, 'Perdix 2');
+  });
+
+  test('adopts a computer already registered by a download', () async {
+    // The download path stores vendor and product separately; the file
+    // carries them as one string. The dive must join the existing device,
+    // not fork a second record for it.
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: const Value('downloaded'),
+            diverId: const Value(diverId),
+            name: const Value('Shearwater Perdix 2'),
+            manufacturer: const Value('Shearwater'),
+            model: const Value('Perdix 2'),
+            serialNumber: const Value('SN-1'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+
+    await runImport([
+      diveEntry(day: 1, model: 'Shearwater Perdix 2', serial: 'SN-1'),
+    ]);
+
+    expect(await db.select(db.diveComputers).get(), hasLength(1));
+    expect((await db.select(db.dives).get()).single.computerId, 'downloaded');
+  });
+}
+
+/// Stands in for a registry that cannot be written, to pin that the importer
+/// treats attribution as best-effort.
+class _FailingComputerRepository extends DiveComputerRepository {
+  @override
+  Future<domain.DiveComputer?> findOrRegisterImportedComputer({
+    required String model,
+    String? manufacturer,
+    String? serialNumber,
+    String? firmwareVersion,
+    String? diverId,
+  }) async => throw StateError('registry unavailable');
+}

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -1363,6 +1363,36 @@ void main() {
       expect(await db.select(db.diveComputers).get(), hasLength(1));
     });
 
+    test('breaks a tie on id so every device resolves alike', () async {
+      // matchImportedComputer's contract is that candidates arrive in a
+      // deterministic preference order. Ordering on updatedAt alone leaves
+      // same-timestamp rows in whatever order SQLite happens to return, so
+      // two devices could attribute the same dives to different rows.
+      await insertComputer(
+        id: 'dc-z',
+        diverId: 'diver-1',
+        manufacturer: null,
+        model: 'Perdix 2',
+        serialNumber: null,
+      );
+      await insertComputer(
+        id: 'dc-a',
+        diverId: 'diver-1',
+        manufacturer: null,
+        model: 'Perdix 2',
+        serialNumber: null,
+      );
+      // Same updatedAt on both, which insertComputer already guarantees.
+      await db.customStatement('UPDATE dive_computers SET updated_at = 1000');
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, 'dc-a');
+    });
+
     test('registers nothing when the model is blank', () async {
       final computer = await repository.findOrRegisterImportedComputer(
         model: '   ',

--- a/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_impl_test.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/imported_computer_identity.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
     as domain;
@@ -1143,6 +1144,246 @@ void main() {
       )..where((t) => t.diveId.equals(diveId))).getSingle();
       expect(source.entryLatitude, 12.34567);
       expect(source.exitLongitude, 98.76489);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findOrRegisterImportedComputer (issue #1288)
+  //
+  // File imports name a computer on every dive but register no
+  // `dive_computers` row, so the Dives filter reports "No dive computers
+  // registered". Registration keys on the serial when the file supplies one
+  // and falls back to the model string when it does not.
+  // ---------------------------------------------------------------------------
+  group('findOrRegisterImportedComputer', () {
+    // dive_computers.diver_id is a real FK, so the owners must exist.
+    setUp(() async {
+      await insertDiver('diver-1');
+      await insertDiver('diver-2');
+    });
+
+    test('creates a computer when nothing matches', () async {
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        manufacturer: 'Shearwater',
+        serialNumber: 'SN-999',
+        diverId: 'diver-1',
+      );
+
+      expect(computer, isNotNull);
+      expect(computer!.model, 'Perdix 2');
+      expect(computer.manufacturer, 'Shearwater');
+      expect(computer.serialNumber, 'SN-999');
+      expect(computer.diverId, 'diver-1');
+      expect(computer.name, 'Shearwater Perdix 2');
+
+      final rows = await db.select(db.diveComputers).get();
+      expect(rows, hasLength(1));
+      expect(rows.single.id, computer.id);
+    });
+
+    test('reuses an existing computer with the same serial', () async {
+      await insertComputer(
+        id: 'existing',
+        diverId: 'diver-1',
+        serialNumber: 'SN-999',
+        manufacturer: 'Shearwater',
+        model: 'Perdix',
+      );
+
+      // A different model spelling must not defeat the serial match: the
+      // serial is the strong key, exactly as on the download path.
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Shearwater Perdix AI',
+        serialNumber: 'SN-999',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, 'existing');
+      expect(await db.select(db.diveComputers).get(), hasLength(1));
+    });
+
+    test('matches a serial despite stored whitespace', () async {
+      await insertComputer(
+        id: 'existing',
+        diverId: 'diver-1',
+        serialNumber: '  SN-999 ',
+      );
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix',
+        serialNumber: 'SN-999',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, 'existing');
+    });
+
+    test('reuses a serial-less computer with the same model', () async {
+      await insertComputer(
+        id: 'existing',
+        diverId: 'diver-1',
+        manufacturer: null,
+        model: 'Perdix 2',
+        serialNumber: null,
+      );
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: '  perdix   2 ',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, 'existing');
+      expect(await db.select(db.diveComputers).get(), hasLength(1));
+    });
+
+    test('matches a serial-less row on its manufacturer plus model', () async {
+      // The download path stores vendor and product separately; a file
+      // usually carries them jammed into one string.
+      await insertComputer(
+        id: 'existing',
+        diverId: 'diver-1',
+        manufacturer: 'Shearwater',
+        model: 'Perdix',
+        serialNumber: null,
+      );
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Shearwater Perdix',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, 'existing');
+    });
+
+    test(
+      'does not adopt a serial-bearing row when the file has no serial',
+      () async {
+        await insertComputer(
+          id: 'registered',
+          diverId: 'diver-1',
+          model: 'Perdix 2',
+          serialNumber: 'SN-999',
+        );
+
+        final computer = await repository.findOrRegisterImportedComputer(
+          model: 'Perdix 2',
+          diverId: 'diver-1',
+        );
+
+        expect(computer!.id, isNot('registered'));
+        expect(await db.select(db.diveComputers).get(), hasLength(2));
+      },
+    );
+
+    test('does not reuse a computer belonging to another diver', () async {
+      await insertComputer(
+        id: 'other-diver',
+        diverId: 'diver-2',
+        serialNumber: 'SN-999',
+      );
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix',
+        serialNumber: 'SN-999',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, isNot('other-diver'));
+      expect(computer.diverId, 'diver-1');
+    });
+
+    test('is idempotent: a second call registers nothing new', () async {
+      final first = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        diverId: 'diver-1',
+      );
+      final second = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        diverId: 'diver-1',
+      );
+
+      expect(second!.id, first!.id);
+      expect(await db.select(db.diveComputers).get(), hasLength(1));
+    });
+
+    test('derives a deterministic id from the normalized identity', () async {
+      // Every device must derive the SAME id for the same physical computer,
+      // or the beforeOpen backfill mints one row per synced device and there
+      // is no merge UI to clean that up.
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        diverId: 'diver-1',
+      );
+
+      expect(
+        computer!.id,
+        importedDiveComputerId(
+          diverId: 'diver-1',
+          model: 'Perdix 2',
+          serialNumber: null,
+        ),
+      );
+      // Normalization feeds the id, so spelling noise cannot fork it.
+      expect(
+        importedDiveComputerId(
+          diverId: 'diver-1',
+          model: '  PERDIX   2 ',
+          serialNumber: null,
+        ),
+        computer.id,
+      );
+    });
+
+    test('adopts the row already holding the deterministic id', () async {
+      // The user renamed a computer that a previous import registered, so
+      // the identity match now misses while the derived id still collides.
+      // Inserting blind would throw UNIQUE constraint failed and abort the
+      // whole import.
+      final id = importedDiveComputerId(
+        diverId: 'diver-1',
+        model: 'Perdix',
+        serialNumber: null,
+      );
+      await insertComputer(
+        id: id,
+        diverId: 'diver-1',
+        manufacturer: null,
+        model: 'My Renamed Perdix',
+        serialNumber: null,
+      );
+
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix',
+        diverId: 'diver-1',
+      );
+
+      expect(computer!.id, id);
+      expect(computer.model, 'My Renamed Perdix');
+      expect(await db.select(db.diveComputers).get(), hasLength(1));
+    });
+
+    test('registers nothing when the model is blank', () async {
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: '   ',
+        diverId: 'diver-1',
+      );
+
+      expect(computer, isNull);
+      expect(await db.select(db.diveComputers).get(), isEmpty);
+    });
+
+    test('marks the new computer pending so it syncs', () async {
+      final computer = await repository.findOrRegisterImportedComputer(
+        model: 'Perdix 2',
+        diverId: 'diver-1',
+      );
+
+      final pending = await (db.select(
+        db.syncRecords,
+      )..where((t) => t.entityType.equals('diveComputers'))).get();
+      expect(pending.map((r) => r.recordId), contains(computer!.id));
+      expect(pending.single.syncStatus, 'pending');
     });
   });
 }


### PR DESCRIPTION
Fixes #1288.

## The bug

A logbook built from a file import (UDDF, FIT, MacDive, Shearwater export, CSV) names a dive computer on every dive's Details card, yet Dives > Filter reads "No dive computers registered" and offers nothing to filter by.

`UddfEntityImporter` wrote only the `dive_computer_model` / `_serial` / `_firmware` display snapshots onto each dive. It never created a `dive_computers` row and never stamped `dives.computer_id`, which is what the filter, the statistics SQL, and "View dives from this computer" all read. `createComputer` had exactly two callers, the BLE/USB download path and the manual "add computer" action, and every file format funnels through the same entity importer.

This is a **different cause from #1064** (the serial-keyed filter, fixed in v1.7.5). The two share a symptom string. The fast tell in a screenshot is the chevron on the Details card: a tappable `Dive Computer  <model>  >` row means a computer is registered, a flat text row means it is not.

## The fix

Option 1 from the issue: register a computer during file import and stamp the attribution.

**Match key.** A file offers a weaker identity than a download does, so the rule has two tiers:

- With a serial, match on the serial alone (scoped to the diver), the same strong key the download path uses. A file's model spelling must not defeat it.
- Without one, match a row that also has no serial and whose model, or whose manufacturer + model, normalizes to the same string. Comparing the combined form is what lets a file's `"Shearwater Perdix"` find a downloaded row stored as manufacturer `"Shearwater"`, model `"Perdix"`.

A serial-less import never adopts a serial-bearing row. Two units of one model are common, and collapsing them would misattribute dives with no way to undo it.

**Deterministic ids.** New rows land on a UUIDv5 derived from the normalized identity, following the `account_identity.dart` precedent. Every device derives the same primary key, so sync's upsert-by-id merges instead of unioning. This is also why no unique index is added: a unique constraint on a replicated table makes an inbound sync insert throw rather than merge.

**Attribution stays explicit.** `Dive.computerId` remains a read-only projection; `createDive` and `updateDive` still omit it from their companions, so saving a dive never rewrites attribution. File import joins the download, consolidation, split, and reparse paths in setting it with deliberate intent, through a new `attributeDiveToComputer`.

**Existing logbooks.** A `beforeOpen` self-heal registers computers from the snapshots of dives that have none, so users need not re-import. It is local-only and idempotent: no HLC bump, nothing marked pending, because every device derives the same rows independently. `beforeOpen` rather than `onUpgrade` because a database arriving by restore or sync-adopt never runs `onUpgrade`.

The self-heal must not undo a deliberate delete, which needs two guards because the two variants leave different traces. `deleteComputer` nulls `dives.computer_id` but leaves the snapshots in place by design, and those are exactly the rows this pass claims:

- A deleted **file-imported** computer is caught by its `deletion_log` tombstone; its id is derivable, and re-minting it would resurrect a tombstoned primary key that the peer which applied the delete would simply delete again.
- A deleted **downloaded** computer is caught by excluding any dive that carries a `source_format = 'dive_computer'` provenance row. Its phantom id would differ from the tombstoned one, so no tombstone check could see it, and the phantom would also be a corrupted copy (the snapshot is the combined full name, with no manufacturer).

**Best-effort.** Registration and attribution are both wrapped, following the precedent `_relinkOrphanedRows` sets. Attribution is cosmetic next to the dives themselves, so a registry failure leaves that one device unattributed rather than costing the user the import. The dive keeps its model snapshot either way.

**UDDF manufacturer.** `<manufacturer><name>` was parsed for the equipment list but dropped from the dive-attribution map, so registered rows had a null vendor. Now plumbed through. The bare-text fallback applies only when the element has no child elements, since `innerText` walks the whole subtree and a `<manufacturer>` carrying only an address would otherwise yield a vendor of "VancouverCanada".

## Testing

`test/features/statistics/data/dive_filter_sql_test.dart`, the parity battery the issue names as the guard, stays green: this adds no filter axis.

New coverage, all written test-first:

- `dive_computer_repository_impl_test.dart`: 12 cases on the match key (serial hit, whitespace, serial-less model hit, full-name hit, no cross-diver bleed, refusal to adopt a serial-bearing row, idempotence, id stability, blank model, sync-pending, and adopting the row already holding the derived id after a rename, which previously threw `UNIQUE constraint failed`).
- `uddf_entity_importer_computer_registration_test.dart` (new): 13 end-to-end cases against a real in-memory database rather than mocks, since the bug was the absence of a write. Includes the query the filter dropdown is built from, which returns empty on `main`.
- `imported_dive_computer_backfill_test.dart` (new): 15 cases including both resurrection guards and the legacy-schema PRAGMA skip.
- `uddf_computer_manufacturer_test.dart` (new): 3 cases on the vendor plumbing.

Full suite: one unrelated failure, `shearwater_cloud_parser_test.dart` with `SqliteException(5): database is locked`, the known cross-session temp-database collision. Passes when run alone. `dart format` and `flutter analyze` clean across the project.

## Follow-up worth filing

A device first seen via file import (no serial) and later downloaded over BLE (serial now present) still produces a second row, and today the only cleanup is delete, which strands the dives. That is inherent to the chosen key. A merge action for `dive_computers` would close it.