### PR TITLE
fix(sync): age-guard remote tombstones so a restore cannot undo itself

### DIFF
--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -1879,8 +1879,9 @@ class SyncService {
           }
           final local = await _serializer.fetchRecord(entityType, recordId);
           // _extractUpdatedAtMillis falls back to createdAt, so a row created
-          // locally after our last sync is protected from a stale remote
-          // tombstone even on append-only child tables that have a createdAt.
+          // locally after our last sync (or after the tombstone itself) is
+          // protected from a stale remote tombstone even on append-only child
+          // tables that have a createdAt.
           // Clockless child tables with neither updatedAt nor createdAt
           // (dive_profiles, dive_tanks, tank_pressure_profiles, sightings) have
           // no age signal: the uuid-keyed ones regenerate with fresh ids on
@@ -1893,10 +1894,24 @@ class SyncService {
               ? deletion.deletedAt
               : remoteExportedAt;
 
-          final hasConflict =
+          // Two independent guards; either one routes to a conflict:
+          //  * edited since our last sync (three-way; needs a horizon), and
+          //  * the tombstone's own age: a local row edited AFTER the peer
+          //    deleted it is newer than the deletion. This mirrors the
+          //    remote-live-vs-local-tombstone rule in _mergeEntity.
+          // The age guard is the ONLY protection when there is no horizon,
+          // which is exactly the state every recovery action leaves behind
+          // (restore, Reset Sync State, adopt, rejoin, backend switch):
+          // lastSyncMs is null there, and without this guard a peer tombstone
+          // deleted every matching row unconditionally, so a freshly restored
+          // library silently undid itself on the next sync (#1340).
+          final editedSinceLastSync =
               localUpdatedAt != null &&
               lastSyncMs != null &&
               localUpdatedAt > lastSyncMs;
+          final newerThanTombstone =
+              localUpdatedAt != null && localUpdatedAt > deletionTimestamp;
+          final hasConflict = editedSinceLastSync || newerThanTombstone;
 
           if (hasConflict) {
             conflicts += 1;

--- a/test/core/services/sync/sync_deletion_propagation_test.dart
+++ b/test/core/services/sync/sync_deletion_propagation_test.dart
@@ -713,4 +713,213 @@ void main() {
       );
     });
   });
+
+  /// Issue #1340. Every recovery action (restore, Reset Sync State, adopting a
+  /// replaced library, rejoining after retirement, a backend switch) leaves
+  /// this device with NO sync horizon (`lastSyncMs == null`). The "edited
+  /// since the last sync" check is then unreachable, so without an age guard
+  /// of its own a peer tombstone deleted every matching local row
+  /// unconditionally: a freshly restored library silently undid itself on the
+  /// next sync. The guard must compare the tombstone's own `deletedAt` against
+  /// the local row, with or without a horizon.
+  group('Remote tombstone age guard', () {
+    late FakeCloudStorageProvider cloud;
+
+    setUp(() async {
+      await setUpTestDatabase();
+      cloud = FakeCloudStorageProvider();
+    });
+
+    tearDown(() async {
+      await tearDownTestDatabase();
+    });
+
+    SyncService buildService() => SyncService(
+      syncRepository: SyncRepository(),
+      serializer: SyncDataSerializer(),
+      cloudProvider: cloud,
+    );
+
+    Map<String, dynamic> siteRow(String id, {required int updatedAt}) => {
+      'id': id,
+      'name': 'Wall Site',
+      'description': '',
+      'notes': '',
+      'isShared': false,
+      'createdAt': 1000,
+      'updatedAt': updatedAt,
+    };
+
+    /// Publish a peer base whose only content is one diveSites tombstone.
+    Future<void> seedPeerTombstone(
+      String id, {
+      required int deletedAt,
+      required int exportedAt,
+    }) async {
+      const data = SyncData();
+      final checksum = sha256
+          .convert(utf8.encode(jsonEncode(data.toJson())))
+          .toString();
+      final payload = SyncPayload(
+        version: syncFormatVersion,
+        exportedAt: exportedAt,
+        deviceId: 'peer-dev',
+        checksum: checksum,
+        data: data,
+        deletions: {
+          'diveSites': [SyncDeletion(id: id, deletedAt: deletedAt)],
+        },
+      );
+      await seedPeerBaseFromPayload(cloud, 'peer-dev', payload);
+    }
+
+    Future<Map<String, dynamic>?> deletionConflictFor(String recordId) async {
+      final conflicts = await SyncRepository().getConflictRecords();
+      for (final c in conflicts) {
+        if (c.entityType == 'diveSites' && c.recordId == recordId) {
+          return jsonDecode(c.conflictData!) as Map<String, dynamic>;
+        }
+      }
+      return null;
+    }
+
+    test('after a restore (no sync horizon) a peer tombstone OLDER than the '
+        'local row is a conflict, not a deletion', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      // The restored library: a site last edited at t=8000.
+      await serializer.upsertRecord(
+        'diveSites',
+        siteRow('site-restored', updatedAt: 8000),
+      );
+      // A peer still republishes a tombstone from t=5000, older than the
+      // row's own last edit.
+      await seedPeerTombstone(
+        'site-restored',
+        deletedAt: 5000,
+        exportedAt: 9000,
+      );
+
+      // The restore path: rebaselineAfterRestore nulls lastSyncTimestamp.
+      await syncRepo.rebaselineAfterRestore(
+        preserveDeviceId: await syncRepo.getDeviceId(),
+      );
+      expect(
+        await syncRepo.getLastSyncTime(),
+        isNull,
+        reason: 'precondition: a restore leaves no sync horizon',
+      );
+
+      final result = await buildService().performSync();
+
+      expect(result.status, isNot(SyncResultStatus.error));
+      expect(
+        await serializer.fetchRecord('diveSites', 'site-restored'),
+        isNotNull,
+        reason:
+            'the row was edited (8000) after the tombstone (5000); with no '
+            'sync horizon the tombstone age is the only guard and it must '
+            'not delete the restored row',
+      );
+      final conflict = await deletionConflictFor('site-restored');
+      expect(
+        conflict,
+        isNotNull,
+        reason: 'the stale tombstone surfaces as a deletion conflict',
+      );
+      expect(conflict!['_deleted'], isTrue);
+      expect(conflict['deletedAt'], 5000);
+    });
+
+    test('after a restore (no sync horizon) a peer tombstone NEWER than the '
+        'local row still deletes it', () async {
+      final serializer = SyncDataSerializer();
+      final syncRepo = SyncRepository();
+
+      await serializer.upsertRecord(
+        'diveSites',
+        siteRow('site-gone', updatedAt: 8000),
+      );
+      await seedPeerTombstone('site-gone', deletedAt: 9000, exportedAt: 9500);
+
+      await syncRepo.rebaselineAfterRestore(
+        preserveDeviceId: await syncRepo.getDeviceId(),
+      );
+
+      final result = await buildService().performSync();
+
+      expect(result.status, isNot(SyncResultStatus.error));
+      expect(
+        await serializer.fetchRecord('diveSites', 'site-gone'),
+        isNull,
+        reason:
+            'a deletion newer than the row (9000 > 8000) is a genuine '
+            'peer delete and must still converge after a restore',
+      );
+      expect(await deletionConflictFor('site-gone'), isNull);
+    });
+
+    test(
+      'with a sync horizon, a tombstone older than the local row is a '
+      'conflict even when the row is unchanged since the last sync',
+      () async {
+        final serializer = SyncDataSerializer();
+
+        await serializer.upsertRecord(
+          'diveSites',
+          siteRow('site-lww', updatedAt: 8000),
+        );
+        await seedPeerTombstone('site-lww', deletedAt: 5000, exportedAt: 9000);
+
+        // Horizon AFTER the local edit: the three-way check reads the row as
+        // unchanged, so only the tombstone's own age can protect it (the
+        // mirror of the merge's remote-live-vs-local-tombstone rule).
+        await impersonateFreshDevice();
+        await setLastSync(DateTime.fromMillisecondsSinceEpoch(9000));
+
+        final result = await buildService().performSync();
+
+        expect(result.status, isNot(SyncResultStatus.error));
+        expect(
+          await serializer.fetchRecord('diveSites', 'site-lww'),
+          isNotNull,
+          reason: 'the local edit (8000) is newer than the deletion (5000)',
+        );
+        expect(await deletionConflictFor('site-lww'), isNotNull);
+      },
+    );
+
+    test(
+      'a legacy tombstone without deletedAt is aged by the payload exportedAt',
+      () async {
+        final serializer = SyncDataSerializer();
+        final syncRepo = SyncRepository();
+
+        await serializer.upsertRecord(
+          'diveSites',
+          siteRow('site-legacy', updatedAt: 8000),
+        );
+        // deletedAt 0 is the pre-timestamp wire format; the payload's
+        // exportedAt (7000) is the best available bound and is older than
+        // the row's edit.
+        await seedPeerTombstone('site-legacy', deletedAt: 0, exportedAt: 7000);
+
+        await syncRepo.rebaselineAfterRestore(
+          preserveDeviceId: await syncRepo.getDeviceId(),
+        );
+
+        final result = await buildService().performSync();
+
+        expect(result.status, isNot(SyncResultStatus.error));
+        expect(
+          await serializer.fetchRecord('diveSites', 'site-legacy'),
+          isNotNull,
+        );
+        final conflict = await deletionConflictFor('site-legacy');
+        expect(conflict, isNotNull);
+        expect(conflict!['deletedAt'], 7000);
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

Closes #1340.

`_applyRemoteDeletions` decided delete-vs-conflict with a single three-way check, `localUpdatedAt > lastSyncMs`. The tombstone's own `deletedAt` was computed into `deletionTimestamp` but only ever used for logging, never for the decision. With `lastSyncMs == null` the conflict branch was unreachable, so every matching peer tombstone fell through to `deleteRecord`.

Every recovery action leaves the device in that state: `rebaselineAfterRestore` (every restore, plus `SyncInitializer.reconcileDeviceIdentity` at launch), `adoptReplacedLibrary`, `_rejoinAfterRetirement`, Reset Sync State, `repairLocalSyncState`, and a backend switch through the provider-scoped `getLastSyncTime`. So the sync after a restore applied every peer tombstone unconditionally and the restore silently undid itself.

The fix adds a second guard, `localUpdatedAt > deletionTimestamp`, OR'd with the existing horizon check. Either one routes to the existing `_deleted` conflict path, which `resolveConflict` already understands (keep local re-marks the row pending so peers revive it; keep remote deletes it).

```dart
final editedSinceLastSync =
    localUpdatedAt != null && lastSyncMs != null && localUpdatedAt > lastSyncMs;
final newerThanTombstone =
    localUpdatedAt != null && localUpdatedAt > deletionTimestamp;
final hasConflict = editedSinceLastSync || newerThanTombstone;
```

This is the mirror of the rule `_mergeEntity` already applies in the other direction (a remote live row against a local tombstone: `remoteUpdatedAt <= deletedAt` stays deleted, otherwise revive) and of `revivedParents`. The age guard is always on, not only when the horizon is null: with a horizon it adds the LWW rule the other direction uses; without one it is the only protection.

A peer deletion newer than the local row still applies, so Merge-mode restores keep converging (deletes do not resurrect) and Replace mode remains the tool for undoing deletions that have already propagated.

Alternatives considered and rejected:

- Treat a null horizon as "everything conflicts": manufactures false conflicts during ordinary multi-peer convergence after Reset Sync State, a backend switch, or an adopt (a peer B tombstone against a row just rebuilt from peer A's base).
- Establish a horizon at restore time: never protects restored rows, since they all predate any horizon you could set.

## Changes

- `lib/core/services/sync/sync_service.dart`: `_applyRemoteDeletions` gains the tombstone age guard (`newerThanTombstone`) alongside the existing `editedSinceLastSync` check; comment updated to describe both guards and the no-horizon case.
- `test/core/services/sync/sync_deletion_propagation_test.dart`: new group `Remote tombstone age guard`, driven through `performSync` against a seeded peer base:
  - after `rebaselineAfterRestore` (no horizon), a tombstone older than the local row is a conflict and the row survives (failed before the fix: row deleted)
  - after `rebaselineAfterRestore`, a tombstone newer than the local row still deletes it
  - with a horizon set after the local edit, a tombstone older than the row is still a conflict (failed before the fix)
  - a legacy `deletedAt: 0` tombstone is aged by the payload `exportedAt` (failed before the fix)

Deliberately unchanged:

- Clockless child tables (`dive_profiles`, `dive_tanks`, `tank_pressure_profiles`, `sightings`) still have no age signal; the existing comment explains why uuid regeneration and the contradicted-key skip cover them.
- The sub-170 compatibility hold that makes old peers republish their whole deletion log is a separate mechanism (#1341 covers adopt bypassing the schema floor).

## Test Plan

- [x] `flutter test` passes (full suite run locally; `test/core/services/sync/` plus the rebaseline and consolidation round-trip tests pass with no fixture changes)
- [x] `flutter analyze` passes
- [x] Manual testing on: not yet exercised on a device; the field scenario (restore from a peer's backup, then sync) is covered by the first new test
