### PR TITLE
fix: a dangling active diver id no longer empties the logbook (#1342)

### DIFF
--- a/lib/features/divers/data/repositories/diver_merge_repository.dart
+++ b/lib/features/divers/data/repositories/diver_merge_repository.dart
@@ -5,6 +5,7 @@ import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart'
     as domain;
 
@@ -178,6 +179,18 @@ class DiverMergeRepository {
       await _syncRepository.logDeletion(
         entityType: 'divers',
         recordId: duplicateId,
+      );
+
+      // The device-local active-diver pointer follows the merge when it named
+      // the duplicate, so the startup validator and the live
+      // CurrentDiverIdNotifier land on the keeper instead of falling back to
+      // whichever diver happens to be default (issue #1342). Deliberately not
+      // part of the snapshot: after an undo the keeper is still a valid
+      // profile, and the selection is UI state, not merged data.
+      await _db.customStatement(
+        'UPDATE settings SET value = ?, updated_at = ? '
+        'WHERE key = ? AND value = ?',
+        [keeperId, now, DiverRepository.activeDiverIdSettingsKey, duplicateId],
       );
     });
 

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -37,7 +37,13 @@ class DiverRepository {
   final SyncRepository _syncRepository = SyncRepository();
   static const _uuid = Uuid();
   static final _log = LoggerService.forClass(DiverRepository);
-  static const _activeDiverIdKey = 'active_diver_id';
+
+  /// Settings-table key holding the device-local active diver id.
+  ///
+  /// Public so writers outside this repository that must keep the pointer
+  /// valid in the same transaction as their own change (diver merge) target
+  /// the same row the readers here consult.
+  static const activeDiverIdSettingsKey = 'active_diver_id';
 
   /// Get all divers ordered by name
   Future<List<domain.Diver>> getAllDivers() async {
@@ -609,7 +615,7 @@ class DiverRepository {
   Future<String?> getActiveDiverIdFromSettings() async {
     try {
       final query = _db.select(_db.settings)
-        ..where((t) => t.key.equals(_activeDiverIdKey));
+        ..where((t) => t.key.equals(activeDiverIdSettingsKey));
       final row = await query.getSingleOrNull();
       return row?.value;
     } catch (e, stackTrace) {
@@ -630,13 +636,13 @@ class DiverRepository {
       if (diverId == null) {
         await (_db.delete(
           _db.settings,
-        )..where((t) => t.key.equals(_activeDiverIdKey))).go();
+        )..where((t) => t.key.equals(activeDiverIdSettingsKey))).go();
       } else {
         await _db
             .into(_db.settings)
             .insertOnConflictUpdate(
               SettingsCompanion(
-                key: const Value(_activeDiverIdKey),
+                key: const Value(activeDiverIdSettingsKey),
                 value: Value(diverId),
                 updatedAt: Value(now),
               ),

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:submersion/core/providers/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
 import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
@@ -57,34 +60,59 @@ final diverByIdProvider = FutureProvider.family<Diver?, String>((
 /// Public so the backup restore flow can sync this value.
 const String currentDiverIdKey = 'current_diver_id';
 
+final _activeDiverLog = LoggerService.forClass(CurrentDiverIdNotifier);
+
+/// Resolves the diver id the app should scope to: the first of [candidates]
+/// that names an existing diver, else the default diver. Null only when no
+/// diver exists at all.
+Future<String?> _resolveActiveDiverId(
+  DiverRepository repository,
+  Iterable<String?> candidates,
+) async {
+  for (final id in candidates.whereType<String>().toSet()) {
+    if (await repository.getDiverById(id) != null) return id;
+  }
+  return (await repository.getDefaultDiver())?.id;
+}
+
 /// After the local database content has been replaced wholesale (backup
 /// restore, or adopting a replaced sync library), realign the active diver:
 /// validate the restored settings' active diver against the divers table,
 /// fall back to the default diver, and persist the result to
 /// SharedPreferences so startup picks up the right diver.
+///
+/// When nothing resolves the stored id is removed rather than left in place.
+/// `current_diver_id` lives in SharedPreferences, which a database swap never
+/// touches, so a leftover id from the previous library would seed the next
+/// launch with a diver that no longer exists and scope every dive query to
+/// nothing (issue #1342). No id means "unscoped", the reading every other
+/// diver-scoped repository already gives a null diver id.
+///
+/// Callers that keep running without a restart need not invalidate
+/// [currentDiverIdProvider]: the live notifier re-validates itself on the
+/// divers-table tick the replace produced.
 Future<void> realignActiveDiverAfterDataReplace(SharedPreferences prefs) async {
   try {
     final repository = DiverRepository();
-
-    var restoredId = await repository.getActiveDiverIdFromSettings();
-
-    if (restoredId != null) {
-      final diver = await repository.getDiverById(restoredId);
-      if (diver == null) {
-        restoredId = null;
-      }
+    final resolvedId = await _resolveActiveDiverId(repository, [
+      await repository.getActiveDiverIdFromSettings(),
+    ]);
+    if (resolvedId != null) {
+      await prefs.setString(currentDiverIdKey, resolvedId);
+    } else if (prefs.containsKey(currentDiverIdKey)) {
+      _activeDiverLog.warning(
+        'No diver resolves after the data replace; clearing stored active '
+        'diver id ${prefs.getString(currentDiverIdKey)}',
+      );
+      await prefs.remove(currentDiverIdKey);
     }
-
-    if (restoredId == null) {
-      final defaultDiver = await repository.getDefaultDiver();
-      restoredId = defaultDiver?.id;
-    }
-
-    if (restoredId != null) {
-      await prefs.setString(currentDiverIdKey, restoredId);
-    }
-  } catch (_) {
-    // Non-fatal: startup validation in CurrentDiverIdNotifier handles it.
+  } catch (e, stackTrace) {
+    // Non-fatal: startup validation in CurrentDiverIdNotifier retries this.
+    _activeDiverLog.error(
+      'Failed to realign the active diver after the data replace',
+      error: e,
+      stackTrace: stackTrace,
+    );
   }
 }
 
@@ -99,13 +127,43 @@ final currentDiverIdProvider =
 class CurrentDiverIdNotifier extends StateNotifier<String?> {
   final SharedPreferences _prefs;
   final DiverRepository _repository;
+  StreamSubscription<void>? _diversChangeSub;
 
   CurrentDiverIdNotifier(this._prefs, this._repository) : super(null) {
     _loadCurrentDiverId();
     _validateAndSync();
+    // A merge, a restore, a replace-adopt, or a sync tombstone can remove the
+    // diver this id names without going through setCurrentDiver. Re-validate
+    // on the divers-table tick so the live notifier never keeps an id that
+    // matches no row (issue #1342). A raw stream subscription rather than a
+    // pause-aware ref.listen: the repair must run even while nothing watches
+    // this provider, so the next reader gets a healed id.
+    try {
+      _diversChangeSub = _repository.watchDiversChanges().listen(
+        (_) => _validateAndSync(),
+      );
+    } catch (e, stackTrace) {
+      // Same footing as the validation above: without a database (a test
+      // that never opened one) the notifier still serves the stored id.
+      _activeDiverLog.error(
+        'Cannot watch the divers table; the active diver id will not '
+        'self-repair until the next launch',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _diversChangeSub?.cancel();
+    super.dispose();
   }
 
   /// Synchronous load from SharedPreferences for immediate UI rendering.
+  ///
+  /// Unvalidated by design (no DB read is possible synchronously);
+  /// [_validateAndSync] follows at once and corrects or clears it.
   void _loadCurrentDiverId() {
     final storedId = _prefs.getString(currentDiverIdKey);
     if (storedId != null && storedId.isNotEmpty) {
@@ -113,50 +171,62 @@ class CurrentDiverIdNotifier extends StateNotifier<String?> {
     }
   }
 
-  /// Async validation that runs after construction.
-  /// Checks the prefs ID is valid, falls back to DB Settings table,
-  /// then to default diver. Syncs resolved ID back to both stores.
+  /// Async validation, run after construction and again on every divers-table
+  /// write. Resolves, in order: the current id if its diver exists, the
+  /// Settings-table id (survives a restore) if its diver exists, then the
+  /// default diver. Syncs the result to both stores.
+  ///
+  /// When nothing resolves the id is cleared from state and prefs. Null means
+  /// "unscoped", the reading every other diver-scoped repository gives a null
+  /// diver id; keeping an id that matches no row would instead scope the
+  /// logbook to a diver that cannot exist and empty it for good.
   Future<void> _validateAndSync() async {
+    // Everything below awaits; if the user switches diver meanwhile, an
+    // answer computed from the old id must not overwrite their choice.
+    final startedFrom = state;
     try {
-      String? resolvedId = state;
+      final dbId = await _repository.getActiveDiverIdFromSettings();
+      final resolvedId = await _resolveActiveDiverId(_repository, [
+        startedFrom,
+        dbId,
+      ]);
+      if (!mounted || state != startedFrom) return;
 
-      // Check if the prefs ID actually exists in the divers table
-      if (resolvedId != null) {
-        final diver = await _repository.getDiverById(resolvedId);
-        if (diver == null) {
-          resolvedId = null;
+      if (resolvedId != startedFrom) {
+        if (resolvedId == null) {
+          _activeDiverLog.warning(
+            'Active diver id $startedFrom matches no diver and none can be '
+            'resolved; clearing it',
+          );
+          await _prefs.remove(currentDiverIdKey);
+        } else {
+          _activeDiverLog.info(
+            'Active diver id resolved to $resolvedId (was $startedFrom)',
+          );
+          await _prefs.setString(currentDiverIdKey, resolvedId);
         }
-      }
-
-      // If prefs ID was stale/empty, try the Settings table (survives restore)
-      if (resolvedId == null) {
-        final dbId = await _repository.getActiveDiverIdFromSettings();
-        if (dbId != null) {
-          final diver = await _repository.getDiverById(dbId);
-          if (diver != null) {
-            resolvedId = dbId;
-          }
-        }
-      }
-
-      // Last resort: fall back to the default diver
-      if (resolvedId == null) {
-        final defaultDiver = await _repository.getDefaultDiver();
-        resolvedId = defaultDiver?.id;
-      }
-
-      // Sync the resolved ID to both stores if it changed
-      if (resolvedId != null && resolvedId != state) {
-        await _prefs.setString(currentDiverIdKey, resolvedId);
+        if (!mounted || state != startedFrom) return;
         state = resolvedId;
       }
 
-      // Ensure the DB Settings table is in sync
-      if (resolvedId != null) {
+      // Keep the DB Settings table in step. Skipped when it already agrees,
+      // so a divers-table tick does not turn into a settings write, and left
+      // alone when nothing resolved: a stale pointer there is harmless (it is
+      // validated on every read) and may name the right diver again once a
+      // replace finishes refilling the divers table.
+      if (resolvedId != null && dbId != resolvedId) {
         await _repository.setActiveDiverIdInSettings(resolvedId);
       }
-    } catch (_) {
-      // Non-fatal: SharedPreferences remains the primary source
+    } catch (e, stackTrace) {
+      // Not cleared: a failed read says nothing about whether the id is
+      // valid. Logged so a transient startup failure that leaves a stale id
+      // in place is visible; the next divers-table write retries.
+      _activeDiverLog.error(
+        'Failed to validate active diver id $startedFrom; keeping it '
+        'unvalidated',
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -272,10 +342,22 @@ class DiverListNotifier extends StateNotifier<AsyncValue<List<Diver>>> {
     final result = await _repository.deleteDiverWithReassignment(id);
     await refresh();
 
-    // If deleted diver was current, clear selection
+    // If the deleted diver was current, move the selection to the diver the
+    // app would resolve at startup (Settings-table pointer, then default)
+    // rather than leaving it null. The notifier's own divers-table tick would
+    // repair it eventually, but that races this method's return; resolving
+    // here makes the state settled by the time the caller continues.
     final currentId = _ref.read(currentDiverIdProvider);
     if (currentId == id) {
-      await _ref.read(currentDiverIdProvider.notifier).clearCurrentDiver();
+      final replacementId = await _resolveActiveDiverId(_repository, [
+        await _repository.getActiveDiverIdFromSettings(),
+      ]);
+      final notifier = _ref.read(currentDiverIdProvider.notifier);
+      if (replacementId != null) {
+        await notifier.setCurrentDiver(replacementId);
+      } else {
+        await notifier.clearCurrentDiver();
+      }
     }
     return result;
   }

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -85,8 +85,8 @@ Future<String?> _resolveActiveDiverId(
 /// `current_diver_id` lives in SharedPreferences, which a database swap never
 /// touches, so a leftover id from the previous library would seed the next
 /// launch with a diver that no longer exists and scope every dive query to
-/// nothing (issue #1342). No id means "unscoped", the reading every other
-/// diver-scoped repository already gives a null diver id.
+/// nothing (issue #1342). With no id the queries run unscoped, which is how
+/// every other diver-scoped repository already treats a null diver id.
 ///
 /// Callers that keep running without a restart need not invalidate
 /// [currentDiverIdProvider]: the live notifier re-validates itself on the
@@ -176,10 +176,11 @@ class CurrentDiverIdNotifier extends StateNotifier<String?> {
   /// Settings-table id (survives a restore) if its diver exists, then the
   /// default diver. Syncs the result to both stores.
   ///
-  /// When nothing resolves the id is cleared from state and prefs. Null means
-  /// "unscoped", the reading every other diver-scoped repository gives a null
-  /// diver id; keeping an id that matches no row would instead scope the
-  /// logbook to a diver that cannot exist and empty it for good.
+  /// When nothing resolves the id is cleared from state and prefs. A null id
+  /// runs the queries unscoped, which is how every other diver-scoped
+  /// repository already treats a null diver id; keeping an id that matches no
+  /// row would instead scope the logbook to a diver that cannot exist and
+  /// empty it for good.
   Future<void> _validateAndSync() async {
     // Everything below awaits; if the user switches diver meanwhile, an
     // answer computed from the old id must not overwrite their choice.

--- a/lib/features/divers/presentation/providers/diver_providers.dart
+++ b/lib/features/divers/presentation/providers/diver_providers.dart
@@ -199,14 +199,20 @@ class CurrentDiverIdNotifier extends StateNotifier<String?> {
             'Active diver id $startedFrom matches no diver and none can be '
             'resolved; clearing it',
           );
-          await _prefs.remove(currentDiverIdKey);
         } else {
           _activeDiverLog.info(
             'Active diver id resolved to $resolvedId (was $startedFrom)',
           );
-          await _prefs.setString(currentDiverIdKey, resolvedId);
         }
-        if (!mounted || state != startedFrom) return;
+        await _persist(resolvedId);
+        if (!mounted) return;
+        if (state != startedFrom) {
+          // The user switched diver while that write was in flight, and
+          // their own write may have landed first. Re-persist the newer state
+          // so prefs do not keep the answer computed for the old one.
+          await _persist(state);
+          return;
+        }
         state = resolvedId;
       }
 
@@ -230,6 +236,10 @@ class CurrentDiverIdNotifier extends StateNotifier<String?> {
       );
     }
   }
+
+  Future<void> _persist(String? id) => id == null
+      ? _prefs.remove(currentDiverIdKey)
+      : _prefs.setString(currentDiverIdKey, id);
 
   Future<void> setCurrentDiver(String diverId) async {
     await _prefs.setString(currentDiverIdKey, diverId);

--- a/test/features/divers/diver_merge_repository_test.dart
+++ b/test/features/divers/diver_merge_repository_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/divers/data/repositories/diver_merge_repository.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/divers/domain/entities/diver.dart'
     as domain;
 
@@ -433,6 +434,64 @@ void main() {
         0,
         reason: 'undo must clear the pending residue the merge created',
       );
+    });
+  });
+
+  group('active diver id in settings', () {
+    const activeKey = DiverRepository.activeDiverIdSettingsKey;
+
+    Future<String?> activeDiverId() async {
+      final row = await (db.select(
+        db.settings,
+      )..where((t) => t.key.equals(activeKey))).getSingleOrNull();
+      return row?.value;
+    }
+
+    Future<void> setActiveDiverId(String id) async {
+      await db
+          .into(db.settings)
+          .insert(
+            SettingsCompanion.insert(
+              key: activeKey,
+              value: Value(id),
+              updatedAt: 0,
+            ),
+          );
+    }
+
+    test('is repointed to the keeper when it named the duplicate', () async {
+      // Deleting the duplicate would otherwise leave settings.active_diver_id
+      // dangling, and the startup validator would fall back to the default
+      // diver rather than the profile the user was actually using (#1342).
+      await setActiveDiverId(dup);
+
+      await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+
+      expect(await activeDiverId(), keeper);
+    });
+
+    test('is left alone when it names an unrelated diver', () async {
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion.insert(
+              id: 'diver-other',
+              name: 'Someone Else',
+              createdAt: 1000,
+              updatedAt: 1000,
+            ),
+          );
+      await setActiveDiverId('diver-other');
+
+      await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+
+      expect(await activeDiverId(), 'diver-other');
+    });
+
+    test('is not created when no active diver is recorded', () async {
+      await repo.mergeDivers(keeperId: keeper, duplicateId: dup);
+
+      expect(await activeDiverId(), isNull);
     });
   });
 

--- a/test/features/divers/presentation/providers/diver_providers_test.dart
+++ b/test/features/divers/presentation/providers/diver_providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/providers/provider.dart';
@@ -23,6 +25,46 @@ Diver _makeDiver({
     createdAt: now,
     updatedAt: now,
   );
+}
+
+/// A [SharedPreferences] that holds its FIRST `setString` open until [release]
+/// completes, then forwards it. Every later call forwards at once, so a write
+/// issued while the first one is in flight lands BEFORE it: the ordering that
+/// lets a validation write clobber a user's diver switch. [forwarded] records
+/// every value that reached the real store, in order, so a test can wait for
+/// the held write to land instead of racing it.
+class _GatedPrefs implements SharedPreferences {
+  _GatedPrefs(this._inner);
+
+  final SharedPreferences _inner;
+  final firstWriteStarted = Completer<void>();
+  final release = Completer<void>();
+  final forwarded = <String>[];
+  bool _gateArmed = true;
+
+  @override
+  Future<bool> setString(String key, String value) async {
+    if (_gateArmed) {
+      _gateArmed = false;
+      firstWriteStarted.complete();
+      await release.future;
+    }
+    final ok = await _inner.setString(key, value);
+    forwarded.add(value);
+    return ok;
+  }
+
+  @override
+  String? getString(String key) => _inner.getString(key);
+
+  @override
+  Future<bool> remove(String key) => _inner.remove(key);
+
+  @override
+  bool containsKey(String key) => _inner.containsKey(key);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 /// Polls [condition] every 10ms for up to a second.
@@ -374,6 +416,51 @@ void main() {
 
       expect(container.read(currentDiverIdProvider), equals(survivor.id));
       expect(prefs.getString(currentDiverIdKey), equals(survivor.id));
+    });
+
+    test('a diver switch made while the validation write is in flight wins in '
+        'prefs as well as in state', () async {
+      final fallback = await repo.createDiver(
+        _makeDiver(name: 'Default', isDefault: true),
+      );
+      final chosen = await repo.createDiver(_makeDiver(name: 'Chosen'));
+      await prefs.setString(currentDiverIdKey, 'ghost');
+      final gated = _GatedPrefs(prefs);
+
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(gated)],
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(currentDiverIdProvider.notifier);
+
+      // Validation resolves the default diver and starts persisting it; the
+      // gate holds that write open.
+      await gated.firstWriteStarted.future.timeout(const Duration(seconds: 2));
+      expect(container.read(currentDiverIdProvider), equals('ghost'));
+
+      // The user switches while that write is in flight. Their write goes
+      // straight through, so the validation's write lands after it.
+      await notifier.setCurrentDiver(chosen.id);
+      expect(gated.forwarded, equals([chosen.id]));
+      gated.release.complete();
+
+      // Wait for the held write to land (it clobbers prefs) and for the
+      // notifier's reconcile to put the chosen id back.
+      await _pollUntil(
+        () =>
+            gated.forwarded.contains(fallback.id) &&
+            prefs.getString(currentDiverIdKey) == chosen.id,
+      );
+      expect(gated.forwarded, contains(fallback.id));
+
+      expect(container.read(currentDiverIdProvider), equals(chosen.id));
+      expect(
+        prefs.getString(currentDiverIdKey),
+        equals(chosen.id),
+        reason:
+            'the validation write for ${fallback.id} landed after the '
+            'switch and must not be what prefs keeps',
+      );
     });
 
     test(

--- a/test/features/divers/presentation/providers/diver_providers_test.dart
+++ b/test/features/divers/presentation/providers/diver_providers_test.dart
@@ -25,6 +25,19 @@ Diver _makeDiver({
   );
 }
 
+/// Polls [condition] every 10ms for up to a second.
+///
+/// [CurrentDiverIdNotifier] validates asynchronously (in its constructor and
+/// again on every divers-table tick), so tests wait for the state to settle
+/// instead of racing it. A never-met condition simply returns, and the
+/// caller's following expect reports the actual state.
+Future<void> _pollUntil(bool Function() condition) async {
+  for (var i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
 void main() {
   late SharedPreferences prefs;
   late DiverRepository repo;
@@ -292,6 +305,109 @@ void main() {
       expect(container.read(currentDiverIdProvider), isNull);
       expect(prefs.getString(currentDiverIdKey), isNull);
     });
+
+    test('clears a dangling id from state and prefs when no diver resolves '
+        '(issue #1342)', () async {
+      // The pref names a diver that no longer exists, the settings table
+      // names nothing, and there is no diver to fall back to. Retaining the
+      // id would scope every dive query to a diver that cannot exist.
+      await prefs.setString(currentDiverIdKey, 'ghost');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      // The synchronous seed exposes the raw pref before validation runs.
+      expect(container.read(currentDiverIdProvider), equals('ghost'));
+
+      await _pollUntil(() => container.read(currentDiverIdProvider) == null);
+
+      expect(container.read(currentDiverIdProvider), isNull);
+      expect(prefs.getString(currentDiverIdKey), isNull);
+    });
+
+    test(
+      'replaces a dangling id with the default diver in every store',
+      () async {
+        final fallback = await repo.createDiver(
+          _makeDiver(name: 'Default', isDefault: true),
+        );
+        await prefs.setString(currentDiverIdKey, 'ghost');
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+
+        await _pollUntil(
+          () => container.read(currentDiverIdProvider) == fallback.id,
+        );
+
+        expect(container.read(currentDiverIdProvider), equals(fallback.id));
+        expect(prefs.getString(currentDiverIdKey), equals(fallback.id));
+        expect(await repo.getActiveDiverIdFromSettings(), equals(fallback.id));
+      },
+    );
+
+    test('revalidates when the active diver is deleted straight from the DB '
+        '(sync-applied deletion)', () async {
+      final survivor = await repo.createDiver(
+        _makeDiver(name: 'Survivor', isDefault: true),
+      );
+      final active = await repo.createDiver(_makeDiver(name: 'Active'));
+      await prefs.setString(currentDiverIdKey, active.id);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+      // An active listener mirrors any screen that watches the diver.
+      final sub = container.listen(currentDiverIdProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      await _pollUntil(
+        () => container.read(currentDiverIdProvider) == active.id,
+      );
+
+      // No notifier call: the row disappears the way a sync tombstone
+      // removes it, so only the divers-table tick can repair the id.
+      await repo.deleteDiverWithReassignment(active.id);
+
+      await _pollUntil(
+        () => container.read(currentDiverIdProvider) == survivor.id,
+      );
+
+      expect(container.read(currentDiverIdProvider), equals(survivor.id));
+      expect(prefs.getString(currentDiverIdKey), equals(survivor.id));
+    });
+
+    test(
+      'follows a merge to the keeper when the active diver was the duplicate',
+      () async {
+        // The keeper is neither default nor oldest, so only the merge's own
+        // settings repoint can select it; the default fallback alone would
+        // land on "Other" instead.
+        await repo.createDiver(_makeDiver(name: 'Other', isDefault: true));
+        final keeper = await repo.createDiver(_makeDiver(name: 'Alex'));
+        final duplicate = await repo.createDiver(_makeDiver(name: 'Alex'));
+        await prefs.setString(currentDiverIdKey, duplicate.id);
+        await repo.setActiveDiverIdInSettings(duplicate.id);
+
+        final container = makeContainer();
+        addTearDown(container.dispose);
+        final sub = container.listen(currentDiverIdProvider, (_, _) {});
+        addTearDown(sub.close);
+        await _pollUntil(
+          () => container.read(currentDiverIdProvider) == duplicate.id,
+        );
+
+        await container
+            .read(diverMergeRepositoryProvider)
+            .mergeDivers(keeperId: keeper.id, duplicateId: duplicate.id);
+
+        await _pollUntil(
+          () => container.read(currentDiverIdProvider) == keeper.id,
+        );
+
+        expect(container.read(currentDiverIdProvider), equals(keeper.id));
+        expect(prefs.getString(currentDiverIdKey), equals(keeper.id));
+      },
+    );
   });
 
   group('DiverListNotifier', () {
@@ -387,14 +503,16 @@ void main() {
       expect(byId[b.id]!.isDefault, isTrue);
     });
 
-    test('deleteDiver returns a DeleteDiverResult and clears current selection '
-        'when the deleted diver was current', () async {
+    test('deleteDiver returns a DeleteDiverResult and moves the selection to '
+        'the surviving diver when the deleted diver was current', () async {
       final a = await repo.createDiver(_makeDiver(name: 'A'));
-      await repo.createDiver(_makeDiver(name: 'B'));
+      final b = await repo.createDiver(_makeDiver(name: 'B'));
       await prefs.setString(currentDiverIdKey, a.id);
 
       final container = makeContainer();
       addTearDown(container.dispose);
+      final sub = container.listen(currentDiverIdProvider, (_, _) {});
+      addTearDown(sub.close);
 
       // Wait for init.
       while (container.read(diverListNotifierProvider).isLoading) {
@@ -406,8 +524,10 @@ void main() {
           .deleteDiver(a.id);
       expect(result.hasReassignments, isFalse);
 
-      // Current diver id cleared once its diver was deleted.
-      expect(container.read(currentDiverIdProvider), isNull);
+      // The selection is not left dangling or null: deleteDiver re-resolves
+      // before returning, so the survivor is current already (#1342).
+      expect(container.read(currentDiverIdProvider), equals(b.id));
+      expect(prefs.getString(currentDiverIdKey), equals(b.id));
     });
 
     test('updateDiver persists changes via notifier', () async {
@@ -448,6 +568,48 @@ void main() {
       // The notifier should resolve to the id from the Settings table.
       expect(container.read(currentDiverIdProvider), equals(d.id));
     });
+  });
+
+  group('realignActiveDiverAfterDataReplace', () {
+    test(
+      'removes a dangling pref when nothing resolves (issue #1342)',
+      () async {
+        // A restore swapped the database file but SharedPreferences still
+        // names a diver from the previous library, and the restored library
+        // has no diver to fall back to. Leaving the pref in place would seed
+        // the next launch with an id that scopes every dive query to nothing.
+        await prefs.setString(currentDiverIdKey, 'ghost');
+
+        await realignActiveDiverAfterDataReplace(prefs);
+
+        expect(prefs.getString(currentDiverIdKey), isNull);
+      },
+    );
+
+    test('replaces a dangling pref with the default diver', () async {
+      final fallback = await repo.createDiver(
+        _makeDiver(name: 'Default', isDefault: true),
+      );
+      await prefs.setString(currentDiverIdKey, 'ghost');
+
+      await realignActiveDiverAfterDataReplace(prefs);
+
+      expect(prefs.getString(currentDiverIdKey), equals(fallback.id));
+    });
+
+    test(
+      'prefers the restored settings active diver over the default',
+      () async {
+        await repo.createDiver(_makeDiver(name: 'Default', isDefault: true));
+        final restored = await repo.createDiver(_makeDiver(name: 'Restored'));
+        await repo.setActiveDiverIdInSettings(restored.id);
+        await prefs.setString(currentDiverIdKey, 'ghost');
+
+        await realignActiveDiverAfterDataReplace(prefs);
+
+        expect(prefs.getString(currentDiverIdKey), equals(restored.id));
+      },
+    );
   });
 
   group('diverMergeRepositoryProvider & duplicateDiverGroupsProvider', () {


### PR DESCRIPTION
## Summary

Fixes #1342.

`current_diver_id` (SharedPreferences) could name a diver that no longer exists: a duplicate merged away, a replace-adopt or a restore that changed the id space, or a sync tombstone. Every dive-list query scopes on `dives.diver_id = ?` with no fallback, so the logbook rendered empty, and because the validator only ever wrote when it resolved something, the dangling id survived relaunches. Restoring a backup did not fix it either: the realign helper never removed the pref and never reached the live notifier.

This makes the source of truth self-healing instead of patching each reader. `CurrentDiverIdNotifier` now clears an id it knows is dangling, re-validates whenever the `divers` table changes, and logs instead of swallowing failures. With that in place all eight raw `currentDiverIdProvider` reads in `dive_providers.dart` are repaired at once. They were deliberately not switched to `validatedCurrentDiverIdProvider`: awaiting that `FutureProvider` would rebuild each of them on every divers-table tick (a loading flash) for no additional safety once the notifier itself is validated.

## Changes

- `CurrentDiverIdNotifier._validateAndSync`: when nothing resolves (pref, Settings-table pointer, default diver) the id is removed from state and prefs; null already means "unscoped" to every other diver-scoped repository. The Settings row is written only when it differs and is never deleted (a stale pointer there is validated on read and may name the right diver again once a replace finishes refilling the table). A result computed before the user switched diver no longer overwrites the switch: `state` is re-checked after each await, and if it moved while the prefs write was in flight the newer state is re-persisted rather than left clobbered. Failures are logged with the id that was kept, instead of `catch (_) {}`.
- The notifier subscribes to `watchDiversChanges()` (a raw stream, so it heals even with no watcher) and re-validates on every tick. A merge, an adopt, or a sync-applied deletion therefore repairs the live notifier without a restart. The subscription is guarded like the validation, so a notifier built without a database (tests) still serves the stored id.
- `realignActiveDiverAfterDataReplace`: removes a dangling pref when nothing resolves and logs failures.
- `DiverMergeRepository.mergeDivers`: repoints `settings.active_diver_id` to the keeper inside the merge transaction, so the notifier lands on the keeper rather than whichever diver happens to be default. Undo leaves the selection on the keeper (still a valid profile). `DiverRepository.activeDiverIdSettingsKey` is now public for this.
- `DiverListNotifier.deleteDiver`: re-resolves the selection (Settings pointer, then default) through `setCurrentDiver` instead of leaving it null. Leaving it null raced the tick-driven repair, so the final state depended on timing.

Not in this PR: `getDefaultDiver()` falling back to the oldest profile (which can be a zero-dive one after a cross-device sync), and the silent no-op restore on a missing source file (#1344).

## Test Plan

- [x] `flutter test` passes (full suite)
- [x] `flutter analyze` passes
- [x] Manual testing on: not run; the behaviour is covered by the provider and repository tests below

New tests. The notifier, `deleteDiver`, realign-removal and merge-repoint cases fail without the fix, in exactly the way the issue describes; the two remaining realign cases pin existing behaviour.

- notifier: clears a dangling id from state and prefs when no diver resolves; replaces it with the default diver in every store; revalidates when the active diver is deleted straight from the DB; follows a merge to the keeper when the active diver was the duplicate
- `deleteDiver` moves the selection to the survivor before returning
- `realignActiveDiverAfterDataReplace` removes a dangling pref; prefers the restored Settings pointer over the default
- `mergeDivers` repoints `settings.active_diver_id` only when it named the duplicate
