### PR TITLE
sync: adopt and retirement-rejoin honor the schema compatibility floor (#1341)

### DIFF
--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -8,7 +8,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart'
-    show SyncRecord, DeletionLogData;
+    show AppDatabase, SyncRecord, DeletionLogData;
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -2981,6 +2981,23 @@ class SyncService {
       currentEpochId,
       excludeDeviceIds: retiredPeers,
     );
+    if (sources.newerSchemaPeerDeviceIds.isNotEmpty) {
+      // Held (#1341): stay fenced. The cloud library exists but was published
+      // from a newer schema, so rebuilding from it would apply what pull
+      // holds, and the re-establish below would push the stale rows the fence
+      // exists to keep out. Marker and local state are left as they are; the
+      // rejoin runs once this device updates.
+      _log.warning(
+        'Retirement fence held: the cloud library was published from a newer '
+        'schema by ${sources.newerSchemaPeerDeviceIds}',
+      );
+      return SyncResult(
+        status: SyncResultStatus.error,
+        message: _l10n.settings_cloudSync_result_cloudLibraryNewerSchema,
+        newerSchemaPeerDeviceIds: sources.newerSchemaPeerDeviceIds,
+        newerSchemaPeerNames: sources.newerSchemaPeerNames,
+      );
+    }
     if (sources.baseFilePaths.isEmpty) {
       // No readable library to rebuild from. Re-establish from the local
       // library instead of bricking (mirrors _recoverUnreadableEpoch): drop
@@ -3135,6 +3152,23 @@ class SyncService {
         folderId,
         marker.epochId,
       );
+      if (sources.newerSchemaPeerDeviceIds.isNotEmpty) {
+        // Held (#1341): the epoch library was published across a breaking
+        // schema change this build predates, so adopting it would apply what
+        // pull holds. Decided before the empty-set branch below, which would
+        // otherwise read a held library as unreadable and re-establish from
+        // local. Nothing changes locally; adopt succeeds after the update.
+        _log.warning(
+          'Adopt held: epoch ${marker.epochId} was published from a newer '
+          'schema by ${sources.newerSchemaPeerDeviceIds}',
+        );
+        return SyncResult(
+          status: SyncResultStatus.error,
+          message: _l10n.settings_cloudSync_result_cloudLibraryNewerSchema,
+          newerSchemaPeerDeviceIds: sources.newerSchemaPeerDeviceIds,
+          newerSchemaPeerNames: sources.newerSchemaPeerNames,
+        );
+      }
       if (sources.baseFilePaths.isEmpty) {
         // No current-format library for this epoch. If the marker is stale
         // (old-format backend or an orphaned replace), re-establish from the
@@ -3425,12 +3459,23 @@ class SyncService {
   /// Replaces the old in-memory collect that decoded every device's whole base
   /// into RAM and OOM-crashed iOS adopting a large library (#358). The caller
   /// owns the returned temp files and must delete them.
+  ///
+  /// Compatibility floor (#1341): an epoch device whose declared floor exceeds
+  /// this build's schema is held exactly as ChangesetReader.pull holds it and
+  /// reported in `newerSchemaPeerDeviceIds`. Pull can hold one peer and merge
+  /// the rest because it is additive; both callers here are delete-all-refill,
+  /// so a partial refill would drop every row that lives only in the held
+  /// base. A held peer therefore voids the whole collection: no bases are
+  /// returned (any already assembled are deleted here), and the caller must
+  /// abort rather than read the empty set as "no library".
   Future<
     ({
       List<String> baseFilePaths,
       List<int> baseExportedAt,
       List<SyncPayload> changesets,
       List<({String deviceId, int baseSeq, int appliedThrough})> cursors,
+      Set<String> newerSchemaPeerDeviceIds,
+      Map<String, String> newerSchemaPeerNames,
     })
   >
   _collectEpochBaseSources(
@@ -3453,6 +3498,8 @@ class SyncService {
     final baseExportedAt = <int>[];
     final changesets = <SyncPayload>[];
     final cursors = <({String deviceId, int baseSeq, int appliedThrough})>[];
+    final newerSchemaPeerDeviceIds = <String>{};
+    final newerSchemaPeerNames = <String, String>{};
     for (final deviceId in deviceIds) {
       if (excludeDeviceIds.contains(deviceId)) continue;
       final manifestFile = byName[ChangesetLogLayout.manifestName(deviceId)];
@@ -3468,6 +3515,23 @@ class SyncService {
       if (manifest.epochId != epochId) continue;
       final baseSeq = manifest.baseSeq;
       if (baseSeq == null) continue;
+      // Compatibility-floor filter, the adopt-side twin of the one in
+      // ChangesetReader.pull: a manifest's schemaVersion is its writer's
+      // AppDatabase.minimumCompatibleSchemaVersion. Checked after the base
+      // check because a base-less peer contributes nothing to adopt either
+      // way (pull holds its changesets on its own).
+      final peerSchema = manifest.schemaVersion;
+      if (peerSchema != null && peerSchema > AppDatabase.currentSchemaVersion) {
+        newerSchemaPeerDeviceIds.add(deviceId);
+        final name = manifest.deviceName;
+        if (name != null && name.isNotEmpty) {
+          newerSchemaPeerNames[deviceId] = name;
+        }
+        continue;
+      }
+      // Once any peer is held the collection is void: keep scanning manifests
+      // only to name every held peer, and fetch no more bases.
+      if (newerSchemaPeerDeviceIds.isNotEmpty) continue;
       final partCount = manifest.basePartCount ?? 0;
       if (partCount <= 0) continue;
       final path = await _baseSink.assemble(
@@ -3503,11 +3567,26 @@ class SyncService {
         appliedThrough: appliedThrough,
       ));
     }
+    if (newerSchemaPeerDeviceIds.isNotEmpty) {
+      for (final path in baseFilePaths) {
+        await _baseSink.deleteQuietly(path);
+      }
+      return (
+        baseFilePaths: const <String>[],
+        baseExportedAt: const <int>[],
+        changesets: const <SyncPayload>[],
+        cursors: const <({String deviceId, int baseSeq, int appliedThrough})>[],
+        newerSchemaPeerDeviceIds: newerSchemaPeerDeviceIds,
+        newerSchemaPeerNames: newerSchemaPeerNames,
+      );
+    }
     return (
       baseFilePaths: baseFilePaths,
       baseExportedAt: baseExportedAt,
       changesets: changesets,
       cursors: cursors,
+      newerSchemaPeerDeviceIds: newerSchemaPeerDeviceIds,
+      newerSchemaPeerNames: newerSchemaPeerNames,
     );
   }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "فشل اعتماد المكتبة المستعادة: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "تعذّرت قراءة المكتبة السابقة؛ وأُعيد إنشاء هذه الخدمة من مكتبة هذا الجهاز.",
   "settings_cloudSync_result_replacementStillUploading": "لا يزال رفع المكتبة المستبدَلة جاريًا. حاول مرة أخرى بعد قليل.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "تم نشر مكتبة السحابة بواسطة إصدار أحدث من Submersion. حدِّث هذا الجهاز ثم حاول مرة أخرى.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, zero{فشل تطبيق {count} سجل} one{فشل تطبيق سجل واحد} two{فشل تطبيق سجلين} few{فشل تطبيق {count} سجلات} many{فشل تطبيق {count} سجلًا} other{فشل تطبيق {count} سجل}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "كان جهاز آخر يتزامن باستخدام هوية هذا الجهاز. اعتمد هذا الجهاز هوية جديدة ودمج بيانات السحابة.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} غير متاح على هذا الجهاز",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Wiederhergestellte Bibliothek konnte nicht übernommen werden: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "Die vorherige Bibliothek konnte nicht gelesen werden; dieses Backend wurde aus der Bibliothek dieses Geräts neu eingerichtet.",
   "settings_cloudSync_result_replacementStillUploading": "Die ersetzte Bibliothek wird noch hochgeladen. Versuchen Sie es in Kürze erneut.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "Die Cloud-Bibliothek wurde von einer neueren Version von Submersion veröffentlicht. Aktualisieren Sie dieses Gerät und versuchen Sie es dann erneut.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 Datensatz konnte nicht angewendet werden} other{{count} Datensätze konnten nicht angewendet werden}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Ein anderes Gerät hat mit der Identität dieses Geräts synchronisiert. Dieses Gerät hat eine neue Identität übernommen und die Cloud-Daten zusammengeführt.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} ist auf diesem Gerät nicht verfügbar",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -18953,6 +18953,7 @@
   "settings_cloudSync_result_adoptFailed": "Failed to adopt the restored library: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "The previous library could not be read; re-established this backend from this device's library.",
   "settings_cloudSync_result_replacementStillUploading": "The replaced library is still uploading. Try again shortly.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "The cloud library was published by a newer version of Submersion. Update this device, then try again.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 record failed to apply} other{{count} records failed to apply}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Another device was syncing with this device's identity. This device adopted a new identity and merged the cloud data.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} is not available on this device",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "No se pudo adoptar la biblioteca restaurada: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "No se pudo leer la biblioteca anterior; este servicio se restableció a partir de la biblioteca de este dispositivo.",
   "settings_cloudSync_result_replacementStillUploading": "La biblioteca reemplazada aún se está subiendo. Inténtalo de nuevo en un momento.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "La biblioteca en la nube fue publicada por una versión más reciente de Submersion. Actualiza este dispositivo y vuelve a intentarlo.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{No se pudo aplicar 1 registro} other{No se pudieron aplicar {count} registros}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Otro dispositivo se estaba sincronizando con la identidad de este dispositivo. Este dispositivo adoptó una identidad nueva y combinó los datos de la nube.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} no está disponible en este dispositivo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Échec de l’adoption de la bibliothèque restaurée : {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "La bibliothèque précédente n’a pas pu être lue ; ce service a été rétabli à partir de la bibliothèque de cet appareil.",
   "settings_cloudSync_result_replacementStillUploading": "La bibliothèque remplacée est encore en cours d’envoi. Réessayez dans un instant.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "La bibliothèque cloud a été publiée par une version plus récente de Submersion. Mettez à jour cet appareil, puis réessayez.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 enregistrement n’a pas pu être appliqué} other{{count} enregistrements n’ont pas pu être appliqués}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Un autre appareil se synchronisait avec l’identité de cet appareil. Cet appareil a adopté une nouvelle identité et a fusionné les données du cloud.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} n’est pas disponible sur cet appareil",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "אימוץ הספרייה המשוחזרת נכשל: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "לא ניתן היה לקרוא את הספרייה הקודמת; השירות הזה הוקם מחדש מהספרייה של מכשיר זה.",
   "settings_cloudSync_result_replacementStillUploading": "הספרייה שהוחלפה עדיין בהעלאה. נסה שוב בעוד רגע.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "ספריית הענן פורסמה על ידי גרסה חדשה יותר של Submersion. עדכן מכשיר זה ונסה שוב.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, one{החלת רשומה אחת נכשלה} two{החלת שתי רשומות נכשלה} many{החלת {count} רשומות נכשלה} other{החלת {count} רשומות נכשלה}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "מכשיר אחר סנכרן באמצעות הזהות של מכשיר זה. מכשיר זה אימץ זהות חדשה ומיזג את נתוני הענן.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} אינו זמין במכשיר זה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Nem sikerült átvenni a visszaállított könyvtárat: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "A korábbi könyvtár nem volt olvasható; ez a szolgáltató ennek az eszköznek a könyvtárából lett újra létrehozva.",
   "settings_cloudSync_result_replacementStillUploading": "A lecserélt könyvtár feltöltése még folyamatban van. Próbálja újra rövidesen.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "A felhőkönyvtárat a Submersion egy újabb verziója tette közzé. Frissítse ezt az eszközt, majd próbálja újra.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 rekordot nem sikerült alkalmazni} other{{count} rekordot nem sikerült alkalmazni}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Egy másik eszköz ennek az eszköznek az azonosságával szinkronizált. Ez az eszköz új azonosságot vett fel, és egyesítette a felhőben lévő adatokat.",
   "settings_cloudSync_launchCheck_unavailable": "A(z) {provider} nem érhető el ezen az eszközön",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Impossibile adottare la libreria ripristinata: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "Non è stato possibile leggere la libreria precedente; questo servizio è stato ristabilito dalla libreria di questo dispositivo.",
   "settings_cloudSync_result_replacementStillUploading": "La libreria sostituita è ancora in fase di caricamento. Riprova tra poco.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "La libreria cloud è stata pubblicata da una versione più recente di Submersion. Aggiorna questo dispositivo e riprova.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 record non è stato applicato} other{{count} record non sono stati applicati}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Un altro dispositivo si stava sincronizzando con l’identità di questo dispositivo. Questo dispositivo ha adottato una nuova identità e ha unito i dati del cloud.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} non è disponibile su questo dispositivo",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -55370,6 +55370,12 @@ abstract class AppLocalizations {
   /// **'The replaced library is still uploading. Try again shortly.'**
   String get settings_cloudSync_result_replacementStillUploading;
 
+  /// No description provided for @settings_cloudSync_result_cloudLibraryNewerSchema.
+  ///
+  /// In en, this message translates to:
+  /// **'The cloud library was published by a newer version of Submersion. Update this device, then try again.'**
+  String get settings_cloudSync_result_cloudLibraryNewerSchema;
+
   /// No description provided for @settings_cloudSync_result_recordsFailed.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -33338,6 +33338,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا يزال رفع المكتبة المستبدَلة جاريًا. حاول مرة أخرى بعد قليل.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'تم نشر مكتبة السحابة بواسطة إصدار أحدث من Submersion. حدِّث هذا الجهاز ثم حاول مرة أخرى.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -33602,6 +33602,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die ersetzte Bibliothek wird noch hochgeladen. Versuchen Sie es in Kürze erneut.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'Die Cloud-Bibliothek wurde von einer neueren Version von Submersion veröffentlicht. Aktualisieren Sie dieses Gerät und versuchen Sie es dann erneut.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -33147,6 +33147,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'The replaced library is still uploading. Try again shortly.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'The cloud library was published by a newer version of Submersion. Update this device, then try again.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -33717,6 +33717,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'La biblioteca reemplazada aún se está subiendo. Inténtalo de nuevo en un momento.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'La biblioteca en la nube fue publicada por una versión más reciente de Submersion. Actualiza este dispositivo y vuelve a intentarlo.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -33768,6 +33768,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'La bibliothèque remplacée est encore en cours d’envoi. Réessayez dans un instant.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'La bibliothèque cloud a été publiée par une version plus récente de Submersion. Mettez à jour cet appareil, puis réessayez.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -32995,6 +32995,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'הספרייה שהוחלפה עדיין בהעלאה. נסה שוב בעוד רגע.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'ספריית הענן פורסמה על ידי גרסה חדשה יותר של Submersion. עדכן מכשיר זה ונסה שוב.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -33546,6 +33546,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'A lecserélt könyvtár feltöltése még folyamatban van. Próbálja újra rövidesen.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'A felhőkönyvtárat a Submersion egy újabb verziója tette közzé. Frissítse ezt az eszközt, majd próbálja újra.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -33670,6 +33670,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'La libreria sostituita è ancora in fase di caricamento. Riprova tra poco.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'La libreria cloud è stata pubblicata da una versione più recente di Submersion. Aggiorna questo dispositivo e riprova.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -33441,6 +33441,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'De vervangen bibliotheek wordt nog geüpload. Probeer het zo meteen opnieuw.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'De cloudbibliotheek is gepubliceerd door een nieuwere versie van Submersion. Werk dit apparaat bij en probeer het daarna opnieuw.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -33684,6 +33684,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'A biblioteca substituída ainda está sendo enviada. Tente novamente em instantes.';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      'A biblioteca na nuvem foi publicada por uma versão mais recente do Submersion. Atualize este dispositivo e tente novamente.';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -31720,6 +31720,10 @@ class AppLocalizationsZh extends AppLocalizations {
       '被替换的资料库仍在上传中。请稍后重试。';
 
   @override
+  String get settings_cloudSync_result_cloudLibraryNewerSchema =>
+      '云端资料库由较新版本的 Submersion 发布。请更新此设备后重试。';
+
+  @override
   String settings_cloudSync_result_recordsFailed(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Kan de herstelde bibliotheek niet overnemen: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "De vorige bibliotheek kon niet worden gelezen; deze provider is opnieuw ingericht vanuit de bibliotheek van dit apparaat.",
   "settings_cloudSync_result_replacementStillUploading": "De vervangen bibliotheek wordt nog geüpload. Probeer het zo meteen opnieuw.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "De cloudbibliotheek is gepubliceerd door een nieuwere versie van Submersion. Werk dit apparaat bij en probeer het daarna opnieuw.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 record kon niet worden toegepast} other{{count} records konden niet worden toegepast}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Een ander apparaat synchroniseerde met de identiteit van dit apparaat. Dit apparaat heeft een nieuwe identiteit overgenomen en de cloudgegevens samengevoegd.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} is niet beschikbaar op dit apparaat",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "Falha ao adotar a biblioteca restaurada: {error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "Não foi possível ler a biblioteca anterior; este provedor foi restabelecido a partir da biblioteca deste dispositivo.",
   "settings_cloudSync_result_replacementStillUploading": "A biblioteca substituída ainda está sendo enviada. Tente novamente em instantes.",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "A biblioteca na nuvem foi publicada por uma versão mais recente do Submersion. Atualize este dispositivo e tente novamente.",
   "settings_cloudSync_result_recordsFailed": "{count, plural, =1{1 registro não pôde ser aplicado} other{{count} registros não puderam ser aplicados}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "Outro dispositivo estava sincronizando com a identidade deste dispositivo. Este dispositivo adotou uma nova identidade e mesclou os dados da nuvem.",
   "settings_cloudSync_launchCheck_unavailable": "{provider} não está disponível neste dispositivo",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -9866,6 +9866,7 @@
   "settings_cloudSync_result_adoptFailed": "采用恢复的资料库失败：{error}",
   "settings_cloudSync_result_previousLibraryUnreadable": "无法读取先前的资料库；已根据本设备的资料库重新建立此后端。",
   "settings_cloudSync_result_replacementStillUploading": "被替换的资料库仍在上传中。请稍后重试。",
+  "settings_cloudSync_result_cloudLibraryNewerSchema": "云端资料库由较新版本的 Submersion 发布。请更新此设备后重试。",
   "settings_cloudSync_result_recordsFailed": "{count, plural, other{{count} 条记录应用失败}}",
   "settings_cloudSync_result_adoptedFreshIdentity": "另一台设备正在使用本设备的身份同步。本设备已采用新身份，并合并了云端数据。",
   "settings_cloudSync_launchCheck_unavailable": "{provider} 在此设备上不可用",

--- a/test/core/services/sync/sync_retirement_fence_test.dart
+++ b/test/core/services/sync/sync_retirement_fence_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
 import 'package:submersion/core/services/sync/changeset_log/retirement_marker.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 import '../../../helpers/changeset_test_helpers.dart';
 import '../../../helpers/mock_providers.dart';
@@ -151,6 +153,72 @@ void main() {
         names.where((n) => ChangesetLogLayout.deviceIdOf(n) == deviceId),
         isNotEmpty,
         reason: 'device republishes its library',
+      );
+    },
+  );
+
+  test(
+    'fence stays closed when the cloud library is from a newer schema (#1341)',
+    () async {
+      final cloud = FakeCloudStorageProvider();
+      final folder = await cloud.getOrCreateSyncFolder();
+      // The current cloud library: peer-1 holds 'keep-1'.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'keep-1', diveNumber: 1),
+      );
+      await seedPeerLog(cloud, 'peer-1'); // resets the local DB afterwards
+      final svc = SyncService(
+        syncRepository: SyncRepository(),
+        serializer: SyncDataSerializer(),
+        cloudProvider: cloud,
+      );
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'stale-1', diveNumber: 2),
+      );
+      expect((await svc.performSync()).status, SyncResultStatus.success);
+
+      // Retired while away; meanwhile peer-1 moved to a newer build whose
+      // compatibility floor this build does not meet.
+      final deviceId = await SyncRepository().getDeviceId();
+      await svc.deleteDeviceSyncFile(deviceId);
+      await cloud.uploadFile(
+        RetirementMarker(deviceId: deviceId, retiredAt: 1).toBytes(),
+        ChangesetLogLayout.retiredMarkerName(deviceId),
+        folderId: folder,
+      );
+      await restampPeerSchemaVersion(
+        cloud,
+        'peer-1',
+        schemaVersion: AppDatabase.currentSchemaVersion + 1,
+      );
+
+      final result = await svc.performSync();
+
+      expect(result.status, SyncResultStatus.error);
+      expect(
+        result.message,
+        l10nForLocaleTag(
+          'en',
+        ).settings_cloudSync_result_cloudLibraryNewerSchema,
+      );
+      expect(result.newerSchemaPeerDeviceIds, {'peer-1'});
+      // Neither rebuilt from the held library nor re-established from local:
+      // rows untouched, the marker still fences us, nothing republished.
+      expect(await hasDive('keep-1'), isTrue);
+      expect(await hasDive('stale-1'), isTrue);
+      final names = (await cloud.listFiles(
+        folderId: folder,
+        namePattern: ChangesetLogLayout.prefix,
+      )).map((f) => f.name).toList();
+      expect(names, contains(ChangesetLogLayout.retiredMarkerName(deviceId)));
+      expect(
+        names.where(
+          (n) =>
+              ChangesetLogLayout.deviceIdOf(n) == deviceId &&
+              !ChangesetLogLayout.isRetiredMarker(n),
+        ),
+        isEmpty,
+        reason: 'a fenced device must not republish its stale library',
       );
     },
   );

--- a/test/core/services/sync/sync_service_epoch_test.dart
+++ b/test/core/services/sync/sync_service_epoch_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
@@ -15,6 +16,7 @@ import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/sync_initializer.dart';
 import 'package:submersion/core/services/sync/sync_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
 import '../../../helpers/changeset_test_helpers.dart';
 import '../../../helpers/fake_cloud_storage_provider.dart';
@@ -603,6 +605,120 @@ void main() {
       expect(result.isSuccess, isFalse);
       expect(result.message, contains('Failed to adopt'));
       expect(await SyncRepository().getLastAcceptedEpochId(), isNull);
+    });
+  });
+
+  group('adoptReplacedLibrary compatibility floor (#1341)', () {
+    const marker = LibraryEpochMarker(
+      epochId: 'e1',
+      replacedAt: 1,
+      deviceId: 'replacer',
+    );
+    final heldMessage = l10nForLocaleTag(
+      'en',
+    ).settings_cloudSync_result_cloudLibraryNewerSchema;
+
+    Future<bool> hasDive(String id) async =>
+        await SyncDataSerializer().fetchRecord('dives', id) != null;
+
+    /// The replacer's current-epoch log carries 'cloud-dive'; after the seed
+    /// (which resets the DB) the local library holds only 'local-only-dive'.
+    Future<void> seedReplacerAndLocal() async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'cloud-dive'),
+      );
+      await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'local-only-dive'),
+      );
+    }
+
+    test('holds, wiping nothing, when the replaced library was published from '
+        'a newer schema', () async {
+      await seedReplacerAndLocal();
+      await restampPeerSchemaVersion(
+        cloud,
+        'replacer',
+        schemaVersion: AppDatabase.currentSchemaVersion + 1,
+      );
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+
+      final result = await service.adoptReplacedLibrary();
+
+      expect(result.status, SyncResultStatus.error);
+      expect(result.message, heldMessage);
+      expect(result.newerSchemaPeerDeviceIds, {'replacer'});
+      // Adopt is delete-all-refill, so a held base must leave the local
+      // library and the epoch bookkeeping exactly as they were.
+      expect(await hasDive('local-only-dive'), isTrue);
+      expect(await hasDive('cloud-dive'), isFalse);
+      expect(await SyncRepository().getLastAcceptedEpochId(), isNull);
+      expect(epochStore.lastAcceptedEpochId, isNull);
+    });
+
+    test('one held base aborts the whole adopt, not just that base', () async {
+      // Two epoch devices: 'replacer' on this build, 'newer' ahead of it.
+      // Pull may hold one peer and merge the rest because it is additive;
+      // adopt may not, because a partial refill drops every row that lives
+      // only in the held base.
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'cloud-dive'),
+      );
+      await seedPeerLog(cloud, 'replacer', epochId: 'e1');
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'newer-dive'),
+      );
+      await seedPeerLog(cloud, 'newer', epochId: 'e1');
+      await restampPeerSchemaVersion(
+        cloud,
+        'newer',
+        schemaVersion: AppDatabase.currentSchemaVersion + 1,
+      );
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'local-only-dive'),
+      );
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+
+      final result = await service.adoptReplacedLibrary();
+
+      expect(result.status, SyncResultStatus.error);
+      expect(result.newerSchemaPeerDeviceIds, {'newer'});
+      expect(await hasDive('local-only-dive'), isTrue);
+      expect(await hasDive('cloud-dive'), isFalse);
+      expect(await hasDive('newer-dive'), isFalse);
+      expect(await SyncRepository().getLastAcceptedEpochId(), isNull);
+    });
+
+    test('a floor at exactly this schema adopts', () async {
+      await seedReplacerAndLocal();
+      await restampPeerSchemaVersion(
+        cloud,
+        'replacer',
+        schemaVersion: AppDatabase.currentSchemaVersion,
+      );
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+
+      final result = await service.adoptReplacedLibrary();
+
+      expect(result.isSuccess, isTrue);
+      expect(result.newerSchemaPeerDeviceIds, isEmpty);
+      expect(await hasDive('cloud-dive'), isTrue);
+      expect(await hasDive('local-only-dive'), isFalse);
+    });
+
+    test('a legacy manifest with no floor adopts', () async {
+      await seedReplacerAndLocal();
+      await restampPeerSchemaVersion(cloud, 'replacer', schemaVersion: null);
+      final service = buildService();
+      await service.writeLibraryEpochMarker(cloud, marker);
+
+      final result = await service.adoptReplacedLibrary();
+
+      expect(result.isSuccess, isTrue);
+      expect(await hasDive('cloud-dive'), isTrue);
     });
   });
 

--- a/test/helpers/changeset_test_helpers.dart
+++ b/test/helpers/changeset_test_helpers.dart
@@ -240,3 +240,32 @@ Future<SyncManifest?> _readManifest(
     return null;
   }
 }
+
+/// Rewrite [peerId]'s published manifest so its compatibility floor reads as
+/// [schemaVersion]; null strips the field, as on a manifest written before it
+/// existed. Lets a test stand in for a peer on a newer (or legacy) build
+/// without touching AppDatabase.currentSchemaVersion.
+Future<void> restampPeerSchemaVersion(
+  CloudStorageProvider cloud,
+  String peerId, {
+  required int? schemaVersion,
+}) async {
+  final folder = await cloud.getOrCreateSyncFolder();
+  final manifestFile = (await cloud.listFiles(
+    folderId: folder,
+    namePattern: ChangesetLogLayout.manifestName(peerId),
+  )).single;
+  final manifest =
+      jsonDecode(utf8.decode(await cloud.downloadFile(manifestFile.id)))
+          as Map<String, dynamic>;
+  if (schemaVersion == null) {
+    manifest.remove('schemaVersion');
+  } else {
+    manifest['schemaVersion'] = schemaVersion;
+  }
+  await cloud.uploadFile(
+    Uint8List.fromList(utf8.encode(jsonEncode(manifest))),
+    manifestFile.name,
+    folderId: folder,
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #1341.

The sync compatibility floor was enforced only in the pull path. `ChangesetReader.pull` holds a peer whose manifest `schemaVersion` (the writer's `minimumCompatibleSchemaVersion`) exceeds this build's schema. `_collectEpochBaseSources` had no such check: it filtered on `epochId`, `baseSeq`, part count and checksums only. Its two callers, `adoptReplacedLibrary` and `_rejoinAfterRetirement`, both clear every synced table and refill from the collected bases, so they refilled from exactly the peer bases pull would have held.

This PR ports the floor check into the collect, makes one held peer abort the whole adopt-family operation, and orders the check ahead of the existing "no bases" recovery branch so a held library is never mistaken for a missing one.

## Changes

- `_collectEpochBaseSources` applies the reader's floor check right after the base check (a base-less peer contributes nothing to adopt either way; pull holds its changesets on its own). Held peers are reported in a new `newerSchemaPeerDeviceIds` / `newerSchemaPeerNames` pair on the returned record.
- One held peer voids the whole collection. Pull can hold one peer and merge the rest because it is additive; adopt is delete-all-refill, so a partial refill would silently drop every row that lives only in the held base. Once a hold is seen the collect stops assembling bases, deletes any it already assembled, and returns an empty base set alongside the held ids.
- `adoptReplacedLibrary` and `_rejoinAfterRetirement` decide "held" **before** their existing empty-set branch. That branch treats "no bases" as "no library" and re-establishes from local: adopt via `_recoverUnreadableEpoch`, the rejoin by deleting the retirement marker and republishing the local library, which is precisely the stale-row resurrection the fence exists to prevent. A held library is readable, just not by this build yet, so both paths now change nothing and return `SyncResultStatus.error` with the held ids/names and a new message, `settings_cloudSync_result_cloudLibraryNewerSchema` (translated in all 11 locales). The adopt or rejoin succeeds once the device updates.
- The gate direction mirrors the reader deliberately. The floor is documented as one-directional (`AppDatabase.minimumCompatibleSchemaVersion`): it protects an older reader from a newer writer, and an older writer's payloads are tolerated on the receiving side by `_withRenamedKeys`. A reverse check here would hold peers that pull accepts.
- `test/helpers/changeset_test_helpers.dart` gains `restampPeerSchemaVersion`, which rewrites a published manifest's floor (or strips it) so a test can stand in for a newer or legacy peer without touching `AppDatabase.currentSchemaVersion`.

Deliberately not in this PR:

- The near-empty-base sanity check the issue floats as a follow-up. A legitimately emptied library must still adopt, so that needs a user confirmation rather than a gate.
- `_rejoinAfterRetirement` not calling `realignActiveDiverAfterDataReplace`. That is #1342's scope.

## Test Plan

- [x] `flutter test` passes (full suite, `--exclude-tags performance`, concurrency 16)
- [x] `flutter analyze` passes (whole project, no issues)
- [x] `dart format --set-exit-if-changed` clean on every changed Dart file
- [x] New tests, written first and observed failing with `Expected: error, Actual: success` before the fix:
  - `sync_service_epoch_test.dart`, group "adoptReplacedLibrary compatibility floor (#1341)": holds wiping nothing when the replaced library is from a newer schema; one held base aborts the whole adopt; a floor at exactly this schema adopts (guards `>` vs `>=`); a legacy manifest with no floor adopts (guards the null check)
  - `sync_retirement_fence_test.dart`: fence stays closed when the cloud library is from a newer schema (local rows untouched, marker still present, nothing republished)
- [ ] Manual testing on: none (requires two devices on different schema versions; covered by the fake-provider tests above)
