### PR TITLE
fix(sites): stop wiping site fields on altitude and GPS write-backs

### DIFF
--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -21,6 +21,7 @@ import 'package:submersion/features/dive_log/domain/entities/dive_times.dart'
 import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/gas_switch.dart';
+import 'package:submersion/features/dive_sites/data/mappers/dive_site_row_mapper.dart';
 import 'package:submersion/features/dive_log/domain/entities/source_profile.dart'
     as domain;
 import 'package:submersion/features/dive_log/domain/entities/profile_event.dart';
@@ -2995,22 +2996,7 @@ class DiveRepository {
     List<domain.BuddyWithRole> buddies = const [],
   }) {
     // Map site if exists
-    domain.DiveSite? domainSite;
-    if (site != null) {
-      domainSite = domain.DiveSite(
-        id: site.id,
-        name: site.name,
-        description: site.description,
-        location: site.latitude != null && site.longitude != null
-            ? domain.GeoPoint(site.latitude!, site.longitude!)
-            : null,
-        maxDepth: site.maxDepth,
-        country: site.country,
-        region: site.region,
-        rating: site.rating,
-        notes: site.notes,
-      );
-    }
+    final domainSite = site == null ? null : mapDiveSiteRow(site);
 
     // Map dive center if exists
     domain.DiveCenter? domainCenter;
@@ -3356,19 +3342,7 @@ class DiveRepository {
         ..where((t) => t.id.equals(row.siteId!));
       final siteRow = await siteQuery.getSingleOrNull();
       if (siteRow != null) {
-        site = domain.DiveSite(
-          id: siteRow.id,
-          name: siteRow.name,
-          description: siteRow.description,
-          location: siteRow.latitude != null && siteRow.longitude != null
-              ? domain.GeoPoint(siteRow.latitude!, siteRow.longitude!)
-              : null,
-          maxDepth: siteRow.maxDepth,
-          country: siteRow.country,
-          region: siteRow.region,
-          rating: siteRow.rating,
-          notes: siteRow.notes,
-        );
+        site = mapDiveSiteRow(siteRow);
       }
     }
 

--- a/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
+++ b/lib/features/dive_log/domain/services/dive_altitude_enricher.dart
@@ -38,9 +38,12 @@ class DiveAltitudeEnricher {
         exitLocation: dive.exitLocation,
         site: dive.site,
       );
-      final writeBack = resolution.siteWriteBack;
+      final writeBack = resolution.siteAltitudeWriteBack;
       if (writeBack != null) {
-        await _sites.updateSite(writeBack);
+        await _sites.updateSiteAltitude(
+          writeBack.siteId,
+          writeBack.altitudeMeters,
+        );
       }
       final meters = resolution.altitudeMeters;
       if (meters == null) return false;

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -2248,19 +2248,26 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     var updatedSite = _selectedSite!.copyWith(location: gps);
     // A site gaining coordinates should also gain its altitude, so later dives
     // there resolve locally without a lookup.
+    double? lookedUpAltitude;
     if (updatedSite.altitude == null) {
-      final meters = await ref
+      lookedUpAltitude = await ref
           .read(elevationServiceProvider)
           .fetchElevation(latitude: gps.latitude, longitude: gps.longitude);
       if (!mounted) return;
-      if (meters != null) {
-        updatedSite = updatedSite.copyWith(altitude: meters);
+      if (lookedUpAltitude != null) {
+        updatedSite = updatedSite.copyWith(altitude: lookedUpAltitude);
       }
     }
 
-    // Update the site via the notifier
+    // Patch only the coordinate columns: _selectedSite may be a partially
+    // hydrated entity, and a whole-entity update would wipe the rest
+    // (issue #1187).
     final siteNotifier = ref.read(siteListNotifierProvider.notifier);
-    await siteNotifier.updateSite(updatedSite);
+    await siteNotifier.updateSiteCoordinates(
+      updatedSite.id,
+      gps,
+      altitude: lookedUpAltitude,
+    );
 
     setState(() {
       _selectedSite = updatedSite;
@@ -4102,12 +4109,16 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
     );
     if (!mounted) return;
 
-    final writeBack = resolution.siteWriteBack;
+    final writeBack = resolution.siteAltitudeWriteBack;
     if (writeBack != null) {
-      await ref.read(siteListNotifierProvider.notifier).updateSite(writeBack);
+      await ref
+          .read(siteListNotifierProvider.notifier)
+          .updateSiteAltitude(writeBack.siteId, writeBack.altitudeMeters);
       if (!mounted) return;
-      if (_selectedSite?.id == writeBack.id) {
-        _selectedSite = writeBack;
+      if (_selectedSite?.id == writeBack.siteId) {
+        _selectedSite = _selectedSite?.copyWith(
+          altitude: writeBack.altitudeMeters,
+        );
       }
     }
 

--- a/lib/features/dive_sites/data/mappers/dive_site_row_mapper.dart
+++ b/lib/features/dive_sites/data/mappers/dive_site_row_mapper.dart
@@ -1,0 +1,49 @@
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
+    as domain;
+
+/// Maps a `dive_sites` row to the domain entity, every column included.
+///
+/// This is the single row-to-entity mapping for sites. Anything that
+/// hydrates a site from a row (the site repository, the dive repository's
+/// `dive.site`) must use it: a partial entity that later flows through
+/// `updateSite` rewrites every column and wipes the ones it never carried
+/// (issue #1187). `photoIds` is not a column and is left empty here; the
+/// site repository fills it where it is needed.
+domain.DiveSite mapDiveSiteRow(DiveSite row) {
+  return domain.DiveSite(
+    id: row.id,
+    diverId: row.diverId,
+    name: row.name,
+    description: row.description,
+    location: row.latitude != null && row.longitude != null
+        ? domain.GeoPoint(row.latitude!, row.longitude!)
+        : null,
+    minDepth: row.minDepth,
+    maxDepth: row.maxDepth,
+    difficulty: domain.SiteDifficulty.fromString(row.difficulty),
+    waterType: row.waterType == null
+        ? null
+        : WaterType.values.asNameMap()[row.waterType],
+    country: row.country,
+    region: row.region,
+    city: row.city,
+    island: row.island,
+    bodyOfWater: row.bodyOfWater,
+    rating: row.rating,
+    notes: row.notes,
+    hazards: row.hazards,
+    accessNotes: row.accessNotes,
+    mooringNumber: row.mooringNumber,
+    parkingInfo: row.parkingInfo,
+    altitude: row.altitude,
+    entryMethod: row.entryMethod == null
+        ? null
+        : EntryMethod.values.asNameMap()[row.entryMethod],
+    exitMethod: row.exitMethod == null
+        ? null
+        : EntryMethod.values.asNameMap()[row.exitMethod],
+    isShared: row.isShared,
+  );
+}

--- a/lib/features/dive_sites/data/repositories/site_repository_impl.dart
+++ b/lib/features/dive_sites/data/repositories/site_repository_impl.dart
@@ -1,7 +1,6 @@
 import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
-import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/data/visibility/visibility_filter.dart';
 import 'package:submersion/core/database/database.dart';
@@ -9,6 +8,7 @@ import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/dive_sites/data/mappers/dive_site_row_mapper.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     as domain;
 import 'package:submersion/features/media/data/repositories/media_repository.dart';
@@ -233,6 +233,30 @@ class SiteRepository {
   ///
   /// Used by the UDDF importer to persist columns that do not flow through
   /// the [domain.DiveSite] entity (e.g. MacDive waterType).
+  /// Stores a looked-up altitude for [siteId] without touching any other
+  /// column. Use this, never `updateSite` with a copied entity, for the
+  /// altitude write-back (issue #1187).
+  Future<void> updateSiteAltitude(String siteId, double altitudeMeters) =>
+      applyImportedMetadata(
+        siteId,
+        DiveSitesCompanion(altitude: Value(altitudeMeters)),
+      );
+
+  /// Stores coordinates (and optionally an altitude) for [siteId] without
+  /// touching any other column.
+  Future<void> updateSiteCoordinates(
+    String siteId,
+    domain.GeoPoint location, {
+    double? altitude,
+  }) => applyImportedMetadata(
+    siteId,
+    DiveSitesCompanion(
+      latitude: Value(location.latitude),
+      longitude: Value(location.longitude),
+      altitude: altitude == null ? const Value.absent() : Value(altitude),
+    ),
+  );
+
   /// Only columns set on [patch] are written; others are left untouched.
   /// Marks the row pending for sync.
   Future<void> applyImportedMetadata(
@@ -817,42 +841,7 @@ class SiteRepository {
     }
   }
 
-  domain.DiveSite _mapRowToSite(DiveSite row) {
-    return domain.DiveSite(
-      id: row.id,
-      diverId: row.diverId,
-      name: row.name,
-      description: row.description,
-      location: row.latitude != null && row.longitude != null
-          ? domain.GeoPoint(row.latitude!, row.longitude!)
-          : null,
-      minDepth: row.minDepth,
-      maxDepth: row.maxDepth,
-      difficulty: domain.SiteDifficulty.fromString(row.difficulty),
-      waterType: row.waterType == null
-          ? null
-          : WaterType.values.asNameMap()[row.waterType],
-      country: row.country,
-      region: row.region,
-      city: row.city,
-      island: row.island,
-      bodyOfWater: row.bodyOfWater,
-      rating: row.rating,
-      notes: row.notes,
-      hazards: row.hazards,
-      accessNotes: row.accessNotes,
-      mooringNumber: row.mooringNumber,
-      parkingInfo: row.parkingInfo,
-      altitude: row.altitude,
-      entryMethod: row.entryMethod == null
-          ? null
-          : EntryMethod.values.asNameMap()[row.entryMethod],
-      exitMethod: row.exitMethod == null
-          ? null
-          : EntryMethod.values.asNameMap()[row.exitMethod],
-      isShared: row.isShared,
-    );
-  }
+  domain.DiveSite _mapRowToSite(DiveSite row) => mapDiveSiteRow(row);
 
   Future<void> _updateSiteRow(domain.DiveSite site, int now) async {
     await (_db.update(_db.diveSites)..where((t) => t.id.equals(site.id))).write(

--- a/lib/features/dive_sites/presentation/providers/site_providers.dart
+++ b/lib/features/dive_sites/presentation/providers/site_providers.dart
@@ -415,6 +415,29 @@ class SiteListNotifier
     await _loadSites();
   }
 
+  /// Altitude write-back for a looked-up site altitude. Patches the one
+  /// column; never send a copied entity through [updateSite] for this
+  /// (issue #1187).
+  Future<void> updateSiteAltitude(String siteId, double altitudeMeters) async {
+    await _repository.updateSiteAltitude(siteId, altitudeMeters);
+    await _loadSites();
+  }
+
+  /// Coordinates (and optionally altitude) write-back, e.g. from a photo's
+  /// GPS. Patches only those columns.
+  Future<void> updateSiteCoordinates(
+    String siteId,
+    domain.GeoPoint location, {
+    double? altitude,
+  }) async {
+    await _repository.updateSiteCoordinates(
+      siteId,
+      location,
+      altitude: altitude,
+    );
+    await _loadSites();
+  }
+
   Future<void> deleteSite(String id) async {
     await _repository.deleteSite(id);
     await _loadSites();

--- a/lib/features/weather/domain/services/altitude_resolver.dart
+++ b/lib/features/weather/domain/services/altitude_resolver.dart
@@ -3,14 +3,17 @@ import 'package:submersion/features/weather/data/services/elevation_service.dart
 
 /// Result of an altitude resolution.
 ///
-/// [siteWriteBack] is non-null only when the altitude came from a lookup of
-/// the site's own coordinates: the caller should persist it so future dives
-/// at that site resolve locally without a network call.
+/// [siteAltitudeWriteBack] is non-null only when the altitude came from a
+/// lookup of the site's own coordinates: the caller should persist it so
+/// future dives at that site resolve locally without a network call. It is
+/// deliberately an id plus a number, not a site entity: callers must patch
+/// the altitude column alone, because writing a whole entity that was
+/// hydrated partially wipes every column it did not carry (issue #1187).
 class AltitudeResolution {
-  const AltitudeResolution({this.altitudeMeters, this.siteWriteBack});
+  const AltitudeResolution({this.altitudeMeters, this.siteAltitudeWriteBack});
 
   final double? altitudeMeters;
-  final DiveSite? siteWriteBack;
+  final ({String siteId, double altitudeMeters})? siteAltitudeWriteBack;
 }
 
 /// Encodes the altitude precedence rule from the 2026-08-06 conditions spec:
@@ -52,7 +55,7 @@ class AltitudeResolver {
       if (meters != null) {
         return AltitudeResolution(
           altitudeMeters: meters,
-          siteWriteBack: site.copyWith(altitude: meters),
+          siteAltitudeWriteBack: (siteId: site.id, altitudeMeters: meters),
         );
       }
     }

--- a/test/features/dive_log/data/repositories/dive_repository_site_mapping_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_site_mapping_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1187: `dive.site` used to be hydrated with 9 of the entity's 24
+/// fields. Any caller that copied that entity and saved it wiped the rest.
+void main() {
+  late DiveRepository dives;
+  late SiteRepository sites;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    dives = DiveRepository();
+    sites = SiteRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  const richSite = DiveSite(
+    id: 'site-rich',
+    name: 'Hertenstein',
+    description: 'Steep wall off the peninsula',
+    location: GeoPoint(47.027631, 8.400640),
+    minDepth: 5,
+    maxDepth: 40,
+    difficulty: SiteDifficulty.advanced,
+    waterType: WaterType.fresh,
+    country: 'Switzerland',
+    region: 'Lucerne',
+    city: 'Weggis',
+    island: 'None',
+    bodyOfWater: 'Lake Lucerne',
+    rating: 4,
+    notes: 'Bring a torch',
+    hazards: 'Boat traffic',
+    accessNotes: 'Steps down from the road',
+    mooringNumber: 'M7',
+    parkingInfo: 'Lay-by 100 m north',
+    altitude: 434,
+    entryMethod: EntryMethod.shore,
+    exitMethod: EntryMethod.ladder,
+    isShared: true,
+  );
+
+  Dive diveAt(DiveSite site) => Dive(
+    id: 'd1',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 8, 25, 10, 0),
+    site: site,
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  void expectFullSite(DiveSite? site) {
+    expect(site, isNotNull);
+    // Photo ids are loaded separately by the site repository; everything
+    // else on the row must be present on the dive's site.
+    expect(site!.copyWith(photoIds: const []), richSite);
+  }
+
+  test('getDiveById hydrates every column of the linked site', () async {
+    await sites.createSite(richSite);
+    await dives.createDive(diveAt(richSite));
+
+    final stored = await dives.getDiveById('d1');
+
+    expectFullSite(stored!.site);
+  });
+
+  test('getAllDives hydrates every column of the linked site', () async {
+    await sites.createSite(richSite);
+    await dives.createDive(diveAt(richSite));
+
+    final all = await dives.getAllDives();
+
+    expect(all, hasLength(1));
+    expectFullSite(all.single.site);
+  });
+}

--- a/test/features/dive_log/domain/services/dive_altitude_enricher_site_fields_test.dart
+++ b/test/features/dive_log/domain/services/dive_altitude_enricher_site_fields_test.dart
@@ -1,0 +1,158 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/database/database.dart' show AppDatabase;
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/weather/data/services/elevation_service.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Regression for issue #1187: the site altitude write-back used to push a
+/// partial `dive.site` entity through `updateSite`, which writes every
+/// column, so difficulty, water type, city, island, body of water, hazards
+/// and the shared flag were nulled on every import at a site with no stored
+/// altitude. The wipe then synced to the diver's other devices.
+void main() {
+  late AppDatabase db;
+  late DiveRepository dives;
+  late SiteRepository sites;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    dives = DiveRepository();
+    sites = SiteRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  ElevationService fixedElevation() => ElevationService(
+    client: MockClient(
+      (_) async => http.Response(
+        jsonEncode({
+          'elevation': [740.2],
+        }),
+        200,
+      ),
+    ),
+  );
+
+  Future<DiveSite> createRichSite() => sites.createSite(
+    const DiveSite(
+      id: 'site-rich',
+      name: 'Hertenstein',
+      description: 'Steep wall off the peninsula',
+      location: GeoPoint(47.027631, 8.400640),
+      minDepth: 5,
+      maxDepth: 40,
+      difficulty: SiteDifficulty.advanced,
+      waterType: WaterType.fresh,
+      country: 'Switzerland',
+      region: 'Lucerne',
+      city: 'Weggis',
+      island: 'None',
+      bodyOfWater: 'Lake Lucerne',
+      rating: 4,
+      notes: 'Bring a torch',
+      hazards: 'Boat traffic',
+      accessNotes: 'Steps down from the road',
+      mooringNumber: 'M7',
+      parkingInfo: 'Lay-by 100 m north',
+      entryMethod: EntryMethod.shore,
+      exitMethod: EntryMethod.ladder,
+      isShared: true,
+    ),
+  );
+
+  Dive diveAt(DiveSite site) => Dive(
+    id: 'd1',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 8, 25, 10, 0),
+    site: site,
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  test('site altitude write-back keeps every other site field intact even '
+      'when the dive carries a partial site entity', () async {
+    await createRichSite();
+    // Mimic the sparse site the dive repository used to hydrate: id, name
+    // and coordinates only. Everything else is null on this entity.
+    const partialSite = DiveSite(
+      id: 'site-rich',
+      name: 'Hertenstein',
+      location: GeoPoint(47.027631, 8.400640),
+    );
+    final dive = await dives.createDive(diveAt(partialSite));
+    final enricher = DiveAltitudeEnricher(
+      elevationService: fixedElevation(),
+      diveRepository: dives,
+      siteRepository: sites,
+    );
+
+    final applied = await enricher.applyForImportedDive(dive);
+
+    expect(applied, isTrue);
+    final stored = await sites.getSiteById('site-rich');
+    expect(stored, isNotNull);
+    expect(stored!.altitude, 740.0, reason: 'the write-back must land');
+    expect(stored.difficulty, SiteDifficulty.advanced);
+    expect(stored.waterType, WaterType.fresh);
+    expect(stored.minDepth, 5);
+    expect(stored.maxDepth, 40);
+    expect(stored.country, 'Switzerland');
+    expect(stored.region, 'Lucerne');
+    expect(stored.city, 'Weggis');
+    expect(stored.island, 'None');
+    expect(stored.bodyOfWater, 'Lake Lucerne');
+    expect(stored.rating, 4);
+    expect(stored.notes, 'Bring a torch');
+    expect(stored.hazards, 'Boat traffic');
+    expect(stored.accessNotes, 'Steps down from the road');
+    expect(stored.mooringNumber, 'M7');
+    expect(stored.parkingInfo, 'Lay-by 100 m north');
+    expect(stored.entryMethod, EntryMethod.shore);
+    expect(stored.exitMethod, EntryMethod.ladder);
+    expect(stored.isShared, isTrue);
+    expect(stored.description, 'Steep wall off the peninsula');
+  });
+
+  test('site altitude write-back marks the site pending for sync', () async {
+    await createRichSite();
+    final dive = await dives.createDive(
+      diveAt(
+        const DiveSite(
+          id: 'site-rich',
+          name: 'Hertenstein',
+          location: GeoPoint(47.027631, 8.400640),
+        ),
+      ),
+    );
+    final enricher = DiveAltitudeEnricher(
+      elevationService: fixedElevation(),
+      diveRepository: dives,
+      siteRepository: sites,
+    );
+
+    await enricher.applyForImportedDive(dive);
+
+    final pending = await (db.select(
+      db.syncRecords,
+    )..where((t) => t.recordId.equals('site-rich'))).get();
+    expect(pending, isNotEmpty, reason: 'the altitude change must sync');
+  });
+}

--- a/test/features/dive_sites/presentation/providers/site_list_notifier_patch_test.dart
+++ b/test/features/dive_sites/presentation/providers/site_list_notifier_patch_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/dive_sites/presentation/providers/site_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1187: the dive edit page's altitude and photo-GPS write-backs used
+/// to send a (possibly partial) site entity through `updateSite`, which
+/// rewrites every column. These targeted patches touch only the columns
+/// they are named for.
+void main() {
+  late ProviderContainer container;
+  late SiteRepository siteRepository;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    await setUpTestDatabase();
+    siteRepository = SiteRepository();
+    container = ProviderContainer(
+      overrides: [
+        siteRepositoryProvider.overrideWithValue(siteRepository),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        validatedCurrentDiverIdProvider.overrideWith((ref) async => null),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await tearDownTestDatabase();
+  });
+
+  const richSite = DiveSite(
+    id: 'site-rich',
+    name: 'Hertenstein',
+    location: GeoPoint(47.027631, 8.400640),
+    minDepth: 5,
+    maxDepth: 40,
+    difficulty: SiteDifficulty.advanced,
+    waterType: WaterType.fresh,
+    country: 'Switzerland',
+    region: 'Lucerne',
+    city: 'Weggis',
+    bodyOfWater: 'Lake Lucerne',
+    rating: 4,
+    hazards: 'Boat traffic',
+    entryMethod: EntryMethod.shore,
+    isShared: true,
+  );
+
+  test('updateSiteAltitude writes only the altitude', () async {
+    await siteRepository.createSite(richSite);
+    final notifier = container.read(siteListNotifierProvider.notifier);
+
+    await notifier.updateSiteAltitude('site-rich', 434.0);
+
+    final stored = await siteRepository.getSiteById('site-rich');
+    expect(stored!.altitude, 434.0);
+    expect(stored.difficulty, SiteDifficulty.advanced);
+    expect(stored.waterType, WaterType.fresh);
+    expect(stored.city, 'Weggis');
+    expect(stored.bodyOfWater, 'Lake Lucerne');
+    expect(stored.hazards, 'Boat traffic');
+    expect(stored.entryMethod, EntryMethod.shore);
+    expect(stored.isShared, isTrue);
+    expect(stored.location, const GeoPoint(47.027631, 8.400640));
+  });
+
+  test('updateSiteCoordinates writes location and altitude only', () async {
+    await siteRepository.createSite(richSite);
+    final notifier = container.read(siteListNotifierProvider.notifier);
+
+    await notifier.updateSiteCoordinates(
+      'site-rich',
+      const GeoPoint(12.1609, -68.2836),
+      altitude: 3.0,
+    );
+
+    final stored = await siteRepository.getSiteById('site-rich');
+    expect(stored!.location, const GeoPoint(12.1609, -68.2836));
+    expect(stored.altitude, 3.0);
+    expect(stored.difficulty, SiteDifficulty.advanced);
+    expect(stored.rating, 4);
+    expect(stored.bodyOfWater, 'Lake Lucerne');
+    expect(stored.isShared, isTrue);
+  });
+
+  test(
+    'updateSiteCoordinates without altitude leaves altitude alone',
+    () async {
+      await siteRepository.createSite(richSite.copyWith(altitude: 434.0));
+      final notifier = container.read(siteListNotifierProvider.notifier);
+
+      await notifier.updateSiteCoordinates(
+        'site-rich',
+        const GeoPoint(12.1609, -68.2836),
+      );
+
+      final stored = await siteRepository.getSiteById('site-rich');
+      expect(stored!.altitude, 434.0);
+    },
+  );
+
+  test('targeted patches refresh the notifier state', () async {
+    await siteRepository.createSite(richSite);
+    final notifier = container.read(siteListNotifierProvider.notifier);
+
+    await notifier.updateSiteAltitude('site-rich', 434.0);
+
+    final state = container.read(siteListNotifierProvider);
+    final site = state.value!.singleWhere((s) => s.id == 'site-rich');
+    expect(site.altitude, 434.0);
+  });
+}

--- a/test/features/weather/domain/services/altitude_resolver_test.dart
+++ b/test/features/weather/domain/services/altitude_resolver_test.dart
@@ -48,7 +48,7 @@ void main() {
       );
 
       expect(result.altitudeMeters, 740.0);
-      expect(result.siteWriteBack, isNull);
+      expect(result.siteAltitudeWriteBack, isNull);
       expect(requests.single.queryParameters['latitude'], '46.4');
     });
 
@@ -71,7 +71,7 @@ void main() {
       );
 
       expect(result.altitudeMeters, 300.0);
-      expect(result.siteWriteBack, isNull);
+      expect(result.siteAltitudeWriteBack, isNull);
     });
 
     test('uses site altitude when the dive has no GPS', () async {
@@ -94,9 +94,10 @@ void main() {
       );
 
       expect(result.altitudeMeters, 740.0);
-      expect(result.siteWriteBack, isNotNull);
-      expect(result.siteWriteBack!.altitude, 740.0);
-      expect(result.siteWriteBack!.id, 'site-1');
+      expect(result.siteAltitudeWriteBack, (
+        siteId: 'site-1',
+        altitudeMeters: 740.0,
+      ));
     });
 
     test('returns empty resolution when nothing is available', () async {
@@ -108,7 +109,7 @@ void main() {
       final result = await resolver.resolve();
 
       expect(result.altitudeMeters, isNull);
-      expect(result.siteWriteBack, isNull);
+      expect(result.siteAltitudeWriteBack, isNull);
       expect(requests, isEmpty);
     });
 
@@ -121,7 +122,7 @@ void main() {
       );
 
       expect(result.altitudeMeters, isNull);
-      expect(result.siteWriteBack, isNull);
+      expect(result.siteAltitudeWriteBack, isNull);
     });
 
     test('cache dedupes lookups for nearby coordinates', () async {


### PR DESCRIPTION
## Summary

Part 1 of 2 for #1187. The reporter's real complaint was that site data they entered by hand (how difficult a site is, among others) disappeared and was then missing on both their Windows and Android devices. This is not a sync bug: sync serialises and applies every `dive_sites` column. The wipe happens locally and sync faithfully replicates it.

**Cause.** `DiveRepository` hydrated `dive.site` with 9 of the entity's 24 fields (no difficulty, water type, min depth, city, island, body of water, hazards, access notes, mooring, parking, entry/exit method, shared flag). `AltitudeResolver` then did `site.copyWith(altitude: ...)` on that partial entity and the altitude enricher (on every file or dive computer import) and the dive edit page (altitude autofill, photo GPS write-back) pushed it through `SiteRepository.updateSite`, which writes every column. The row got a fresh HLC, so the diver's other device accepted the wipe as a newer edit.

Values already lost cannot be recovered by the app.

## Changes

- One shared `mapDiveSiteRow` mapper (`lib/features/dive_sites/data/mappers/`) used by both the site repository and the dive repository, so `dive.site` carries every column.
- `AltitudeResolution.siteWriteBack` (a whole entity) becomes `siteAltitudeWriteBack: ({siteId, altitudeMeters})`.
- New column patches `SiteRepository.updateSiteAltitude` / `updateSiteCoordinates` (built on the existing `applyImportedMetadata`, which marks pending and stamps HLC like `updateSite`), with `SiteListNotifier` wrappers; the altitude enricher and both dive edit page write-backs use them. A targeted patch cannot clobber columns it never read.

## Test Plan

- [x] `flutter test` passes (20,095 passed, 19 skipped)
- [x] `flutter analyze` passes
- [x] Manual testing on: not yet exercised on a device

- `dive_altitude_enricher_site_fields_test.dart`: imports a dive at a fully described site with no altitude via a deliberately partial `dive.site`; every field survives and the row is marked pending. Failed before the fix on `difficulty`.
- `dive_repository_site_mapping_test.dart`: `getDiveById` / `getAllDives` hydrate every site column.
- `site_list_notifier_patch_test.dart`: the two patches touch only their columns and refresh the notifier.
- `altitude_resolver_test.dart` updated to the record write-back.