### PR TITLE
fix(backup): report a missing restore source instead of Restore Complete

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -16,6 +16,7 @@ import 'package:submersion/core/database/sqlcipher_setup.dart'
     as sqlcipher_setup;
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/restore_source_missing_exception.dart';
 import 'package:submersion/core/services/security/database_encryption_migrator.dart';
 import 'package:submersion/core/services/security/database_locked_exception.dart';
 import 'package:submersion/core/services/security/database_security_sidecar.dart';
@@ -733,6 +734,10 @@ class DatabaseService {
   /// [onMigrationProgress] is forwarded to the post-swap [initialize]: when
   /// the restored file carries an older schema, the reopen runs the upgrade
   /// ladder, and this callback is the only feedback the user gets during it.
+  ///
+  /// Throws [RestoreSourceMissingException] when [backupPath] does not exist.
+  /// The live database is left open and untouched in that case; the throw is
+  /// what lets callers tell "nothing happened" from a completed restore.
   Future<void> restore(
     String backupPath, {
     void Function(int currentStep, int totalSteps)? onMigrationProgress,
@@ -745,12 +750,22 @@ class DatabaseService {
     // effective no-op that still opened a needless "database unavailable"
     // window — during which a provider rebuild caches a fatal
     // "Database not initialized" error.
+    //
+    // Leaving the data alone is right; returning normally was not. Every
+    // caller treated the void return as a completed restore and showed
+    // "Restore Complete", so a user recovering from data loss could not tell a
+    // restore that did nothing from a restore of an empty library (issue
+    // #1344). The absence is reported as a typed failure instead.
     if (!await backupFile.exists()) {
       // Still sweep any temp files a prior restore may have stranded (e.g. a
       // large .pre-restore copy left by a best-effort cleanup that failed), so
       // they don't accumulate on disk. Best-effort; the live DB is untouched.
       await _sweepRestoreTempFiles(destinationPath);
-      return;
+      _log.warning(
+        'Restore source not found at $backupPath; the live database was left '
+        'untouched',
+      );
+      throw RestoreSourceMissingException(backupPath);
     }
 
     // Copy the backup to a staging file NEXT TO the destination while the live

--- a/lib/core/services/restore_source_missing_exception.dart
+++ b/lib/core/services/restore_source_missing_exception.dart
@@ -1,0 +1,22 @@
+/// Thrown by `DatabaseService.restore` when the backup it was asked to swap
+/// in does not exist at [backupPath].
+///
+/// The live database is left exactly as it was: the swap never starts, so no
+/// "database unavailable" window opens and no data changes. That is the right
+/// thing to do with the data, but it must not pass for a completed restore.
+/// A user recovering from data loss cannot tell a restore that did nothing
+/// apart from a restore of an empty library, and the two have very different
+/// root causes (issue #1344). Callers surface this as "nothing was restored",
+/// never as "Restore Complete".
+class RestoreSourceMissingException implements Exception {
+  /// The path the restore was pointed at; the file was absent by the time
+  /// the swap ran (a download that produced no bytes, a temp directory reaped
+  /// between materialization and use, a swallowed upstream error).
+  final String backupPath;
+
+  const RestoreSourceMissingException(this.backupPath);
+
+  @override
+  String toString() =>
+      'RestoreSourceMissingException: backup file not found: $backupPath';
+}

--- a/lib/core/services/restore_source_missing_exception.dart
+++ b/lib/core/services/restore_source_missing_exception.dart
@@ -16,7 +16,14 @@ class RestoreSourceMissingException implements Exception {
 
   const RestoreSourceMissingException(this.backupPath);
 
+  /// Written to be shown as-is. The backup flow maps this exception to a
+  /// localized message, but the startup recovery restore and the settings
+  /// export restore render `'$e'` unlocalized, so the text is a sentence
+  /// rather than a class name. It names the file because at those two call
+  /// sites the path is the user's own pick or the app's recovery backup, and
+  /// "which file" is the one detail that helps.
   @override
   String toString() =>
-      'RestoreSourceMissingException: backup file not found: $backupPath';
+      'Nothing was restored: the backup file could not be found at '
+      '$backupPath';
 }

--- a/lib/features/backup/data/services/backup_database_adapter.dart
+++ b/lib/features/backup/data/services/backup_database_adapter.dart
@@ -15,6 +15,9 @@ abstract class BackupDatabaseAdapter {
   /// [onMigrationProgress] fires per migration step when the restored file
   /// carries an older schema and the reopen runs the upgrade ladder — the only
   /// long-running phase of the swap, and otherwise invisible to the user.
+  ///
+  /// Throws `RestoreSourceMissingException` when [backupPath] does not exist;
+  /// the live database is left untouched and nothing was restored.
   Future<void> restore(
     String backupPath, {
     void Function(int currentStep, int totalSteps)? onMigrationProgress,

--- a/lib/features/backup/presentation/providers/backup_providers.dart
+++ b/lib/features/backup/presentation/providers/backup_providers.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/restore_source_missing_exception.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
@@ -364,6 +365,15 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
       // would swallow it into an error state and close the dialog on success.
       state = const BackupOperationState(status: BackupOperationStatus.idle);
       rethrow;
+    } on RestoreSourceMissingException {
+      // The source was gone by the time the swap ran, so DatabaseService left
+      // the live database untouched (issue #1344). Say exactly that: the
+      // generic "Restore failed: ..." below reads as a botched restore, and
+      // restoreComplete would read as a restore of an empty library.
+      state = BackupOperationState(
+        status: BackupOperationStatus.error,
+        message: _l10n.backup_operation_restoreSourceMissing,
+      );
     } catch (e) {
       state = BackupOperationState(
         status: BackupOperationStatus.error,
@@ -552,6 +562,12 @@ class BackupOperationNotifier extends StateNotifier<BackupOperationState> {
       // would swallow it into an error state and close the dialog on success.
       state = const BackupOperationState(status: BackupOperationStatus.idle);
       rethrow;
+    } on RestoreSourceMissingException {
+      // Nothing was restored; see restoreFromBackup (issue #1344).
+      state = BackupOperationState(
+        status: BackupOperationStatus.error,
+        message: _l10n.backup_operation_restoreSourceMissing,
+      );
     } catch (e) {
       state = BackupOperationState(
         status: BackupOperationStatus.error,

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "فشل النسخ الاحتياطي: {error}",
   "backup_operation_restoring": "جارٍ استعادة النسخة الاحتياطية...",
   "backup_operation_restoreFailed": "فشلت الاستعادة: {error}",
+  "backup_operation_restoreSourceMissing": "لم تتم استعادة أي شيء: تعذر العثور على ملف النسخة الاحتياطية. بياناتك الحالية لم تتغير.",
   "backup_operation_deleting": "جارٍ حذف النسخة الاحتياطية...",
   "backup_operation_deleted": "تم حذف النسخة الاحتياطية",
   "backup_operation_deleteFailed": "فشل الحذف: {error}",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Sicherung fehlgeschlagen: {error}",
   "backup_operation_restoring": "Sicherung wird wiederhergestellt...",
   "backup_operation_restoreFailed": "Wiederherstellung fehlgeschlagen: {error}",
+  "backup_operation_restoreSourceMissing": "Es wurde nichts wiederhergestellt: Die Sicherungsdatei wurde nicht gefunden. Ihre aktuellen Daten sind unverändert.",
   "backup_operation_deleting": "Sicherung wird gelöscht...",
   "backup_operation_deleted": "Sicherung gelöscht",
   "backup_operation_deleteFailed": "Löschen fehlgeschlagen: {error}",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -18917,6 +18917,7 @@
   "backup_operation_backupFailed": "Backup failed: {error}",
   "backup_operation_restoring": "Restoring backup...",
   "backup_operation_restoreFailed": "Restore failed: {error}",
+  "backup_operation_restoreSourceMissing": "Nothing was restored: the backup file could not be found. Your current data is unchanged.",
   "backup_operation_deleting": "Deleting backup...",
   "backup_operation_deleted": "Backup deleted",
   "backup_operation_deleteFailed": "Delete failed: {error}",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Error en la copia de seguridad: {error}",
   "backup_operation_restoring": "Restaurando la copia de seguridad...",
   "backup_operation_restoreFailed": "Error al restaurar: {error}",
+  "backup_operation_restoreSourceMissing": "No se restauró nada: no se encontró el archivo de copia de seguridad. Sus datos actuales no han cambiado.",
   "backup_operation_deleting": "Eliminando la copia de seguridad...",
   "backup_operation_deleted": "Copia de seguridad eliminada",
   "backup_operation_deleteFailed": "Error al eliminar: {error}",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Échec de la sauvegarde : {error}",
   "backup_operation_restoring": "Restauration de la sauvegarde...",
   "backup_operation_restoreFailed": "Échec de la restauration : {error}",
+  "backup_operation_restoreSourceMissing": "Rien n'a été restauré : le fichier de sauvegarde est introuvable. Vos données actuelles sont inchangées.",
   "backup_operation_deleting": "Suppression de la sauvegarde...",
   "backup_operation_deleted": "Sauvegarde supprimée",
   "backup_operation_deleteFailed": "Échec de la suppression : {error}",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "הגיבוי נכשל: {error}",
   "backup_operation_restoring": "משחזר גיבוי...",
   "backup_operation_restoreFailed": "השחזור נכשל: {error}",
+  "backup_operation_restoreSourceMissing": "לא שוחזר דבר: קובץ הגיבוי לא נמצא. הנתונים הנוכחיים שלך לא השתנו.",
   "backup_operation_deleting": "מוחק גיבוי...",
   "backup_operation_deleted": "הגיבוי נמחק",
   "backup_operation_deleteFailed": "המחיקה נכשלה: {error}",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "A biztonsági mentés nem sikerült: {error}",
   "backup_operation_restoring": "Biztonsági mentés visszaállítása...",
   "backup_operation_restoreFailed": "A visszaállítás nem sikerült: {error}",
+  "backup_operation_restoreSourceMissing": "Nem történt visszaállítás: a biztonsági mentés fájlja nem található. A jelenlegi adatok változatlanok.",
   "backup_operation_deleting": "Biztonsági mentés törlése...",
   "backup_operation_deleted": "A biztonsági mentés törölve",
   "backup_operation_deleteFailed": "A törlés nem sikerült: {error}",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Backup non riuscito: {error}",
   "backup_operation_restoring": "Ripristino del backup in corso...",
   "backup_operation_restoreFailed": "Ripristino non riuscito: {error}",
+  "backup_operation_restoreSourceMissing": "Nessun dato ripristinato: il file di backup non è stato trovato. I dati correnti sono invariati.",
   "backup_operation_deleting": "Eliminazione del backup...",
   "backup_operation_deleted": "Backup eliminato",
   "backup_operation_deleteFailed": "Eliminazione non riuscita: {error}",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -55136,6 +55136,12 @@ abstract class AppLocalizations {
   /// **'Restore failed: {error}'**
   String backup_operation_restoreFailed(String error);
 
+  /// No description provided for @backup_operation_restoreSourceMissing.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing was restored: the backup file could not be found. Your current data is unchanged.'**
+  String get backup_operation_restoreSourceMissing;
+
   /// No description provided for @backup_operation_deleting.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -33153,6 +33153,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'لم تتم استعادة أي شيء: تعذر العثور على ملف النسخة الاحتياطية. بياناتك الحالية لم تتغير.';
+
+  @override
   String get backup_operation_deleting => 'جارٍ حذف النسخة الاحتياطية...';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -33420,6 +33420,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Es wurde nichts wiederhergestellt: Die Sicherungsdatei wurde nicht gefunden. Ihre aktuellen Daten sind unverändert.';
+
+  @override
   String get backup_operation_deleting => 'Sicherung wird gelöscht...';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -32970,6 +32970,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Nothing was restored: the backup file could not be found. Your current data is unchanged.';
+
+  @override
   String get backup_operation_deleting => 'Deleting backup...';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -33533,6 +33533,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'No se restauró nada: no se encontró el archivo de copia de seguridad. Sus datos actuales no han cambiado.';
+
+  @override
   String get backup_operation_deleting => 'Eliminando la copia de seguridad...';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -33585,6 +33585,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Rien n\'a été restauré : le fichier de sauvegarde est introuvable. Vos données actuelles sont inchangées.';
+
+  @override
   String get backup_operation_deleting => 'Suppression de la sauvegarde...';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -32816,6 +32816,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'לא שוחזר דבר: קובץ הגיבוי לא נמצא. הנתונים הנוכחיים שלך לא השתנו.';
+
+  @override
   String get backup_operation_deleting => 'מוחק גיבוי...';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -33363,6 +33363,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Nem történt visszaállítás: a biztonsági mentés fájlja nem található. A jelenlegi adatok változatlanok.';
+
+  @override
   String get backup_operation_deleting => 'Biztonsági mentés törlése...';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -33488,6 +33488,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Nessun dato ripristinato: il file di backup non è stato trovato. I dati correnti sono invariati.';
+
+  @override
   String get backup_operation_deleting => 'Eliminazione del backup...';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -33260,6 +33260,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Er is niets hersteld: het back-upbestand is niet gevonden. Uw huidige gegevens zijn ongewijzigd.';
+
+  @override
   String get backup_operation_deleting => 'Back-up verwijderen...';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -33501,6 +33501,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      'Nada foi restaurado: o arquivo de backup não foi encontrado. Seus dados atuais permanecem inalterados.';
+
+  @override
   String get backup_operation_deleting => 'Excluindo backup...';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -31554,6 +31554,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get backup_operation_restoreSourceMissing =>
+      '未恢复任何内容：找不到备份文件。当前数据未发生变化。';
+
+  @override
   String get backup_operation_deleting => '正在删除备份...';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Back-up mislukt: {error}",
   "backup_operation_restoring": "Back-up herstellen...",
   "backup_operation_restoreFailed": "Herstellen mislukt: {error}",
+  "backup_operation_restoreSourceMissing": "Er is niets hersteld: het back-upbestand is niet gevonden. Uw huidige gegevens zijn ongewijzigd.",
   "backup_operation_deleting": "Back-up verwijderen...",
   "backup_operation_deleted": "Back-up verwijderd",
   "backup_operation_deleteFailed": "Verwijderen mislukt: {error}",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "Falha no backup: {error}",
   "backup_operation_restoring": "Restaurando backup...",
   "backup_operation_restoreFailed": "Falha na restauração: {error}",
+  "backup_operation_restoreSourceMissing": "Nada foi restaurado: o arquivo de backup não foi encontrado. Seus dados atuais permanecem inalterados.",
   "backup_operation_deleting": "Excluindo backup...",
   "backup_operation_deleted": "Backup excluído",
   "backup_operation_deleteFailed": "Falha ao excluir: {error}",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -9830,6 +9830,7 @@
   "backup_operation_backupFailed": "备份失败：{error}",
   "backup_operation_restoring": "正在恢复备份...",
   "backup_operation_restoreFailed": "恢复失败：{error}",
+  "backup_operation_restoreSourceMissing": "未恢复任何内容：找不到备份文件。当前数据未发生变化。",
   "backup_operation_deleting": "正在删除备份...",
   "backup_operation_deleted": "备份已删除",
   "backup_operation_deleteFailed": "删除失败：{error}",

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -564,11 +564,20 @@ void main() {
       await expectLater(
         DatabaseService.instance.restore(missingPath),
         throwsA(
-          isA<RestoreSourceMissingException>().having(
-            (e) => e.backupPath,
-            'backupPath',
-            missingPath,
-          ),
+          isA<RestoreSourceMissingException>()
+              .having((e) => e.backupPath, 'backupPath', missingPath)
+              // Two callers (startup recovery, settings export) render '$e'
+              // to the user unlocalized, so the text must read as a sentence
+              // that names the file, not as a class name.
+              .having(
+                (e) => '$e',
+                'toString',
+                allOf(
+                  contains(missingPath),
+                  contains('Nothing was restored'),
+                  isNot(contains('Exception')),
+                ),
+              ),
         ),
       );
 

--- a/test/core/services/database_service_isolate_test.dart
+++ b/test/core/services/database_service_isolate_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
 import 'package:submersion/core/services/database_location_service.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/restore_source_missing_exception.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart'
     as domain;
@@ -461,7 +462,7 @@ void main() {
   );
 
   test(
-    'a no-op restore sweeps restore temp files stranded by a prior run',
+    'a missing-source restore still sweeps temp files stranded by a prior run',
     () async {
       final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
       await DatabaseService.instance.initialize(
@@ -476,9 +477,11 @@ void main() {
       File('$defaultPath.pre-restore').writeAsStringSync('stale');
       File('$defaultPath.restore-staging').writeAsStringSync('stale');
 
-      // A restore pointed at a missing file is a no-op, but still sweeps temps.
-      await DatabaseService.instance.restore(
-        p.join(tempDir.path, 'missing.db'),
+      // A restore pointed at a missing file swaps nothing in and reports
+      // that (issue #1344), but still sweeps the temps on the way out.
+      await expectLater(
+        DatabaseService.instance.restore(p.join(tempDir.path, 'missing.db')),
+        throwsA(isA<RestoreSourceMissingException>()),
       );
 
       expect(File('$defaultPath.pre-restore').existsSync(), isFalse);
@@ -532,28 +535,49 @@ void main() {
     expect(one.read<int>('v'), 1);
   });
 
-  test('restore with a missing backup file leaves the live DB open', () async {
-    // A restore pointed at a nonexistent file must be a true no-op: it must
-    // NOT close the database (which would open an unavailable window for
-    // nothing). The database stays queryable throughout.
-    final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
-    await DatabaseService.instance.initialize(
-      locationService: _FakeLocation(defaultPath),
-    );
-    await DatabaseService.instance.database
-        .customSelect('SELECT 1')
-        .getSingle();
+  test(
+    'restore with a missing backup file throws and leaves the live DB open',
+    () async {
+      // Issue #1344. A restore pointed at a nonexistent file must NOT close
+      // the database (that would open an unavailable window for nothing), but
+      // it must not pass for a completed restore either: a caller has to be
+      // able to tell "nothing happened" from "restored an empty library". So
+      // the live database stays queryable throughout AND the call fails with
+      // a typed exception naming the missing source.
+      final defaultPath = p.join(tempDir.path, 'Submersion', 'submersion.db');
+      await DatabaseService.instance.initialize(
+        locationService: _FakeLocation(defaultPath),
+      );
+      await DatabaseService.instance.database
+          .customSelect('SELECT 1')
+          .getSingle();
+      // A temp file stranded by an earlier restore is still swept on the way
+      // out, exactly as the silent no-op used to do.
+      final stranded = File('$defaultPath.pre-restore');
+      await stranded.writeAsString('stale');
 
-    var windowOpened = false;
-    DatabaseService.instance.debugOnRestoreWindowOpen = (_) =>
-        windowOpened = true;
+      var windowOpened = false;
+      DatabaseService.instance.debugOnRestoreWindowOpen = (_) =>
+          windowOpened = true;
 
-    await DatabaseService.instance.restore(p.join(tempDir.path, 'nope.db'));
+      final missingPath = p.join(tempDir.path, 'nope.db');
+      await expectLater(
+        DatabaseService.instance.restore(missingPath),
+        throwsA(
+          isA<RestoreSourceMissingException>().having(
+            (e) => e.backupPath,
+            'backupPath',
+            missingPath,
+          ),
+        ),
+      );
 
-    expect(windowOpened, isFalse);
-    final one = await DatabaseService.instance.database
-        .customSelect('SELECT 1 AS v')
-        .getSingle();
-    expect(one.read<int>('v'), 1);
-  });
+      expect(windowOpened, isFalse);
+      expect(stranded.existsSync(), isFalse);
+      final one = await DatabaseService.instance.database
+          .customSelect('SELECT 1 AS v')
+          .getSingle();
+      expect(one.read<int>('v'), 1);
+    },
+  );
 }

--- a/test/features/backup/data/services/backup_service_test.dart
+++ b/test/features/backup/data/services/backup_service_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/backup_bookmark_service.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/restore_source_missing_exception.dart';
 import 'package:submersion/core/services/sync/crypto/keyslots.dart';
 import 'package:submersion/core/services/sync/library_epoch_store.dart';
 import 'package:submersion/core/services/sync/post_restore_sync_store.dart';
@@ -32,6 +33,11 @@ class FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   String? lastBackupPath;
   String? lastRestorePath;
 
+  /// When set, [restore] records the call and then throws this, modelling a
+  /// swap that DatabaseService refused (e.g. the source vanished between
+  /// materialization and the swap, issue #1344).
+  Object? restoreError;
+
   @override
   Future<void> backup(String destinationPath) async {
     backupCallCount++;
@@ -49,6 +55,8 @@ class FakeBackupDatabaseAdapter implements BackupDatabaseAdapter {
   }) async {
     restoreCallCount++;
     lastRestorePath = backupPath;
+    final error = restoreError;
+    if (error != null) throw error;
   }
 
   @override
@@ -324,6 +332,87 @@ void main() {
           intentStore.pending,
           isFalse,
           reason: 'Replace uses pendingReplace, not the merge intent',
+        );
+      });
+    });
+
+    group('missing restore source (issue #1344)', () {
+      // DatabaseService.restore leaves the live database untouched when the
+      // source file is gone and reports that as RestoreSourceMissingException.
+      // BackupService must let that through unchanged, so the notifier can
+      // land on an error instead of restoreComplete, and must not treat the
+      // untouched live library as freshly restored on the way out.
+      Future<File> vanishingSource(String tag) async {
+        final src = File(
+          '${Directory.systemTemp.path}/restore_${tag}_'
+          '${DateTime.now().microsecondsSinceEpoch}.db',
+        );
+        await src.writeAsString('db');
+        addTearDown(() async {
+          if (await src.exists()) await src.delete();
+        });
+        return src;
+      }
+
+      test('a merge restore propagates it and arms no sync fix-up', () async {
+        final prefs = await SharedPreferences.getInstance();
+        final intentStore = PostRestoreSyncStore(prefs);
+        final spy = _SpySyncRepository();
+        fakeDb.restoreError = const RestoreSourceMissingException('/gone.db');
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: spy,
+          postRestoreSyncStore: intentStore,
+        );
+        final src = await vanishingSource('missing_merge');
+
+        await expectLater(
+          service.restoreFromFile(src.path),
+          throwsA(isA<RestoreSourceMissingException>()),
+        );
+
+        expect(fakeDb.restoreCallCount, 1);
+        expect(
+          spy.rebaselineCalls,
+          0,
+          reason:
+              'nothing was swapped in, so there is no restored sync '
+              'position to re-baseline',
+        );
+        expect(
+          intentStore.pending,
+          isFalse,
+          reason:
+              'a restore that did not happen must not arm the '
+              'post-restore reconciling sync',
+        );
+      });
+
+      test('a replace restore propagates it and mints no replace', () async {
+        final prefs = await SharedPreferences.getInstance();
+        final epochStore = LibraryEpochStore(prefs);
+        fakeDb.restoreError = const RestoreSourceMissingException('/gone.db');
+        final service = BackupService(
+          dbAdapter: fakeDb,
+          preferences: preferences,
+          syncRepository: _SpySyncRepository(),
+          epochStore: epochStore,
+          postRestoreSyncStore: PostRestoreSyncStore(prefs),
+        );
+        final src = await vanishingSource('missing_replace');
+
+        await expectLater(
+          service.restoreFromFile(src.path, mode: RestoreMode.replace),
+          throwsA(isA<RestoreSourceMissingException>()),
+        );
+
+        expect(
+          epochStore.pendingReplace,
+          isNull,
+          reason:
+              'minting a replace here would push the UNTOUCHED live '
+              'library to every synced device as the "restored" one',
         );
       });
     });

--- a/test/features/backup/presentation/providers/backup_providers_restore_test.dart
+++ b/test/features/backup/presentation/providers/backup_providers_restore_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/database/database.dart' show AppDatabase;
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/restore_source_missing_exception.dart';
 import 'package:submersion/features/backup/data/repositories/backup_preferences.dart';
 import 'package:submersion/features/backup/data/services/backup_service.dart';
 import 'package:submersion/features/backup/domain/entities/backup_record.dart';
@@ -57,6 +58,11 @@ class _RecordingBackupService extends BackupService {
   /// [WrongPassphraseException], modelling a wrong passphrase on retry.
   String? correctSecret;
 
+  /// When true, restore throws [RestoreSourceMissingException], modelling a
+  /// source file that vanished between materialization and the swap
+  /// (issue #1344).
+  bool sourceMissing = false;
+
   /// When set, restore awaits this before returning, so a test can observe the
   /// in-flight (mid-restore) state.
   Completer<void>? restoreGate;
@@ -75,6 +81,9 @@ class _RecordingBackupService extends BackupService {
     }
     if (correctSecret != null && secret != null && secret != correctSecret) {
       throw const WrongPassphraseException();
+    }
+    if (sourceMissing) {
+      throw const RestoreSourceMissingException('/gone.db');
     }
   }
 
@@ -571,6 +580,55 @@ void main() {
     expect(sweep.capturedIsCancelled!(), isFalse);
     notifier.skipSafetyReviewSweep();
     expect(sweep.capturedIsCancelled!(), isTrue);
+  });
+
+  test(
+    'a missing restore source lands on error, not restoreComplete',
+    () async {
+      // Issue #1344. DatabaseService.restore leaves the live database alone
+      // when the source file is gone and reports that as a typed failure. The
+      // notifier must not reach restoreComplete (which pushes the Restore
+      // Complete page and offers the restart), or a user recovering from data
+      // loss cannot tell "nothing happened" from "restored an empty library".
+      final sweep = _FakePostRestoreSafetyReview();
+      final container = makeContainer(sweep: sweep);
+      service.sourceMissing = true;
+
+      await container
+          .read(backupOperationProvider.notifier)
+          .restoreFromFilePath(await tempBackupPath('missing'));
+
+      final state = container.read(backupOperationProvider);
+      expect(state.status, BackupOperationStatus.error);
+      expect(state.isRestoring, isFalse, reason: 'the barrier must come down');
+      expect(
+        state.message,
+        'Nothing was restored: the backup file could not be found. '
+        'Your current data is unchanged.',
+      );
+      expect(sweep.calls, 0, reason: 'nothing was restored, nothing to review');
+    },
+  );
+
+  test('restoreFromBackup reports a missing source the same way', () async {
+    final container = makeContainer();
+    service.sourceMissing = true;
+    final record = BackupRecord(
+      id: 'r-missing',
+      filename: 'gone.db',
+      timestamp: DateTime(2026),
+      sizeBytes: 1,
+      location: BackupLocation.local,
+    );
+
+    await container
+        .read(backupOperationProvider.notifier)
+        .restoreFromBackup(record);
+
+    final state = container.read(backupOperationProvider);
+    expect(state.status, BackupOperationStatus.error);
+    expect(state.isRestoring, isFalse);
+    expect(state.message, startsWith('Nothing was restored'));
   });
 
   test('backup encryption providers wire their real dependencies', () async {


### PR DESCRIPTION
## Summary

Fixes #1344.

A restore whose source file was missing by the time the swap ran did nothing, returned normally, and the app showed "Restore Complete". A user recovering from data loss could not tell that outcome from a restore of an empty library, and reasonably concluded their data was gone (the field report behind the issue).

`DatabaseService.restore` deliberately leaves the live database untouched when the file is absent (the alternative, close and reopen the same file, opened a needless "database unavailable" window that cached a fatal error in any provider that rebuilt during it). That part stays. What changes is that the absence is now reported instead of swallowed.

One consequence that was not in the issue: because the no-op returned normally, `BackupService` went on to arm the post-restore reconciling sync (merge mode) or mint a pending "replace everywhere" (replace mode) against the untouched live library. In replace mode, a missing-source restore would have pushed the user's current, possibly empty, library to the cloud as the "restored" one. The throw stops that too, and the new `BackupService` tests pin it.

## Changes

- New `RestoreSourceMissingException` (`lib/core/services/restore_source_missing_exception.dart`), carrying the missing path.
- `DatabaseService.restore` still sweeps stranded `.restore-staging` / `.pre-restore` temp files, then logs and throws `RestoreSourceMissingException` instead of returning. The live database is never closed on this path (the exists check runs before `close(strict: true)`).
- `BackupOperationNotifier.restoreFromBackup` / `restoreFromFilePath` catch that type and land on `BackupOperationStatus.error` with a dedicated message, "Nothing was restored: the backup file could not be found. Your current data is unchanged." (`backup_operation_restoreSourceMissing`, translated in all 11 locales). They never reach `restoreComplete`, so `RestoreCompletePage` and its restart are not offered, and the restore barrier comes down.
- The other two direct callers, startup recovery (`startup_page.dart`) and the settings export restore (`export_providers.dart`), already wrap `restore` in a catch that surfaces `$e`; they now report the failure instead of continuing as if the restore had happened.
- Doc line on `BackupDatabaseAdapter.restore` stating the contract.

Deliberately left out, as separate design calls: the three related silent successes listed in the issue (`realignActiveDiverAfterDataReplace`, tracked as #1342; the non-fatal sync re-baseline; the newer-schema guard degrading to `null` on an unreadable file).

## Test Plan

- [x] `flutter test` passes (full suite run locally in the worktree)
- [x] `flutter analyze` passes
- [ ] Manual testing on: not run; the change is fully exercised by unit tests below

Tests (written first, watched fail, then made green):

- `database_service_isolate_test.dart`: the two missing-file cases flipped from "is a no-op" to "throws `RestoreSourceMissingException`, never opens the unavailable window, still sweeps stranded temp files, and the live database stays queryable".
- `backup_service_test.dart`: new group proving the exception propagates unchanged through `restoreFromFile`, with no sync re-baseline, no post-restore sync intent (merge) and no pending replace (replace). These pass on main too; they guard the propagation contract against a future broad catch around the swap.
- `backup_providers_restore_test.dart`: both notifier entry points land on `error` with the dedicated message, `isRestoring` is cleared, and the post-restore safety sweep does not run.
