### PR TITLE
fix(statistics): pair the Deco / No Deco legend labels with their bar segments

### DIFF
--- a/lib/features/statistics/presentation/pages/statistics_profile_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_profile_page.dart
@@ -266,21 +266,26 @@ class StatisticsProfilePage extends ConsumerWidget {
                 ),
               ),
               const SizedBox(height: 8),
+              // The bar paints the deco share in orange from the leading edge
+              // and leaves the no-deco remainder in green, so the legend has
+              // to name them in that order. Row and LinearProgressIndicator
+              // are both direction-aware, which keeps the pairing intact in
+              // RTL locales.
               ExcludeSemantics(
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      context.l10n.statistics_profile_deco_noDeco,
-                      style: Theme.of(
-                        context,
-                      ).textTheme.bodySmall?.copyWith(color: Colors.green),
-                    ),
-                    Text(
                       context.l10n.statistics_profile_deco_decoLabel,
                       style: Theme.of(
                         context,
                       ).textTheme.bodySmall?.copyWith(color: Colors.orange),
+                    ),
+                    Text(
+                      context.l10n.statistics_profile_deco_noDeco,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodySmall?.copyWith(color: Colors.green),
                     ),
                   ],
                 ),

--- a/test/features/statistics/presentation/pages/statistics_profile_deco_legend_test.dart
+++ b/test/features/statistics/presentation/pages/statistics_profile_deco_legend_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/features/statistics/presentation/pages/statistics_profile_page.dart';
+import 'package:submersion/features/statistics/presentation/providers/statistics_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Minimal mock SettingsNotifier using noSuchMethod to avoid re-implementing
+/// the full interface. Matches the pattern used in the other statistics page
+/// tests.
+class _MockSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _MockSettingsNotifier() : super(const AppSettings());
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Mock CurrentDiverIdNotifier that does not access the database.
+class _MockCurrentDiverIdNotifier extends StateNotifier<String?>
+    implements CurrentDiverIdNotifier {
+  _MockCurrentDiverIdNotifier() : super(null);
+
+  @override
+  Future<void> setCurrentDiver(String id) async => state = id;
+
+  @override
+  Future<void> clearCurrentDiver() async => state = null;
+}
+
+void main() {
+  group('Decompression Obligation legend', () {
+    const decoCount = 29;
+    const noDecoCount = 194;
+
+    late SharedPreferences prefs;
+
+    setUpAll(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+    });
+
+    Future<void> pumpPage(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            decoObligationStatsProvider.overrideWith(
+              (ref) async => (
+                decoCount: decoCount,
+                noDecoCount: noDecoCount,
+                unknownCount: 0,
+              ),
+            ),
+            ascentDescentRatesProvider.overrideWith(
+              (ref) async => (avgAscent: null, avgDescent: null),
+            ),
+            timeAtDepthRangesProvider.overrideWith((ref) async => []),
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            settingsProvider.overrideWith((ref) => _MockSettingsNotifier()),
+            currentDiverIdProvider.overrideWith(
+              (ref) => _MockCurrentDiverIdNotifier(),
+            ),
+          ],
+          child: const MaterialApp(
+            locale: Locale('en'),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: StatisticsProfilePage(embedded: true),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    /// The legend labels are the only colored copies of these strings; the
+    /// stat tiles above render the same words in onSurfaceVariant.
+    Finder legendLabel(String text, Color color) => find.byWidgetPredicate(
+      (widget) =>
+          widget is Text && widget.data == text && widget.style?.color == color,
+      description: '$text label styled $color',
+    );
+
+    testWidgets('bar fills with the deco share', (tester) async {
+      await pumpPage(tester);
+
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+
+      expect(bar.value, closeTo(decoCount / (decoCount + noDecoCount), 0.001));
+      expect(bar.valueColor?.value, Colors.orange);
+    });
+
+    testWidgets('each label sits under the segment it names', (tester) async {
+      await pumpPage(tester);
+
+      final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      // The bar paints valueColor from the leading edge and leaves the
+      // remainder in backgroundColor, so the label naming the filled share
+      // has to be the leading one.
+      final fillColor = bar.valueColor!.value!;
+
+      final decoFinder = legendLabel('Deco', fillColor);
+      final noDecoFinder = legendLabel('No Deco', Colors.green);
+      expect(decoFinder, findsOneWidget);
+      expect(noDecoFinder, findsOneWidget);
+
+      expect(
+        tester.getCenter(decoFinder).dx,
+        lessThan(tester.getCenter(noDecoFinder).dx),
+        reason:
+            'the orange "Deco" label must sit under the orange leading fill, '
+            'not opposite it',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

User-reported: on Profile Analysis, the **Decompression Obligation** card's Deco and No Deco legend labels are swapped relative to the bar they describe.

The card renders a proportion bar plus a two-item legend, and the two disagreed about which end is which:

```dart
LinearProgressIndicator(
  value: percentage / 100,                                   // the DECO share
  backgroundColor: Colors.green.withValues(alpha: 0.3),      // no-deco remainder
  valueColor: const AlwaysStoppedAnimation(Colors.orange),   // deco fill
)
```

`value` is the deco fraction, so orange fills the leading portion and green covers the trailing remainder. The legend `Row` (`MainAxisAlignment.spaceBetween`) listed green "No Deco" first and orange "Deco" last, placing each word at the opposite end from the segment it names. In the reported screenshot (29 deco / 194 no-deco, 13.0%) the bar shows a short orange stub on the left under a green "No Deco" caption, and a long green tail on the right under an orange "Deco" caption.

The fix swaps the two `Text` children so the orange label leads with the orange fill.

## Changes

- `statistics_profile_page.dart`: legend labels reordered to Deco then No Deco, with a comment recording why the order is tied to the bar's fill direction.
- New `statistics_profile_deco_legend_test.dart`: 2 widget tests using the reported 29/194 fixture.

## Notes for review

- **RTL is unaffected.** `LinearProgressIndicator` reads `Directionality.of(context)` and positions its fill by `textDirection`; `Row` lays children out in reading order. Both flip together, so the labels stay paired with their segments in `ar` and `he`. No `left`/`right` reasoning is baked in.
- **No accessibility impact.** The bar's `Semantics` label ("Decompression rate: X% of dives required deco stops") was already correct, and the legend is wrapped in `ExcludeSemantics`, which is why this only ever affected sighted users.
- **The test derives the invariant instead of hardcoding a side.** It reads `valueColor` off the rendered indicator and asserts that the legend label styled with that color sits at the leading edge, so it stays valid if a future change fixes a regression by inverting the bar rather than by relabeling. Against the old code it failed with "Deco" at x=739 vs "No Deco" at x=79.
- **No other card has this shape.** Every other `LinearProgressIndicator` in `lib/` is a progress bar, not a two-sided proportion bar with a legend, so there is no sibling instance of this bug.
- No string changes; `statistics_profile_deco_decoLabel` and `statistics_profile_deco_noDeco` are reused as-is in all 11 locales.

## Test Plan

- [x] `flutter test` passes: 20498 passed, 19 skipped, 0 failures.
- [x] `flutter analyze` passes: no issues found.
- [x] `dart format .`: no drift (0 of 4162 files changed).
- [x] New test fails on the pre-fix code and passes after, confirming it actually covers the defect.
- [x] Manual testing: not run; the widget tests assert the rendered geometry and colors directly.
