### PR TITLE
fix(sync): join the base part temp path instead of interpolating '/'

### DIFF
--- a/lib/core/services/sync/changeset_log/base_part_file_sink.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_sink.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
@@ -27,7 +28,7 @@ class BasePartFileSink {
     required Future<Uint8List?> Function(int index) downloadPart,
   }) async {
     final dir = await _tempDir();
-    final path = '${dir.path}/$name.${_uuid.v4()}.base';
+    final path = basePartTempPath(dir.path, name, _uuid.v4());
     final file = File(path);
     final out = file.openWrite();
 
@@ -79,6 +80,31 @@ class BasePartFileSink {
     }
   }
 }
+
+/// Path a downloaded base is assembled into: `<temp dir>/<name>.<uuid>.base`.
+///
+/// Joins rather than interpolating a literal `/`. [dirPath] comes from
+/// `resolveSyncTempDir`, which on Windows is backslashed, so interpolation
+/// produced a mixed-separator path
+/// (`C:\Users\...\AppData\Local\Temp/ssv1_base_devA_7.<uuid>.base`). Win32
+/// accepts that for open and delete, which is all the two callers of
+/// [BasePartFileSink.assemble] do with it, so nothing was broken -- but it is
+/// character-for-character the shape that killed every Windows base publish in
+/// #1304, where a `split(Platform.pathSeparator)` split on `\` only and left
+/// the `Temp/` segment glued to the front of the "filename". Adding a basename,
+/// a split or a manifest key downstream would have been enough to reproduce it,
+/// so #1327 removes the shape rather than the one consumer.
+///
+/// [context] exists so the Windows style can be pinned in tests running on a
+/// POSIX host, where `Platform.pathSeparator` is `/` and the mixed form is
+/// indistinguishable from a correct one; production always wants the platform's
+/// own.
+String basePartTempPath(
+  String dirPath,
+  String name,
+  String id, {
+  p.Context? context,
+}) => (context ?? p.context).join(dirPath, '$name.$id.base');
 
 /// Minimal `Sink<Digest>` that captures the single digest emitted at close.
 /// Avoids depending on `package:convert`'s `AccumulatorSink` (not exported by

--- a/lib/core/services/sync/changeset_log/resumable_base_publish.dart
+++ b/lib/core/services/sync/changeset_log/resumable_base_publish.dart
@@ -307,8 +307,9 @@ Future<Directory> resolveBasePublishDir() async {
 /// Where an export at [sourcePath] is moved to inside the publish directory.
 ///
 /// Takes the name with [p.Context.basename] rather than splitting on
-/// [Platform.pathSeparator]. Sync assembles its paths by interpolating a
-/// literal `/`, so on Windows an export path mixes separators
+/// [Platform.pathSeparator]. Sync used to assemble its paths by interpolating a
+/// literal `/` (every such site now joins instead -- #1304, #1327), so on
+/// Windows an export path mixed separators
 /// (`C:\Users\...\Local\Temp/ssv1_base_x.json`) and a backslash split kept the
 /// `Temp/` in front of the name. That moved the export into a subdirectory of
 /// the publish directory which nothing ever creates, so every base publish on

--- a/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 
@@ -99,6 +100,67 @@ void main() {
     await sink.deleteQuietly(f.path);
     expect(f.existsSync(), isFalse);
     await sink.deleteQuietly('${dir.path}/does-not-exist'); // no throw
+  });
+
+  // Issue #1327: the temp path was built by interpolating a literal '/' into
+  // a directory that is backslashed on Windows, producing the exact
+  // mixed-separator shape that killed every Windows base publish in #1304 once
+  // something split it on Platform.pathSeparator. Nothing splits these paths
+  // today, so the bug was latent -- these tests keep it that way by pinning the
+  // Windows style, which is the only way a POSIX CI host can see the
+  // difference at all.
+  group('temp path construction (#1327)', () {
+    final windows = p.Context(style: p.Style.windows);
+
+    test('joins with the platform separator, never a literal /', () {
+      final path = basePartTempPath(
+        r'C:\Users\diver\AppData\Local\Temp',
+        'ssv1_base_devA_7',
+        'a1b2c3',
+        context: windows,
+      );
+      expect(
+        path,
+        r'C:\Users\diver\AppData\Local\Temp\ssv1_base_devA_7.a1b2c3.base',
+      );
+      expect(path, isNot(contains('/')));
+    });
+
+    test('survives the #1304 basename split on Windows', () {
+      final path = basePartTempPath(
+        r'C:\Users\diver\AppData\Local\Temp',
+        'ssv1_base_devA_7',
+        'a1b2c3',
+        context: windows,
+      );
+      // The #1304 consumer pattern: split on the Windows separator only. With
+      // a mixed path this yielded 'Temp/ssv1_base_devA_7.a1b2c3.base'.
+      expect(path.split(r'\').last, 'ssv1_base_devA_7.a1b2c3.base');
+      expect(windows.basename(path), 'ssv1_base_devA_7.a1b2c3.base');
+    });
+
+    test('defaults to the host context', () {
+      final path = basePartTempPath('/tmp/sync', 'base', 'u');
+      expect(path, p.join('/tmp/sync', 'base.u.base'));
+    });
+
+    test(
+      'assemble returns a path the host context accepts as joined',
+      () async {
+        final part = bytes('payload');
+        final path = await sink.assemble(
+          name: 'ssv1_base_devA_7',
+          partCount: 1,
+          wholeChecksum: BaseChunker.checksum(part),
+          partChecksums: [BaseChunker.checksum(part)],
+          downloadPart: (_) async => part,
+        );
+        expect(path, isNotNull);
+        expect(p.dirname(path!), dir.path);
+        expect(p.basename(path), startsWith('ssv1_base_devA_7.'));
+        expect(p.basename(path), endsWith('.base'));
+      },
+    );
   });
 
   // Issue #509: with no injected temp dir, the sink must default to the


### PR DESCRIPTION
Closes #1327. Follow-up to #1304 / #1307.

## The problem

`BasePartFileSink.assemble` built its temp path by interpolation:

```dart
final path = '${dir.path}/$name.${_uuid.v4()}.base';
```

`dir` comes from `resolveSyncTempDir`, which is backslashed on Windows, so the
literal `/` produced a mixed-separator path:

```
C:\Users\<u>\AppData\Local\Temp/ssv1_base_devA_7.<uuid>.base
```

That is character-for-character the shape that killed every Windows base
publish in #1304.

## Why it was not failing

Both consumers of `assemble` only hand the returned string to `File(...)` for
reading and to `deleteQuietly`:

- `lib/core/services/sync/sync_service.dart` (adopt path)
- `lib/core/services/sync/changeset_log/changeset_reader.dart` (`_fetchBaseToFile`)

Win32 accepts mixed separators for open and delete, so nothing broke. The #1304
failure needed a second ingredient: a basename taken with
`split(Platform.pathSeparator)`, which on Windows splits on `\` only and left
the `Temp/` segment glued to the front of the filename. Nothing does that to
these paths today, so this was latent, not live. It became a real bug the
moment anyone added a basename, a split, or a manifest key derived from it.

## The fix

Extract a pure `basePartTempPath(dirPath, name, id, {p.Context? context})` that
joins via `package:path`, mirroring the `basePublishTargetPath` seam #1307
extracted. It takes the uuid as a parameter rather than generating it, so it is
deterministic and testable without touching `Uuid`.

Removing the shape protects every future consumer, not just the two that exist
now.

Also refreshes one doc comment in `resumable_base_publish.dart` that asserted in
the present tense that sync still interpolates a literal `/`. The `p.basename`
defence it explains is untouched.

## Tests

Four new cases in `base_part_file_sink_test.dart`, written first and confirmed
red (`Method not found: 'basePartTempPath'`):

1. A Windows context yields `C:\...\Temp\ssv1_base_devA_7.a1b2c3.base` with no
   `/` anywhere.
2. The #1304 consumer pattern replayed against the new path:
   `path.split(r'\').last` now returns the real basename instead of
   `Temp/ssv1_...`.
3. The default context matches the host.
4. `assemble` end to end: `p.dirname` equals the temp dir, `p.basename` carries
   the expected prefix and suffix.

Test 2 is the load-bearing one. It does not check the fix's output, it replays
the exact buggy consumer from #1304 and shows it now behaves.

## Why CI could not have caught this

`Platform.pathSeparator` is `/` on Linux and macOS, so a mixed path happens to
behave correctly there and the entire CI matrix is blind to it. Only an
explicit `p.Context(style: p.Style.windows)` exercises the Windows behaviour
from a POSIX host, which is why the seam accepts an injectable context.

## Verification

- `flutter test test/core/services/sync/changeset_log/` - 160/160 pass
- `flutter test test/core/services/sync/` - 720/720 pass
- `flutter analyze` (whole project) - no issues
- `dart format .` clean

A re-sweep of `lib/core/services/sync/` for `.path}/` and
`Platform.pathSeparator` finds no remaining producers, so this closes the class
within sync.
