### PR TITLE
fix(sync): keep base publishes off a phantom Temp subdirectory on Windows (#1304)

### DIFF
--- a/lib/core/services/sync/changeset_log/changeset_writer.dart
+++ b/lib/core/services/sync/changeset_log/changeset_writer.dart
@@ -506,8 +506,7 @@ class ChangesetWriter {
     String? uploadNonce,
   ) async {
     final dir = await _resumable.directory;
-    final target =
-        '${dir.path}/${base.path.split(Platform.pathSeparator).last}';
+    final target = basePublishTargetPath(dir.path, base.path);
     final source = File(base.path);
     try {
       await source.rename(target);

--- a/lib/core/services/sync/changeset_log/resumable_base_publish.dart
+++ b/lib/core/services/sync/changeset_log/resumable_base_publish.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart' show FlutterError;
 import 'package:flutter/services.dart' show MissingPluginException;
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 /// A full base export that has been written to disk but not yet fully uploaded.
@@ -298,7 +299,29 @@ Future<Directory> resolveBasePublishDir() async {
     if (!e.toString().contains('Binding has not yet been initialized')) rethrow;
     base = Directory.systemTemp;
   }
-  final dir = Directory('${base.path}/sync_base_publish');
+  final dir = Directory(p.join(base.path, 'sync_base_publish'));
   await dir.create(recursive: true);
   return dir;
+}
+
+/// Where an export at [sourcePath] is moved to inside the publish directory.
+///
+/// Takes the name with [p.Context.basename] rather than splitting on
+/// [Platform.pathSeparator]. Sync assembles its paths by interpolating a
+/// literal `/`, so on Windows an export path mixes separators
+/// (`C:\Users\...\Local\Temp/ssv1_base_x.json`) and a backslash split kept the
+/// `Temp/` in front of the name. That moved the export into a subdirectory of
+/// the publish directory which nothing ever creates, so every base publish on
+/// Windows failed with `PathNotFoundException` (#1304). `basename` treats both
+/// separators as separators under the Windows style, so either shape resolves.
+///
+/// [context] exists so the Windows style can be pinned in tests running on a
+/// POSIX host; production always wants the platform's own.
+String basePublishTargetPath(
+  String publishDirPath,
+  String sourcePath, {
+  p.Context? context,
+}) {
+  final ctx = context ?? p.context;
+  return ctx.join(publishDirPath, ctx.basename(sourcePath));
 }

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
@@ -982,8 +983,13 @@ class SyncDataSerializer {
     Future<Directory> Function()? tempDir,
   }) async {
     final dir = await (tempDir?.call() ?? resolveSyncTempDir());
-    final path =
-        '${dir.path}/ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json';
+    // p.join, not a literal '/': on Windows the temp dir is backslashed, and a
+    // path mixing both separators is what broke the move into the publish
+    // directory in #1304.
+    final path = p.join(
+      dir.path,
+      'ssv1_base_${deviceId}_${seq ?? 0}.${_baseTempUuid.v4()}.json',
+    );
     final raf = await File(path).open(mode: FileMode.write);
     final digestSink = _Sha256DigestSink();
     final dataHash = sha256.startChunkedConversion(digestSink);

--- a/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
+++ b/test/core/services/sync/changeset_log/resumable_base_publish_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -249,6 +250,63 @@ void main() {
 
       expect(await File(mine).exists(), isFalse);
       expect(await File(theirs).exists(), isTrue);
+    });
+  });
+
+  /// Issue #1304: every base publish on Windows died with
+  /// `PathNotFoundException` because the export's basename was taken by
+  /// splitting on `Platform.pathSeparator`. Export paths are assembled by
+  /// interpolation, so on Windows they mix separators and the backslash split
+  /// left a leading `Temp/` on the name -- moving the export into a
+  /// subdirectory of the publish dir that nothing ever creates.
+  ///
+  /// The host running these tests is POSIX, so the Windows style is pinned
+  /// explicitly rather than inherited from the platform.
+  group('basePublishTargetPath', () {
+    final windows = p.Context(style: p.Style.windows);
+    const name =
+        'ssv1_base_11d9442e-c184-4e1f-8fd1-8f6dc8ff8f05_1.'
+        '7dd38a42-104f-495a-937d-48ced42d37bd.json';
+
+    const publishDirPath =
+        'C:\\Users\\chaeh\\AppData\\Roaming\\Eric Griffin\\submersion'
+        '\\sync_base_publish';
+
+    test('lands a mixed-separator Windows export in the publish dir', () {
+      // Exactly the shapes from the #1304 report: the temp dir carries
+      // backslashes, the filename was appended with a literal '/'.
+      final target = basePublishTargetPath(
+        publishDirPath,
+        'C:\\Users\\chaeh\\AppData\\Local\\Temp/$name',
+        context: windows,
+      );
+
+      expect(windows.basename(target), name);
+      expect(
+        windows.dirname(target),
+        publishDirPath,
+        reason: 'a "Temp" segment here is a directory that never gets created',
+      );
+    });
+
+    test('lands a pure-backslash Windows export in the publish dir', () {
+      final target = basePublishTargetPath(
+        publishDirPath,
+        'C:\\Users\\chaeh\\AppData\\Local\\Temp\\$name',
+        context: windows,
+      );
+
+      expect(target, '$publishDirPath\\$name');
+    });
+
+    test('leaves POSIX paths flat in the publish dir', () {
+      final target = basePublishTargetPath(
+        '/var/support/sync_base_publish',
+        '/var/folders/t7/T/$name',
+        context: p.Context(style: p.Style.posix),
+      );
+
+      expect(target, '/var/support/sync_base_publish/$name');
     });
   });
 


### PR DESCRIPTION
Fixes #1304.

Moving the sync backend from S3 to Google Drive forces a full base publish. On Windows every attempt failed:

```
PathNotFoundException: Cannot copy file to
'C:\Users\chaeh\AppData\Roaming\Eric Griffin\submersion/sync_base_publish/Temp/ssv1_base_<dev>_1.<uuid>.json',
path = 'C:\Users\chaeh\AppData\Local\Temp\ssv1_base_<dev>_1.<uuid>.json'
(OS Error: Das System kann den angegebenen Pfad nicht finden, errno = 3)
```

Note the `Temp/` segment in the destination. That is the whole bug.

## Root cause

Two halves, and neither one is visible on a POSIX host:

1. Sync assembles paths by interpolating a **literal `/`** (`'${dir.path}/ssv1_base_...'` in `SyncDataSerializer.exportBaseToTempFile`, `'${base.path}/sync_base_publish'` in `resolveBasePublishDir`). On Windows the temp dir is backslashed, so the export path **mixes separators**: `C:\Users\x\AppData\Local\Temp/ssv1_base_<dev>_1.<uuid>.json`.

2. `ChangesetWriter._recordResumable` took the filename with `base.path.split(Platform.pathSeparator).last`. On Windows that splits on `\` only, so the last segment was `Temp/ssv1_base_....json` rather than the bare name. The move target became `<publishDir>/Temp/<name>` — a subdirectory nothing ever creates. `rename` failed, and the `copy` fallback threw `PathNotFoundException` (errno 3 is `ERROR_PATH_NOT_FOUND`, i.e. a missing directory component) uncaught, failing the publish.

Reconstructing both strings from those two operations reproduces the reported source and destination **character for character**.

The backend switch is what made this reproducible for the reporter, but it was not specific to it: any full base publish on Windows hit this.

## Why CI never caught it

On macOS and Linux `Platform.pathSeparator` is `/`, so the malformed mixed-separator path splits correctly by luck. The four existing `ChangesetWriter resume` integration tests drive this exact code and pass either way. No `dart:io` test on a POSIX host can observe this class of bug.

## The fix

- Extracted `basePublishTargetPath(publishDirPath, sourcePath, {p.Context? context})` in `resumable_base_publish.dart`, built on `p.basename` + `p.join`. Under the Windows style, `basename` treats **both** separators as separators, so either path shape resolves correctly.
- `ChangesetWriter._recordResumable` now calls it instead of hand-rolling the split.
- Stopped the mixed shape at both origins: `p.join` in `exportBaseToTempFile` and in `resolveBasePublishDir`.

The `context` parameter is the reason the helper exists as a separate seam at all: it lets the regression tests pin `p.Style.windows` from a POSIX host. Production always uses the platform's own context.

## Tests

Three cases in `resumable_base_publish_test.dart` pinned to `p.Context(style: p.Style.windows)`: the mixed-separator shape from the report, a pure-backslash shape, and a POSIX shape to confirm nothing changed there.

These were verified to actually catch the defect: the helper was first implemented with the *old* split logic, and the mixed-separator test failed with a `dirname` of `...\sync_base_publish\Temp` — exactly the segment from the bug report — before the real fix was applied.

## Scope check

Swept for the same defect class elsewhere. Not affected:

- `split('/').last` in the S3 provider and the S3/Dropbox `Content-Range` parsers operate on protocol strings, not filesystem paths.
- `scanFolderForImportableFiles` splits paths that came straight from `Directory.list`, which is separator-consistent.
- `deleteLeftoverBaseTempFiles` matches on `entity.uri.pathSegments.last`, which normalizes either shape.

## Migration

None needed. The copy threw before creating anything at the target, and the orphaned export is left in the OS temp dir, which `deleteLeftoverBaseTempFiles` already sweeps on repair.

## Verification

- `dart format .` — 0 files changed
- `flutter analyze` — no issues
- `flutter test test/core/services/sync` — 701 passed
- `flutter test` (full suite) — 20,282 passed, 19 skipped
