### PR TITLE
fix(dive-computer): keep every transmitter's pressure on multi-tank dives

### DIFF
--- a/lib/features/dive_computer/data/services/dive_parser.dart
+++ b/lib/features/dive_computer/data/services/dive_parser.dart
@@ -30,6 +30,8 @@ class DiveParser {
           heading: sample.heading,
           // Preserve tank index for multi-tank pressure tracking
           tankIndex: sample.tankIndex,
+          // Every transmitter's reading at this sample (issue #1223)
+          tankPressures: sample.tankPressures,
           // Decompression and rebreather data
           setpoint: sample.setpoint,
           ppO2: sample.ppo2,

--- a/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
+++ b/lib/features/dive_computer/data/services/parsed_dive_mapper.dart
@@ -56,6 +56,7 @@ DownloadedDive parsedDiveToDownloaded(pigeon.ParsedDive parsed) {
             temperature: s.temperatureCelsius,
             pressure: s.pressureBar,
             tankIndex: s.tankIndex,
+            tankPressures: s.tankPressuresBar,
             heartRate: s.heartRate,
             heading: s.heading,
             setpoint: s.setpoint,

--- a/lib/features/dive_computer/data/services/reparse_service.dart
+++ b/lib/features/dive_computer/data/services/reparse_service.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/features/dive_computer/data/services/libdc_dive_mode.dart';
 import 'package:submersion/features/dive_log/domain/services/bottom_time_calculator.dart';
 import 'package:submersion/features/dive_computer/data/services/parsed_tank_resolver.dart';
+import 'package:submersion/features/dive_log/domain/services/tank_pressure_series.dart';
 
 /// Service responsible for applying re-parsed dive computer data back to the
 /// database while respecting the computer-authored vs user-authored field
@@ -747,18 +748,18 @@ class ReparseService {
   }) async {
     if (tankIdsByIndex.isEmpty) return;
 
-    // Group sample pressures by tank index.
-    final pressuresByTank = <int, List<({int timestamp, double pressure})>>{};
-    for (final s in parsed.samples) {
-      final pressure = s.pressureBar;
-      if (pressure != null) {
-        final idx = s.tankIndex ?? 0;
-        pressuresByTank.putIfAbsent(idx, () => []).add((
-          timestamp: s.timeSeconds,
-          pressure: pressure,
-        ));
-      }
-    }
+    // Group sample pressures by tank index. A sample can carry a reading per
+    // air-integrated transmitter (issue #1223), so this walks tankPressuresBar
+    // rather than the single pressureBar/tankIndex pair.
+    final pressuresByTank = groupPressuresByTank([
+      for (final s in parsed.samples)
+        (
+          timeSeconds: s.timeSeconds,
+          pressureBar: s.pressureBar,
+          tankIndex: s.tankIndex,
+          tankPressuresBar: s.tankPressuresBar,
+        ),
+    ]);
     if (pressuresByTank.isEmpty) return;
 
     // Insert the pressure time-series for each known tank.

--- a/lib/features/dive_computer/domain/entities/downloaded_dive.dart
+++ b/lib/features/dive_computer/domain/entities/downloaded_dive.dart
@@ -201,6 +201,13 @@ class ProfileSample {
   /// Tank index for pressure (0-based)
   final int? tankIndex;
 
+  /// Every tank's pressure in bar at this sample, indexed by tank index, with
+  /// null where that tank reported nothing. libdivecomputer reports one
+  /// pressure per air-integrated transmitter, so a single sample can carry
+  /// several; [pressure]/[tankIndex] hold only the last of them (issue #1223).
+  /// Null when the source reports at most one pressure per sample.
+  final List<double?>? tankPressures;
+
   /// Heart rate in bpm (if available)
   final int? heartRate;
 
@@ -265,6 +272,7 @@ class ProfileSample {
     this.temperature,
     this.pressure,
     this.tankIndex,
+    this.tankPressures,
     this.heartRate,
     this.heading,
     this.setpoint,

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -26,6 +26,7 @@ import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart'
     show GeoPoint;
 import 'package:submersion/features/dive_log/domain/services/bottom_time_calculator.dart';
 import 'package:submersion/features/dive_log/domain/services/dive_altitude_enricher.dart';
+import 'package:submersion/features/dive_log/domain/services/tank_pressure_series.dart';
 import 'package:submersion/features/equipment/data/services/dive_equipment_defaulter.dart';
 import 'package:submersion/features/pre_dive/data/services/checklist_dive_linker.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -1426,19 +1427,18 @@ class DiveComputerRepository {
 
       // Insert per-tank pressure time-series data (batch insert, no individual sync)
       if (tankIdsByIndex.isNotEmpty) {
-        // Group pressure readings by tank index
-        final pressuresByTank =
-            <int, List<({int timestamp, double pressure})>>{};
-        for (final point in points) {
-          if (point.pressure != null) {
-            final tankIdx = point.tankIndex ?? 0;
-            pressuresByTank.putIfAbsent(tankIdx, () => []);
-            pressuresByTank[tankIdx]!.add((
-              timestamp: point.timestamp,
-              pressure: point.pressure!,
-            ));
-          }
-        }
+        // Group pressure readings by tank index. A sample can carry a reading
+        // per air-integrated transmitter (issue #1223), so this walks
+        // tankPressures rather than the single pressure/tankIndex pair.
+        final pressuresByTank = groupPressuresByTank([
+          for (final point in points)
+            (
+              timeSeconds: point.timestamp,
+              pressureBar: point.pressure,
+              tankIndex: point.tankIndex,
+              tankPressuresBar: point.tankPressures,
+            ),
+        ]);
 
         // Batch insert pressure data for each tank
         // No individual sync records - parent dive sync covers child data
@@ -2075,6 +2075,13 @@ class ProfilePointData {
   /// Tank index for pressure (0-based), used for multi-tank pressure tracking
   final int? tankIndex;
 
+  /// Every tank's pressure in bar at this sample, indexed by tank index, with
+  /// null where that tank reported nothing. A dive computer reports one
+  /// pressure per air-integrated transmitter, so a single sample can carry
+  /// several; [pressure]/[tankIndex] hold only the last of them (issue #1223).
+  /// Null for sources that report at most one pressure per sample.
+  final List<double?>? tankPressures;
+
   /// CCR setpoint in bar
   final double? setpoint;
 
@@ -2133,6 +2140,7 @@ class ProfilePointData {
     this.heartRate,
     this.heading,
     this.tankIndex,
+    this.tankPressures,
     this.setpoint,
     this.ppO2,
     this.cns,

--- a/lib/features/dive_log/domain/services/tank_pressure_series.dart
+++ b/lib/features/dive_log/domain/services/tank_pressure_series.dart
@@ -1,0 +1,53 @@
+/// One pressure reading in a tank's time series, in seconds from dive start.
+typedef TankPressurePoint = ({int timestamp, double pressure});
+
+/// The pressure fields of one dive-computer sample.
+///
+/// [tankPressuresBar] is the complete record: libdivecomputer reports one
+/// pressure per air-integrated transmitter, so a single sample can carry
+/// several. [pressureBar]/[tankIndex] hold only the last of them, and are the
+/// fallback for sources that never report more than one tank per sample (UDDF
+/// and FIT imports, and native builds predating issue #1223).
+typedef TankPressureSampleView = ({
+  int timeSeconds,
+  double? pressureBar,
+  int? tankIndex,
+  List<double?>? tankPressuresBar,
+});
+
+/// Splits per-sample transmitter readings into one time series per tank index.
+///
+/// Samples are read in order, so each series comes out in sample order. Tanks
+/// that reported nothing at a sample are simply absent from that timestamp: a
+/// transmitter that loses comms leaves a hole rather than a stale or zero
+/// reading.
+Map<int, List<TankPressurePoint>> groupPressuresByTank(
+  Iterable<TankPressureSampleView> samples,
+) {
+  final byTank = <int, List<TankPressurePoint>>{};
+
+  void add(int tankIndex, int timeSeconds, double pressure) {
+    byTank.putIfAbsent(tankIndex, () => []).add((
+      timestamp: timeSeconds,
+      pressure: pressure,
+    ));
+  }
+
+  for (final sample in samples) {
+    final perTank = sample.tankPressuresBar;
+    if (perTank != null) {
+      // The per-tank list supersedes pressureBar, which is one of its entries.
+      for (var index = 0; index < perTank.length; index++) {
+        final pressure = perTank[index];
+        if (pressure != null) add(index, sample.timeSeconds, pressure);
+      }
+      continue;
+    }
+    final pressure = sample.pressureBar;
+    if (pressure != null) {
+      add(sample.tankIndex ?? 0, sample.timeSeconds, pressure);
+    }
+  }
+
+  return byTank;
+}

--- a/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
+++ b/packages/libdivecomputer_plugin/android/src/main/cpp/libdc_jni.cpp
@@ -999,7 +999,11 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSampleCount(
 }
 
 // Must match SAMPLE_FIELD_COUNT in SampleDecoder.kt.
-#define LIBDC_SAMPLE_FIELD_COUNT 28
+#define LIBDC_SAMPLE_FIELD_COUNT (28 + LIBDC_MAX_TANKS)
+
+// Index of the first per-tank pressure slot; must match TANK_PRESSURE_OFFSET in
+// SampleDecoder.kt.
+#define LIBDC_TANK_PRESSURE_OFFSET 28
 
 extern "C" JNIEXPORT jdoubleArray JNICALL
 Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSample(
@@ -1008,7 +1012,8 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSample(
     if (index < 0 || static_cast<unsigned int>(index) >= dive->sample_count) return nullptr;
 
     const libdc_sample_t *s = &dive->samples[index];
-    // All 28 fields (14 base + 6 O2 cells + gas mix + heading + 6 cell mV).
+    // 28 scalar fields (14 base + 6 O2 cells + gas mix + heading + 6 cell mV),
+    // then one slot per tank for the per-transmitter pressures (issue #1223).
     // Integer sentinels (UINT32_MAX) are cast to double; NAN doubles pass
     // through and become null on the Kotlin side. Kotlin indexes this array
     // positionally (see SampleDecoder.kt): append only, never insert.
@@ -1042,6 +1047,9 @@ Java_com_submersion_libdivecomputer_LibdcWrapper_nativeGetDiveSample(
         static_cast<jdouble>(s->o2_sensor_mv[4]),
         static_cast<jdouble>(s->o2_sensor_mv[5])
     };
+    for (unsigned int t = 0; t < LIBDC_MAX_TANKS; t++) {
+        values[LIBDC_TANK_PRESSURE_OFFSET + t] = s->tank_pressure[t];
+    }
     jdoubleArray result = env->NewDoubleArray(LIBDC_SAMPLE_FIELD_COUNT);
     env->SetDoubleArrayRegion(result, 0, LIBDC_SAMPLE_FIELD_COUNT, values);
     return result;

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/DiveComputerApi.g.kt
@@ -129,6 +129,16 @@ data class ProfileSample (
   val temperatureCelsius: Double? = null,
   val pressureBar: Double? = null,
   val tankIndex: Long? = null,
+  /**
+   * Every tank's pressure in bar at this sample, indexed by tank index, with
+   * null where that tank reported nothing. libdivecomputer fires one pressure
+   * reading per air-integrated transmitter, so a single sample can carry
+   * several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+   * rest (issue #1223). Null when the sample carries no pressure at all, and
+   * trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+   * short list per sample.
+   */
+  val tankPressuresBar: List<Double?>? = null,
   val heartRate: Long? = null,
   /**
    * Compass heading in degrees (0-359) from DC_SAMPLE_BEARING; null when the
@@ -179,30 +189,31 @@ data class ProfileSample (
       val temperatureCelsius = pigeonVar_list[2] as Double?
       val pressureBar = pigeonVar_list[3] as Double?
       val tankIndex = pigeonVar_list[4] as Long?
-      val heartRate = pigeonVar_list[5] as Long?
-      val heading = pigeonVar_list[6] as Double?
-      val setpoint = pigeonVar_list[7] as Double?
-      val ppo2 = pigeonVar_list[8] as Double?
-      val cns = pigeonVar_list[9] as Double?
-      val rbt = pigeonVar_list[10] as Long?
-      val decoType = pigeonVar_list[11] as Long?
-      val decoTime = pigeonVar_list[12] as Long?
-      val decoDepth = pigeonVar_list[13] as Double?
-      val tts = pigeonVar_list[14] as Long?
-      val o2Sensor1 = pigeonVar_list[15] as Double?
-      val o2Sensor2 = pigeonVar_list[16] as Double?
-      val o2Sensor3 = pigeonVar_list[17] as Double?
-      val o2Sensor4 = pigeonVar_list[18] as Double?
-      val o2Sensor5 = pigeonVar_list[19] as Double?
-      val o2Sensor6 = pigeonVar_list[20] as Double?
-      val o2SensorMv1 = pigeonVar_list[21] as Long?
-      val o2SensorMv2 = pigeonVar_list[22] as Long?
-      val o2SensorMv3 = pigeonVar_list[23] as Long?
-      val o2SensorMv4 = pigeonVar_list[24] as Long?
-      val o2SensorMv5 = pigeonVar_list[25] as Long?
-      val o2SensorMv6 = pigeonVar_list[26] as Long?
-      val gasMixIndex = pigeonVar_list[27] as Long?
-      return ProfileSample(timeSeconds, depthMeters, temperatureCelsius, pressureBar, tankIndex, heartRate, heading, setpoint, ppo2, cns, rbt, decoType, decoTime, decoDepth, tts, o2Sensor1, o2Sensor2, o2Sensor3, o2Sensor4, o2Sensor5, o2Sensor6, o2SensorMv1, o2SensorMv2, o2SensorMv3, o2SensorMv4, o2SensorMv5, o2SensorMv6, gasMixIndex)
+      val tankPressuresBar = pigeonVar_list[5] as List<Double?>?
+      val heartRate = pigeonVar_list[6] as Long?
+      val heading = pigeonVar_list[7] as Double?
+      val setpoint = pigeonVar_list[8] as Double?
+      val ppo2 = pigeonVar_list[9] as Double?
+      val cns = pigeonVar_list[10] as Double?
+      val rbt = pigeonVar_list[11] as Long?
+      val decoType = pigeonVar_list[12] as Long?
+      val decoTime = pigeonVar_list[13] as Long?
+      val decoDepth = pigeonVar_list[14] as Double?
+      val tts = pigeonVar_list[15] as Long?
+      val o2Sensor1 = pigeonVar_list[16] as Double?
+      val o2Sensor2 = pigeonVar_list[17] as Double?
+      val o2Sensor3 = pigeonVar_list[18] as Double?
+      val o2Sensor4 = pigeonVar_list[19] as Double?
+      val o2Sensor5 = pigeonVar_list[20] as Double?
+      val o2Sensor6 = pigeonVar_list[21] as Double?
+      val o2SensorMv1 = pigeonVar_list[22] as Long?
+      val o2SensorMv2 = pigeonVar_list[23] as Long?
+      val o2SensorMv3 = pigeonVar_list[24] as Long?
+      val o2SensorMv4 = pigeonVar_list[25] as Long?
+      val o2SensorMv5 = pigeonVar_list[26] as Long?
+      val o2SensorMv6 = pigeonVar_list[27] as Long?
+      val gasMixIndex = pigeonVar_list[28] as Long?
+      return ProfileSample(timeSeconds, depthMeters, temperatureCelsius, pressureBar, tankIndex, tankPressuresBar, heartRate, heading, setpoint, ppo2, cns, rbt, decoType, decoTime, decoDepth, tts, o2Sensor1, o2Sensor2, o2Sensor3, o2Sensor4, o2Sensor5, o2Sensor6, o2SensorMv1, o2SensorMv2, o2SensorMv3, o2SensorMv4, o2SensorMv5, o2SensorMv6, gasMixIndex)
     }
   }
   fun toList(): List<Any?> {
@@ -212,6 +223,7 @@ data class ProfileSample (
       temperatureCelsius,
       pressureBar,
       tankIndex,
+      tankPressuresBar,
       heartRate,
       heading,
       setpoint,

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SampleDecoder.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/SampleDecoder.kt
@@ -2,19 +2,47 @@ package com.submersion.libdivecomputer
 
 internal const val UINT32_SENTINEL: Long = 4294967295L // UINT32_MAX = unavailable
 
+/** Per-sample pressure slots the JNI side packs. Mirrors LIBDC_MAX_TANKS in libdc_wrapper.h. */
+internal const val LIBDC_MAX_TANKS = 16
+
 /**
  * Field count marshalled per sample by nativeGetDiveSample. The JNI side packs
  * these positionally and must be changed together with this file. Append only:
  * inserting a field silently renumbers every field after it, with no error on
  * either side.
  */
-internal const val SAMPLE_FIELD_COUNT = 28
+internal const val SAMPLE_FIELD_COUNT = 28 + LIBDC_MAX_TANKS
+
+/** Index of the first per-tank pressure slot. Matches LIBDC_TANK_PRESSURE_OFFSET in libdc_jni.cpp. */
+private const val TANK_PRESSURE_OFFSET = 28
 
 private fun sentinelLong(s: DoubleArray, i: Int): Long? =
     if (s[i].toLong() == UINT32_SENTINEL) null else s[i].toLong()
 
 private fun cellMillivolt(s: DoubleArray, i: Int): Long? =
-    if (s.size < SAMPLE_FIELD_COUNT) null else sentinelLong(s, i)
+    if (s.size < 28) null else sentinelLong(s, i)
+
+/**
+ * Every tank's pressure at this sample, indexed by tank index, NaN decoded to
+ * null. Trailing nulls are trimmed and an all-null sample decodes to null, so an
+ * ordinary single-transmitter dive carries a one-element list per sample.
+ *
+ * Issue #1223: libdivecomputer reports one pressure per air-integrated
+ * transmitter, so a sample can carry several and `pressureBar`/`tankIndex` keep
+ * only the last of them.
+ */
+private fun tankPressures(s: DoubleArray): List<Double?>? {
+    if (s.size < SAMPLE_FIELD_COUNT) return null
+    val values = ArrayList<Double?>(LIBDC_MAX_TANKS)
+    for (t in 0 until LIBDC_MAX_TANKS) {
+        val v = s[TANK_PRESSURE_OFFSET + t]
+        values.add(if (v.isNaN()) null else v)
+    }
+    while (values.isNotEmpty() && values.last() == null) {
+        values.removeAt(values.size - 1)
+    }
+    return if (values.isEmpty()) null else values
+}
 
 /**
  * Decodes one positional sample array into a [ProfileSample]. Shared by the
@@ -26,6 +54,7 @@ internal fun decodeProfileSample(s: DoubleArray): ProfileSample = ProfileSample(
     temperatureCelsius = if (s[2].isNaN()) null else s[2],
     pressureBar = if (s[3].isNaN()) null else s[3],
     tankIndex = sentinelLong(s, 4),
+    tankPressuresBar = tankPressures(s),
     heartRate = sentinelLong(s, 5),
     heading = if (s.size < 22 || s[21].toLong() == UINT32_SENTINEL) null else s[21],
     setpoint = if (s[6].isNaN()) null else s[6],

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SampleDecoderTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/SampleDecoderTest.kt
@@ -71,4 +71,50 @@ class SampleDecoderTest {
         a[22] = 0.0
         assertEquals(0L, decodeProfileSample(a).o2SensorMv1)
     }
+
+    /** Issue #1223: a sample can carry one pressure per air-integrated
+     * transmitter, packed one slot per tank from index 28. */
+    @Test
+    fun `tank pressures decode from index 28 onward`() {
+        val a = sampleArray()
+        a[28] = 192.6 // tank 0 (O2)
+        a[29] = 191.4 // tank 1 (diluent)
+        assertEquals(listOf(192.6, 191.4), decodeProfileSample(a).tankPressuresBar)
+    }
+
+    /** A transmitter out of comms leaves a hole, not a zero. */
+    @Test
+    fun `a tank with no reading decodes as null within the list`() {
+        val a = sampleArray()
+        a[29] = 191.4
+        assertEquals(listOf(null, 191.4), decodeProfileSample(a).tankPressuresBar)
+    }
+
+    /** Trailing empty slots are trimmed, so a single-transmitter dive carries a
+     * one-element list rather than a full LIBDC_MAX_TANKS one. */
+    @Test
+    fun `trailing empty tanks are trimmed`() {
+        val a = sampleArray()
+        a[28] = 200.0
+        assertEquals(listOf(200.0), decodeProfileSample(a).tankPressuresBar)
+    }
+
+    /** A sample with no pressure at all carries no list. */
+    @Test
+    fun `all-NaN tank pressures decode as null`() {
+        assertNull(decodeProfileSample(sampleArray()).tankPressuresBar)
+    }
+
+    /** A stale .so returns the pre-#1223 28-wide array; the Dart layer then
+     * falls back to pressureBar/tankIndex rather than seeing a bogus list. */
+    @Test
+    fun `short array yields null tank pressures`() {
+        val a = sampleArray()
+        a[3] = 190.0 // pressure
+        a[4] = 0.0 // tank
+        val s = decodeProfileSample(a.copyOf(28))
+        assertNull(s.tankPressuresBar)
+        assertEquals(190.0, s.pressureBar!!, 1e-9)
+        assertEquals(0L, s.tankIndex)
+    }
 }

--- a/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
+++ b/packages/libdivecomputer_plugin/darwin/Sources/LibDCDarwin/DiveComputerHostApiImpl.swift
@@ -734,6 +734,7 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
                     temperatureCelsius: s.temperature.isNaN ? nil : s.temperature,
                     pressureBar: s.pressure.isNaN ? nil : s.pressure,
                     tankIndex: s.tank == UInt32.max ? nil : Int64(s.tank),
+                    tankPressuresBar: tankPressures(of: s),
                     heartRate: s.heartbeat == UInt32.max ? nil : Int64(s.heartbeat),
                     heading: s.heading == UInt32.max ? nil : Double(s.heading),
                     setpoint: s.setpoint.isNaN ? nil : s.setpoint,
@@ -986,6 +987,25 @@ class DiveComputerHostApiImpl: DiveComputerHostApi {
             )) { _ in }
         }
     }
+}
+
+/// Every tank's pressure at one sample, indexed by tank index, NAN unpacked to
+/// nil. Trailing nils are trimmed and an all-nil sample returns nil, so the
+/// common single-transmitter dive marshals a one-element list per sample rather
+/// than a full LIBDC_MAX_TANKS one. See issue #1223: a sample can carry a
+/// reading per air-integrated transmitter, and `pressure`/`tank` hold only the
+/// last of them.
+private func tankPressures(of sample: libdc_sample_t) -> [Double?]? {
+    let capacity = Int(LIBDC_MAX_TANKS)
+    var values = withUnsafePointer(to: sample.tank_pressure) { tuplePtr in
+        tuplePtr.withMemoryRebound(to: Double.self, capacity: capacity) { buffer in
+            (0..<capacity).map { buffer[$0].isNaN ? nil : buffer[$0] }
+        }
+    }
+    while let last = values.last, last == nil {
+        values.removeLast()
+    }
+    return values.isEmpty ? nil : values
 }
 
 private final class BlePeripheralResolver: NSObject, CBCentralManagerDelegate {

--- a/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
+++ b/packages/libdivecomputer_plugin/ios/Classes/DiveComputerApi.g.swift
@@ -154,6 +154,14 @@ struct ProfileSample {
   var temperatureCelsius: Double? = nil
   var pressureBar: Double? = nil
   var tankIndex: Int64? = nil
+  /// Every tank's pressure in bar at this sample, indexed by tank index, with
+  /// null where that tank reported nothing. libdivecomputer fires one pressure
+  /// reading per air-integrated transmitter, so a single sample can carry
+  /// several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+  /// rest (issue #1223). Null when the sample carries no pressure at all, and
+  /// trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+  /// short list per sample.
+  var tankPressuresBar: [Double?]? = nil
   var heartRate: Int64? = nil
   /// Compass heading in degrees (0-359) from DC_SAMPLE_BEARING; null when the
   /// computer does not report bearing samples.
@@ -196,29 +204,30 @@ struct ProfileSample {
     let temperatureCelsius: Double? = nilOrValue(pigeonVar_list[2])
     let pressureBar: Double? = nilOrValue(pigeonVar_list[3])
     let tankIndex: Int64? = nilOrValue(pigeonVar_list[4])
-    let heartRate: Int64? = nilOrValue(pigeonVar_list[5])
-    let heading: Double? = nilOrValue(pigeonVar_list[6])
-    let setpoint: Double? = nilOrValue(pigeonVar_list[7])
-    let ppo2: Double? = nilOrValue(pigeonVar_list[8])
-    let cns: Double? = nilOrValue(pigeonVar_list[9])
-    let rbt: Int64? = nilOrValue(pigeonVar_list[10])
-    let decoType: Int64? = nilOrValue(pigeonVar_list[11])
-    let decoTime: Int64? = nilOrValue(pigeonVar_list[12])
-    let decoDepth: Double? = nilOrValue(pigeonVar_list[13])
-    let tts: Int64? = nilOrValue(pigeonVar_list[14])
-    let o2Sensor1: Double? = nilOrValue(pigeonVar_list[15])
-    let o2Sensor2: Double? = nilOrValue(pigeonVar_list[16])
-    let o2Sensor3: Double? = nilOrValue(pigeonVar_list[17])
-    let o2Sensor4: Double? = nilOrValue(pigeonVar_list[18])
-    let o2Sensor5: Double? = nilOrValue(pigeonVar_list[19])
-    let o2Sensor6: Double? = nilOrValue(pigeonVar_list[20])
-    let o2SensorMv1: Int64? = nilOrValue(pigeonVar_list[21])
-    let o2SensorMv2: Int64? = nilOrValue(pigeonVar_list[22])
-    let o2SensorMv3: Int64? = nilOrValue(pigeonVar_list[23])
-    let o2SensorMv4: Int64? = nilOrValue(pigeonVar_list[24])
-    let o2SensorMv5: Int64? = nilOrValue(pigeonVar_list[25])
-    let o2SensorMv6: Int64? = nilOrValue(pigeonVar_list[26])
-    let gasMixIndex: Int64? = nilOrValue(pigeonVar_list[27])
+    let tankPressuresBar: [Double?]? = nilOrValue(pigeonVar_list[5])
+    let heartRate: Int64? = nilOrValue(pigeonVar_list[6])
+    let heading: Double? = nilOrValue(pigeonVar_list[7])
+    let setpoint: Double? = nilOrValue(pigeonVar_list[8])
+    let ppo2: Double? = nilOrValue(pigeonVar_list[9])
+    let cns: Double? = nilOrValue(pigeonVar_list[10])
+    let rbt: Int64? = nilOrValue(pigeonVar_list[11])
+    let decoType: Int64? = nilOrValue(pigeonVar_list[12])
+    let decoTime: Int64? = nilOrValue(pigeonVar_list[13])
+    let decoDepth: Double? = nilOrValue(pigeonVar_list[14])
+    let tts: Int64? = nilOrValue(pigeonVar_list[15])
+    let o2Sensor1: Double? = nilOrValue(pigeonVar_list[16])
+    let o2Sensor2: Double? = nilOrValue(pigeonVar_list[17])
+    let o2Sensor3: Double? = nilOrValue(pigeonVar_list[18])
+    let o2Sensor4: Double? = nilOrValue(pigeonVar_list[19])
+    let o2Sensor5: Double? = nilOrValue(pigeonVar_list[20])
+    let o2Sensor6: Double? = nilOrValue(pigeonVar_list[21])
+    let o2SensorMv1: Int64? = nilOrValue(pigeonVar_list[22])
+    let o2SensorMv2: Int64? = nilOrValue(pigeonVar_list[23])
+    let o2SensorMv3: Int64? = nilOrValue(pigeonVar_list[24])
+    let o2SensorMv4: Int64? = nilOrValue(pigeonVar_list[25])
+    let o2SensorMv5: Int64? = nilOrValue(pigeonVar_list[26])
+    let o2SensorMv6: Int64? = nilOrValue(pigeonVar_list[27])
+    let gasMixIndex: Int64? = nilOrValue(pigeonVar_list[28])
 
     return ProfileSample(
       timeSeconds: timeSeconds,
@@ -226,6 +235,7 @@ struct ProfileSample {
       temperatureCelsius: temperatureCelsius,
       pressureBar: pressureBar,
       tankIndex: tankIndex,
+      tankPressuresBar: tankPressuresBar,
       heartRate: heartRate,
       heading: heading,
       setpoint: setpoint,
@@ -258,6 +268,7 @@ struct ProfileSample {
       temperatureCelsius,
       pressureBar,
       tankIndex,
+      tankPressuresBar,
       heartRate,
       heading,
       setpoint,

--- a/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
+++ b/packages/libdivecomputer_plugin/lib/src/generated/dive_computer_api.g.dart
@@ -108,6 +108,7 @@ class ProfileSample {
     this.temperatureCelsius,
     this.pressureBar,
     this.tankIndex,
+    this.tankPressuresBar,
     this.heartRate,
     this.heading,
     this.setpoint,
@@ -142,6 +143,15 @@ class ProfileSample {
   double? pressureBar;
 
   int? tankIndex;
+
+  /// Every tank's pressure in bar at this sample, indexed by tank index, with
+  /// null where that tank reported nothing. libdivecomputer fires one pressure
+  /// reading per air-integrated transmitter, so a single sample can carry
+  /// several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+  /// rest (issue #1223). Null when the sample carries no pressure at all, and
+  /// trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+  /// short list per sample.
+  List<double?>? tankPressuresBar;
 
   int? heartRate;
 
@@ -206,6 +216,7 @@ class ProfileSample {
       temperatureCelsius,
       pressureBar,
       tankIndex,
+      tankPressuresBar,
       heartRate,
       heading,
       setpoint,
@@ -240,29 +251,30 @@ class ProfileSample {
       temperatureCelsius: result[2] as double?,
       pressureBar: result[3] as double?,
       tankIndex: result[4] as int?,
-      heartRate: result[5] as int?,
-      heading: result[6] as double?,
-      setpoint: result[7] as double?,
-      ppo2: result[8] as double?,
-      cns: result[9] as double?,
-      rbt: result[10] as int?,
-      decoType: result[11] as int?,
-      decoTime: result[12] as int?,
-      decoDepth: result[13] as double?,
-      tts: result[14] as int?,
-      o2Sensor1: result[15] as double?,
-      o2Sensor2: result[16] as double?,
-      o2Sensor3: result[17] as double?,
-      o2Sensor4: result[18] as double?,
-      o2Sensor5: result[19] as double?,
-      o2Sensor6: result[20] as double?,
-      o2SensorMv1: result[21] as int?,
-      o2SensorMv2: result[22] as int?,
-      o2SensorMv3: result[23] as int?,
-      o2SensorMv4: result[24] as int?,
-      o2SensorMv5: result[25] as int?,
-      o2SensorMv6: result[26] as int?,
-      gasMixIndex: result[27] as int?,
+      tankPressuresBar: (result[5] as List<Object?>?)?.cast<double?>(),
+      heartRate: result[6] as int?,
+      heading: result[7] as double?,
+      setpoint: result[8] as double?,
+      ppo2: result[9] as double?,
+      cns: result[10] as double?,
+      rbt: result[11] as int?,
+      decoType: result[12] as int?,
+      decoTime: result[13] as int?,
+      decoDepth: result[14] as double?,
+      tts: result[15] as int?,
+      o2Sensor1: result[16] as double?,
+      o2Sensor2: result[17] as double?,
+      o2Sensor3: result[18] as double?,
+      o2Sensor4: result[19] as double?,
+      o2Sensor5: result[20] as double?,
+      o2Sensor6: result[21] as double?,
+      o2SensorMv1: result[22] as int?,
+      o2SensorMv2: result[23] as int?,
+      o2SensorMv3: result[24] as int?,
+      o2SensorMv4: result[25] as int?,
+      o2SensorMv5: result[26] as int?,
+      o2SensorMv6: result[27] as int?,
+      gasMixIndex: result[28] as int?,
     );
   }
 }

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.cc
@@ -192,6 +192,7 @@ struct _LibdivecomputerPluginProfileSample {
   double* temperature_celsius;
   double* pressure_bar;
   int64_t* tank_index;
+  FlValue* tank_pressures_bar;
   int64_t* heart_rate;
   double* heading;
   double* setpoint;
@@ -224,6 +225,7 @@ static void libdivecomputer_plugin_profile_sample_dispose(GObject* object) {
   g_clear_pointer(&self->temperature_celsius, g_free);
   g_clear_pointer(&self->pressure_bar, g_free);
   g_clear_pointer(&self->tank_index, g_free);
+  g_clear_pointer(&self->tank_pressures_bar, fl_value_unref);
   g_clear_pointer(&self->heart_rate, g_free);
   g_clear_pointer(&self->heading, g_free);
   g_clear_pointer(&self->setpoint, g_free);
@@ -257,7 +259,7 @@ static void libdivecomputer_plugin_profile_sample_class_init(LibdivecomputerPlug
   G_OBJECT_CLASS(klass)->dispose = libdivecomputer_plugin_profile_sample_dispose;
 }
 
-LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* heading, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6, int64_t* o2_sensor_mv1, int64_t* o2_sensor_mv2, int64_t* o2_sensor_mv3, int64_t* o2_sensor_mv4, int64_t* o2_sensor_mv5, int64_t* o2_sensor_mv6, int64_t* gas_mix_index) {
+LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, FlValue* tank_pressures_bar, int64_t* heart_rate, double* heading, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6, int64_t* o2_sensor_mv1, int64_t* o2_sensor_mv2, int64_t* o2_sensor_mv3, int64_t* o2_sensor_mv4, int64_t* o2_sensor_mv5, int64_t* o2_sensor_mv6, int64_t* gas_mix_index) {
   LibdivecomputerPluginProfileSample* self = LIBDIVECOMPUTER_PLUGIN_PROFILE_SAMPLE(g_object_new(libdivecomputer_plugin_profile_sample_get_type(), nullptr));
   self->time_seconds = time_seconds;
   self->depth_meters = depth_meters;
@@ -281,6 +283,12 @@ LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(in
   }
   else {
     self->tank_index = nullptr;
+  }
+  if (tank_pressures_bar != nullptr) {
+    self->tank_pressures_bar = fl_value_ref(tank_pressures_bar);
+  }
+  else {
+    self->tank_pressures_bar = nullptr;
   }
   if (heart_rate != nullptr) {
     self->heart_rate = static_cast<int64_t*>(malloc(sizeof(int64_t)));
@@ -471,6 +479,11 @@ int64_t* libdivecomputer_plugin_profile_sample_get_tank_index(LibdivecomputerPlu
   return self->tank_index;
 }
 
+FlValue* libdivecomputer_plugin_profile_sample_get_tank_pressures_bar(LibdivecomputerPluginProfileSample* self) {
+  g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
+  return self->tank_pressures_bar;
+}
+
 int64_t* libdivecomputer_plugin_profile_sample_get_heart_rate(LibdivecomputerPluginProfileSample* self) {
   g_return_val_if_fail(LIBDIVECOMPUTER_PLUGIN_IS_PROFILE_SAMPLE(self), nullptr);
   return self->heart_rate;
@@ -593,6 +606,7 @@ static FlValue* libdivecomputer_plugin_profile_sample_to_list(LibdivecomputerPlu
   fl_value_append_take(values, self->temperature_celsius != nullptr ? fl_value_new_float(*self->temperature_celsius) : fl_value_new_null());
   fl_value_append_take(values, self->pressure_bar != nullptr ? fl_value_new_float(*self->pressure_bar) : fl_value_new_null());
   fl_value_append_take(values, self->tank_index != nullptr ? fl_value_new_int(*self->tank_index) : fl_value_new_null());
+  fl_value_append_take(values, self->tank_pressures_bar != nullptr ? fl_value_ref(self->tank_pressures_bar) : fl_value_new_null());
   fl_value_append_take(values, self->heart_rate != nullptr ? fl_value_new_int(*self->heart_rate) : fl_value_new_null());
   fl_value_append_take(values, self->heading != nullptr ? fl_value_new_float(*self->heading) : fl_value_new_null());
   fl_value_append_take(values, self->setpoint != nullptr ? fl_value_new_float(*self->setpoint) : fl_value_new_null());
@@ -646,167 +660,172 @@ static LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample
     tank_index = &tank_index_value;
   }
   FlValue* value5 = fl_value_get_list_value(values, 5);
-  int64_t* heart_rate = nullptr;
-  int64_t heart_rate_value;
+  FlValue* tank_pressures_bar = nullptr;
   if (fl_value_get_type(value5) != FL_VALUE_TYPE_NULL) {
-    heart_rate_value = fl_value_get_int(value5);
-    heart_rate = &heart_rate_value;
+    tank_pressures_bar = value5;
   }
   FlValue* value6 = fl_value_get_list_value(values, 6);
-  double* heading = nullptr;
-  double heading_value;
+  int64_t* heart_rate = nullptr;
+  int64_t heart_rate_value;
   if (fl_value_get_type(value6) != FL_VALUE_TYPE_NULL) {
-    heading_value = fl_value_get_float(value6);
-    heading = &heading_value;
+    heart_rate_value = fl_value_get_int(value6);
+    heart_rate = &heart_rate_value;
   }
   FlValue* value7 = fl_value_get_list_value(values, 7);
-  double* setpoint = nullptr;
-  double setpoint_value;
+  double* heading = nullptr;
+  double heading_value;
   if (fl_value_get_type(value7) != FL_VALUE_TYPE_NULL) {
-    setpoint_value = fl_value_get_float(value7);
-    setpoint = &setpoint_value;
+    heading_value = fl_value_get_float(value7);
+    heading = &heading_value;
   }
   FlValue* value8 = fl_value_get_list_value(values, 8);
-  double* ppo2 = nullptr;
-  double ppo2_value;
+  double* setpoint = nullptr;
+  double setpoint_value;
   if (fl_value_get_type(value8) != FL_VALUE_TYPE_NULL) {
-    ppo2_value = fl_value_get_float(value8);
-    ppo2 = &ppo2_value;
+    setpoint_value = fl_value_get_float(value8);
+    setpoint = &setpoint_value;
   }
   FlValue* value9 = fl_value_get_list_value(values, 9);
-  double* cns = nullptr;
-  double cns_value;
+  double* ppo2 = nullptr;
+  double ppo2_value;
   if (fl_value_get_type(value9) != FL_VALUE_TYPE_NULL) {
-    cns_value = fl_value_get_float(value9);
-    cns = &cns_value;
+    ppo2_value = fl_value_get_float(value9);
+    ppo2 = &ppo2_value;
   }
   FlValue* value10 = fl_value_get_list_value(values, 10);
-  int64_t* rbt = nullptr;
-  int64_t rbt_value;
+  double* cns = nullptr;
+  double cns_value;
   if (fl_value_get_type(value10) != FL_VALUE_TYPE_NULL) {
-    rbt_value = fl_value_get_int(value10);
-    rbt = &rbt_value;
+    cns_value = fl_value_get_float(value10);
+    cns = &cns_value;
   }
   FlValue* value11 = fl_value_get_list_value(values, 11);
-  int64_t* deco_type = nullptr;
-  int64_t deco_type_value;
+  int64_t* rbt = nullptr;
+  int64_t rbt_value;
   if (fl_value_get_type(value11) != FL_VALUE_TYPE_NULL) {
-    deco_type_value = fl_value_get_int(value11);
-    deco_type = &deco_type_value;
+    rbt_value = fl_value_get_int(value11);
+    rbt = &rbt_value;
   }
   FlValue* value12 = fl_value_get_list_value(values, 12);
-  int64_t* deco_time = nullptr;
-  int64_t deco_time_value;
+  int64_t* deco_type = nullptr;
+  int64_t deco_type_value;
   if (fl_value_get_type(value12) != FL_VALUE_TYPE_NULL) {
-    deco_time_value = fl_value_get_int(value12);
-    deco_time = &deco_time_value;
+    deco_type_value = fl_value_get_int(value12);
+    deco_type = &deco_type_value;
   }
   FlValue* value13 = fl_value_get_list_value(values, 13);
-  double* deco_depth = nullptr;
-  double deco_depth_value;
+  int64_t* deco_time = nullptr;
+  int64_t deco_time_value;
   if (fl_value_get_type(value13) != FL_VALUE_TYPE_NULL) {
-    deco_depth_value = fl_value_get_float(value13);
-    deco_depth = &deco_depth_value;
+    deco_time_value = fl_value_get_int(value13);
+    deco_time = &deco_time_value;
   }
   FlValue* value14 = fl_value_get_list_value(values, 14);
-  int64_t* tts = nullptr;
-  int64_t tts_value;
+  double* deco_depth = nullptr;
+  double deco_depth_value;
   if (fl_value_get_type(value14) != FL_VALUE_TYPE_NULL) {
-    tts_value = fl_value_get_int(value14);
-    tts = &tts_value;
+    deco_depth_value = fl_value_get_float(value14);
+    deco_depth = &deco_depth_value;
   }
   FlValue* value15 = fl_value_get_list_value(values, 15);
-  double* o2_sensor1 = nullptr;
-  double o2_sensor1_value;
+  int64_t* tts = nullptr;
+  int64_t tts_value;
   if (fl_value_get_type(value15) != FL_VALUE_TYPE_NULL) {
-    o2_sensor1_value = fl_value_get_float(value15);
-    o2_sensor1 = &o2_sensor1_value;
+    tts_value = fl_value_get_int(value15);
+    tts = &tts_value;
   }
   FlValue* value16 = fl_value_get_list_value(values, 16);
-  double* o2_sensor2 = nullptr;
-  double o2_sensor2_value;
+  double* o2_sensor1 = nullptr;
+  double o2_sensor1_value;
   if (fl_value_get_type(value16) != FL_VALUE_TYPE_NULL) {
-    o2_sensor2_value = fl_value_get_float(value16);
-    o2_sensor2 = &o2_sensor2_value;
+    o2_sensor1_value = fl_value_get_float(value16);
+    o2_sensor1 = &o2_sensor1_value;
   }
   FlValue* value17 = fl_value_get_list_value(values, 17);
-  double* o2_sensor3 = nullptr;
-  double o2_sensor3_value;
+  double* o2_sensor2 = nullptr;
+  double o2_sensor2_value;
   if (fl_value_get_type(value17) != FL_VALUE_TYPE_NULL) {
-    o2_sensor3_value = fl_value_get_float(value17);
-    o2_sensor3 = &o2_sensor3_value;
+    o2_sensor2_value = fl_value_get_float(value17);
+    o2_sensor2 = &o2_sensor2_value;
   }
   FlValue* value18 = fl_value_get_list_value(values, 18);
-  double* o2_sensor4 = nullptr;
-  double o2_sensor4_value;
+  double* o2_sensor3 = nullptr;
+  double o2_sensor3_value;
   if (fl_value_get_type(value18) != FL_VALUE_TYPE_NULL) {
-    o2_sensor4_value = fl_value_get_float(value18);
-    o2_sensor4 = &o2_sensor4_value;
+    o2_sensor3_value = fl_value_get_float(value18);
+    o2_sensor3 = &o2_sensor3_value;
   }
   FlValue* value19 = fl_value_get_list_value(values, 19);
-  double* o2_sensor5 = nullptr;
-  double o2_sensor5_value;
+  double* o2_sensor4 = nullptr;
+  double o2_sensor4_value;
   if (fl_value_get_type(value19) != FL_VALUE_TYPE_NULL) {
-    o2_sensor5_value = fl_value_get_float(value19);
-    o2_sensor5 = &o2_sensor5_value;
+    o2_sensor4_value = fl_value_get_float(value19);
+    o2_sensor4 = &o2_sensor4_value;
   }
   FlValue* value20 = fl_value_get_list_value(values, 20);
-  double* o2_sensor6 = nullptr;
-  double o2_sensor6_value;
+  double* o2_sensor5 = nullptr;
+  double o2_sensor5_value;
   if (fl_value_get_type(value20) != FL_VALUE_TYPE_NULL) {
-    o2_sensor6_value = fl_value_get_float(value20);
-    o2_sensor6 = &o2_sensor6_value;
+    o2_sensor5_value = fl_value_get_float(value20);
+    o2_sensor5 = &o2_sensor5_value;
   }
   FlValue* value21 = fl_value_get_list_value(values, 21);
-  int64_t* o2_sensor_mv1 = nullptr;
-  int64_t o2_sensor_mv1_value;
+  double* o2_sensor6 = nullptr;
+  double o2_sensor6_value;
   if (fl_value_get_type(value21) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv1_value = fl_value_get_int(value21);
-    o2_sensor_mv1 = &o2_sensor_mv1_value;
+    o2_sensor6_value = fl_value_get_float(value21);
+    o2_sensor6 = &o2_sensor6_value;
   }
   FlValue* value22 = fl_value_get_list_value(values, 22);
-  int64_t* o2_sensor_mv2 = nullptr;
-  int64_t o2_sensor_mv2_value;
+  int64_t* o2_sensor_mv1 = nullptr;
+  int64_t o2_sensor_mv1_value;
   if (fl_value_get_type(value22) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv2_value = fl_value_get_int(value22);
-    o2_sensor_mv2 = &o2_sensor_mv2_value;
+    o2_sensor_mv1_value = fl_value_get_int(value22);
+    o2_sensor_mv1 = &o2_sensor_mv1_value;
   }
   FlValue* value23 = fl_value_get_list_value(values, 23);
-  int64_t* o2_sensor_mv3 = nullptr;
-  int64_t o2_sensor_mv3_value;
+  int64_t* o2_sensor_mv2 = nullptr;
+  int64_t o2_sensor_mv2_value;
   if (fl_value_get_type(value23) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv3_value = fl_value_get_int(value23);
-    o2_sensor_mv3 = &o2_sensor_mv3_value;
+    o2_sensor_mv2_value = fl_value_get_int(value23);
+    o2_sensor_mv2 = &o2_sensor_mv2_value;
   }
   FlValue* value24 = fl_value_get_list_value(values, 24);
-  int64_t* o2_sensor_mv4 = nullptr;
-  int64_t o2_sensor_mv4_value;
+  int64_t* o2_sensor_mv3 = nullptr;
+  int64_t o2_sensor_mv3_value;
   if (fl_value_get_type(value24) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv4_value = fl_value_get_int(value24);
-    o2_sensor_mv4 = &o2_sensor_mv4_value;
+    o2_sensor_mv3_value = fl_value_get_int(value24);
+    o2_sensor_mv3 = &o2_sensor_mv3_value;
   }
   FlValue* value25 = fl_value_get_list_value(values, 25);
-  int64_t* o2_sensor_mv5 = nullptr;
-  int64_t o2_sensor_mv5_value;
+  int64_t* o2_sensor_mv4 = nullptr;
+  int64_t o2_sensor_mv4_value;
   if (fl_value_get_type(value25) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv5_value = fl_value_get_int(value25);
-    o2_sensor_mv5 = &o2_sensor_mv5_value;
+    o2_sensor_mv4_value = fl_value_get_int(value25);
+    o2_sensor_mv4 = &o2_sensor_mv4_value;
   }
   FlValue* value26 = fl_value_get_list_value(values, 26);
-  int64_t* o2_sensor_mv6 = nullptr;
-  int64_t o2_sensor_mv6_value;
+  int64_t* o2_sensor_mv5 = nullptr;
+  int64_t o2_sensor_mv5_value;
   if (fl_value_get_type(value26) != FL_VALUE_TYPE_NULL) {
-    o2_sensor_mv6_value = fl_value_get_int(value26);
-    o2_sensor_mv6 = &o2_sensor_mv6_value;
+    o2_sensor_mv5_value = fl_value_get_int(value26);
+    o2_sensor_mv5 = &o2_sensor_mv5_value;
   }
   FlValue* value27 = fl_value_get_list_value(values, 27);
+  int64_t* o2_sensor_mv6 = nullptr;
+  int64_t o2_sensor_mv6_value;
+  if (fl_value_get_type(value27) != FL_VALUE_TYPE_NULL) {
+    o2_sensor_mv6_value = fl_value_get_int(value27);
+    o2_sensor_mv6 = &o2_sensor_mv6_value;
+  }
+  FlValue* value28 = fl_value_get_list_value(values, 28);
   int64_t* gas_mix_index = nullptr;
   int64_t gas_mix_index_value;
-  if (fl_value_get_type(value27) != FL_VALUE_TYPE_NULL) {
-    gas_mix_index_value = fl_value_get_int(value27);
+  if (fl_value_get_type(value28) != FL_VALUE_TYPE_NULL) {
+    gas_mix_index_value = fl_value_get_int(value28);
     gas_mix_index = &gas_mix_index_value;
   }
-  return libdivecomputer_plugin_profile_sample_new(time_seconds, depth_meters, temperature_celsius, pressure_bar, tank_index, heart_rate, heading, setpoint, ppo2, cns, rbt, deco_type, deco_time, deco_depth, tts, o2_sensor1, o2_sensor2, o2_sensor3, o2_sensor4, o2_sensor5, o2_sensor6, o2_sensor_mv1, o2_sensor_mv2, o2_sensor_mv3, o2_sensor_mv4, o2_sensor_mv5, o2_sensor_mv6, gas_mix_index);
+  return libdivecomputer_plugin_profile_sample_new(time_seconds, depth_meters, temperature_celsius, pressure_bar, tank_index, tank_pressures_bar, heart_rate, heading, setpoint, ppo2, cns, rbt, deco_type, deco_time, deco_depth, tts, o2_sensor1, o2_sensor2, o2_sensor3, o2_sensor4, o2_sensor5, o2_sensor6, o2_sensor_mv1, o2_sensor_mv2, o2_sensor_mv3, o2_sensor_mv4, o2_sensor_mv5, o2_sensor_mv6, gas_mix_index);
 }
 
 struct _LibdivecomputerPluginGasMix {

--- a/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/linux/dive_computer_api.g.h
@@ -179,6 +179,7 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginProfileSample, libdivecomputer_plugin_
  * temperature_celsius: field in this object.
  * pressure_bar: field in this object.
  * tank_index: field in this object.
+ * tank_pressures_bar: field in this object.
  * heart_rate: field in this object.
  * heading: field in this object.
  * setpoint: field in this object.
@@ -207,7 +208,7 @@ G_DECLARE_FINAL_TYPE(LibdivecomputerPluginProfileSample, libdivecomputer_plugin_
  *
  * Returns: a new #LibdivecomputerPluginProfileSample
  */
-LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, int64_t* heart_rate, double* heading, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6, int64_t* o2_sensor_mv1, int64_t* o2_sensor_mv2, int64_t* o2_sensor_mv3, int64_t* o2_sensor_mv4, int64_t* o2_sensor_mv5, int64_t* o2_sensor_mv6, int64_t* gas_mix_index);
+LibdivecomputerPluginProfileSample* libdivecomputer_plugin_profile_sample_new(int64_t time_seconds, double depth_meters, double* temperature_celsius, double* pressure_bar, int64_t* tank_index, FlValue* tank_pressures_bar, int64_t* heart_rate, double* heading, double* setpoint, double* ppo2, double* cns, int64_t* rbt, int64_t* deco_type, int64_t* deco_time, double* deco_depth, int64_t* tts, double* o2_sensor1, double* o2_sensor2, double* o2_sensor3, double* o2_sensor4, double* o2_sensor5, double* o2_sensor6, int64_t* o2_sensor_mv1, int64_t* o2_sensor_mv2, int64_t* o2_sensor_mv3, int64_t* o2_sensor_mv4, int64_t* o2_sensor_mv5, int64_t* o2_sensor_mv6, int64_t* gas_mix_index);
 
 /**
  * libdivecomputer_plugin_profile_sample_get_time_seconds
@@ -258,6 +259,22 @@ double* libdivecomputer_plugin_profile_sample_get_pressure_bar(LibdivecomputerPl
  * Returns: the field value.
  */
 int64_t* libdivecomputer_plugin_profile_sample_get_tank_index(LibdivecomputerPluginProfileSample* object);
+
+/**
+ * libdivecomputer_plugin_profile_sample_get_tank_pressures_bar
+ * @object: a #LibdivecomputerPluginProfileSample.
+ *
+ * Every tank's pressure in bar at this sample, indexed by tank index, with
+ * null where that tank reported nothing. libdivecomputer fires one pressure
+ * reading per air-integrated transmitter, so a single sample can carry
+ * several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+ * rest (issue #1223). Null when the sample carries no pressure at all, and
+ * trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+ * short list per sample.
+ *
+ * Returns: the field value.
+ */
+FlValue* libdivecomputer_plugin_profile_sample_get_tank_pressures_bar(LibdivecomputerPluginProfileSample* object);
 
 /**
  * libdivecomputer_plugin_profile_sample_get_heart_rate

--- a/packages/libdivecomputer_plugin/linux/dive_converter.c
+++ b/packages/libdivecomputer_plugin/linux/dive_converter.c
@@ -141,15 +141,44 @@ LibdivecomputerPluginParsedDive* convert_parsed_dive(
                     (s->o2_sensor_mv[c] == UINT32_MAX) ? NULL : &mv_vals[c];
             }
 
+            // Every tank's pressure at this sample (issue #1223): a sample can
+            // carry one reading per air-integrated transmitter, and `pressure`
+            // above holds only the last of them. NaN -> null, trailing nulls
+            // trimmed, all-NaN -> NULL so the field stays absent. The
+            // constructor takes its own reference, so unref ours afterwards.
+            int last_tank = -1;
+            for (int t = LIBDC_MAX_TANKS - 1; t >= 0; t--) {
+                if (!isnan(s->tank_pressure[t])) {
+                    last_tank = t;
+                    break;
+                }
+            }
+            FlValue* tank_pressures = NULL;
+            if (last_tank >= 0) {
+                tank_pressures = fl_value_new_list();
+                for (int t = 0; t <= last_tank; t++) {
+                    fl_value_append_take(
+                        tank_pressures,
+                        isnan(s->tank_pressure[t])
+                            ? fl_value_new_null()
+                            : fl_value_new_float(s->tank_pressure[t]));
+                }
+            }
+
             LibdivecomputerPluginProfileSample* sample =
                 libdivecomputer_plugin_profile_sample_new(
                     time_seconds, s->depth, temp_c, pressure, tank_index,
+                    tank_pressures,
                     heart_rate, heading, setpoint, ppo2, cns, rbt, deco_type,
                     deco_time, deco_depth, tts, o2_sensor[0], o2_sensor[1],
                     o2_sensor[2], o2_sensor[3], o2_sensor[4], o2_sensor[5],
                     o2_sensor_mv[0], o2_sensor_mv[1], o2_sensor_mv[2],
                     o2_sensor_mv[3], o2_sensor_mv[4], o2_sensor_mv[5],
                     gas_mix_index);
+
+            if (tank_pressures != NULL) {
+                fl_value_unref(tank_pressures);
+            }
 
             fl_value_append_take(
                 samples,

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_download.c
@@ -223,6 +223,9 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.temperature = NAN;
         state->current_sample.pressure = NAN;
         state->current_sample.tank = UINT32_MAX;
+        for (unsigned int t = 0; t < LIBDC_MAX_TANKS; t++) {
+            state->current_sample.tank_pressure[t] = NAN;
+        }
         // Carry the active gas forward across samples, not just the switch sample.
         state->current_sample.gasmix = state->current_gasmix;
         state->current_sample.heartbeat = UINT32_MAX;
@@ -252,6 +255,14 @@ static void sample_callback(dc_sample_type_t type,
         state->current_sample.temperature = value->temperature;
         break;
     case DC_SAMPLE_PRESSURE:
+        // Issue #1223. libdivecomputer fires this once per transmitter, so a
+        // single sample can carry a reading for several tanks. Record each one
+        // against its own tank; keeping only the pair below dropped every tank
+        // but the last, which drew the others as a flat "(est.)" line.
+        if (value->pressure.tank < LIBDC_MAX_TANKS) {
+            state->current_sample.tank_pressure[value->pressure.tank] =
+                value->pressure.value;
+        }
         state->current_sample.pressure = value->pressure.value;
         state->current_sample.tank = value->pressure.tank;
         break;

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.h
@@ -157,6 +157,14 @@ typedef struct {
     double temperature;        // celsius (NAN if unavailable)
     double pressure;           // bar (NAN if unavailable)
     unsigned int tank;         // tank index (UINT32_MAX if unavailable)
+    // Per-tank pressure at this sample, indexed by libdivecomputer's tank
+    // index; NAN where that tank reported nothing. Issue #1223: a dive logged
+    // with two AI transmitters fires DC_SAMPLE_PRESSURE twice per sample, and
+    // the single `pressure`/`tank` pair above kept only the last one, so every
+    // tank but the highest-numbered lost its curve. `pressure`/`tank` still
+    // carry that last reading, for the single-pressure profile column; this
+    // array is the complete record.
+    double tank_pressure[LIBDC_MAX_TANKS];
     unsigned int gasmix;       // active gas mix index (UINT32_MAX if unavailable)
     // New fields for full sample capture
     unsigned int heartbeat;    // bpm (UINT32_MAX if unavailable)

--- a/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
+++ b/packages/libdivecomputer_plugin/pigeons/dive_computer_api.dart
@@ -57,6 +57,7 @@ class ProfileSample {
     this.temperatureCelsius,
     this.pressureBar,
     this.tankIndex,
+    this.tankPressuresBar,
     this.heartRate,
     this.heading,
     this.setpoint,
@@ -86,6 +87,15 @@ class ProfileSample {
   final double? temperatureCelsius;
   final double? pressureBar;
   final int? tankIndex;
+
+  /// Every tank's pressure in bar at this sample, indexed by tank index, with
+  /// null where that tank reported nothing. libdivecomputer fires one pressure
+  /// reading per air-integrated transmitter, so a single sample can carry
+  /// several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+  /// rest (issue #1223). Null when the sample carries no pressure at all, and
+  /// trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+  /// short list per sample.
+  final List<double?>? tankPressuresBar;
   final int? heartRate;
 
   /// Compass heading in degrees (0-359) from DC_SAMPLE_BEARING; null when the

--- a/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/test/native/CMakeLists.txt
@@ -185,6 +185,27 @@ if(WIN32)
     target_link_libraries(test_shearwater_o2_millivolt PRIVATE SetupAPI.lib ws2_32.lib)
 endif()
 
+# Regression test for issue #1223: a sample carrying two transmitter pressures
+# must keep both. Goes through the wrapper, since the loss was in its per-sample
+# accumulator rather than in libdivecomputer.
+add_executable(test_multi_transmitter_pressure
+    test_multi_transmitter_pressure.c
+    ${WRAPPER_DIR}/libdc_wrapper.c
+    ${WRAPPER_DIR}/libdc_download.c
+    ${LIBDC_ALL_SOURCES}
+)
+target_include_directories(test_multi_transmitter_pressure PRIVATE
+    ${WRAPPER_DIR}
+    ${LIBDC_DIR}/include
+    ${LIBDC_DIR}/src
+    ${PLATFORM_CONFIG_DIR}
+)
+target_compile_definitions(test_multi_transmitter_pressure PRIVATE HAVE_CONFIG_H)
+if(WIN32)
+    target_compile_definitions(test_multi_transmitter_pressure PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(test_multi_transmitter_pressure PRIVATE SetupAPI.lib ws2_32.lib)
+endif()
+
 enable_testing()
 add_test(NAME test_dive_converter COMMAND test_dive_converter)
 add_test(NAME test_serial_callbacks COMMAND test_serial_callbacks)
@@ -194,6 +215,9 @@ add_test(NAME test_hw_ostc3_read COMMAND test_hw_ostc3_read)
 add_test(NAME test_shearwater_petrel_foreach COMMAND test_shearwater_petrel_foreach)
 add_test(NAME test_shearwater_common_download COMMAND test_shearwater_common_download)
 add_test(NAME test_parse_raw_dive COMMAND test_parse_raw_dive
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+add_test(NAME test_multi_transmitter_pressure COMMAND test_multi_transmitter_pressure
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 add_test(NAME test_shearwater_o2_millivolt COMMAND test_shearwater_o2_millivolt

--- a/packages/libdivecomputer_plugin/test/native/test_multi_transmitter_pressure.c
+++ b/packages/libdivecomputer_plugin/test/native/test_multi_transmitter_pressure.c
@@ -1,0 +1,172 @@
+/* Issue #1223: a dive logged with two AI transmitters showed one tank as a flat
+   "(est.)" line, because the wrapper kept a single pressure per sample.
+
+   libdivecomputer fires DC_SAMPLE_PRESSURE once per transmitter, so a sample can
+   carry several readings before the next DC_SAMPLE_TIME closes it. The wrapper
+   stored them in one `pressure`/`tank` pair, so the last transmitter of each
+   sample overwrote every earlier one and the lower-numbered tank kept only the
+   readings taken while the higher-numbered transmitter was out of comms.
+
+   Fixture: the Petrel 3 CCR dive already used by test_shearwater_o2_millivolt
+   (issue #810). It carries an O2 and a diluent transmitter, and 407 of its 419
+   samples report both. */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "libdc_wrapper.h"
+
+/* Both transmitters report on nearly every sample of the fixture. Counted from
+   the parser directly (dc_parser_samples_foreach over DC_SAMPLE_PRESSURE). */
+#define EXPECTED_TANK0_READINGS 413
+#define EXPECTED_TANK1_READINGS 410
+#define EXPECTED_SAMPLES        419
+
+static unsigned int load_fixture(const char *path, unsigned char **out) {
+    *out = NULL;
+    FILE *f = fopen(path, "rb");
+    if (!f) return 0;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (len <= 0) { fclose(f); return 0; }
+    unsigned char *buf = (unsigned char *)malloc((size_t)len);
+    if (!buf) { fclose(f); return 0; }
+    size_t read = fread(buf, 1, (size_t)len, f);
+    fclose(f);
+    if (read != (size_t)len) { free(buf); return 0; }
+    *out = buf;
+    return (unsigned int)read;
+}
+
+static void parse_fixture(libdc_parsed_dive_t *dive) {
+    unsigned char *data = NULL;
+    unsigned int size = load_fixture("fixtures/petrel3_ccr_o2_cells.bin", &data);
+    assert(size == 22400);
+    assert(data != NULL);
+
+    char err[256] = {0};
+    int rc = libdc_parse_raw_dive("Shearwater", "Petrel 3", 10, data, size, dive,
+                                  err, sizeof(err));
+    if (rc != 0) {
+        printf("FAIL: libdc_parse_raw_dive returned %d (%s)\n", rc, err);
+    }
+    assert(rc == 0);
+    free(data);
+}
+
+/* Count the samples that carry a reading for each tank. */
+static void count_per_tank(const libdc_parsed_dive_t *dive,
+                           unsigned int *counts, unsigned int ntanks) {
+    memset(counts, 0, ntanks * sizeof(*counts));
+    for (unsigned int i = 0; i < dive->sample_count; i++) {
+        for (unsigned int t = 0; t < ntanks; t++) {
+            if (!isnan(dive->samples[i].tank_pressure[t])) counts[t]++;
+        }
+    }
+}
+
+/* The heart of #1223: neither transmitter may be dropped when both report on
+   the same sample. */
+static void test_both_transmitters_survive(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    assert(dive.tank_count == 2);
+    assert(dive.sample_count == EXPECTED_SAMPLES);
+
+    unsigned int counts[2];
+    count_per_tank(&dive, counts, 2);
+    printf("  tank 0: %u readings, tank 1: %u readings\n", counts[0], counts[1]);
+    assert(counts[0] == EXPECTED_TANK0_READINGS);
+    assert(counts[1] == EXPECTED_TANK1_READINGS);
+
+    /* libdc_parse_raw_dive fills a caller-owned struct: free its arrays, not it. */
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_both_transmitters_survive\n");
+}
+
+/* The two series must be distinct: before the fix tank 0's readings were
+   whatever tank 1 last reported, so the curves were identical wherever both
+   transmitters were in comms. */
+static void test_tanks_carry_distinct_pressures(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    unsigned int both = 0;
+    unsigned int differing = 0;
+    for (unsigned int i = 0; i < dive.sample_count; i++) {
+        double p0 = dive.samples[i].tank_pressure[0];
+        double p1 = dive.samples[i].tank_pressure[1];
+        if (isnan(p0) || isnan(p1)) continue;
+        both++;
+        if (fabs(p0 - p1) > 0.01) differing++;
+    }
+    printf("  %u samples report both tanks, %u of them differ\n", both, differing);
+    assert(both >= 400);
+    assert(differing == both);
+
+    /* libdc_parse_raw_dive fills a caller-owned struct: free its arrays, not it. */
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_tanks_carry_distinct_pressures\n");
+}
+
+/* Sanity: the per-sample series must agree with the dive-level tank summary
+   libdivecomputer reports, so the two cannot be attributed to opposite tanks. */
+static void test_series_match_tank_summary(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    for (unsigned int t = 0; t < 2; t++) {
+        double first = NAN, last = NAN;
+        for (unsigned int i = 0; i < dive.sample_count; i++) {
+            double p = dive.samples[i].tank_pressure[t];
+            if (isnan(p)) continue;
+            if (isnan(first)) first = p;
+            last = p;
+        }
+        printf("  tank %u: series %.1f -> %.1f bar, summary %.1f -> %.1f bar\n",
+               t, first, last, dive.tanks[t].beginpressure,
+               dive.tanks[t].endpressure);
+        assert(fabs(first - dive.tanks[t].beginpressure) < 1.0);
+        assert(fabs(last - dive.tanks[t].endpressure) < 1.0);
+    }
+
+    /* libdc_parse_raw_dive fills a caller-owned struct: free its arrays, not it. */
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_series_match_tank_summary\n");
+}
+
+/* A tank that reported nothing at a sample must stay unset, so the Dart layer
+   can tell "no reading" from "0 bar". */
+static void test_absent_tank_is_nan(void) {
+    libdc_parsed_dive_t dive;
+    parse_fixture(&dive);
+
+    for (unsigned int i = 0; i < dive.sample_count; i++) {
+        for (unsigned int t = 2; t < LIBDC_MAX_TANKS; t++) {
+            assert(isnan(dive.samples[i].tank_pressure[t]));
+        }
+    }
+
+    /* libdc_parse_raw_dive fills a caller-owned struct: free its arrays, not it. */
+    free(dive.samples);
+    free(dive.events);
+    printf("PASS: test_absent_tank_is_nan\n");
+}
+
+int main(void) {
+    printf("Running multi-transmitter pressure tests (issue #1223)...\n");
+    test_both_transmitters_survive();
+    test_tanks_carry_distinct_pressures();
+    test_series_match_tank_summary();
+    test_absent_tank_is_nan();
+    printf("All multi-transmitter pressure tests passed\n");
+    return 0;
+}

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.cc
@@ -221,6 +221,7 @@ ProfileSample::ProfileSample(
   const double* temperature_celsius,
   const double* pressure_bar,
   const int64_t* tank_index,
+  const EncodableList* tank_pressures_bar,
   const int64_t* heart_rate,
   const double* heading,
   const double* setpoint,
@@ -249,6 +250,7 @@ ProfileSample::ProfileSample(
     temperature_celsius_(temperature_celsius ? std::optional<double>(*temperature_celsius) : std::nullopt),
     pressure_bar_(pressure_bar ? std::optional<double>(*pressure_bar) : std::nullopt),
     tank_index_(tank_index ? std::optional<int64_t>(*tank_index) : std::nullopt),
+    tank_pressures_bar_(tank_pressures_bar ? std::optional<EncodableList>(*tank_pressures_bar) : std::nullopt),
     heart_rate_(heart_rate ? std::optional<int64_t>(*heart_rate) : std::nullopt),
     heading_(heading ? std::optional<double>(*heading) : std::nullopt),
     setpoint_(setpoint ? std::optional<double>(*setpoint) : std::nullopt),
@@ -327,6 +329,19 @@ void ProfileSample::set_tank_index(const int64_t* value_arg) {
 
 void ProfileSample::set_tank_index(int64_t value_arg) {
   tank_index_ = value_arg;
+}
+
+
+const EncodableList* ProfileSample::tank_pressures_bar() const {
+  return tank_pressures_bar_ ? &(*tank_pressures_bar_) : nullptr;
+}
+
+void ProfileSample::set_tank_pressures_bar(const EncodableList* value_arg) {
+  tank_pressures_bar_ = value_arg ? std::optional<EncodableList>(*value_arg) : std::nullopt;
+}
+
+void ProfileSample::set_tank_pressures_bar(const EncodableList& value_arg) {
+  tank_pressures_bar_ = value_arg;
 }
 
 
@@ -631,12 +646,13 @@ void ProfileSample::set_gas_mix_index(int64_t value_arg) {
 
 EncodableList ProfileSample::ToEncodableList() const {
   EncodableList list;
-  list.reserve(28);
+  list.reserve(29);
   list.push_back(EncodableValue(time_seconds_));
   list.push_back(EncodableValue(depth_meters_));
   list.push_back(temperature_celsius_ ? EncodableValue(*temperature_celsius_) : EncodableValue());
   list.push_back(pressure_bar_ ? EncodableValue(*pressure_bar_) : EncodableValue());
   list.push_back(tank_index_ ? EncodableValue(*tank_index_) : EncodableValue());
+  list.push_back(tank_pressures_bar_ ? EncodableValue(*tank_pressures_bar_) : EncodableValue());
   list.push_back(heart_rate_ ? EncodableValue(*heart_rate_) : EncodableValue());
   list.push_back(heading_ ? EncodableValue(*heading_) : EncodableValue());
   list.push_back(setpoint_ ? EncodableValue(*setpoint_) : EncodableValue());
@@ -679,95 +695,99 @@ ProfileSample ProfileSample::FromEncodableList(const EncodableList& list) {
   if (!encodable_tank_index.IsNull()) {
     decoded.set_tank_index(std::get<int64_t>(encodable_tank_index));
   }
-  auto& encodable_heart_rate = list[5];
+  auto& encodable_tank_pressures_bar = list[5];
+  if (!encodable_tank_pressures_bar.IsNull()) {
+    decoded.set_tank_pressures_bar(std::get<EncodableList>(encodable_tank_pressures_bar));
+  }
+  auto& encodable_heart_rate = list[6];
   if (!encodable_heart_rate.IsNull()) {
     decoded.set_heart_rate(std::get<int64_t>(encodable_heart_rate));
   }
-  auto& encodable_heading = list[6];
+  auto& encodable_heading = list[7];
   if (!encodable_heading.IsNull()) {
     decoded.set_heading(std::get<double>(encodable_heading));
   }
-  auto& encodable_setpoint = list[7];
+  auto& encodable_setpoint = list[8];
   if (!encodable_setpoint.IsNull()) {
     decoded.set_setpoint(std::get<double>(encodable_setpoint));
   }
-  auto& encodable_ppo2 = list[8];
+  auto& encodable_ppo2 = list[9];
   if (!encodable_ppo2.IsNull()) {
     decoded.set_ppo2(std::get<double>(encodable_ppo2));
   }
-  auto& encodable_cns = list[9];
+  auto& encodable_cns = list[10];
   if (!encodable_cns.IsNull()) {
     decoded.set_cns(std::get<double>(encodable_cns));
   }
-  auto& encodable_rbt = list[10];
+  auto& encodable_rbt = list[11];
   if (!encodable_rbt.IsNull()) {
     decoded.set_rbt(std::get<int64_t>(encodable_rbt));
   }
-  auto& encodable_deco_type = list[11];
+  auto& encodable_deco_type = list[12];
   if (!encodable_deco_type.IsNull()) {
     decoded.set_deco_type(std::get<int64_t>(encodable_deco_type));
   }
-  auto& encodable_deco_time = list[12];
+  auto& encodable_deco_time = list[13];
   if (!encodable_deco_time.IsNull()) {
     decoded.set_deco_time(std::get<int64_t>(encodable_deco_time));
   }
-  auto& encodable_deco_depth = list[13];
+  auto& encodable_deco_depth = list[14];
   if (!encodable_deco_depth.IsNull()) {
     decoded.set_deco_depth(std::get<double>(encodable_deco_depth));
   }
-  auto& encodable_tts = list[14];
+  auto& encodable_tts = list[15];
   if (!encodable_tts.IsNull()) {
     decoded.set_tts(std::get<int64_t>(encodable_tts));
   }
-  auto& encodable_o2_sensor1 = list[15];
+  auto& encodable_o2_sensor1 = list[16];
   if (!encodable_o2_sensor1.IsNull()) {
     decoded.set_o2_sensor1(std::get<double>(encodable_o2_sensor1));
   }
-  auto& encodable_o2_sensor2 = list[16];
+  auto& encodable_o2_sensor2 = list[17];
   if (!encodable_o2_sensor2.IsNull()) {
     decoded.set_o2_sensor2(std::get<double>(encodable_o2_sensor2));
   }
-  auto& encodable_o2_sensor3 = list[17];
+  auto& encodable_o2_sensor3 = list[18];
   if (!encodable_o2_sensor3.IsNull()) {
     decoded.set_o2_sensor3(std::get<double>(encodable_o2_sensor3));
   }
-  auto& encodable_o2_sensor4 = list[18];
+  auto& encodable_o2_sensor4 = list[19];
   if (!encodable_o2_sensor4.IsNull()) {
     decoded.set_o2_sensor4(std::get<double>(encodable_o2_sensor4));
   }
-  auto& encodable_o2_sensor5 = list[19];
+  auto& encodable_o2_sensor5 = list[20];
   if (!encodable_o2_sensor5.IsNull()) {
     decoded.set_o2_sensor5(std::get<double>(encodable_o2_sensor5));
   }
-  auto& encodable_o2_sensor6 = list[20];
+  auto& encodable_o2_sensor6 = list[21];
   if (!encodable_o2_sensor6.IsNull()) {
     decoded.set_o2_sensor6(std::get<double>(encodable_o2_sensor6));
   }
-  auto& encodable_o2_sensor_mv1 = list[21];
+  auto& encodable_o2_sensor_mv1 = list[22];
   if (!encodable_o2_sensor_mv1.IsNull()) {
     decoded.set_o2_sensor_mv1(std::get<int64_t>(encodable_o2_sensor_mv1));
   }
-  auto& encodable_o2_sensor_mv2 = list[22];
+  auto& encodable_o2_sensor_mv2 = list[23];
   if (!encodable_o2_sensor_mv2.IsNull()) {
     decoded.set_o2_sensor_mv2(std::get<int64_t>(encodable_o2_sensor_mv2));
   }
-  auto& encodable_o2_sensor_mv3 = list[23];
+  auto& encodable_o2_sensor_mv3 = list[24];
   if (!encodable_o2_sensor_mv3.IsNull()) {
     decoded.set_o2_sensor_mv3(std::get<int64_t>(encodable_o2_sensor_mv3));
   }
-  auto& encodable_o2_sensor_mv4 = list[24];
+  auto& encodable_o2_sensor_mv4 = list[25];
   if (!encodable_o2_sensor_mv4.IsNull()) {
     decoded.set_o2_sensor_mv4(std::get<int64_t>(encodable_o2_sensor_mv4));
   }
-  auto& encodable_o2_sensor_mv5 = list[25];
+  auto& encodable_o2_sensor_mv5 = list[26];
   if (!encodable_o2_sensor_mv5.IsNull()) {
     decoded.set_o2_sensor_mv5(std::get<int64_t>(encodable_o2_sensor_mv5));
   }
-  auto& encodable_o2_sensor_mv6 = list[26];
+  auto& encodable_o2_sensor_mv6 = list[27];
   if (!encodable_o2_sensor_mv6.IsNull()) {
     decoded.set_o2_sensor_mv6(std::get<int64_t>(encodable_o2_sensor_mv6));
   }
-  auto& encodable_gas_mix_index = list[27];
+  auto& encodable_gas_mix_index = list[28];
   if (!encodable_gas_mix_index.IsNull()) {
     decoded.set_gas_mix_index(std::get<int64_t>(encodable_gas_mix_index));
   }

--- a/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_api.g.h
@@ -173,6 +173,7 @@ class ProfileSample {
     const double* temperature_celsius,
     const double* pressure_bar,
     const int64_t* tank_index,
+    const flutter::EncodableList* tank_pressures_bar,
     const int64_t* heart_rate,
     const double* heading,
     const double* setpoint,
@@ -214,6 +215,17 @@ class ProfileSample {
   const int64_t* tank_index() const;
   void set_tank_index(const int64_t* value_arg);
   void set_tank_index(int64_t value_arg);
+
+  // Every tank's pressure in bar at this sample, indexed by tank index, with
+  // null where that tank reported nothing. libdivecomputer fires one pressure
+  // reading per air-integrated transmitter, so a single sample can carry
+  // several; [pressureBar]/[tankIndex] hold only the last of them and lose the
+  // rest (issue #1223). Null when the sample carries no pressure at all, and
+  // trimmed of trailing nulls, so an ordinary single-transmitter dive costs one
+  // short list per sample.
+  const flutter::EncodableList* tank_pressures_bar() const;
+  void set_tank_pressures_bar(const flutter::EncodableList* value_arg);
+  void set_tank_pressures_bar(const flutter::EncodableList& value_arg);
 
   const int64_t* heart_rate() const;
   void set_heart_rate(const int64_t* value_arg);
@@ -329,6 +341,7 @@ class ProfileSample {
   std::optional<double> temperature_celsius_;
   std::optional<double> pressure_bar_;
   std::optional<int64_t> tank_index_;
+  std::optional<flutter::EncodableList> tank_pressures_bar_;
   std::optional<int64_t> heart_rate_;
   std::optional<double> heading_;
   std::optional<double> setpoint_;

--- a/packages/libdivecomputer_plugin/windows/dive_converter.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_converter.cc
@@ -110,6 +110,20 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
                               static_cast<int64_t>(s.o2_sensor_mv[c]));
             }
 
+            // Every tank's pressure at this sample (issue #1223): a sample can
+            // carry one reading per air-integrated transmitter, and `pressure`
+            // above holds only the last of them. NaN -> null, trailing nulls
+            // trimmed, all-NaN -> no list at all.
+            std::optional<flutter::EncodableList> tank_pressures;
+            for (int t = LIBDC_MAX_TANKS - 1; t >= 0; t--) {
+                if (!tank_pressures && std::isnan(s.tank_pressure[t])) continue;
+                if (!tank_pressures) tank_pressures.emplace(t + 1);
+                (*tank_pressures)[t] =
+                    std::isnan(s.tank_pressure[t])
+                        ? flutter::EncodableValue()
+                        : flutter::EncodableValue(s.tank_pressure[t]);
+            }
+
             // Nullable ints: UINT32_MAX -> nullptr.
             std::optional<int64_t> tank_index =
                 (s.tank == UINT32_MAX)
@@ -156,6 +170,7 @@ ParsedDive ConvertParsedDive(const libdc_parsed_dive_t& dive) {
                     temp_c ? &*temp_c : nullptr,
                     pressure ? &*pressure : nullptr,
                     tank_index ? &*tank_index : nullptr,
+                    tank_pressures ? &*tank_pressures : nullptr,
                     heart_rate ? &*heart_rate : nullptr,
                     heading ? &*heading : nullptr,
                     setpoint ? &*setpoint : nullptr,

--- a/test/features/dive_computer/data/services/reparse_service_test.dart
+++ b/test/features/dive_computer/data/services/reparse_service_test.dart
@@ -1663,6 +1663,104 @@ void main() {
       expect(tank.endPressure, 90.0);
     });
 
+    test('keeps both transmitters when a sample reports two tank pressures '
+        '(issue #1223)', () async {
+      // A CCR dive with an O2 and a diluent transmitter: libdivecomputer
+      // reports both on the same sample. The wrapper used to keep only the last
+      // one, so the O2 tank ended up with no readings at all and the chart drew
+      // it as a flat "(est.)" line between its start and end pressure.
+      await insertDive('dive-1');
+      await insertComputer('comp-1');
+      await insertSource(
+        id: 'src-1',
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        isPrimary: true,
+      );
+
+      final parsed = makeParsedDive(
+        tanks: [
+          pigeon.TankInfo(index: 0, gasMixIndex: 0, usage: 1),
+          pigeon.TankInfo(index: 1, gasMixIndex: 1, usage: 2),
+        ],
+        gasMixes: [
+          pigeon.GasMix(index: 0, o2Percent: 100.0, hePercent: 0.0),
+          pigeon.GasMix(index: 1, o2Percent: 21.0, hePercent: 0.0),
+        ],
+        samples: [
+          // pressureBar/tankIndex still carry the last reading of each sample;
+          // the per-tank list is the complete record.
+          pigeon.ProfileSample(
+            timeSeconds: 0,
+            depthMeters: 0.0,
+            pressureBar: 191.0,
+            tankIndex: 1,
+            tankPressuresBar: const [193.0, 191.0],
+          ),
+          pigeon.ProfileSample(
+            timeSeconds: 60,
+            depthMeters: 18.0,
+            pressureBar: 150.0,
+            tankIndex: 1,
+            tankPressuresBar: const [188.0, 150.0],
+          ),
+          // The diluent transmitter drops out: the O2 tank keeps reporting and
+          // must not inherit the gap.
+          pigeon.ProfileSample(
+            timeSeconds: 120,
+            depthMeters: 5.0,
+            pressureBar: 185.0,
+            tankIndex: 0,
+            tankPressuresBar: const [185.0],
+          ),
+        ],
+      );
+
+      await service.applyParsedUpdate(
+        diveId: 'dive-1',
+        sourceRowId: 'src-1',
+        parsed: parsed,
+        descriptorVendor: null,
+        descriptorProduct: null,
+        descriptorModel: null,
+        libdivecomputerVersion: null,
+      );
+
+      final tanks =
+          await (db.select(db.diveTanks)
+                ..where((t) => t.diveId.equals('dive-1'))
+                ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+              .get();
+      expect(tanks, hasLength(2));
+
+      Future<List<double>> pressuresFor(String tankId) async {
+        final rows =
+            await (db.select(db.tankPressureProfiles)
+                  ..where((t) => t.tankId.equals(tankId))
+                  ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+                .get();
+        return [for (final r in rows) r.pressure];
+      }
+
+      expect(await pressuresFor(tanks[0].id), [
+        193.0,
+        188.0,
+        185.0,
+      ], reason: 'the O2 transmitter must keep every reading it reported');
+      expect(
+        await pressuresFor(tanks[1].id),
+        [191.0, 150.0],
+        reason: 'the diluent transmitter keeps its own readings, gap included',
+      );
+
+      // Start/end pressure is backfilled per tank from its own series, so the
+      // O2 tank no longer borrows the diluent's numbers.
+      expect(tanks[0].startPressure, 193.0);
+      expect(tanks[0].endPressure, 185.0);
+      expect(tanks[1].startPressure, 191.0);
+      expect(tanks[1].endPressure, 150.0);
+    });
+
     test('derives and inserts gas switches from per-sample gas-mix '
         'transitions on a single-source primary re-parse', () async {
       // Shearwater-style multi-gas dive: transmitter tank 0 breathes 32%, then

--- a/test/features/dive_log/data/repositories/dive_computer_multi_transmitter_pressure_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_multi_transmitter_pressure_test.dart
@@ -1,0 +1,234 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1223: a CCR dive logged with an O2 and a diluent transmitter reports
+/// both pressures on the same sample. The download path used to keep a single
+/// pressure per sample, so the lower-numbered tank kept only the readings taken
+/// while the other transmitter was out of comms -- often none at all, which the
+/// profile chart drew as a flat "(est.)" line.
+void main() {
+  late DiveComputerRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveComputerRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertComputer() async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: const Value('computer-1'),
+            name: const Value('Shearwater Petrel 3'),
+            manufacturer: const Value('Shearwater'),
+            model: const Value('Petrel 3'),
+            serialNumber: const Value('SN-1223'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+    return 'computer-1';
+  }
+
+  Future<List<({int timestamp, double pressure})>> seriesFor(
+    String tankId,
+  ) async {
+    final rows =
+        await (db.select(db.tankPressureProfiles)
+              ..where((t) => t.tankId.equals(tankId))
+              ..orderBy([(t) => OrderingTerm.asc(t.timestamp)]))
+            .get();
+    return [
+      for (final r in rows) (timestamp: r.timestamp, pressure: r.pressure),
+    ];
+  }
+
+  Future<List<DiveTank>> tanksFor(String diveId) =>
+      (db.select(db.diveTanks)
+            ..where((t) => t.diveId.equals(diveId))
+            ..orderBy([(t) => OrderingTerm.asc(t.tankOrder)]))
+          .get();
+
+  test('both transmitters keep their own pressure series', () async {
+    final computerId = await insertComputer();
+
+    final diveId = await repository.importProfile(
+      computerId: computerId,
+      profileStartTime: DateTime(2026, 8, 15, 16, 27),
+      points: const [
+        // pressure/tankIndex hold whichever transmitter the computer reported
+        // last; tankPressures is the complete record.
+        ProfilePointData(
+          timestamp: 0,
+          depth: 0.0,
+          pressure: 191.4,
+          tankIndex: 1,
+          tankPressures: [192.6, 191.4],
+        ),
+        ProfilePointData(
+          timestamp: 600,
+          depth: 27.2,
+          pressure: 150.0,
+          tankIndex: 1,
+          tankPressures: [180.0, 150.0],
+        ),
+        ProfilePointData(
+          timestamp: 1200,
+          depth: 5.0,
+          pressure: 104.5,
+          tankIndex: 1,
+          tankPressures: [162.7, 104.5],
+        ),
+      ],
+      durationSeconds: 1800,
+      maxDepth: 27.2,
+      tanks: const [
+        TankData(index: 0, o2Percent: 100.0, role: 'oxygenSupply'),
+        TankData(index: 1, o2Percent: 21.0, role: 'diluent'),
+      ],
+    );
+
+    final tanks = await tanksFor(diveId);
+    expect(tanks, hasLength(2));
+
+    expect(await seriesFor(tanks[0].id), [
+      (timestamp: 0, pressure: 192.6),
+      (timestamp: 600, pressure: 180.0),
+      (timestamp: 1200, pressure: 162.7),
+    ], reason: 'the O2 transmitter must not be overwritten by the diluent');
+    expect(await seriesFor(tanks[1].id), [
+      (timestamp: 0, pressure: 191.4),
+      (timestamp: 600, pressure: 150.0),
+      (timestamp: 1200, pressure: 104.5),
+    ]);
+  });
+
+  test(
+    'a transmitter that drops out leaves a gap, not a borrowed reading',
+    () async {
+      final computerId = await insertComputer();
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: DateTime(2026, 8, 8, 10, 53),
+        points: const [
+          ProfilePointData(
+            timestamp: 0,
+            depth: 0.0,
+            pressure: 204.1,
+            tankIndex: 1,
+            tankPressures: [187.4, 204.1],
+          ),
+          // "No comms" on the diluent transmitter: only the O2 tank reports.
+          ProfilePointData(
+            timestamp: 60,
+            depth: 10.0,
+            pressure: 185.0,
+            tankIndex: 0,
+            tankPressures: [185.0],
+          ),
+          ProfilePointData(
+            timestamp: 120,
+            depth: 20.0,
+            pressure: 190.0,
+            tankIndex: 1,
+            tankPressures: [183.0, 190.0],
+          ),
+        ],
+        durationSeconds: 600,
+        maxDepth: 20.0,
+        tanks: const [
+          TankData(index: 0, o2Percent: 100.0, role: 'oxygenSupply'),
+          TankData(index: 1, o2Percent: 21.0, role: 'diluent'),
+        ],
+      );
+
+      final tanks = await tanksFor(diveId);
+      expect(
+        await seriesFor(tanks[0].id).then((s) => s.map((p) => p.timestamp)),
+        [0, 60, 120],
+      );
+      expect(
+        await seriesFor(tanks[1].id).then((s) => s.map((p) => p.timestamp)),
+        [0, 120],
+        reason: 'the diluent has no reading at 60s and must not invent one',
+      );
+    },
+  );
+
+  test(
+    'start and end pressure are backfilled per tank from its own series',
+    () async {
+      final computerId = await insertComputer();
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: DateTime(2026, 8, 15, 16, 27),
+        points: const [
+          ProfilePointData(
+            timestamp: 0,
+            depth: 0.0,
+            tankPressures: [192.6, 191.4],
+          ),
+          ProfilePointData(
+            timestamp: 1200,
+            depth: 5.0,
+            tankPressures: [162.7, 104.5],
+          ),
+        ],
+        durationSeconds: 1800,
+        maxDepth: 27.2,
+        // No summary pressures: they come from the transmitter stream.
+        tanks: const [
+          TankData(index: 0, o2Percent: 100.0, role: 'oxygenSupply'),
+          TankData(index: 1, o2Percent: 21.0, role: 'diluent'),
+        ],
+      );
+
+      final tanks = await tanksFor(diveId);
+      expect(tanks[0].startPressure, 192.6);
+      expect(tanks[0].endPressure, 162.7);
+      expect(tanks[1].startPressure, 191.4);
+      expect(tanks[1].endPressure, 104.5);
+    },
+  );
+
+  test(
+    'a single-transmitter dive still imports through the fallback path',
+    () async {
+      // UDDF/FIT imports and older native builds report one pressure per sample
+      // with no per-tank list.
+      final computerId = await insertComputer();
+
+      final diveId = await repository.importProfile(
+        computerId: computerId,
+        profileStartTime: DateTime(2026, 8, 15, 16, 27),
+        points: const [
+          ProfilePointData(timestamp: 0, depth: 0.0, pressure: 200.0),
+          ProfilePointData(timestamp: 600, depth: 20.0, pressure: 150.0),
+        ],
+        durationSeconds: 1200,
+        maxDepth: 20.0,
+        tanks: const [TankData(index: 0, o2Percent: 32.0)],
+      );
+
+      final tanks = await tanksFor(diveId);
+      expect(tanks, hasLength(1));
+      expect(await seriesFor(tanks[0].id), [
+        (timestamp: 0, pressure: 200.0),
+        (timestamp: 600, pressure: 150.0),
+      ]);
+    },
+  );
+}

--- a/test/features/dive_log/domain/services/tank_pressure_series_test.dart
+++ b/test/features/dive_log/domain/services/tank_pressure_series_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/services/tank_pressure_series.dart';
+
+TankPressureSampleView _sample(
+  int timeSeconds, {
+  double? pressureBar,
+  int? tankIndex,
+  List<double?>? tankPressuresBar,
+}) => (
+  timeSeconds: timeSeconds,
+  pressureBar: pressureBar,
+  tankIndex: tankIndex,
+  tankPressuresBar: tankPressuresBar,
+);
+
+void main() {
+  group('groupPressuresByTank', () {
+    test('keeps every transmitter reported on the same sample', () {
+      // Issue #1223: a CCR dive with an O2 and a diluent transmitter reports
+      // both on nearly every sample.
+      final series = groupPressuresByTank([
+        _sample(0, tankPressuresBar: [193.0, 191.0]),
+        _sample(10, tankPressuresBar: [192.0, 180.0]),
+        _sample(20, tankPressuresBar: [191.0, 170.0]),
+      ]);
+
+      expect(series.keys, unorderedEquals([0, 1]));
+      expect(series[0]!.map((p) => p.pressure), [193.0, 192.0, 191.0]);
+      expect(series[1]!.map((p) => p.pressure), [191.0, 180.0, 170.0]);
+      expect(series[0]!.map((p) => p.timestamp), [0, 10, 20]);
+    });
+
+    test('skips the tanks that reported nothing at a sample', () {
+      // A transmitter that drops out ("no comms") leaves a hole, and the other
+      // tank must not inherit it.
+      final series = groupPressuresByTank([
+        _sample(0, tankPressuresBar: [193.0, 191.0]),
+        _sample(10, tankPressuresBar: [192.0, null]),
+        _sample(20, tankPressuresBar: [null, 170.0]),
+      ]);
+
+      expect(series[0]!.map((p) => p.timestamp), [0, 10]);
+      expect(series[1]!.map((p) => p.timestamp), [0, 20]);
+    });
+
+    test('falls back to the single reading when no per-tank list is given', () {
+      // UDDF/FIT imports and older native builds report one pressure per sample.
+      final series = groupPressuresByTank([
+        _sample(0, pressureBar: 200.0, tankIndex: 1),
+        _sample(10, pressureBar: 190.0, tankIndex: 1),
+      ]);
+
+      expect(series.keys, [1]);
+      expect(series[1]!.map((p) => p.pressure), [200.0, 190.0]);
+    });
+
+    test('treats a missing tank index on the fallback path as tank 0', () {
+      final series = groupPressuresByTank([_sample(0, pressureBar: 200.0)]);
+
+      expect(series.keys, [0]);
+      expect(series[0]!.single.pressure, 200.0);
+    });
+
+    test('prefers the per-tank list over the single reading', () {
+      // pressureBar carries whichever transmitter libdivecomputer reported last,
+      // so honouring both would duplicate that tank's reading.
+      final series = groupPressuresByTank([
+        _sample(
+          0,
+          pressureBar: 191.0,
+          tankIndex: 1,
+          tankPressuresBar: [193.0, 191.0],
+        ),
+      ]);
+
+      expect(series[0]!.single.pressure, 193.0);
+      expect(series[1]!.single.pressure, 191.0);
+      expect(series[1]!, hasLength(1));
+    });
+
+    test('ignores samples with no pressure at all', () {
+      final series = groupPressuresByTank([
+        _sample(0),
+        _sample(10, tankPressuresBar: [null, null]),
+      ]);
+
+      expect(series, isEmpty);
+    });
+
+    test('handles an empty sample list', () {
+      expect(groupPressuresByTank(const []), isEmpty);
+    });
+
+    test('preserves sample order within each tank', () {
+      final series = groupPressuresByTank([
+        for (var t = 0; t < 5; t++)
+          _sample(t * 10, tankPressuresBar: [200.0 - t, 150.0 - t]),
+      ]);
+
+      expect(series[0]!.map((p) => p.timestamp), [0, 10, 20, 30, 40]);
+      expect(series[1]!.map((p) => p.pressure), [
+        150.0,
+        149.0,
+        148.0,
+        147.0,
+        146.0,
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1223.

## The bug

Not a transmitter-to-tank mis-mapping, which is what the symptom looked like.

libdivecomputer fires `DC_SAMPLE_PRESSURE` **once per air-integrated transmitter**, so a single profile sample can carry a reading for several tanks. `libdc_download.c`'s `sample_callback` accumulated one flat `libdc_sample_t` per `DC_SAMPLE_TIME` with a single `pressure` + `tank` pair, so on a two-transmitter dive **the second reading silently overwrote the first**.

The lower-numbered tank was left with only the readings taken while the other transmitter was out of comms. On the reported dive the diluent transmitter never dropped out, so the O2 tank ended up with **zero** samples and `dive_profile_chart.dart` drew it as a flat "(est.)" line between the tank's start and end pressure.

The same bug class was already fixed one case-branch away: `DC_SAMPLE_PPO2` fires once per O2 cell and stores into `o2_sensor[6]` indexed by sensor. Pressure was left scalar.

## Evidence

Replayed the reporter's raw records against their Shearwater Cloud export:

| | before | after | Shearwater CSV |
| --- | --- | --- | --- |
| dive 436 (8/15) tank 0 | **0** readings | **2142** | 2142 numeric T1 |
| dive 436 tank 1 | 2201 | 2201 | 2201 numeric T2 |
| dive 433 (8/8) tank 0 | 22 | 1827 | 1799 numeric T1 |
| dive 433 tank 1 | 1997 | 1997 | 1976 numeric T2 |

Endpoints match exactly: tank 0 runs 192.6 -> 162.7 bar, which is the CSV's 2794 -> 2360 psi. libdivecomputer reports tank 0 as `usage=1` (oxygen) and tank 1 as `usage=2` (diluent), matching the reporter's description of their O2 and D1 transmitters, so the attribution was correct all along.

## The change

- `libdc_sample_t` gains `double tank_pressure[LIBDC_MAX_TANKS]`, NAN where a tank reported nothing. `pressure`/`tank` keep their current meaning: they feed the single `dive_profiles.pressure` column, which has no tank index, so nothing downstream of it changes.
- Carried across the bridge as pigeon `ProfileSample.tankPressuresBar: List<double?>?`, trimmed of trailing nulls and null when the sample has no pressure at all, so an ordinary single-transmitter dive still marshals a one-element list. Implemented for Swift, JNI + Kotlin, Windows C++ and Linux GObject.
- New `lib/features/dive_log/domain/services/tank_pressure_series.dart` holds `groupPressuresByTank`, now shared by the download path (`dive_computer_repository_impl`) and the re-parse path (`reparse_service`), which had duplicated the grouping loop. It prefers the per-tank list and falls back to the old `pressureBar`/`tankIndex` pair for UDDF/FIT imports and for a stale native library.

### Deliberately not changed

`parsed_tank_resolver._dominantGasIndex` still reads the single `s.tankIndex`. It answers "which gas was breathed on this tank", not "which tank reported at this sample". On a CCR both transmitters share one active gas, so making it array-aware would relabel the O2 tank as 21/0 - a regression, not a fix.

## Recovery for existing dives

No migration. The raw records are stored, and the dive computer detail page already has "Re-parse all dives", which rebuilds `tank_pressure_profiles` from them.

## Follow-up

#1314 tracks the reporter's other request, letting the diver reassign a transmitter's pressure series to a different tank.

## Testing

- New `test_multi_transmitter_pressure.c` (4 cases) exercising the wrapper through `libdc_parse_raw_dive`: both tanks survive, the two series are distinct on all 407 shared samples, each series matches libdivecomputer's own dive-level tank summary, and an absent tank stays NAN. It reuses the existing `petrel3_ccr_o2_cells.bin` fixture from #810, which already carries two transmitters, so no new binary blob. Confirmed red before the fix (0 and 0 readings), green after.
- New `tank_pressure_series_test.dart` (8 cases) covering the grouping helper, including the dropout hole and the single-reading fallback.
- New `dive_computer_multi_transmitter_pressure_test.dart` (4 cases) driving `importProfile` end to end against the database, asserting per-tank series, dropout gaps, per-tank start/end backfill, and the single-transmitter path.
- New re-parse case in `reparse_service_test.dart` covering the same through `applyParsedUpdate`.
- 5 new Kotlin `SampleDecoderTest` cases pinning the appended JNI slots, including the short-array path a stale `.so` produces.
- Full local run: 10/10 native C tests, `flutter test` 20506 passed, macOS build, debug APK build, analyze and format clean.
