### PR TITLE
feat(safety): add bulk dismiss for safety review findings

### DIFF
--- a/lib/features/dive_log/data/repositories/safety_findings_repository.dart
+++ b/lib/features/dive_log/data/repositories/safety_findings_repository.dart
@@ -150,6 +150,91 @@ class SafetyFindingsRepository {
     SyncEventBus.notifyLocalChange();
   }
 
+  /// Chunk size for the `dive_id IN (...)` clause of a bulk dismiss. SQLite
+  /// caps the number of bound variables per statement, and one transaction
+  /// spanning a whole logbook would hold the write lock for the entire run.
+  static const int dismissChunkSize = 200;
+
+  /// Dismisses or restores every finding on [diveIds] whose rule is in
+  /// [enabledRuleIds], returning how many findings actually changed.
+  ///
+  /// [enabledRuleIds] carries the rules the user has switched on, so a rule
+  /// hidden in settings is never silently dismissed. It also excludes rows
+  /// whose rule_id this build does not recognise (a newer app or sync payload):
+  /// dismissing an observation we cannot render would hide it for good.
+  ///
+  /// Only rows whose dismissed state really flips are touched. An
+  /// unconditional UPDATE would mark every listed dive pending, and the
+  /// incremental exporter gates on `dives.hlc`, so a no-op tap would push the
+  /// whole logbook.
+  Future<int> setDismissedForDives({
+    required List<String> diveIds,
+    required bool dismissed,
+    required Set<String> enabledRuleIds,
+    required DateTime now,
+    int chunkSize = dismissChunkSize,
+  }) async {
+    if (diveIds.isEmpty || enabledRuleIds.isEmpty) return 0;
+    final nowMs = now.millisecondsSinceEpoch;
+    final ruleIds = enabledRuleIds.toList();
+    var changed = 0;
+
+    try {
+      for (var start = 0; start < diveIds.length; start += chunkSize) {
+        final end = start + chunkSize;
+        final chunk = diveIds.sublist(
+          start,
+          end < diveIds.length ? end : diveIds.length,
+        );
+        Expression<bool> pending($DiveSafetyFindingsTable t) =>
+            t.diveId.isIn(chunk) &
+            t.ruleId.isIn(ruleIds) &
+            (dismissed ? t.dismissedAt.isNull() : t.dismissedAt.isNotNull());
+
+        await _db.transaction(() async {
+          // Read the affected ids first: the UPDATE below cannot report which
+          // rows it touched, and each one needs its own markRecordPending.
+          final rows = await (_db.select(
+            _db.diveSafetyFindings,
+          )..where(pending)).get();
+          if (rows.isEmpty) return;
+
+          await (_db.update(_db.diveSafetyFindings)..where(pending)).write(
+            DiveSafetyFindingsCompanion(
+              dismissedAt: Value(dismissed ? nowMs : null),
+            ),
+          );
+          for (final row in rows) {
+            await _syncRepository.markRecordPending(
+              entityType: 'diveSafetyFindings',
+              recordId: row.id,
+              localUpdatedAt: nowMs,
+            );
+          }
+          // Same parent-HLC rule as setDismissed: findings carry no HLC
+          // of their own, so the incremental exporter only picks them up
+          // for dives whose HLC advanced. Bump only the dives that
+          // actually changed.
+          for (final diveId in {for (final row in rows) row.diveId}) {
+            await _syncRepository.markRecordPending(
+              entityType: 'dives',
+              recordId: diveId,
+              localUpdatedAt: nowMs,
+            );
+          }
+          changed += rows.length;
+        });
+      }
+    } finally {
+      // Each chunk is its own transaction, so a failure partway through
+      // leaves the earlier ones committed and marked pending. Announce them
+      // anyway or those records sit unsynced until an unrelated write happens
+      // to kick the sync layer.
+      if (changed > 0) SyncEventBus.notifyLocalChange();
+    }
+    return changed;
+  }
+
   /// Invalidation hook for profile writes: drops the review so the next view
   /// recomputes against the new profile. Static so both dive repositories
   /// can call it without holding a SafetyFindingsRepository.

--- a/lib/features/dive_log/presentation/providers/safety_review_providers.dart
+++ b/lib/features/dive_log/presentation/providers/safety_review_providers.dart
@@ -92,3 +92,43 @@ Future<void> setSafetyFindingDismissed(
       );
   ref.invalidate(safetyReviewProvider(diveId));
 }
+
+/// The safety rule ids the diver currently has switched on, as stored
+/// dbValues.
+///
+/// Bulk dismiss/restore is scoped to this set so a rule hidden in settings is
+/// never acted on behind the user's back, and so a finding written by a newer
+/// build (an unrecognised rule_id, which [SafetyFindingsRepository.getReview]
+/// already drops) is never dismissed sight unseen.
+Set<String> enabledSafetyRuleIds(AppSettings settings) => {
+  for (final rule in SafetyRuleId.values)
+    if (!settings.safetyReviewDisabledRules.contains(rule.dbValue))
+      rule.dbValue,
+};
+
+/// Dismisses or restores every finding on [diveId] whose rule is enabled,
+/// returning how many changed.
+///
+/// The bulk sibling of [setSafetyFindingDismissed], with the same UI
+/// housekeeping: a dismissed finding can no longer be the chart selection.
+Future<int> setAllSafetyFindingsDismissed(
+  WidgetRef ref, {
+  required String diveId,
+  required bool dismissed,
+}) async {
+  final changed = await ref
+      .read(safetyFindingsRepositoryProvider)
+      .setDismissedForDives(
+        diveIds: [diveId],
+        dismissed: dismissed,
+        enabledRuleIds: enabledSafetyRuleIds(ref.read(settingsProvider)),
+        now: DateTime.now(),
+      );
+  // Clear the selection only once the write lands. Clearing first would drop
+  // the user's chart highlight as the sole visible effect of a failed write.
+  if (dismissed) {
+    ref.read(selectedSafetyFindingProvider(diveId).notifier).state = null;
+  }
+  ref.invalidate(safetyReviewProvider(diveId));
+  return changed;
+}

--- a/lib/features/dive_log/presentation/widgets/safety_review_section.dart
+++ b/lib/features/dive_log/presentation/widgets/safety_review_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:submersion/core/utils/log_failure.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
@@ -13,7 +14,8 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// Dive detail section listing the post-dive safety review findings.
 ///
 /// Tone rules (safety-features spec): neutral wording and iconography, no
-/// alarm red, per-finding dismiss. Collapses to nothing when the review is
+/// alarm red, per-finding dismiss plus a footer action that dismisses (or
+/// restores) the whole dive at once. Collapses to nothing when the review is
 /// disabled, absent, or has no findings to show.
 class SafetyReviewSection extends ConsumerStatefulWidget {
   final String diveId;
@@ -79,31 +81,53 @@ class _SafetyReviewSectionState extends ConsumerState<SafetyReviewSection> {
                 onDismissChanged: (dismissed) =>
                     _setDismissed(finding, dismissed),
               ),
-            if (dismissed.isNotEmpty) ...[
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: TextButton(
-                  onPressed: () =>
-                      setState(() => _showDismissed = !_showDismissed),
-                  child: Text(
-                    l10n.safetyReview_showDismissed(dismissed.length),
-                  ),
-                ),
-              ),
-              if (_showDismissed)
-                for (final finding in dismissed)
-                  Opacity(
-                    opacity: 0.6,
-                    child: _FindingTile(
-                      finding: finding,
-                      units: units,
-                      selected: selectedFinding?.id == finding.id,
-                      onTap: _tapHandlerFor(finding),
-                      onDismissChanged: (dismissed) =>
-                          _setDismissed(finding, dismissed),
+            // Footer: the dismissed-findings toggle on the left, the bulk
+            // action on the right. The bulk action flips to "restore all"
+            // once nothing active is left, so the row never offers a no-op.
+            //
+            // OverflowBar, not Row: after a "dismiss all" both controls are on
+            // screen at once, and in the longer locales that pair does not fit
+            // a narrow phone. OverflowBar stacks them instead of overflowing.
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: OverflowBar(
+                alignment: dismissed.isEmpty
+                    ? MainAxisAlignment.end
+                    : MainAxisAlignment.spaceBetween,
+                overflowAlignment: OverflowBarAlignment.end,
+                children: [
+                  if (dismissed.isNotEmpty)
+                    TextButton(
+                      onPressed: () =>
+                          setState(() => _showDismissed = !_showDismissed),
+                      child: Text(
+                        l10n.safetyReview_showDismissed(dismissed.length),
+                      ),
+                    ),
+                  TextButton(
+                    onPressed: () => _onBulkPressed(active.isNotEmpty),
+                    child: Text(
+                      active.isNotEmpty
+                          ? l10n.safetyReview_dismissAll
+                          : l10n.safetyReview_restoreAll,
                     ),
                   ),
-            ],
+                ],
+              ),
+            ),
+            if (dismissed.isNotEmpty && _showDismissed)
+              for (final finding in dismissed)
+                Opacity(
+                  opacity: 0.6,
+                  child: _FindingTile(
+                    finding: finding,
+                    units: units,
+                    selected: selectedFinding?.id == finding.id,
+                    onTap: _tapHandlerFor(finding),
+                    onDismissChanged: (dismissed) =>
+                        _setDismissed(finding, dismissed),
+                  ),
+                ),
             const SizedBox(height: 8),
           ],
         ),
@@ -141,6 +165,25 @@ class _SafetyReviewSectionState extends ConsumerState<SafetyReviewSection> {
       ref,
       finding: finding,
       dismissed: dismissed,
+    );
+  }
+
+  /// Dismisses every active finding on the dive, or restores every dismissed
+  /// one when nothing is active. Scoped to the enabled rules, so findings the
+  /// diver has hidden in settings are left as they are.
+  ///
+  /// The button callback cannot await, so a failed write would otherwise reach
+  /// the zone handler with no clue where it came from; logFailure attributes
+  /// it. The list simply does not change, which is the user-visible signal.
+  void _onBulkPressed(bool dismissed) {
+    logFailure(
+      setAllSafetyFindingsDismissed(
+        ref,
+        diveId: widget.diveId,
+        dismissed: dismissed,
+      ),
+      _SafetyReviewSectionState,
+      dismissed ? 'dismiss all safety findings' : 'restore all safety findings',
     );
   }
 }

--- a/lib/features/settings/presentation/pages/safety_settings_page.dart
+++ b/lib/features/settings/presentation/pages/safety_settings_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_sweep.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
@@ -19,9 +22,22 @@ class SafetySettingsPage extends ConsumerStatefulWidget {
 }
 
 class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
+  static final _log = LoggerService.forClass(_SafetySettingsPageState);
+
+  /// Dives per bulk-dismiss write. The repository chunks its own SQL; this is
+  /// purely how often the progress bar advances on a large logbook.
+  static const int _dismissChunk = 50;
+
   bool _analyzing = false;
   int _analyzeDone = 0;
   int _analyzeTotal = 0;
+  bool _dismissing = false;
+  int _dismissDone = 0;
+  int _dismissTotal = 0;
+
+  /// Both long-running actions write over the whole logbook, so each locks the
+  /// page while it runs rather than interleaving with the other.
+  bool get _busy => _analyzing || _dismissing;
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +56,7 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
             value: enabled,
             // Locked during a backfill sweep: toggling off mid-run would leave
             // the progress UI counting to a misleading "Analysis complete".
-            onChanged: _analyzing
+            onChanged: _busy
                 ? null
                 : (value) => notifier.setSafetyReviewEnabled(value),
           ),
@@ -60,7 +76,7 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
               value: !settings.safetyReviewDisabledRules.contains(rule.dbValue),
               // Same gating as the master toggle: keep the active rule set
               // fixed while a sweep is computing over it.
-              onChanged: enabled && !_analyzing
+              onChanged: enabled && !_busy
                   ? (value) => notifier.setSafetyRuleEnabled(rule, value)
                   : null,
             ),
@@ -125,8 +141,33 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
                     ],
                   )
                 : Text(l10n.safetySettings_analyzeAll_subtitle),
-            enabled: enabled && !_analyzing,
-            onTap: enabled && !_analyzing ? _analyzeAllDives : null,
+            enabled: enabled && !_busy,
+            onTap: enabled && !_busy ? _analyzeAllDives : null,
+          ),
+          ListTile(
+            leading: const Icon(Icons.done_all),
+            title: Text(l10n.safetySettings_dismissAll),
+            subtitle: _dismissing
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l10n.safetySettings_dismissAll_progress(
+                          _dismissDone,
+                          _dismissTotal,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      LinearProgressIndicator(
+                        value: _dismissTotal == 0
+                            ? null
+                            : _dismissDone / _dismissTotal,
+                      ),
+                    ],
+                  )
+                : Text(l10n.safetySettings_dismissAll_subtitle),
+            enabled: enabled && !_busy,
+            onTap: enabled && !_busy ? _dismissAllFindings : null,
           ),
         ],
       ),
@@ -144,6 +185,110 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
     };
   }
 
+  /// Marks every observation in the active diver's logbook as reviewed.
+  ///
+  /// Destructive enough to confirm first: it clears the findings badge on
+  /// every dive at once. Restoring is per-dive, from that dive's safety review
+  /// section, so the dialog says so.
+  Future<void> _dismissAllFindings() async {
+    final l10n = context.l10n;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.safetySettings_dismissAll_confirmTitle),
+        content: Text(l10n.safetySettings_dismissAll_confirmBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l10n.safetySettings_dismissAll_cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(l10n.safetySettings_dismissAll_confirm),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    // Scoped to the active diver, matching "Analyze all dives", and to the
+    // rules that diver has switched on so a hidden rule is never dismissed
+    // out from under them.
+    final diverId = ref.read(currentDiverIdProvider);
+    final enabledRuleIds = enabledSafetyRuleIds(ref.read(settingsProvider));
+    setState(() {
+      _dismissing = true;
+      _dismissDone = 0;
+      _dismissTotal = 0;
+    });
+
+    var changed = 0;
+    var failedDives = 0;
+    var listFailed = false;
+    try {
+      final diveIds = await ref
+          .read(diveRepositoryProvider)
+          .getOrderedDiveIds(diverId: diverId);
+      if (!mounted) return;
+      setState(() => _dismissTotal = diveIds.length);
+
+      final repo = ref.read(safetyFindingsRepositoryProvider);
+      final now = DateTime.now();
+      for (var start = 0; start < diveIds.length; start += _dismissChunk) {
+        final end = start + _dismissChunk;
+        final stop = end < diveIds.length ? end : diveIds.length;
+        final chunk = diveIds.sublist(start, stop);
+        try {
+          changed += await repo.setDismissedForDives(
+            diveIds: chunk,
+            dismissed: true,
+            enabledRuleIds: enabledRuleIds,
+            now: now,
+          );
+        } catch (error, stackTrace) {
+          // One unwritable chunk must not strand the rest of the logbook.
+          // Its dives stay undismissed and are counted for the summary.
+          failedDives += chunk.length;
+          _log.error(
+            'Failed to dismiss findings for ${chunk.length} dives',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
+        // Leaving the page ends the run. Unlike the analyze sweep this is NOT
+        // lossless: dismissal is user intent that nothing recreates, so the
+        // dives already written stay dismissed and the rest stay as they were.
+        if (!mounted) return;
+        setState(() => _dismissDone = stop);
+      }
+    } catch (error, stackTrace) {
+      // The dive list itself failed, so no chunk ever ran and nothing was
+      // written. That is retry-safe, unlike a partial run, so say so.
+      listFailed = true;
+      _log.error(
+        'Failed to list dives for bulk dismiss',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      if (mounted) setState(() => _dismissing = false);
+    }
+
+    if (!mounted) return;
+    // Per-dive safetyReviewProvider instances refresh on their own: the
+    // findings write ticks watchDiveDetailChanges, which they self-invalidate
+    // on. Nothing to invalidate here.
+    final message = switch ((listFailed, failedDives)) {
+      (true, _) => context.l10n.safetySettings_dismissAll_failed,
+      (false, 0) => context.l10n.safetySettings_dismissAll_done(changed),
+      (false, final failed) =>
+        context.l10n.safetySettings_dismissAll_doneWithErrors(changed, failed),
+    };
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
   Future<void> _analyzeAllDives() async {
     // Scope the sweep to the active diver's logbook so "Analyze all dives"
     // only touches the current diver's dives, not every diver on the device.
@@ -154,24 +299,42 @@ class _SafetySettingsPageState extends ConsumerState<SafetySettingsPage> {
       _analyzeTotal = 0;
     });
 
-    final result = await ref
-        .read(safetyReviewSweepProvider)
-        .run(
-          diverId: diverId,
-          // _analyzeDone tracks dives swept (the progress bar's position), so
-          // it advances on failure too; the failure count is surfaced
-          // separately when the sweep completes.
-          onProgress: (done, total) {
-            if (!mounted) return;
-            setState(() {
-              _analyzeDone = done;
-              _analyzeTotal = total;
-            });
-          },
-          // Leaving the page ends the sweep, matching the previous
-          // `if (!mounted) return;` guard inside the loop.
-          isCancelled: () => !mounted,
-        );
+    final SafetyReviewSweepResult result;
+    try {
+      result = await ref
+          .read(safetyReviewSweepProvider)
+          .run(
+            diverId: diverId,
+            // _analyzeDone tracks dives swept (the progress bar's position),
+            // so it advances on failure too; the failure count is surfaced
+            // separately when the sweep completes.
+            onProgress: (done, total) {
+              if (!mounted) return;
+              setState(() {
+                _analyzeDone = done;
+                _analyzeTotal = total;
+              });
+            },
+            // Leaving the page ends the sweep, matching the previous
+            // `if (!mounted) return;` guard inside the loop.
+            isCancelled: () => !mounted,
+          );
+    } catch (error, stackTrace) {
+      // run() catches per-dive analysis failures itself, so reaching here
+      // means the sweep could not start at all. Without this the _analyzing
+      // flag would stay set, and _busy now disables every control on the page.
+      _log.error(
+        'Safety review sweep failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) return;
+      setState(() => _analyzing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.safetySettings_analyzeAll_failed)),
+      );
+      return;
+    }
 
     if (!mounted) return;
     setState(() => _analyzing = false);

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "تجاهل",
   "safetyReview_restore": "استعادة",
+  "safetyReview_dismissAll": "تجاهل الكل",
+  "safetyReview_restoreAll": "استعادة الكل",
+  "safetySettings_dismissAll": "تجاهل جميع الملاحظات",
+  "safetySettings_dismissAll_subtitle": "وضع علامة مراجَعة على جميع الملاحظات في هذا السجل",
+  "safetySettings_dismissAll_confirmTitle": "تجاهل جميع الملاحظات؟",
+  "safetySettings_dismissAll_confirmBody": "ستوضع علامة مراجَعة على كل ملاحظة في كل غطسة تم تحليلها. يمكنك استعادتها غطسة بغطسة من قسم مراجعة السلامة الخاص بها.",
+  "safetySettings_dismissAll_confirm": "تجاهل الكل",
+  "safetySettings_dismissAll_cancel": "إلغاء",
+  "safetySettings_dismissAll_progress": "تم فحص {done} من {total} غطسة",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{لا توجد ملاحظات لتجاهلها} =1{تم تجاهل ملاحظة واحدة} other{تم تجاهل {count} ملاحظات}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{لم يتم تجاهل أي ملاحظة} =1{تم تجاهل ملاحظة واحدة} other{تم تجاهل {count} ملاحظات}}، {failed, plural, =1{تعذّر تحديث غطسة واحدة} other{تعذّر تحديث {failed} غطسات}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "تعذّرت قراءة قائمة الغطسات. لم يتم تغيير أي شيء.",
+  "safetySettings_analyzeAll_failed": "تعذّر تحليل الغطسات.",
   "safetyReview_details": "التفاصيل",
   "safetyReview_clearHighlight": "مسح التمييز",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{ملاحظة سلامة واحدة} other{{count} ملاحظات سلامة}}",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Ausblenden",
   "safetyReview_restore": "Wiederherstellen",
+  "safetyReview_dismissAll": "Alle ausblenden",
+  "safetyReview_restoreAll": "Alle wiederherstellen",
+  "safetySettings_dismissAll": "Alle Beobachtungen ausblenden",
+  "safetySettings_dismissAll_subtitle": "Alle Beobachtungen in diesem Logbuch als geprüft markieren",
+  "safetySettings_dismissAll_confirmTitle": "Alle Beobachtungen ausblenden?",
+  "safetySettings_dismissAll_confirmBody": "Jede Beobachtung zu jedem analysierten Tauchgang wird als geprüft markiert. Du kannst sie im Abschnitt Sicherheitsüberprüfung eines Tauchgangs einzeln wiederherstellen.",
+  "safetySettings_dismissAll_confirm": "Alle ausblenden",
+  "safetySettings_dismissAll_cancel": "Abbrechen",
+  "safetySettings_dismissAll_progress": "{done} von {total} Tauchgängen geprüft",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Keine Beobachtungen zum Ausblenden} =1{1 Beobachtung ausgeblendet} other{{count} Beobachtungen ausgeblendet}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Keine Beobachtungen ausgeblendet} =1{1 Beobachtung ausgeblendet} other{{count} Beobachtungen ausgeblendet}}, {failed, plural, =1{1 Tauchgang konnte nicht aktualisiert werden} other{{failed} Tauchgänge konnten nicht aktualisiert werden}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Die Tauchgangsliste konnte nicht gelesen werden. Es wurde nichts geändert.",
+  "safetySettings_analyzeAll_failed": "Die Tauchgänge konnten nicht analysiert werden.",
   "safetyReview_details": "Details",
   "safetyReview_clearHighlight": "Hervorhebung entfernen",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 Sicherheitshinweis} other{{count} Sicherheitshinweise}}",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -8462,6 +8462,46 @@
   },
   "safetyReview_dismiss": "Dismiss",
   "safetyReview_restore": "Restore",
+  "safetyReview_dismissAll": "Dismiss all",
+  "safetyReview_restoreAll": "Restore all",
+  "safetySettings_dismissAll": "Dismiss all observations",
+  "safetySettings_dismissAll_subtitle": "Mark every observation in this logbook as reviewed",
+  "safetySettings_dismissAll_confirmTitle": "Dismiss all observations?",
+  "safetySettings_dismissAll_confirmBody": "Every observation on every analyzed dive is marked as reviewed. You can restore them one dive at a time from that dive’s safety review section.",
+  "safetySettings_dismissAll_confirm": "Dismiss all",
+  "safetySettings_dismissAll_cancel": "Cancel",
+  "safetySettings_dismissAll_progress": "Checked {done} of {total} dives",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{No observations to dismiss} =1{1 observation dismissed} other{{count} observations dismissed}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{No observations dismissed} =1{1 observation dismissed} other{{count} observations dismissed}}, {failed, plural, =1{1 dive could not be updated} other{{failed} dives could not be updated}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Could not read your dive list. No dives were changed.",
+  "safetySettings_analyzeAll_failed": "Could not analyze your dives.",
   "safetyReview_details": "Details",
   "@safetyReview_details": {
     "description": "Link in the chart finding callout that scrolls to the full safety review section"

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Descartar",
   "safetyReview_restore": "Restaurar",
+  "safetyReview_dismissAll": "Descartar todo",
+  "safetyReview_restoreAll": "Restaurar todo",
+  "safetySettings_dismissAll": "Descartar todas las observaciones",
+  "safetySettings_dismissAll_subtitle": "Marcar como revisadas todas las observaciones de este cuaderno",
+  "safetySettings_dismissAll_confirmTitle": "¿Descartar todas las observaciones?",
+  "safetySettings_dismissAll_confirmBody": "Todas las observaciones de todas las inmersiones analizadas se marcarán como revisadas. Puedes restaurarlas inmersión por inmersión desde su sección de revisión de seguridad.",
+  "safetySettings_dismissAll_confirm": "Descartar todo",
+  "safetySettings_dismissAll_cancel": "Cancelar",
+  "safetySettings_dismissAll_progress": "{done} de {total} inmersiones revisadas",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{No hay observaciones que descartar} =1{1 observación descartada} other{{count} observaciones descartadas}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{No se descartó ninguna observación} =1{1 observación descartada} other{{count} observaciones descartadas}}, {failed, plural, =1{no se pudo actualizar 1 inmersión} other{no se pudieron actualizar {failed} inmersiones}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "No se pudo leer la lista de inmersiones. No se cambió nada.",
+  "safetySettings_analyzeAll_failed": "No se pudieron analizar las inmersiones.",
   "safetyReview_details": "Detalles",
   "safetyReview_clearHighlight": "Quitar resaltado",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observación de seguridad} other{{count} observaciones de seguridad}}",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Ignorer",
   "safetyReview_restore": "Restaurer",
+  "safetyReview_dismissAll": "Tout ignorer",
+  "safetyReview_restoreAll": "Tout restaurer",
+  "safetySettings_dismissAll": "Ignorer toutes les observations",
+  "safetySettings_dismissAll_subtitle": "Marquer comme relues toutes les observations de ce carnet",
+  "safetySettings_dismissAll_confirmTitle": "Ignorer toutes les observations ?",
+  "safetySettings_dismissAll_confirmBody": "Toutes les observations de toutes les plongées analysées seront marquées comme relues. Vous pouvez les restaurer plongée par plongée depuis sa section bilan de sécurité.",
+  "safetySettings_dismissAll_confirm": "Tout ignorer",
+  "safetySettings_dismissAll_cancel": "Annuler",
+  "safetySettings_dismissAll_progress": "{done} plongées sur {total} vérifiées",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Aucune observation à ignorer} =1{1 observation ignorée} other{{count} observations ignorées}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Aucune observation ignorée} =1{1 observation ignorée} other{{count} observations ignorées}}, {failed, plural, =1{1 plongée n’a pas pu être mise à jour} other{{failed} plongées n’ont pas pu être mises à jour}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Impossible de lire la liste des plongées. Rien n’a été modifié.",
+  "safetySettings_analyzeAll_failed": "Impossible d’analyser les plongées.",
   "safetyReview_details": "Détails",
   "safetyReview_clearHighlight": "Effacer la surbrillance",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observation de sécurité} other{{count} observations de sécurité}}",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "התעלם",
   "safetyReview_restore": "שחזר",
+  "safetyReview_dismissAll": "התעלם מהכול",
+  "safetyReview_restoreAll": "שחזר הכול",
+  "safetySettings_dismissAll": "התעלם מכל התצפיות",
+  "safetySettings_dismissAll_subtitle": "סמן את כל התצפיות ביומן זה כנסקרו",
+  "safetySettings_dismissAll_confirmTitle": "להתעלם מכל התצפיות?",
+  "safetySettings_dismissAll_confirmBody": "כל תצפית בכל צלילה שנותחה תסומן כנסקרה. אפשר לשחזר אותן צלילה אחר צלילה במקטע סקירת הבטיחות שלה.",
+  "safetySettings_dismissAll_confirm": "התעלם מהכול",
+  "safetySettings_dismissAll_cancel": "ביטול",
+  "safetySettings_dismissAll_progress": "נבדקו {done} מתוך {total} צלילות",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{אין תצפיות להתעלם מהן} =1{בוצעה התעלמות מתצפית אחת} other{בוצעה התעלמות מ-{count} תצפיות}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{לא בוצעה התעלמות מתצפיות} =1{בוצעה התעלמות מתצפית אחת} other{בוצעה התעלמות מ-{count} תצפיות}}, {failed, plural, =1{לא ניתן היה לעדכן צלילה אחת} other{לא ניתן היה לעדכן {failed} צלילות}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "לא ניתן לקרוא את רשימת הצלילות. דבר לא שונה.",
+  "safetySettings_analyzeAll_failed": "לא ניתן לנתח את הצלילות.",
   "safetyReview_details": "פרטים",
   "safetyReview_clearHighlight": "ניקוי הדגשה",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{ממצא בטיחות אחד} other{{count} ממצאי בטיחות}}",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Elvetés",
   "safetyReview_restore": "Visszaállítás",
+  "safetyReview_dismissAll": "Összes elvetése",
+  "safetyReview_restoreAll": "Összes visszaállítása",
+  "safetySettings_dismissAll": "Összes megfigyelés elvetése",
+  "safetySettings_dismissAll_subtitle": "A naplóban szereplő összes megfigyelés megjelölése átnézettként",
+  "safetySettings_dismissAll_confirmTitle": "Elveted az összes megfigyelést?",
+  "safetySettings_dismissAll_confirmBody": "Minden elemzett merülés minden megfigyelése átnézettként lesz megjelölve. Merülésenként visszaállíthatod őket az adott merülés biztonsági áttekintés szakaszában.",
+  "safetySettings_dismissAll_confirm": "Összes elvetése",
+  "safetySettings_dismissAll_cancel": "Mégse",
+  "safetySettings_dismissAll_progress": "{done} / {total} merülés ellenőrizve",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Nincs elvetendő megfigyelés} =1{1 megfigyelés elvetve} other{{count} megfigyelés elvetve}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nem lett megfigyelés elvetve} =1{1 megfigyelés elvetve} other{{count} megfigyelés elvetve}}, {failed, plural, =1{1 merülést nem sikerült frissíteni} other{{failed} merülést nem sikerült frissíteni}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "A merüléslista nem olvasható. Semmi sem változott.",
+  "safetySettings_analyzeAll_failed": "A merüléseket nem sikerült elemezni.",
   "safetyReview_details": "Részletek",
   "safetyReview_clearHighlight": "Kiemelés törlése",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 biztonsági megállapítás} other{{count} biztonsági megállapítás}}",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Ignora",
   "safetyReview_restore": "Ripristina",
+  "safetyReview_dismissAll": "Ignora tutto",
+  "safetyReview_restoreAll": "Ripristina tutto",
+  "safetySettings_dismissAll": "Ignora tutte le osservazioni",
+  "safetySettings_dismissAll_subtitle": "Contrassegna come riviste tutte le osservazioni di questo diario",
+  "safetySettings_dismissAll_confirmTitle": "Ignorare tutte le osservazioni?",
+  "safetySettings_dismissAll_confirmBody": "Tutte le osservazioni di ogni immersione analizzata verranno contrassegnate come riviste. Puoi ripristinarle una immersione alla volta dalla sua sezione revisione di sicurezza.",
+  "safetySettings_dismissAll_confirm": "Ignora tutto",
+  "safetySettings_dismissAll_cancel": "Annulla",
+  "safetySettings_dismissAll_progress": "{done} di {total} immersioni controllate",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Nessuna osservazione da ignorare} =1{1 osservazione ignorata} other{{count} osservazioni ignorate}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nessuna osservazione ignorata} =1{1 osservazione ignorata} other{{count} osservazioni ignorate}}, {failed, plural, =1{1 immersione non è stata aggiornata} other{{failed} immersioni non sono state aggiornate}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Impossibile leggere l’elenco delle immersioni. Nulla è stato modificato.",
+  "safetySettings_analyzeAll_failed": "Impossibile analizzare le immersioni.",
   "safetyReview_details": "Dettagli",
   "safetyReview_clearHighlight": "Rimuovi evidenziazione",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 rilievo di sicurezza} other{{count} rilievi di sicurezza}}",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -23752,6 +23752,84 @@ abstract class AppLocalizations {
   /// **'Restore'**
   String get safetyReview_restore;
 
+  /// No description provided for @safetyReview_dismissAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss all'**
+  String get safetyReview_dismissAll;
+
+  /// No description provided for @safetyReview_restoreAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore all'**
+  String get safetyReview_restoreAll;
+
+  /// No description provided for @safetySettings_dismissAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss all observations'**
+  String get safetySettings_dismissAll;
+
+  /// No description provided for @safetySettings_dismissAll_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark every observation in this logbook as reviewed'**
+  String get safetySettings_dismissAll_subtitle;
+
+  /// No description provided for @safetySettings_dismissAll_confirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss all observations?'**
+  String get safetySettings_dismissAll_confirmTitle;
+
+  /// No description provided for @safetySettings_dismissAll_confirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Every observation on every analyzed dive is marked as reviewed. You can restore them one dive at a time from that dive’s safety review section.'**
+  String get safetySettings_dismissAll_confirmBody;
+
+  /// No description provided for @safetySettings_dismissAll_confirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss all'**
+  String get safetySettings_dismissAll_confirm;
+
+  /// No description provided for @safetySettings_dismissAll_cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get safetySettings_dismissAll_cancel;
+
+  /// No description provided for @safetySettings_dismissAll_progress.
+  ///
+  /// In en, this message translates to:
+  /// **'Checked {done} of {total} dives'**
+  String safetySettings_dismissAll_progress(int done, int total);
+
+  /// No description provided for @safetySettings_dismissAll_done.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No observations to dismiss} =1{1 observation dismissed} other{{count} observations dismissed}}'**
+  String safetySettings_dismissAll_done(int count);
+
+  /// No description provided for @safetySettings_dismissAll_doneWithErrors.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No observations dismissed} =1{1 observation dismissed} other{{count} observations dismissed}}, {failed, plural, =1{1 dive could not be updated} other{{failed} dives could not be updated}}'**
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed);
+
+  /// No description provided for @safetySettings_dismissAll_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read your dive list. No dives were changed.'**
+  String get safetySettings_dismissAll_failed;
+
+  /// No description provided for @safetySettings_analyzeAll_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not analyze your dives.'**
+  String get safetySettings_analyzeAll_failed;
+
   /// Link in the chart finding callout that scrolls to the full safety review section
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -13822,6 +13822,74 @@ class AppLocalizationsAr extends AppLocalizations {
   String get safetyReview_restore => 'استعادة';
 
   @override
+  String get safetyReview_dismissAll => 'تجاهل الكل';
+
+  @override
+  String get safetyReview_restoreAll => 'استعادة الكل';
+
+  @override
+  String get safetySettings_dismissAll => 'تجاهل جميع الملاحظات';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'وضع علامة مراجَعة على جميع الملاحظات في هذا السجل';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle => 'تجاهل جميع الملاحظات؟';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'ستوضع علامة مراجَعة على كل ملاحظة في كل غطسة تم تحليلها. يمكنك استعادتها غطسة بغطسة من قسم مراجعة السلامة الخاص بها.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'تجاهل الكل';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'إلغاء';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return 'تم فحص $done من $total غطسة';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تم تجاهل $count ملاحظات',
+      one: 'تم تجاهل ملاحظة واحدة',
+      zero: 'لا توجد ملاحظات لتجاهلها',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تم تجاهل $count ملاحظات',
+      one: 'تم تجاهل ملاحظة واحدة',
+      zero: 'لم يتم تجاهل أي ملاحظة',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: 'تعذّر تحديث $failed غطسات',
+      one: 'تعذّر تحديث غطسة واحدة',
+    );
+    return '$_temp0، $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'تعذّرت قراءة قائمة الغطسات. لم يتم تغيير أي شيء.';
+
+  @override
+  String get safetySettings_analyzeAll_failed => 'تعذّر تحليل الغطسات.';
+
+  @override
   String get safetyReview_details => 'التفاصيل';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -14054,6 +14054,76 @@ class AppLocalizationsDe extends AppLocalizations {
   String get safetyReview_restore => 'Wiederherstellen';
 
   @override
+  String get safetyReview_dismissAll => 'Alle ausblenden';
+
+  @override
+  String get safetyReview_restoreAll => 'Alle wiederherstellen';
+
+  @override
+  String get safetySettings_dismissAll => 'Alle Beobachtungen ausblenden';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Alle Beobachtungen in diesem Logbuch als geprüft markieren';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Alle Beobachtungen ausblenden?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Jede Beobachtung zu jedem analysierten Tauchgang wird als geprüft markiert. Du kannst sie im Abschnitt Sicherheitsüberprüfung eines Tauchgangs einzeln wiederherstellen.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Alle ausblenden';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Abbrechen';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done von $total Tauchgängen geprüft';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Beobachtungen ausgeblendet',
+      one: '1 Beobachtung ausgeblendet',
+      zero: 'Keine Beobachtungen zum Ausblenden',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Beobachtungen ausgeblendet',
+      one: '1 Beobachtung ausgeblendet',
+      zero: 'Keine Beobachtungen ausgeblendet',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed Tauchgänge konnten nicht aktualisiert werden',
+      one: '1 Tauchgang konnte nicht aktualisiert werden',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Die Tauchgangsliste konnte nicht gelesen werden. Es wurde nichts geändert.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Die Tauchgänge konnten nicht analysiert werden.';
+
+  @override
   String get safetyReview_details => 'Details';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -13840,6 +13840,76 @@ class AppLocalizationsEn extends AppLocalizations {
   String get safetyReview_restore => 'Restore';
 
   @override
+  String get safetyReview_dismissAll => 'Dismiss all';
+
+  @override
+  String get safetyReview_restoreAll => 'Restore all';
+
+  @override
+  String get safetySettings_dismissAll => 'Dismiss all observations';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Mark every observation in this logbook as reviewed';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Dismiss all observations?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Every observation on every analyzed dive is marked as reviewed. You can restore them one dive at a time from that dive’s safety review section.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Dismiss all';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Cancel';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return 'Checked $done of $total dives';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observations dismissed',
+      one: '1 observation dismissed',
+      zero: 'No observations to dismiss',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observations dismissed',
+      one: '1 observation dismissed',
+      zero: 'No observations dismissed',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed dives could not be updated',
+      one: '1 dive could not be updated',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Could not read your dive list. No dives were changed.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Could not analyze your dives.';
+
+  @override
   String get safetyReview_details => 'Details';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -14060,6 +14060,76 @@ class AppLocalizationsEs extends AppLocalizations {
   String get safetyReview_restore => 'Restaurar';
 
   @override
+  String get safetyReview_dismissAll => 'Descartar todo';
+
+  @override
+  String get safetyReview_restoreAll => 'Restaurar todo';
+
+  @override
+  String get safetySettings_dismissAll => 'Descartar todas las observaciones';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Marcar como revisadas todas las observaciones de este cuaderno';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      '¿Descartar todas las observaciones?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Todas las observaciones de todas las inmersiones analizadas se marcarán como revisadas. Puedes restaurarlas inmersión por inmersión desde su sección de revisión de seguridad.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Descartar todo';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Cancelar';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done de $total inmersiones revisadas';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observaciones descartadas',
+      one: '1 observación descartada',
+      zero: 'No hay observaciones que descartar',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observaciones descartadas',
+      one: '1 observación descartada',
+      zero: 'No se descartó ninguna observación',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: 'no se pudieron actualizar $failed inmersiones',
+      one: 'no se pudo actualizar 1 inmersión',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'No se pudo leer la lista de inmersiones. No se cambió nada.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'No se pudieron analizar las inmersiones.';
+
+  @override
   String get safetyReview_details => 'Detalles';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -14110,6 +14110,76 @@ class AppLocalizationsFr extends AppLocalizations {
   String get safetyReview_restore => 'Restaurer';
 
   @override
+  String get safetyReview_dismissAll => 'Tout ignorer';
+
+  @override
+  String get safetyReview_restoreAll => 'Tout restaurer';
+
+  @override
+  String get safetySettings_dismissAll => 'Ignorer toutes les observations';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Marquer comme relues toutes les observations de ce carnet';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Ignorer toutes les observations ?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Toutes les observations de toutes les plongées analysées seront marquées comme relues. Vous pouvez les restaurer plongée par plongée depuis sa section bilan de sécurité.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Tout ignorer';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Annuler';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done plongées sur $total vérifiées';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observations ignorées',
+      one: '1 observation ignorée',
+      zero: 'Aucune observation à ignorer',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observations ignorées',
+      one: '1 observation ignorée',
+      zero: 'Aucune observation ignorée',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed plongées n’ont pas pu être mises à jour',
+      one: '1 plongée n’a pas pu être mise à jour',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Impossible de lire la liste des plongées. Rien n’a été modifié.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Impossible d’analyser les plongées.';
+
+  @override
   String get safetyReview_details => 'Détails';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -13729,6 +13729,74 @@ class AppLocalizationsHe extends AppLocalizations {
   String get safetyReview_restore => 'שחזר';
 
   @override
+  String get safetyReview_dismissAll => 'התעלם מהכול';
+
+  @override
+  String get safetyReview_restoreAll => 'שחזר הכול';
+
+  @override
+  String get safetySettings_dismissAll => 'התעלם מכל התצפיות';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'סמן את כל התצפיות ביומן זה כנסקרו';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle => 'להתעלם מכל התצפיות?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'כל תצפית בכל צלילה שנותחה תסומן כנסקרה. אפשר לשחזר אותן צלילה אחר צלילה במקטע סקירת הבטיחות שלה.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'התעלם מהכול';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'ביטול';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return 'נבדקו $done מתוך $total צלילות';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'בוצעה התעלמות מ-$count תצפיות',
+      one: 'בוצעה התעלמות מתצפית אחת',
+      zero: 'אין תצפיות להתעלם מהן',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'בוצעה התעלמות מ-$count תצפיות',
+      one: 'בוצעה התעלמות מתצפית אחת',
+      zero: 'לא בוצעה התעלמות מתצפיות',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: 'לא ניתן היה לעדכן $failed צלילות',
+      one: 'לא ניתן היה לעדכן צלילה אחת',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'לא ניתן לקרוא את רשימת הצלילות. דבר לא שונה.';
+
+  @override
+  String get safetySettings_analyzeAll_failed => 'לא ניתן לנתח את הצלילות.';
+
+  @override
   String get safetyReview_details => 'פרטים';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -14022,6 +14022,76 @@ class AppLocalizationsHu extends AppLocalizations {
   String get safetyReview_restore => 'Visszaállítás';
 
   @override
+  String get safetyReview_dismissAll => 'Összes elvetése';
+
+  @override
+  String get safetyReview_restoreAll => 'Összes visszaállítása';
+
+  @override
+  String get safetySettings_dismissAll => 'Összes megfigyelés elvetése';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'A naplóban szereplő összes megfigyelés megjelölése átnézettként';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Elveted az összes megfigyelést?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Minden elemzett merülés minden megfigyelése átnézettként lesz megjelölve. Merülésenként visszaállíthatod őket az adott merülés biztonsági áttekintés szakaszában.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Összes elvetése';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Mégse';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done / $total merülés ellenőrizve';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count megfigyelés elvetve',
+      one: '1 megfigyelés elvetve',
+      zero: 'Nincs elvetendő megfigyelés',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count megfigyelés elvetve',
+      one: '1 megfigyelés elvetve',
+      zero: 'Nem lett megfigyelés elvetve',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed merülést nem sikerült frissíteni',
+      one: '1 merülést nem sikerült frissíteni',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'A merüléslista nem olvasható. Semmi sem változott.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'A merüléseket nem sikerült elemezni.';
+
+  @override
   String get safetyReview_details => 'Részletek';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -14069,6 +14069,76 @@ class AppLocalizationsIt extends AppLocalizations {
   String get safetyReview_restore => 'Ripristina';
 
   @override
+  String get safetyReview_dismissAll => 'Ignora tutto';
+
+  @override
+  String get safetyReview_restoreAll => 'Ripristina tutto';
+
+  @override
+  String get safetySettings_dismissAll => 'Ignora tutte le osservazioni';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Contrassegna come riviste tutte le osservazioni di questo diario';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Ignorare tutte le osservazioni?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Tutte le osservazioni di ogni immersione analizzata verranno contrassegnate come riviste. Puoi ripristinarle una immersione alla volta dalla sua sezione revisione di sicurezza.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Ignora tutto';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Annulla';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done di $total immersioni controllate';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count osservazioni ignorate',
+      one: '1 osservazione ignorata',
+      zero: 'Nessuna osservazione da ignorare',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count osservazioni ignorate',
+      one: '1 osservazione ignorata',
+      zero: 'Nessuna osservazione ignorata',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed immersioni non sono state aggiornate',
+      one: '1 immersione non è stata aggiornata',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Impossibile leggere l’elenco delle immersioni. Nulla è stato modificato.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Impossibile analizzare le immersioni.';
+
+  @override
   String get safetyReview_details => 'Dettagli';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -13965,6 +13965,76 @@ class AppLocalizationsNl extends AppLocalizations {
   String get safetyReview_restore => 'Herstellen';
 
   @override
+  String get safetyReview_dismissAll => 'Alles negeren';
+
+  @override
+  String get safetyReview_restoreAll => 'Alles herstellen';
+
+  @override
+  String get safetySettings_dismissAll => 'Alle observaties negeren';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Alle observaties in dit logboek als beoordeeld markeren';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Alle observaties negeren?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Elke observatie bij elke geanalyseerde duik wordt als beoordeeld gemarkeerd. Je kunt ze per duik herstellen in de sectie veiligheidscontrole.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Alles negeren';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Annuleren';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done van $total duiken gecontroleerd';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observaties genegeerd',
+      one: '1 observatie genegeerd',
+      zero: 'Geen observaties om te negeren',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observaties genegeerd',
+      one: '1 observatie genegeerd',
+      zero: 'Geen observaties genegeerd',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed duiken konden niet worden bijgewerkt',
+      one: '1 duik kon niet worden bijgewerkt',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Kan de duiklijst niet lezen. Er is niets gewijzigd.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Kan de duiken niet analyseren.';
+
+  @override
   String get safetyReview_details => 'Details';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -14068,6 +14068,76 @@ class AppLocalizationsPt extends AppLocalizations {
   String get safetyReview_restore => 'Restaurar';
 
   @override
+  String get safetyReview_dismissAll => 'Dispensar tudo';
+
+  @override
+  String get safetyReview_restoreAll => 'Restaurar tudo';
+
+  @override
+  String get safetySettings_dismissAll => 'Dispensar todas as observações';
+
+  @override
+  String get safetySettings_dismissAll_subtitle =>
+      'Marcar como revistas todas as observações deste diário';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle =>
+      'Dispensar todas as observações?';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      'Todas as observações de todos os mergulhos analisados serão marcadas como revistas. Pode restaurá-las mergulho a mergulho na respetiva secção de revisão de segurança.';
+
+  @override
+  String get safetySettings_dismissAll_confirm => 'Dispensar tudo';
+
+  @override
+  String get safetySettings_dismissAll_cancel => 'Cancelar';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '$done de $total mergulhos verificados';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observações dispensadas',
+      one: '1 observação dispensada',
+      zero: 'Nenhuma observação para dispensar',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count observações dispensadas',
+      one: '1 observação dispensada',
+      zero: 'Nenhuma observação dispensada',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed mergulhos não puderam ser atualizados',
+      one: '1 mergulho não pôde ser atualizado',
+    );
+    return '$_temp0, $_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed =>
+      'Não foi possível ler a lista de mergulhos. Nada foi alterado.';
+
+  @override
+  String get safetySettings_analyzeAll_failed =>
+      'Não foi possível analisar os mergulhos.';
+
+  @override
   String get safetyReview_details => 'Detalhes';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -13422,6 +13422,71 @@ class AppLocalizationsZh extends AppLocalizations {
   String get safetyReview_restore => '恢复';
 
   @override
+  String get safetyReview_dismissAll => '全部忽略';
+
+  @override
+  String get safetyReview_restoreAll => '全部恢复';
+
+  @override
+  String get safetySettings_dismissAll => '忽略所有观察';
+
+  @override
+  String get safetySettings_dismissAll_subtitle => '将此日志中的所有观察标记为已查看';
+
+  @override
+  String get safetySettings_dismissAll_confirmTitle => '忽略所有观察？';
+
+  @override
+  String get safetySettings_dismissAll_confirmBody =>
+      '所有已分析潜水的每一条观察都会被标记为已查看。你可以在各次潜水的安全回顾部分逐条恢复。';
+
+  @override
+  String get safetySettings_dismissAll_confirm => '全部忽略';
+
+  @override
+  String get safetySettings_dismissAll_cancel => '取消';
+
+  @override
+  String safetySettings_dismissAll_progress(int done, int total) {
+    return '已检查 $done / $total 次潜水';
+  }
+
+  @override
+  String safetySettings_dismissAll_done(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已忽略 $count 条观察',
+      one: '已忽略 1 条观察',
+      zero: '没有可忽略的观察',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String safetySettings_dismissAll_doneWithErrors(int count, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已忽略 $count 条观察',
+      one: '已忽略 1 条观察',
+      zero: '没有忽略任何观察',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed 次潜水无法更新',
+    );
+    return '$_temp0，$_temp1';
+  }
+
+  @override
+  String get safetySettings_dismissAll_failed => '无法读取潜水列表，未做任何更改。';
+
+  @override
+  String get safetySettings_analyzeAll_failed => '无法分析潜水记录。';
+
+  @override
   String get safetyReview_details => '详情';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Negeren",
   "safetyReview_restore": "Herstellen",
+  "safetyReview_dismissAll": "Alles negeren",
+  "safetyReview_restoreAll": "Alles herstellen",
+  "safetySettings_dismissAll": "Alle observaties negeren",
+  "safetySettings_dismissAll_subtitle": "Alle observaties in dit logboek als beoordeeld markeren",
+  "safetySettings_dismissAll_confirmTitle": "Alle observaties negeren?",
+  "safetySettings_dismissAll_confirmBody": "Elke observatie bij elke geanalyseerde duik wordt als beoordeeld gemarkeerd. Je kunt ze per duik herstellen in de sectie veiligheidscontrole.",
+  "safetySettings_dismissAll_confirm": "Alles negeren",
+  "safetySettings_dismissAll_cancel": "Annuleren",
+  "safetySettings_dismissAll_progress": "{done} van {total} duiken gecontroleerd",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Geen observaties om te negeren} =1{1 observatie genegeerd} other{{count} observaties genegeerd}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Geen observaties genegeerd} =1{1 observatie genegeerd} other{{count} observaties genegeerd}}, {failed, plural, =1{1 duik kon niet worden bijgewerkt} other{{failed} duiken konden niet worden bijgewerkt}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Kan de duiklijst niet lezen. Er is niets gewijzigd.",
+  "safetySettings_analyzeAll_failed": "Kan de duiken niet analyseren.",
   "safetyReview_details": "Details",
   "safetyReview_clearHighlight": "Markering wissen",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 veiligheidsbevinding} other{{count} veiligheidsbevindingen}}",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "Dispensar",
   "safetyReview_restore": "Restaurar",
+  "safetyReview_dismissAll": "Dispensar tudo",
+  "safetyReview_restoreAll": "Restaurar tudo",
+  "safetySettings_dismissAll": "Dispensar todas as observações",
+  "safetySettings_dismissAll_subtitle": "Marcar como revistas todas as observações deste diário",
+  "safetySettings_dismissAll_confirmTitle": "Dispensar todas as observações?",
+  "safetySettings_dismissAll_confirmBody": "Todas as observações de todos os mergulhos analisados serão marcadas como revistas. Pode restaurá-las mergulho a mergulho na respetiva secção de revisão de segurança.",
+  "safetySettings_dismissAll_confirm": "Dispensar tudo",
+  "safetySettings_dismissAll_cancel": "Cancelar",
+  "safetySettings_dismissAll_progress": "{done} de {total} mergulhos verificados",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{Nenhuma observação para dispensar} =1{1 observação dispensada} other{{count} observações dispensadas}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nenhuma observação dispensada} =1{1 observação dispensada} other{{count} observações dispensadas}}, {failed, plural, =1{1 mergulho não pôde ser atualizado} other{{failed} mergulhos não puderam ser atualizados}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "Não foi possível ler a lista de mergulhos. Nada foi alterado.",
+  "safetySettings_analyzeAll_failed": "Não foi possível analisar os mergulhos.",
   "safetyReview_details": "Detalhes",
   "safetyReview_clearHighlight": "Limpar destaque",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 observação de segurança} other{{count} observações de segurança}}",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -7128,6 +7128,46 @@
   },
   "safetyReview_dismiss": "忽略",
   "safetyReview_restore": "恢复",
+  "safetyReview_dismissAll": "全部忽略",
+  "safetyReview_restoreAll": "全部恢复",
+  "safetySettings_dismissAll": "忽略所有观察",
+  "safetySettings_dismissAll_subtitle": "将此日志中的所有观察标记为已查看",
+  "safetySettings_dismissAll_confirmTitle": "忽略所有观察？",
+  "safetySettings_dismissAll_confirmBody": "所有已分析潜水的每一条观察都会被标记为已查看。你可以在各次潜水的安全回顾部分逐条恢复。",
+  "safetySettings_dismissAll_confirm": "全部忽略",
+  "safetySettings_dismissAll_cancel": "取消",
+  "safetySettings_dismissAll_progress": "已检查 {done} / {total} 次潜水",
+  "@safetySettings_dismissAll_progress": {
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_done": "{count, plural, =0{没有可忽略的观察} =1{已忽略 1 条观察} other{已忽略 {count} 条观察}}",
+  "@safetySettings_dismissAll_done": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{没有忽略任何观察} =1{已忽略 1 条观察} other{已忽略 {count} 条观察}}，{failed, plural, other{{failed} 次潜水无法更新}}",
+  "@safetySettings_dismissAll_doneWithErrors": {
+  "placeholders": {
+    "count": {
+      "type": "int"
+    },
+    "failed": {
+      "type": "int"
+    }
+  }
+},
+  "safetySettings_dismissAll_failed": "无法读取潜水列表，未做任何更改。",
+  "safetySettings_analyzeAll_failed": "无法分析潜水记录。",
   "safetyReview_details": "详情",
   "safetyReview_clearHighlight": "清除高亮",
   "safetyReview_findingGroupSemantics": "{count, plural, =1{1 条安全提示} other{{count} 条安全提示}}",

--- a/test/features/dive_log/data/repositories/safety_findings_repository_test.dart
+++ b/test/features/dive_log/data/repositories/safety_findings_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
 import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 
@@ -18,9 +19,10 @@ void main() {
   SafetyFinding finding(
     String id, {
     SafetyRuleId rule = SafetyRuleId.rapidAscent,
+    String diveId = 'dive-1',
   }) => SafetyFinding(
     id: id,
-    diveId: 'dive-1',
+    diveId: diveId,
     ruleId: rule,
     severity: SafetySeverity.caution,
     startTimestamp: 100,
@@ -312,4 +314,301 @@ void main() {
       );
     },
   );
+
+  group('setDismissedForDives', () {
+    // Every rule is enabled unless a test narrows the set.
+    final allRules = {for (final r in SafetyRuleId.values) r.dbValue};
+
+    Future<void> seed(String diveId, List<SafetyFinding> findings) async {
+      await repo.saveReview(
+        SafetyReview(
+          diveId: diveId,
+          engineVersion: 1,
+          reviewedAt: now,
+          findings: findings,
+        ),
+      );
+    }
+
+    Future<Set<String>> dismissedIds(String diveId) async {
+      final review = await repo.getReview(diveId);
+      return review!.findings
+          .where((f) => f.isDismissed)
+          .map((f) => f.id)
+          .toSet();
+    }
+
+    test('dismisses every active finding across the given dives', () async {
+      await createTestDive('dive-2');
+      await seed('dive-1', [finding('f1'), finding('f2')]);
+      await seed('dive-2', [finding('f3', diveId: 'dive-2')]);
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1', 'dive-2'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      expect(changed, 3);
+      expect(await dismissedIds('dive-1'), {'f1', 'f2'});
+      expect(await dismissedIds('dive-2'), {'f3'});
+    });
+
+    test('leaves dives outside the id list untouched', () async {
+      await createTestDive('dive-2');
+      await seed('dive-1', [finding('f1')]);
+      await seed('dive-2', [finding('f3', diveId: 'dive-2')]);
+
+      await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      expect(await dismissedIds('dive-2'), isEmpty);
+    });
+
+    test('skips findings whose rule is not enabled', () async {
+      await seed('dive-1', [
+        finding('f1'),
+        finding('f2', rule: SafetyRuleId.sawtoothProfile),
+      ]);
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: {SafetyRuleId.rapidAscent.dbValue},
+        now: now,
+      );
+
+      expect(changed, 1);
+      expect(await dismissedIds('dive-1'), {
+        'f1',
+      }, reason: 'a rule the user has hidden must not be silently dismissed');
+    });
+
+    test('skips rows whose rule_id is not a known SafetyRuleId', () async {
+      await seed('dive-1', [finding('f1')]);
+      await db
+          .into(db.diveSafetyFindings)
+          .insert(
+            DiveSafetyFindingsCompanion.insert(
+              id: 'from-the-future',
+              diveId: 'dive-1',
+              ruleId: 'brand_new_rule',
+              severity: SafetySeverity.caution.dbValue,
+              engineVersion: 1,
+              createdAt: now.millisecondsSinceEpoch,
+            ),
+          );
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      expect(changed, 1);
+      final row = await (db.select(
+        db.diveSafetyFindings,
+      )..where((t) => t.id.equals('from-the-future'))).getSingle();
+      expect(
+        row.dismissedAt,
+        isNull,
+        reason: 'a finding this build cannot render must not be dismissed',
+      );
+    });
+
+    test('restores dismissed findings when dismissed is false', () async {
+      await seed('dive-1', [finding('f1'), finding('f2')]);
+      await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: false,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      expect(changed, 2);
+      expect(await dismissedIds('dive-1'), isEmpty);
+    });
+
+    test('counts only findings whose state actually changes', () async {
+      await seed('dive-1', [finding('f1'), finding('f2')]);
+      await repo.setDismissed(findingId: 'f1', dismissed: true, now: now);
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      expect(changed, 1, reason: 'f1 was already dismissed');
+    });
+
+    test('spans more dives than one query chunk', () async {
+      final diveIds = <String>['dive-1'];
+      await seed('dive-1', [finding('f1')]);
+      for (var i = 2; i <= 7; i++) {
+        final diveId = 'dive-$i';
+        await createTestDive(diveId);
+        await seed(diveId, [finding('f$i', diveId: diveId)]);
+        diveIds.add(diveId);
+      }
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: diveIds,
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+        chunkSize: 2,
+      );
+
+      expect(changed, 7);
+      for (final diveId in diveIds) {
+        expect(await dismissedIds(diveId), hasLength(1));
+      }
+    });
+
+    test('advances the parent dive HLC so the change syncs', () async {
+      await syncRepository.markRecordPending(
+        entityType: 'dives',
+        recordId: 'dive-1',
+        localUpdatedAt: now.millisecondsSinceEpoch,
+      );
+      await seed('dive-1', [finding('f1')]);
+
+      final watermark =
+          (await db
+                  .customSelect("SELECT hlc FROM dives WHERE id = 'dive-1'")
+                  .getSingle())
+              .read<String>('hlc');
+      final serializer = SyncDataSerializer();
+      final deviceId = await syncRepository.getDeviceId();
+
+      await repo.setDismissedForDives(
+        diveIds: ['dive-1'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      final after = await serializer.exportChangeset(
+        deviceId: deviceId,
+        hlcWatermark: watermark,
+        deletions: const [],
+      );
+      final exported = after.data.diveSafetyFindings.firstWhere(
+        (f) => f['id'] == 'f1',
+      );
+      expect(exported['dismissedAt'], isNotNull);
+    });
+
+    test(
+      'announces the chunks that committed even when a later one throws',
+      () async {
+        // A multi-chunk run is several transactions. If chunk 2 fails, chunk 1
+        // is already committed and its rows are marked pending; skipping the
+        // local-change notification would strand them until some unrelated
+        // write happened to kick the sync layer.
+        final failing = _FailingSyncRepository();
+        final failRepo = SafetyFindingsRepository(
+          db: db,
+          syncRepository: failing,
+        );
+        await createTestDive('dive-2');
+        await seed('dive-1', [finding('f1')]);
+        await seed('dive-2', [finding('f2', diveId: 'dive-2')]);
+
+        final notifications = <void>[];
+        final subscription = SyncEventBus.changes.listen(notifications.add);
+        addTearDown(() => subscription.cancel());
+
+        failing.failAfter = 2;
+        await expectLater(
+          failRepo.setDismissedForDives(
+            diveIds: ['dive-1', 'dive-2'],
+            dismissed: true,
+            enabledRuleIds: allRules,
+            now: now,
+            chunkSize: 1,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(await dismissedIds('dive-1'), {'f1'});
+        expect(await dismissedIds('dive-2'), isEmpty);
+        expect(
+          notifications,
+          hasLength(1),
+          reason: 'the committed chunk must still reach the sync layer',
+        );
+      },
+    );
+
+    test('leaves the dive HLC alone when nothing changes', () async {
+      // An unconditional UPDATE would bump every dive's HLC and push the whole
+      // library on every tap; only dives with a real change may be marked.
+      await createTestDive('dive-2');
+      await seed('dive-1', [finding('f1')]);
+      await seed('dive-2', [finding('f3', diveId: 'dive-2')]);
+      await repo.setDismissed(findingId: 'f3', dismissed: true, now: now);
+
+      final before =
+          (await db
+                  .customSelect("SELECT hlc FROM dives WHERE id = 'dive-2'")
+                  .getSingle())
+              .read<String>('hlc');
+
+      final changed = await repo.setDismissedForDives(
+        diveIds: ['dive-1', 'dive-2'],
+        dismissed: true,
+        enabledRuleIds: allRules,
+        now: now,
+      );
+
+      final after =
+          (await db
+                  .customSelect("SELECT hlc FROM dives WHERE id = 'dive-2'")
+                  .getSingle())
+              .read<String>('hlc');
+      expect(changed, 1);
+      expect(after, before, reason: 'dive-2 had nothing to dismiss');
+    });
+  });
+}
+
+/// A [SyncRepository] that fails once a set number of pending marks have been
+/// recorded, to force a mid-run failure in a multi-chunk bulk write.
+class _FailingSyncRepository extends SyncRepository {
+  int? failAfter;
+  int _marks = 0;
+
+  @override
+  Future<void> markRecordPending({
+    required String entityType,
+    required String recordId,
+    required int localUpdatedAt,
+  }) async {
+    if (failAfter != null && _marks >= failAfter!) {
+      throw StateError('sync bookkeeping failed');
+    }
+    _marks++;
+    return super.markRecordPending(
+      entityType: entityType,
+      recordId: recordId,
+      localUpdatedAt: localUpdatedAt,
+    );
+  }
 }

--- a/test/features/dive_log/presentation/widgets/safety_review_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/safety_review_section_test.dart
@@ -462,11 +462,184 @@ void main() {
       );
     });
   });
+
+  group('bulk dismiss', () {
+    Future<_RecordingSafetyRepo> pumpBulk(
+      WidgetTester tester,
+      SafetyReview review, {
+      AppSettings? settings,
+    }) async {
+      final repo = _RecordingSafetyRepo();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingsProvider.overrideWith(
+              (ref) => MockSettingsNotifier(settings),
+            ),
+            safetyFindingsRepositoryProvider.overrideWithValue(repo),
+            safetyReviewProvider('dive-1').overrideWith((ref) async => review),
+          ],
+          child: localizedMaterialApp(
+            home: const Scaffold(
+              body: SingleChildScrollView(
+                child: SafetyReviewSection(diveId: 'dive-1'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return repo;
+    }
+
+    testWidgets('dismiss all sends one bulk call for the dive', (tester) async {
+      final repo = await pumpBulk(
+        tester,
+        reviewWith([
+          rapidAscent(),
+          finding(
+            SafetyRuleId.sawtoothProfile,
+            severity: SafetySeverity.info,
+            value: 4,
+            id: 'f2',
+          ),
+        ]),
+      );
+
+      await tester.tap(find.text('Dismiss all'));
+      await tester.pumpAndSettle();
+
+      expect(repo.bulkCalls, hasLength(1));
+      expect(repo.bulkCalls.single.diveIds, ['dive-1']);
+      expect(repo.bulkCalls.single.dismissed, isTrue);
+      expect(
+        repo.calls,
+        isEmpty,
+        reason: 'one bulk write, not one call per finding',
+      );
+    });
+
+    testWidgets('offers restore all once nothing is active', (tester) async {
+      final repo = await pumpBulk(
+        tester,
+        reviewWith([rapidAscent(dismissedAt: now)]),
+      );
+
+      expect(find.text('Dismiss all'), findsNothing);
+      await tester.tap(find.text('Restore all'));
+      await tester.pumpAndSettle();
+
+      expect(repo.bulkCalls.single.dismissed, isFalse);
+    });
+
+    testWidgets('passes only the rules the diver has enabled', (tester) async {
+      final repo = await pumpBulk(
+        tester,
+        reviewWith([rapidAscent()]),
+        settings: const AppSettings(
+          safetyReviewDisabledRules: {'sawtoothProfile'},
+        ),
+      );
+
+      await tester.tap(find.text('Dismiss all'));
+      await tester.pumpAndSettle();
+
+      final ruleIds = repo.bulkCalls.single.ruleIds;
+      expect(ruleIds, contains(SafetyRuleId.rapidAscent.dbValue));
+      expect(
+        ruleIds,
+        isNot(contains(SafetyRuleId.sawtoothProfile.dbValue)),
+        reason: 'a rule hidden in settings must not be dismissed unseen',
+      );
+    });
+
+    testWidgets('dismiss all clears the chart highlight', (tester) async {
+      final repo = _RecordingSafetyRepo();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+            safetyFindingsRepositoryProvider.overrideWithValue(repo),
+            safetyReviewProvider(
+              'dive-1',
+            ).overrideWith((ref) async => reviewWith([rapidAscent()])),
+          ],
+          child: localizedMaterialApp(
+            home: const Scaffold(
+              body: SingleChildScrollView(
+                child: SafetyReviewSection(diveId: 'dive-1'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Ascent exceeded'));
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SafetyReviewSection)),
+      );
+      expect(
+        container.read(selectedSafetyFindingProvider('dive-1')),
+        isNotNull,
+      );
+
+      await tester.tap(find.text('Dismiss all'));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(selectedSafetyFindingProvider('dive-1')),
+        isNull,
+        reason: 'a dismissed finding must not stay highlighted on the chart',
+      );
+    });
+
+    testWidgets('the footer fits a narrow screen in a long locale', (
+      tester,
+    ) async {
+      // The state the primary action lands in: everything dismissed, so the
+      // "show dismissed" toggle and "restore all" render side by side. German
+      // labels are roughly twice the width of the English ones, which is why
+      // an English-only test would not catch a row overflow here.
+      await tester.binding.setSurfaceSize(const Size(360, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+            safetyFindingsRepositoryProvider.overrideWithValue(
+              _RecordingSafetyRepo(),
+            ),
+            safetyReviewProvider('dive-1').overrideWith(
+              (ref) async => reviewWith([rapidAscent(dismissedAt: now)]),
+            ),
+          ],
+          child: localizedMaterialApp(
+            locale: const Locale('de'),
+            home: const Scaffold(
+              body: SingleChildScrollView(
+                child: SafetyReviewSection(diveId: 'dive-1'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alle wiederherstellen'), findsOneWidget);
+      expect(find.textContaining('Ausgeblendete anzeigen'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
 }
 
-/// Records [setDismissed] calls without touching a database.
+/// Records dismiss calls without touching a database.
 class _RecordingSafetyRepo extends SafetyFindingsRepository {
   final List<(String, bool)> calls = [];
+  final List<({List<String> diveIds, bool dismissed, Set<String> ruleIds})>
+  bulkCalls = [];
 
   @override
   Future<void> setDismissed({
@@ -475,5 +648,21 @@ class _RecordingSafetyRepo extends SafetyFindingsRepository {
     required DateTime now,
   }) async {
     calls.add((findingId, dismissed));
+  }
+
+  @override
+  Future<int> setDismissedForDives({
+    required List<String> diveIds,
+    required bool dismissed,
+    required Set<String> enabledRuleIds,
+    required DateTime now,
+    int chunkSize = SafetyFindingsRepository.dismissChunkSize,
+  }) async {
+    bulkCalls.add((
+      diveIds: diveIds,
+      dismissed: dismissed,
+      ruleIds: enabledRuleIds,
+    ));
+    return diveIds.length;
   }
 }

--- a/test/features/settings/presentation/pages/safety_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/safety_settings_page_test.dart
@@ -8,6 +8,8 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/safety_findings_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/safety_finding.dart';
 import 'package:submersion/features/dive_log/presentation/providers/safety_review_providers.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/safety/domain/services/no_fly_service.dart';
@@ -149,6 +151,303 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Analysis complete'), findsOneWidget);
   });
+
+  testWidgets('dismiss all does nothing when the confirmation is cancelled', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final repo = _RecordingBulkRepo();
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(['d1'])),
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    expect(find.text('Dismiss all observations?'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(repo.calls, isEmpty);
+  });
+
+  testWidgets('confirming dismiss all writes through and reports the count', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final repo = _RecordingBulkRepo(changedPerCall: 3);
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(
+          _FakeDiveRepository(['d1', 'd2']),
+        ),
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pumpAndSettle();
+
+    expect(repo.calls.single, ['d1', 'd2']);
+    expect(repo.dismissed.single, isTrue);
+    expect(find.text('3 observations dismissed'), findsOneWidget);
+  });
+
+  testWidgets('dismiss all scopes the write to the enabled rules', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final repo = _RecordingBulkRepo();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith(
+            (ref) => MockSettingsNotifier(
+              const AppSettings(safetyReviewDisabledRules: {'sawtoothProfile'}),
+            ),
+          ),
+          currentDiverIdProvider.overrideWith(
+            (ref) => MockCurrentDiverIdNotifier(),
+          ),
+          diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(['d1'])),
+          safetyFindingsRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SafetySettingsPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pumpAndSettle();
+
+    expect(
+      repo.ruleIds.single,
+      isNot(contains(SafetyRuleId.sawtoothProfile.dbValue)),
+      reason: 'a rule hidden in settings must not be dismissed unseen',
+    );
+    expect(repo.ruleIds.single, contains(SafetyRuleId.rapidAscent.dbValue));
+  });
+
+  testWidgets('dismiss all reports when there was nothing to dismiss', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(['d1'])),
+        safetyFindingsRepositoryProvider.overrideWithValue(
+          _RecordingBulkRepo(changedPerCall: 0),
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No observations to dismiss'), findsOneWidget);
+  });
+
+  testWidgets('dismiss all shows progress and locks the analyze sweep', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final gate = Completer<void>();
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(['d1'])),
+        safetyFindingsRepositoryProvider.overrideWithValue(
+          _RecordingBulkRepo(gate: gate),
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.textContaining('Checked 0 of 1 dives'), findsOneWidget);
+    final analyzeTile = tester.widget<ListTile>(
+      find.widgetWithText(ListTile, 'Analyze all dives'),
+    );
+    expect(
+      analyzeTile.onTap,
+      isNull,
+      reason: 'the two long-running actions must not overlap',
+    );
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+  });
+
+  testWidgets('a failed chunk is reported alongside the partial count', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    // 60 dives spans two write chunks; the second throws, so the run has both
+    // a real partial result and a real failure to report.
+    final diveIds = [for (var i = 0; i < 60; i++) 'd$i'];
+    final repo = _RecordingBulkRepo(changedPerCall: 3, throwOnCall: 2);
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_FakeDiveRepository(diveIds)),
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('3 observations dismissed, 10 dives could not be updated'),
+      findsOneWidget,
+      reason: 'a partial write must be reported, not silently dropped',
+    );
+    final tile = tester.widget<ListTile>(
+      find.widgetWithText(ListTile, 'Dismiss all observations'),
+    );
+    expect(tile.onTap, isNotNull, reason: 'the page must not stay locked');
+  });
+
+  testWidgets('a failure to list dives says nothing was changed', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final repo = _RecordingBulkRepo();
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_ThrowingDiveRepository()),
+        safetyFindingsRepositoryProvider.overrideWithValue(repo),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dismiss all observations'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Dismiss all'));
+    await tester.pumpAndSettle();
+
+    expect(repo.calls, isEmpty);
+    expect(
+      find.text('Could not read your dive list. No dives were changed.'),
+      findsOneWidget,
+    );
+    final tile = tester.widget<ListTile>(
+      find.widgetWithText(ListTile, 'Dismiss all observations'),
+    );
+    expect(tile.onTap, isNotNull);
+  });
+
+  testWidgets('a failed analyze sweep does not leave the page locked', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(400, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      backfillApp([
+        diveRepositoryProvider.overrideWithValue(_ThrowingDiveRepository()),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Analyze all dives'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not analyze your dives.'), findsOneWidget);
+    // Without a finally the sweep leaves _analyzing true forever, which now
+    // also disables the master toggle, every rule, and bulk dismiss.
+    for (final title in ['Analyze all dives', 'Dismiss all observations']) {
+      expect(
+        tester.widget<ListTile>(find.widgetWithText(ListTile, title)).onTap,
+        isNotNull,
+        reason: '$title must recover after a failed sweep',
+      );
+    }
+  });
+}
+
+/// A [DiveRepository] whose id query always fails.
+class _ThrowingDiveRepository implements DiveRepository {
+  @override
+  Future<List<String>> getOrderedDiveIds({
+    String? diverId,
+    DiveFilterState filter = const DiveFilterState(),
+    SortState<DiveSortField>? sort,
+  }) async => throw StateError('dive list unavailable');
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Records bulk dismiss calls without touching a database.
+class _RecordingBulkRepo extends SafetyFindingsRepository {
+  _RecordingBulkRepo({this.gate, this.changedPerCall = 1, this.throwOnCall});
+
+  final Completer<void>? gate;
+  final int changedPerCall;
+
+  /// 1-based index of the call that should throw, or null for none.
+  final int? throwOnCall;
+  final List<List<String>> calls = [];
+  final List<bool> dismissed = [];
+  final List<Set<String>> ruleIds = [];
+
+  @override
+  Future<int> setDismissedForDives({
+    required List<String> diveIds,
+    required bool dismissed,
+    required Set<String> enabledRuleIds,
+    required DateTime now,
+    int chunkSize = SafetyFindingsRepository.dismissChunkSize,
+  }) async {
+    calls.add(diveIds);
+    this.dismissed.add(dismissed);
+    ruleIds.add(enabledRuleIds);
+    if (gate != null) await gate!.future;
+    if (calls.length == throwOnCall) {
+      throw StateError('bulk dismiss failed');
+    }
+    return changedPerCall;
+  }
 }
 
 /// Minimal [DiveRepository] fake returning a fixed ordered id list.


### PR DESCRIPTION
## What

Dismissing safety review observations one at a time is tedious on a dive with several findings, and impossible across a whole logbook. This adds a bulk action at both levels.

**Per dive.** A footer action in the safety review section dismisses every active finding at once. It flips to **Restore all** once nothing active is left, so the button never offers a no-op. The label is derived from the current finding list rather than stored in state, so a sync-driven rebuild cannot leave it disagreeing with what is on screen.

**Whole logbook.** A **Dismiss all observations** action in Safety settings, scoped to the active diver the same way "Analyze all dives" is, behind a confirm dialog and with a progress bar.

Both are scoped to the rules the diver has switched on. A rule hidden in settings is never dismissed behind the user's back, and the same filter excludes findings whose `rule_id` this build does not recognise (a newer app or sync payload). Those rows already do not render, so dismissing them would hide them permanently.

## How

`SafetyFindingsRepository.setDismissedForDives` chunks the `dive_id IN (...)` clause and touches only the rows whose dismissed state really flips.

Two constraints shaped it:

- **Only changed rows may be marked pending.** `dive_safety_findings` has no HLC of its own, so each write must bump the parent dive too, and the incremental exporter gates on `dives.hlc`. An unconditional `UPDATE` would therefore push the entire logbook on a tap that changed nothing. There is a test that reads `dives.hlc` before and after and asserts a dive with nothing to dismiss is untouched.
- **The local-change notification lives in a `finally`.** Each chunk is its own transaction, so a failure partway through leaves the earlier chunks committed and marked pending. Skipping the notification would strand those records until some unrelated write happened to kick the sync layer. This was a real bug caught in review and is now pinned by a test that injects a failing `SyncRepository` mid-run.

Per-dive `safetyReviewProvider` instances are deliberately not invalidated by the global action: they self-invalidate on `watchDiveDetailChanges()`, which covers both safety tables, so the findings write refreshes them on its own.

## Error handling

The settings action reports three distinct outcomes, because they call for different responses from the user:

| Outcome | Message |
| --- | --- |
| Clean run | `N observations dismissed` |
| Partial run | `N observations dismissed, M dives could not be updated` |
| Dive list unreadable | `Could not read your dive list. No dives were changed.` |

A failing chunk is logged and counted rather than aborting the run, so one unwritable dive does not strand the rest of the logbook. The last case is retry-safe; the middle one is not, which is why they are worded differently.

This also gives the pre-existing analyze sweep the `try/finally` it never had. It could leave `_analyzing` set forever, and the new shared busy flag would then disable the master toggle, every rule switch, and both actions.

## Notable fix found in review

The footer originally used a `Row` with a `Spacer`. After a dismiss-all, both the "show dismissed" toggle and "restore all" are on screen together, and in German that pair overflows a 360dp phone by 339 pixels. English fits, so an English-only test would never have caught it. It now uses an `OverflowBar`, which stacks the controls instead of overflowing, pinned by a test that pumps the both-buttons state under `Locale('de')` at 360x800.

## Localization

Thirteen new keys across all ten locales, plus a reworded progress string. Progress counts dives while the result counts observations, so "Dismissed 900 of 900" followed by "37 observations dismissed" read as 863 failures. It now says `Checked {done} of {total} dives`.

## Testing

Written before the implementation at each layer.

- **Repository (11 new):** cross-dive dismissal and restore, dive-list scoping, rule scoping, unknown `rule_id` rows left alone, accurate change counts, multi-chunk spans, the parent-HLC bump, no HLC bump when nothing changes, and the sync notification surviving a mid-run failure.
- **Section (5 new):** one bulk call rather than one per finding, the dismiss/restore flip, rule scoping, chart-highlight clearing, and the narrow-screen German layout.
- **Settings page (8 new):** confirm and cancel, the reported count, rule scoping, the zero case, progress and mutual locking, a failed chunk reported with its partial count, an unreadable dive list, and a failed analyze sweep leaving the page usable.

`flutter analyze` clean across the project. Full suite: 20482 passed, 19 skipped, 0 failed.
