### PR TITLE
Pair Surface GPS with Tide and Cylinders with Weights on wide dive-detail panes

### DIFF
--- a/lib/core/constants/dive_detail_section_pairs.dart
+++ b/lib/core/constants/dive_detail_section_pairs.dart
@@ -1,0 +1,53 @@
+import 'package:submersion/core/constants/dive_detail_sections.dart';
+
+/// Two dive-detail sections whose cards render side by side when the detail
+/// pane is wide enough.
+///
+/// [left] and [right] fix the on-screen arrangement independently of where
+/// each section sits in the diver's configured order, so a saved order that
+/// predates the pair still lays out the intended way.
+class DiveDetailSectionPair {
+  const DiveDetailSectionPair(this.left, this.right);
+
+  /// The section shown in the left column (top card when stacked).
+  final DiveDetailSectionId left;
+
+  /// The section shown in the right column (bottom card when stacked).
+  final DiveDetailSectionId right;
+
+  /// The other half of the pair, or null when [id] is not part of it.
+  DiveDetailSectionId? partnerOf(DiveDetailSectionId id) {
+    if (id == left) return right;
+    if (id == right) return left;
+    return null;
+  }
+}
+
+/// Every dive-detail card pair, in left-then-right order.
+///
+/// A section belongs to at most one pair; [diveDetailSectionPairFor] relies on
+/// that. The default section order in [DiveDetailSectionId] lists each pair's
+/// halves adjacently and in this same order.
+const List<DiveDetailSectionPair> kDiveDetailSectionPairs = [
+  DiveDetailSectionPair(
+    DiveDetailSectionId.details,
+    DiveDetailSectionId.environment,
+  ),
+  DiveDetailSectionPair(
+    DiveDetailSectionId.surfaceGps,
+    DiveDetailSectionId.tide,
+  ),
+  DiveDetailSectionPair(DiveDetailSectionId.tanks, DiveDetailSectionId.weights),
+  DiveDetailSectionPair(
+    DiveDetailSectionId.buddies,
+    DiveDetailSectionId.signatures,
+  ),
+];
+
+/// The pair [id] belongs to, or null when the section never pairs.
+DiveDetailSectionPair? diveDetailSectionPairFor(DiveDetailSectionId id) {
+  for (final pair in kDiveDetailSectionPairs) {
+    if (pair.partnerOf(id) != null) return pair;
+  }
+  return null;
+}

--- a/lib/core/constants/dive_detail_sections.dart
+++ b/lib/core/constants/dive_detail_sections.dart
@@ -6,6 +6,10 @@ import 'package:submersion/l10n/arb/app_localizations.dart';
 ///
 /// Declaration order defines the default display order. The two fixed sections
 /// (Header and Dive Profile Chart) are not included — they always render first.
+///
+/// Sections that pair side by side on a wide pane are declared adjacently, in
+/// left-then-right order (see `kDiveDetailSectionPairs`), so the default order
+/// already reads the way the paired layout renders.
 enum DiveDetailSectionId {
   decoO2,
   safetyReview,
@@ -13,12 +17,12 @@ enum DiveDetailSectionId {
   details,
   environment,
   altitude,
+  surfaceGps,
   tide,
   reefHealth,
-  surfaceGps,
+  tanks,
   weights,
   buoyancy,
-  tanks,
   buddies,
   signatures,
   equipment,
@@ -186,12 +190,12 @@ class DiveDetailSectionConfig {
     DiveDetailSectionConfig(id: DiveDetailSectionId.details, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.environment, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.altitude, visible: true),
+    DiveDetailSectionConfig(id: DiveDetailSectionId.surfaceGps, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.tide, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.reefHealth, visible: true),
-    DiveDetailSectionConfig(id: DiveDetailSectionId.surfaceGps, visible: true),
+    DiveDetailSectionConfig(id: DiveDetailSectionId.tanks, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.weights, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.buoyancy, visible: true),
-    DiveDetailSectionConfig(id: DiveDetailSectionId.tanks, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.buddies, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.signatures, visible: true),
     DiveDetailSectionConfig(id: DiveDetailSectionId.equipment, visible: true),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart' show DateFormat;
 import 'package:latlong2/latlong.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/core/constants/dive_detail_section_pairs.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/equipment/presentation/utils/equipment_type_icon.dart';
@@ -418,28 +419,10 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         return [_buildReefHealthSection(context, ref, dive)];
       },
       DiveDetailSectionId.surfaceGps: () {
-        if (dive.entryLocation == null && dive.exitLocation == null) return [];
+        if (!_hasSurfaceGps(dive)) return [];
         return [
           const SizedBox(height: 24),
-          Consumer(
-            builder: (context, ref, _) {
-              final viewedSourceId = ref.watch(
-                activeDiveSourceProvider(dive.id),
-              );
-              final dataSources = computerReadingsAsync.valueOrNull ?? [];
-              final attribution = FieldAttributionService.computeAttribution(
-                dataSources,
-                viewedSourceId: viewedSourceId,
-                nameOf: (s) => resolveSourceName(s, _sourceNameLabels(context)),
-              );
-              final showBadges =
-                  settings.showDataSourceBadges && attribution.isNotEmpty;
-              return SurfaceGpsSection(
-                dive: dive,
-                sourceName: showBadges ? attribution['gps'] : null,
-              );
-            },
-          ),
+          _surfaceGpsCard(dive, computerReadingsAsync, settings),
         ];
       },
       DiveDetailSectionId.weights: () {
@@ -460,12 +443,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         if (dive.tanks.isEmpty) return [];
         return [
           const SizedBox(height: 24),
-          CylindersCard(
-            dive: dive,
-            units: units,
-            settings: settings,
-            sacUnit: ref.watch(sacUnitProvider),
-          ),
+          _cylindersCard(dive, units, settings),
         ];
       },
       DiveDetailSectionId.buddies: () {
@@ -556,6 +534,48 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     };
   }
 
+  /// Whether the dive has a surface GPS fix to map.
+  bool _hasSurfaceGps(Dive dive) =>
+      dive.entryLocation != null || dive.exitLocation != null;
+
+  /// The Surface GPS card, including its data-source attribution [Consumer].
+  /// Extracted so both the normal section flow and the side-by-side pairing
+  /// (with Tide) render identical content.
+  Widget _surfaceGpsCard(
+    Dive dive,
+    AsyncValue<List<DiveDataSource>> computerReadingsAsync,
+    AppSettings settings,
+  ) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final viewedSourceId = ref.watch(activeDiveSourceProvider(dive.id));
+        final dataSources = computerReadingsAsync.valueOrNull ?? [];
+        final attribution = FieldAttributionService.computeAttribution(
+          dataSources,
+          viewedSourceId: viewedSourceId,
+          nameOf: (s) => resolveSourceName(s, _sourceNameLabels(context)),
+        );
+        final showBadges =
+            settings.showDataSourceBadges && attribution.isNotEmpty;
+        return SurfaceGpsSection(
+          dive: dive,
+          sourceName: showBadges ? attribution['gps'] : null,
+        );
+      },
+    );
+  }
+
+  /// The Cylinders card. Extracted so both the normal section flow and the
+  /// side-by-side pairing (with Weights) render identical content.
+  Widget _cylindersCard(Dive dive, UnitFormatter units, AppSettings settings) {
+    return CylindersCard(
+      dive: dive,
+      units: units,
+      settings: settings,
+      sacUnit: ref.watch(sacUnitProvider),
+    );
+  }
+
   /// The Details card, including its data-source attribution [Consumer].
   /// Extracted so both the normal section flow and the side-by-side pairing
   /// (with Conditions) render identical content.
@@ -609,13 +629,21 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
   }
 
-  /// Builds the ordered configurable-section widgets, pairing two specific
-  /// adjacent card pairs side by side when the pane is wide enough:
-  /// Details + Conditions, and Buddies + Signatures.
+  /// Builds the ordered configurable-section widgets, rendering the fixed card
+  /// pairs in [kDiveDetailSectionPairs] side by side when the pane is wide
+  /// enough: Details + Conditions, Surface GPS + Tide, Cylinders + Weights,
+  /// and Buddies + Signatures.
   ///
-  /// Pairing is fixed-pairs and adjacency-gated: the two must be immediately
-  /// adjacent in the configured (visible) order and the second must have
-  /// content, otherwise each section renders full-width exactly as before.
+  /// A pair forms whenever both halves are visible and both have content to
+  /// show, wherever they sit in the configured order. The row renders at the
+  /// slot of whichever half comes first and anything between them drops below,
+  /// which is what lets a diver whose saved order predates a pair (Water
+  /// Conditions between Tide and Surface GPS, Buoyancy between Weights and
+  /// Cylinders) still get the paired layout. Left/right come from the pair
+  /// definition rather than the configured order, so the arrangement is the
+  /// same either way. When either half has nothing to show, both render
+  /// full-width in their own slots exactly as before.
+  ///
   /// [ResponsiveSectionPair] then decides row-vs-stacked from its own measured
   /// width, so narrow panes stay stacked and unchanged.
   List<Widget> _buildOrderedSections({
@@ -633,54 +661,37 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         if (section.visible && !(dive.isGauge && section.id.hiddenInGaugeMode))
           section.id,
     ];
-
-    // Conditions self-suppresses when empty (cheap, no provider). The
-    // Signatures presence gate needs buddiesForDiveProvider, so it is read
-    // lazily inside the Buddies+Signatures branch below -- only when that pair
-    // is actually adjacent -- to avoid coupling the whole page to buddy
-    // changes when the pair can never form.
-    final hasConditions = _hasEnvironmentData(dive);
+    final visibleIds = visible.toSet();
 
     final children = <Widget>[];
-    for (var i = 0; i < visible.length; i++) {
-      final id = visible[i];
-      final next = i + 1 < visible.length ? visible[i + 1] : null;
+    final consumed = <DiveDetailSectionId>{};
 
-      if (id == DiveDetailSectionId.details &&
-          next == DiveDetailSectionId.environment &&
-          hasConditions) {
-        // Details has no leading spacer today; the pair keeps that.
-        children.add(
-          ResponsiveSectionPair(
-            first: _detailsCard(
-              context,
-              dive,
-              units,
-              computerReadingsAsync,
-              settings,
-            ),
-            second: _buildEnvironmentSection(context, dive, units),
-          ),
+    for (final id in visible) {
+      // The trailing half of a pair already rendered at the leading half's
+      // slot.
+      if (consumed.contains(id)) continue;
+
+      final pair = diveDetailSectionPairFor(id);
+      if (pair != null && visibleIds.contains(pair.partnerOf(id)!)) {
+        final cards = _buildPairCards(
+          pair,
+          context: context,
+          ref: ref,
+          dive: dive,
+          units: units,
+          computerReadingsAsync: computerReadingsAsync,
+          settings: settings,
         );
-        i++;
-        continue;
-      }
-
-      if (id == DiveDetailSectionId.buddies &&
-          next == DiveDetailSectionId.signatures) {
-        // Signatures self-erases unless the dive has buddies or a course.
-        final buddies =
-            ref.watch(buddiesForDiveProvider(dive.id)).valueOrNull ??
-            const <BuddyWithRole>[];
-        if (buddies.isNotEmpty || dive.courseId != null) {
-          children.add(const SizedBox(height: 24)); // Buddies' leading gap.
+        if (cards != null) {
+          // Details is the one section that emits no leading gap of its own
+          // (it butts against the profile chart); the pair keeps that.
+          if (pair.left != DiveDetailSectionId.details) {
+            children.add(const SizedBox(height: 24));
+          }
           children.add(
-            ResponsiveSectionPair(
-              first: _buildBuddiesSection(context, ref, dive),
-              second: _signaturesColumn(context, ref, dive),
-            ),
+            ResponsiveSectionPair(first: cards.$1, second: cards.$2),
           );
-          i++;
+          consumed.addAll([pair.left, pair.right]);
           continue;
         }
       }
@@ -688,6 +699,62 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       children.addAll(builders[id]?.call() ?? const []);
     }
     return children;
+  }
+
+  /// The two bare cards for [pair] in left-then-right order, or null when
+  /// either half has nothing to show -- in which case both sections fall back
+  /// to rendering full-width in their own slots.
+  ///
+  /// The presence gates mirror what each section builder would decide for
+  /// itself: Conditions, Tide and Signatures all self-erase when empty, so
+  /// without these checks a pair could put a blank column beside a half-width
+  /// card.
+  (Widget, Widget)? _buildPairCards(
+    DiveDetailSectionPair pair, {
+    required BuildContext context,
+    required WidgetRef ref,
+    required Dive dive,
+    required UnitFormatter units,
+    required AsyncValue<List<DiveDataSource>> computerReadingsAsync,
+    required AppSettings settings,
+  }) {
+    switch (pair.left) {
+      case DiveDetailSectionId.details:
+        if (!_hasEnvironmentData(dive)) return null;
+        return (
+          _detailsCard(context, dive, units, computerReadingsAsync, settings),
+          _buildEnvironmentSection(context, dive, units),
+        );
+
+      case DiveDetailSectionId.surfaceGps:
+        if (!_hasSurfaceGps(dive)) return null;
+        final tide = _tideCard(context, ref, dive);
+        if (tide == null) return null;
+        return (_surfaceGpsCard(dive, computerReadingsAsync, settings), tide);
+
+      case DiveDetailSectionId.tanks:
+        if (dive.tanks.isEmpty || !_hasWeights(dive)) return null;
+        return (
+          _cylindersCard(dive, units, settings),
+          _buildWeightSection(context, dive, units),
+        );
+
+      case DiveDetailSectionId.buddies:
+        // Signatures self-erases unless the dive has buddies or a course. The
+        // read is deferred to here so the page only couples to buddy changes
+        // when the pair can actually form.
+        final buddies =
+            ref.watch(buddiesForDiveProvider(dive.id)).valueOrNull ??
+            const <BuddyWithRole>[];
+        if (buddies.isEmpty && dive.courseId == null) return null;
+        return (
+          _buildBuddiesSection(context, ref, dive),
+          _signaturesColumn(context, ref, dive),
+        );
+
+      default:
+        return null;
+    }
   }
 
   /// Overflow entry for the pre-dive checklist link (#1066). PR #913 removed
@@ -3670,18 +3737,24 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   /// takes up zero space.  The 24-px top spacer is included only when the
   /// section actually renders content.
   Widget _buildTideSection(BuildContext context, WidgetRef ref, Dive dive) {
+    final card = _tideCard(context, ref, dive);
+    if (card == null) return const SizedBox.shrink();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [const SizedBox(height: 24), card],
+    );
+  }
+
+  /// The tide card without its leading section gap, or null when the dive has
+  /// no tide data to show.
+  ///
+  /// Extracted from [_buildTideSection] so the side-by-side pairing (with
+  /// Surface GPS) can use the same null result both as the presence gate and
+  /// as the bare card to place in the row.
+  Widget? _tideCard(BuildContext context, WidgetRef ref, Dive dive) {
     // Freshwater sites have no tides; hide the section entirely, even
     // when an old stored record exists.
-    if (dive.site?.waterType == WaterType.fresh) {
-      return const SizedBox.shrink();
-    }
-
-    Widget withSpacing(Widget card) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [const SizedBox(height: 24), card],
-      );
-    }
+    if (dive.site?.waterType == WaterType.fresh) return null;
 
     // First try to get stored tide record (lazily self-healed against a
     // fresh computation when the site has coordinates)
@@ -3693,32 +3766,26 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       )),
     );
 
-    return tideRecordAsync.when(
+    return tideRecordAsync.when<Widget?>(
       data: (tideRecord) {
         if (tideRecord != null) {
-          return withSpacing(
-            _buildTideCard(
-              context,
-              tideRecord,
-              entryTime: dive.effectiveEntryTime,
-            ),
+          return _buildTideCard(
+            context,
+            tideRecord,
+            entryTime: dive.effectiveEntryTime,
           );
         }
 
         // No stored record - try to calculate from tide model if we have coordinates
-        if (dive.site?.hasCoordinates != true) {
-          return const SizedBox.shrink();
-        }
+        if (dive.site?.hasCoordinates != true) return null;
 
         final location = dive.site!.location!;
         final entryTime = dive.effectiveEntryTime;
         final calculatorAsync = ref.watch(tideCalculatorProvider(location));
 
-        return calculatorAsync.when(
+        return calculatorAsync.when<Widget?>(
           data: (calculator) {
-            if (calculator == null) {
-              return const SizedBox.shrink(); // No tide data for this location
-            }
+            if (calculator == null) return null; // No tide data here.
 
             final status = calculator.getStatus(entryTime);
             final record = TideRecord.fromStatus(
@@ -3727,21 +3794,19 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               status: status,
             );
 
-            return withSpacing(
-              _buildTideCard(
-                context,
-                record,
-                isCalculated: true,
-                entryTime: entryTime,
-              ),
+            return _buildTideCard(
+              context,
+              record,
+              isCalculated: true,
+              entryTime: entryTime,
             );
           },
-          loading: () => const SizedBox.shrink(),
-          error: (_, _) => const SizedBox.shrink(),
+          loading: () => null,
+          error: (_, _) => null,
         );
       },
-      loading: () => const SizedBox.shrink(),
-      error: (_, _) => const SizedBox.shrink(),
+      loading: () => null,
+      error: (_, _) => null,
     );
   }
 
@@ -3835,9 +3900,14 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               ),
             )
           : null,
+      // The cycle range is secondary to the card itself: in a half-width
+      // column it trims rather than wrapping the header onto three lines.
       trailing: isExpanded && dateTimeLabel.isNotEmpty
           ? Text(
               dateTimeLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: colorScheme.onSurfaceVariant,
               ),

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -683,9 +683,12 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
           settings: settings,
         );
         if (cards != null) {
-          // Details is the one section that emits no leading gap of its own
-          // (it butts against the profile chart); the pair keeps that.
-          if (pair.left != DiveDetailSectionId.details) {
+          // The row takes the leading gap of the slot it lands in, which is
+          // this half's -- not necessarily the pair's left half, since the
+          // diver may have ordered the right half first. Details is the one
+          // section that emits no gap of its own (it butts against the
+          // profile chart).
+          if (id != DiveDetailSectionId.details) {
             children.add(const SizedBox(height: 24));
           }
           children.add(

--- a/lib/features/dive_log/presentation/widgets/collapsible_section.dart
+++ b/lib/features/dive_log/presentation/widgets/collapsible_section.dart
@@ -2,6 +2,21 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
 
+/// Wraps a header's trailing widget so it yields space instead of starving the
+/// title.
+///
+/// Laid out plainly, a trailing widget is inflexible: [Row] gives it its full
+/// natural width first and leaves the title whatever remains, which can be
+/// nothing at all once a card is only half a pane wide (the side-by-side
+/// section pairs on the dive detail page). Making it [Flexible] caps it at
+/// half the free space; the [Align] keeps it flush right whenever it fits
+/// inside that cap, so nothing moves on a full-width card.
+Widget _flexibleTrailing(Widget trailing) {
+  return Flexible(
+    child: Align(alignment: Alignment.centerRight, child: trailing),
+  );
+}
+
 /// A collapsible section widget that wraps content with an expandable header.
 ///
 /// When collapsed, shows only the header bar. When expanded, shows the
@@ -94,7 +109,7 @@ class CollapsibleSection extends StatelessWidget {
                       ),
                     ),
                     if (trailing != null && !isExpanded) ...[
-                      trailing!,
+                      _flexibleTrailing(trailing!),
                       const SizedBox(width: 8),
                     ],
                     AnimatedRotation(
@@ -226,7 +241,7 @@ class CollapsibleCardSection extends StatelessWidget {
                     ],
                     // Always show the trailing widget
                     if (trailing != null) ...[
-                      trailing!,
+                      _flexibleTrailing(trailing!),
                       const SizedBox(width: 8),
                     ],
                     AnimatedRotation(

--- a/test/core/constants/dive_detail_section_pairs_test.dart
+++ b/test/core/constants/dive_detail_section_pairs_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/dive_detail_section_pairs.dart';
+import 'package:submersion/core/constants/dive_detail_sections.dart';
+
+void main() {
+  group('DiveDetailSectionPair', () {
+    test('partnerOf resolves either half and rejects outsiders', () {
+      const pair = DiveDetailSectionPair(
+        DiveDetailSectionId.tanks,
+        DiveDetailSectionId.weights,
+      );
+
+      expect(pair.partnerOf(DiveDetailSectionId.tanks), pair.right);
+      expect(pair.partnerOf(DiveDetailSectionId.weights), pair.left);
+      expect(pair.partnerOf(DiveDetailSectionId.notes), isNull);
+    });
+  });
+
+  group('kDiveDetailSectionPairs', () {
+    test('pairs the four card pairs, left half first', () {
+      expect(kDiveDetailSectionPairs.map((p) => (p.left, p.right)), [
+        (DiveDetailSectionId.details, DiveDetailSectionId.environment),
+        (DiveDetailSectionId.surfaceGps, DiveDetailSectionId.tide),
+        (DiveDetailSectionId.tanks, DiveDetailSectionId.weights),
+        (DiveDetailSectionId.buddies, DiveDetailSectionId.signatures),
+      ]);
+    });
+
+    // diveDetailSectionPairFor returns the first match, so a section in two
+    // pairs would silently lose one of them.
+    test('no section appears in more than one pair', () {
+      final seen = <DiveDetailSectionId>{};
+      for (final pair in kDiveDetailSectionPairs) {
+        expect(seen.add(pair.left), isTrue, reason: '${pair.left} repeats');
+        expect(seen.add(pair.right), isTrue, reason: '${pair.right} repeats');
+      }
+    });
+
+    // Pairing looks ahead, so a gap would still pair -- but the settings list
+    // reads as the page renders only while the halves sit together.
+    test('default order lists each pair adjacently, left half first', () {
+      final order = DiveDetailSectionConfig.defaultSections
+          .map((s) => s.id)
+          .toList();
+
+      for (final pair in kDiveDetailSectionPairs) {
+        expect(
+          order.indexOf(pair.right),
+          order.indexOf(pair.left) + 1,
+          reason: '${pair.left} should be followed by ${pair.right}',
+        );
+      }
+    });
+
+    test('the declaration order matches the default section order', () {
+      expect(
+        DiveDetailSectionConfig.defaultSections.map((s) => s.id),
+        DiveDetailSectionId.values,
+      );
+    });
+  });
+
+  group('diveDetailSectionPairFor', () {
+    test('finds the pair from either half', () {
+      expect(
+        diveDetailSectionPairFor(DiveDetailSectionId.tide)?.left,
+        DiveDetailSectionId.surfaceGps,
+      );
+      expect(
+        diveDetailSectionPairFor(DiveDetailSectionId.surfaceGps)?.right,
+        DiveDetailSectionId.tide,
+      );
+    });
+
+    test('returns null for a section that never pairs', () {
+      expect(diveDetailSectionPairFor(DiveDetailSectionId.buoyancy), isNull);
+      expect(diveDetailSectionPairFor(DiveDetailSectionId.reefHealth), isNull);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_page_paired_sections_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_paired_sections_test.dart
@@ -6,20 +6,26 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/constants/dive_detail_sections.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/tide/entities/tide_extremes.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_data_source.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_weight.dart';
 import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/responsive_section_pair.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/surface_gps_section.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
+import 'package:submersion/features/tides/domain/entities/tide_record.dart';
+import 'package:submersion/features/tides/presentation/providers/tide_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
 typedef Override = riverpod.Override;
@@ -99,6 +105,66 @@ Dive _diveWithConditions(String id) => Dive(
   waterTemp: 20.0,
   currentStrength: CurrentStrength.moderate,
 );
+
+/// A dive with entry/exit fixes so the Surface GPS card renders.
+Dive _diveWithGps(String id) => Dive(
+  id: id,
+  dateTime: DateTime(2026, 3, 15, 10, 0),
+  entryLocation: const GeoPoint(12.34567, 98.76543),
+  exitLocation: const GeoPoint(12.34612, 98.76489),
+);
+
+/// A dive with a cylinder and a weight so both of those cards render.
+Dive _diveWithGasAndWeights(String id) => Dive(
+  id: id,
+  dateTime: DateTime(2026, 3, 15, 10, 0),
+  tanks: const [
+    DiveTank(
+      id: 't1',
+      name: 'AL80',
+      volume: 11.1,
+      workingPressure: 207,
+      startPressure: 200,
+      endPressure: 50,
+    ),
+  ],
+  weights: [
+    DiveWeight(id: 'w1', diveId: id, weightType: WeightType.belt, amountKg: 6),
+  ],
+);
+
+TideRecord _tideRecord(String diveId) => TideRecord(
+  id: 'tide-1',
+  diveId: diveId,
+  heightMeters: 1.6,
+  tideState: TideState.rising,
+  rateOfChange: 0.4,
+  highTideHeight: 2.4,
+  highTideTime: DateTime.utc(2026, 3, 15, 14),
+  lowTideHeight: 0.4,
+  lowTideTime: DateTime.utc(2026, 3, 15, 8),
+  createdAt: DateTime.utc(2026, 3, 15, 12),
+);
+
+/// Overrides the healed tide record for [dive]; [record] null = no tide data.
+Override _tideOverride(Dive dive, TideRecord? record) =>
+    healedTideRecordProvider((
+      diveId: dive.id,
+      location: dive.site?.location,
+      entryTime: dive.effectiveEntryTime,
+    )).overrideWith((ref) async => record);
+
+/// Section config listing [order] as the visible sections, in that order.
+AppSettings _settingsWithOrder(List<DiveDetailSectionId> order) {
+  return AppSettings(
+    diveDetailSections: [
+      for (final id in order) DiveDetailSectionConfig(id: id, visible: true),
+      for (final id in DiveDetailSectionId.values)
+        if (!order.contains(id))
+          DiveDetailSectionConfig(id: id, visible: false),
+    ],
+  );
+}
 
 final _buddy = BuddyWithRole(
   buddy: Buddy(
@@ -206,36 +272,19 @@ void main() {
       expect(find.text('Environment'), findsNothing);
     });
 
-    testWidgets('no pairing when the two are reordered apart', (tester) async {
+    testWidgets('still pairs when another section sits between them', (
+      tester,
+    ) async {
       await tester.binding.setSurfaceSize(const Size(1000, 2000));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
       final dive = _diveWithConditions('reordered');
       // Put another visible section between details and environment.
-      final settings = AppSettings(
-        diveDetailSections: [
-          const DiveDetailSectionConfig(
-            id: DiveDetailSectionId.details,
-            visible: true,
-          ),
-          const DiveDetailSectionConfig(
-            id: DiveDetailSectionId.notes,
-            visible: true,
-          ),
-          const DiveDetailSectionConfig(
-            id: DiveDetailSectionId.environment,
-            visible: true,
-          ),
-          ...DiveDetailSectionId.values
-              .where(
-                (id) =>
-                    id != DiveDetailSectionId.details &&
-                    id != DiveDetailSectionId.notes &&
-                    id != DiveDetailSectionId.environment,
-              )
-              .map((id) => DiveDetailSectionConfig(id: id, visible: false)),
-        ],
-      );
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.details,
+        DiveDetailSectionId.notes,
+        DiveDetailSectionId.environment,
+      ]);
 
       await tester.pumpWidget(
         _buildTestWidget(
@@ -246,10 +295,17 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Adjacency broken => full-width, no pairing (both cards still present).
-      expect(find.byType(ResponsiveSectionPair), findsNothing);
-      expect(find.text('Details'), findsOneWidget);
-      expect(find.text('Environment'), findsOneWidget);
+      // Pairing looks ahead past Notes, so the pair still forms at Details'
+      // slot and Notes drops below it.
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      expect(_pairContaining('Details'), findsOneWidget);
+      expect(_pairContaining('Environment'), findsOneWidget);
+
+      final detailsY = tester.getTopLeft(find.text('Details')).dy;
+      final envY = tester.getTopLeft(find.text('Environment')).dy;
+      final notesY = tester.getTopLeft(find.text('Notes')).dy;
+      expect((detailsY - envY).abs(), lessThan(4));
+      expect(notesY, greaterThan(detailsY));
     });
   });
 
@@ -307,6 +363,315 @@ void main() {
 
       // Signatures self-erases, Buddies renders full-width: no pair.
       expect(find.byType(ResponsiveSectionPair), findsNothing);
+    });
+  });
+
+  group('Surface GPS + Tide pairing', () {
+    testWidgets('pairs side by side on a wide pane', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGps('gps-tide-wide');
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.surfaceGps,
+        DiveDetailSectionId.tide,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: [
+            ..._renderOverrides(dive.id, prefs),
+            _tideOverride(dive, _tideRecord(dive.id)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byType(SurfaceGpsSection),
+          matching: find.byType(ResponsiveSectionPair),
+        ),
+        findsOneWidget,
+      );
+      expect(_pairContaining('Tide'), findsOneWidget);
+
+      // Surface GPS sits to the left of Tide, at the same vertical offset.
+      final gpsPos = tester.getTopLeft(find.text('Surface GPS'));
+      final tidePos = tester.getTopLeft(find.text('Tide'));
+      expect(gpsPos.dx, lessThan(tidePos.dx));
+      expect((gpsPos.dy - tidePos.dy).abs(), lessThan(4));
+    });
+
+    testWidgets('pairs across an intervening Water Conditions section', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGps('gps-tide-gap');
+      // The pre-existing default order, which every upgrading user has saved.
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.tide,
+        DiveDetailSectionId.reefHealth,
+        DiveDetailSectionId.surfaceGps,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: [
+            ..._renderOverrides(dive.id, prefs),
+            _tideOverride(dive, _tideRecord(dive.id)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Surface GPS stays on the left even though Tide comes first in the
+      // saved order.
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      final gpsPos = tester.getTopLeft(find.text('Surface GPS'));
+      final tidePos = tester.getTopLeft(find.text('Tide'));
+      expect(gpsPos.dx, lessThan(tidePos.dx));
+      expect((gpsPos.dy - tidePos.dy).abs(), lessThan(4));
+    });
+
+    testWidgets('stacks on a narrow pane', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(700, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGps('gps-tide-narrow');
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.surfaceGps,
+        DiveDetailSectionId.tide,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: [
+            ..._renderOverrides(dive.id, prefs),
+            _tideOverride(dive, _tideRecord(dive.id)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      final gpsY = tester.getTopLeft(find.text('Surface GPS')).dy;
+      final tideY = tester.getTopLeft(find.text('Tide')).dy;
+      expect(gpsY, lessThan(tideY));
+    });
+
+    testWidgets('no pairing when the dive has no tide data', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGps('gps-no-tide');
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.surfaceGps,
+        DiveDetailSectionId.tide,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: [
+            ..._renderOverrides(dive.id, prefs),
+            _tideOverride(dive, null),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsNothing);
+      expect(find.byType(SurfaceGpsSection), findsOneWidget);
+      expect(find.text('Tide'), findsNothing);
+    });
+
+    testWidgets('no pairing when the dive has no GPS fixes', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = Dive(id: 'no-gps', dateTime: DateTime(2026, 3, 15, 10, 0));
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.surfaceGps,
+        DiveDetailSectionId.tide,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: [
+            ..._renderOverrides(dive.id, prefs),
+            _tideOverride(dive, _tideRecord(dive.id)),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsNothing);
+      expect(find.byType(SurfaceGpsSection), findsNothing);
+      expect(find.text('Tide'), findsOneWidget);
+    });
+  });
+
+  group('Cylinders + Weights pairing', () {
+    testWidgets('pairs side by side on a wide pane', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGasAndWeights('gas-weights-wide');
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.tanks,
+        DiveDetailSectionId.weights,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: _renderOverrides(dive.id, prefs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      expect(_pairContaining('Cylinders'), findsOneWidget);
+      expect(_pairContaining('Weight'), findsOneWidget);
+
+      final cylPos = tester.getTopLeft(find.text('Cylinders'));
+      final weightPos = tester.getTopLeft(find.text('Weight'));
+      expect(cylPos.dx, lessThan(weightPos.dx));
+      expect((cylPos.dy - weightPos.dy).abs(), lessThan(4));
+    });
+
+    testWidgets('pairs across an intervening Buoyancy section', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGasAndWeights('gas-weights-gap');
+      // The pre-existing default order, which every upgrading user has saved.
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.weights,
+        DiveDetailSectionId.buoyancy,
+        DiveDetailSectionId.tanks,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: _renderOverrides(dive.id, prefs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Cylinders stays on the left even though Weights comes first in the
+      // saved order.
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      final cylPos = tester.getTopLeft(find.text('Cylinders'));
+      final weightPos = tester.getTopLeft(find.text('Weight'));
+      expect(cylPos.dx, lessThan(weightPos.dx));
+      expect((cylPos.dy - weightPos.dy).abs(), lessThan(4));
+    });
+
+    testWidgets('stacks on a narrow pane', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(700, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGasAndWeights('gas-weights-narrow');
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.tanks,
+        DiveDetailSectionId.weights,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: _renderOverrides(dive.id, prefs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+      final cylY = tester.getTopLeft(find.text('Cylinders')).dy;
+      final weightY = tester.getTopLeft(find.text('Weight')).dy;
+      expect(cylY, lessThan(weightY));
+    });
+
+    testWidgets('no pairing when the dive carries no weights', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = Dive(
+        id: 'gas-only',
+        dateTime: DateTime(2026, 3, 15, 10, 0),
+        tanks: const [
+          DiveTank(
+            id: 't1',
+            name: 'AL80',
+            volume: 11.1,
+            workingPressure: 207,
+            startPressure: 200,
+            endPressure: 50,
+          ),
+        ],
+      );
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.tanks,
+        DiveDetailSectionId.weights,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: _renderOverrides(dive.id, prefs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsNothing);
+      expect(find.text('Cylinders'), findsOneWidget);
+      expect(find.text('Weight'), findsNothing);
+    });
+
+    testWidgets('no pairing on a gauge dive, where Cylinders is hidden', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 3000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final dive = _diveWithGasAndWeights(
+        'gauge-dive',
+      ).copyWith(diveMode: DiveMode.gauge);
+      final settings = _settingsWithOrder([
+        DiveDetailSectionId.tanks,
+        DiveDetailSectionId.weights,
+      ]);
+
+      await tester.pumpWidget(
+        _buildTestWidget(
+          dive: dive,
+          settings: settings,
+          extraOverrides: _renderOverrides(dive.id, prefs),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ResponsiveSectionPair), findsNothing);
+      expect(find.text('Cylinders'), findsNothing);
+      expect(find.text('Weight'), findsOneWidget);
     });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_detail_page_paired_sections_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_page_paired_sections_test.dart
@@ -307,6 +307,52 @@ void main() {
       expect((detailsY - envY).abs(), lessThan(4));
       expect(notesY, greaterThan(detailsY));
     });
+
+    testWidgets('takes the leading gap of the slot it occupies', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 2000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      // Details is the one section that emits no leading gap of its own;
+      // Environment emits the usual 24. A pair renders at the slot of
+      // whichever half the diver ordered first, so that is the gap it must
+      // inherit -- not whichever half the pair table calls the left one.
+      final dive = _diveWithConditions('gap-slot');
+
+      Future<double> pairTop(List<DiveDetailSectionId> order) async {
+        // Tear the tree down first: pumping a second ProviderScope over the
+        // live one keeps the existing SettingsNotifier, so the new section
+        // order would never reach the page.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpWidget(
+          _buildTestWidget(
+            dive: dive,
+            settings: _settingsWithOrder(order),
+            extraOverrides: _renderOverrides(dive.id, prefs),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(ResponsiveSectionPair), findsOneWidget);
+        // Details stays on the left either way.
+        expect(
+          tester.getTopLeft(find.text('Details')).dx,
+          lessThan(tester.getTopLeft(find.text('Environment')).dx),
+        );
+        return tester.getTopLeft(find.byType(ResponsiveSectionPair)).dy;
+      }
+
+      final detailsFirst = await pairTop([
+        DiveDetailSectionId.details,
+        DiveDetailSectionId.environment,
+      ]);
+      final environmentFirst = await pairTop([
+        DiveDetailSectionId.environment,
+        DiveDetailSectionId.details,
+      ]);
+
+      expect(environmentFirst - detailsFirst, 24);
+    });
   });
 
   group('Buddies + Signatures pairing', () {


### PR DESCRIPTION
Details and Environment already sit side by side on a wide dive-detail pane.
This does the same for two more pairs that read as one thought: the surface
fixes next to the tide they were taken on, and the cylinders next to the lead
that offsets them.

```
Details        | Environment
Altitude
Surface GPS    | Tide
Water Conditions
Cylinders      | Weights
Buoyancy
Buddies        | Signatures
```

Below the 700px threshold everything stacks exactly as it does today.

## Why adjacency had to go

The shipped rule required a pair's two halves to be **immediately adjacent** in
the diver's configured section order. Neither new pair was: Water Conditions
sat between Tide and Surface GPS, and Buoyancy between Weights and Cylinders.

Buoyancy is the harder case. It renders exactly when the dive has cylinders,
which is the condition for a Cylinders card to exist at all. Under adjacency,
Cylinders + Weights was not merely unlucky, it was unreachable.

So pairing now **looks ahead**. A pair forms whenever both halves are visible
and both have content, wherever they sit; the row renders at the slot of
whichever half comes first, and the section between them drops below. Left and
right come from the pair table rather than the configured order, so a diver
whose saved order predates a pair still gets Surface GPS and Cylinders on the
left instead of a mirrored layout. When either half has nothing to show, both
render full-width in their own slots exactly as before.

**This changes behavior for the two pre-existing pairs too**, and that is
deliberate. Two pairing rules in one loop is a trap for whoever adds the fifth
pair. The case adjacency protected -- a diver who deliberately parked a section
between Details and Environment to break the pair -- is also indistinguishable
from a diver who simply never touched the old default order. One test that
asserted the old adjacency behavior now asserts the new behavior.

## A layout bug this surfaced

Placing a card in a half-width column is a different layout regime, and it
immediately found a latent bug in the shared collapsible header.

Both `CollapsibleSection` and `CollapsibleCardSection` laid out `trailing`
inflexibly, so `RenderFlex` gave it its full natural width before the
`Expanded` title got anything. On a full-width card there was always room to
spare. Halve the card and there is not: the Tide header's cycle range measured
384px against a 436px row, the title collapsed to **zero width** and rendered
"Tide" as a column of single letters, and the row still overflowed by 8.4px.

The fix wraps the trailing widget in `Flexible` so it can only claim half the
free space, and in an `Align` so it stays flush right whenever it fits inside
that cap. A full-width card lays out exactly as before; only a card too narrow
for its own header behaves differently, and there the title survives. The tide
cycle label also ellipsizes now rather than wrapping the header onto three
lines.

Worth knowing for any card added to a pair later: the same class of bug is
waiting in any header that hands a wide inflexible widget to a Row.

## Structure

The four pairs move into a `const` table
(`lib/core/constants/dive_detail_section_pairs.dart`) so a fifth is a one-line
addition rather than another branch in a 5,477-line page. `_buildPairCards`
holds the per-pair presence gates, which mirror what each section builder
already decides for itself -- without them a pair could put a blank column
beside a half-width card.

Splitting `_tideCard` out of `_buildTideSection` gives the pair a bare card to
place and a `null` to gate on from one code path, so the section and the pair
cannot disagree about whether there is tide data.

The default section order is reshuffled to list each pair's halves together.
Existing saved orders are untouched and pair anyway, which is the point of the
lookahead.

## Testing

- `dive_detail_page_paired_sections_test.dart`: 16 tests, 10 new. Wide and
  narrow panes for both new pairs, the intervening-section case for each (using
  the exact pre-existing default order every upgrading diver has saved), and
  every empty-half fallback including a gauge dive, where Cylinders is hidden
  and Weights must render alone.
- `dive_detail_section_pairs_test.dart`: new. Pair table shape, the
  no-section-in-two-pairs invariant that `diveDetailSectionPairFor` depends on,
  and that the default order keeps each pair adjacent.
- Full suite green before the rebase (20,419 passed / 19 skipped / 0 failed);
  `test/features/dive_log`, `test/features/tides` and `test/core/constants`
  re-run green on the rebased base (3,358 passed).
- `flutter analyze` and `dart format .` clean.
