### PR TITLE
fix(ipad): anchor the export share sheets to the control that opened them

### DIFF
--- a/lib/core/services/export/export_service.dart
+++ b/lib/core/services/export/export_service.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Rect;
+
 import 'package:submersion/core/constants/units.dart';
 import 'package:submersion/core/services/export/csv/csv_export_service.dart';
 import 'package:submersion/core/services/export/excel/excel_export_service.dart';
@@ -409,8 +411,15 @@ class ExportService {
   Future<String> getExportFilePath(String fileName) =>
       file_utils.getExportFilePath(fileName);
 
-  Future<String> exportImageAsPng(List<int> pngBytes, String fileName) =>
-      file_utils.exportImageAsPng(pngBytes, fileName);
+  Future<String> exportImageAsPng(
+    List<int> pngBytes,
+    String fileName, {
+    Rect? sharePositionOrigin,
+  }) => file_utils.exportImageAsPng(
+    pngBytes,
+    fileName,
+    sharePositionOrigin: sharePositionOrigin,
+  );
 
   Future<String> saveImageToPhotos(List<int> pngBytes, String fileName) =>
       file_utils.saveImageToPhotos(pngBytes, fileName);
@@ -418,8 +427,15 @@ class ExportService {
   Future<String?> saveImageToFile(List<int> pngBytes, String fileName) =>
       file_utils.saveImageToFile(pngBytes, fileName);
 
-  Future<String> sharePdfBytes(List<int> pdfBytes, String fileName) =>
-      file_utils.sharePdfBytes(pdfBytes, fileName);
+  Future<String> sharePdfBytes(
+    List<int> pdfBytes,
+    String fileName, {
+    Rect? sharePositionOrigin,
+  }) => file_utils.sharePdfBytes(
+    pdfBytes,
+    fileName,
+    sharePositionOrigin: sharePositionOrigin,
+  );
 
   Future<String?> savePdfToFile(List<int> pdfBytes, String fileName) =>
       file_utils.savePdfToFile(pdfBytes, fileName);

--- a/lib/core/services/export/shared/file_export_utils.dart
+++ b/lib/core/services/export/shared/file_export_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
+import 'dart:ui' show Rect;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:gal/gal.dart';
@@ -13,11 +14,19 @@ import 'package:share_plus/share_plus.dart';
 /// pick a destination on disk should use the matching `save*ToFile` helper
 /// instead -- those return `null` when the save dialog is cancelled, which this
 /// function has no way to express.
+///
+/// [sharePositionOrigin] is the screen rect the iPad share popover points at,
+/// normally from `shareAnchorFrom` on the button's context. It is optional
+/// because not every caller can name a control: the settings export chain runs
+/// several service layers below the widget that started it, and dismisses its
+/// format picker before sharing. Null means "let the platform decide", which
+/// share_plus honours by centring the popover.
 Future<String> saveAndShareFile(
   String content,
   String fileName,
-  String mimeType,
-) async {
+  String mimeType, {
+  Rect? sharePositionOrigin,
+}) async {
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsString(content);
@@ -26,6 +35,7 @@ Future<String> saveAndShareFile(
     ShareParams(
       files: [XFile(file.path, mimeType: mimeType)],
       subject: fileName,
+      sharePositionOrigin: sharePositionOrigin,
     ),
   );
 
@@ -34,12 +44,14 @@ Future<String> saveAndShareFile(
 
 /// Save raw bytes to a file and open the system share sheet.
 ///
-/// See [saveAndShareFile] for why this never opens a save dialog.
+/// See [saveAndShareFile] for why this never opens a save dialog, and for what
+/// [sharePositionOrigin] is and when it is null.
 Future<String> saveAndShareFileBytes(
   List<int> bytes,
   String fileName,
-  String mimeType,
-) async {
+  String mimeType, {
+  Rect? sharePositionOrigin,
+}) async {
   final directory = await getApplicationDocumentsDirectory();
   final file = File('${directory.path}/$fileName');
   await file.writeAsBytes(bytes);
@@ -48,6 +60,7 @@ Future<String> saveAndShareFileBytes(
     ShareParams(
       files: [XFile(file.path, mimeType: mimeType)],
       subject: fileName,
+      sharePositionOrigin: sharePositionOrigin,
     ),
   );
 
@@ -63,8 +76,17 @@ Future<String> getExportFilePath(String fileName) async {
 /// Export PNG image bytes via the system share sheet.
 ///
 /// Use this with RenderRepaintBoundary.toImage() to export widgets as images.
-Future<String> exportImageAsPng(List<int> pngBytes, String fileName) async {
-  return saveAndShareFileBytes(pngBytes, fileName, 'image/png');
+Future<String> exportImageAsPng(
+  List<int> pngBytes,
+  String fileName, {
+  Rect? sharePositionOrigin,
+}) async {
+  return saveAndShareFileBytes(
+    pngBytes,
+    fileName,
+    'image/png',
+    sharePositionOrigin: sharePositionOrigin,
+  );
 }
 
 /// Save an image directly to the device's photo library.
@@ -114,8 +136,17 @@ Future<String?> saveImageToFile(List<int> pngBytes, String fileName) async {
 }
 
 /// Share PDF bytes via the system share sheet.
-Future<String> sharePdfBytes(List<int> pdfBytes, String fileName) async {
-  return saveAndShareFileBytes(pdfBytes, fileName, 'application/pdf');
+Future<String> sharePdfBytes(
+  List<int> pdfBytes,
+  String fileName, {
+  Rect? sharePositionOrigin,
+}) async {
+  return saveAndShareFileBytes(
+    pdfBytes,
+    fileName,
+    'application/pdf',
+    sharePositionOrigin: sharePositionOrigin,
+  );
 }
 
 /// Save string content to a user-selected file location.

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -20,6 +20,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/export/export_service.dart';
 import 'package:submersion/core/services/pdf_templates/pdf_date_formatter.dart';
 import 'package:submersion/core/tide/entities/tide_extremes.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
@@ -169,6 +170,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
 
   /// Key for capturing the entire dive details page as an image for PNG export
   final GlobalKey _pageExportKey = GlobalKey();
+
+  /// The overflow buttons that open the export sheet, so the iPad share
+  /// popover can point at one of them.
+  ///
+  /// The sheet pops before the export runs, so it cannot anchor the popover
+  /// itself; the button that opened it is still mounted and is where iOS
+  /// normally points a toolbar-initiated share sheet. Two keys because the
+  /// standalone page and the embedded master-detail header each render their
+  /// own button, and a GlobalKey may only be mounted once.
+  final GlobalKey _appBarMenuKey = GlobalKey();
+  final GlobalKey _headerMenuKey = GlobalKey();
 
   /// Whether an export is currently in progress
   bool _isExportingProfile = false;
@@ -922,10 +934,16 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             onPressed: () => context.push('/dives/$diveId/edit'),
           ),
           PopupMenuButton<String>(
+            key: _appBarMenuKey,
             onSelected: (value) {
               switch (value) {
                 case 'export':
-                  _showExportOptions(context, ref, dive);
+                  _showExportOptions(
+                    context,
+                    ref,
+                    dive,
+                    shareAnchorFrom(_appBarMenuKey.currentContext),
+                  );
                   break;
                 case 'reparse':
                   _reparseDive(context, ref, dive);
@@ -1100,12 +1118,18 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
           ),
           // More options
           PopupMenuButton<String>(
+            key: _headerMenuKey,
             icon: const Icon(Icons.more_vert, size: 20),
             padding: EdgeInsets.zero,
             onSelected: (value) {
               switch (value) {
                 case 'export':
-                  _showExportOptions(context, ref, dive);
+                  _showExportOptions(
+                    context,
+                    ref,
+                    dive,
+                    shareAnchorFrom(_headerMenuKey.currentContext),
+                  );
                   break;
                 case 'reparse':
                   _reparseDive(context, ref, dive);
@@ -1804,21 +1828,31 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                               ),
                             ),
                     const SizedBox(width: 8),
-                    IconButton(
-                      icon: _isExportingProfile
-                          ? const SizedBox(
-                              width: 18,
-                              height: 18,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(Icons.share),
-                      tooltip: context
-                          .l10n
-                          .diveLog_detail_tooltip_exportProfileImage,
-                      visualDensity: VisualDensity.compact,
-                      onPressed: _isExportingProfile
-                          ? null
-                          : () => _exportProfileChart(dive),
+                    // A Builder so the share anchor resolves to this button
+                    // rather than the whole profile card; it contributes no
+                    // render object, so the lookup descends to the IconButton.
+                    Builder(
+                      builder: (shareContext) => IconButton(
+                        icon: _isExportingProfile
+                            ? const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.share),
+                        tooltip: context
+                            .l10n
+                            .diveLog_detail_tooltip_exportProfileImage,
+                        visualDensity: VisualDensity.compact,
+                        onPressed: _isExportingProfile
+                            ? null
+                            : () => _exportProfileChart(
+                                dive,
+                                shareAnchorFrom(shareContext),
+                              ),
+                      ),
                     ),
                     IconButton(
                       icon: const Icon(Icons.fullscreen),
@@ -2706,7 +2740,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   /// Export the profile chart as a PNG image and share it
-  Future<void> _exportProfileChart(Dive dive) async {
+  Future<void> _exportProfileChart(Dive dive, Rect? shareAnchor) async {
     // Show options bottom sheet
     final action = await showModalBottomSheet<_ProfileExportAction>(
       context: context,
@@ -2830,7 +2864,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             );
           }
         case _ProfileExportAction.share:
-          await exportService.exportImageAsPng(pngBytes, fileName);
+          await exportService.exportImageAsPng(
+            pngBytes,
+            fileName,
+            sharePositionOrigin: shareAnchor,
+          );
       }
     } catch (e) {
       if (mounted) {
@@ -2848,7 +2886,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   /// Export the entire dive details page as a PNG image
-  Future<void> _exportDiveDetailsPage(Dive dive) async {
+  Future<void> _exportDiveDetailsPage(Dive dive, Rect? shareAnchor) async {
     // Show options bottom sheet
     final action = await showModalBottomSheet<_ProfileExportAction>(
       context: context,
@@ -2972,7 +3010,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             );
           }
         case _ProfileExportAction.share:
-          await exportService.exportImageAsPng(pngBytes, fileName);
+          await exportService.exportImageAsPng(
+            pngBytes,
+            fileName,
+            sharePositionOrigin: shareAnchor,
+          );
       }
     } catch (e) {
       if (mounted) {
@@ -2990,7 +3032,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
   }
 
   /// Export the dive as a PDF with save/share options
-  Future<void> _exportDivePdf(Dive dive) async {
+  Future<void> _exportDivePdf(Dive dive, Rect? shareAnchor) async {
     // Show options bottom sheet
     final action = await showModalBottomSheet<_PdfExportAction>(
       context: context,
@@ -3083,7 +3125,11 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
             );
           }
         case _PdfExportAction.share:
-          await exportService.sharePdfBytes(result.bytes, result.fileName);
+          await exportService.sharePdfBytes(
+            result.bytes,
+            result.fileName,
+            sharePositionOrigin: shareAnchor,
+          );
       }
     } catch (e) {
       // Try to close loading dialog if it's still open
@@ -5408,7 +5454,17 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
     );
   }
 
-  void _showExportOptions(BuildContext context, WidgetRef ref, Dive dive) {
+  /// [shareAnchor] is the overflow button this sheet was opened from.
+  ///
+  /// The sheet pops itself before either export runs, so it cannot be the
+  /// anchor for the iPad popover. The button that opened it is still mounted,
+  /// which is also where iOS normally points a toolbar-initiated share sheet.
+  void _showExportOptions(
+    BuildContext context,
+    WidgetRef ref,
+    Dive dive,
+    Rect? shareAnchor,
+  ) {
     showModalBottomSheet(
       context: context,
       builder: (sheetContext) => SafeArea(
@@ -5431,7 +5487,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
               subtitle: Text(context.l10n.diveLog_export_pdfDescription),
               onTap: () {
                 Navigator.of(sheetContext).pop();
-                _exportDivePdf(dive);
+                _exportDivePdf(dive, shareAnchor);
               },
             ),
             ListTile(
@@ -5490,7 +5546,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   ? null
                   : () {
                       Navigator.of(sheetContext).pop();
-                      _exportDiveDetailsPage(dive);
+                      _exportDiveDetailsPage(dive, shareAnchor);
                     },
             ),
             const SizedBox(height: 8),

--- a/lib/features/planner/presentation/pages/plan_canvas_page.dart
+++ b/lib/features/planner/presentation/pages/plan_canvas_page.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
@@ -166,53 +167,61 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
             tooltip: context.l10n.divePlanner_action_savePlan,
             onPressed: planState.isDirty ? _savePlan : null,
           ),
-          PopupMenuButton<String>(
-            icon: const Icon(Icons.more_vert),
-            tooltip: context.l10n.divePlanner_action_moreOptions,
-            onSelected: _onMenu,
-            itemBuilder: (context) => [
-              _menuItem(
-                'quickPlan',
-                Icons.auto_awesome,
-                context.l10n.divePlanner_action_quickPlan,
-              ),
-              _menuItem(
-                'saved',
-                Icons.folder_open,
-                context.l10n.plannerCanvas_saved_title,
-              ),
-              _menuItem(
-                'follow',
-                Icons.history,
-                context.l10n.plannerCanvas_follow_title,
-              ),
-              _menuItem(
-                'settings',
-                Icons.tune,
-                context.l10n.divePlanner_label_planSettings,
-              ),
-              _menuItem(
-                'convert',
-                Icons.scuba_diving,
-                context.l10n.divePlanner_action_convertToDive,
-              ),
-              _menuItem(
-                'slate',
-                Icons.picture_as_pdf,
-                context.l10n.plannerCanvas_slate_menu,
-              ),
-              _menuItem(
-                'share',
-                Icons.ios_share,
-                context.l10n.plannerCanvas_share_menu,
-              ),
-              _menuItem(
-                'reset',
-                Icons.refresh,
-                context.l10n.divePlanner_action_resetPlan,
-              ),
-              if (canDelete) _deleteMenuItem(context),
-            ],
+          // A Builder so the share anchor resolves to the overflow button
+          // rather than the whole app bar: it contributes no render object, so
+          // findRenderObject descends to the PopupMenuButton below it. The
+          // button is still mounted when the share sheet opens; the menu item
+          // the user actually tapped is not.
+          Builder(
+            builder: (menuContext) => PopupMenuButton<String>(
+              icon: const Icon(Icons.more_vert),
+              tooltip: context.l10n.divePlanner_action_moreOptions,
+              onSelected: (value) =>
+                  _onMenu(value, shareAnchorFrom(menuContext)),
+              itemBuilder: (context) => [
+                _menuItem(
+                  'quickPlan',
+                  Icons.auto_awesome,
+                  context.l10n.divePlanner_action_quickPlan,
+                ),
+                _menuItem(
+                  'saved',
+                  Icons.folder_open,
+                  context.l10n.plannerCanvas_saved_title,
+                ),
+                _menuItem(
+                  'follow',
+                  Icons.history,
+                  context.l10n.plannerCanvas_follow_title,
+                ),
+                _menuItem(
+                  'settings',
+                  Icons.tune,
+                  context.l10n.divePlanner_label_planSettings,
+                ),
+                _menuItem(
+                  'convert',
+                  Icons.scuba_diving,
+                  context.l10n.divePlanner_action_convertToDive,
+                ),
+                _menuItem(
+                  'slate',
+                  Icons.picture_as_pdf,
+                  context.l10n.plannerCanvas_slate_menu,
+                ),
+                _menuItem(
+                  'share',
+                  Icons.ios_share,
+                  context.l10n.plannerCanvas_share_menu,
+                ),
+                _menuItem(
+                  'reset',
+                  Icons.refresh,
+                  context.l10n.divePlanner_action_resetPlan,
+                ),
+                if (canDelete) _deleteMenuItem(context),
+              ],
+            ),
           ),
         ],
       ),
@@ -259,7 +268,7 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
     );
   }
 
-  void _onMenu(String value) {
+  void _onMenu(String value, Rect? shareAnchor) {
     switch (value) {
       case 'quickPlan':
         showDialog<void>(
@@ -275,9 +284,17 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
       case 'convert':
         logFailure(_convertToDive(), _PlanCanvasPageState, 'convert to dive');
       case 'slate':
-        logFailure(_exportSlate(), _PlanCanvasPageState, 'export slate');
+        logFailure(
+          _exportSlate(shareAnchor),
+          _PlanCanvasPageState,
+          'export slate',
+        );
       case 'share':
-        logFailure(_sharePlanFile(), _PlanCanvasPageState, 'share plan file');
+        logFailure(
+          _sharePlanFile(shareAnchor),
+          _PlanCanvasPageState,
+          'share plan file',
+        );
       case 'reset':
         _resetPlan();
       case 'delete':
@@ -507,7 +524,7 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
 
   // --- Actions ---
 
-  Future<void> _sharePlanFile() async {
+  Future<void> _sharePlanFile(Rect? shareAnchor) async {
     final state = ref.read(divePlanNotifierProvider);
     final json = planToSubplanJson(divePlanFromState(state));
     final safeName = state.name
@@ -518,10 +535,11 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
       json,
       '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
       'application/json',
+      sharePositionOrigin: shareAnchor,
     );
   }
 
-  Future<void> _exportSlate() async {
+  Future<void> _exportSlate(Rect? shareAnchor) async {
     final l10n = context.l10n;
     final state = ref.read(divePlanNotifierProvider);
     final labels = PlanSlateLabels(
@@ -558,6 +576,7 @@ class _PlanCanvasPageState extends ConsumerState<PlanCanvasPage> {
     await sharePdfBytes(
       bytes,
       '${safeName.isEmpty ? 'dive_plan' : safeName}_slate.pdf',
+      sharePositionOrigin: shareAnchor,
     );
   }
 

--- a/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
+++ b/lib/features/planner/presentation/widgets/saved_plans_sheet.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+import 'package:submersion/core/utils/share_anchor.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
 import 'package:submersion/features/planner/data/services/plan_file_codec.dart';
 import 'package:submersion/features/planner/domain/entities/dive_plan.dart';
@@ -244,52 +245,62 @@ class _PlanTile extends ConsumerWidget {
             onPressed: () =>
                 _confirmAndDeletePlan(context, ref, summary.id, summary.name),
           ),
-          PopupMenuButton<String>(
-            onSelected: (value) async {
-              final repository = ref.read(divePlanRepositoryProvider);
-              if (value == 'rename') {
-                final plan = await repository.getPlan(summary.id);
-                if (plan == null || !context.mounted) return;
-                final entered = await showPlanNameDialog(
-                  context,
-                  initialName: plan.name,
-                  title: context.l10n.divePlanner_action_renamePlan,
-                );
-                if (entered == null) return;
-                // No summary is passed, so the denormalized depth/runtime
-                // columns stay absent in the companion and the upsert
-                // preserves them along with the tile's subtitle.
-                await repository.savePlan(plan.copyWith(name: entered));
-              } else if (value == 'duplicate') {
-                await repository.duplicatePlan(summary.id);
-              } else if (value == 'share') {
-                final plan = await repository.getPlan(summary.id);
-                if (plan == null) return;
-                final safeName = plan.name
-                    .replaceAll(RegExp(r'[^\w\s-]'), '')
-                    .trim()
-                    .replaceAll(RegExp(r'\s+'), '_');
-                await saveAndShareFile(
-                  planToSubplanJson(plan),
-                  '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
-                  'application/json',
-                );
-              }
-            },
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'rename',
-                child: Text(context.l10n.divePlanner_action_renamePlan),
-              ),
-              PopupMenuItem(
-                value: 'duplicate',
-                child: Text(context.l10n.plannerCanvas_saved_duplicate),
-              ),
-              PopupMenuItem(
-                value: 'share',
-                child: Text(context.l10n.plannerCanvas_share_menu),
-              ),
-            ],
+          // A Builder so the share anchor resolves to the overflow button
+          // rather than the whole row: it contributes no render object, so
+          // findRenderObject descends to the PopupMenuButton below it.
+          Builder(
+            builder: (menuContext) => PopupMenuButton<String>(
+              onSelected: (value) async {
+                final repository = ref.read(divePlanRepositoryProvider);
+                if (value == 'rename') {
+                  final plan = await repository.getPlan(summary.id);
+                  if (plan == null || !context.mounted) return;
+                  final entered = await showPlanNameDialog(
+                    context,
+                    initialName: plan.name,
+                    title: context.l10n.divePlanner_action_renamePlan,
+                  );
+                  if (entered == null) return;
+                  // No summary is passed, so the denormalized depth/runtime
+                  // columns stay absent in the companion and the upsert
+                  // preserves them along with the tile's subtitle.
+                  await repository.savePlan(plan.copyWith(name: entered));
+                } else if (value == 'duplicate') {
+                  await repository.duplicatePlan(summary.id);
+                } else if (value == 'share') {
+                  // Resolved before the await: the popover anchor has to be
+                  // read while the button is certainly mounted and at its
+                  // current position, not after a database round trip.
+                  final anchor = shareAnchorFrom(menuContext);
+                  final plan = await repository.getPlan(summary.id);
+                  if (plan == null) return;
+                  final safeName = plan.name
+                      .replaceAll(RegExp(r'[^\w\s-]'), '')
+                      .trim()
+                      .replaceAll(RegExp(r'\s+'), '_');
+                  await saveAndShareFile(
+                    planToSubplanJson(plan),
+                    '${safeName.isEmpty ? 'dive_plan' : safeName}.$subplanExtension',
+                    'application/json',
+                    sharePositionOrigin: anchor,
+                  );
+                }
+              },
+              itemBuilder: (context) => [
+                PopupMenuItem(
+                  value: 'rename',
+                  child: Text(context.l10n.divePlanner_action_renamePlan),
+                ),
+                PopupMenuItem(
+                  value: 'duplicate',
+                  child: Text(context.l10n.plannerCanvas_saved_duplicate),
+                ),
+                PopupMenuItem(
+                  value: 'share',
+                  child: Text(context.l10n.plannerCanvas_share_menu),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/test/core/services/export/shared/save_and_share_file_test.dart
+++ b/test/core/services/export/shared/save_and_share_file_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+import 'dart:ui' show Rect;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:submersion/core/services/export/export_service.dart';
+import 'package:submersion/core/services/export/shared/file_export_utils.dart';
+
+/// The share helpers write into getApplicationDocumentsDirectory(), a platform
+/// channel with no implementation under flutter_test. Unstubbed it never
+/// completes and the await hangs forever.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+/// Records what reached the platform so the anchor can be asserted without a
+/// real share sheet.
+class _FakeSharePlatform extends SharePlatform {
+  final List<ShareParams> calls = [];
+
+  @override
+  Future<ShareResult> share(ShareParams params) async {
+    calls.add(params);
+    return const ShareResult('ok', ShareResultStatus.success);
+  }
+}
+
+void main() {
+  late Directory documents;
+  final platform = _FakeSharePlatform();
+
+  // SharePlus.instance is a `static final` that captures SharePlatform.instance
+  // the first time it is read and keeps it for the life of the isolate, so the
+  // fake has to be in place before the first share.
+  setUpAll(() => SharePlatform.instance = platform);
+
+  setUp(() {
+    documents = Directory.systemTemp.createTempSync('save_and_share_file_test');
+    PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    platform.calls.clear();
+  });
+
+  tearDown(() => documents.deleteSync(recursive: true));
+
+  const anchor = Rect.fromLTWH(12, 34, 56, 78);
+
+  test('saveAndShareFile forwards the anchor to the share sheet', () async {
+    await saveAndShareFile(
+      '<uddf/>',
+      'dives.uddf',
+      'application/xml',
+      sharePositionOrigin: anchor,
+    );
+
+    expect(platform.calls.single.sharePositionOrigin, anchor);
+  });
+
+  test(
+    'saveAndShareFileBytes forwards the anchor to the share sheet',
+    () async {
+      await saveAndShareFileBytes(
+        [1, 2, 3],
+        'dives.xlsx',
+        'application/vnd.ms-excel',
+        sharePositionOrigin: anchor,
+      );
+
+      expect(platform.calls.single.sharePositionOrigin, anchor);
+    },
+  );
+
+  test('sharePdfBytes forwards the anchor to the share sheet', () async {
+    await sharePdfBytes([1, 2, 3], 'logbook.pdf', sharePositionOrigin: anchor);
+
+    expect(platform.calls.single.sharePositionOrigin, anchor);
+  });
+
+  test('exportImageAsPng forwards the anchor to the share sheet', () async {
+    await exportImageAsPng(
+      [1, 2, 3],
+      'profile.png',
+      sharePositionOrigin: anchor,
+    );
+
+    expect(platform.calls.single.sharePositionOrigin, anchor);
+  });
+
+  test('an omitted anchor leaves the platform to place the popover', () async {
+    // Callers with no BuildContext (the settings export chain, the debug log
+    // provider) must keep working. share_plus centres the popover itself when
+    // the origin is absent, so null is a supported value, not a bug.
+    await saveAndShareFile('<uddf/>', 'dives.uddf', 'application/xml');
+
+    expect(platform.calls.single.sharePositionOrigin, isNull);
+  });
+
+  group('ExportService pass-throughs', () {
+    // These two are one-line delegates, which is exactly why the anchor can
+    // reach them from the dive detail page at all. A delegate that forgets to
+    // forward the argument still compiles and silently re-centres the popover.
+    test('exportImageAsPng forwards the anchor', () async {
+      await ExportService().exportImageAsPng(
+        [1, 2, 3],
+        'profile.png',
+        sharePositionOrigin: anchor,
+      );
+
+      expect(platform.calls.single.sharePositionOrigin, anchor);
+    });
+
+    test('sharePdfBytes forwards the anchor', () async {
+      await ExportService().sharePdfBytes(
+        [1, 2, 3],
+        'logbook.pdf',
+        sharePositionOrigin: anchor,
+      );
+
+      expect(platform.calls.single.sharePositionOrigin, anchor);
+    });
+  });
+}

--- a/test/core/utils/share_anchor_test.dart
+++ b/test/core/utils/share_anchor_test.dart
@@ -85,4 +85,40 @@ void main() {
   test('returns null for a null context', () {
     expect(shareAnchorFrom(null), isNull);
   });
+
+  testWidgets('resolves a button addressed by GlobalKey, not its page', (
+    tester,
+  ) async {
+    // The other way to name a share button, used by the dive detail page's
+    // two overflow menus: their onSelected bodies are large switch statements
+    // that a Builder wrapper would have re-indented wholesale, and the state
+    // class already addresses widgets by key.
+    final key = GlobalKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            actions: [
+              PopupMenuButton<String>(
+                key: key,
+                itemBuilder: (_) => const [
+                  PopupMenuItem(value: 'export', child: Text('Export')),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final rect = shareAnchorFrom(key.currentContext);
+    expect(rect, tester.getRect(find.byKey(key)));
+
+    // And it really is the button rather than the app bar or the page behind
+    // it, which is the whole point of naming a control.
+    final pageWidth =
+        tester.view.physicalSize.width / tester.view.devicePixelRatio;
+    expect(rect!.width, lessThan(pageWidth));
+  });
 }

--- a/test/features/planner/plan_canvas_share_anchor_test.dart
+++ b/test/features/planner/plan_canvas_share_anchor_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:submersion/core/constants/map_style.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/planner/presentation/pages/plan_canvas_page.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+
+import '../../helpers/test_app.dart';
+import '../../helpers/test_database.dart';
+
+/// Sharing writes the plan to getApplicationDocumentsDirectory() first, a
+/// platform channel with no implementation under flutter_test.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+/// Records what reached the platform so the iPad popover anchor can be
+/// asserted without a real share sheet.
+class _FakeSharePlatform extends SharePlatform {
+  final List<ShareParams> calls = [];
+
+  @override
+  Future<ShareResult> share(ShareParams params) async {
+    calls.add(params);
+    return const ShareResult('ok', ShareResultStatus.success);
+  }
+}
+
+class _TestSettingsNotifier extends StateNotifier<AppSettings>
+    implements SettingsNotifier {
+  _TestSettingsNotifier() : super(const AppSettings());
+
+  @override
+  Future<void> setMapStyle(MapStyle style) async =>
+      state = state.copyWith(mapStyle: style);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory documents;
+  final sharePlatform = _FakeSharePlatform();
+
+  // SharePlus.instance is a `static final` that captures SharePlatform.instance
+  // on first read and keeps it for the life of the isolate.
+  setUpAll(() => SharePlatform.instance = sharePlatform);
+
+  setUp(() async {
+    await setUpTestDatabase();
+    documents = Directory.systemTemp.createTempSync('plan_canvas_share_test');
+    PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    sharePlatform.calls.clear();
+  });
+
+  tearDown(() {
+    DatabaseService.instance.resetForTesting();
+    documents.deleteSync(recursive: true);
+  });
+
+  Widget harness() => testApp(
+    overrides: [
+      settingsProvider.overrideWith((ref) => _TestSettingsNotifier()),
+    ],
+    locale: const Locale('en'),
+    child: const PlanCanvasPage(),
+  );
+
+  /// Sharing writes with real dart:io, which parks under the FakeAsync zone
+  /// testWidgets runs in. runAsync turns the real event loop so the write
+  /// lands; the pump after it drains the continuation FakeAsync then queues.
+  /// Neither alone gets as far as the share sheet.
+  Future<void> settleRealIo(WidgetTester tester) async {
+    for (var i = 0; i < 50 && sharePlatform.calls.isEmpty; i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+      await tester.pump();
+    }
+  }
+
+  Future<void> chooseFromOverflow(WidgetTester tester, String label) async {
+    await tester.tap(find.byType(PopupMenuButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(label).last);
+    await tester.pumpAndSettle();
+    await settleRealIo(tester);
+  }
+
+  testWidgets('sharing the plan file anchors to the app bar overflow button', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // The overflow button is still mounted when the share sheet opens; the
+    // menu item that was tapped is not.
+    final overflowRect = tester.getRect(find.byType(PopupMenuButton<String>));
+
+    await chooseFromOverflow(tester, 'Share plan file');
+
+    expect(sharePlatform.calls.single.sharePositionOrigin, overflowRect);
+  });
+
+  testWidgets('exporting the slate PDF anchors to the same overflow button', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    final overflowRect = tester.getRect(find.byType(PopupMenuButton<String>));
+
+    // The slate goes out through sharePdfBytes rather than saveAndShareFile,
+    // a separate helper with its own optional anchor, so it needs its own
+    // coverage.
+    await chooseFromOverflow(tester, 'Export slate (PDF)');
+
+    expect(sharePlatform.calls.single.sharePositionOrigin, overflowRect);
+  });
+}

--- a/test/features/planner/saved_plans_sheet_test.dart
+++ b/test/features/planner/saved_plans_sheet_test.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:submersion/core/constants/map_style.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -16,6 +19,29 @@ import 'package:submersion/features/settings/presentation/providers/settings_pro
 import '../../helpers/mock_file_picker_platform.dart';
 import '../../helpers/test_app.dart';
 import '../../helpers/test_database.dart';
+
+/// Sharing a plan writes it to getApplicationDocumentsDirectory() first, a
+/// platform channel with no implementation under flutter_test.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.documentsPath);
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+/// Records what reached the platform so the iPad popover anchor can be
+/// asserted without a real share sheet.
+class _FakeSharePlatform extends SharePlatform {
+  final List<ShareParams> calls = [];
+
+  @override
+  Future<ShareResult> share(ShareParams params) async {
+    calls.add(params);
+    return const ShareResult('ok', ShareResultStatus.success);
+  }
+}
 
 class _TestSettingsNotifier extends StateNotifier<AppSettings>
     implements SettingsNotifier {
@@ -40,14 +66,25 @@ DivePlan _plan(String id, String name) => DivePlan(
 
 void main() {
   late DivePlanRepository repository;
+  late Directory documents;
+  final sharePlatform = _FakeSharePlatform();
+
+  // SharePlus.instance is a `static final` that captures SharePlatform.instance
+  // on first read and keeps it for the life of the isolate, so the fake has to
+  // be installed before the first share.
+  setUpAll(() => SharePlatform.instance = sharePlatform);
 
   setUp(() async {
     await setUpTestDatabase();
     repository = DivePlanRepository();
+    documents = Directory.systemTemp.createTempSync('saved_plans_sheet_test');
+    PathProviderPlatform.instance = _FakePathProvider(documents.path);
+    sharePlatform.calls.clear();
   });
 
   tearDown(() {
     DatabaseService.instance.resetForTesting();
+    documents.deleteSync(recursive: true);
   });
 
   Widget harness() => testApp(
@@ -145,6 +182,39 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(await repository.getAllPlanSummaries(), hasLength(2));
+  });
+
+  testWidgets('share anchors the iPad popover to the row overflow button', (
+    tester,
+  ) async {
+    await repository.savePlan(_plan('a', 'Reef dive'));
+
+    await tester.pumpWidget(harness());
+    await tester.pumpAndSettle();
+
+    // The overflow button stays mounted while the menu is up and after it
+    // pops, so it is a valid anchor at the moment the share sheet opens --
+    // unlike the menu item, which is gone by then.
+    final button = find.byType(PopupMenuButton<String>);
+    final buttonRect = tester.getRect(button);
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Share plan file').last);
+    await tester.pumpAndSettle();
+
+    // Sharing writes the plan with real dart:io, which parks under the
+    // FakeAsync zone testWidgets runs in: runAsync turns the real event loop
+    // so the write lands, and the following pump drains the continuation that
+    // FakeAsync then has queued. Neither alone gets to the share sheet.
+    for (var i = 0; i < 50 && sharePlatform.calls.isEmpty; i++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+      await tester.pump();
+    }
+
+    expect(sharePlatform.calls.single.sharePositionOrigin, buttonRect);
   });
 
   testWidgets('tapping a plan opens it', (tester) async {


### PR DESCRIPTION
Follow-up to #1323, which anchored 8 of the 10 `SharePlus.instance.share` call
sites for #1315 and deliberately left the two helpers in `file_export_utils.dart`
centred.

## What the earlier reasoning missed

The note on #1315 put the cost of reaching those helpers at **41 signatures**
across `ExportNotifier`, `ExportService` and 15 per-format services, for an
anchor that would end up pointing at a format picker the flow has already
dismissed. That is accurate, and this PR leaves that chain alone.

It is not the whole picture. Six user-facing share actions call the helpers
**straight from widget code** and never touch `ExportNotifier` at all:

| Action | Helper | Anchor |
| --- | --- | --- |
| Planner: Share plan file | `saveAndShareFile` | app bar overflow button |
| Planner: Export slate (PDF) | `sharePdfBytes` | app bar overflow button |
| Saved plans: Share plan file | `saveAndShareFile` | that row's overflow button |
| Dive detail: share profile chart | `exportImageAsPng` | the chart's share button |
| Dive detail: share page as image | `exportImageAsPng` | the overflow button that opened the export sheet |
| Dive detail: share dive PDF | `sharePdfBytes` | the overflow button that opened the export sheet |

Reaching those cost **six** signatures, not 41.

## Shape

`saveAndShareFile`, `saveAndShareFileBytes`, `sharePdfBytes` and
`exportImageAsPng` take an optional `Rect? sharePositionOrigin`, forwarded to
`ShareParams`. `ExportService`'s two one-line delegates forward it too. Null
stays a supported value and still means "let the platform decide", which is
what the settings export chain and the debug log provider keep getting.

Two ways to name the button, both already in the codebase:

- **`Builder`** where the button is built inline (planner app bar, saved plans
  row, the profile chart's share button). A `Builder` contributes no render
  object, so `findRenderObject` descends to the button rather than the page.
- **`GlobalKey`** on the two dive detail overflow buttons, whose `onSelected`
  bodies are large `switch` statements that a `Builder` wrapper would have
  re-indented wholesale. `_DiveDetailPageState` already addresses widgets this
  way (`_safetyReviewSectionKey`). Two keys, because the standalone page and
  the embedded master-detail header each render their own button.

Three of the six flows dismiss a sheet before sharing, so the sheet cannot be
the anchor. They point at the control that opened it instead, which is where
iOS normally points a toolbar-initiated share sheet.

In the saved plans row the anchor is resolved **before** the database read
rather than after, so the rect is taken while the button is certainly mounted
and at its current position. `use_build_context_synchronously` flags the other
order.

## Tests

- `save_and_share_file_test.dart` (new): all four helpers forward the rect to
  `ShareParams`; an omitted anchor stays null; both `ExportService` delegates
  forward it.
- `plan_canvas_share_anchor_test.dart` (new): drives the real overflow menu and
  asserts the rect that reaches the platform equals the overflow button's rect,
  for both the plan file and the slate PDF.
- `saved_plans_sheet_test.dart`: the same assertion for the row overflow button.
- `share_anchor_test.dart`: the `GlobalKey`-addressed button resolves to the
  button, covering the idiom the dive detail page uses.

The share helpers write the file with real `dart:io`, which parks under the
`FakeAsync` zone `testWidgets` runs in. The widget tests interleave
`tester.runAsync` (so the write lands on the real event loop) with `pump` (so
`FakeAsync` drains the continuation it then has queued). Neither alone reaches
the share sheet.

## Not covered

The three dive detail flows are wired but not driven end to end by a widget
test: each one generates a real PDF or rasterises a `RepaintBoundary` behind a
`CircularProgressIndicator`, which never settles. Their two anchor idioms are
covered by the tests above.

As #1315 says, the popover itself can only be verified on a real iPad: the
branch does not execute on iPhone, desktop, or under `flutter test`. These
tests assert the rect reaches `ShareParams`, not that it looks right.
