### PR TITLE
fix(windows): move app data off the legacy company directory

### DIFF
--- a/lib/core/services/windows_app_data_migration.dart
+++ b/lib/core/services/windows_app_data_migration.dart
@@ -131,10 +131,28 @@ Future<AppDataMigrationReport> migrateCompanyDirectory({
       );
     } catch (_) {
       // Rename can fail across volumes or when another process holds a handle
-      // on something in the tree. Fall back to a copy, and deliberately keep
-      // the legacy tree: a copy is not atomic, so leaving the original in place
-      // guarantees one intact copy survives a crash mid-copy.
-      await _copyTree(legacyDir, targetDir);
+      // on something in the tree. Fall back to a copy.
+      //
+      // The copy lands in a staging sibling and is renamed into place, never
+      // directly into the target. A copy is not atomic, and a half-copied
+      // target would look populated to the next launch: the migration would
+      // report targetAlreadyPopulated forever while the app ran on partial
+      // data and the real settings sat stranded under the legacy name. Staging
+      // keeps the target all-or-nothing. The promotion is also a rename WITHIN
+      // the new company directory, so it is same-volume even when the original
+      // rename failed because it crossed volumes.
+      final staging = Directory('$targetPath.migrating');
+      await _deleteQuietly(staging); // leftover from an interrupted attempt
+      try {
+        await _copyTree(legacyDir, staging);
+        await staging.rename(targetPath);
+      } catch (_) {
+        await _deleteQuietly(staging);
+        rethrow;
+      }
+      // The legacy tree is deliberately retained. The target is now complete,
+      // so the next launch no-ops on it; keeping the source costs disk and
+      // buys a manual recovery path.
       return AppDataMigrationReport(
         outcome: AppDataMigrationOutcome.copied,
         legacyPath: legacyPath,
@@ -148,6 +166,16 @@ Future<AppDataMigrationReport> migrateCompanyDirectory({
       targetPath: targetPath,
       error: e,
     );
+  }
+}
+
+/// Best effort removal. Used only for staging leftovers, where a failure to
+/// clean up must not mask the real error or abort the migration.
+Future<void> _deleteQuietly(Directory dir) async {
+  try {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  } catch (_) {
+    // A stale staging directory is harmless; the next attempt overwrites it.
   }
 }
 

--- a/lib/core/services/windows_app_data_migration.dart
+++ b/lib/core/services/windows_app_data_migration.dart
@@ -1,0 +1,205 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// The `CompanyName` the Windows runner shipped with through v1.7.5. It came
+/// from the Flutter template and was never changed, so `path_provider_windows`
+/// placed every Windows user's application-support and cache data under the
+/// developer's personal name.
+const legacyWindowsCompanyName = 'Eric Griffin';
+
+/// The `CompanyName` in `windows/runner/Runner.rc`. These two MUST stay in
+/// sync: `path_provider_windows` reads the value out of the executable's
+/// VERSIONINFO resource via `VerQueryValue`, not from anything in Dart, and
+/// this migration has to be able to name the directory that produces.
+const windowsCompanyName = 'Submersion';
+
+/// The `ProductName` in `windows/runner/Runner.rc`, unchanged.
+const windowsProductName = 'submersion';
+
+/// What a single company-directory migration attempt did.
+enum AppDataMigrationOutcome {
+  /// No legacy directory on disk. The overwhelmingly common case: a fresh
+  /// install, or a machine that already migrated on an earlier launch.
+  noLegacyData,
+
+  /// Legacy and target resolve to the same directory, so there is nothing to
+  /// move.
+  notNeeded,
+
+  /// The target already holds data. The legacy tree is left alone rather than
+  /// clobbering whatever the user has been using.
+  targetAlreadyPopulated,
+
+  /// Renamed atomically. The legacy directory is gone.
+  moved,
+
+  /// Rename failed, so the tree was copied. The legacy directory is retained.
+  copied,
+
+  /// Nothing was moved and the legacy directory is untouched.
+  failed,
+}
+
+/// The result of one migration attempt, including the paths considered so a
+/// debug log can show exactly which directories were involved.
+class AppDataMigrationReport {
+  const AppDataMigrationReport({
+    required this.outcome,
+    required this.legacyPath,
+    required this.targetPath,
+    this.error,
+  });
+
+  final AppDataMigrationOutcome outcome;
+  final String legacyPath;
+  final String targetPath;
+  final Object? error;
+
+  @override
+  String toString() =>
+      'AppDataMigrationReport(${outcome.name}, legacy: $legacyPath, '
+      'target: $targetPath${error == null ? '' : ', error: $error'})';
+}
+
+Future<Directory> _defaultRename(Directory source, String targetPath) =>
+    source.rename(targetPath);
+
+/// Moves `<rootPath>/<legacyCompany>/<product>` to
+/// `<rootPath>/<company>/<product>`.
+///
+/// Never throws: a failure is reported as [AppDataMigrationOutcome.failed] with
+/// the legacy directory left exactly as it was found. This runs during startup
+/// before anything has opened a file, so a thrown error here would be a blank
+/// app rather than a lost setting.
+///
+/// [rename] is injectable so the copy fallback is reachable from a test on a
+/// POSIX host, where a rename within one filesystem always succeeds.
+Future<AppDataMigrationReport> migrateCompanyDirectory({
+  required String rootPath,
+  required String legacyCompany,
+  required String company,
+  required String product,
+  Future<Directory> Function(Directory source, String targetPath)? rename,
+}) async {
+  final legacyPath = p.join(rootPath, legacyCompany, product);
+  final targetPath = p.join(rootPath, company, product);
+
+  // Windows filenames are case-insensitive, so a company name differing only in
+  // case names the same directory and a "move" would be a self-rename.
+  if (legacyCompany.toLowerCase() == company.toLowerCase()) {
+    return AppDataMigrationReport(
+      outcome: AppDataMigrationOutcome.notNeeded,
+      legacyPath: legacyPath,
+      targetPath: targetPath,
+    );
+  }
+
+  final legacyDir = Directory(legacyPath);
+  final targetDir = Directory(targetPath);
+
+  try {
+    if (!await legacyDir.exists()) {
+      return AppDataMigrationReport(
+        outcome: AppDataMigrationOutcome.noLegacyData,
+        legacyPath: legacyPath,
+        targetPath: targetPath,
+      );
+    }
+
+    if (await targetDir.exists()) {
+      if (!await _isEmpty(targetDir)) {
+        return AppDataMigrationReport(
+          outcome: AppDataMigrationOutcome.targetAlreadyPopulated,
+          legacyPath: legacyPath,
+          targetPath: targetPath,
+        );
+      }
+      // An empty target is an artefact of a previous launch that created the
+      // directory without writing anything. Clear it so the rename can land.
+      await targetDir.delete();
+    }
+
+    await Directory(p.dirname(targetPath)).create(recursive: true);
+
+    try {
+      await (rename ?? _defaultRename)(legacyDir, targetPath);
+      return AppDataMigrationReport(
+        outcome: AppDataMigrationOutcome.moved,
+        legacyPath: legacyPath,
+        targetPath: targetPath,
+      );
+    } catch (_) {
+      // Rename can fail across volumes or when another process holds a handle
+      // on something in the tree. Fall back to a copy, and deliberately keep
+      // the legacy tree: a copy is not atomic, so leaving the original in place
+      // guarantees one intact copy survives a crash mid-copy.
+      await _copyTree(legacyDir, targetDir);
+      return AppDataMigrationReport(
+        outcome: AppDataMigrationOutcome.copied,
+        legacyPath: legacyPath,
+        targetPath: targetPath,
+      );
+    }
+  } catch (e) {
+    return AppDataMigrationReport(
+      outcome: AppDataMigrationOutcome.failed,
+      legacyPath: legacyPath,
+      targetPath: targetPath,
+      error: e,
+    );
+  }
+}
+
+Future<bool> _isEmpty(Directory dir) async =>
+    await dir.list(followLinks: false).isEmpty;
+
+Future<void> _copyTree(Directory from, Directory to) async {
+  await to.create(recursive: true);
+  await for (final entity in from.list(followLinks: false)) {
+    final destination = p.join(to.path, p.basename(entity.path));
+    if (entity is Directory) {
+      await _copyTree(entity, Directory(destination));
+    } else if (entity is File) {
+      await entity.copy(destination);
+    }
+    // Links are skipped: nothing the app writes under app-support is a link.
+  }
+}
+
+/// Relocates the Windows roaming and local app-data trees off the legacy
+/// company name.
+///
+/// Must run before ANY other code touches those directories. In particular it
+/// has to precede `SharedPreferences.getInstance()`: on Windows
+/// `shared_preferences_windows` resolves its file through
+/// `PathProviderWindows.getApplicationSupportPath()`, so reading prefs first
+/// would create an empty file at the new path, leave the user's real settings
+/// stranded, and make the target look populated to this migration.
+///
+/// The database is NOT affected -- it lives under
+/// `getApplicationDocumentsDirectory()`, which has no company component.
+///
+/// Returns an empty list off Windows. Never throws.
+Future<List<AppDataMigrationReport>> migrateWindowsAppDataDirectories() async {
+  if (!Platform.isWindows) return const <AppDataMigrationReport>[];
+
+  // APPDATA backs getApplicationSupportDirectory (FOLDERID_RoamingAppData);
+  // LOCALAPPDATA backs getApplicationCacheDirectory (FOLDERID_LocalAppData).
+  const roots = ['APPDATA', 'LOCALAPPDATA'];
+
+  final reports = <AppDataMigrationReport>[];
+  for (final variable in roots) {
+    final root = Platform.environment[variable];
+    if (root == null || root.isEmpty) continue;
+    reports.add(
+      await migrateCompanyDirectory(
+        rootPath: root,
+        legacyCompany: legacyWindowsCompanyName,
+        company: windowsCompanyName,
+        product: windowsProductName,
+      ),
+    );
+  }
+  return reports;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:submersion/core/services/global_error_handler.dart';
 import 'package:submersion/core/services/log_file_service.dart';
 import 'package:submersion/core/services/log_environment.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/windows_app_data_migration.dart';
 
 import 'package:submersion/app.dart';
 import 'package:submersion/core/services/database_location_service.dart';
@@ -56,6 +57,17 @@ Future<void> _bootstrap() async {
   // image decode honours the 75 MB ceiling.
   applyMediaCacheCaps();
 
+  // Relocate the Windows app-data trees off the legacy "Eric Griffin" company
+  // directory. MUST precede SharedPreferences.getInstance(): on Windows
+  // shared_preferences resolves its file through
+  // PathProviderWindows.getApplicationSupportPath(), so reading prefs first
+  // would strand the user's real settings under the old company name. Never
+  // throws; the reports are logged once file logging is up.
+  // (Windows-only and inside main(), so not reachable from the test host.)
+  // coverage:ignore-start
+  final appDataMigrations = await migrateWindowsAppDataDirectories();
+  // coverage:ignore-end
+
   // Initialize SharedPreferences first (needed for storage config)
   final prefs = await SharedPreferences.getInstance();
 
@@ -80,6 +92,22 @@ Future<void> _bootstrap() async {
     // channel, and the write is serialized behind LoggerService's queue.
     unawaited(logSessionEnvironment());
   }
+
+  // Now that file logging is wired, report what the app-data migration did.
+  // Anything other than "no legacy data" is worth a line in a shared log:
+  // a failure here is the difference between a user's settings surviving an
+  // upgrade and appearing to reset.
+  // coverage:ignore-start
+  const migrationLogger = LoggerService('AppDataMigration');
+  for (final report in appDataMigrations) {
+    if (report.outcome == AppDataMigrationOutcome.noLegacyData) continue;
+    if (report.outcome == AppDataMigrationOutcome.failed) {
+      migrationLogger.error('Windows app-data migration failed', error: report);
+    } else {
+      migrationLogger.info('Windows app-data migration: $report');
+    }
+  }
+  // coverage:ignore-end
 
   // Create location service and get storage config
   final locationService = DatabaseLocationService(prefs);

--- a/test/core/services/windows_app_data_migration_test.dart
+++ b/test/core/services/windows_app_data_migration_test.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/windows_app_data_migration.dart';
+
+/// These tests exercise the pure directory-move core on the host filesystem so
+/// the behaviour is covered on the POSIX CI matrix. The Windows-only decision
+/// of WHICH roots to migrate lives in migrateWindowsAppDataDirectories and is
+/// guarded by Platform.isWindows.
+void main() {
+  late Directory root;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('win_appdata_migration_test_');
+  });
+
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  String legacyPath() => p.join(root.path, 'Eric Griffin', 'submersion');
+  String targetPath() => p.join(root.path, 'Submersion', 'submersion');
+
+  Future<AppDataMigrationReport> migrate({
+    Future<Directory> Function(Directory, String)? rename,
+  }) {
+    return migrateCompanyDirectory(
+      rootPath: root.path,
+      legacyCompany: 'Eric Griffin',
+      company: 'Submersion',
+      product: 'submersion',
+      rename: rename,
+    );
+  }
+
+  void seedLegacy() {
+    Directory(p.join(legacyPath(), 'logs')).createSync(recursive: true);
+    File(p.join(legacyPath(), 'shared_preferences.json'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"unit_system":"metric"}');
+    File(
+      p.join(legacyPath(), 'logs', 'submersion-debug.log'),
+    ).writeAsStringSync('line one');
+  }
+
+  group('migrateCompanyDirectory', () {
+    test(
+      'moves the legacy company directory onto the new company name',
+      () async {
+        seedLegacy();
+
+        final report = await migrate();
+
+        expect(report.outcome, AppDataMigrationOutcome.moved);
+        expect(Directory(targetPath()).existsSync(), isTrue);
+        expect(Directory(legacyPath()).existsSync(), isFalse);
+      },
+    );
+
+    test('carries nested file contents across the move', () async {
+      seedLegacy();
+
+      await migrate();
+
+      expect(
+        File(
+          p.join(targetPath(), 'shared_preferences.json'),
+        ).readAsStringSync(),
+        '{"unit_system":"metric"}',
+      );
+      expect(
+        File(
+          p.join(targetPath(), 'logs', 'submersion-debug.log'),
+        ).readAsStringSync(),
+        'line one',
+      );
+    });
+
+    test('does nothing when there is no legacy directory', () async {
+      final report = await migrate();
+
+      expect(report.outcome, AppDataMigrationOutcome.noLegacyData);
+      expect(Directory(targetPath()).existsSync(), isFalse);
+    });
+
+    test(
+      'leaves both directories untouched when the target already has data',
+      () async {
+        seedLegacy();
+        File(p.join(targetPath(), 'shared_preferences.json'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('{"unit_system":"imperial"}');
+
+        final report = await migrate();
+
+        expect(report.outcome, AppDataMigrationOutcome.targetAlreadyPopulated);
+        expect(Directory(legacyPath()).existsSync(), isTrue);
+        expect(
+          File(
+            p.join(targetPath(), 'shared_preferences.json'),
+          ).readAsStringSync(),
+          '{"unit_system":"imperial"}',
+        );
+      },
+    );
+
+    test('replaces an empty target directory rather than refusing', () async {
+      seedLegacy();
+      Directory(targetPath()).createSync(recursive: true);
+
+      final report = await migrate();
+
+      expect(report.outcome, AppDataMigrationOutcome.moved);
+      expect(
+        File(
+          p.join(targetPath(), 'shared_preferences.json'),
+        ).readAsStringSync(),
+        '{"unit_system":"metric"}',
+      );
+    });
+
+    test('is a no-op when the legacy and target names are identical', () async {
+      seedLegacy();
+
+      final report = await migrateCompanyDirectory(
+        rootPath: root.path,
+        legacyCompany: 'Eric Griffin',
+        company: 'Eric Griffin',
+        product: 'submersion',
+      );
+
+      expect(report.outcome, AppDataMigrationOutcome.notNeeded);
+      expect(Directory(legacyPath()).existsSync(), isTrue);
+    });
+
+    test(
+      'copies the tree when rename fails, keeping the legacy directory',
+      () async {
+        seedLegacy();
+
+        final report = await migrate(
+          rename: (_, _) => Future<Directory>.error(
+            const FileSystemException('cross-device link'),
+          ),
+        );
+
+        expect(report.outcome, AppDataMigrationOutcome.copied);
+        expect(
+          File(
+            p.join(targetPath(), 'logs', 'submersion-debug.log'),
+          ).readAsStringSync(),
+          'line one',
+        );
+        // The legacy tree is deliberately retained: if the app dies mid-copy the
+        // user still has one intact copy.
+        expect(Directory(legacyPath()).existsSync(), isTrue);
+      },
+    );
+
+    test('reports failure without deleting the legacy directory', () async {
+      seedLegacy();
+      // A FILE where the new company directory needs to be, so creating the
+      // target parent cannot succeed.
+      File(
+        p.join(root.path, 'Submersion'),
+      ).writeAsStringSync('not a directory');
+
+      final report = await migrate();
+
+      expect(report.outcome, AppDataMigrationOutcome.failed);
+      expect(report.error, isNotNull);
+      expect(Directory(legacyPath()).existsSync(), isTrue);
+      expect(
+        File(
+          p.join(legacyPath(), 'shared_preferences.json'),
+        ).readAsStringSync(),
+        '{"unit_system":"metric"}',
+      );
+    });
+
+    test('reports the paths it considered', () async {
+      seedLegacy();
+
+      final report = await migrate();
+
+      expect(report.legacyPath, legacyPath());
+      expect(report.targetPath, targetPath());
+    });
+  });
+
+  group('migrateWindowsAppDataDirectories', () {
+    test('does nothing off Windows', () async {
+      final reports = await migrateWindowsAppDataDirectories();
+
+      expect(reports, isEmpty, skip: Platform.isWindows);
+    });
+  });
+}

--- a/test/core/services/windows_app_data_migration_test.dart
+++ b/test/core/services/windows_app_data_migration_test.dart
@@ -16,6 +16,12 @@ void main() {
   });
 
   tearDown(() {
+    // Re-open anything a test locked with chmod so the tree can be removed.
+    // Shelled out rather than walked in Dart: a 000 directory cannot be
+    // listed, so a recursive Dart walk throws before it can unlock anything.
+    if (!Platform.isWindows) {
+      Process.runSync('chmod', ['-R', 'u+rwX', root.path]);
+    }
     if (root.existsSync()) root.deleteSync(recursive: true);
   });
 
@@ -152,9 +158,12 @@ void main() {
           ).readAsStringSync(),
           'line one',
         );
-        // The legacy tree is deliberately retained: if the app dies mid-copy the
-        // user still has one intact copy.
+        // The legacy tree is deliberately retained. The target is complete, so
+        // the next launch no-ops on it; keeping the source buys a manual
+        // recovery path at the cost of some disk.
         expect(Directory(legacyPath()).existsSync(), isTrue);
+        // Staging is promoted by rename, never left lying around.
+        expect(Directory('${targetPath()}.migrating').existsSync(), isFalse);
       },
     );
 
@@ -179,6 +188,70 @@ void main() {
       );
     });
 
+    // A copy is not atomic. If it lands directly in the real target and then
+    // fails, the next launch sees a populated target, reports
+    // targetAlreadyPopulated, and never retries -- so the app runs on a partial
+    // copy while the real settings sit stranded in the legacy directory.
+    // Copying via a staging directory keeps the target all-or-nothing.
+    test(
+      'leaves no partial target when the copy fails mid-tree',
+      () async {
+        seedLegacy();
+        final locked = Directory(p.join(legacyPath(), 'locked'))
+          ..createSync(recursive: true);
+        File(p.join(locked.path, 'inner.json')).writeAsStringSync('{}');
+        Process.runSync('chmod', ['000', locked.path]);
+
+        final report = await migrate(
+          rename: (_, _) => Future<Directory>.error(
+            const FileSystemException('cross-device'),
+          ),
+        );
+
+        expect(report.outcome, AppDataMigrationOutcome.failed);
+        expect(
+          Directory(targetPath()).existsSync(),
+          isFalse,
+          reason: 'a half-copied target would be mistaken for a finished one',
+        );
+        expect(Directory(legacyPath()).existsSync(), isTrue);
+      },
+      skip: Platform.isWindows
+          ? 'chmod-based failure injection is POSIX-only'
+          : null,
+    );
+
+    test(
+      'retries on the next run after a failed copy',
+      () async {
+        seedLegacy();
+        final locked = Directory(p.join(legacyPath(), 'locked'))
+          ..createSync(recursive: true);
+        Process.runSync('chmod', ['000', locked.path]);
+
+        await migrate(
+          rename: (_, _) => Future<Directory>.error(
+            const FileSystemException('cross-device'),
+          ),
+        );
+
+        // Whatever blocked the copy clears, and the second attempt succeeds.
+        Process.runSync('chmod', ['755', locked.path]);
+        final second = await migrate();
+
+        expect(second.outcome, AppDataMigrationOutcome.moved);
+        expect(
+          File(
+            p.join(targetPath(), 'shared_preferences.json'),
+          ).readAsStringSync(),
+          '{"unit_system":"metric"}',
+        );
+      },
+      skip: Platform.isWindows
+          ? 'chmod-based failure injection is POSIX-only'
+          : null,
+    );
+
     test('reports the paths it considered', () async {
       seedLegacy();
 
@@ -190,10 +263,16 @@ void main() {
   });
 
   group('migrateWindowsAppDataDirectories', () {
-    test('does nothing off Windows', () async {
-      final reports = await migrateWindowsAppDataDirectories();
-
-      expect(reports, isEmpty, skip: Platform.isWindows);
-    });
+    // Skipped at the TEST level, not the assertion level: the call itself would
+    // migrate the developer's real %APPDATA% / %LOCALAPPDATA% on a Windows box.
+    test(
+      'does nothing off Windows',
+      () async {
+        expect(await migrateWindowsAppDataDirectories(), isEmpty);
+      },
+      skip: Platform.isWindows
+          ? 'would touch the real %APPDATA% tree on this machine'
+          : null,
+    );
   });
 }

--- a/test/core/services/windows_runner_company_name_test.dart
+++ b/test/core/services/windows_runner_company_name_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/windows_app_data_migration.dart';
+
+/// `path_provider_windows` builds the application-support path from the
+/// CompanyName/ProductName baked into the executable's VERSIONINFO resource,
+/// which Dart cannot read at runtime on any other platform. The migration in
+/// windows_app_data_migration.dart therefore hardcodes those names, and this
+/// test is the only thing keeping the two in sync. It runs on the POSIX CI
+/// matrix, which is where a drifting Runner.rc would otherwise go unnoticed.
+void main() {
+  String rcValue(String contents, String key) {
+    final match = RegExp('VALUE\\s+"$key",\\s+"([^"]*)"').firstMatch(contents);
+    expect(match, isNotNull, reason: 'no VALUE "$key" in Runner.rc');
+    return match!.group(1)!;
+  }
+
+  group('windows/runner/Runner.rc', () {
+    late String contents;
+
+    setUp(() {
+      contents = File('windows/runner/Runner.rc').readAsStringSync();
+    });
+
+    test('CompanyName matches windowsCompanyName', () {
+      expect(rcValue(contents, 'CompanyName'), windowsCompanyName);
+    });
+
+    test('ProductName matches windowsProductName', () {
+      expect(rcValue(contents, 'ProductName'), windowsProductName);
+    });
+
+    test('CompanyName has moved off the legacy name', () {
+      expect(rcValue(contents, 'CompanyName'), isNot(legacyWindowsCompanyName));
+    });
+  });
+}

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -99,7 +99,7 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "Eric Griffin" "\0"
+            VALUE "CompanyName", "Submersion" "\0"
             VALUE "FileDescription", "submersion" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "submersion" "\0"


### PR DESCRIPTION
Windows app data lived under `%APPDATA%\Eric Griffin\submersion`. Reported by a
ScubaBoard tester, whose #1304 error string exposed the path:

```
PathNotFoundException: Cannot copy file to
'C:\Users\Angel\AppData\Roaming\Eric Griffin\submersion/sync_base_publish/...'
```

(The crash itself is #1304, already fixed by #1307 and shipping in 1.7.6. This
PR addresses only the directory name the log revealed.)

## Where the name comes from

`path_provider_windows` does not read `pubspec.yaml`. It reads the running
`.exe`'s **VERSIONINFO** resource via `VerQueryValue` and builds
`RoamingAppData\<CompanyName>\<ProductName>`. Those values live in
`windows/runner/Runner.rc`, which still carried the Flutter template's default.

## What changed

- `windows/runner/Runner.rc`: `CompanyName` `Eric Griffin` -> `Submersion`.
- New `lib/core/services/windows_app_data_migration.dart`: a one-time move of
  both company-scoped trees, `%APPDATA%` (backing
  `getApplicationSupportDirectory`) and `%LOCALAPPDATA%` (backing
  `getApplicationCacheDirectory`).
- `lib/main.dart`: runs it, then logs the outcome once file logging is up.

## Three things worth reviewing carefully

**1. Ordering is load-bearing.** The migration runs before
`SharedPreferences.getInstance()`, which is `main()`'s first real act. On
Windows `shared_preferences_windows` resolves its file through
`PathProviderWindows.getApplicationSupportPath()`, the same company directory.
Reading prefs first would strand the user's real settings under the old name
*and* create an empty file at the new path that makes this migration believe it
had already run. Moving this call later reintroduces the bug silently.

**2. The database was never in scope.** `getDefaultDatabasePath()` uses
`getApplicationDocumentsDirectory()` = `FOLDERID_Documents`, which has no
company component, so `submersion.db` is at `Documents\Submersion\` and a
`CompanyName` change cannot reach it. Only settings, logs and caches move.

**3. The target is all-or-nothing.** `rename` is atomic; the copy fallback is
not. So the copy lands in a `<target>.migrating` sibling and is renamed into
place, never directly into the target. A half-copied target would look
populated to the next launch, which would report `targetAlreadyPopulated`
forever while the app ran on partial data and the real settings sat stranded
under the legacy name. The promotion is a rename *within* the new company
directory, so it is same-volume even when the original `legacy -> target`
rename failed because it crossed volumes.

The legacy tree is still retained after a successful copy, but purely as a
manual recovery path, not as crash protection: `path_provider` points the app
at the new location, so a legacy copy the app never reads would not rescue
anything. Nothing is ever deleted on failure, and the function never throws,
since a throw at this point in startup would be a blank app rather than a lost
setting.

`AppPublisher=Eric Griffin` in `submersion.iss` and `LegalCopyright` are
unchanged and correct: `DefaultDirName={autopf}\Submersion`, so the publisher
name only feeds the Add/Remove Programs column.

## Tests

12 tests over the move itself (moved / no legacy data / target populated /
empty target / identical names / copy fallback / failure leaves legacy intact /
no partial target on a mid-copy failure / retry after a failed copy / reported
paths), plus 3 that parse `Runner.rc` and pin `CompanyName` and `ProductName`
to the Dart constants.

That pinning test matters more than it looks: the migration has to hardcode the
old and new names, because `path_provider` only ever reports the *current*
`CompanyName` and so cannot locate the old directory. Nothing else stops those
constants drifting from the `.rc`. I verified the test is not vacuous by
reverting the `.rc` and watching 2 of its 3 assertions fail.

- Full suite: **20710 passed, 19 skipped, 0 failed**
- `flutter analyze`: clean
- `dart format .`: clean

## Not verified

The `Runner.rc` half has no test of its real effect. The pinning test proves
the string matches the Dart constant; it cannot prove `rc.exe` compiles it into
VERSIONINFO or that `VerQueryValue` reads it back. The migration logic is only
exercised against POSIX temp directories. First real proof arrives on a Windows
build. Flagged and consciously accepted.

## Follow-up

#1327 tracks the last remaining literal-`/` path builder in the sync temp
family (`base_part_file_sink.dart:30`). Latent, not live, and deliberately kept
out of this PR.
