### PR TITLE
fix: media uploaded on one device reads as not backed up on another

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/auto_update/presentation/providers/update_me
 import 'package:submersion/features/backup/presentation/pages/restore_complete_page.dart';
 import 'package:submersion/features/backup/presentation/providers/backup_providers.dart';
 import 'package:submersion/features/backup/presentation/widgets/restore_barrier.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_origin_republish_provider.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 import 'package:submersion/features/settings/presentation/providers/sync_providers.dart';
@@ -110,6 +111,7 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _maybeSyncOnLaunch();
       _resumeMediaTransfers();
+      _republishOwnedMedia();
       _fileShareHandler.initialize();
     });
   }
@@ -174,6 +176,15 @@ class _SubmersionAppState extends ConsumerState<SubmersionApp>
   /// callback later still.
   void _resumeMediaTransfers() {
     unawaited(ref.read(mediaTransferResumeProvider)());
+  }
+
+  /// One-time repair of media rows whose cloud stamps a peer dropped before
+  /// the origin-device fix. Launch only: it is flagged after its first
+  /// success, and the provider checks the flag before building anything.
+  /// Same database timing argument as [_resumeMediaTransfers], and the
+  /// provider contains its own failures, so it is safe to leave unawaited.
+  void _republishOwnedMedia() {
+    unawaited(ref.read(mediaOriginRepublishProvider)());
   }
 
   Future<void> _maybeSyncOnLaunch() async {

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -721,6 +721,50 @@ class MediaRepository {
     }
   }
 
+  /// Records the outcome of an explicit check on one row: `lastVerifiedAt`
+  /// always, and the orphan flag only when the check actually learned it
+  /// ([isOrphaned] non-null).
+  ///
+  /// Narrow for the same reason [markVerified] is. `MediaItemVerifier`'s
+  /// callers hold a snapshot of the row, and an upload that completes after
+  /// the snapshot was taken stamps `remoteUploadedAt` on the row; a whole-row
+  /// write from the snapshot ([updateMedia]) would roll that stamp back to
+  /// null, and the pending mark would then sync the rollback fleet-wide.
+  ///
+  /// Unlike [markVerified] this always writes: the user asked for a check
+  /// and the date of that check is the answer, whether or not the flag moved.
+  Future<void> stampVerification(
+    String id, {
+    required DateTime verifiedAt,
+    bool? isOrphaned,
+  }) async {
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await (_db.update(_db.media)..where((t) => t.id.equals(id))).write(
+        MediaCompanion(
+          isOrphaned: isOrphaned == null
+              ? const Value.absent()
+              : Value(isOrphaned),
+          lastVerifiedAt: Value(verifiedAt.millisecondsSinceEpoch),
+          updatedAt: Value(now),
+        ),
+      );
+      await _syncRepository.markRecordPending(
+        entityType: 'media',
+        recordId: id,
+        localUpdatedAt: now,
+      );
+      SyncEventBus.notifyLocalChange();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to stamp verification: $id',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get all orphaned media
   /// Includes enrichment data (depth, temperature) if available
   Future<List<domain.MediaItem>> getOrphanedMedia() async {

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -1766,11 +1766,18 @@ class MediaRepository {
   /// gain protection soonest. Scoped to rows linked to a dive or site so
   /// orphaned rows are never uploaded (orphan-prevention spec section 4.1).
   Future<List<String>> getBackfillCandidateIds() async {
+    // A row another device imported is that device's to upload: this one
+    // cannot read its path, so enqueueing it only manufactures a "source
+    // unavailable" failure. Rows from before origin tracking carry no id
+    // and keep today's verdict.
+    final thisDevice = await _syncRepository.getDeviceId();
     final id = _db.media.id;
     final query = _db.selectOnly(_db.media)
       ..addColumns([id])
       ..where(
         isLinkedToDiveOrSite(_db.media) &
+            (_db.media.originDeviceId.isNull() |
+                _db.media.originDeviceId.equals(thisDevice)) &
             // Photos from any uploadable source.
             ((_db.media.remoteUploadedAt.isNull() &
                     _db.media.remoteCompressedUploadedAt.isNull() &

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -733,6 +733,8 @@ class MediaRepository {
   ///
   /// Unlike [markVerified] this always writes: the user asked for a check
   /// and the date of that check is the answer, whether or not the flag moved.
+  /// Like it, a row that is gone by the time the check lands (deleted during
+  /// a Check all media pass) gets no pending record pointing at nothing.
   Future<void> stampVerification(
     String id, {
     required DateTime verifiedAt,
@@ -740,15 +742,17 @@ class MediaRepository {
   }) async {
     try {
       final now = DateTime.now().millisecondsSinceEpoch;
-      await (_db.update(_db.media)..where((t) => t.id.equals(id))).write(
-        MediaCompanion(
-          isOrphaned: isOrphaned == null
-              ? const Value.absent()
-              : Value(isOrphaned),
-          lastVerifiedAt: Value(verifiedAt.millisecondsSinceEpoch),
-          updatedAt: Value(now),
-        ),
-      );
+      final rowsWritten =
+          await (_db.update(_db.media)..where((t) => t.id.equals(id))).write(
+            MediaCompanion(
+              isOrphaned: isOrphaned == null
+                  ? const Value.absent()
+                  : Value(isOrphaned),
+              lastVerifiedAt: Value(verifiedAt.millisecondsSinceEpoch),
+              updatedAt: Value(now),
+            ),
+          );
+      if (rowsWritten == 0) return;
       await _syncRepository.markRecordPending(
         entityType: 'media',
         recordId: id,

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -765,6 +765,92 @@ class MediaRepository {
     }
   }
 
+  /// Rows this device imported that carry the "missing" flag.
+  ///
+  /// Feeds the one-time origin republish: before the origin-device fix a
+  /// peer could flag a row it never had, and that flag synced back to the
+  /// device that does have the file. Re-checking these here is the only way
+  /// to find out; a peer's rows are that peer's to judge.
+  Future<List<domain.MediaItem>> getOrphanedMediaOwnedBy(
+    String deviceId,
+  ) async {
+    try {
+      final query =
+          _db.select(_db.media).join([
+            leftOuterJoin(
+              _db.mediaEnrichment,
+              _db.mediaEnrichment.mediaId.equalsExp(_db.media.id),
+            ),
+          ])..where(
+            _db.media.isOrphaned.equals(true) &
+                _db.media.originDeviceId.equals(deviceId),
+          );
+      final rows = await query.get();
+      return rows.map((row) {
+        final mediaRow = row.readTable(_db.media);
+        final enrichmentRow = row.readTableOrNull(_db.mediaEnrichment);
+        return mediaItemFromRow(mediaRow, enrichmentRow);
+      }).toList();
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to get orphaned media for device $deviceId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Ids of rows this device imported that carry any media store stamp.
+  ///
+  /// These are the rows whose stamps a peer may have dropped (the
+  /// pending-skip in sync's merge); republishing them hands the stamps back.
+  Future<List<String>> getStoreStampedMediaIdsOwnedBy(String deviceId) async {
+    final id = _db.media.id;
+    final query = _db.selectOnly(_db.media)
+      ..addColumns([id])
+      ..where(
+        _db.media.originDeviceId.equals(deviceId) &
+            (_db.media.remoteUploadedAt.isNotNull() |
+                _db.media.remoteThumbUploadedAt.isNotNull() |
+                _db.media.remoteCompressedUploadedAt.isNotNull()),
+      );
+    final rows = await query.get();
+    return [for (final row in rows) row.read(id)!];
+  }
+
+  /// Marks [ids] pending for sync without changing a column, so the next
+  /// changeset carries the rows exactly as they are. Returns how many.
+  ///
+  /// One transaction: markRecordPending's own per-row transaction nests as a
+  /// savepoint, so a library with thousands of stamped rows commits once.
+  Future<int> republishForSync(Iterable<String> ids) async {
+    final list = ids.toList();
+    if (list.isEmpty) return 0;
+    try {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await _db.transaction(() async {
+        for (final id in list) {
+          await _syncRepository.markRecordPending(
+            entityType: 'media',
+            recordId: id,
+            localUpdatedAt: now,
+          );
+        }
+      });
+      SyncEventBus.notifyLocalChange();
+      _log.info('Republished ${list.length} media rows for sync');
+      return list.length;
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to republish ${list.length} media rows',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Get all orphaned media
   /// Includes enrichment data (depth, temperature) if available
   Future<List<domain.MediaItem>> getOrphanedMedia() async {

--- a/lib/features/media/data/resolvers/local_file_resolver.dart
+++ b/lib/features/media/data/resolvers/local_file_resolver.dart
@@ -64,10 +64,12 @@ class LocalFileResolver implements MediaSourceResolver {
     DateTime Function()? clock,
     MediaFetchGate? gate,
     bool Function()? usesSecurityScopedBookmarks,
+    Future<String?> Function()? localDeviceId,
   }) : _bookmarkStorage = bookmarkStorage,
        _platform = platform,
        _exifExtractor = exifExtractor,
        _videoThumbnails = videoThumbnails,
+       _localDeviceId = localDeviceId,
        _volumeOnline = (volumeStatus ?? VolumeStatus()).newExpiringProbe(
          ttl: volumeProbeTtl,
          clock: clock,
@@ -106,6 +108,15 @@ class LocalFileResolver implements MediaSourceResolver {
   /// file, and the whole point of this resolver on Apple platforms —
   /// unexecuted in CI. Production always gets the real check.
   final bool Function() _usesSecurityScopedBookmarks;
+
+  /// This device's sync id, for telling a file that is gone from one that
+  /// was never here. Null when built without a source (direct construction
+  /// in tests), in which case every row reads as this device's.
+  final Future<String?> Function()? _localDeviceId;
+
+  /// [_localDeviceId]'s answer, memoized once it succeeds. A failed fetch
+  /// (no database open yet) is not cached, so the next resolution asks again.
+  String? _knownDeviceId;
   final _log = LoggerService.forClass(LocalFileResolver);
 
   @override
@@ -113,8 +124,42 @@ class LocalFileResolver implements MediaSourceResolver {
 
   @override
   bool canResolveOnThisDevice(MediaItem item) {
-    // Device-local pointers don't cross machines.
-    return true;
+    // Device-local pointers don't cross machines, and every localFile row
+    // records the device that imported it. This check is synchronous by
+    // contract, so it can only consult an id a resolution has already
+    // fetched; until then it stays optimistic and [resolve], which does
+    // await the id, is the authority.
+    final local = _knownDeviceId;
+    final origin = item.originDeviceId;
+    if (local == null || origin == null) return true;
+    return origin == local;
+  }
+
+  /// Whether [item]'s bytes were imported on a different device.
+  ///
+  /// Only consulted after a read has failed: a shared volume can make
+  /// another device's path readable here, and a file that reads is a file,
+  /// whoever imported it. Rows from before origin tracking carry no id and
+  /// keep the plain verdict.
+  Future<bool> _importedElsewhere(MediaItem item) async {
+    final origin = item.originDeviceId;
+    if (origin == null) return false;
+    final local = await _thisDeviceId();
+    return local != null && origin != local;
+  }
+
+  Future<String?> _thisDeviceId() async {
+    if (_knownDeviceId != null) return _knownDeviceId;
+    final source = _localDeviceId;
+    if (source == null) return null;
+    try {
+      return _knownDeviceId = await source();
+    } on Object catch (e) {
+      // No database yet, or the metadata read failed: "unknown" is not
+      // "elsewhere". The row keeps today's verdict rather than a guess.
+      _log.debug('Local device id unavailable', error: e);
+      return null;
+    }
   }
 
   /// Coalescing key: rows are reference-linked, so the same photo attached to
@@ -146,7 +191,19 @@ class LocalFileResolver implements MediaSourceResolver {
     // always answers, so this fallback cannot be reached; it is written as a
     // total function rather than a `!` so a future change cannot turn a
     // resolver bug into a crash on a grid tile.
-    return data ?? const UnavailableData(kind: UnavailableKind.notFound);
+    final resolved =
+        data ?? const UnavailableData(kind: UnavailableKind.notFound);
+    // Outside the gate: rows sharing a file share the read, but each row
+    // carries its own origin. A dead pointer on the device that imported the
+    // file is a missing file; the same pointer anywhere else is a file this
+    // device never had, and notFound is the one verdict that orphans a row
+    // and syncs that claim back to the device that still has it.
+    if (resolved is UnavailableData &&
+        resolved.kind == UnavailableKind.notFound &&
+        await _importedElsewhere(item)) {
+      return const UnavailableData(kind: UnavailableKind.fromOtherDevice);
+    }
+    return resolved;
   }
 
   Future<MediaSourceData> _resolveInner(MediaItem item) async {
@@ -383,6 +440,11 @@ class LocalFileResolver implements MediaSourceResolver {
     if (data is! UnavailableData) return VerifyResult.available;
     if (data.kind == UnavailableKind.volumeOffline) {
       return VerifyResult.volumeOffline;
+    }
+    // Another device's file: a reachability fact about this device, not a
+    // finding about the bytes. The verifier treats it as such.
+    if (data.kind == UnavailableKind.fromOtherDevice) {
+      return VerifyResult.fromOtherDevice;
     }
     // "Still fetching" is a statement about time, not about whether the file
     // is there: the read outlived the gate's budget and is very likely still

--- a/lib/features/media/data/services/media_item_verifier.dart
+++ b/lib/features/media/data/services/media_item_verifier.dart
@@ -70,15 +70,20 @@ class MediaItemVerifier {
       // fires for every Lightroom row when the account is disconnected, the
       // second for a row whose bytes live on another machine. Orphaning
       // either would report a reachability problem as data loss.
+      //
+      // Narrow writes, never `updateMedia`: [item] is the caller's snapshot,
+      // and an upload finishing after it was taken has stamped the row since.
+      // Writing the snapshot back would roll those stamps to null and sync
+      // the rollback, which is how a second device ends up believing a
+      // backed-up photo has no backup.
       if (result != VerifyResult.available && result != VerifyResult.notFound) {
-        await _repository.updateMedia(item.copyWith(lastVerifiedAt: stamp));
+        await _repository.stampVerification(item.id, verifiedAt: stamp);
         return result;
       }
-      await _repository.updateMedia(
-        item.copyWith(
-          isOrphaned: result == VerifyResult.notFound,
-          lastVerifiedAt: stamp,
-        ),
+      await _repository.stampVerification(
+        item.id,
+        verifiedAt: stamp,
+        isOrphaned: result == VerifyResult.notFound,
       );
     } on Object {
       return VerifyResult.transientError;

--- a/lib/features/media/presentation/providers/media_resolver_providers.dart
+++ b/lib/features/media/presentation/providers/media_resolver_providers.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
 import 'package:submersion/features/media/data/repositories/manifest_subscription_repository.dart';
@@ -103,6 +104,10 @@ final localFileResolverProvider = Provider<LocalFileResolver>(
     platform: ref.watch(localMediaPlatformProvider),
     exifExtractor: ref.watch(exifExtractorProvider),
     videoThumbnails: ref.watch(videoThumbnailServiceProvider),
+    // Fetched lazily, only when a read fails on a row that names an origin,
+    // and memoized by the resolver; the provider itself never touches the
+    // database.
+    localDeviceId: () => SyncRepository().getDeviceId(),
   ),
 );
 

--- a/lib/features/media_store/data/media_origin_republish_sweep.dart
+++ b/lib/features/media_store/data/media_origin_republish_sweep.dart
@@ -1,0 +1,106 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/services/media_item_verifier.dart';
+import 'package:submersion/features/media/domain/value_objects/verify_result.dart';
+
+/// What one run of [MediaOriginRepublishSweep] did.
+typedef MediaOriginRepublishOutcome = ({
+  /// Own rows that carried the "missing" flag and were re-checked.
+  int rechecked,
+
+  /// Of those, rows whose file turned out to be present, so the flag came off.
+  int unflagged,
+
+  /// Own store-stamped rows marked pending so peers receive the stamps again.
+  int republished,
+});
+
+/// One-time repair for libraries damaged before the origin-device fix.
+///
+/// Until `LocalFileResolver` honoured `originDeviceId`, a device that merely
+/// rendered another device's local-file row flagged it "missing". That write
+/// made the row locally pending, and sync's merge skips a peer's copy of any
+/// pending row, so the importing device's cloud stamps (`remoteUploadedAt`
+/// and friends) were dropped on arrival and never re-sent. The importing
+/// device still has the stamps, and usually the peer's flag as well.
+///
+/// So, once per device: re-check every own row that carries the flag (a
+/// present file clears it, through the verifier's own write discipline), and
+/// mark every own store-stamped row pending so the next changeset carries
+/// the stamps to every peer. Peers apply them as long as nothing is pending
+/// on their side, which the resolver fix guarantees for rows they do not own.
+///
+/// Rows another device imported are left alone in both steps: this device
+/// cannot read them and has nothing of theirs to republish.
+///
+/// Flagged in SharedPreferences like `AccountStartupMigration`: the flag is
+/// set only after both steps succeed, so a failed launch retries. Every step
+/// is idempotent (a re-check writes the same verdict; a republish only bumps
+/// the row's clock).
+class MediaOriginRepublishSweep {
+  MediaOriginRepublishSweep({
+    required MediaRepository mediaRepository,
+    required MediaItemVerifier verifier,
+    required Future<String> Function() deviceId,
+    required SharedPreferences prefs,
+  }) : _mediaRepository = mediaRepository,
+       _verifier = verifier,
+       _deviceId = deviceId,
+       _prefs = prefs;
+
+  static const String doneFlagKey = 'media_origin_republish_v1';
+
+  /// Whether this device has already done the repair. Cheap, so callers can
+  /// ask before building anything the sweep would need.
+  static bool isDone(SharedPreferences prefs) =>
+      prefs.getBool(doneFlagKey) ?? false;
+
+  final MediaRepository _mediaRepository;
+  final MediaItemVerifier _verifier;
+  final Future<String> Function() _deviceId;
+  final SharedPreferences _prefs;
+  final _log = LoggerService.forClass(MediaOriginRepublishSweep);
+
+  /// Runs the repair, or returns null when it already ran or could not
+  /// complete (logged; the flag stays unset so the next launch retries).
+  Future<MediaOriginRepublishOutcome?> run() async {
+    if (isDone(_prefs)) return null;
+    try {
+      final me = await _deviceId();
+
+      final flagged = await _mediaRepository.getOrphanedMediaOwnedBy(me);
+      var unflagged = 0;
+      for (final item in flagged) {
+        // verify never throws by contract; it persists the verdict itself.
+        if (await _verifier.verify(item) == VerifyResult.available) {
+          unflagged++;
+        }
+      }
+
+      final republished = await _mediaRepository.republishForSync(
+        await _mediaRepository.getStoreStampedMediaIdsOwnedBy(me),
+      );
+
+      await _prefs.setBool(doneFlagKey, true);
+      final outcome = (
+        rechecked: flagged.length,
+        unflagged: unflagged,
+        republished: republished,
+      );
+      _log.info(
+        'Origin republish done: rechecked ${outcome.rechecked}, '
+        'unflagged ${outcome.unflagged}, republished ${outcome.republished}',
+      );
+      return outcome;
+    } on Object catch (e, stackTrace) {
+      _log.error(
+        'Origin republish failed; will retry next launch',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+}

--- a/lib/features/media_store/data/media_upload_pipeline.dart
+++ b/lib/features/media_store/data/media_upload_pipeline.dart
@@ -101,7 +101,16 @@ class MediaUploadPipeline {
     var latestResumeJson = entry.resumeStateJson;
     String? resumableUploadKey;
     try {
-      staged = await _materialize(item);
+      final source = await _registry.resolverFor(item.sourceType).resolve(item);
+      if (source is UnavailableData &&
+          source.kind == UnavailableKind.fromOtherDevice) {
+        // The device that imported this file is the one that uploads it.
+        // Nothing here can ever read the bytes, so the entry finishes now
+        // rather than parking in Transfers as a failure that retries daily.
+        await _queue.markDone(entry.id);
+        return UploadOutcome.skippedIneligible;
+      }
+      staged = await _stage(source);
       if (staged == null) {
         // Resolution failure is rate-limited on a 24h/3d/7d clock of its own,
         // so retrying on the queue's minute-scale ladder would consume the
@@ -351,10 +360,9 @@ class MediaUploadPipeline {
     return resolver.canResolveOnThisDevice(item);
   }
 
-  /// Resolves the item's bytes to a private temp file the pipeline owns.
-  Future<File?> _materialize(MediaItem item) async {
-    final resolver = _registry.resolverFor(item.sourceType);
-    final data = await resolver.resolve(item);
+  /// Copies resolved bytes to a private temp file the pipeline owns, or null
+  /// when there are none to copy.
+  Future<File?> _stage(MediaSourceData data) async {
     switch (data) {
       case FileData(file: final f):
         final staged = await _cache.stagingFile();

--- a/lib/features/media_store/data/media_verify_service.dart
+++ b/lib/features/media_store/data/media_verify_service.dart
@@ -6,7 +6,16 @@ import 'package:submersion/features/media_store/data/media_transfer_queue_reposi
 
 /// Outcome of one Verify Library run (orphan-prevention spec 6.3).
 class VerifyLibraryReport {
+  /// Every stored object the sweep listed, across all three namespaces.
+  ///
+  /// A photo is stored as an original plus a thumbnail, and as a rendition
+  /// too when it was compressed, so this is two to three times the number
+  /// of photos. The per-namespace counts below are what make it explainable
+  /// to someone who knows how many photos they have.
   final int objectsChecked;
+  final int originalsChecked;
+  final int thumbsChecked;
+  final int renditionsChecked;
   final int orphansRemoved;
   final int bytesReclaimed;
   final int sessionsAborted;
@@ -14,6 +23,9 @@ class VerifyLibraryReport {
 
   const VerifyLibraryReport({
     required this.objectsChecked,
+    required this.originalsChecked,
+    required this.thumbsChecked,
+    required this.renditionsChecked,
     required this.orphansRemoved,
     required this.bytesReclaimed,
     required this.sessionsAborted,
@@ -87,8 +99,11 @@ class MediaVerifyService {
     final presentThumbs = <String>{};
     final presentRenditions = <String>{};
 
-    Future<void> sweepNamespace(String prefix, Set<String> present) async {
+    /// Returns how many objects the namespace listed.
+    Future<int> sweepNamespace(String prefix, Set<String> present) async {
+      var listed = 0;
       await for (final info in _store.list(prefix)) {
+        listed++;
         objectsChecked++;
         onProgress?.call(objectsChecked);
         final hash = _hashFromKey(info.key, prefix);
@@ -107,11 +122,18 @@ class MediaVerifyService {
           _log.warning('Verify sweep delete failed for ${info.key}', error: e);
         }
       }
+      return listed;
     }
 
-    await sweepNamespace(_objectsPrefix, presentOriginals);
-    await sweepNamespace(_thumbsPrefix, presentThumbs);
-    await sweepNamespace(_renditionsPrefix, presentRenditions);
+    final originalsChecked = await sweepNamespace(
+      _objectsPrefix,
+      presentOriginals,
+    );
+    final thumbsChecked = await sweepNamespace(_thumbsPrefix, presentThumbs);
+    final renditionsChecked = await sweepNamespace(
+      _renditionsPrefix,
+      presentRenditions,
+    );
 
     // Reverse repair (spec 6.2): a stamp whose object is absent is stale -
     // clear it and queue a re-upload; the pipeline re-materializes local
@@ -154,6 +176,9 @@ class MediaVerifyService {
 
     return VerifyLibraryReport(
       objectsChecked: objectsChecked,
+      originalsChecked: originalsChecked,
+      thumbsChecked: thumbsChecked,
+      renditionsChecked: renditionsChecked,
       orphansRemoved: orphansRemoved,
       bytesReclaimed: bytesReclaimed,
       sessionsAborted: sessionsAborted,

--- a/lib/features/media_store/presentation/pages/media_storage_page.dart
+++ b/lib/features/media_store/presentation/pages/media_storage_page.dart
@@ -318,6 +318,9 @@ class _MediaStoragePageState extends ConsumerState<MediaStoragePage> {
       _showSnack(
         l10n.settings_mediaStorage_verify_summary(
           report.objectsChecked,
+          report.originalsChecked,
+          report.thumbsChecked,
+          report.renditionsChecked,
           report.orphansRemoved,
           report.repairsQueued,
           report.sessionsAborted,

--- a/lib/features/media_store/presentation/providers/media_origin_republish_provider.dart
+++ b/lib/features/media_store/presentation/providers/media_origin_republish_provider.dart
@@ -1,0 +1,46 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/features/media/data/services/media_item_verifier.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media_store/data/media_origin_republish_sweep.dart';
+
+/// Runs [MediaOriginRepublishSweep] once per device, at launch.
+///
+/// Checks the done flag before reading the resolver registry: building the
+/// registry constructs every resolver in the app, which is fine on the one
+/// launch that repairs and waste on every launch after.
+///
+/// Contains its own failures: the call site is fire-and-forget, so an
+/// escaping throw would land in the zone handler with nothing to catch it
+/// (the shape of #942). A failure leaves the flag unset and the next launch
+/// tries again.
+// no-tick: the value is a CLOSURE, not a query result. Every read happens
+// inside it at call time via ref.read, so there is no cached row to go stale.
+final mediaOriginRepublishProvider = Provider<Future<void> Function()>((ref) {
+  return () async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (MediaOriginRepublishSweep.isDone(prefs)) return;
+      final repository = ref.read(mediaRepositoryProvider);
+      await MediaOriginRepublishSweep(
+        mediaRepository: repository,
+        verifier: MediaItemVerifier(
+          registry: ref.read(mediaSourceResolverRegistryProvider),
+          repository: repository,
+        ),
+        deviceId: () => SyncRepository().getDeviceId(),
+        prefs: prefs,
+      ).run();
+    } on Object catch (e, stackTrace) {
+      LoggerService.forClass(MediaOriginRepublishSweep).warning(
+        'Could not run the origin republish',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  };
+});

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} في انتظار إعادة المحاولة",
   "settings_mediaStorage_verify_action": "التحقق من المكتبة",
   "settings_mediaStorage_verify_running": "جارٍ التحقق من مكتبة الوسائط...",
-  "settings_mediaStorage_verify_summary": "تم فحص {checked} عنصرًا: أزيل {removed} يتيمًا، وأُدرج {repaired} إصلاحًا في قائمة الانتظار، وأُلغي {aborted} رفعًا قديمًا",
+  "settings_mediaStorage_verify_summary": "تم فحص {checked} عنصرًا سحابيًا ({originals} أصلية، {thumbs} صور مصغرة، {renditions} نسخ مضغوطة): أزيل {removed} يتيمًا، وأُدرج {repaired} إصلاحًا في قائمة الانتظار، وأُلغي {aborted} رفعًا قديمًا",
   "settings_mediaStorage_backfill_action": "رفع المكتبة الحالية",
   "settings_mediaStorage_backfill_enqueued": "{count} عمليات رفع في قائمة الانتظار",
   "settings_mediaStorage_policy_autoUpload": "رفع الصور تلقائيا",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} في انتظار إعادة المحاولة",
   "settings_mediaStorage_verify_action": "التحقق من المكتبة",
   "settings_mediaStorage_verify_running": "جارٍ التحقق من مكتبة الوسائط...",
-  "settings_mediaStorage_verify_summary": "تم فحص {checked} عنصرًا سحابيًا ({originals} أصلية، {thumbs} صور مصغرة، {renditions} نسخ مضغوطة): أزيل {removed} يتيمًا، وأُدرج {repaired} إصلاحًا في قائمة الانتظار، وأُلغي {aborted} رفعًا قديمًا",
+  "settings_mediaStorage_verify_summary": "تم فحص {checked} عنصرًا سحابيًا ({originals, plural, =1{أصل واحد} other{{originals} أصلية}}، {thumbs, plural, =1{صورة مصغرة واحدة} other{{thumbs} صور مصغرة}}، {renditions, plural, =1{نسخة مضغوطة واحدة} other{{renditions} نسخ مضغوطة}}): أزيل {removed} يتيمًا، وأُدرج {repaired} إصلاحًا في قائمة الانتظار، وأُلغي {aborted} رفعًا قديمًا",
   "settings_mediaStorage_backfill_action": "رفع المكتبة الحالية",
   "settings_mediaStorage_backfill_enqueued": "{count} عمليات رفع في قائمة الانتظار",
   "settings_mediaStorage_policy_autoUpload": "رفع الصور تلقائيا",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} warten auf Wiederholung",
   "settings_mediaStorage_verify_action": "Bibliothek überprüfen",
   "settings_mediaStorage_verify_running": "Medienbibliothek wird überprüft...",
-  "settings_mediaStorage_verify_summary": "{checked} Objekte geprüft: {removed} verwaiste entfernt, {repaired} Reparaturen eingereiht, {aborted} veraltete Uploads abgebrochen",
+  "settings_mediaStorage_verify_summary": "{checked} Cloud-Objekte geprüft ({originals} Originale, {thumbs} Miniaturansichten, {renditions} komprimierte Versionen): {removed} verwaiste entfernt, {repaired} Reparaturen eingereiht, {aborted} veraltete Uploads abgebrochen",
   "settings_mediaStorage_backfill_action": "Vorhandene Bibliothek hochladen",
   "settings_mediaStorage_backfill_enqueued": "{count} Uploads eingereiht",
   "settings_mediaStorage_policy_autoUpload": "Fotos automatisch hochladen",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} warten auf Wiederholung",
   "settings_mediaStorage_verify_action": "Bibliothek überprüfen",
   "settings_mediaStorage_verify_running": "Medienbibliothek wird überprüft...",
-  "settings_mediaStorage_verify_summary": "{checked} Cloud-Objekte geprüft ({originals} Originale, {thumbs} Miniaturansichten, {renditions} komprimierte Versionen): {removed} verwaiste entfernt, {repaired} Reparaturen eingereiht, {aborted} veraltete Uploads abgebrochen",
+  "settings_mediaStorage_verify_summary": "{checked} Cloud-Objekte geprüft ({originals, plural, =1{1 Original} other{{originals} Originale}}, {thumbs, plural, =1{1 Miniaturansicht} other{{thumbs} Miniaturansichten}}, {renditions, plural, =1{1 komprimierte Version} other{{renditions} komprimierte Versionen}}): {removed} verwaiste entfernt, {repaired} Reparaturen eingereiht, {aborted} veraltete Uploads abgebrochen",
   "settings_mediaStorage_backfill_action": "Vorhandene Bibliothek hochladen",
   "settings_mediaStorage_backfill_enqueued": "{count} Uploads eingereiht",
   "settings_mediaStorage_policy_autoUpload": "Fotos automatisch hochladen",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15229,7 +15229,7 @@
   },
   "settings_mediaStorage_verify_action": "Verify library",
   "settings_mediaStorage_verify_running": "Verifying media library...",
-  "settings_mediaStorage_verify_summary": "Checked {checked} cloud objects ({originals} originals, {thumbs} thumbnails, {renditions} compressed versions): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads",
+  "settings_mediaStorage_verify_summary": "Checked {checked} cloud objects ({originals, plural, =1{1 original} other{{originals} originals}}, {thumbs, plural, =1{1 thumbnail} other{{thumbs} thumbnails}}, {renditions, plural, =1{1 compressed version} other{{renditions} compressed versions}}): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads",
   "@settings_mediaStorage_verify_summary": {
     "placeholders": {
       "checked": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15229,10 +15229,19 @@
   },
   "settings_mediaStorage_verify_action": "Verify library",
   "settings_mediaStorage_verify_running": "Verifying media library...",
-  "settings_mediaStorage_verify_summary": "Checked {checked} objects: removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads",
+  "settings_mediaStorage_verify_summary": "Checked {checked} cloud objects ({originals} originals, {thumbs} thumbnails, {renditions} compressed versions): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads",
   "@settings_mediaStorage_verify_summary": {
     "placeholders": {
       "checked": {
+        "type": "int"
+      },
+      "originals": {
+        "type": "int"
+      },
+      "thumbs": {
+        "type": "int"
+      },
+      "renditions": {
         "type": "int"
       },
       "removed": {

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} esperando para reintentar",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando la biblioteca multimedia...",
-  "settings_mediaStorage_verify_summary": "Se comprobaron {checked} objetos en la nube ({originals} originales, {thumbs} miniaturas, {renditions} versiones comprimidas): {removed} huérfanos eliminados, {repaired} reparaciones en cola, {aborted} subidas obsoletas canceladas",
+  "settings_mediaStorage_verify_summary": "Se comprobaron {checked} objetos en la nube ({originals, plural, =1{1 original} other{{originals} originales}}, {thumbs, plural, =1{1 miniatura} other{{thumbs} miniaturas}}, {renditions, plural, =1{1 versión comprimida} other{{renditions} versiones comprimidas}}): {removed} huérfanos eliminados, {repaired} reparaciones en cola, {aborted} subidas obsoletas canceladas",
   "settings_mediaStorage_backfill_action": "Subir biblioteca existente",
   "settings_mediaStorage_backfill_enqueued": "{count} subidas en cola",
   "settings_mediaStorage_policy_autoUpload": "Subir fotos automáticamente",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} esperando para reintentar",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando la biblioteca multimedia...",
-  "settings_mediaStorage_verify_summary": "Se comprobaron {checked} objetos: {removed} huérfanos eliminados, {repaired} reparaciones en cola, {aborted} subidas obsoletas canceladas",
+  "settings_mediaStorage_verify_summary": "Se comprobaron {checked} objetos en la nube ({originals} originales, {thumbs} miniaturas, {renditions} versiones comprimidas): {removed} huérfanos eliminados, {repaired} reparaciones en cola, {aborted} subidas obsoletas canceladas",
   "settings_mediaStorage_backfill_action": "Subir biblioteca existente",
   "settings_mediaStorage_backfill_enqueued": "{count} subidas en cola",
   "settings_mediaStorage_policy_autoUpload": "Subir fotos automáticamente",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} en attente de nouvelle tentative",
   "settings_mediaStorage_verify_action": "Vérifier la bibliothèque",
   "settings_mediaStorage_verify_running": "Vérification de la médiathèque...",
-  "settings_mediaStorage_verify_summary": "{checked} objets cloud vérifiés ({originals} originaux, {thumbs} miniatures, {renditions} versions compressées) : {removed} orphelins supprimés, {repaired} réparations en file, {aborted} envois périmés annulés",
+  "settings_mediaStorage_verify_summary": "{checked} objets cloud vérifiés ({originals, plural, =1{1 original} other{{originals} originaux}}, {thumbs, plural, =1{1 miniature} other{{thumbs} miniatures}}, {renditions, plural, =1{1 version compressée} other{{renditions} versions compressées}}) : {removed} orphelins supprimés, {repaired} réparations en file, {aborted} envois périmés annulés",
   "settings_mediaStorage_backfill_action": "Envoyer la bibliothèque existante",
   "settings_mediaStorage_backfill_enqueued": "{count} envois en file",
   "settings_mediaStorage_policy_autoUpload": "Envoyer les photos automatiquement",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} en attente de nouvelle tentative",
   "settings_mediaStorage_verify_action": "Vérifier la bibliothèque",
   "settings_mediaStorage_verify_running": "Vérification de la médiathèque...",
-  "settings_mediaStorage_verify_summary": "{checked} objets vérifiés : {removed} orphelins supprimés, {repaired} réparations en file, {aborted} envois périmés annulés",
+  "settings_mediaStorage_verify_summary": "{checked} objets cloud vérifiés ({originals} originaux, {thumbs} miniatures, {renditions} versions compressées) : {removed} orphelins supprimés, {repaired} réparations en file, {aborted} envois périmés annulés",
   "settings_mediaStorage_backfill_action": "Envoyer la bibliothèque existante",
   "settings_mediaStorage_backfill_enqueued": "{count} envois en file",
   "settings_mediaStorage_policy_autoUpload": "Envoyer les photos automatiquement",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} ממתינים לניסיון חוזר",
   "settings_mediaStorage_verify_action": "אימות הספרייה",
   "settings_mediaStorage_verify_running": "מאמת את ספריית המדיה...",
-  "settings_mediaStorage_verify_summary": "נבדקו {checked} אובייקטים: הוסרו {removed} יתומים, {repaired} תיקונים נוספו לתור, {aborted} העלאות ישנות בוטלו",
+  "settings_mediaStorage_verify_summary": "נבדקו {checked} אובייקטים בענן ({originals} מקוריים, {thumbs} תמונות ממוזערות, {renditions} גרסאות דחוסות): הוסרו {removed} יתומים, {repaired} תיקונים נוספו לתור, {aborted} העלאות ישנות בוטלו",
   "settings_mediaStorage_backfill_action": "העלה ספריה קיימת",
   "settings_mediaStorage_backfill_enqueued": "{count} העלאות בתור",
   "settings_mediaStorage_policy_autoUpload": "העלה תמונות אוטומטית",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} ממתינים לניסיון חוזר",
   "settings_mediaStorage_verify_action": "אימות הספרייה",
   "settings_mediaStorage_verify_running": "מאמת את ספריית המדיה...",
-  "settings_mediaStorage_verify_summary": "נבדקו {checked} אובייקטים בענן ({originals} מקוריים, {thumbs} תמונות ממוזערות, {renditions} גרסאות דחוסות): הוסרו {removed} יתומים, {repaired} תיקונים נוספו לתור, {aborted} העלאות ישנות בוטלו",
+  "settings_mediaStorage_verify_summary": "נבדקו {checked} אובייקטים בענן ({originals, plural, =1{מקורי אחד} other{{originals} מקוריים}}, {thumbs, plural, =1{תמונה ממוזערת אחת} other{{thumbs} תמונות ממוזערות}}, {renditions, plural, =1{גרסה דחוסה אחת} other{{renditions} גרסאות דחוסות}}): הוסרו {removed} יתומים, {repaired} תיקונים נוספו לתור, {aborted} העלאות ישנות בוטלו",
   "settings_mediaStorage_backfill_action": "העלה ספריה קיימת",
   "settings_mediaStorage_backfill_enqueued": "{count} העלאות בתור",
   "settings_mediaStorage_policy_autoUpload": "העלה תמונות אוטומטית",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} újrapróbálkozásra vár",
   "settings_mediaStorage_verify_action": "Könyvtár ellenőrzése",
   "settings_mediaStorage_verify_running": "Médiatár ellenőrzése...",
-  "settings_mediaStorage_verify_summary": "{checked} objektum ellenőrizve: {removed} árva eltávolítva, {repaired} javítás sorba állítva, {aborted} elavult feltöltés megszakítva",
+  "settings_mediaStorage_verify_summary": "{checked} felhőobjektum ellenőrizve ({originals} eredeti, {thumbs} bélyegkép, {renditions} tömörített változat): {removed} árva eltávolítva, {repaired} javítás sorba állítva, {aborted} elavult feltöltés megszakítva",
   "settings_mediaStorage_backfill_action": "Meglévő könyvtár feltöltése",
   "settings_mediaStorage_backfill_enqueued": "{count} feltöltés sorban",
   "settings_mediaStorage_policy_autoUpload": "Fotók automatikus feltöltése",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} in attesa di riprovare",
   "settings_mediaStorage_verify_action": "Verifica libreria",
   "settings_mediaStorage_verify_running": "Verifica della libreria multimediale...",
-  "settings_mediaStorage_verify_summary": "Controllati {checked} oggetti: {removed} orfani rimossi, {repaired} riparazioni in coda, {aborted} caricamenti obsoleti annullati",
+  "settings_mediaStorage_verify_summary": "Controllati {checked} oggetti nel cloud ({originals} originali, {thumbs} miniature, {renditions} versioni compresse): {removed} orfani rimossi, {repaired} riparazioni in coda, {aborted} caricamenti obsoleti annullati",
   "settings_mediaStorage_backfill_action": "Carica libreria esistente",
   "settings_mediaStorage_backfill_enqueued": "{count} caricamenti in coda",
   "settings_mediaStorage_policy_autoUpload": "Carica foto automaticamente",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} in attesa di riprovare",
   "settings_mediaStorage_verify_action": "Verifica libreria",
   "settings_mediaStorage_verify_running": "Verifica della libreria multimediale...",
-  "settings_mediaStorage_verify_summary": "Controllati {checked} oggetti nel cloud ({originals} originali, {thumbs} miniature, {renditions} versioni compresse): {removed} orfani rimossi, {repaired} riparazioni in coda, {aborted} caricamenti obsoleti annullati",
+  "settings_mediaStorage_verify_summary": "Controllati {checked} oggetti nel cloud ({originals, plural, =1{1 originale} other{{originals} originali}}, {thumbs, plural, =1{1 miniatura} other{{thumbs} miniature}}, {renditions, plural, =1{1 versione compressa} other{{renditions} versioni compresse}}): {removed} orfani rimossi, {repaired} riparazioni in coda, {aborted} caricamenti obsoleti annullati",
   "settings_mediaStorage_backfill_action": "Carica libreria esistente",
   "settings_mediaStorage_backfill_enqueued": "{count} caricamenti in coda",
   "settings_mediaStorage_policy_autoUpload": "Carica foto automaticamente",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39130,7 +39130,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_mediaStorage_verify_summary.
   ///
   /// In en, this message translates to:
-  /// **'Checked {checked} cloud objects ({originals} originals, {thumbs} thumbnails, {renditions} compressed versions): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads'**
+  /// **'Checked {checked} cloud objects ({originals, plural, =1{1 original} other{{originals} originals}}, {thumbs, plural, =1{1 thumbnail} other{{thumbs} thumbnails}}, {renditions, plural, =1{1 compressed version} other{{renditions} compressed versions}}): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads'**
   String settings_mediaStorage_verify_summary(
     int checked,
     int originals,

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39130,9 +39130,12 @@ abstract class AppLocalizations {
   /// No description provided for @settings_mediaStorage_verify_summary.
   ///
   /// In en, this message translates to:
-  /// **'Checked {checked} objects: removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads'**
+  /// **'Checked {checked} cloud objects ({originals} originals, {thumbs} thumbnails, {renditions} compressed versions): removed {removed} orphans, queued {repaired} repairs, aborted {aborted} stale uploads'**
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23360,7 +23360,25 @@ class AppLocalizationsAr extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return 'تم فحص $checked عنصرًا سحابيًا ($originals أصلية، $thumbs صور مصغرة، $renditions نسخ مضغوطة): أزيل $removed يتيمًا، وأُدرج $repaired إصلاحًا في قائمة الانتظار، وأُلغي $aborted رفعًا قديمًا';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals أصلية',
+      one: 'أصل واحد',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs صور مصغرة',
+      one: 'صورة مصغرة واحدة',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions نسخ مضغوطة',
+      one: 'نسخة مضغوطة واحدة',
+    );
+    return 'تم فحص $checked عنصرًا سحابيًا ($_temp0، $_temp1، $_temp2): أزيل $removed يتيمًا، وأُدرج $repaired إصلاحًا في قائمة الانتظار، وأُلغي $aborted رفعًا قديمًا';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23353,11 +23353,14 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return 'تم فحص $checked عنصرًا: أزيل $removed يتيمًا، وأُدرج $repaired إصلاحًا في قائمة الانتظار، وأُلغي $aborted رفعًا قديمًا';
+    return 'تم فحص $checked عنصرًا سحابيًا ($originals أصلية، $thumbs صور مصغرة، $renditions نسخ مضغوطة): أزيل $removed يتيمًا، وأُدرج $repaired إصلاحًا في قائمة الانتظار، وأُلغي $aborted رفعًا قديمًا';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23732,7 +23732,25 @@ class AppLocalizationsDe extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return '$checked Cloud-Objekte geprüft ($originals Originale, $thumbs Miniaturansichten, $renditions komprimierte Versionen): $removed verwaiste entfernt, $repaired Reparaturen eingereiht, $aborted veraltete Uploads abgebrochen';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals Originale',
+      one: '1 Original',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs Miniaturansichten',
+      one: '1 Miniaturansicht',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions komprimierte Versionen',
+      one: '1 komprimierte Version',
+    );
+    return '$checked Cloud-Objekte geprüft ($_temp0, $_temp1, $_temp2): $removed verwaiste entfernt, $repaired Reparaturen eingereiht, $aborted veraltete Uploads abgebrochen';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23725,11 +23725,14 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '$checked Objekte geprüft: $removed verwaiste entfernt, $repaired Reparaturen eingereiht, $aborted veraltete Uploads abgebrochen';
+    return '$checked Cloud-Objekte geprüft ($originals Originale, $thumbs Miniaturansichten, $renditions komprimierte Versionen): $removed verwaiste entfernt, $repaired Reparaturen eingereiht, $aborted veraltete Uploads abgebrochen';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23377,11 +23377,14 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return 'Checked $checked objects: removed $removed orphans, queued $repaired repairs, aborted $aborted stale uploads';
+    return 'Checked $checked cloud objects ($originals originals, $thumbs thumbnails, $renditions compressed versions): removed $removed orphans, queued $repaired repairs, aborted $aborted stale uploads';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23384,7 +23384,25 @@ class AppLocalizationsEn extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return 'Checked $checked cloud objects ($originals originals, $thumbs thumbnails, $renditions compressed versions): removed $removed orphans, queued $repaired repairs, aborted $aborted stale uploads';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originals',
+      one: '1 original',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs thumbnails',
+      one: '1 thumbnail',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions compressed versions',
+      one: '1 compressed version',
+    );
+    return 'Checked $checked cloud objects ($_temp0, $_temp1, $_temp2): removed $removed orphans, queued $repaired repairs, aborted $aborted stale uploads';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23790,11 +23790,14 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return 'Se comprobaron $checked objetos: $removed huérfanos eliminados, $repaired reparaciones en cola, $aborted subidas obsoletas canceladas';
+    return 'Se comprobaron $checked objetos en la nube ($originals originales, $thumbs miniaturas, $renditions versiones comprimidas): $removed huérfanos eliminados, $repaired reparaciones en cola, $aborted subidas obsoletas canceladas';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23797,7 +23797,25 @@ class AppLocalizationsEs extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return 'Se comprobaron $checked objetos en la nube ($originals originales, $thumbs miniaturas, $renditions versiones comprimidas): $removed huérfanos eliminados, $repaired reparaciones en cola, $aborted subidas obsoletas canceladas';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originales',
+      one: '1 original',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs miniaturas',
+      one: '1 miniatura',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions versiones comprimidas',
+      one: '1 versión comprimida',
+    );
+    return 'Se comprobaron $checked objetos en la nube ($_temp0, $_temp1, $_temp2): $removed huérfanos eliminados, $repaired reparaciones en cola, $aborted subidas obsoletas canceladas';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23852,11 +23852,14 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '$checked objets vérifiés : $removed orphelins supprimés, $repaired réparations en file, $aborted envois périmés annulés';
+    return '$checked objets cloud vérifiés ($originals originaux, $thumbs miniatures, $renditions versions compressées) : $removed orphelins supprimés, $repaired réparations en file, $aborted envois périmés annulés';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23859,7 +23859,25 @@ class AppLocalizationsFr extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return '$checked objets cloud vérifiés ($originals originaux, $thumbs miniatures, $renditions versions compressées) : $removed orphelins supprimés, $repaired réparations en file, $aborted envois périmés annulés';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originaux',
+      one: '1 original',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs miniatures',
+      one: '1 miniature',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions versions compressées',
+      one: '1 version compressée',
+    );
+    return '$checked objets cloud vérifiés ($_temp0, $_temp1, $_temp2) : $removed orphelins supprimés, $repaired réparations en file, $aborted envois périmés annulés';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23183,11 +23183,14 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return 'נבדקו $checked אובייקטים: הוסרו $removed יתומים, $repaired תיקונים נוספו לתור, $aborted העלאות ישנות בוטלו';
+    return 'נבדקו $checked אובייקטים בענן ($originals מקוריים, $thumbs תמונות ממוזערות, $renditions גרסאות דחוסות): הוסרו $removed יתומים, $repaired תיקונים נוספו לתור, $aborted העלאות ישנות בוטלו';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23190,7 +23190,25 @@ class AppLocalizationsHe extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return 'נבדקו $checked אובייקטים בענן ($originals מקוריים, $thumbs תמונות ממוזערות, $renditions גרסאות דחוסות): הוסרו $removed יתומים, $repaired תיקונים נוספו לתור, $aborted העלאות ישנות בוטלו';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals מקוריים',
+      one: 'מקורי אחד',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs תמונות ממוזערות',
+      one: 'תמונה ממוזערת אחת',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions גרסאות דחוסות',
+      one: 'גרסה דחוסה אחת',
+    );
+    return 'נבדקו $checked אובייקטים בענן ($_temp0, $_temp1, $_temp2): הוסרו $removed יתומים, $repaired תיקונים נוספו לתור, $aborted העלאות ישנות בוטלו';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23688,11 +23688,14 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '$checked objektum ellenőrizve: $removed árva eltávolítva, $repaired javítás sorba állítva, $aborted elavult feltöltés megszakítva';
+    return '$checked felhőobjektum ellenőrizve ($originals eredeti, $thumbs bélyegkép, $renditions tömörített változat): $removed árva eltávolítva, $repaired javítás sorba állítva, $aborted elavult feltöltés megszakítva';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23780,7 +23780,25 @@ class AppLocalizationsIt extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return 'Controllati $checked oggetti nel cloud ($originals originali, $thumbs miniature, $renditions versioni compresse): $removed orfani rimossi, $repaired riparazioni in coda, $aborted caricamenti obsoleti annullati';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originali',
+      one: '1 originale',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs miniature',
+      one: '1 miniatura',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions versioni compresse',
+      one: '1 versione compressa',
+    );
+    return 'Controllati $checked oggetti nel cloud ($_temp0, $_temp1, $_temp2): $removed orfani rimossi, $repaired riparazioni in coda, $aborted caricamenti obsoleti annullati';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23773,11 +23773,14 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return 'Controllati $checked oggetti: $removed orfani rimossi, $repaired riparazioni in coda, $aborted caricamenti obsoleti annullati';
+    return 'Controllati $checked oggetti nel cloud ($originals originali, $thumbs miniature, $renditions versioni compresse): $removed orfani rimossi, $repaired riparazioni in coda, $aborted caricamenti obsoleti annullati';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23598,7 +23598,25 @@ class AppLocalizationsNl extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return '$checked cloudobjecten gecontroleerd ($originals originelen, $thumbs miniaturen, $renditions gecomprimeerde versies): $removed wezen verwijderd, $repaired reparaties in wachtrij, $aborted verouderde uploads afgebroken';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originelen',
+      one: '1 origineel',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs miniaturen',
+      one: '1 miniatuur',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions gecomprimeerde versies',
+      one: '1 gecomprimeerde versie',
+    );
+    return '$checked cloudobjecten gecontroleerd ($_temp0, $_temp1, $_temp2): $removed wezen verwijderd, $repaired reparaties in wachtrij, $aborted verouderde uploads afgebroken';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23591,11 +23591,14 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '$checked objecten gecontroleerd: $removed wezen verwijderd, $repaired reparaties in wachtrij, $aborted verouderde uploads afgebroken';
+    return '$checked cloudobjecten gecontroleerd ($originals originelen, $thumbs miniaturen, $renditions gecomprimeerde versies): $removed wezen verwijderd, $repaired reparaties in wachtrij, $aborted verouderde uploads afgebroken';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23779,7 +23779,25 @@ class AppLocalizationsPt extends AppLocalizations {
     int repaired,
     int aborted,
   ) {
-    return '$checked objetos na nuvem verificados ($originals originais, $thumbs miniaturas, $renditions versões comprimidas): $removed órfãos removidos, $repaired reparos na fila, $aborted envios obsoletos cancelados';
+    String _temp0 = intl.Intl.pluralLogic(
+      originals,
+      locale: localeName,
+      other: '$originals originais',
+      one: '1 original',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      thumbs,
+      locale: localeName,
+      other: '$thumbs miniaturas',
+      one: '1 miniatura',
+    );
+    String _temp2 = intl.Intl.pluralLogic(
+      renditions,
+      locale: localeName,
+      other: '$renditions versões comprimidas',
+      one: '1 versão comprimida',
+    );
+    return '$checked objetos na nuvem verificados ($_temp0, $_temp1, $_temp2): $removed órfãos removidos, $repaired reparos na fila, $aborted envios obsoletos cancelados';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23772,11 +23772,14 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '$checked objetos verificados: $removed órfãos removidos, $repaired reparos na fila, $aborted envios obsoletos cancelados';
+    return '$checked objetos na nuvem verificados ($originals originais, $thumbs miniaturas, $renditions versões comprimidas): $removed órfãos removidos, $repaired reparos na fila, $aborted envios obsoletos cancelados';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22549,11 +22549,14 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String settings_mediaStorage_verify_summary(
     int checked,
+    int originals,
+    int thumbs,
+    int renditions,
     int removed,
     int repaired,
     int aborted,
   ) {
-    return '已检查 $checked 个对象：移除 $removed 个孤立文件，排队 $repaired 个修复，中止 $aborted 个过期上传';
+    return '已检查 $checked 个云端对象（$originals 个原图、$thumbs 个缩略图、$renditions 个压缩版本）：移除 $removed 个孤立文件，排队 $repaired 个修复，中止 $aborted 个过期上传';
   }
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} wachten op nieuwe poging",
   "settings_mediaStorage_verify_action": "Bibliotheek verifiëren",
   "settings_mediaStorage_verify_running": "Mediabibliotheek wordt geverifieerd...",
-  "settings_mediaStorage_verify_summary": "{checked} cloudobjecten gecontroleerd ({originals} originelen, {thumbs} miniaturen, {renditions} gecomprimeerde versies): {removed} wezen verwijderd, {repaired} reparaties in wachtrij, {aborted} verouderde uploads afgebroken",
+  "settings_mediaStorage_verify_summary": "{checked} cloudobjecten gecontroleerd ({originals, plural, =1{1 origineel} other{{originals} originelen}}, {thumbs, plural, =1{1 miniatuur} other{{thumbs} miniaturen}}, {renditions, plural, =1{1 gecomprimeerde versie} other{{renditions} gecomprimeerde versies}}): {removed} wezen verwijderd, {repaired} reparaties in wachtrij, {aborted} verouderde uploads afgebroken",
   "settings_mediaStorage_backfill_action": "Bestaande bibliotheek uploaden",
   "settings_mediaStorage_backfill_enqueued": "{count} uploads in wachtrij",
   "settings_mediaStorage_policy_autoUpload": "Foto's automatisch uploaden",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} wachten op nieuwe poging",
   "settings_mediaStorage_verify_action": "Bibliotheek verifiëren",
   "settings_mediaStorage_verify_running": "Mediabibliotheek wordt geverifieerd...",
-  "settings_mediaStorage_verify_summary": "{checked} objecten gecontroleerd: {removed} wezen verwijderd, {repaired} reparaties in wachtrij, {aborted} verouderde uploads afgebroken",
+  "settings_mediaStorage_verify_summary": "{checked} cloudobjecten gecontroleerd ({originals} originelen, {thumbs} miniaturen, {renditions} gecomprimeerde versies): {removed} wezen verwijderd, {repaired} reparaties in wachtrij, {aborted} verouderde uploads afgebroken",
   "settings_mediaStorage_backfill_action": "Bestaande bibliotheek uploaden",
   "settings_mediaStorage_backfill_enqueued": "{count} uploads in wachtrij",
   "settings_mediaStorage_policy_autoUpload": "Foto's automatisch uploaden",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} aguardando nova tentativa",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando a biblioteca de mídia...",
-  "settings_mediaStorage_verify_summary": "{checked} objetos verificados: {removed} órfãos removidos, {repaired} reparos na fila, {aborted} envios obsoletos cancelados",
+  "settings_mediaStorage_verify_summary": "{checked} objetos na nuvem verificados ({originals} originais, {thumbs} miniaturas, {renditions} versões comprimidas): {removed} órfãos removidos, {repaired} reparos na fila, {aborted} envios obsoletos cancelados",
   "settings_mediaStorage_backfill_action": "Enviar biblioteca existente",
   "settings_mediaStorage_backfill_enqueued": "{count} envios na fila",
   "settings_mediaStorage_policy_autoUpload": "Enviar fotos automaticamente",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} aguardando nova tentativa",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",
   "settings_mediaStorage_verify_running": "Verificando a biblioteca de mídia...",
-  "settings_mediaStorage_verify_summary": "{checked} objetos na nuvem verificados ({originals} originais, {thumbs} miniaturas, {renditions} versões comprimidas): {removed} órfãos removidos, {repaired} reparos na fila, {aborted} envios obsoletos cancelados",
+  "settings_mediaStorage_verify_summary": "{checked} objetos na nuvem verificados ({originals, plural, =1{1 original} other{{originals} originais}}, {thumbs, plural, =1{1 miniatura} other{{thumbs} miniaturas}}, {renditions, plural, =1{1 versão comprimida} other{{renditions} versões comprimidas}}): {removed} órfãos removidos, {repaired} reparos na fila, {aborted} envios obsoletos cancelados",
   "settings_mediaStorage_backfill_action": "Enviar biblioteca existente",
   "settings_mediaStorage_backfill_enqueued": "{count} envios na fila",
   "settings_mediaStorage_policy_autoUpload": "Enviar fotos automaticamente",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6717,7 +6717,7 @@
   "settings_mediaStorage_transfers_waitingRetry": "{count} 个等待重试",
   "settings_mediaStorage_verify_action": "验证媒体库",
   "settings_mediaStorage_verify_running": "正在验证媒体库...",
-  "settings_mediaStorage_verify_summary": "已检查 {checked} 个对象：移除 {removed} 个孤立文件，排队 {repaired} 个修复，中止 {aborted} 个过期上传",
+  "settings_mediaStorage_verify_summary": "已检查 {checked} 个云端对象（{originals} 个原图、{thumbs} 个缩略图、{renditions} 个压缩版本）：移除 {removed} 个孤立文件，排队 {repaired} 个修复，中止 {aborted} 个过期上传",
   "settings_mediaStorage_backfill_action": "上传现有媒体库",
   "settings_mediaStorage_backfill_enqueued": "已排队 {count} 个上传",
   "settings_mediaStorage_policy_autoUpload": "自动上传照片",

--- a/test/features/media/data/media_repository_backfill_scope_test.dart
+++ b/test/features/media/data/media_repository_backfill_scope_test.dart
@@ -47,6 +47,7 @@ void main() {
     String? siteId,
     MediaType mediaType = MediaType.photo,
     MediaSourceType sourceType = MediaSourceType.platformGallery,
+    String? originDeviceId,
   }) => MediaItem(
     id: '',
     mediaType: mediaType,
@@ -56,6 +57,7 @@ void main() {
     originalFilename: name,
     diveId: diveId,
     siteId: siteId,
+    originDeviceId: originDeviceId,
     takenAt: DateTime(2026, 1, 1),
     createdAt: DateTime(2026, 1, 1),
     updatedAt: DateTime(2026, 1, 1),
@@ -88,6 +90,31 @@ void main() {
       expect(ids.toSet(), {linkedToDive.id, linkedToSite.id});
     },
   );
+
+  test('a row another device imported is never a candidate here', () async {
+    // The desktop imported the file and its row synced over. This device
+    // cannot read the desktop's path, so enqueueing it only produces a
+    // "source unavailable" failure; the desktop is the one that uploads.
+    await insertDive('dive-1');
+    final fromDesktop = await repo.createMedia(
+      item(
+        'desktop.jpg',
+        diveId: 'dive-1',
+        sourceType: MediaSourceType.localFile,
+        originDeviceId: 'some-other-device',
+      ),
+    );
+    // Imported here: createMedia stamps this device's own id.
+    final mine = await repo.createMedia(
+      item('mine.jpg', diveId: 'dive-1', sourceType: MediaSourceType.localFile),
+    );
+    // Rows from before origin tracking carry no id and keep today's verdict.
+    final legacy = await repo.createMedia(item('legacy.jpg', diveId: 'dive-1'));
+
+    final ids = await repo.getBackfillCandidateIds();
+    expect(ids, isNot(contains(fromDesktop.id)));
+    expect(ids, containsAll([mine.id, legacy.id]));
+  });
 
   group('videos are backfill candidates', () {
     test('an unbacked localFile video is a candidate', () async {

--- a/test/features/media/data/media_repository_origin_republish_test.dart
+++ b/test/features/media/data/media_repository_origin_republish_test.dart
@@ -1,0 +1,124 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Queries behind the one-time origin republish: which rows this device
+/// imported still carry a store stamp (peers may have dropped it), and which
+/// of its own rows carry the "missing" flag (a peer may have put it there).
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
+  });
+  tearDown(tearDownTestDatabase);
+
+  Future<MediaItem> row(
+    String name, {
+    String? origin,
+    MediaSourceType sourceType = MediaSourceType.localFile,
+    bool stamped = false,
+    bool thumbOnly = false,
+    bool flagged = false,
+  }) async {
+    final created = await repo.createMedia(
+      MediaItem(
+        id: '',
+        mediaType: MediaType.photo,
+        sourceType: sourceType,
+        filePath: '/tmp/$name',
+        localPath: '/tmp/$name',
+        originalFilename: name,
+        diveId: 'd1',
+        originDeviceId: origin,
+        contentHash: stamped || thumbOnly ? 'hash-$name' : null,
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    if (stamped) {
+      await repo.stampRemoteUploaded(created.id, uploadedAt: DateTime(2026, 2));
+    }
+    if (thumbOnly) {
+      await repo.stampRemoteThumbUploaded(
+        created.id,
+        uploadedAt: DateTime(2026, 2),
+      );
+    }
+    if (flagged) await repo.markAsOrphaned(created.id);
+    return created;
+  }
+
+  test('stamped ids are scoped to rows this device imported', () async {
+    final mine = await row('mine.jpg', origin: 'me', stamped: true);
+    final mineThumb = await row('thumb.jpg', origin: 'me', thumbOnly: true);
+    await row('unstamped.jpg', origin: 'me');
+    await row('theirs.jpg', origin: 'other', stamped: true);
+    // Gallery rows carry no origin: device-portable, nothing to republish.
+    await row(
+      'gallery.jpg',
+      sourceType: MediaSourceType.platformGallery,
+      stamped: true,
+    );
+
+    final ids = await repo.getStoreStampedMediaIdsOwnedBy('me');
+
+    expect(ids.toSet(), {mine.id, mineThumb.id});
+  });
+
+  test('flagged rows are scoped to rows this device imported', () async {
+    final mine = await row('mine.jpg', origin: 'me', flagged: true);
+    await row('fine.jpg', origin: 'me');
+    await row('theirs.jpg', origin: 'other', flagged: true);
+
+    final flagged = await repo.getOrphanedMediaOwnedBy('me');
+
+    expect(flagged.map((m) => m.id), [mine.id]);
+    expect(flagged.single.isOrphaned, isTrue);
+  });
+
+  test('republishing marks the rows pending without touching them', () async {
+    final a = await row('a.jpg', origin: 'me', stamped: true);
+    final b = await row('b.jpg', origin: 'me', stamped: true, flagged: true);
+    await SyncRepository().clearPendingRecords();
+
+    final count = await repo.republishForSync([a.id, b.id]);
+
+    expect(count, 2);
+    final pending = await SyncRepository().getPendingRecords();
+    expect(pending.map((r) => (r.entityType, r.recordId)).toSet(), {
+      ('media', a.id),
+      ('media', b.id),
+    });
+    final after = (await repo.getMediaById(b.id))!;
+    expect(after.remoteUploadedAt, DateTime(2026, 2));
+    expect(after.isOrphaned, isTrue, reason: 'republish changes no column');
+  });
+
+  test('republishing nothing is a no-op', () async {
+    await SyncRepository().clearPendingRecords();
+
+    expect(await repo.republishForSync(const []), 0);
+    expect(await SyncRepository().getPendingRecords(), isEmpty);
+  });
+}

--- a/test/features/media/data/media_repository_stamp_verification_test.dart
+++ b/test/features/media/data/media_repository_stamp_verification_test.dart
@@ -1,0 +1,110 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// The verifier persists what a check learned through this write. It has to
+/// be narrow: the verifier's callers hold a snapshot of the row, and an upload
+/// that completes after the snapshot was taken stamps `remoteUploadedAt` on
+/// the row. A whole-row write from the snapshot would roll that stamp back to
+/// null, and `markRecordPending` would then sync the rollback to every other
+/// device (the bug behind "no backup available" on a second device).
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+
+  Future<MediaItem> stampedPhoto() async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('dive-1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
+    final created = await repo.createMedia(
+      MediaItem(
+        id: '',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        filePath: '/tmp/reef.jpg',
+        localPath: '/tmp/reef.jpg',
+        originalFilename: 'reef.jpg',
+        diveId: 'dive-1',
+        contentHash: 'aabbccdd',
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    await repo.stampRemoteUploaded(created.id, uploadedAt: DateTime(2026, 2));
+    await repo.stampRemoteThumbUploaded(
+      created.id,
+      uploadedAt: DateTime(2026, 2),
+    );
+    return created;
+  }
+
+  test('a finding moves the flag and the date and nothing else', () async {
+    final photo = await stampedPhoto();
+    final checkedAt = DateTime(2026, 3, 1, 12);
+
+    await repo.stampVerification(
+      photo.id,
+      verifiedAt: checkedAt,
+      isOrphaned: true,
+    );
+
+    final row = (await repo.getMediaById(photo.id))!;
+    expect(row.isOrphaned, isTrue);
+    expect(row.lastVerifiedAt, checkedAt);
+    expect(row.remoteUploadedAt, DateTime(2026, 2));
+    expect(row.remoteThumbUploadedAt, DateTime(2026, 2));
+    expect(row.contentHash, 'aabbccdd');
+  });
+
+  test('a reachability outcome stamps the date and leaves the flag', () async {
+    final photo = await stampedPhoto();
+    await repo.stampVerification(
+      photo.id,
+      verifiedAt: DateTime(2026, 3, 1),
+      isOrphaned: true,
+    );
+
+    await repo.stampVerification(photo.id, verifiedAt: DateTime(2026, 3, 2));
+
+    final row = (await repo.getMediaById(photo.id))!;
+    expect(row.isOrphaned, isTrue, reason: 'nothing was learned about it');
+    expect(row.lastVerifiedAt, DateTime(2026, 3, 2));
+  });
+
+  test('the write is sync-visible', () async {
+    final photo = await stampedPhoto();
+    // createMedia and the stamps above already queued the row; clear that
+    // so the assertion is about this write alone.
+    await SyncRepository().clearPendingRecords();
+
+    await repo.stampVerification(photo.id, verifiedAt: DateTime(2026, 3));
+
+    final pending = await SyncRepository().getPendingRecords();
+    expect(
+      pending.map((r) => (r.entityType, r.recordId)),
+      contains(('media', photo.id)),
+    );
+  });
+}

--- a/test/features/media/data/media_repository_stamp_verification_test.dart
+++ b/test/features/media/data/media_repository_stamp_verification_test.dart
@@ -93,6 +93,22 @@ void main() {
     expect(row.lastVerifiedAt, DateTime(2026, 3, 2));
   });
 
+  test('a row that is gone by the time the check lands leaves nothing '
+      'pending', () async {
+    // Check all media runs asynchronously over a snapshot of rows; a row
+    // deleted meanwhile must not gain a pending sync record pointing at
+    // nothing (markVerified guards the same way).
+    await SyncRepository().clearPendingRecords();
+
+    await repo.stampVerification(
+      'no-such-row',
+      verifiedAt: DateTime(2026, 3),
+      isOrphaned: true,
+    );
+
+    expect(await SyncRepository().getPendingRecords(), isEmpty);
+  });
+
   test('the write is sync-visible', () async {
     final photo = await stampedPhoto();
     // createMedia and the stamps above already queued the row; clear that

--- a/test/features/media/data/resolvers/local_file_resolver_test.dart
+++ b/test/features/media/data/resolvers/local_file_resolver_test.dart
@@ -71,12 +71,17 @@ class _StubPlatform implements LocalMediaPlatform {
       throw UnimplementedError('${invocation.memberName} should not be called');
 }
 
-MediaItem _localFile({String? localPath, String? bookmarkRef}) => MediaItem(
+MediaItem _localFile({
+  String? localPath,
+  String? bookmarkRef,
+  String? originDeviceId,
+}) => MediaItem(
   id: 'x',
   mediaType: MediaType.photo,
   sourceType: MediaSourceType.localFile,
   localPath: localPath,
   bookmarkRef: bookmarkRef,
+  originDeviceId: originDeviceId,
   takenAt: DateTime.utc(2024, 1, 1),
   createdAt: DateTime.utc(2024, 1, 1),
   updatedAt: DateTime.utc(2024, 1, 1),
@@ -805,6 +810,97 @@ void main() {
         VerifyResult.transientError,
         reason: 'notFound here would flag a reachable file missing, stickily',
       );
+    });
+  });
+
+  group('origin device', () {
+    // Every localFile row records the device that imported it
+    // (MediaItem.originDeviceId). On any other device the path is a pointer
+    // into a filesystem this machine does not have, so a failed read there
+    // means "lives elsewhere", never "gone". The difference matters because
+    // notFound is the one verdict that orphans a row, and the orphan flag
+    // syncs back to the device that actually has the file.
+    LocalFileResolver phone() => LocalFileResolver(
+      bookmarkStorage: _NullBookmarkStorage(),
+      platform: LocalMediaPlatform(),
+      exifExtractor: ExifExtractor(),
+      localDeviceId: () async => 'phone',
+    );
+
+    MediaItem desktopRow() => _localFile(
+      localPath: '${tempDir.path}/on-the-desktop.jpg',
+      originDeviceId: 'desktop',
+    );
+
+    test('a missing file another device imported reads fromOtherDevice, '
+        'not notFound', () async {
+      final data = await phone().resolve(desktopRow());
+      expect(data, isA<UnavailableData>());
+      expect((data as UnavailableData).kind, UnavailableKind.fromOtherDevice);
+    });
+
+    test('verify reports fromOtherDevice for that row', () async {
+      expect(await phone().verify(desktopRow()), VerifyResult.fromOtherDevice);
+    });
+
+    test('a file another device imported still reads when the path exists '
+        'here (shared volume)', () async {
+      final f = File('${tempDir.path}/shared.jpg')..writeAsBytesSync([1]);
+      final data = await phone().resolve(
+        _localFile(localPath: f.path, originDeviceId: 'desktop'),
+      );
+      expect(data, isA<FileData>());
+    });
+
+    test('a missing file this device imported stays notFound', () async {
+      final data = await phone().resolve(
+        _localFile(
+          localPath: '${tempDir.path}/gone.jpg',
+          originDeviceId: 'phone',
+        ),
+      );
+      expect((data as UnavailableData).kind, UnavailableKind.notFound);
+    });
+
+    test('a row with no origin device stays notFound', () async {
+      // Rows from before origin tracking: nothing says they belong
+      // elsewhere, so the pre-existing verdict stands.
+      final data = await phone().resolve(
+        _localFile(localPath: '${tempDir.path}/legacy.jpg'),
+      );
+      expect((data as UnavailableData).kind, UnavailableKind.notFound);
+    });
+
+    test('an unknown local id leaves the verdict at notFound', () async {
+      // The id source failing (no database yet) must degrade to today's
+      // behaviour, never to a crash on a grid tile.
+      final r = LocalFileResolver(
+        bookmarkStorage: _NullBookmarkStorage(),
+        platform: LocalMediaPlatform(),
+        exifExtractor: ExifExtractor(),
+        localDeviceId: () async => throw StateError('no database'),
+      );
+      final data = await r.resolve(desktopRow());
+      expect((data as UnavailableData).kind, UnavailableKind.notFound);
+    });
+
+    test('canResolveOnThisDevice is false for another device\'s row once '
+        'the local id is known', () async {
+      final r = phone();
+      final foreign = desktopRow();
+      // Optimistic until a resolution has fetched the id (the check is
+      // synchronous, the id is not)...
+      expect(r.canResolveOnThisDevice(foreign), isTrue);
+      await r.resolve(foreign);
+      // ...and authoritative from then on.
+      expect(r.canResolveOnThisDevice(foreign), isFalse);
+      expect(
+        r.canResolveOnThisDevice(
+          _localFile(localPath: '/x.jpg', originDeviceId: 'phone'),
+        ),
+        isTrue,
+      );
+      expect(r.canResolveOnThisDevice(_localFile(localPath: '/x.jpg')), isTrue);
     });
   });
 }

--- a/test/features/media/data/services/media_item_verifier_test.dart
+++ b/test/features/media/data/services/media_item_verifier_test.dart
@@ -39,11 +39,22 @@ class _StubResolver implements MediaSourceResolver {
   Future<VerifyResult> verify(MediaItem item) async => _result;
 }
 
+/// One narrow verification write, as the verifier asked for it.
+typedef _Stamp = ({DateTime verifiedAt, bool? isOrphaned});
+
+/// Captures the narrow write and nothing else. `updateMedia` is deliberately
+/// left unstubbed: a whole-row write from a caller's snapshot would roll back
+/// the cloud stamps an upload put on the row since, so reaching for it here
+/// must fail the test.
 class _CapturingRepository implements MediaRepository {
-  final List<MediaItem> written = [];
+  final List<_Stamp> written = [];
 
   @override
-  Future<void> updateMedia(MediaItem item) async => written.add(item);
+  Future<void> stampVerification(
+    String id, {
+    required DateTime verifiedAt,
+    bool? isOrphaned,
+  }) async => written.add((verifiedAt: verifiedAt, isOrphaned: isOrphaned));
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>
@@ -84,7 +95,7 @@ void main() {
 
       expect(result, VerifyResult.available);
       expect(repository.written.single.isOrphaned, isFalse);
-      expect(repository.written.single.lastVerifiedAt, stamp);
+      expect(repository.written.single.verifiedAt, stamp);
     },
   );
 
@@ -93,7 +104,7 @@ void main() {
 
     expect(result, VerifyResult.notFound);
     expect(repository.written.single.isOrphaned, isTrue);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   // notFound is the ONLY positive finding. Everything below describes a
@@ -108,8 +119,8 @@ void main() {
     ).verify(_item(isOrphaned: false));
 
     expect(result, VerifyResult.unauthenticated);
-    expect(repository.written.single.isOrphaned, isFalse);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.isOrphaned, isNull);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   test('fromOtherDevice stamps the date but never orphans', () async {
@@ -121,14 +132,14 @@ void main() {
     ).verify(_item(isOrphaned: false));
 
     expect(result, VerifyResult.fromOtherDevice);
-    expect(repository.written.single.isOrphaned, isFalse);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.isOrphaned, isNull);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   test('neither clears an existing orphan flag', () async {
     await build(VerifyResult.fromOtherDevice).verify(_item(isOrphaned: true));
 
-    expect(repository.written.single.isOrphaned, isTrue);
+    expect(repository.written.single.isOrphaned, isNull);
   });
 
   // volumeOffline and transientError are recoverable conditions, not dead
@@ -143,16 +154,16 @@ void main() {
       ).verify(_item(isOrphaned: false));
 
       expect(result, VerifyResult.volumeOffline);
-      expect(repository.written.single.isOrphaned, isFalse);
-      expect(repository.written.single.lastVerifiedAt, stamp);
+      expect(repository.written.single.isOrphaned, isNull);
+      expect(repository.written.single.verifiedAt, stamp);
     },
   );
 
   test('transientError does not clear an existing orphan flag', () async {
     await build(VerifyResult.transientError).verify(_item(isOrphaned: true));
 
-    expect(repository.written.single.isOrphaned, isTrue);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.isOrphaned, isNull);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   // accessDenied is the one that used to arrive as notFound. A revoked photo
@@ -165,8 +176,8 @@ void main() {
     ).verify(_item(isOrphaned: false));
 
     expect(result, VerifyResult.accessDenied);
-    expect(repository.written.single.isOrphaned, isFalse);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.isOrphaned, isNull);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   test('accessDenied does not clear an existing orphan flag either', () async {
@@ -174,8 +185,8 @@ void main() {
     // the flag in either direction.
     await build(VerifyResult.accessDenied).verify(_item(isOrphaned: true));
 
-    expect(repository.written.single.isOrphaned, isTrue);
-    expect(repository.written.single.lastVerifiedAt, stamp);
+    expect(repository.written.single.isOrphaned, isNull);
+    expect(repository.written.single.verifiedAt, stamp);
   });
 
   // A row whose source type has no registered resolver is a programmer

--- a/test/features/media_store/media_origin_republish_provider_test.dart
+++ b/test/features/media_store/media_origin_republish_provider_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/presentation/providers/media_resolver_providers.dart';
+import 'package:submersion/features/media_store/data/media_origin_republish_sweep.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_origin_republish_provider.dart';
+
+void main() {
+  // Building the resolver registry constructs every resolver in the app.
+  // That is fine once, on the launch that does the repair, and wasteful on
+  // every launch after, so the flag is checked before the registry is read.
+  test('a finished repair never builds the resolver registry', () async {
+    SharedPreferences.setMockInitialValues({
+      MediaOriginRepublishSweep.doneFlagKey: true,
+    });
+    final container = ProviderContainer(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWith(
+          (ref) => throw StateError('registry must not be built'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(mediaOriginRepublishProvider)(),
+      completes,
+    );
+  });
+
+  // The call site is fire-and-forget at launch, so an escaping throw would
+  // land in the zone handler with nothing to catch it.
+  test('contains its failures and leaves the flag unset', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer(
+      overrides: [
+        mediaSourceResolverRegistryProvider.overrideWith(
+          (ref) => MediaSourceResolverRegistry(const {}),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // No database is initialized here, so the device id read throws.
+    await expectLater(
+      container.read(mediaOriginRepublishProvider)(),
+      completes,
+    );
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool(MediaOriginRepublishSweep.doneFlagKey), isNull);
+  });
+}

--- a/test/features/media_store/media_origin_republish_sweep_test.dart
+++ b/test/features/media_store/media_origin_republish_sweep_test.dart
@@ -1,0 +1,180 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/resolvers/local_file_resolver.dart';
+import 'package:submersion/features/media/data/services/exif_extractor.dart';
+import 'package:submersion/features/media/data/services/local_bookmark_storage.dart';
+import 'package:submersion/features/media/data/services/local_media_platform.dart';
+import 'package:submersion/features/media/data/services/media_item_verifier.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media_store/data/media_origin_republish_sweep.dart';
+
+import '../../helpers/test_database.dart';
+
+class _NullBookmarkStorage extends LocalBookmarkStorage {
+  _NullBookmarkStorage() : super(storage: null as dynamic);
+
+  @override
+  Future<Uint8List?> read(String ref) async => null;
+}
+
+class _ThrowingRepository extends MediaRepository {
+  @override
+  Future<List<String>> getStoreStampedMediaIdsOwnedBy(String deviceId) {
+    throw StateError('db unavailable');
+  }
+}
+
+/// One-time repair for libraries damaged before the origin-device fix.
+///
+/// The desktop uploaded; the phone flagged the desktop's rows "missing" and
+/// that write made sync drop the desktop's cloud stamps on the phone. The
+/// desktop still has the stamps, and (usually) the phone's flag. Republishing
+/// its own stamped rows hands the stamps back to every peer; re-checking its
+/// own flagged rows clears a flag it never earned.
+void main() {
+  late AppDatabase db;
+  late MediaRepository repo;
+  late SharedPreferences prefs;
+  late Directory dir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    db = await setUpTestDatabase();
+    repo = MediaRepository();
+    dir = await Directory.systemTemp.createTemp('origin_republish');
+    final epoch = DateTime(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diveDateTime: Value(epoch),
+            createdAt: Value(epoch),
+            updatedAt: Value(epoch),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  MediaOriginRepublishSweep sweep({MediaRepository? repository}) {
+    final r = repository ?? repo;
+    return MediaOriginRepublishSweep(
+      mediaRepository: r,
+      verifier: MediaItemVerifier(
+        registry: MediaSourceResolverRegistry({
+          MediaSourceType.localFile: LocalFileResolver(
+            bookmarkStorage: _NullBookmarkStorage(),
+            platform: LocalMediaPlatform(),
+            exifExtractor: ExifExtractor(),
+            localDeviceId: () async => 'me',
+          ),
+        }),
+        repository: r,
+      ),
+      deviceId: () async => 'me',
+      prefs: prefs,
+    );
+  }
+
+  Future<MediaItem> row(
+    String name, {
+    required String origin,
+    bool present = false,
+    bool stamped = false,
+    bool flagged = false,
+  }) async {
+    final path = '${dir.path}/$name';
+    if (present) File(path).writeAsBytesSync([1, 2, 3]);
+    final created = await repo.createMedia(
+      MediaItem(
+        id: '',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        filePath: path,
+        localPath: path,
+        originalFilename: name,
+        diveId: 'd1',
+        originDeviceId: origin,
+        contentHash: stamped ? 'hash-$name' : null,
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    if (stamped) {
+      await repo.stampRemoteUploaded(created.id, uploadedAt: DateTime(2026, 2));
+    }
+    if (flagged) await repo.markAsOrphaned(created.id);
+    return created;
+  }
+
+  Future<Set<String>> pendingMediaIds() async => {
+    for (final r in await SyncRepository().getPendingRecords())
+      if (r.entityType == 'media') r.recordId,
+  };
+
+  test('republishes every stamped row this device imported, and nothing '
+      'else', () async {
+    final mine = await row('mine.jpg', origin: 'me', stamped: true);
+    await row('unstamped.jpg', origin: 'me');
+    await row('theirs.jpg', origin: 'other', stamped: true);
+    await SyncRepository().clearPendingRecords();
+
+    final outcome = await sweep().run();
+
+    expect(outcome?.republished, 1);
+    expect(await pendingMediaIds(), {mine.id});
+  });
+
+  test('clears the missing flag on an own row whose file is present', () async {
+    final present = await row(
+      'present.jpg',
+      origin: 'me',
+      present: true,
+      flagged: true,
+    );
+    final gone = await row('gone.jpg', origin: 'me', flagged: true);
+    // A peer's row this device cannot read: not this device's call to make.
+    final theirs = await row('theirs.jpg', origin: 'other', flagged: true);
+
+    final outcome = await sweep().run();
+
+    expect(outcome?.rechecked, 2);
+    expect(outcome?.unflagged, 1);
+    expect((await repo.getMediaById(present.id))!.isOrphaned, isFalse);
+    expect((await repo.getMediaById(gone.id))!.isOrphaned, isTrue);
+    expect((await repo.getMediaById(theirs.id))!.isOrphaned, isTrue);
+  });
+
+  test('runs once per device', () async {
+    await row('mine.jpg', origin: 'me', stamped: true);
+    expect(await sweep().run(), isNotNull);
+    await SyncRepository().clearPendingRecords();
+
+    expect(await sweep().run(), isNull);
+
+    expect(await pendingMediaIds(), isEmpty);
+    expect(prefs.getBool(MediaOriginRepublishSweep.doneFlagKey), isTrue);
+  });
+
+  test('a failure leaves the flag unset so the next launch retries', () async {
+    final outcome = await sweep(repository: _ThrowingRepository()).run();
+
+    expect(outcome, isNull);
+    expect(prefs.getBool(MediaOriginRepublishSweep.doneFlagKey), isNull);
+  });
+}

--- a/test/features/media_store/media_storage_page_test.dart
+++ b/test/features/media_store/media_storage_page_test.dart
@@ -714,6 +714,9 @@ void main() {
               runs++;
               return const VerifyLibraryReport(
                 objectsChecked: 12,
+                originalsChecked: 7,
+                thumbsChecked: 4,
+                renditionsChecked: 1,
                 orphansRemoved: 3,
                 bytesReclaimed: 999,
                 sessionsAborted: 1,
@@ -735,7 +738,15 @@ void main() {
     });
 
     expect(runs, 1);
-    expect(find.textContaining('Checked 12 objects'), findsOneWidget);
+    // A photo is stored as an original plus a thumbnail (plus a rendition
+    // when compressed), so the object count exceeds the photo count; the
+    // summary says so rather than leaving the reader to count twice.
+    expect(
+      find.textContaining(
+        'Checked 12 cloud objects (7 originals, 4 thumbnails, 1 compressed versions)',
+      ),
+      findsOneWidget,
+    );
   });
 
   Widget throwingVerifyApp(Object error) => app(

--- a/test/features/media_store/media_storage_page_test.dart
+++ b/test/features/media_store/media_storage_page_test.dart
@@ -743,7 +743,7 @@ void main() {
     // summary says so rather than leaving the reader to count twice.
     expect(
       find.textContaining(
-        'Checked 12 cloud objects (7 originals, 4 thumbnails, 1 compressed versions)',
+        'Checked 12 cloud objects (7 originals, 4 thumbnails, 1 compressed version)',
       ),
       findsOneWidget,
     );

--- a/test/features/media_store/media_upload_pipeline_test.dart
+++ b/test/features/media_store/media_upload_pipeline_test.dart
@@ -73,11 +73,14 @@ class _FakeLocalFileResolver implements MediaSourceResolver {
   /// gallery resolver's pre-compressed poster bytes for videos).
   MediaSourceData? thumbnailData;
 
+  /// Models the real resolvers' origin-device check.
+  bool canResolve = true;
+
   @override
   MediaSourceType get sourceType => MediaSourceType.localFile;
 
   @override
-  bool canResolveOnThisDevice(domain.MediaItem item) => true;
+  bool canResolveOnThisDevice(domain.MediaItem item) => canResolve;
 
   @override
   Future<MediaSourceData> resolve(domain.MediaItem item) async => data;
@@ -276,6 +279,37 @@ void main() {
     expect(row.errorMessage, contains('unavailable'));
     expect(fakeStore.objects, isEmpty);
     expect((await mediaRepository.getMediaById(id))!.remoteUploadedAt, isNull);
+  });
+
+  test('a row another device owns completes as ineligible instead of '
+      'failing', () async {
+    // The phone holds a row the desktop imported: the path is the
+    // desktop's, and the resolver says so. Nothing on this device can
+    // upload it, so the queue entry must finish quietly rather than sit
+    // in Transfers as "source unavailable" forever.
+    await enqueueLocalFileItem(bytes: [1], name: 'desktop.jpg');
+    resolver.data = const UnavailableData(
+      kind: UnavailableKind.fromOtherDevice,
+    );
+
+    final entry = (await queue.nextPending(DateTime.now()))!;
+    expect(await pipeline.process(entry), UploadOutcome.skippedIneligible);
+
+    final row = (await queue.allForTesting()).single;
+    expect(row.state, 'done');
+    expect(row.errorMessage, isNull);
+    expect(fakeStore.objects, isEmpty);
+  });
+
+  test('a resolver that declines the device skips the row before reading '
+      'anything', () async {
+    await enqueueLocalFileItem(bytes: [1], name: 'desktop.jpg');
+    resolver.canResolve = false;
+
+    final entry = (await queue.nextPending(DateTime.now()))!;
+    expect(await pipeline.process(entry), UploadOutcome.skippedIneligible);
+    expect((await queue.allForTesting()).single.state, 'done');
+    expect(fakeStore.objects, isEmpty);
   });
 
   test('thumb object uploads alongside the original and stamps '

--- a/test/features/media_store/media_verify_service_test.dart
+++ b/test/features/media_store/media_verify_service_test.dart
@@ -151,6 +151,11 @@ void main() {
     expect(report.orphansRemoved, 3);
     expect(report.bytesReclaimed, 11); // 3 + 5 + 3
     expect(report.objectsChecked, 6); // marker is outside the namespaces
+    // The total counts every stored object, so a library of N photos reads
+    // as 2N or 3N; the breakdown is what makes that number explainable.
+    expect(report.originalsChecked, 4);
+    expect(report.thumbsChecked, 1);
+    expect(report.renditionsChecked, 1);
     expect(report.repairsQueued, 0);
   });
 


### PR DESCRIPTION
## Summary

A user reported three things after uploading 12 photos to the media store from the desktop app: the phone showed the same photos as not backed up, the phone's File Transfers queued them for upload and failed them with "source unavailable", and Verify Library reported 24 objects for 12 photos. The first two are one bug; the third is a wording problem.

### Root cause

Every `localFile` row records the device that imported it (`originDeviceId`), and the `MediaSourceResolver` contract says `canResolveOnThisDevice` returns false when that points elsewhere. `LocalFileResolver` never consulted it. On the phone the desktop's path simply did not exist, so the resolver answered `notFound`, which is the one verdict that orphans a row.

That single wrong verdict fans out:

1. The grid tile's passive reconciliation wrote `isOrphaned = true` on a row the phone did not own. That write marks the row pending. `_mergeEntity` skips a peer's copy of any locally pending row (media is a clockless entity), and the cursor still advances, so the desktop's `contentHash` / `remoteUploadedAt` / `remoteThumbUploadedAt` were dropped on arrival and never re-sent. With no stamps, `storeConfirmed` stays false and the store fallback never engages: "Not backed up".
2. `getBackfillCandidateIds` selects on synced columns only and `canResolveOnThisDevice` said yes, so the phone enqueued the desktop's rows; `_materialize` then failed them with "source unavailable on this device" and parked them for 25 hours.
3. `MediaVerifyService.objectsChecked` counts every stored object across `smv1/objects/`, `smv1/thumbs/` and `smv1/renditions/`. 12 photos are 12 originals plus 12 thumbnails: 24 is correct, the copy just gave no way to see that.

Every downstream consumer of `UnavailableKind.fromOtherDevice` / `VerifyResult.fromOtherDevice` already did the right thing (the reconciler leaves the flag alone, the verifier never orphans, the placeholder says "From another device"); nothing produced the value.

### Changes

- `LocalFileResolver` answers `fromOtherDevice` for a failed read on a row whose `originDeviceId` is not this device's. A shared volume that does resolve still resolves; the check only reclassifies a failure. `verify` maps it, and `canResolveOnThisDevice` honours the origin once the id is known (the id source is injected and memoized; the provider passes `SyncRepository().getDeviceId()`, fetched lazily and only when a failed read names an origin).
- `MediaUploadPipeline` completes such an entry as `skippedIneligible` instead of failing it, so the phone's existing "source unavailable" entries clear on the next drain.
- `getBackfillCandidateIds` excludes rows another device imported; rows with no origin (pre-provenance) keep today's verdict.
- `VerifyLibraryReport` carries per-namespace counts and the summary reads "Checked 24 cloud objects (12 originals, 12 thumbnails, 0 compressed versions): ..." in all 11 locales.
- `MediaItemVerifier` (Check now / Check all media) persists through a new narrow `MediaRepository.stampVerification` instead of a whole-row `updateMedia` from the caller's snapshot, closing the same stamp-rollback hazard `markVerified`'s doc comment already describes for the grid tiles.

### What this deliberately leaves alone

- The sync engine's pending-skip for clockless entities. It is the loss mechanism here, but it is also the engine's chosen answer for every clockless table, and with the resolver fixed nothing automatic creates a pending record on a foreign row any more. A user editing a caption on the phone while the desktop's upload is in flight can still race it, which is the same race every clockless entity has.
- Gallery rows (`platformGallery`), which are device-portable by design and re-matched through `AssetResolutionService`.

### Recovery for libraries already in this state

Automatic, once per device, at launch (`MediaOriginRepublishSweep`, hosted beside `mediaTransferResumeProvider`, flagged in SharedPreferences like `AccountStartupMigration`):

1. Every row this device imported that carries the "missing" flag is re-checked through `MediaItemVerifier`; a present file clears the flag (the phone put it there), a genuinely missing one keeps it.
2. Every store-stamped row this device imported is marked pending in one transaction (`MediaRepository.republishForSync`, no column changes), so the next changeset carries the stamps to every peer. Peers apply them because, with the resolver fixed, nothing automatic leaves a pending record on a row they do not own.

Rows another device imported are left alone in both steps. The flag is set only after both steps succeed, so a failed launch retries; both steps are idempotent. Both devices should be updated before the next sync, since an un-updated phone would flag the republished rows again.

## Test plan

- New: one-time origin republish (repository queries scoped to this device's rows, republish marks pending without touching columns, sweep clears a present file's flag and leaves a peer's rows alone, runs once, a failure leaves the flag unset; provider skips the registry build once done and contains failures); resolver origin-device group (fromOtherDevice on resolve and verify, shared volume still resolves, own/legacy rows stay notFound, unknown id degrades to notFound, canResolveOnThisDevice after the id is known); pipeline other-device entry completes as ineligible; backfill excludes other-device rows; verify report breakdown and summary copy; verifier uses the narrow write; `stampVerification` preserves cloud stamps and is sync-visible.
- `flutter analyze` clean, `dart format` clean, all 11 ARBs updated and `flutter gen-l10n` run last (German getter spot-checked).
- Full `flutter test` run once in the worktree before the republish commit: 21,560 passed, 19 skipped, 0 failed. After it: `test/features/media`, `test/features/media_store`, `test/app_test.dart`, `test/l10n` (2,300 tests; the one known concurrent-suite flake, `media_share_helper_test`, passed alone).
- Not done: two-device hardware smoke. To reproduce the original report: import a photo on device A with the store attached, sync, open the dive on device B before A's upload finishes, sync both again; before this change B stays "Not backed up" forever.
