### PR TITLE
Let the weather backfill actually retry a miss on the next view

### DIFF
--- a/lib/features/trips/presentation/providers/trip_day_weather_providers.dart
+++ b/lib/features/trips/presentation/providers/trip_day_weather_providers.dart
@@ -33,67 +33,72 @@ final tripDayWeatherProvider =
 /// stored and no dive to supply it, then writes what it finds.
 ///
 /// The story is its only reactive input, so assigning dives to a trip
-/// re-evaluates what is still missing. Not auto-disposed: one pass per trip
-/// per provider container lifetime.
-final tripDayWeatherBackfillProvider = FutureProvider.family<void, String>((
-  ref,
-  tripId,
-) async {
-  final story = await ref.watch(tripStoryProvider(tripId).future);
-  final repository = ref.watch(tripDayWeatherRepositoryProvider);
-  final service = ref.watch(weatherServiceProvider);
+/// re-evaluates what is still missing.
+///
+/// autoDispose is what makes the retry policy above true. A miss writes no
+/// row precisely so the day is tried again later; a provider that outlived
+/// the view would serve its completed state on every subsequent navigation
+/// and a transient failure would stand until the app restarted. Disposing
+/// with the view means returning to the trip runs the pass again, which skips
+/// the days that succeeded and retries only the ones still missing. While the
+/// view stays mounted the provider stays alive, so scrolling does not refetch.
+final tripDayWeatherBackfillProvider = FutureProvider.autoDispose
+    .family<void, String>((ref, tripId) async {
+      final story = await ref.watch(tripStoryProvider(tripId).future);
+      final repository = ref.watch(tripDayWeatherRepositoryProvider);
+      final service = ref.watch(weatherServiceProvider);
 
-  final stored = await repository.getForTrip(tripId);
-  final targets = TripDayWeatherBackfill.targetsFor(
-    story: story,
-    stored: stored,
-  );
-  if (targets.isEmpty) return;
+      final stored = await repository.getForTrip(tripId);
+      final targets = TripDayWeatherBackfill.targetsFor(
+        story: story,
+        stored: stored,
+      );
+      if (targets.isEmpty) return;
 
-  // Sequential on purpose: a two-week trip would otherwise open with a burst
-  // of parallel requests, and rows landing one at a time let the day headers
-  // fill in progressively.
-  for (final target in targets) {
-    final weather = await service.fetchWeather(
-      latitude: target.latitude,
-      longitude: target.longitude,
-      date: target.date,
-      entryTime: target.localNoon,
-      useLocationTimezone: true,
-    );
-    // A miss writes nothing and is retried on the next view, which is what
-    // makes this correct against the archive's few-day publication lag.
-    if (weather == null) continue;
+      // Sequential on purpose: a two-week trip would otherwise open with a burst
+      // of parallel requests, and rows landing one at a time let the day headers
+      // fill in progressively.
+      for (final target in targets) {
+        final weather = await service.fetchWeather(
+          latitude: target.latitude,
+          longitude: target.longitude,
+          date: target.date,
+          entryTime: target.localNoon,
+          useLocationTimezone: true,
+        );
+        // A miss writes nothing and is retried on the next view, which is what
+        // makes this correct against the archive's few-day publication lag.
+        if (weather == null) continue;
 
-    final now = DateTime.now();
-    final dayMillis = tripDayMillis(target.date);
-    final row = TripDayWeather(
-      // The repository derives this same id from (trip, day) and never takes
-      // the caller's, so every device converges on one row. Derived here too
-      // rather than left as a placeholder: an entity carrying an id that is
-      // not its own reaches logs and any future validation as a lie.
-      id: tripDayWeatherRowId(tripId: tripId, dayMillis: dayMillis),
-      tripId: tripId,
-      date: target.date,
-      latitude: target.latitude,
-      longitude: target.longitude,
-      airTemp: weather.airTemp,
-      cloudCover: weather.cloudCover,
-      precipitation: weather.precipitation,
-      windSpeed: weather.windSpeed,
-      windDirection: weather.windDirection,
-      humidity: weather.humidity,
-      surfacePressure: weather.surfacePressure,
-      weatherCode: weather.weatherCode,
-      fetchedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    );
+        final now = DateTime.now();
+        final dayMillis = tripDayMillis(target.date);
+        final row = TripDayWeather(
+          // The repository derives this same id from (trip, day) and never takes
+          // the caller's, so every device converges on one row. Derived here too
+          // rather than left as a placeholder: an entity carrying an id that is
+          // not its own reaches logs and any future validation as a lie.
+          id: tripDayWeatherRowId(tripId: tripId, dayMillis: dayMillis),
+          tripId: tripId,
+          date: target.date,
+          latitude: target.latitude,
+          longitude: target.longitude,
+          airTemp: weather.airTemp,
+          cloudCover: weather.cloudCover,
+          precipitation: weather.precipitation,
+          windSpeed: weather.windSpeed,
+          windDirection: weather.windDirection,
+          humidity: weather.humidity,
+          surfacePressure: weather.surfacePressure,
+          weatherCode: weather.weatherCode,
+          fetchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        );
 
-    // A row the header could render nothing from is worse than no row: it
-    // would suppress the retry that a later archive update would satisfy.
-    if (!row.hasRenderableWeather) continue;
+        // A row the header could render nothing from is worse than no row: it
+        // would suppress the retry that a later archive update would satisfy.
+        if (!row.hasRenderableWeather) continue;
 
-    await repository.upsert(row);
-  }
-});
+        await repository.upsert(row);
+      }
+    });

--- a/test/features/trips/presentation/providers/trip_day_weather_providers_test.dart
+++ b/test/features/trips/presentation/providers/trip_day_weather_providers_test.dart
@@ -215,6 +215,59 @@ void main() {
       expect(repository.upserts.single.date, DateTime(2026, 3, 9));
     });
 
+    test('a miss is retried when the trip is viewed again', () async {
+      // The documented policy is that a miss writes nothing and is retried on
+      // the next view. A provider that stays alive for the container's
+      // lifetime would serve its completed state instead, so a transient
+      // failure would not be retried until the app restarted.
+      var calls = 0;
+      final repository = FakeTripDayWeatherRepository();
+      final container = containerWith(
+        client: MockClient((_) async {
+          calls++;
+          return http.Response('', 500);
+        }),
+        repository: repository,
+      );
+
+      // First visit: the view mounts, watches, and the pass runs.
+      final first = container.listen(
+        tripDayWeatherBackfillProvider('trip-1'),
+        (_, _) {},
+      );
+      await container.read(tripDayWeatherBackfillProvider('trip-1').future);
+      expect(calls, 2, reason: 'two days, both missing');
+
+      // Leaving the trip drops the last listener.
+      first.close();
+      await Future<void>.delayed(Duration.zero);
+
+      // Returning to the trip must run the pass again.
+      container.listen(tripDayWeatherBackfillProvider('trip-1'), (_, _) {});
+      await container.read(tripDayWeatherBackfillProvider('trip-1').future);
+
+      expect(calls, 4);
+    });
+
+    test('the pass does not re-run while the view stays mounted', () async {
+      var calls = 0;
+      final repository = FakeTripDayWeatherRepository();
+      final container = containerWith(
+        client: MockClient((_) async {
+          calls++;
+          return http.Response('', 500);
+        }),
+        repository: repository,
+      );
+
+      container.listen(tripDayWeatherBackfillProvider('trip-1'), (_, _) {});
+      await container.read(tripDayWeatherBackfillProvider('trip-1').future);
+      // A rebuild re-watches; that must not start another pass.
+      await container.read(tripDayWeatherBackfillProvider('trip-1').future);
+
+      expect(calls, 2);
+    });
+
     test('fetches run one at a time', () async {
       final gate = Completer<void>();
       var started = 0;


### PR DESCRIPTION
Addresses the remaining review comment on #1319. Stacked on `worktree-trip-day-weather`.

## The contradiction

`tripDayWeatherBackfillProvider` documented two things that could not both be true:

- near the fetch loop: "A miss writes nothing and is retried on the next view, which is what makes this correct against the archive's few-day publication lag."
- on the declaration: "Not auto-disposed: one pass per trip per provider container lifetime."

The second was the truth. A non-`autoDispose` `FutureProvider.family` keeps its completed state for the life of the container, so every later navigation to that trip re-watched a provider that had already finished and never ran the pass again. A transient network failure stood until the app restarted.

That defeats the point of the miss-writes-no-row rule. Writing no row exists so the day gets another chance; if nothing ever tries again in that process, the day is blank for the session no matter how many times the diver opens the trip. Intermittent connectivity is the normal case on a liveaboard.

## The fix

`autoDispose` ties the pass to the view:

- returning to the trip runs it again, which skips days that already have rows and retries only the ones still missing
- while the view stays mounted the provider stays alive, so scrolling does not refetch

The display provider `tripDayWeatherProvider` stays non-`autoDispose` on purpose. It rides the table tick, and caching its rows across navigation is what makes a revisited trip render its badges immediately instead of flickering through a load.

## Testing

Two tests, one for each half, because the fix is only correct if both hold:

- `a miss is retried when the trip is viewed again`: listen, run the pass, drop the listener, listen again, and assert the fetch count doubled. This failed before the change.
- `the pass does not re-run while the view stays mounted`: a rebuild re-watching must not start a second pass. This passed before and still does, so `autoDispose` did not trade one problem for the other.

629 trips tests pass. `flutter analyze` clean.
