### PR TITLE
fix(ipad): anchor the share popover to the control that opened it

### DIFF
--- a/lib/core/utils/share_anchor.dart
+++ b/lib/core/utils/share_anchor.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+
+/// The screen rectangle of the widget [context] resolves to, for anchoring the
+/// iPad share popover.
+///
+/// On iPad the system share sheet is a popover and must point at the control
+/// that opened it. `share_plus` takes this as `ShareParams.sharePositionOrigin`
+/// in global (window) coordinates; when it is absent or empty the plugin falls
+/// back to the centre of the screen, which reads as an arrow pointing at
+/// nothing. iPhone ignores the value entirely, so passing it is always safe.
+///
+/// Pass the **button's** context, not the enclosing page's. `findRenderObject`
+/// returns the render object of the element the context belongs to, so a page's
+/// context yields a page-sized rect and anchors the popover to the whole
+/// screen. The usual way to get a button's context without a [GlobalKey] is to
+/// wrap it in a [Builder]: a [Builder] contributes no render object of its own,
+/// so the lookup descends to the button below it.
+///
+/// Returns null when no usable rect exists -- an unmounted context, or a render
+/// object that is not a laid-out [RenderBox]. Callers should treat null as "let
+/// the platform decide" and pass it through unchanged, since resolving the
+/// anchor after an `await` can legitimately race the widget being disposed.
+Rect? shareAnchorFrom(BuildContext? context) {
+  if (context == null || !context.mounted) return null;
+
+  final renderObject = context.findRenderObject();
+  if (renderObject is! RenderBox) return null;
+  if (!renderObject.attached || !renderObject.hasSize) return null;
+
+  return renderObject.localToGlobal(Offset.zero) & renderObject.size;
+}

--- a/lib/features/backup/presentation/pages/backup_settings_page.dart
+++ b/lib/features/backup/presentation/pages/backup_settings_page.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
+
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion_saf/submersion_saf.dart';
 
 import 'package:submersion/core/database/database.dart';
@@ -46,13 +48,18 @@ class BackupSettingsPage extends ConsumerWidget {
               operationState.status != BackupOperationStatus.idle)
             _buildStatusMessage(context, operationState),
           // Export card
-          _buildActionCard(
-            context: context,
-            icon: Icons.backup,
-            title: context.l10n.backup_export_title,
-            subtitle: context.l10n.backup_export_subtitle,
-            enabled: !isInProgress,
-            onTap: () => _handleExport(context, ref),
+          // Builder so the iPad share popover anchors to the export card:
+          // findRenderObject from a Builder's context descends to the card,
+          // whereas the page's context would yield the whole page.
+          Builder(
+            builder: (cardContext) => _buildActionCard(
+              context: context,
+              icon: Icons.backup,
+              title: context.l10n.backup_export_title,
+              subtitle: context.l10n.backup_export_subtitle,
+              enabled: !isInProgress,
+              onTap: () => _handleExport(cardContext, ref),
+            ),
           ),
           // Import card
           _buildActionCard(
@@ -171,6 +178,9 @@ class BackupSettingsPage extends ConsumerWidget {
 
   void _handleExport(BuildContext context, WidgetRef ref) {
     final encrypted = ref.read(backupSettingsProvider).backupEncryptionEnabled;
+    // Captured now: the export sheet is dismissed before onShare runs, so the
+    // anchor has to come from the card that opened it.
+    final anchor = shareAnchorFrom(context);
     ExportBottomSheet.show(
       context,
       onSaveToFile: () async {
@@ -208,7 +218,7 @@ class BackupSettingsPage extends ConsumerWidget {
             .exportForSharing();
         if (file != null && context.mounted) {
           await SharePlus.instance.share(
-            ShareParams(files: [XFile(file.path)]),
+            ShareParams(files: [XFile(file.path)], sharePositionOrigin: anchor),
           );
         }
       },

--- a/lib/features/certifications/presentation/widgets/certification_share_sheet.dart
+++ b/lib/features/certifications/presentation/widgets/certification_share_sheet.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/features/certifications/domain/certification_title.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
@@ -95,7 +96,7 @@ class _CertificationShareSheetState
     );
   }
 
-  Future<void> _shareAsCard() async {
+  Future<void> _shareAsCard(Rect? anchor) async {
     setState(() => _isExporting = true);
 
     try {
@@ -122,7 +123,10 @@ class _CertificationShareSheetState
 
       // Share the file
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: 'image/png')]),
+        ShareParams(
+          files: [XFile(file.path, mimeType: 'image/png')],
+          sharePositionOrigin: anchor,
+        ),
       );
     } catch (e) {
       if (mounted) {
@@ -132,7 +136,7 @@ class _CertificationShareSheetState
     }
   }
 
-  Future<void> _shareAsCertificate() async {
+  Future<void> _shareAsCertificate(Rect? anchor) async {
     setState(() => _isExporting = true);
 
     try {
@@ -161,7 +165,10 @@ class _CertificationShareSheetState
 
       // Share the file
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: 'image/png')]),
+        ShareParams(
+          files: [XFile(file.path, mimeType: 'image/png')],
+          sharePositionOrigin: anchor,
+        ),
       );
     } catch (e) {
       if (mounted) {
@@ -196,7 +203,11 @@ class _ShareOptionTile extends StatelessWidget {
   final IconData icon;
   final String title;
   final String subtitle;
-  final VoidCallback? onTap;
+
+  /// Receives the tile's screen rect, so the iPad share popover can anchor to
+  /// the tapped option. Captured at tap time because this sheet dismisses
+  /// itself before the share sheet opens.
+  final void Function(Rect? anchor)? onTap;
   final bool isLoading;
 
   const _ShareOptionTile({
@@ -217,7 +228,7 @@ class _ShareOptionTile extends StatelessWidget {
       child: Card(
         margin: EdgeInsets.zero,
         child: InkWell(
-          onTap: onTap,
+          onTap: onTap == null ? null : () => onTap!(shareAnchorFrom(context)),
           borderRadius: BorderRadius.circular(12),
           child: Padding(
             padding: const EdgeInsets.all(16),

--- a/lib/features/media/presentation/helpers/document_open_helper.dart
+++ b/lib/features/media/presentation/helpers/document_open_helper.dart
@@ -4,6 +4,8 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
+import 'package:submersion/core/utils/share_anchor.dart';
+
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/data/services/document_import_service.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
@@ -49,6 +51,9 @@ class DocumentOpenHelper {
     MediaItem item,
   ) async {
     final l10n = context.l10n;
+    // Captured before the awaits: on iPad this anchors the share popover to
+    // whatever the caller tapped, instead of the middle of the screen.
+    final anchor = shareAnchorFrom(context);
     final resolved = await ref.read(mediaBytesProvider(item).future);
     if (resolved.isUnavailable || resolved.bytes == null) {
       if (context.mounted) {
@@ -67,7 +72,10 @@ class DocumentOpenHelper {
       await Process.run('xdg-open', [file.path]);
     } else {
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: item.shareMimeType)]),
+        ShareParams(
+          files: [XFile(file.path, mimeType: item.shareMimeType)],
+          sharePositionOrigin: anchor,
+        ),
       );
     }
   }

--- a/lib/features/media/presentation/helpers/media_share_helper.dart
+++ b/lib/features/media/presentation/helpers/media_share_helper.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
@@ -12,12 +13,21 @@ import 'package:submersion/l10n/l10n_extension.dart';
 /// resolving and an error snackbar when nothing could be resolved. Shared by
 /// the full-screen viewer (single item) and the library selection bar
 /// (multi-item).
+///
+/// [anchor] is the iPad share popover's origin; pass the share button's rect
+/// (see `shareAnchorFrom`). Ignored on every other platform.
 Future<void> shareMediaItems(
   BuildContext context,
   WidgetRef ref,
-  List<MediaItem> items,
-) async {
+  List<MediaItem> items, {
+  Rect? anchor,
+}) async {
   final l10n = context.l10n;
+  // Falls back to [context] so callers that only have a page or bar context
+  // still anchor somewhere sensible instead of the middle of the screen.
+  // Resolved up front: the progress dialog below and the awaits after it can
+  // outlive the widget that supplied it.
+  final sharePositionOrigin = anchor ?? shareAnchorFrom(context);
 
   showDialog<void>(
     context: context,
@@ -46,7 +56,9 @@ Future<void> shareMediaItems(
       }
       return;
     }
-    await SharePlus.instance.share(ShareParams(files: files));
+    await SharePlus.instance.share(
+      ShareParams(files: files, sharePositionOrigin: sharePositionOrigin),
+    );
   } catch (e) {
     if (context.mounted) {
       Navigator.of(context, rootNavigator: true).pop();

--- a/lib/features/media/presentation/pages/document_viewer_page.dart
+++ b/lib/features/media/presentation/pages/document_viewer_page.dart
@@ -3,6 +3,7 @@ import 'package:pdfrx/pdfrx.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/media_bytes_providers.dart';
@@ -40,10 +41,15 @@ class _DocumentViewerPageState extends ConsumerState<DocumentViewerPage> {
           overflow: TextOverflow.ellipsis,
         ),
         actions: [
-          IconButton(
-            icon: const Icon(Icons.share),
-            tooltip: context.l10n.media_photoViewer_shareTooltip,
-            onPressed: () => _share(context),
+          // Builder so the share popover anchors to this button on iPad:
+          // findRenderObject from a Builder's context descends to the
+          // IconButton, whereas the page's context would yield the whole page.
+          Builder(
+            builder: (buttonContext) => IconButton(
+              icon: const Icon(Icons.share),
+              tooltip: context.l10n.media_photoViewer_shareTooltip,
+              onPressed: () => _share(buttonContext),
+            ),
           ),
         ],
       ),
@@ -82,6 +88,8 @@ class _DocumentViewerPageState extends ConsumerState<DocumentViewerPage> {
 
   Future<void> _share(BuildContext context) async {
     final l10n = context.l10n;
+    // Resolved before the awaits below: the button is guaranteed mounted now.
+    final anchor = shareAnchorFrom(context);
     try {
       final resolved = await ref.read(mediaBytesProvider(widget.item).future);
       if (resolved.isUnavailable || resolved.bytes == null) {
@@ -96,6 +104,7 @@ class _DocumentViewerPageState extends ConsumerState<DocumentViewerPage> {
       await SharePlus.instance.share(
         ShareParams(
           files: [XFile(file.path, mimeType: widget.item.shareMimeType)],
+          sharePositionOrigin: anchor,
         ),
       );
     } catch (e) {

--- a/lib/features/media/presentation/pages/media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/media_viewer_page.dart
@@ -11,6 +11,7 @@ import 'package:video_player/video_player.dart';
 
 import 'package:submersion/core/constants/feature_flags.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/core/router/section_navigation.dart';
 import 'package:submersion/core/services/lightroom/lightroom_api_client.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
@@ -474,7 +475,8 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
                     currentIndex: currentIndex,
                     totalCount: mediaList.length,
                     onClose: () => Navigator.of(context).pop(),
-                    onShare: () => _shareCurrentPhoto(currentItem),
+                    onShare: (anchor) =>
+                        _shareCurrentPhoto(currentItem, anchor),
                     onWriteMetadata: () => _writeMetadataToPhoto(currentItem),
                     // The viewer is deliberately NOT popped first: leaving it
                     // on the stack is what lets Back return the user to the
@@ -638,9 +640,9 @@ class _MediaViewerPageState extends ConsumerState<MediaViewerPage> {
     return LightroomApiClient.assetWebUrl(catalogId, item.remoteAssetId!);
   }
 
-  Future<void> _shareCurrentPhoto(MediaItem item) async {
+  Future<void> _shareCurrentPhoto(MediaItem item, Rect? anchor) async {
     // Shared resolve-and-share flow (also used by the library selection bar).
-    await shareMediaItems(context, ref, [item]);
+    await shareMediaItems(context, ref, [item], anchor: anchor);
   }
 
   void _showError(String message) {
@@ -1325,7 +1327,7 @@ class _TopOverlay extends StatelessWidget {
   final int currentIndex;
   final int totalCount;
   final VoidCallback onClose;
-  final VoidCallback onShare;
+  final void Function(Rect? anchor) onShare;
   final VoidCallback onWriteMetadata;
   final bool hasEnrichment;
 
@@ -1437,10 +1439,15 @@ class _TopOverlay extends StatelessWidget {
                   tooltip: context.l10n.media_info_title,
                   onPressed: () => showMediaInfoSheet(context, item),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.share, color: Colors.white),
-                  tooltip: context.l10n.media_photoViewer_shareTooltip,
-                  onPressed: onShare,
+                // Builder so the iPad share popover anchors to this
+                // button: findRenderObject from a Builder's context descends
+                // to the IconButton rather than yielding the whole overlay.
+                Builder(
+                  builder: (buttonContext) => IconButton(
+                    icon: const Icon(Icons.share, color: Colors.white),
+                    tooltip: context.l10n.media_photoViewer_shareTooltip,
+                    onPressed: () => onShare(shareAnchorFrom(buttonContext)),
+                  ),
                 ),
                 MediaReuploadButton(item: item, color: Colors.white),
               ],

--- a/lib/features/media/presentation/pages/site_media_viewer_page.dart
+++ b/lib/features/media/presentation/pages/site_media_viewer_page.dart
@@ -6,6 +6,7 @@ import 'package:photo_view/photo_view_gallery.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/features/media/data/services/media_share_temp_file.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
@@ -211,7 +212,7 @@ class _SiteMediaViewerPageState extends ConsumerState<SiteMediaViewerPage> {
                     currentIndex: currentIndex,
                     totalCount: mediaList.length,
                     onClose: () => Navigator.of(context).pop(),
-                    onShare: () => _shareCurrentItem(currentItem),
+                    onShare: (anchor) => _shareCurrentItem(currentItem, anchor),
                   ),
                   // Previous / next controls. Mounted with the rest of the
                   // chrome, so the tap-to-hide gesture takes them away too.
@@ -249,7 +250,7 @@ class _SiteMediaViewerPageState extends ConsumerState<SiteMediaViewerPage> {
     );
   }
 
-  Future<void> _shareCurrentItem(MediaItem item) async {
+  Future<void> _shareCurrentItem(MediaItem item, Rect? anchor) async {
     final l10n = context.l10n;
 
     // Show loading indicator
@@ -277,7 +278,10 @@ class _SiteMediaViewerPageState extends ConsumerState<SiteMediaViewerPage> {
       if (mounted) Navigator.of(context, rootNavigator: true).pop();
 
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path, mimeType: item.shareMimeType)]),
+        ShareParams(
+          files: [XFile(file.path, mimeType: item.shareMimeType)],
+          sharePositionOrigin: anchor,
+        ),
       );
     } catch (e) {
       if (mounted) Navigator.of(context, rootNavigator: true).pop();
@@ -335,7 +339,7 @@ class _TopOverlay extends StatelessWidget {
   final int currentIndex;
   final int totalCount;
   final VoidCallback onClose;
-  final VoidCallback onShare;
+  final void Function(Rect? anchor) onShare;
 
   const _TopOverlay({
     required this.currentIndex,
@@ -384,10 +388,15 @@ class _TopOverlay extends StatelessWidget {
                     ),
                   ),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.share, color: Colors.white),
-                  tooltip: context.l10n.media_photoViewer_shareTooltip,
-                  onPressed: onShare,
+                // Builder so the iPad share popover anchors to this
+                // button: findRenderObject from a Builder's context descends
+                // to the IconButton rather than yielding the whole overlay.
+                Builder(
+                  builder: (buttonContext) => IconButton(
+                    icon: const Icon(Icons.share, color: Colors.white),
+                    tooltip: context.l10n.media_photoViewer_shareTooltip,
+                    onPressed: () => onShare(shareAnchorFrom(buttonContext)),
+                  ),
                 ),
               ],
             ),

--- a/lib/features/settings/presentation/pages/debug_log_viewer_page.dart
+++ b/lib/features/settings/presentation/pages/debug_log_viewer_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:submersion/core/models/log_entry.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_log_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/debug_mode_provider.dart';
 import 'package:submersion/features/settings/presentation/widgets/log_entry_tile.dart';
@@ -129,14 +130,22 @@ class _DebugLogViewerPageState extends ConsumerState<DebugLogViewerPage> {
         child: Row(
           children: [
             Expanded(
-              child: OutlinedButton.icon(
-                onPressed: () async {
-                  final l10n = context.l10n;
-                  final service = ref.read(logFileServiceProvider);
-                  await shareLogFile(service, l10n);
-                },
-                icon: const Icon(Icons.share, size: 18),
-                label: Text(context.l10n.common_action_share),
+              // Builder so the iPad share popover anchors to this button;
+              // shareLogFile lives in the provider layer and has no context.
+              child: Builder(
+                builder: (buttonContext) => OutlinedButton.icon(
+                  onPressed: () async {
+                    final l10n = context.l10n;
+                    final service = ref.read(logFileServiceProvider);
+                    await shareLogFile(
+                      service,
+                      l10n,
+                      sharePositionOrigin: shareAnchorFrom(buttonContext),
+                    );
+                  },
+                  icon: const Icon(Icons.share, size: 18),
+                  label: Text(context.l10n.common_action_share),
+                ),
               ),
             ),
             const SizedBox(width: 8),

--- a/lib/features/settings/presentation/providers/debug_log_providers.dart
+++ b/lib/features/settings/presentation/providers/debug_log_providers.dart
@@ -155,10 +155,15 @@ Future<Uint8List> _exportBytes(File file, String header) async {
 ///
 /// Shares a header-prefixed copy rather than the log file itself, so the
 /// recipient sees which build and device produced the lines.
+///
+/// [sharePositionOrigin] anchors the iPad share popover; this function has no
+/// [BuildContext] of its own, so the caller resolves it from the share button
+/// (see `shareAnchorFrom`). Ignored on every other platform.
 Future<void> shareLogFile(
   LogFileService service,
   AppLocalizations l10n, {
   LogEnvironment? environment,
+  Rect? sharePositionOrigin,
 }) async {
   final file = File(service.logFilePath);
   if (!file.existsSync()) return;
@@ -178,6 +183,7 @@ Future<void> shareLogFile(
     ShareParams(
       files: [XFile(export.path, mimeType: 'text/plain')],
       subject: l10n.settings_debugLog_shareSubject,
+      sharePositionOrigin: sharePositionOrigin,
     ),
   );
 }

--- a/test/core/utils/share_anchor_test.dart
+++ b/test/core/utils/share_anchor_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
+
+void main() {
+  testWidgets('resolves the rect of the widget the context belongs to', (
+    tester,
+  ) async {
+    late BuildContext buttonContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 20, top: 40),
+              child: Builder(
+                builder: (context) {
+                  buttonContext = context;
+                  return const SizedBox(width: 100, height: 30);
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // A Builder creates no RenderObject, so findRenderObject descends to the
+    // SizedBox below it. That is exactly why wrapping a share button in a
+    // Builder yields the button's rect rather than the whole page's.
+    expect(
+      shareAnchorFrom(buttonContext),
+      const Rect.fromLTWH(20, 40, 100, 30),
+    );
+  });
+
+  testWidgets('a page-level context yields the whole page, not a button', (
+    tester,
+  ) async {
+    late BuildContext pageContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            pageContext = context;
+            return const Scaffold(body: SizedBox(width: 100, height: 30));
+          },
+        ),
+      ),
+    );
+
+    // Documents the trap this helper exists to make visible: handing it the
+    // enclosing page's context anchors the popover to the entire screen, which
+    // is no better than share_plus's centred fallback.
+    final rect = shareAnchorFrom(pageContext);
+    expect(rect, isNotNull);
+    expect(rect!.size, tester.view.physicalSize / tester.view.devicePixelRatio);
+  });
+
+  testWidgets('returns null for an unmounted context', (tester) async {
+    late BuildContext captured;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            captured = context;
+            return const SizedBox(width: 10, height: 10);
+          },
+        ),
+      ),
+    );
+
+    // Replace the tree so the captured element is defunct. Callers that resolve
+    // the anchor after an await can land here, and must get null rather than an
+    // exception.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    expect(shareAnchorFrom(captured), isNull);
+  });
+
+  test('returns null for a null context', () {
+    expect(shareAnchorFrom(null), isNull);
+  });
+}

--- a/test/features/media/presentation/media_share_helper_test.dart
+++ b/test/features/media/presentation/media_share_helper_test.dart
@@ -73,6 +73,7 @@ void main() {
   Widget host({
     required List<MediaItem> items,
     required ResolvedAssetResult Function(MediaItem) resolve,
+    Rect? anchor,
   }) {
     return ProviderScope(
       overrides: [
@@ -87,7 +88,8 @@ void main() {
         home: Scaffold(
           body: Consumer(
             builder: (context, ref, _) => TextButton(
-              onPressed: () => shareMediaItems(context, ref, items),
+              onPressed: () =>
+                  shareMediaItems(context, ref, items, anchor: anchor),
               child: const Text('SHARE'),
             ),
           ),
@@ -249,5 +251,40 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(find.textContaining('Failed to share'), findsOneWidget);
     expect(platform.calls, isEmpty);
+  });
+
+  group('iPad share popover anchor', () {
+    // On iPad the share sheet is a popover and must point at the control that
+    // opened it. share_plus takes that as ShareParams.sharePositionOrigin;
+    // with none it centres the popover, so the arrow points at nothing.
+    testWidgets('an explicit anchor reaches ShareParams', (tester) async {
+      const anchor = Rect.fromLTWH(12, 34, 56, 78);
+
+      await tester.pumpWidget(
+        host(items: [item('a')], resolve: (_) => resolved(), anchor: anchor),
+      );
+
+      await tapShareAndDrain(tester);
+
+      expect(platform.calls.single.sharePositionOrigin, anchor);
+    });
+
+    testWidgets('falls back to the calling widget rather than nothing', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(items: [item('a')], resolve: (_) => resolved()),
+      );
+
+      await tapShareAndDrain(tester);
+
+      final origin = platform.calls.single.sharePositionOrigin;
+      expect(origin, isNotNull);
+      // The host hands over a Consumer's context, which contributes no render
+      // object, so the rect resolves to the share button below it -- the whole
+      // TextButton, not just its label.
+      expect(origin, tester.getRect(find.byType(TextButton)));
+      expect(origin!.isEmpty, isFalse);
+    });
   });
 }


### PR DESCRIPTION
Closes #1315.

> Stacked on #1312 (`worktree-ipad-uddf-and-fit-air`). Both branches change
> `dive_detail_page.dart`, so this is based on that one to avoid a guaranteed
> conflict. Review or merge #1312 first; the diff below is this commit only.

On iPad the system share sheet is a popover and must point at the control that
opened it, via `ShareParams.sharePositionOrigin`. Nothing in the app ever
supplied it, so every share sheet floated mid-screen with its arrow pointing at
nothing.

This is cosmetic, not a crash. `share_plus` 13.3.0 centres the popover itself
when the rect is empty (`FPPSharePlusPlugin.m`), which is what has been
masking it.

## What changed

`lib/core/utils/share_anchor.dart` adds `shareAnchorFrom(BuildContext?)`, the
repo's first `BuildContext` to global `Rect` helper. There were 16 ad-hoc
`findRenderObject()` sites and no shared utility. It returns null for an
unmounted context or a non-laid-out render object, since resolving an anchor
after an `await` can legitimately race disposal, and null just means "let the
platform decide".

8 of the 10 `SharePlus.instance.share` call sites now pass an anchor, by three
different routes depending on where the button lives:

| Technique | Sites |
| --- | --- |
| `Builder` wrapper, no signature change | document viewer, backup export card, debug log button |
| Callback carries the rect | media viewer overlay, site media viewer overlay, certification tiles |
| Resolve from the context the caller already passes | document open helper, `shareMediaItems` fallback |

The `Builder` trick is the interesting one: a `Builder` contributes no render
object, so `findRenderObject` from its context descends to the button below it.
Passing a page's context instead yields a screen-sized rect, which anchors the
popover to the whole display and is no better than the centred fallback. There
is a test that pins exactly that distinction so the trap is visible.

**Two sheets dismiss themselves before sharing** - the certification sheet's
`// Pop before sharing to avoid UI issues`, and the backup export sheet - so
their anchor is captured at tap time while the control is still mounted. The
rect stays valid and points where the user just tapped.

Only one signature changed: `shareLogFile`, which lives in the provider layer
and has no `BuildContext`.

## What deliberately did not change

The two helpers in `lib/core/services/export/shared/file_export_utils.dart`
keep the centred fallback, so UDDF/CSV/PDF/Excel/KML/GPX export share sheets
are still unanchored.

Reaching them from the UI means threading a `Rect` through **41 method
signatures** across `ExportNotifier`, `ExportService` and 15 per-format
services (37 excluding two dead paths: `exportTripToPdf` has no callers,
`exportTripsToCsv` is test-only). And the export flows dismiss their format
picker before the share sheet opens, so the anchor bought by all that plumbing
would point at a dismissed sheet. Worst trade of the available options; noted
on the issue instead.

If those specifically need anchoring later, the cheaper route is a surrogate
anchor on the app-bar button that opened the menu, which outlives the sheet.

## Tests

- `test/core/utils/share_anchor_test.dart` - button rect, the page-context
  trap, unmounted context, null context.
- `test/features/media/presentation/media_share_helper_test.dart` - two cases
  asserting the anchor reaches `ShareParams`, using the existing fake
  `SharePlatform`. Note that file's constraint: `SharePlus.instance` is a
  `static final` capturing `SharePlatform.instance` on first read for the whole
  isolate, so there is one fake with `calls.clear()` between tests.

Full suite: 20,525 passed, 0 failed. `dart format` and `flutter analyze` clean.

**Needs an iPad to verify.** The popover branch does not execute on iPhone,
desktop, or in widget tests - the tests prove the rect reaches `ShareParams`,
not that the result looks right.
