### PR TITLE
Exclude a dive from statistics (#526, #1272)

### DIFF
--- a/docs/superpowers/plans/2026-08-28-exclude-dive-from-statistics.md
+++ b/docs/superpowers/plans/2026-08-28-exclude-dive-from-statistics.md
@@ -1,0 +1,2419 @@
+# Exclude a Dive from Statistics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a diver mark a dive as excluded from all statistics, or from gas statistics only, while keeping it fully visible and editable in the logbook.
+
+**Architecture:** Two boolean columns on `dives`, enforced by a single shared SQL predicate helper (`DiveStatsScope`) that every descriptive aggregate query interpolates. The helper is applied *orthogonally* to the diver's `DiveFilterState` view filter, never inside it, so the exclusion cannot evaporate when no view filter is active. A source-census test prevents future aggregates from silently skipping the scope.
+
+**Tech Stack:** Flutter, Drift (SQLite), Riverpod, raw `customSelect` SQL throughout.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md`
+
+## Global Constraints
+
+- **Schema version 178.** Main is at 175; 176 is claimed by open PR #1328, 177 by open PR #1361. Before pushing, re-run BOTH claim scans (open-PR diffs and every worktree's working-tree scalar). A rung claimed below main's scalar merges with no conflict marker and its migration step then silently never runs.
+- **Worktree:** all work happens in `.claude/worktrees/issue-526-exclude-from-stats` on branch `worktree-issue-526-exclude-from-stats`. Use absolute paths or `git -C`; the Bash working directory resets to the main checkout between calls.
+- **No em-dashes** (U+2014) in any output: code, comments, docs, commit messages. No en-dashes as prose punctuation, no double hyphens, no spaced hyphens as punctuation.
+- **No emojis** in code, comments, or documentation.
+- **Localization:** every new user-facing string needs keys in all eleven locales: `ar de en es fr he hu it nl pt zh`. English-only additions fail `arb_parity_test` against every other locale.
+- **Immutability:** never mutate objects or arrays. All domain entities have `copyWith`.
+- **TDD:** write the failing test first, watch it fail, then implement.
+- **Commit frequently**, one commit per task minimum. No `Co-Authored-By` trailer. No Claude Code attribution or session URL in commit messages or PR bodies.
+- **Never run `git add -A` or `git add -u`** in this shared checkout. Stage explicit paths only; `-A` sweeps a sibling session's uncommitted work into your commit.
+- **Never pipe `flutter test` into `grep`.** The pipeline returns grep's exit status, not the test runner's.
+- **Do not overlap local test runs.** Two concurrent runs fake a lone failure.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+| --- | --- |
+| `lib/core/database/dive_stats_scope.dart` | The single canonical SQL predicate for "which dives count as statistics". Pure string builder, no I/O. |
+| `test/core/database/dive_stats_scope_test.dart` | Unit tests for the predicate strings. |
+| `test/core/database/dive_stats_scope_census_test.dart` | Source census: every `FROM dives` query either carries the scope or is explicitly marked exempt. |
+| `test/features/statistics/dive_stats_scope_behavior_test.dart` | Behavioral guard suite over a seeded fixture, covering every descriptive aggregate. |
+| `test/features/dive_log/dive_stats_exclusion_migration_test.dart` | v177 to v178 migration, backstop idempotency, minimal-schema self-guard. |
+
+**Modified (principal):**
+
+| File | Change |
+| --- | --- |
+| `lib/core/database/database.dart` | Two columns on `Dives`, `currentSchemaVersion` to 178, `_assertDiveStatsExclusionColumns()`, `onUpgrade` rung, `beforeOpen` backstop. |
+| `lib/features/statistics/data/repositories/statistics_repository.dart` | `_diveFilter` emits the scope unconditionally; four hand patches; seven gas queries switch to `gas: true`. |
+| `lib/features/dive_log/data/repositories/dive_repository_impl.dart` | Five aggregate methods get the scope; entity mappers and companions carry the two flags. |
+| `lib/features/dive_log/domain/entities/dive.dart` | Two fields, constructor defaults, `copyWith`, equality list. |
+| `lib/features/dive_log/domain/models/dive_filter_state.dart` | `excludedFromStatsOnly` axis. |
+| `lib/features/dive_log/presentation/pages/dive_edit_page.dart` | Two checkboxes in The Dive section; two gated bulk-edit rows. |
+| `lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart` | Two `BulkField` values, two `BulkScalarInputs` fields. |
+| Nine per-entity repositories | Scope added to descriptive count queries (Task 6). |
+| `lib/l10n/arb/app_*.arb` (11 files) | New keys. |
+
+---
+
+### Task 1: Schema columns and migration
+
+**Files:**
+- Modify: `lib/core/database/database.dart` (Dives table ~line 731, `currentSchemaVersion` line 3291, helper near `_assertBuddyFavoriteColumn` ~line 5412, `onUpgrade` rung ~line 9073, `beforeOpen` backstop ~line 9310)
+- Test: `test/features/dive_log/dive_stats_exclusion_migration_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: columns `dives.excluded_from_stats` and `dives.excluded_from_gas_stats`, both `INTEGER NOT NULL DEFAULT 0`. Drift getters `excludedFromStats` and `excludedFromGasStats` of type `BoolColumn`. Method `AppDatabase._assertDiveStatsExclusionColumns()`.
+
+- [ ] **Step 1: Write the failing migration test**
+
+Create `test/features/dive_log/dive_stats_exclusion_migration_test.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<Set<String>> diveColumnNames(AppDatabase database) async {
+    final cols = await database
+        .customSelect("PRAGMA table_info('dives')")
+        .get();
+    return cols.map((c) => c.read<String>('name')).toSet();
+  }
+
+  test('schema version is 178', () {
+    expect(AppDatabase.currentSchemaVersion, 178);
+  });
+
+  test('a fresh database has both exclusion columns defaulting to 0', () async {
+    final names = await diveColumnNames(db);
+    expect(names, contains('excluded_from_stats'));
+    expect(names, contains('excluded_from_gas_stats'));
+
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_date_time) VALUES ('d1', 0)",
+    );
+    final row = await db
+        .customSelect(
+          'SELECT excluded_from_stats, excluded_from_gas_stats '
+          "FROM dives WHERE id = 'd1'",
+        )
+        .getSingle();
+    expect(row.read<int>('excluded_from_stats'), 0);
+    expect(row.read<int>('excluded_from_gas_stats'), 0);
+  });
+
+  test('the column assert is idempotent across repeated calls', () async {
+    await db.assertDiveStatsExclusionColumnsForTesting();
+    await db.assertDiveStatsExclusionColumnsForTesting();
+    final names = await diveColumnNames(db);
+    expect(names, contains('excluded_from_stats'));
+    expect(names, contains('excluded_from_gas_stats'));
+  });
+
+  test('the column assert self-guards when dives does not exist', () async {
+    await db.customStatement('DROP TABLE dives');
+    await expectLater(
+      db.assertDiveStatsExclusionColumnsForTesting(),
+      completes,
+    );
+  });
+
+  test('an upgrade from v177 adds both columns to an existing dives table',
+      () async {
+    await db.customStatement('DROP TABLE dives');
+    await db.customStatement(
+      'CREATE TABLE dives (id TEXT NOT NULL PRIMARY KEY, '
+      'dive_date_time INTEGER NOT NULL, '
+      'is_planned INTEGER NOT NULL DEFAULT 0)',
+    );
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_date_time) VALUES ('legacy', 0)",
+    );
+
+    await db.assertDiveStatsExclusionColumnsForTesting();
+
+    final row = await db
+        .customSelect(
+          'SELECT excluded_from_stats, excluded_from_gas_stats '
+          "FROM dives WHERE id = 'legacy'",
+        )
+        .getSingle();
+    expect(row.read<int>('excluded_from_stats'), 0,
+        reason: 'pre-existing rows must default to included');
+    expect(row.read<int>('excluded_from_gas_stats'), 0);
+  });
+}
+```
+
+Note: if `AppDatabase.forTesting` does not exist under that exact name in this repo, use whatever constructor the neighbouring migration tests in `test/` already use. Find it with:
+
+```bash
+grep -rn "AppDatabase(" test/ --include='*.dart' | head -5
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/issue-526-exclude-from-stats
+flutter test test/features/dive_log/dive_stats_exclusion_migration_test.dart
+```
+
+Expected: FAIL. `AppDatabase.currentSchemaVersion` is 175, the columns do not exist, and `assertDiveStatsExclusionColumnsForTesting` is undefined.
+
+- [ ] **Step 3: Add the two columns to the Dives table**
+
+In `lib/core/database/database.dart`, immediately after the `isFavorite` getter (~line 731):
+
+```dart
+  // Statistics exclusion (schema v178, issues #526 and #1272).
+  // excludedFromStats is the master flag: the dive stays in the logbook but
+  // contributes to no descriptive aggregate, its count included.
+  // excludedFromGasStats drops the dive from SAC/RMV and gas-mix aggregates
+  // only, for an otherwise ordinary dive whose gas number is unrepresentative
+  // (for example purging the tank for an end-of-dive weight check).
+  // The master flag implies the gas flag; see DiveStatsScope.
+  BoolColumn get excludedFromStats =>
+      boolean().withDefault(const Constant(false))();
+  BoolColumn get excludedFromGasStats =>
+      boolean().withDefault(const Constant(false))();
+```
+
+- [ ] **Step 4: Bump the schema version**
+
+At `lib/core/database/database.dart:3291`, change:
+
+```dart
+  static const int currentSchemaVersion = 175;
+```
+
+to:
+
+```dart
+  static const int currentSchemaVersion = 178;
+```
+
+- [ ] **Step 5: Add the idempotent column-assert helper**
+
+In `lib/core/database/database.dart`, next to `_assertBuddyFavoriteColumn` (~line 5412):
+
+```dart
+  /// Idempotent DDL for the v178 dives.excluded_from_stats and
+  /// dives.excluded_from_gas_stats columns (issues #526 and #1272), letting a
+  /// diver keep a dive in the logbook while removing it from statistics.
+  /// Self-guards on the table existing, and defaults every pre-existing row to
+  /// included. Same dual-call contract (onUpgrade + beforeOpen backstop) as
+  /// the other column-assert helpers.
+  Future<void> _assertDiveStatsExclusionColumns() async {
+    final cols = await customSelect("PRAGMA table_info('dives')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('excluded_from_stats')) {
+      await customStatement(
+        'ALTER TABLE dives ADD COLUMN excluded_from_stats '
+        'INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+    if (!names.contains('excluded_from_gas_stats')) {
+      await customStatement(
+        'ALTER TABLE dives ADD COLUMN excluded_from_gas_stats '
+        'INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+  }
+
+  /// Test-only entry point for [_assertDiveStatsExclusionColumns].
+  @visibleForTesting
+  Future<void> assertDiveStatsExclusionColumnsForTesting() =>
+      _assertDiveStatsExclusionColumns();
+```
+
+If `@visibleForTesting` is not already imported in this file, add `import 'package:meta/meta.dart';` to the import block. Check first:
+
+```bash
+grep -n "visibleForTesting" lib/core/database/database.dart | head -3
+```
+
+- [ ] **Step 6: Add the onUpgrade rung**
+
+In `onUpgrade`, immediately after the `if (from < 175) await reportProgress();` line (~line 9073):
+
+```dart
+        // v178: dives.excluded_from_stats and dives.excluded_from_gas_stats
+        // (issues #526 and #1272). Column-only rung, no backfill: every
+        // pre-existing row correctly defaults to included.
+        if (from < 178) {
+          await _assertDiveStatsExclusionColumns();
+        }
+        if (from < 178) await reportProgress();
+```
+
+- [ ] **Step 7: Add the beforeOpen backstop**
+
+In `beforeOpen`, immediately after the v175 backstop call (~line 9310):
+
+```dart
+        // v178 backstop: re-assert the dives statistics-exclusion columns
+        // (same parallel-branch version-collision self-heal). Safe to re-run
+        // on every open: the helper is column-only with no backfill, so it
+        // cannot resurrect or overwrite diver data.
+        await _assertDiveStatsExclusionColumns();
+```
+
+- [ ] **Step 8: Regenerate Drift code**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/issue-526-exclude-from-stats
+dart run build_runner build --delete-conflicting-outputs
+```
+
+Expected: `database.g.dart` regenerates with `excludedFromStats` and `excludedFromGasStats` on both the table class and the data class. If only one of the two has them, the build was interrupted; re-run before continuing.
+
+- [ ] **Step 9: Run the migration test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/dive_stats_exclusion_migration_test.dart
+```
+
+Expected: PASS, all five tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/issue-526-exclude-from-stats
+git add lib/core/database/database.dart lib/core/database/database.g.dart \
+  test/features/dive_log/dive_stats_exclusion_migration_test.dart
+git commit -m "feat(db): add dives statistics-exclusion columns at schema v178
+
+Two boolean columns, excluded_from_stats (master) and
+excluded_from_gas_stats (SAC/RMV only), both defaulting to included.
+Column-only rung with a beforeOpen backstop; no backfill needed."
+```
+
+---
+
+### Task 2: The DiveStatsScope predicate helper
+
+**Files:**
+- Create: `lib/core/database/dive_stats_scope.dart`
+- Test: `test/core/database/dive_stats_scope_test.dart`
+
+**Interfaces:**
+- Consumes: the column names from Task 1.
+- Produces: `DiveStatsScope.predicate({String alias = 'd', bool gas = false}) -> String` and `DiveStatsScope.and({String alias = 'd', bool gas = false}) -> String`. `and()` returns `predicate()` prefixed with a leading space and `AND `, for appending into an existing WHERE clause. Both are `static`; the class is not instantiable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/core/database/dive_stats_scope_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
+
+void main() {
+  group('DiveStatsScope.predicate', () {
+    test('defaults to alias d and the two descriptive rules', () {
+      expect(
+        DiveStatsScope.predicate(),
+        'd.excluded_from_stats = 0 AND d.is_planned = 0',
+      );
+    });
+
+    test('honours a custom alias on every term', () {
+      expect(
+        DiveStatsScope.predicate(alias: 'd2'),
+        'd2.excluded_from_stats = 0 AND d2.is_planned = 0',
+      );
+    });
+
+    test('the gas variant adds the gas flag and the gauge-mode rule', () {
+      expect(
+        DiveStatsScope.predicate(gas: true),
+        'd.excluded_from_stats = 0 AND d.is_planned = 0 '
+        "AND d.excluded_from_gas_stats = 0 AND d.dive_mode <> 'gauge'",
+      );
+    });
+
+    test('the gas variant honours a custom alias on every term', () {
+      final sql = DiveStatsScope.predicate(alias: 'dives', gas: true);
+      expect(sql.contains('d.'), isFalse,
+          reason: 'no term may fall back to the default alias');
+      expect(sql, contains('dives.excluded_from_gas_stats = 0'));
+      expect(sql, contains("dives.dive_mode <> 'gauge'"));
+    });
+  });
+
+  group('DiveStatsScope.and', () {
+    test('prefixes the predicate for appending into an existing WHERE', () {
+      expect(
+        DiveStatsScope.and(),
+        ' AND d.excluded_from_stats = 0 AND d.is_planned = 0',
+      );
+    });
+
+    test('carries alias and gas through to the predicate', () {
+      expect(
+        DiveStatsScope.and(alias: 'x', gas: true),
+        ' AND ${DiveStatsScope.predicate(alias: 'x', gas: true)}',
+      );
+    });
+
+    test('never emits a bind placeholder', () {
+      expect(DiveStatsScope.and(gas: true).contains('?'), isFalse,
+          reason: 'callers must not have to thread params for the scope');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/core/database/dive_stats_scope_test.dart
+```
+
+Expected: FAIL with "Target of URI doesn't exist: package:submersion/core/database/dive_stats_scope.dart".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/core/database/dive_stats_scope.dart`:
+
+```dart
+/// The canonical SQL predicate deciding which dives contribute to
+/// *descriptive* statistics.
+///
+/// Two rules always apply:
+///
+/// - `excluded_from_stats = 0`: the diver ticked "exclude from statistics"
+///   (issue #526), for example a 90 minute session at 12 ft that is not an
+///   official dive by most agency standards.
+/// - `is_planned = 0`: a dive the planner created that has not happened.
+///   Before schema v178 these counted toward every total, which was a bug.
+///
+/// The [gas] variant adds two more, for SAC/RMV and gas-mix aggregates:
+///
+/// - `excluded_from_gas_stats = 0`: the diver ticked "exclude from gas
+///   statistics" (issue #1272), for example purging the tank down to 500 psi
+///   for an end-of-dive weight check.
+/// - `dive_mode <> 'gauge'`: gauge-mode dives carry no usable gas data. This
+///   rule predates v178 and was hand-copied into seven queries in
+///   StatisticsRepository; it now lives here.
+///
+/// **This is deliberately NOT folded into `buildFilteredDiveIdSubquery`.**
+/// That function implements the diver's transient *view* filter and correctly
+/// returns an empty no-op when no axis is active. This scope is a persistent
+/// property of the dive and must apply unconditionally. Merging the two would
+/// either make the exclusion evaporate for every diver who never opens the
+/// filter sheet, or silently scope the deliberately-unfiltered surfaces
+/// (dashboard quick stats, dive-log summary, species detail page).
+///
+/// **Operational counts deliberately ignore this scope.** Equipment service
+/// intervals, course-requirement progress, and the logbook list header all
+/// count excluded dives on purpose; each carries a doc comment saying so. A
+/// practice dive still cycled the regulator, and a dive the diver linked to a
+/// course requirement was linked on purpose.
+///
+/// See `docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md`.
+class DiveStatsScope {
+  const DiveStatsScope._();
+
+  /// The bare predicate, with no leading conjunction. Use when the query has
+  /// no WHERE clause yet: `WHERE ${DiveStatsScope.predicate()}`.
+  ///
+  /// [alias] must match the alias the query already gives the `dives` table
+  /// (or `dives` itself when the query does not alias it). Queries that join
+  /// `dives` to itself need one call per alias.
+  static String predicate({String alias = 'd', bool gas = false}) {
+    final parts = <String>[
+      '$alias.excluded_from_stats = 0',
+      '$alias.is_planned = 0',
+    ];
+    if (gas) {
+      parts.add('$alias.excluded_from_gas_stats = 0');
+      parts.add("$alias.dive_mode <> 'gauge'");
+    }
+    return parts.join(' AND ');
+  }
+
+  /// The predicate prefixed with ` AND `, for appending into an existing
+  /// WHERE clause. Emits no bind placeholders, so callers never thread params
+  /// for the scope.
+  static String and({String alias = 'd', bool gas = false}) =>
+      ' AND ${predicate(alias: alias, gas: gas)}';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+flutter test test/core/database/dive_stats_scope_test.dart
+```
+
+Expected: PASS, all seven tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/database/dive_stats_scope.dart \
+  test/core/database/dive_stats_scope_test.dart
+git commit -m "feat(db): add DiveStatsScope, the canonical statistics predicate
+
+One place deciding which dives count as statistics. Absorbs the
+gauge-mode rule that was hand-copied into seven gas queries, and adds
+is_planned, which no aggregate filtered on before."
+```
+
+---
+
+### Task 3: Entity and mapper plumbing
+
+**Files:**
+- Modify: `lib/features/dive_log/domain/entities/dive.dart` (fields ~line 120, constructor ~line 235, `copyWith` params ~line 587, `copyWith` body ~line 682, props list ~line 780)
+- Modify: `lib/features/dive_log/domain/entities/dive_summary.dart`
+- Modify: `lib/features/dive_log/domain/services/dive_merge_builder.dart`
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (mappers ~3562 and ~3944, companions ~1409 and ~1664)
+- Test: `test/features/dive_log/dive_stats_exclusion_entity_test.dart`
+
+**Interfaces:**
+- Consumes: `dives.excludedFromStats` / `excludedFromGasStats` from Task 1.
+- Produces: `Dive.excludedFromStats` and `Dive.excludedFromGasStats`, both `final bool`, defaulting to `false` in the constructor, present in `copyWith` as `bool?` and in the equality props list. Same two fields on `DiveSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/dive_stats_exclusion_entity_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+void main() {
+  Dive makeDive() => Dive(id: 'd1', diveDateTime: DateTime(2026, 1, 1));
+
+  test('both exclusion flags default to false', () {
+    final dive = makeDive();
+    expect(dive.excludedFromStats, isFalse);
+    expect(dive.excludedFromGasStats, isFalse);
+  });
+
+  test('copyWith sets each flag independently', () {
+    final dive = makeDive();
+    expect(dive.copyWith(excludedFromStats: true).excludedFromStats, isTrue);
+    expect(
+      dive.copyWith(excludedFromStats: true).excludedFromGasStats,
+      isFalse,
+      reason: 'the master flag must not write through to the gas flag; '
+          'the implication lives in SQL, not in the entity',
+    );
+    expect(
+      dive.copyWith(excludedFromGasStats: true).excludedFromGasStats,
+      isTrue,
+    );
+  });
+
+  test('copyWith preserves the flags when they are not passed', () {
+    final excluded = makeDive().copyWith(
+      excludedFromStats: true,
+      excludedFromGasStats: true,
+    );
+    final renamed = excluded.copyWith(notes: 'changed');
+    expect(renamed.excludedFromStats, isTrue);
+    expect(renamed.excludedFromGasStats, isTrue);
+  });
+
+  test('the flags participate in equality', () {
+    final a = makeDive();
+    final b = makeDive().copyWith(excludedFromStats: true);
+    expect(a, isNot(equals(b)));
+  });
+}
+```
+
+If `Dive`'s required constructor arguments differ from `id` and `diveDateTime`, adjust `makeDive()` to the minimal valid set. Check with:
+
+```bash
+sed -n '225,245p' lib/features/dive_log/domain/entities/dive.dart
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/dive_log/dive_stats_exclusion_entity_test.dart
+```
+
+Expected: FAIL, "The getter 'excludedFromStats' isn't defined for the class 'Dive'".
+
+- [ ] **Step 3: Add the fields to the Dive entity**
+
+In `lib/features/dive_log/domain/entities/dive.dart`, immediately after `final bool isFavorite;` (~line 120):
+
+```dart
+  /// Excluded from every descriptive statistic, its count included (#526).
+  /// The dive stays fully visible and editable in the logbook.
+  final bool excludedFromStats;
+
+  /// Excluded from SAC/RMV and gas-mix aggregates only (#1272), for a dive
+  /// whose gas number is unrepresentative. Implied by [excludedFromStats];
+  /// the implication is applied in SQL by DiveStatsScope, not here.
+  final bool excludedFromGasStats;
+```
+
+After `this.isFavorite = false,` in the constructor (~line 235):
+
+```dart
+    this.excludedFromStats = false,
+    this.excludedFromGasStats = false,
+```
+
+After `bool? isFavorite,` in the `copyWith` signature (~line 587):
+
+```dart
+    bool? excludedFromStats,
+    bool? excludedFromGasStats,
+```
+
+After `isFavorite: isFavorite ?? this.isFavorite,` in the `copyWith` body (~line 682):
+
+```dart
+      excludedFromStats: excludedFromStats ?? this.excludedFromStats,
+      excludedFromGasStats: excludedFromGasStats ?? this.excludedFromGasStats,
+```
+
+After `isFavorite,` in the props list (~line 780):
+
+```dart
+    excludedFromStats,
+    excludedFromGasStats,
+```
+
+- [ ] **Step 4: Run the entity test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/dive_stats_exclusion_entity_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Plumb the mappers and companions**
+
+Find every place `isFavorite` crosses the database boundary and add the two flags beside it:
+
+```bash
+grep -n "isFavorite" lib/features/dive_log/data/repositories/dive_repository_impl.dart
+grep -n "isFavorite" lib/features/dive_log/domain/entities/dive_summary.dart
+grep -n "isFavorite" lib/features/dive_log/domain/services/dive_merge_builder.dart
+```
+
+For each row-to-entity mapper, add:
+
+```dart
+      excludedFromStats: row.excludedFromStats,
+      excludedFromGasStats: row.excludedFromGasStats,
+```
+
+For each entity-to-companion site, add:
+
+```dart
+      excludedFromStats: Value(dive.excludedFromStats),
+      excludedFromGasStats: Value(dive.excludedFromGasStats),
+```
+
+`DiveSummary` gets the same two `final bool` fields with `= false` defaults, and its mapper gets the same two lines. `dive_merge_builder.dart` treats them exactly as it treats `isFavorite`.
+
+- [ ] **Step 6: Verify the whole project analyzes clean**
+
+```bash
+flutter analyze
+```
+
+Expected: no errors. Any "isn't defined" error names a mapper or companion site missed in Step 5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/dive_log/domain/entities/dive.dart \
+  lib/features/dive_log/domain/entities/dive_summary.dart \
+  lib/features/dive_log/domain/services/dive_merge_builder.dart \
+  lib/features/dive_log/data/repositories/dive_repository_impl.dart \
+  test/features/dive_log/dive_stats_exclusion_entity_test.dart
+git commit -m "feat(dive): carry statistics-exclusion flags on the Dive entity
+
+Mirrors the isFavorite plumbing across entity, summary, merge builder,
+mappers and companions."
+```
+
+---
+
+### Task 4: Enforce the scope in the statistics feature
+
+**Files:**
+- Modify: `lib/features/statistics/data/repositories/statistics_repository.dart`
+- Test: `test/features/statistics/dive_stats_scope_behavior_test.dart` (created here, extended in Tasks 5 and 6)
+
+**Interfaces:**
+- Consumes: `DiveStatsScope.and` from Task 2.
+- Produces: `StatisticsRepository._diveFilter` gains a `bool gas = false` parameter and now emits the scope unconditionally, whether or not the `DiveFilterState` has active axes.
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+Create `test/features/statistics/dive_stats_scope_behavior_test.dart`. Seed five dives and assert the aggregates ignore the right ones:
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  /// Seeds one included dive and four that every descriptive aggregate must
+  /// ignore. All five are 30 minutes at 30 m so any leak shows up as an
+  /// inflated count or a shifted average, not as a subtle rounding change.
+  Future<void> seed() async {
+    Future<void> insert(
+      String id, {
+      bool excludedFromStats = false,
+      bool excludedFromGasStats = false,
+      bool isPlanned = false,
+      String diveMode = 'oc',
+    }) async {
+      await db.customStatement(
+        'INSERT INTO dives (id, dive_date_time, max_depth, avg_depth, '
+        'bottom_time, dive_mode, is_planned, excluded_from_stats, '
+        'excluded_from_gas_stats) VALUES (?, ?, 30.0, 15.0, 1800, ?, ?, ?, ?)',
+        [
+          id,
+          DateTime(2026, 1, 1).millisecondsSinceEpoch,
+          diveMode,
+          isPlanned ? 1 : 0,
+          excludedFromStats ? 1 : 0,
+          excludedFromGasStats ? 1 : 0,
+        ],
+      );
+    }
+
+    await insert('included');
+    await insert('excluded', excludedFromStats: true);
+    await insert('gas-excluded', excludedFromGasStats: true);
+    await insert('planned', isPlanned: true);
+    await insert('gauge', diveMode: 'gauge');
+  }
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = StatisticsRepository(db);
+    await seed();
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('getDivesPerYear counts only the included dive', () async {
+    final rows = await repo.getDivesPerYear();
+    final total = rows.fold<int>(0, (sum, r) => sum + r.count);
+    expect(total, 1,
+        reason: 'excluded, planned and gas-excluded dives must not be counted; '
+            'gauge dives are excluded from gas stats only, so this counts it '
+            'as well and the expected total is 2 if gauge is included');
+  });
+
+  test('getCumulativeDiveCount ignores excluded and planned dives', () async {
+    final rows = await repo.getCumulativeDiveCount();
+    expect(rows.isEmpty || rows.last.count <= 2, isTrue);
+  });
+
+  test('getDepthProgressionTrend ignores excluded and planned dives',
+      () async {
+    final rows = await repo.getDepthProgressionTrend();
+    expect(rows.length, lessThanOrEqualTo(2));
+  });
+
+  test('getSacVolumeTrend ignores gas-excluded and gauge dives', () async {
+    final rows = await repo.getSacVolumeTrend();
+    expect(rows, isEmpty,
+        reason: 'no dive_tanks rows were seeded, so this asserts the query '
+            'runs and returns nothing rather than throwing on the new columns');
+  });
+}
+```
+
+Adjust the expected counts once you see which of the five each aggregate legitimately includes. The gauge dive is excluded from gas aggregates only, so non-gas aggregates count two dives (`included` and `gauge`), and gas aggregates count one. Encode whichever is correct per method; do not weaken an assertion to make it pass.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: FAIL. Counts include the excluded and planned dives.
+
+- [ ] **Step 3: Make `_diveFilter` emit the scope unconditionally**
+
+In `lib/features/statistics/data/repositories/statistics_repository.dart`, replace the `_diveFilter` helper (~line 189):
+
+```dart
+  /// Builds the always-on statistics scope plus, when the diver has active
+  /// filter axes, the `AND <alias>.id IN (<subquery>)` fragment and its raw
+  /// params.
+  ///
+  /// The scope is emitted unconditionally and the user filter conditionally.
+  /// They are deliberately separate: [buildFilteredDiveIdSubquery] is the
+  /// diver's transient view filter and no-ops when nothing is selected, while
+  /// [DiveStatsScope] is a persistent property of the dive. Folding the scope
+  /// into the subquery would make the exclusion evaporate for every diver who
+  /// never opens the filter sheet.
+  ///
+  /// Pass `gas: true` for SAC/RMV and gas-mix aggregates, which additionally
+  /// drop per-dive gas exclusions and gauge-mode dives.
+  ({String clause, List<Object?> params}) _diveFilter(
+    DiveFilterState filter, {
+    String alias = 'dives',
+    bool gas = false,
+  }) {
+    final scope = DiveStatsScope.and(alias: alias, gas: gas);
+    final f = buildFilteredDiveIdSubquery(filter);
+    if (f.subquery.isEmpty) {
+      return (clause: scope, params: const <Object?>[]);
+    }
+    return (
+      clause: '$scope AND $alias.id IN (${f.subquery})',
+      params: f.params,
+    );
+  }
+```
+
+Add the import at the top of the file:
+
+```dart
+import 'package:submersion/core/database/dive_stats_scope.dart';
+```
+
+- [ ] **Step 4: Switch the seven gas queries to the gas variant**
+
+In each of the seven gas methods, change the `_diveFilter` call to pass `gas: true` and delete the now-duplicated literal `AND d.dive_mode <> 'gauge'` from the SQL.
+
+The methods: `getSacVolumeTrend`, `getSacPressureTrend`, `getGasMixDistribution`, `getSacVolumeRecords`, `getSacPressureRecords`, `getSacVolumeByTankRole`, `getSacPressureByTankRole`.
+
+For each:
+
+```dart
+      final df = _diveFilter(filter, alias: 'd', gas: true);
+```
+
+and in the SQL, change:
+
+```sql
+        WHERE d.dive_date_time >= ? AND d.dive_mode <> 'gauge' $diverFilter ${df.clause}
+```
+
+to:
+
+```sql
+        WHERE d.dive_date_time >= ? $diverFilter ${df.clause}
+```
+
+Confirm all seven literals are gone:
+
+```bash
+grep -n "dive_mode <> 'gauge'" lib/features/statistics/data/repositories/statistics_repository.dart
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Hand-patch the three methods that bypass `_diveFilter`**
+
+`getYearStats`, `getEntryExitMethodPairsForSite`, and `getSiteHistoryByName` build their own WHERE clauses. In each, append the scope to the existing WHERE using the alias that query already gives `dives`:
+
+```dart
+${DiveStatsScope.and(alias: 'd')}
+```
+
+If a query does not alias the table, use `alias: 'dives'`.
+
+- [ ] **Step 6: Patch the self-join inside getSurfaceIntervalStats**
+
+`getSurfaceIntervalStats` has a nested `FROM dives d2` subquery (~line 2025) that the filter clause has never reached. Add the scope to the inner alias as well as the outer:
+
+```dart
+${DiveStatsScope.and(alias: 'd2')}
+```
+
+- [ ] **Step 7: Run the behavioral test to verify it passes**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the whole statistics suite for regressions**
+
+```bash
+flutter test test/features/statistics/
+```
+
+Expected: PASS. Failures here are most likely tests that seed a planned dive and expect it counted; leave them failing and record them for Task 8 rather than weakening the new behavior.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/features/statistics/data/repositories/statistics_repository.dart \
+  test/features/statistics/dive_stats_scope_behavior_test.dart
+git commit -m "feat(stats): honour the statistics scope in StatisticsRepository
+
+_diveFilter now emits the scope unconditionally, covering 37 aggregates
+in one edit. Four methods that build their own WHERE are patched by
+hand, including the getSurfaceIntervalStats self-join the user filter
+never reached. The seven gas queries drop their hand-copied gauge-mode
+literal in favour of the shared gas variant."
+```
+
+---
+
+### Task 5: Enforce the scope in the dive log repository
+
+**Files:**
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (`getStatistics` ~2816, `getRecords` ~2984, `getPersonalRecordIds` ~3224, `countDivesSince` ~3137, `getOnThisDayDiveIds` ~3155, and the doc comment on `getDiveCount` ~2190)
+- Test: `test/features/statistics/dive_stats_scope_behavior_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `DiveStatsScope.and` from Task 2.
+- Produces: no signature changes. `getDiveCount` keeps its current behavior and gains a doc comment explaining why.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/features/statistics/dive_stats_scope_behavior_test.dart`, inside the existing `main()`:
+
+```dart
+  group('DiveRepository aggregates', () {
+    late DiveRepositoryImpl diveRepo;
+
+    setUp(() {
+      diveRepo = DiveRepositoryImpl(db);
+    });
+
+    test('getStatistics counts only dives in scope', () async {
+      final stats = await diveRepo.getStatistics();
+      expect(stats.totalDives, 2,
+          reason: 'included and gauge; excluded, gas-excluded and planned '
+              'are all out of scope for a non-gas aggregate');
+    });
+
+    test('getRecords ignores out-of-scope dives', () async {
+      await db.customStatement(
+        'UPDATE dives SET max_depth = 99.0 WHERE id = ?',
+        ['excluded'],
+      );
+      final records = await diveRepo.getRecords();
+      expect(records.deepestDive?.id, isNot('excluded'),
+          reason: 'an excluded dive must never become a record');
+    });
+
+    test('getPersonalRecordIds ignores out-of-scope dives', () async {
+      await db.customStatement(
+        'UPDATE dives SET bottom_time = 99999 WHERE id = ?',
+        ['planned'],
+      );
+      final ids = await diveRepo.getPersonalRecordIds();
+      expect(ids.values, isNot(contains('planned')));
+    });
+
+    test('countDivesSince ignores out-of-scope dives', () async {
+      final count = await diveRepo.countDivesSince(DateTime(2020));
+      expect(count, 2);
+    });
+
+    test('getDiveCount deliberately still counts excluded dives', () async {
+      final count = await diveRepo.getDiveCount();
+      expect(count, 5,
+          reason: 'the logbook list header counts what is in the logbook; '
+              'an excluded dive is still in the logbook');
+    });
+  });
+```
+
+Add the import:
+
+```dart
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+```
+
+Adjust the constructor call and the record accessor names (`deepestDive`, `values`) to whatever the real types expose. Find them with:
+
+```bash
+grep -n "class DiveRecords\|deepest" lib/features/dive_log/domain/ -r | head -10
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: FAIL on the four scope tests, PASS on `getDiveCount` (which is asserting current behavior stays put).
+
+- [ ] **Step 3: Add the scope to the four aggregate methods**
+
+Add the import to `dive_repository_impl.dart`:
+
+```dart
+import 'package:submersion/core/database/dive_stats_scope.dart';
+```
+
+`getStatistics` (~2816) builds `fBare`, `fAliasD` and `basicWhere` fragments and issues four statements. Append the scope to each statement's WHERE with the alias that statement uses. For an unaliased `FROM dives`, use `alias: 'dives'`; for `FROM dives d`, use `alias: 'd'`.
+
+`getRecords` (~2984), `getPersonalRecordIds` (~3224), `countDivesSince` (~3137) and `getOnThisDayDiveIds` (~3155) get the same treatment, statement by statement. `getRecords` and `getPersonalRecordIds` each issue roughly six superlative statements; every one needs the scope, or a single record will still surface an excluded dive.
+
+Verify none were missed:
+
+```bash
+grep -c "DiveStatsScope" lib/features/dive_log/data/repositories/dive_repository_impl.dart
+```
+
+Expected: at least 20 occurrences across the five methods.
+
+- [ ] **Step 4: Document the deliberate exemption on getDiveCount**
+
+Above `getDiveCount` (~2190), add:
+
+```dart
+  /// Counts the dives in the logbook list, matching the diver's active view
+  /// filter.
+  ///
+  /// Deliberately does NOT apply [DiveStatsScope]: an excluded dive is still
+  /// in the logbook and the list still shows it, so the header still counts
+  /// it. Only descriptive *statistics* honour the exclusion. Do not "fix"
+  /// this; see the design doc and the census test's exemption list.
+  // stats-scope-exempt: logbook list header, not a statistic
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/dive_log/data/repositories/dive_repository_impl.dart \
+  test/features/statistics/dive_stats_scope_behavior_test.dart
+git commit -m "feat(dive): honour the statistics scope in DiveRepository aggregates
+
+getStatistics, getRecords, getPersonalRecordIds, countDivesSince and
+getOnThisDayDiveIds all scope out excluded and planned dives.
+getDiveCount deliberately does not: the logbook list counts what is in
+the logbook."
+```
+
+---
+
+### Task 6: Enforce the scope in per-entity descriptive counts
+
+**Files:**
+- Modify: nine repositories, listed in the table below
+- Test: `test/features/statistics/dive_stats_scope_behavior_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `DiveStatsScope.and` from Task 2.
+- Produces: no signature changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a group to the behavioral suite. Seed a buddy, a site and a trip linked to both the `included` and the `excluded` dive, then assert each count is 1 rather than 2:
+
+```dart
+  group('per-entity descriptive counts', () {
+    setUp(() async {
+      await db.customStatement(
+        "INSERT INTO buddies (id, name) VALUES ('b1', 'Test Buddy')",
+      );
+      await db.customStatement(
+        "INSERT INTO dive_buddies (dive_id, buddy_id) VALUES ('included', 'b1')",
+      );
+      await db.customStatement(
+        "INSERT INTO dive_buddies (dive_id, buddy_id) VALUES ('excluded', 'b1')",
+      );
+    });
+
+    test('getDiveCountForBuddy ignores excluded dives', () async {
+      final repo = BuddyRepository(db);
+      expect(await repo.getDiveCountForBuddy('b1'), 1);
+    });
+
+    test('getBuddyStats ignores excluded dives', () async {
+      final repo = BuddyRepository(db);
+      final stats = await repo.getBuddyStats('b1');
+      expect(stats.diveCount, 1);
+    });
+  });
+```
+
+Add equivalent tests for sites, trips and tags following the same shape: link both `included` and `excluded`, assert the count is 1. Adjust constructor names and result accessors to the real types.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: FAIL, each count returns 2.
+
+- [ ] **Step 3: Add the scope to each query**
+
+For every method in the table, add `${DiveStatsScope.and(alias: '<the query's alias>')}` to the WHERE clause, and add the import to each file:
+
+```dart
+import 'package:submersion/core/database/dive_stats_scope.dart';
+```
+
+| File | Methods |
+| --- | --- |
+| `lib/features/buddies/data/repositories/buddy_repository.dart` | `getAllBuddies` (both inline aggregate joins), `getDiveCountForBuddy`, `getDiveIdsForBuddy`, `getBuddyStats` (main query and the favourite-site query) |
+| `lib/features/dive_sites/data/repositories/site_repository_impl.dart` | `getDiveAggregatesBySite` |
+| `lib/features/trips/data/repositories/trip_repository.dart` | `getTripWithStats`, `getAllTripsWithStats`, `getDiveCountForTrip` |
+| `lib/features/dive_centers/data/repositories/dive_center_repository.dart` | `getDiveCountForCenter` |
+| `lib/features/tags/data/repositories/tag_repository.dart` | the three per-tag `dive_count` queries |
+| `lib/features/dive_types/data/repositories/dive_type_repository.dart` | the two per-type `dive_count` queries |
+| `lib/features/dive_roles/data/repositories/dive_role_repository.dart` | the usage-count query |
+| `lib/features/divers/data/repositories/diver_repository.dart` | `getDiveCountForDiver`, `getTotalBottomTimeForDiver` |
+| `lib/features/marine_life/data/repositories/seen_species_repository.dart` | `getSeenSpecies`, `getSightingsForSpecies` |
+| `lib/features/marine_life/data/repositories/species_repository.dart` | `sightingCountsBySpecies`, `getSpeciesSpottedAtSite` |
+| `lib/features/dive_log/data/repositories/dive_repository_impl.dart` | the dive-computer count query (~line 6239) |
+
+**Queries that need a join added first.** `getDiveCountForBuddy`, and the tag and dive-type count queries, currently count junction-table rows without touching `dives` at all. For example:
+
+```sql
+SELECT COUNT(*) as count FROM dive_buddies WHERE buddy_id = ?
+```
+
+becomes:
+
+```sql
+SELECT COUNT(*) as count FROM dive_buddies db
+JOIN dives d ON d.id = db.dive_id
+WHERE db.buddy_id = ?${DiveStatsScope.and(alias: 'd')}
+```
+
+Adding the join changes performance characteristics. Confirm `dive_buddies.dive_id` and the equivalent junction columns are indexed:
+
+```bash
+grep -rn "dive_buddies\|dive_tags\|dive_dive_types" lib/core/database/performance_indexes.dart
+```
+
+If any is missing an index on its `dive_id` column, add one in that file as part of this task.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+flutter test test/features/statistics/dive_stats_scope_behavior_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the affected feature suites**
+
+```bash
+flutter test test/features/buddies/ test/features/trips/ test/features/tags/ \
+  test/features/dive_sites/ test/features/marine_life/ test/features/divers/
+```
+
+Expected: PASS, except for planned-dive fallout recorded for Task 8.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/buddies lib/features/dive_sites lib/features/trips \
+  lib/features/dive_centers lib/features/tags lib/features/dive_types \
+  lib/features/dive_roles lib/features/divers lib/features/marine_life \
+  lib/features/dive_log/data/repositories/dive_repository_impl.dart \
+  lib/core/database/performance_indexes.dart \
+  test/features/statistics/dive_stats_scope_behavior_test.dart
+git commit -m "feat: honour the statistics scope in per-entity dive counts
+
+Buddy, site, trip, dive-centre, tag, dive-type, role, diver, marine-life
+and dive-computer counts all stop counting excluded and planned dives.
+Three junction-table counts gain a join to dives to see the flags."
+```
+
+---
+
+### Task 7: Document the operational exemptions and add the census test
+
+**Files:**
+- Modify: `lib/features/equipment/data/repositories/equipment_repository_impl.dart`, `lib/features/equipment/domain/services/service_due_engine.dart`, `lib/features/courses/data/repositories/course_repository.dart`, `lib/features/courses/data/repositories/course_requirement_repository.dart`
+- Create: `test/core/database/dive_stats_scope_census_test.dart`
+
+**Interfaces:**
+- Consumes: the marker comment convention `// stats-scope-exempt: <reason>` introduced in Task 5.
+- Produces: a test that fails when a new `FROM dives` query carries neither the scope nor an exemption marker.
+
+- [ ] **Step 1: Write the failing census test**
+
+Create `test/core/database/dive_stats_scope_census_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Every source file holding aggregate SQL over `dives`. A query in one of
+/// these files that neither applies DiveStatsScope nor carries an explicit
+/// exemption marker is a bug: someone added an aggregate without deciding
+/// whether an excluded dive should count.
+const _censusFiles = <String>[
+  'lib/features/statistics/data/repositories/statistics_repository.dart',
+  'lib/features/dive_log/data/repositories/dive_repository_impl.dart',
+  'lib/features/buddies/data/repositories/buddy_repository.dart',
+  'lib/features/dive_sites/data/repositories/site_repository_impl.dart',
+  'lib/features/trips/data/repositories/trip_repository.dart',
+  'lib/features/dive_centers/data/repositories/dive_center_repository.dart',
+  'lib/features/tags/data/repositories/tag_repository.dart',
+  'lib/features/dive_types/data/repositories/dive_type_repository.dart',
+  'lib/features/dive_roles/data/repositories/dive_role_repository.dart',
+  'lib/features/divers/data/repositories/diver_repository.dart',
+  'lib/features/marine_life/data/repositories/seen_species_repository.dart',
+  'lib/features/marine_life/data/repositories/species_repository.dart',
+  'lib/features/equipment/data/repositories/equipment_repository_impl.dart',
+  'lib/features/courses/data/repositories/course_repository.dart',
+  'lib/features/courses/data/repositories/course_requirement_repository.dart',
+];
+
+void main() {
+  test('every dives aggregate applies the scope or is marked exempt', () {
+    final offenders = <String>[];
+
+    for (final path in _censusFiles) {
+      final file = File(path);
+      expect(file.existsSync(), isTrue,
+          reason: '$path is in the census list but does not exist. If it was '
+              'renamed, update _censusFiles.');
+
+      final source = file.readAsStringSync();
+
+      // Split on customSelect/customStatement boundaries so each chunk is one
+      // query plus the code immediately preceding it (where its exemption
+      // marker lives).
+      final chunks = source.split(RegExp(r'custom(Select|Statement)\('));
+
+      for (var i = 0; i < chunks.length; i++) {
+        final chunk = chunks[i];
+        if (!RegExp(r'\bFROM\s+dives\b', caseSensitive: false)
+            .hasMatch(chunk)) {
+          continue;
+        }
+        final applied = chunk.contains('DiveStatsScope') ||
+            chunk.contains('excluded_from_stats');
+        // The marker may sit just above the call, which lands at the end of
+        // the previous chunk.
+        final previous = i > 0 ? chunks[i - 1] : '';
+        final exempt = chunk.contains('stats-scope-exempt') ||
+            previous.contains('stats-scope-exempt');
+
+        if (!applied && !exempt) {
+          final snippet = chunk
+              .split('\n')
+              .firstWhere(
+                (l) => l.toUpperCase().contains('FROM DIVES'),
+                orElse: () => chunk.split('\n').first,
+              )
+              .trim();
+          offenders.add('$path: $snippet');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'These queries read `dives` but neither apply DiveStatsScope '
+          'nor carry a `// stats-scope-exempt: <reason>` marker.\n\n'
+          'Decide which this query is:\n'
+          '  - Descriptive (a statistic a diver reads): apply the scope.\n'
+          '  - Operational (gear wear, course credit, the logbook list): add\n'
+          '    the marker with a one-line reason.\n\n'
+          'Offenders:\n${offenders.join('\n')}',
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/core/database/dive_stats_scope_census_test.dart
+```
+
+Expected: FAIL, listing the equipment and course queries as offenders. If it also lists a query from Tasks 4 to 6, that query was missed; go back and add the scope.
+
+- [ ] **Step 3: Add exemption markers to the operational queries**
+
+In `equipment_repository_impl.dart`, above `getUsageSamplesForEquipment`:
+
+```dart
+  /// Usage samples (date, duration) for the equipment's service clock.
+  ///
+  /// Deliberately does NOT apply [DiveStatsScope]. A dive the diver excluded
+  /// from statistics still physically happened: it cycled the regulator and
+  /// put hours on it. Suppressing it here would push a real service interval
+  /// later than it should be, which is a safety-relevant error, not a
+  /// cosmetic one. Do not "fix" this.
+  // stats-scope-exempt: gear wear is physical, not descriptive
+```
+
+Add the same shape of comment and marker above `getDiveCountForEquipment` and `getTripCountForEquipment`.
+
+In `course_repository.dart` above `getDiveCountForCourse`, and in `course_requirement_repository.dart` above `getCourseProgress` and `getSuggestedDives`:
+
+```dart
+  /// Deliberately does NOT apply [DiveStatsScope]. The diver linked this dive
+  /// to a course requirement on purpose; excluding it from statistics is a
+  /// statement about their logbook averages, not a retraction of course
+  /// credit. Do not "fix" this.
+  // stats-scope-exempt: course credit is deliberate, not descriptive
+```
+
+Also add a note to `ServiceDueEngine` (`service_due_engine.dart:12`) recording that its inputs are deliberately unscoped, so a reader of the engine does not go looking for a missing filter.
+
+- [ ] **Step 4: Run the census test to verify it passes**
+
+```bash
+flutter test test/core/database/dive_stats_scope_census_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify the census actually catches a regression**
+
+Temporarily add a fake unscoped aggregate to `tag_repository.dart`:
+
+```dart
+  Future<int> temporaryCensusProbe() async {
+    final r = await _db
+        .customSelect('SELECT COUNT(*) AS c FROM dives')
+        .getSingle();
+    return r.read<int>('c');
+  }
+```
+
+Run the census test. Expected: FAIL, naming that query. Then delete the probe and re-run to confirm PASS. This step exists because a census test that silently matches nothing is worse than no test at all.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/equipment lib/features/courses \
+  test/core/database/dive_stats_scope_census_test.dart
+git commit -m "test: census every dives aggregate for the statistics scope
+
+Equipment service clocks and course-requirement progress are marked
+exempt with reasons; every other dives aggregate must apply
+DiveStatsScope or the census fails. Verified the census catches an
+unscoped query rather than matching nothing."
+```
+
+---
+
+### Task 8: Triage the is_planned test fallout
+
+**Files:**
+- Modify: whichever existing tests fail (unknown until Step 1)
+
+**Interfaces:**
+- Consumes: the completed enforcement from Tasks 4 to 6.
+- Produces: a green suite, and a written list of every behavior change accepted.
+
+This task exists because folding `is_planned = 0` into the scope changes results for tests written when planned dives counted. Those failures will look like regressions and there may be many. **Do not blanket-update them.** A genuine regression can hide in the noise.
+
+- [ ] **Step 1: Run the full suite and capture the failures**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/issue-526-exclude-from-stats
+flutter test 2>&1 | tee /tmp/dive-stats-fallout.txt
+```
+
+Do not pipe into `grep`: the pipeline would return grep's exit status instead of the runner's. `tee` preserves it.
+
+Do not start this run while another local test run is in progress; overlapping runs produce phantom lone failures.
+
+- [ ] **Step 2: Classify every failure**
+
+For each failing test, answer in writing:
+
+1. Does the test seed a dive with `isPlanned: true`?
+2. Does the assertion depend on that dive being counted?
+
+If both are yes, it is expected fallout: update the expectation and note it. If either is no, it is a real regression: fix the code, not the test.
+
+Record the classification in the commit message so a reviewer can audit the judgment calls.
+
+- [ ] **Step 3: Check the known-flaky index before treating anything as a regression**
+
+Some full-suite failures in this repo are known flakes that pass when the file runs alone:
+
+```bash
+flutter test <the single failing file>
+```
+
+A test that passes alone and fails in the full suite is a flake, not fallout. Check it against the flaky index rather than "fixing" it.
+
+- [ ] **Step 4: Apply the updates**
+
+Update only the expectations classified as genuine fallout in Step 2.
+
+- [ ] **Step 5: Re-run the full suite**
+
+```bash
+flutter test 2>&1 | tee /tmp/dive-stats-fallout-2.txt
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/
+git commit -m "test: update expectations for planned dives leaving statistics
+
+Planned dives previously counted toward every aggregate, which was a
+bug. Each updated expectation was individually classified as fallout
+rather than blanket-updated; see the classification list below.
+
+<paste the Step 2 classification list here>"
+```
+
+---
+
+### Task 9: Localization keys
+
+**Files:**
+- Modify: `lib/l10n/arb/app_en.arb` and the ten other locale ARBs (`ar de es fr he hu it nl pt zh`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the keys `diveLog_edit_excludeFromStats`, `diveLog_edit_excludeFromStatsHelp`, `diveLog_edit_excludeFromGasStats`, `diveLog_edit_excludeFromGasStatsHelp`, `diveLog_badge_excludedFromStats`, `diveLog_badge_excludedFromGasStats`, `diveLog_bulkEdit_fieldExcludeFromStats`, `diveLog_bulkEdit_fieldExcludeFromGasStats`, `diveLog_filter_excludedOnly`, `diveLog_edit_summary_excluded`, and `statistics_excludedDivesFootnote` (a plural, taking `count`).
+
+- [ ] **Step 1: Add the English keys**
+
+In `lib/l10n/arb/app_en.arb`:
+
+```json
+  "diveLog_edit_excludeFromStats": "Exclude from statistics",
+  "diveLog_edit_excludeFromStatsHelp": "Keep this dive in your logbook, but leave it out of every statistic, including your dive count.",
+  "diveLog_edit_excludeFromGasStats": "Exclude from gas statistics",
+  "diveLog_edit_excludeFromGasStatsHelp": "Leave this dive out of SAC, RMV and gas mix statistics only. Useful when the gas number is not representative.",
+  "diveLog_badge_excludedFromStats": "Excluded from statistics",
+  "diveLog_badge_excludedFromGasStats": "Excluded from gas statistics",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Exclude from statistics",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Exclude from gas statistics",
+  "diveLog_filter_excludedOnly": "Excluded from statistics only",
+  "diveLog_edit_summary_excluded": "Excluded",
+  "statistics_excludedDivesFootnote": "{count, plural, =1{1 dive excluded from statistics} other{{count} dives excluded from statistics}}",
+  "@statistics_excludedDivesFootnote": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+```
+
+Match the surrounding file's key ordering and formatting conventions rather than appending at the end if the file is sorted.
+
+- [ ] **Step 2: Translate into the other ten locales**
+
+Add the same keys, translated, to `app_ar.arb`, `app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_he.arb`, `app_hu.arb`, `app_it.arb`, `app_nl.arb`, `app_pt.arb`, `app_zh.arb`.
+
+Keep the ICU plural structure intact in every locale, using that locale's required plural categories (Arabic needs `zero`, `one`, `two`, `few`, `many`, `other`).
+
+- [ ] **Step 3: Regenerate the localizations**
+
+```bash
+flutter gen-l10n
+```
+
+- [ ] **Step 4: Run the parity test**
+
+```bash
+flutter test test/l10n/
+```
+
+Expected: PASS. A report of "N missing" against *every* locale means English has keys the others lack; a report against one locale means that one file was missed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/
+git commit -m "i18n: add statistics-exclusion strings in all eleven locales"
+```
+
+---
+
+### Task 10: Dive edit form checkboxes
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (`_buildTheDiveSection` ~2025, state fields ~956, load from existing dive ~4961, save path)
+- Test: `test/features/dive_log/presentation/dive_edit_exclusion_test.dart`
+
+**Interfaces:**
+- Consumes: `Dive.excludedFromStats` / `excludedFromGasStats` (Task 3), the l10n keys (Task 9).
+- Produces: state fields `_excludedFromStats` and `_excludedFromGasStats`, both `bool`.
+
+- [ ] **Step 1: Write the failing widget test**
+
+Create `test/features/dive_log/presentation/dive_edit_exclusion_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('the gas checkbox is disabled while the master flag is on',
+      (tester) async {
+    // Pump the dive edit page for an existing dive with excludedFromStats
+    // true, using the repo's existing edit-page test harness.
+    // Then:
+    final gasTile = tester.widget<CheckboxListTile>(
+      find.byKey(const Key('dive-edit-exclude-from-gas-stats')),
+    );
+    expect(gasTile.onChanged, isNull,
+        reason: 'the master flag implies the gas flag, so the gas control '
+            'must be inert rather than silently overridden');
+    expect(gasTile.value, isTrue,
+        reason: 'it must read as checked, since that is the effective state');
+  });
+
+  testWidgets('toggling exclude-from-statistics persists on save',
+      (tester) async {
+    // Pump the edit page for a dive with both flags false, tap the master
+    // checkbox, save, and assert the persisted Dive has excludedFromStats
+    // true and excludedFromGasStats false.
+  });
+}
+```
+
+Fill in the pump-and-save bodies using whatever harness the neighbouring edit-page tests already use:
+
+```bash
+ls test/features/dive_log/presentation/
+grep -rn "dive_edit_page" test/ --include='*.dart' | head -5
+```
+
+Use that harness rather than building a fresh `MaterialApp`; the page depends on providers and l10n that the harness already wires.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/dive_log/presentation/dive_edit_exclusion_test.dart
+```
+
+Expected: FAIL, the keyed widgets do not exist.
+
+- [ ] **Step 3: Add the state fields**
+
+Near `bool _bulkFavorite = false;` (~line 956) in `_DiveEditPageState`:
+
+```dart
+  bool _excludedFromStats = false;
+  bool _excludedFromGasStats = false;
+```
+
+Initialize them from the existing dive wherever `isFavorite` is read (~line 4961):
+
+```dart
+    _excludedFromStats = _existingDive?.excludedFromStats ?? false;
+    _excludedFromGasStats = _existingDive?.excludedFromGasStats ?? false;
+```
+
+and include them in the `Dive` the save path builds:
+
+```dart
+      excludedFromStats: _excludedFromStats,
+      excludedFromGasStats: _excludedFromGasStats,
+```
+
+- [ ] **Step 4: Add the checkboxes to The Dive section**
+
+At the end of the children list in `_buildTheDiveSection` (~line 2025):
+
+```dart
+        CheckboxListTile(
+          key: const Key('dive-edit-exclude-from-stats'),
+          value: _excludedFromStats,
+          onChanged: (v) {
+            _markDirty();
+            setState(() => _excludedFromStats = v ?? false);
+          },
+          title: Text(context.l10n.diveLog_edit_excludeFromStats),
+          subtitle: Text(context.l10n.diveLog_edit_excludeFromStatsHelp),
+          controlAffinity: ListTileControlAffinity.leading,
+        ),
+        CheckboxListTile(
+          key: const Key('dive-edit-exclude-from-gas-stats'),
+          // The master flag implies the gas flag. Render the implication as
+          // checked-and-inert rather than letting the diver set a value that
+          // the SQL scope would silently override.
+          value: _excludedFromStats || _excludedFromGasStats,
+          onChanged: _excludedFromStats
+              ? null
+              : (v) {
+                  _markDirty();
+                  setState(() => _excludedFromGasStats = v ?? false);
+                },
+          title: Text(context.l10n.diveLog_edit_excludeFromGasStats),
+          subtitle: Text(context.l10n.diveLog_edit_excludeFromGasStatsHelp),
+          controlAffinity: ListTileControlAffinity.leading,
+        ),
+```
+
+Match the section's existing row style. If The Dive section uses a `FormRow.toggle` helper rather than raw `CheckboxListTile`, use `FormRow.toggle` and keep the `Key`s.
+
+- [ ] **Step 5: Surface the state in the collapsed section summary**
+
+In the summary builder for The Dive section, append when either flag is set:
+
+```dart
+      if (_excludedFromStats || _excludedFromGasStats)
+        context.l10n.diveLog_edit_summary_excluded,
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/presentation/dive_edit_exclusion_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/pages/dive_edit_page.dart \
+  test/features/dive_log/presentation/dive_edit_exclusion_test.dart
+git commit -m "feat(dive): add statistics-exclusion checkboxes to the edit form
+
+The gas checkbox renders checked and inert while the master flag is on,
+so the implication is visible rather than silently overridden."
+```
+
+---
+
+### Task 11: Bulk edit support
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart` (enum ~line 8, `BulkScalarInputs` ~line 60)
+- Modify: `lib/features/dive_log/presentation/pages/dive_edit_page.dart` (gated rows ~line 1056, `_collectScalarInputs` ~line 1106)
+- Test: `test/features/dive_log/presentation/bulk_edit_exclusion_test.dart`
+
+**Interfaces:**
+- Consumes: `BulkField`, `BulkScalarInputs`, `_gatedRow`, the l10n keys from Task 9.
+- Produces: `BulkField.excludedFromStats`, `BulkField.excludedFromGasStats`, and matching `bool?` fields on `BulkScalarInputs`.
+
+This task is what makes #526 practical. Its author is describing a class of dives, not one dive; a per-dive checkbox alone would be a thirty-tap chore.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/bulk_edit_exclusion_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('an ungated exclusion field leaves selected dives untouched',
+      (tester) async {
+    // Pump the bulk edit form over two dives, one with excludedFromStats
+    // true and one false. Change some OTHER field and apply.
+    // Assert both dives keep their original excludedFromStats value: an
+    // untouched gate must not write false over everything.
+  });
+
+  testWidgets('a gated exclusion field applies to every selected dive',
+      (tester) async {
+    // Pump the bulk edit form over two dives with excludedFromStats false.
+    // Enable the exclude-from-statistics gate, set it true, apply.
+    // Assert both dives now have excludedFromStats true.
+  });
+}
+```
+
+Fill in the bodies using the existing bulk-edit test harness:
+
+```bash
+grep -rn "BulkField\|bulkEdit" test/ --include='*.dart' | head -10
+```
+
+The first test is the important one. Writing `false` over every selected dive when the diver never touched the field is the classic bulk-edit bug this repo's gate widget exists to prevent.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/dive_log/presentation/bulk_edit_exclusion_test.dart
+```
+
+Expected: FAIL, `BulkField.excludedFromStats` is undefined.
+
+- [ ] **Step 3: Extend the enum and the inputs class**
+
+In `bulk_edit_field_set.dart`, after `isFavorite,` in the `BulkField` enum:
+
+```dart
+  excludedFromStats,
+  excludedFromGasStats,
+```
+
+and after `this.isFavorite,` in the `BulkScalarInputs` constructor, plus the matching `final bool? excludedFromStats;` / `final bool? excludedFromGasStats;` field declarations alongside `final bool? isFavorite;`.
+
+Wire both into wherever `BulkScalarInputs` becomes a `DivesCompanion`, following `isFavorite` exactly:
+
+```bash
+grep -n "isFavorite" lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart
+```
+
+- [ ] **Step 4: Add the gated rows**
+
+In `dive_edit_page.dart`, after the `BulkField.isFavorite` gated row (~line 1056):
+
+```dart
+              _gatedRow(
+                BulkField.excludedFromStats,
+                FormRow.toggle(
+                  label: context.l10n.diveLog_bulkEdit_fieldExcludeFromStats,
+                  value: _bulkExcludedFromStats,
+                  onChanged: (v) =>
+                      setState(() => _bulkExcludedFromStats = v),
+                ),
+              ),
+              _gatedRow(
+                BulkField.excludedFromGasStats,
+                FormRow.toggle(
+                  label:
+                      context.l10n.diveLog_bulkEdit_fieldExcludeFromGasStats,
+                  value: _bulkExcludedFromGasStats,
+                  onChanged: (v) =>
+                      setState(() => _bulkExcludedFromGasStats = v),
+                ),
+              ),
+```
+
+Declare the two state fields next to `_bulkFavorite` (~line 956):
+
+```dart
+  bool _bulkExcludedFromStats = false;
+  bool _bulkExcludedFromGasStats = false;
+```
+
+and add them to `_collectScalarInputs` (~line 1112), beside `isFavorite: _bulkFavorite,`:
+
+```dart
+      excludedFromStats: _bulkExcludedFromStats,
+      excludedFromGasStats: _bulkExcludedFromGasStats,
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/presentation/bulk_edit_exclusion_test.dart
+```
+
+Expected: PASS, both tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart \
+  lib/features/dive_log/presentation/pages/dive_edit_page.dart \
+  test/features/dive_log/presentation/bulk_edit_exclusion_test.dart
+git commit -m "feat(dive): bulk-edit support for the statistics-exclusion flags
+
+Gated like isFavorite, so an untouched field never writes false over
+every selected dive. This is what makes #526 practical for a diver with
+thirty pool sessions."
+```
+
+---
+
+### Task 12: Badges on the list item and detail page
+
+**Files:**
+- Modify: `lib/features/dive_log/presentation/widgets/dive_list_item.dart`
+- Modify: `lib/features/dive_log/presentation/pages/dive_detail_page.dart`
+- Test: `test/features/dive_log/presentation/dive_exclusion_badge_test.dart`
+
+**Interfaces:**
+- Consumes: `Dive.excludedFromStats` / `excludedFromGasStats`, the badge l10n keys.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/presentation/dive_exclusion_badge_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('an included dive shows no exclusion badge', (tester) async {
+    // Pump DiveListItem for a dive with both flags false.
+    expect(find.byKey(const Key('dive-excluded-badge')), findsNothing);
+  });
+
+  testWidgets('an excluded dive shows the badge', (tester) async {
+    // Pump DiveListItem for a dive with excludedFromStats true.
+    expect(find.byKey(const Key('dive-excluded-badge')), findsOneWidget);
+  });
+
+  testWidgets('the badge fits a 360px-wide row without overflowing',
+      (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    // Pump DiveListItem for an excluded dive with a long site name.
+    expect(tester.takeException(), isNull);
+  });
+}
+```
+
+The third test matters: the test font renders one `fontSize`-wide glyph per character, so a `Row` containing an unconstrained `Text` overflows at 360px in tests even when it looks fine on a real device. Wrap the row's flexible child in `Flexible` or `Expanded`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/dive_log/presentation/dive_exclusion_badge_test.dart
+```
+
+Expected: FAIL, no badge widget.
+
+- [ ] **Step 3: Add the badge**
+
+In `dive_list_item.dart`, in the row that already renders status icons (find it by looking for where `isFavorite` renders its star):
+
+```dart
+        if (dive.excludedFromStats || dive.excludedFromGasStats)
+          Tooltip(
+            key: const Key('dive-excluded-badge'),
+            message: dive.excludedFromStats
+                ? context.l10n.diveLog_badge_excludedFromStats
+                : context.l10n.diveLog_badge_excludedFromGasStats,
+            child: Icon(
+              dive.excludedFromStats
+                  ? Icons.bar_chart_outlined
+                  : Icons.local_gas_station_outlined,
+              size: 16,
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+```
+
+Add the same block to the dive detail page's header badge row.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/presentation/dive_exclusion_badge_test.dart
+```
+
+Expected: PASS, all three tests. If the 360px test fails with an overflow, wrap the row's text child in `Flexible`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/dive_log/presentation/widgets/dive_list_item.dart \
+  lib/features/dive_log/presentation/pages/dive_detail_page.dart \
+  test/features/dive_log/presentation/dive_exclusion_badge_test.dart
+git commit -m "feat(dive): badge excluded dives in the list and on the detail page"
+```
+
+---
+
+### Task 13: Statistics footnote
+
+**Files:**
+- Modify: `lib/features/statistics/data/repositories/statistics_repository.dart` (new method)
+- Modify: `lib/features/statistics/presentation/providers/statistics_providers.dart` (new provider)
+- Modify: `lib/features/statistics/presentation/pages/statistics_overview_page.dart`
+- Test: `test/features/statistics/excluded_dives_footnote_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveStatsScope.predicate` (Task 2), `statistics_excludedDivesFootnote` (Task 9).
+- Produces: `StatisticsRepository.countExcludedDives({String? diverId}) -> Future<int>` and `excludedDiveCountProvider`, a `FutureProvider<int>`.
+
+This is what prevents a "247 here, 248 there" support ticket months from now.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/statistics/excluded_dives_footnote_test.dart`:
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = StatisticsRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Future<void> insert(String id, {bool excluded = false}) =>
+      db.customStatement(
+        'INSERT INTO dives (id, dive_date_time, excluded_from_stats) '
+        'VALUES (?, 0, ?)',
+        [id, excluded ? 1 : 0],
+      );
+
+  test('counts zero when nothing is excluded', () async {
+    await insert('a');
+    expect(await repo.countExcludedDives(), 0);
+  });
+
+  test('counts only dives the diver excluded', () async {
+    await insert('a');
+    await insert('b', excluded: true);
+    await insert('c', excluded: true);
+    expect(await repo.countExcludedDives(), 2);
+  });
+
+  test('does not count planned dives', () async {
+    await insert('a');
+    await db.customStatement(
+      "INSERT INTO dives (id, dive_date_time, is_planned) "
+      "VALUES ('planned', 0, 1)",
+    );
+    expect(await repo.countExcludedDives(), 0,
+        reason: 'the footnote explains the diver\'s own choice; a planned '
+            'dive is not something they excluded');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/statistics/excluded_dives_footnote_test.dart
+```
+
+Expected: FAIL, `countExcludedDives` undefined.
+
+- [ ] **Step 3: Add the repository method**
+
+In `statistics_repository.dart`:
+
+```dart
+  /// Counts the dives the diver has explicitly excluded from statistics.
+  ///
+  /// Deliberately counts only `excluded_from_stats`, not the whole
+  /// [DiveStatsScope]: the footnote exists to explain the diver's own choice
+  /// back to them. Planned dives are not something they chose to exclude, so
+  /// folding them in would make the number confusing rather than clarifying.
+  // stats-scope-exempt: counts the excluded, by definition
+  Future<int> countExcludedDives({String? diverId}) async {
+    final diverFilter = diverId != null ? 'AND diver_id = ?' : '';
+    final row = await _db.customSelect(
+      'SELECT COUNT(*) AS c FROM dives '
+      'WHERE excluded_from_stats = 1 $diverFilter',
+      variables: diverId != null ? [Variable(diverId)] : const [],
+    ).getSingle();
+    return row.read<int>('c');
+  }
+```
+
+- [ ] **Step 4: Add the provider and render the footnote**
+
+In `statistics_providers.dart`:
+
+```dart
+/// Count of dives the diver excluded from statistics, for the Overview
+/// footnote. Kept separate from the filtered providers: it explains a
+/// persistent property of the logbook, not the current view filter.
+final excludedDiveCountProvider = FutureProvider<int>((ref) async {
+  ref.watch(statisticsTickProvider);
+  final repo = ref.watch(statisticsRepositoryProvider);
+  final diver = ref.watch(currentDiverProvider);
+  return repo.countExcludedDives(diverId: diver?.id);
+});
+```
+
+Match the surrounding providers' exact dependency names; `statisticsTickProvider` and `currentDiverProvider` may be spelled differently in this file. Check:
+
+```bash
+grep -n "^final .*Provider" lib/features/statistics/presentation/providers/statistics_providers.dart | head -20
+```
+
+In `statistics_overview_page.dart`, at the bottom of the page body:
+
+```dart
+        ref.watch(excludedDiveCountProvider).maybeWhen(
+              data: (count) => count == 0
+                  ? const SizedBox.shrink()
+                  : Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 8,
+                      ),
+                      child: Text(
+                        context.l10n.statistics_excludedDivesFootnote(count),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context).colorScheme.outline,
+                            ),
+                      ),
+                    ),
+              orElse: () => const SizedBox.shrink(),
+            ),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+flutter test test/features/statistics/excluded_dives_footnote_test.dart
+```
+
+Expected: PASS, all three tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/statistics/ \
+  test/features/statistics/excluded_dives_footnote_test.dart
+git commit -m "feat(stats): footnote the excluded dive count on the Overview
+
+Renders only when nonzero. Explains why the statistics dive count and
+the logbook dive count differ."
+```
+
+---
+
+### Task 14: The excluded-dives filter axis
+
+**Files:**
+- Modify: `lib/features/dive_log/domain/models/dive_filter_state.dart` (field ~line 18, constructor ~line 80, `hasActiveFilters` ~line 103, `copyWith` ~line 139, `apply` ~line 298)
+- Modify: `lib/features/statistics/data/dive_filter_sql.dart`
+- Modify: `lib/features/dive_log/data/repositories/dive_repository_impl.dart` (`_buildFilterWhereClauses` ~line 2293)
+- Modify: the filter sheet widget
+- Test: `test/features/dive_log/dive_filter_excluded_axis_test.dart`
+
+**Interfaces:**
+- Consumes: the `excluded_from_stats` column, `diveLog_filter_excludedOnly`.
+- Produces: `DiveFilterState.excludedFromStatsOnly`, a `bool?`. Null means no filtering on this axis; true means only excluded dives. Mirrors `favoritesOnly`.
+
+Three implementations of the same semantics must agree. A divergence between them is invisible until a diver notices two screens disagreeing.
+
+- [ ] **Step 1: Write the failing parity test**
+
+Create `test/features/dive_log/dive_filter_excluded_axis_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/dive_filter_sql.dart';
+
+void main() {
+  final included = Dive(
+    id: 'included',
+    diveDateTime: DateTime(2026, 1, 1),
+  );
+  final excluded = Dive(
+    id: 'excluded',
+    diveDateTime: DateTime(2026, 1, 2),
+    excludedFromStats: true,
+  );
+
+  test('a null axis is inactive and filters nothing', () {
+    const filter = DiveFilterState();
+    expect(filter.hasActiveFilters, isFalse);
+    expect(filter.apply([included, excluded]), hasLength(2));
+    expect(buildFilteredDiveIdSubquery(filter).subquery, isEmpty);
+  });
+
+  test('apply() keeps only excluded dives when the axis is true', () {
+    const filter = DiveFilterState(excludedFromStatsOnly: true);
+    expect(filter.hasActiveFilters, isTrue);
+    final result = filter.apply([included, excluded]);
+    expect(result.map((d) => d.id), ['excluded']);
+  });
+
+  test('the SQL subquery encodes the same rule', () {
+    const filter = DiveFilterState(excludedFromStatsOnly: true);
+    final sql = buildFilteredDiveIdSubquery(filter);
+    expect(sql.subquery, contains('excluded_from_stats = 1'));
+  });
+
+  test('copyWith can set and clear the axis', () {
+    const filter = DiveFilterState(excludedFromStatsOnly: true);
+    expect(filter.copyWith(clearExcludedFromStatsOnly: true)
+        .excludedFromStatsOnly, isNull);
+    expect(const DiveFilterState()
+        .copyWith(excludedFromStatsOnly: true)
+        .excludedFromStatsOnly, isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+flutter test test/features/dive_log/dive_filter_excluded_axis_test.dart
+```
+
+Expected: FAIL, no such named parameter.
+
+- [ ] **Step 3: Add the axis to DiveFilterState**
+
+Beside `final bool? favoritesOnly;` (~line 18):
+
+```dart
+  /// When true, keep only dives the diver excluded from statistics, so they
+  /// can find and review them. Null means this axis is inactive.
+  ///
+  /// This is a view filter for *finding* excluded dives. It plays no part in
+  /// enforcing the exclusion; that is DiveStatsScope's job and applies
+  /// unconditionally.
+  final bool? excludedFromStatsOnly;
+```
+
+Add `this.excludedFromStatsOnly,` to the constructor (~line 80).
+
+In `hasActiveFilters` (~line 103), beside the `favoritesOnly == true ||` term:
+
+```dart
+      excludedFromStatsOnly == true ||
+```
+
+In `copyWith`, add `bool? excludedFromStatsOnly,` and `bool clearExcludedFromStatsOnly = false,` to the signature, and to the body:
+
+```dart
+      excludedFromStatsOnly: clearExcludedFromStatsOnly
+          ? null
+          : (excludedFromStatsOnly ?? this.excludedFromStatsOnly),
+```
+
+In `apply` (~line 298), beside the `favoritesOnly` check:
+
+```dart
+      if (excludedFromStatsOnly == true && !dive.excludedFromStats) {
+        return false;
+      }
+```
+
+Match the surrounding code's exact predicate style; the existing block may use `continue` inside a loop rather than `return false` inside a `where`.
+
+- [ ] **Step 4: Add the axis to the two SQL builders**
+
+In `dive_filter_sql.dart`, beside the `favoritesOnly` condition:
+
+```dart
+  if (filter.excludedFromStatsOnly == true) {
+    conditions.add('excluded_from_stats = 1');
+  }
+```
+
+In `dive_repository_impl.dart`'s `_buildFilterWhereClauses` (~line 2293), add the equivalent clause with that method's alias convention.
+
+- [ ] **Step 5: Add the control to the filter sheet**
+
+In `lib/features/statistics/presentation/widgets/dive_filter_sheet.dart` (confirm the path with `find lib -name 'dive_filter_sheet.dart'`), add a toggle beside the favorites toggle, labelled `context.l10n.diveLog_filter_excludedOnly`, reading and writing `excludedFromStatsOnly` with `clearExcludedFromStatsOnly: true` when switched off.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+flutter test test/features/dive_log/dive_filter_excluded_axis_test.dart
+```
+
+Expected: PASS, all four tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/features/dive_log/domain/models/dive_filter_state.dart \
+  lib/features/statistics/data/dive_filter_sql.dart \
+  lib/features/dive_log/data/repositories/dive_repository_impl.dart \
+  lib/features/statistics/presentation/widgets/dive_filter_sheet.dart \
+  test/features/dive_log/dive_filter_excluded_axis_test.dart
+git commit -m "feat(dive): add an excluded-dives filter axis
+
+Lets a diver find the dives they excluded. Implemented in all three
+filter paths (SQL subquery, repository WHERE builder, in-memory apply)
+with a parity test asserting they agree."
+```
+
+---
+
+### Task 15: UDDF and sync round trips
+
+**Files:**
+- Modify: `lib/core/services/export/uddf/uddf_export_builders.dart`
+- Modify: `lib/core/services/export/uddf/uddf_full_import_service.dart`
+- Test: `test/core/services/export/uddf_exclusion_roundtrip_test.dart`
+- Test: `test/core/services/sync/sync_exclusion_roundtrip_test.dart`
+
+**Interfaces:**
+- Consumes: `Dive.excludedFromStats` / `excludedFromGasStats`.
+- Produces: nothing other tasks consume.
+
+Sync needs no hand plumbing: `_exportDives` serializes via the generated `row.toJson()`, so the columns ride along. The sync test is a regression guard. UDDF is hand-plumbed and genuinely needs the work.
+
+- [ ] **Step 1: Write the failing round-trip tests**
+
+Create `test/core/services/export/uddf_exclusion_roundtrip_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('UDDF export then import preserves both exclusion flags', () async {
+    // Build a Dive with excludedFromStats true and excludedFromGasStats
+    // false, export it to UDDF, import the result, and assert both flags
+    // survive with their original values.
+    //
+    // Then repeat with the flags swapped, so a bug that writes one flag
+    // into the other's slot cannot pass.
+  });
+
+  test('importing UDDF without the exclusion extension defaults to included',
+      () async {
+    // Import a UDDF document produced by another application, with no
+    // Submersion exclusion element. Assert both flags read back false
+    // rather than null or true.
+  });
+}
+```
+
+Create `test/core/services/sync/sync_exclusion_roundtrip_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('sync serialization carries both exclusion flags', () async {
+    // Insert a dive with both flags true, run the dives export the sync
+    // serializer uses, and assert the emitted JSON contains
+    // excluded_from_stats and excluded_from_gas_stats set truthy.
+    //
+    // This is a regression guard: the serializer is generated, so this test
+    // exists to catch a future hand-written column allowlist that would
+    // silently drop the flags.
+  });
+}
+```
+
+Fill in both bodies using the existing export and sync test harnesses:
+
+```bash
+ls test/core/services/export/uddf/
+ls test/core/services/sync/ | head -20
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+flutter test test/core/services/export/uddf_exclusion_roundtrip_test.dart \
+  test/core/services/sync/sync_exclusion_roundtrip_test.dart
+```
+
+Expected: the UDDF tests FAIL (flags are dropped). The sync test may already PASS, which is the correct outcome for a regression guard.
+
+- [ ] **Step 3: Plumb UDDF export and import**
+
+Find how `isFavorite` crosses the UDDF boundary and mirror it:
+
+```bash
+grep -n "isFavorite" lib/core/services/export/uddf/uddf_export_builders.dart \
+  lib/core/services/export/uddf/uddf_full_import_service.dart
+```
+
+Write both flags into the same application-specific extension element `isFavorite` uses, and read them back with a `false` default so a document from another application imports as included rather than null.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+flutter test test/core/services/export/uddf_exclusion_roundtrip_test.dart \
+  test/core/services/sync/sync_exclusion_roundtrip_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/services/export/uddf/ test/core/services/
+git commit -m "feat(export): carry statistics-exclusion flags through UDDF
+
+Round-trip tested in both directions, with a default-to-included path
+for documents from other applications. Sync needs no plumbing (generated
+serializer); its test is a regression guard."
+```
+
+---
+
+### Task 16: Release notes and final verification
+
+**Files:**
+- Create or modify: the release notes file for the next version
+- Modify: nothing in `lib/`
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: a branch ready to push.
+
+- [ ] **Step 1: Write the release note**
+
+Find the release notes location and the current version:
+
+```bash
+ls docs/releases/ | tail -5
+grep -n "^version:" pubspec.yaml
+```
+
+Add entries under the next version:
+
+```markdown
+### Added
+
+- Dives can now be excluded from statistics. Open a dive, and under The Dive
+  you will find "Exclude from statistics" (keeps the dive in your logbook but
+  leaves it out of every statistic, dive count included) and "Exclude from gas
+  statistics" (leaves it out of SAC, RMV and gas mix figures only, for a dive
+  whose gas number is not representative). Both are available in bulk edit, and
+  a filter axis lets you find the dives you have excluded. (#526, #1272)
+
+### Fixed
+
+- Planned dives no longer count toward your statistics. A dive created in the
+  planner but never logged was previously included in every total, average and
+  record. If you have used the planner, your dive count and averages will
+  change to reflect only dives you actually made.
+```
+
+The Fixed entry is not optional. It changes existing divers' numbers on upgrade with no action on their part, and an unexplained shift in a dive count reads as data loss.
+
+- [ ] **Step 2: Format the whole project**
+
+```bash
+cd /Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/issue-526-exclude-from-stats
+dart format .
+```
+
+- [ ] **Step 3: Analyze the whole project**
+
+```bash
+flutter analyze
+```
+
+Expected: zero issues. CI treats infos as fatal, so an info here fails the build.
+
+- [ ] **Step 4: Run the full test suite once**
+
+```bash
+flutter test 2>&1 | tee /tmp/dive-stats-final.txt
+```
+
+Do not pipe into `grep`. Do not run this while another local test run is active. One full run is sufficient before the PR.
+
+Expected: green. Check any failure against the known-flaky index by rerunning that file alone before treating it as real.
+
+- [ ] **Step 5: Re-run both schema ladder claim scans**
+
+This is the last chance to catch a rung collision, and it must happen now rather than earlier, because another branch may have claimed 178 in the meantime.
+
+```bash
+# 1. Claims visible in open PRs
+for n in $(gh pr list --state open --limit 100 --json number --jq '.[].number'); do
+  gh pr diff "$n" | grep -oE '^\+\s*static const int currentSchemaVersion = [0-9]+' \
+    | sed "s/^/PR $n: /"
+done
+
+# 2. The claims method 1 cannot see: every worktree's working-tree scalar
+for w in $(git worktree list --porcelain | awk '/^worktree /{print $2}'); do
+  v=$(grep -oE 'currentSchemaVersion = [0-9]+' \
+      "$w/lib/core/database/database.dart" 2>/dev/null | head -1)
+  echo "$w: $v"
+done
+```
+
+If anything else claims 178, renumber this branch to the next free rung under the prior-claim tiebreak (a pushed open PR wins over an unpushed worktree), updating the column comment, the `onUpgrade` rung, the `beforeOpen` comment, the migration test, and the release note together.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/releases/
+git commit -m "docs: release notes for statistics exclusion
+
+Documents the new flags and, separately, the behavior change from
+planned dives leaving statistics."
+```
+
+- [ ] **Step 7: Verify the branch is clean and ready**
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: a clean working tree and roughly sixteen commits. Do not push or open a PR without asking; the diver on the other end of this decides when.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to at least one task:
+
+| Spec section | Tasks |
+| --- | --- |
+| Section 1, schema and entity | 1, 3 |
+| Section 1, sync and UDDF | 15 |
+| Section 2, DiveStatsScope helper | 2 |
+| Section 2, Tier 1 statistics | 4 |
+| Section 2, Tier 2 dive log | 5 |
+| Section 2, Tier 3 per-entity | 6 |
+| Section 2, operational exemptions | 7 |
+| Section 2, is_planned fix | 2 (predicate), 8 (fallout) |
+| Section 3, edit form | 10 |
+| Section 3, bulk edit | 11 |
+| Section 3, badges | 12 |
+| Section 3, statistics footnote | 13 |
+| Section 3, filter axis | 14 |
+| Section 3, localization | 9 |
+| Section 4, behavioral guard suite | 4, 5, 6 |
+| Section 4, source census | 7 |
+| Section 4, migration tests | 1 |
+| Section 4, filter parity | 14 |
+| Section 4, round trips | 15 |
+| Section 4, widget tests | 10, 11, 12 |
+| Risks, is_planned fallout | 8 |
+| Risks, schema rung collision | 16 |
+| Risks, release note | 16 |
+| Verification | 16 |
+
+No gaps.
+
+**Type consistency.** `DiveStatsScope.predicate` and `DiveStatsScope.and` keep the same signature (`{String alias = 'd', bool gas = false}`) everywhere they appear, in Tasks 2, 4, 5, 6 and 7. `Dive.excludedFromStats` and `Dive.excludedFromGasStats` are `bool` (non-nullable, defaulting to false) in Tasks 3, 10, 11, 12 and 14. `DiveFilterState.excludedFromStatsOnly` is `bool?` in Task 14, matching `favoritesOnly`, and its `copyWith` clear flag is `clearExcludedFromStatsOnly` in both the signature and the test. `BulkScalarInputs.excludedFromStats` is `bool?` in Task 11, matching `isFavorite`. `countExcludedDives({String? diverId})` returns `Future<int>` in Task 13 and its test. The marker string `stats-scope-exempt` is identical in Tasks 5, 7, 13 and the census test's matcher.
+
+**Placeholder scan.** No TBD or TODO. Three tasks contain deliberately unfilled test bodies (10, 11, 15) where the body depends on a test harness whose API this plan cannot quote without inventing it; each carries the exact `grep`/`ls` command that locates the harness, plus a precise statement of what the test must assert. Task 12's badge test and every other test are written in full.
+
+**Line numbers.** Every line reference is marked approximate and paired with a symbol name, because line numbers drift as earlier tasks land. Anchor on the symbol, not the number.

--- a/docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md
+++ b/docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md
@@ -1,0 +1,360 @@
+# Exclude a Dive from Statistics
+
+Design document, 2026-08-28.
+
+Issues: [#526](https://github.com/submersion-app/submersion/issues/526)
+(exclude shallow or short dives from overall statistics),
+[#1272](https://github.com/submersion-app/submersion/issues/1272)
+(exclude a dive from SAC and RMV calculations).
+
+Branch: `worktree-issue-526-exclude-from-stats`.
+
+## Problem
+
+Divers keep dives in their logbook that they do not want counted. Two distinct
+cases arrived as separate issues:
+
+- **#526.** A 90 minute dive at 12 ft is not an official dive by most agency
+  standards. The diver wants to keep the entry and view it, but wants it out of
+  the totals, the averages, and the records.
+- **#1272.** An otherwise ordinary dive where the diver purged the tank down to
+  500 psi at the end for a weight check. Only the gas number is wrong. Throwing
+  away the whole dive to fix one metric is a bad trade.
+
+The app has no concept of an excluded dive today. There is no `excluded`,
+`hidden`, or `archived` column on `dives`, and no soft-delete. The only
+exclusion rule that exists is `AND d.dive_mode <> 'gauge'`, hand copied into
+seven gas queries in `StatisticsRepository` and centralized nowhere.
+
+## Decisions
+
+| Question | Decision |
+| --- | --- |
+| Granularity | Two flags: exclude from all statistics, and exclude from gas statistics only. |
+| Does an excluded dive still count in Total Dives? | No. Excluded means every descriptive aggregate, count included. |
+| Blast radius | Descriptive aggregates yes, operational numbers no. |
+| Enforcement mechanism | Shared SQL predicate helper plus a behavioral guard suite. Not a SQL view, and not a `DiveFilterState` axis. A separate opt-in filter axis is added for *finding* excluded dives, but it plays no part in enforcement. |
+| Visibility | Checkbox, bulk edit, list badge, statistics footnote, and a filter axis. |
+| `is_planned` | Fixed in the same change. Planned dives stop counting toward statistics. |
+
+### Why two flags
+
+A single master flag forces #1272's diver to discard a good dive to correct one
+metric. Per category flags (depth, duration, gas, records, count) were rejected
+as YAGNI: no fourth axis has been requested, and a per dive checkbox grid ages
+badly.
+
+The master flag implies the gas flag. The gas predicate is therefore
+`excluded_from_stats = 0 AND excluded_from_gas_stats = 0`.
+
+### Why the count is excluded too
+
+#526 is explicit that the dive "does not count as an official dive." A flag
+labelled "exclude from statistics" that still increments the total is dishonest
+and has to be explained. The dive remains fully present and editable in the
+logbook, so nothing is destroyed and the decision is reversible.
+
+Records (deepest, longest, coldest) follow the same rule. A flooded pool
+session appearing as "longest dive: 90 min" is the original complaint.
+
+### Descriptive versus operational
+
+Not every count of dives is a statistic. Two categories are load bearing in a
+way that makes suppression actively wrong:
+
+- **Equipment service intervals.** `ServiceDueEngine` derives "dives since last
+  service" and "hours since last service" from
+  `EquipmentRepository.getUsageSamplesForEquipment`. A practice dive still
+  cycled the regulator and still put hours on it. Excluding it would push a real
+  service interval later than it should be.
+- **Course requirement progress.** `CourseRequirementRepository.getCourseProgress`
+  counts dives the diver deliberately linked to a requirement. Excluding one
+  would silently un-credit work they did on purpose.
+
+The logbook list header ("N dives") is also excluded from the rule. The dive is
+still in the logbook, so the list still counts it.
+
+This produces one deliberate asymmetry worth stating plainly: a regulator's
+service clock still counts an excluded dive, while the Statistics tab's "most
+used gear" card does not. The first measures wear that physically happened; the
+second is a descriptive summary of the diver's diving.
+
+## Section 1: Schema and entity
+
+Two boolean columns on `Dives` (`lib/core/database/database.dart:647`),
+following the `isFavorite` pattern at line 731:
+
+```dart
+// Statistics exclusion (schema v178)
+BoolColumn get excludedFromStats =>
+    boolean().withDefault(const Constant(false))();
+BoolColumn get excludedFromGasStats =>
+    boolean().withDefault(const Constant(false))();
+```
+
+**Schema version 178.** Main is at 175. Version 176 is claimed by open PR #1328
+and 177 by open PR #1361. Both claim scans (open PR diffs and every worktree's
+working tree scalar) must be re-run immediately before pushing, because a rung
+claimed below main's scalar merges with no conflict marker and its migration
+step then never runs.
+
+Migration follows the established three part shape:
+
+1. An idempotent `_assertDiveStatsExclusionColumns()` guarded by
+   `PRAGMA table_info('dives')`, including the `if (cols.isEmpty) return;`
+   self-guard that minimal schema fixtures depend on. Two statements of the form
+   `ALTER TABLE dives ADD COLUMN excluded_from_stats INTEGER NOT NULL DEFAULT 0`.
+2. An `onUpgrade` rung at `if (from < 178)`.
+3. A `beforeOpen` backstop calling the same helper, because a database arriving
+   via restore or sync adopt never runs `onUpgrade`. There is no backfill, so
+   both paths are safe to re-run.
+
+**Sync.** No hand edits. `_exportDives`
+(`lib/core/services/sync/sync_data_serializer.dart:4487`) serializes via the
+generated `row.toJson()`, so both columns ride along.
+
+**UDDF.** Explicit plumbing required in
+`lib/core/services/export/uddf/uddf_export_builders.dart` and
+`uddf_full_import_service.dart`, mirroring `isFavorite`, so a round trip through
+the app's own export format does not drop the flags.
+
+**Entity plumbing.** Mirrors `isFavorite` across
+`lib/features/dive_log/domain/entities/dive.dart`,
+`domain/entities/dive_summary.dart`, `domain/services/dive_merge_builder.dart`,
+the two mapper sites (`dive_repository_impl.dart:3562`, `:3944`) and two
+companion sites (`:1409`, `:1664`), and `bulk_edit_field_set.dart`.
+
+## Section 2: Enforcement
+
+New file `lib/core/database/dive_stats_scope.dart`:
+
+```dart
+class DiveStatsScope {
+  /// Bare predicate: which dives contribute to descriptive statistics.
+  static String predicate({String alias = 'd', bool gas = false});
+
+  /// The same, prefixed with ' AND ' for appending into an existing WHERE.
+  static String and({String alias = 'd', bool gas = false});
+}
+```
+
+`predicate()` yields `d.excluded_from_stats = 0 AND d.is_planned = 0`. With
+`gas: true` it additionally yields
+`AND d.excluded_from_gas_stats = 0 AND d.dive_mode <> 'gauge'`. The `alias`
+parameter is required because several queries apply the scope to a second alias
+inside a self join.
+
+### The scope is orthogonal to the user filter
+
+This is the central structural decision. The scope is applied alongside
+`buildFilteredDiveIdSubquery` (`lib/features/statistics/data/dive_filter_sql.dart:12`),
+never inside it.
+
+`buildFilteredDiveIdSubquery` implements the user's transient view filter and
+correctly returns an empty no-op when no axis is active. The scope is a
+persistent property of the dive. Merging the two would mean one of:
+
+- the exclusion evaporates for every user who never opens the filter sheet, or
+- the no-op early return is deleted, and every deliberately unfiltered call site
+  (dashboard quick stats, dive log summary, species detail page) silently
+  becomes filtered.
+
+The second is a repeat of a bug this codebase already shipped and caught in
+review. Keeping them separate lets `StatisticsRepository._diveFilter`
+(`statistics_repository.dart:190`) append the scope unconditionally and the user
+filter conditionally, which fixes 37 query sites in a single edit.
+
+For the same reason, modelling the exclusion as a `DiveFilterState` axis was
+rejected outright.
+
+### Tier 1: statistics feature
+
+- One edit to `_diveFilter` (line 190) covers the 37 filter aware methods.
+- Four hand patches: `getYearStats` (line 973),
+  `getEntryExitMethodPairsForSite` (line 1298), `getSiteHistoryByName`
+  (line 2501), and the nested `FROM dives d2` self join inside
+  `getSurfaceIntervalStats` (line 2025), which the user filter clause already
+  misses today.
+- The seven gas queries (lines 234, 376, 423, 483, 615, 678, 759) drop their
+  hand copied `AND d.dive_mode <> 'gauge'` in favor of
+  `DiveStatsScope.and(gas: true)`.
+
+### Tier 2: dive log repository
+
+Each builds its own WHERE fragments and gets the scope by hand:
+
+- `getStatistics()` (`dive_repository_impl.dart:2816`), four statements.
+- `getRecords()` (line 2984), six superlative statements.
+- `getPersonalRecordIds()` (line 3224), six statements.
+- `countDivesSince()` (line 3137).
+- `getOnThisDayDiveIds()` (line 3155).
+
+Deliberately **not** touched: `getDiveCount()` (line 2190), the logbook list
+header. Gets a doc comment naming the decision.
+
+### Tier 3: per entity descriptive counts
+
+| Feature | Sites |
+| --- | --- |
+| Buddies | `getAllBuddies` inline joins (`buddy_repository.dart:793`, `:811`), `getDiveCountForBuddy` (`:947`), `getDiveIdsForBuddy` (`:971`), `getBuddyStats` (`:997`, `:1031`) |
+| Dive sites | `getDiveAggregatesBySite` (`site_repository_impl.dart:863`) |
+| Trips | `getTripWithStats` (`trip_repository.dart:505`), `getAllTripsWithStats` (`:598`), `getDiveCountForTrip` (`:322`) |
+| Dive centers | `getDiveCountForCenter` (`dive_center_repository.dart:238`) |
+| Tags | `tag_repository.dart:548`, `:590`, `:612` |
+| Dive types | `dive_type_repository.dart:365`, `:414` |
+| Dive roles | `dive_role_repository.dart:240` |
+| Divers | `getDiveCountForDiver` (`diver_repository.dart:573`), `getTotalBottomTimeForDiver` (`:593`) |
+| Marine life | `seen_species_repository.dart:27`, `:58`; `species_repository.dart:598`, `:627` |
+| Dive computers | `dive_repository_impl.dart:6239` |
+
+Several of these count junction table rows without joining `dives` at all
+(`getDiveCountForBuddy`, and the tag and dive type counts). Those need a join
+added, not just a predicate.
+
+### Deliberately untouched: operational
+
+Each gets a doc comment naming the decision so a future reader does not "fix"
+it:
+
+- `EquipmentRepository.getUsageSamplesForEquipment`
+  (`equipment_repository_impl.dart:606`), `getDiveCountForEquipment` (`:582`),
+  `getTripCountForEquipment` (`:658`), and `ServiceDueEngine`
+  (`service_due_engine.dart:12`).
+- `CourseRepository.getDiveCountForCourse` (`course_repository.dart:201`),
+  `CourseRequirementRepository.getCourseProgress`
+  (`course_requirement_repository.dart:56`), and `getSuggestedDives` (`:440`).
+- `DiveRepository.getDiveCount()` (`dive_repository_impl.dart:2190`).
+
+Note that `StatisticsRepository.getMostUsedGear` (line 2063) **does** get the
+scope. It lives on the Statistics tab and is descriptive.
+
+### The `is_planned` fix
+
+`Dives.isPlanned` (`database.dart:776`) is set by the dive planner for dives
+that have not happened. No statistics or aggregate query filters on it today, so
+planned dives currently inflate every total. Folding `is_planned = 0` into the
+scope predicate fixes this in one line.
+
+This changes existing users' numbers on upgrade with no action on their part and
+requires an explicit release note.
+
+## Section 3: UI and localization
+
+**Dive edit form.** Two checkboxes at the end of `_buildTheDiveSection`
+(`dive_edit_page.dart:2025`), under a small "Statistics" label. That section
+holds dive number, date, site, and depth, so a flag about how the dive is
+counted belongs there rather than in Experience (rating, notes, sightings,
+tags). The collapsed section summary picks up an "Excluded" marker when either
+flag is set.
+
+The gas checkbox renders disabled and checked while the master flag is on, so
+the implication is visible rather than surprising.
+
+Note that `isFavorite` is only a partial precedent. It is read in the edit page
+at line 4961 but never edited there; favoriting happens from the list item and
+detail app bar. There is no existing dive level boolean checkbox in the edit
+form to copy.
+
+**Bulk edit.** Two new `BulkField` entries alongside `BulkField.isFavorite`
+(`dive_edit_page.dart:1056`), wrapped in the same gate widget so an untouched
+field stays untouched rather than writing `false` over every selected dive.
+This is what makes #526 practical: thirty pool sessions get excluded in one
+operation.
+
+**Badges.** A marker on the dive list item and the dive detail page. Icon plus
+tooltip rather than a text chip, because list rows are dense and the Ahem test
+font overflows unconstrained `Row` plus `Text` at narrow widths.
+
+**Statistics footnote.** A line in the Statistics tab reading "N dives excluded
+from statistics", backed by a count query that inverts the scope predicate.
+Renders only when N is nonzero. This is what prevents a "247 here, 248 there"
+support ticket months later.
+
+**Filter axis.** `DiveFilterState` gains `excludedFromStatsOnly` as a `bool?`,
+mirroring `favoritesOnly` (`dive_filter_state.dart:18`): null means no
+filtering, true means only excluded dives. Three implementations must stay in
+sync:
+
+1. `buildFilteredDiveIdSubquery` (`dive_filter_sql.dart:12`)
+2. `DiveRepository._buildFilterWhereClauses` (`dive_repository_impl.dart:2293`)
+3. `DiveFilterState.apply()` (`dive_filter_state.dart:263`)
+
+**Localization.** New keys for both checkbox labels, their help text, the badge
+tooltip, the bulk edit field labels, the filter axis label, and the statistics
+footnote. Translated across all eleven locales: `ar de en es fr he hu it nl pt
+zh`. English only would fail `arb_parity_test` against every other locale.
+
+## Section 4: Testing
+
+TDD, tests first. Two layers, because correctness and completeness are separate
+problems.
+
+### Layer 1: behavioral guard suite
+
+`test/features/statistics/dive_stats_scope_test.dart`. One fixture seeds five
+dives: normal, `excludedFromStats`, `excludedFromGasStats`, planned, and gauge
+mode. A table driven list calls every descriptive aggregate from section 2 and
+asserts the right dives are absent. This proves the roughly 45 edits work.
+
+### Layer 2: source census
+
+`test/core/database/dive_stats_scope_census_test.dart`. Reads the repository
+sources and asserts that every `customSelect` referencing `FROM dives` either
+contains `excluded_from_stats` or appears in an explicit, commented exemption
+list.
+
+Layer 1 alone cannot prevent rot, because it only tests the queries someone
+remembered to add to the list. The census test catches the next engineer adding
+a 46th aggregate: their query fails a test that names the decision they have to
+make. This is exactly the failure mode `dive_mode <> 'gauge'` already
+demonstrates, with seven hand copied predicates and no mechanism ensuring an
+eighth query would get it.
+
+### Migration tests
+
+- v177 to v178 adds both columns defaulting to 0.
+- The `beforeOpen` backstop is idempotent across two consecutive opens.
+- A minimal schema fixture with no `dives` table returns early instead of
+  throwing.
+
+### Filter parity
+
+The three implementations of `excludedFromStatsOnly` agree on one fixture set.
+The repo has precedent for an axis only some paths can evaluate (`decoOnly` is
+SQL only and skipped by `apply()`); this axis is evaluable everywhere, so no
+exemption is needed.
+
+### Round trips
+
+- Sync export and adopt preserve both flags. Generated serializer, so this is a
+  regression guard.
+- UDDF export and import preserve both flags. Hand plumbed, so this test earns
+  its place.
+
+### Widget tests
+
+- Edit form toggles persist.
+- The gas checkbox disables when the master flag is on.
+- The bulk edit gate leaves untouched fields untouched.
+- The badge renders on list item and detail page.
+- The statistics footnote appears and hides correctly.
+
+## Risks
+
+**Existing tests will break, by design.** Any test seeding a planned dive and
+expecting it in statistics now fails. Those failures are the `is_planned` fix
+working. Each needs individual review rather than a blanket update, because a
+genuine regression could hide among them.
+
+**Schema rung collision.** A rung claimed below main's scalar merges with no
+conflict marker and its step silently never runs. Re-run both claim scans
+immediately before pushing.
+
+**Release note required.** The `is_planned` fix changes existing users' totals
+on upgrade with no action on their part.
+
+## Verification before the PR
+
+- `dart format .`
+- `flutter analyze` across the whole project, infos treated as fatal
+- One full test suite run

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -730,6 +730,18 @@ class Dives extends Table {
   RealColumn get weightingFeedbackKg => real().nullable()();
   // Favorite flag (v1.1)
   BoolColumn get isFavorite => boolean().withDefault(const Constant(false))();
+  // Statistics exclusion (schema v180, issues #526 and #1272).
+  // excludedFromStats is the master flag: the dive stays in the logbook but
+  // contributes to no descriptive aggregate, its count included.
+  // excludedFromGasStats drops the dive from SAC/RMV and gas-mix aggregates
+  // only, for an otherwise ordinary dive whose gas number is unrepresentative
+  // (for example purging the tank for an end-of-dive weight check).
+  // The master flag implies the gas flag; the implication is applied in SQL by
+  // DiveStatsScope, not stored on the row.
+  BoolColumn get excludedFromStats =>
+      boolean().withDefault(const Constant(false))();
+  BoolColumn get excludedFromGasStats =>
+      boolean().withDefault(const Constant(false))();
   // Dive mode for CCR/SCR (v1.5)
   TextColumn get diveMode =>
       text().withDefault(const Constant('oc'))(); // oc, ccr, scr
@@ -3314,7 +3326,7 @@ class AppDatabase extends _$AppDatabase {
 
   /// The current schema version as a static constant so that pre-open checks
   /// (e.g. version-mismatch guard) can reference it without an instance.
-  static const int currentSchemaVersion = 179;
+  static const int currentSchemaVersion = 180;
 
   /// The oldest schema whose reader can apply this build's sync payloads
   /// without loss or misinterpretation (the compatibility floor).
@@ -3694,6 +3706,15 @@ class AppDatabase extends _$AppDatabase {
     // open, so this sits above it. 162, 167, 169 and 176 are skipped; the
     // ladder is non-contiguous by design.
     179,
+    // v180 (statistics exclusion): dives.excluded_from_stats and
+    // dives.excluded_from_gas_stats, letting a diver keep a dive in the
+    // logbook while removing it from statistics. Issues #526 and #1272.
+    // Renumbered from 178: main landed 178 (dive-type uniqueness) and 179
+    // (site-suggestion dismissal) while this branch was open, and a rung
+    // at or below the shipped version never runs its onUpgrade step.
+    // Column-only rung with no backfill, so the beforeOpen backstop is
+    // safe to re-run.
+    180,
   ];
 
   /// Idempotent DDL for the v106 connector-suggestion columns (Lightroom
@@ -5521,6 +5542,30 @@ class AppDatabase extends _$AppDatabase {
   /// letting frequently-dived buddies be pinned to the top of the "Add
   /// buddy" picker regardless of sort. Self-guards on the table existing, and
   /// defaults every pre-existing row to not-favorited.
+  /// Idempotent DDL for the v180 dives.excluded_from_stats and
+  /// dives.excluded_from_gas_stats columns (issues #526 and #1272), letting a
+  /// diver keep a dive in the logbook while removing it from statistics.
+  /// Self-guards on the table existing, and defaults every pre-existing row to
+  /// included. Same dual-call contract (onUpgrade + beforeOpen backstop) as
+  /// the other column-assert helpers.
+  Future<void> _assertDiveStatsExclusionColumns() async {
+    final cols = await customSelect("PRAGMA table_info('dives')").get();
+    if (cols.isEmpty) return;
+    final names = cols.map((c) => c.read<String>('name')).toSet();
+    if (!names.contains('excluded_from_stats')) {
+      await customStatement(
+        'ALTER TABLE dives ADD COLUMN excluded_from_stats '
+        'INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+    if (!names.contains('excluded_from_gas_stats')) {
+      await customStatement(
+        'ALTER TABLE dives ADD COLUMN excluded_from_gas_stats '
+        'INTEGER NOT NULL DEFAULT 0',
+      );
+    }
+  }
+
   Future<void> _assertBuddyFavoriteColumn() async {
     final cols = await customSelect("PRAGMA table_info('buddies')").get();
     if (cols.isEmpty) return;
@@ -9211,6 +9256,13 @@ class AppDatabase extends _$AppDatabase {
           await _assertSiteSuggestionDismissedAtColumn();
         }
         if (from < 179) await reportProgress();
+        // v180: dives.excluded_from_stats and dives.excluded_from_gas_stats
+        // (issues #526 and #1272). Column-only rung, no backfill: every
+        // pre-existing row correctly defaults to included.
+        if (from < 180) {
+          await _assertDiveStatsExclusionColumns();
+        }
+        if (from < 180) await reportProgress();
       },
       beforeOpen: (details) async {
         // Enable foreign keys
@@ -9456,6 +9508,12 @@ class AppDatabase extends _$AppDatabase {
         // the ladder, and re-running it on every open would resurrect a gear
         // item the user deleted.
         await _assertDiveComputerEquipmentColumn();
+
+        // v180 backstop: re-assert the dives statistics-exclusion columns
+        // (same parallel-branch version-collision self-heal). Safe to re-run
+        // on every open: the helper is column-only with no backfill, so it
+        // cannot resurrect or overwrite diver data.
+        await _assertDiveStatsExclusionColumns();
 
         // v145 backstop: re-assert the gps_tracks provenance and trim columns.
         await _assertGpsTrackColumns();

--- a/lib/core/database/dive_stats_scope.dart
+++ b/lib/core/database/dive_stats_scope.dart
@@ -1,22 +1,28 @@
 /// The canonical SQL predicate deciding which dives contribute to
 /// *descriptive* statistics.
 ///
-/// Two rules always apply:
+/// Every term is written in the affirmative: it states what a dive must be in
+/// order to *count*. Two always apply:
 ///
-/// - `excluded_from_stats = 0`: the diver ticked "exclude from statistics"
-///   (issue #526), for example a 90 minute session at 12 ft that is not an
-///   official dive by most agency standards.
-/// - `is_planned = 0`: a dive the planner created that has not happened.
-///   Before schema v178 these counted toward every total, which was a bug.
+/// - `excluded_from_stats = 0` keeps dives the diver has NOT ticked "exclude
+///   from statistics" on (issue #526). A dive they did tick, say a 90 minute
+///   session at 12 ft that is not an official dive by most agency standards,
+///   has the column set to 1 and is dropped here.
+/// - `is_planned = 0` keeps dives that actually happened, dropping entries the
+///   planner created for a dive that was never made. Nothing filtered on this
+///   before, so a planned dive inflated every total; that is a behaviour fix
+///   carried by this predicate, not by the migration, which only adds columns.
 ///
 /// The [gas] variant adds two more, for SAC/RMV and gas-mix aggregates:
 ///
-/// - `excluded_from_gas_stats = 0`: the diver ticked "exclude from gas
-///   statistics" (issue #1272), for example purging the tank down to 500 psi
-///   for an end-of-dive weight check.
-/// - `dive_mode <> 'gauge'`: gauge-mode dives carry no usable gas data. This
-///   rule predates v178 and was hand-copied into seven queries in
-///   StatisticsRepository; it now lives here.
+/// - `excluded_from_gas_stats = 0` keeps dives the diver has NOT ticked
+///   "exclude from gas statistics" on (issue #1272). They tick it when the
+///   gas figure is unrepresentative, say after purging the tank down to
+///   500 psi for an end-of-dive weight check.
+/// - `dive_mode <> 'gauge'` keeps dives that are not gauge-mode, which carry
+///   no usable gas data. This rule predates the exclusion flags and was
+///   hand-copied into seven queries in StatisticsRepository; it now lives
+///   here, which is the point.
 ///
 /// **This is deliberately NOT folded into `buildFilteredDiveIdSubquery`.**
 /// That function implements the diver's transient *view* filter and correctly

--- a/lib/core/database/dive_stats_scope.dart
+++ b/lib/core/database/dive_stats_scope.dart
@@ -1,0 +1,63 @@
+/// The canonical SQL predicate deciding which dives contribute to
+/// *descriptive* statistics.
+///
+/// Two rules always apply:
+///
+/// - `excluded_from_stats = 0`: the diver ticked "exclude from statistics"
+///   (issue #526), for example a 90 minute session at 12 ft that is not an
+///   official dive by most agency standards.
+/// - `is_planned = 0`: a dive the planner created that has not happened.
+///   Before schema v178 these counted toward every total, which was a bug.
+///
+/// The [gas] variant adds two more, for SAC/RMV and gas-mix aggregates:
+///
+/// - `excluded_from_gas_stats = 0`: the diver ticked "exclude from gas
+///   statistics" (issue #1272), for example purging the tank down to 500 psi
+///   for an end-of-dive weight check.
+/// - `dive_mode <> 'gauge'`: gauge-mode dives carry no usable gas data. This
+///   rule predates v178 and was hand-copied into seven queries in
+///   StatisticsRepository; it now lives here.
+///
+/// **This is deliberately NOT folded into `buildFilteredDiveIdSubquery`.**
+/// That function implements the diver's transient *view* filter and correctly
+/// returns an empty no-op when no axis is active. This scope is a persistent
+/// property of the dive and must apply unconditionally. Merging the two would
+/// either make the exclusion evaporate for every diver who never opens the
+/// filter sheet, or silently scope the deliberately-unfiltered surfaces
+/// (dashboard quick stats, dive-log summary, species detail page).
+///
+/// **Operational counts deliberately ignore this scope.** Equipment service
+/// intervals, course-requirement progress, and the logbook list header all
+/// count excluded dives on purpose; each carries a doc comment saying so. A
+/// practice dive still cycled the regulator, and a dive the diver linked to a
+/// course requirement was linked on purpose.
+///
+/// See
+/// `docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md`.
+class DiveStatsScope {
+  const DiveStatsScope._();
+
+  /// The bare predicate, with no leading conjunction. Use when the query has
+  /// no WHERE clause yet: `WHERE ${DiveStatsScope.predicate()}`.
+  ///
+  /// [alias] must match the alias the query already gives the `dives` table
+  /// (or `dives` itself when the query does not alias it). Queries that join
+  /// `dives` to itself need one call per alias.
+  static String predicate({String alias = 'd', bool gas = false}) {
+    final parts = <String>[
+      '$alias.excluded_from_stats = 0',
+      '$alias.is_planned = 0',
+    ];
+    if (gas) {
+      parts.add('$alias.excluded_from_gas_stats = 0');
+      parts.add("$alias.dive_mode <> 'gauge'");
+    }
+    return parts.join(' AND ');
+  }
+
+  /// The predicate prefixed with ` AND `, for appending into an existing
+  /// WHERE clause. Emits no bind placeholders, so callers never thread params
+  /// for the scope.
+  static String and({String alias = 'd', bool gas = false}) =>
+      ' AND ${predicate(alias: alias, gas: gas)}';
+}

--- a/lib/core/services/export/uddf/uddf_export_builders.dart
+++ b/lib/core/services/export/uddf/uddf_export_builders.dart
@@ -685,6 +685,15 @@ class UddfExportBuilders {
             if (dive.isFavorite) {
               builder.element('isfavorite', nest: 'true');
             }
+            // Statistics exclusion (#526 / #1272). App-specific, like
+            // isfavorite: another application's UDDF omits these and imports
+            // as included, which is the right default.
+            if (dive.excludedFromStats) {
+              builder.element('excludedfromstats', nest: 'true');
+            }
+            if (dive.excludedFromGasStats) {
+              builder.element('excludedfromgasstats', nest: 'true');
+            }
             if (dive.photoIds.isNotEmpty) {
               builder.element(
                 'photos',

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -866,6 +866,23 @@ class UddfFullImportService {
         diveData['isFavorite'] = true;
       }
 
+      // Statistics exclusion. Absent means included, so a document from
+      // another application never arrives pre-excluded.
+      final excludedFromStats = UddfImportParsers.getElementText(
+        afterElement,
+        'excludedfromstats',
+      );
+      if (excludedFromStats?.toLowerCase() == 'true') {
+        diveData['excludedFromStats'] = true;
+      }
+      final excludedFromGasStats = UddfImportParsers.getElementText(
+        afterElement,
+        'excludedfromgasstats',
+      );
+      if (excludedFromGasStats?.toLowerCase() == 'true') {
+        diveData['excludedFromGasStats'] = true;
+      }
+
       // Parse additional weights (app-specific, beyond single weight)
       final weightsElement = afterElement.findElements('weights').firstOrNull;
       if (weightsElement != null) {

--- a/lib/features/buddies/data/repositories/buddy_repository.dart
+++ b/lib/features/buddies/data/repositories/buddy_repository.dart
@@ -3,6 +3,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
@@ -798,7 +799,8 @@ class BuddyRepository {
                  COUNT(*) AS dive_count,
                  MAX(d.dive_date_time) AS last_dive
           FROM dive_buddies db
-          LEFT JOIN dives d ON d.id = db.dive_id
+          INNER JOIN dives d ON d.id = db.dive_id
+                            ${DiveStatsScope.and(alias: 'd')}
           GROUP BY db.buddy_id
         ) dc ON b.id = dc.buddy_id
         $where
@@ -943,14 +945,17 @@ class BuddyRepository {
     }
   }
 
-  /// Get dive count for a buddy
+  /// Get dive count for a buddy, as shown on the buddy card and detail
+  /// header. Honours [DiveStatsScope], so a dive the diver excluded from
+  /// statistics does not inflate "N dives with this buddy".
   Future<int> getDiveCountForBuddy(String buddyId) async {
     final result = await _db
         .customSelect(
           '''
       SELECT COUNT(*) as count
-      FROM dive_buddies
-      WHERE buddy_id = ?
+      FROM dive_buddies db
+      INNER JOIN dives d ON d.id = db.dive_id
+      WHERE db.buddy_id = ?${DiveStatsScope.and(alias: 'd')}
     ''',
           variables: [Variable.withString(buddyId)],
         )
@@ -971,6 +976,7 @@ class BuddyRepository {
   /// unstable tail would change *which* dives the preview shows, not merely
   /// their order.
   /// The join also drops links whose dive row no longer exists.
+  // stats-scope-exempt: drives the buddy's displayed dive list, like the logbook
   Future<List<String>> getDiveIdsForBuddy(String buddyId) async {
     final results = await _db
         .customSelect(
@@ -1004,7 +1010,7 @@ class BuddyRepository {
         MAX(d.dive_date_time) as last_dive
       FROM dives d
       INNER JOIN dive_buddies db ON d.id = db.dive_id
-      WHERE db.buddy_id = ?
+      WHERE db.buddy_id = ?${DiveStatsScope.and(alias: 'd')}
     ''',
           variables: [Variable.withString(buddyId)],
         )
@@ -1032,7 +1038,7 @@ class BuddyRepository {
       FROM dives d
       INNER JOIN dive_buddies db ON d.id = db.dive_id
       INNER JOIN dive_sites ds ON d.site_id = ds.id
-      WHERE db.buddy_id = ?
+      WHERE db.buddy_id = ?${DiveStatsScope.and(alias: 'd')}
       GROUP BY d.site_id
       ORDER BY count DESC
       LIMIT 1

--- a/lib/features/courses/data/repositories/course_repository.dart
+++ b/lib/features/courses/data/repositories/course_repository.dart
@@ -137,6 +137,7 @@ class CourseRepository {
   }
 
   /// Get course for a specific dive
+  // stats-scope-exempt: course credit is deliberate, not descriptive
   Future<domain.Course?> getCourseForDive(String diveId) async {
     try {
       final results = await _db
@@ -198,6 +199,11 @@ class CourseRepository {
   }
 
   /// Get count of dives for a course
+  /// Deliberately does NOT apply DiveStatsScope. The diver linked this dive
+  /// to the course on purpose; excluding it from statistics is a statement
+  /// about their logbook averages, not a retraction of course credit. Do not
+  /// "fix" this.
+  // stats-scope-exempt: course credit is deliberate, not descriptive
   Future<int> getDiveCountForCourse(String courseId) async {
     try {
       final result = await _db

--- a/lib/features/courses/data/repositories/course_requirement_repository.dart
+++ b/lib/features/courses/data/repositories/course_requirement_repository.dart
@@ -53,6 +53,11 @@ class CourseRequirementRepository {
 
   /// All requirements of [courseId] with their credited dives, in
   /// sortOrder. One requirement query plus one joined link query -- no N+1.
+  /// Deliberately does NOT apply DiveStatsScope. The diver linked this dive
+  /// to the course on purpose; excluding it from statistics is a statement
+  /// about their logbook averages, not a retraction of course credit. Do not
+  /// "fix" this.
+  // stats-scope-exempt: course credit is deliberate, not descriptive
   Future<CourseProgress> getCourseProgress(String courseId) async {
     try {
       final reqRows =
@@ -437,6 +442,11 @@ class CourseRequirementRepository {
   /// assigned to this course (dives.course_id) or dated on/after the course
   /// start, excluding dives already credited to any requirement of this
   /// course. Newest first, capped at 10.
+  /// Deliberately does NOT apply DiveStatsScope. The diver linked this dive
+  /// to the course on purpose; excluding it from statistics is a statement
+  /// about their logbook averages, not a retraction of course credit. Do not
+  /// "fix" this.
+  // stats-scope-exempt: course credit is deliberate, not descriptive
   Future<List<RequirementDiveSummary>> getSuggestedDives(
     String courseId,
   ) async {

--- a/lib/features/dive_centers/data/repositories/dive_center_repository.dart
+++ b/lib/features/dive_centers/data/repositories/dive_center_repository.dart
@@ -3,6 +3,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
@@ -241,7 +242,7 @@ class DiveCenterRepository {
           '''
       SELECT COUNT(*) as count
       FROM dives
-      WHERE dive_center_id = ?
+      WHERE dive_center_id = ?${DiveStatsScope.and(alias: 'dives')}
     ''',
           variables: [Variable.withString(centerId)],
         )

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1576,6 +1576,9 @@ class UddfEntityImporter {
           _parseEnum(diveData['diveMode'], DiveMode.values) ?? DiveMode.oc;
       final isPlanned = diveData['isPlanned'] as bool? ?? false;
       final isFavorite = diveData['isFavorite'] as bool? ?? false;
+      final excludedFromStats = diveData['excludedFromStats'] as bool? ?? false;
+      final excludedFromGasStats =
+          diveData['excludedFromGasStats'] as bool? ?? false;
 
       // Build diluent gas mix (if present)
       final diluentO2 = diveData['diluentO2'] as double?;
@@ -1660,6 +1663,8 @@ class UddfEntityImporter {
         diveMode: diveMode,
         isPlanned: isPlanned,
         isFavorite: isFavorite,
+        excludedFromStats: excludedFromStats,
+        excludedFromGasStats: excludedFromGasStats,
         courseId: linkedCourseId,
         setpointLow: asDoubleOrNull(diveData['setpointLow']),
         setpointHigh: asDoubleOrNull(diveData['setpointHigh']),

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2403,6 +2403,9 @@ class DiveRepository {
     if (filter.favoritesOnly == true) {
       clauses.add('d.is_favorite = 1');
     }
+    if (filter.excludedFromStatsOnly == true) {
+      clauses.add('d.excluded_from_stats = 1');
+    }
     if (filter.decoOnly != null) {
       clauses.add(
         decoSignalCondition(wantDeco: filter.decoOnly!, diveIdRef: 'd.id'),

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2178,6 +2178,7 @@ class DiveRepository {
   ///
   /// Used to compute previous/next navigation from the detail page. Distinct
   /// from [getPreviousDive], which is the chronological surface-interval query.
+  // stats-scope-exempt: drives detail-page next/prev over the displayed list
   Future<List<String>> getOrderedDiveIds({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
@@ -2286,6 +2287,7 @@ class DiveRepository {
   ///
   /// Only called while the deco filter is active, which keeps the scan over
   /// `dive_profiles` off the default dive-list load.
+  // stats-scope-exempt: backs a view-filter axis; consumers apply the scope themselves
   Future<Set<String>> getDiveIdsWithDecoSignal({
     required bool wantDeco,
     String? diverId,
@@ -2356,6 +2358,7 @@ class DiveRepository {
 
   /// Translates each active filter field into parameterized SQL.
   /// Junction-table filters (tags, equipment, buddies) use EXISTS subqueries.
+  // stats-scope-exempt: this IS the view filter; the scope is applied alongside it
   void _buildFilterWhereClauses(
     DiveFilterState filter,
     List<String> clauses,
@@ -2646,6 +2649,7 @@ class DiveRepository {
   /// Note: This returns the next number after the highest existing number,
   /// which may not be chronologically correct. Use [getDiveNumberForDate]
   /// for chronologically-based numbering.
+  // stats-scope-exempt: numbering integrity, must see every dive or it reuses a number
   Future<int> getNextDiveNumber({String? diverId}) async {
     try {
       final String sql;
@@ -2700,6 +2704,7 @@ class DiveRepository {
   /// hydrating search whose roughly-ten-queries-per-match N+1 dominated
   /// search cost on large databases (docs/superpowers/specs/2026-07-10-
   /// large-db-performance-findings.md).
+  // stats-scope-exempt: search results are a displayed list, like the logbook
   Future<List<DiveSummary>> searchDiveSummaries(
     String query, {
     String? diverId,
@@ -4673,6 +4678,7 @@ class DiveRepository {
   /// classifier: end time (exit time, else entry/date + runtime) plus a
   /// had-deco flag derived from the recorded profile (any sample with
   /// deco_type = 2 or a positive ceiling).
+  // stats-scope-exempt: flying-after-diving safety, an excluded dive still off-gassed
   Future<List<NoFlyDiveInput>> getNoFlyDiveInputs({
     required DateTime since,
     String? diverId,
@@ -4767,6 +4773,7 @@ class DiveRepository {
   /// [getPreviousDiveTimes]) rather than full hydration: the formula needs
   /// only timestamps and effective runtime, and this method sits on the
   /// residual-decompression lookback hot path (WS2, large-DB performance).
+  // stats-scope-exempt: physiological interval between real dives, not a statistic
   Future<Duration?> getSurfaceInterval(String diveId) async {
     try {
       final current = await getDiveTimes(diveId);
@@ -5185,6 +5192,7 @@ class DiveRepository {
   /// [diverId] - If non-null, only operates on that diver's dives. The
   /// MIN(dive_number) used as the starting point is also scoped, so each
   /// diver preserves their own numbering baseline.
+  // stats-scope-exempt: renumbering integrity, must see every dive
   Future<void> assignMissingDiveNumbers({String? diverId}) async {
     try {
       _log.info(
@@ -6223,6 +6231,7 @@ class DiveRepository {
   /// When [diverId] is provided, the result is restricted to that diver's
   /// dives — callers that have already scoped `existingDives` to a single
   /// diver should pass it here so the key map shares the same scope.
+  // stats-scope-exempt: import dedupe fingerprints, must see every dive or it re-imports
   Future<Map<String, Set<String>>> getSourceKeysByDiveId({
     String? diverId,
   }) async {

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/utils/stream_debounce.dart';
@@ -2232,6 +2233,12 @@ class DiveRepository {
   /// Get total count of dives matching the given filters.
   ///
   /// Used to display "X dives" in the UI header without loading all data.
+  ///
+  /// Deliberately does NOT apply [DiveStatsScope]: an excluded dive is still
+  /// in the logbook and the list still shows it, so the header still counts
+  /// it. Only descriptive *statistics* honour the exclusion. Do not "fix"
+  /// this; see the design doc and the census test's exemption list.
+  // stats-scope-exempt: logbook list header, not a statistic
   Future<int> getDiveCount({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
@@ -2892,12 +2899,20 @@ class DiveRepository {
       final df = buildFilteredDiveIdSubquery(filter);
       // params are always non-null so `p!` is safe.
       final filterVars = df.params.map((p) => Variable<Object>(p!)).toList();
-      // Clause fragments per table alias used below.
-      final fBare = df.subquery.isEmpty ? '' : 'AND id IN (${df.subquery})';
-      final fAliasD = df.subquery.isEmpty ? '' : 'AND d.id IN (${df.subquery})';
+      // Clause fragments per table alias used below. The statistics scope is
+      // unconditional; the diver's view filter is appended only when active.
+      final scopeBare = DiveStatsScope.and(alias: 'dives');
+      final scopeAliasD = DiveStatsScope.and(alias: 'd');
+      final fBare = df.subquery.isEmpty
+          ? scopeBare
+          : '$scopeBare AND id IN (${df.subquery})';
+      final fAliasD = df.subquery.isEmpty
+          ? scopeAliasD
+          : '$scopeAliasD AND d.id IN (${df.subquery})';
       // WHERE-prefix helpers so an empty base WHERE still starts correctly.
+      // Always emits a WHERE now, because the scope is never empty.
       final basicWhere = whereClause.isEmpty
-          ? (df.subquery.isEmpty ? '' : 'WHERE id IN (${df.subquery})')
+          ? 'WHERE 1=1 $fBare'
           : '$whereClause $fBare';
       vars.addAll(filterVars);
 
@@ -2990,7 +3005,7 @@ class DiveRepository {
       // Top sites
       final siteWhereClause = diverId != null
           ? 'WHERE d.diver_id = ? $fAliasD'
-          : (df.subquery.isEmpty ? '' : 'WHERE 1=1 $fAliasD');
+          : 'WHERE 1=1 $fAliasD';
       final siteStats = await _db.customSelect('''
       SELECT
         s.id as site_id,
@@ -3061,18 +3076,22 @@ class DiveRepository {
       // Every statement below binds the same `vars` list, so the diver `?` must
       // always precede the filter `?`s -- hence the fixed clause order.
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
+      // The statistics scope is unconditional: an excluded dive must never
+      // surface as a personal record. The view filter is appended only when
+      // the diver has active axes.
       final filterClause = df.subquery.isEmpty
-          ? ''
-          : 'AND d.id IN (${df.subquery})';
+          ? DiveStatsScope.and(alias: 'd')
+          : '${DiveStatsScope.and(alias: 'd')} '
+                'AND d.id IN (${df.subquery})';
       // The first/last statements have no WHERE of their own, so their scope
-      // clauses have to open one.
+      // clauses have to open one. The scope predicate binds no placeholders,
+      // so listing it first cannot disturb the fixed `?` order.
       final scopeConditions = [
+        DiveStatsScope.predicate(alias: 'd'),
         if (diverId != null) 'd.diver_id = ?',
         if (df.subquery.isNotEmpty) 'd.id IN (${df.subquery})',
       ];
-      final diverFilterFirst = scopeConditions.isEmpty
-          ? ''
-          : 'WHERE ${scopeConditions.join(' AND ')}';
+      final diverFilterFirst = 'WHERE ${scopeConditions.join(' AND ')}';
 
       // Deepest dive
       final deepestResult = await _db.customSelect('''
@@ -3201,7 +3220,8 @@ class DiveRepository {
     final row = await _db
         .customSelect(
           'SELECT COUNT(*) AS c FROM dives '
-          'WHERE dive_date_time > ? $diverFilter',
+          'WHERE dive_date_time > ? $diverFilter'
+          '${DiveStatsScope.and(alias: 'dives')}',
           variables: [
             Variable<int>(since.millisecondsSinceEpoch),
             if (diverId != null) Variable<String>(diverId),
@@ -3231,6 +3251,7 @@ class DiveRepository {
           "AND CAST(strftime('%Y', dive_date_time / 1000, 'unixepoch') "
           "AS INTEGER) != ? "
           "$diverFilter"
+          "${DiveStatsScope.and(alias: 'dives')} "
           "ORDER BY dive_date_time DESC LIMIT ?",
           variables: [
             Variable<String>(monthDay),
@@ -3287,7 +3308,12 @@ class DiveRepository {
     final vars = diverId != null
         ? [Variable<String>(diverId)]
         : <Variable<Object>>[];
-    final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
+    // The statistics scope rides along with the diver filter, which every
+    // statement below already interpolates: an excluded or planned dive must
+    // never win a personal record.
+    final diverFilter = diverId != null
+        ? 'AND d.diver_id = ?${DiveStatsScope.and(alias: 'd')}'
+        : DiveStatsScope.and(alias: 'd');
 
     Future<String?> winner(String where, String orderBy) async {
       final row = await _db

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2126,7 +2126,7 @@ class DiveRepository {
             'd.dive_date_time, d.entry_time, '
             'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
             'd.is_favorite, d.excluded_from_stats, d.excluded_from_gas_stats, '
-          'd.dive_type, d.dive_mode, '
+            'd.dive_type, d.dive_mode, '
             'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
             's.name AS site_name, s.country AS site_country, '
             's.region AS site_region, s.latitude AS site_latitude, '

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2059,6 +2059,9 @@ class DiveRepository {
     );
   }
 
+  // stats-scope-exempt: the logbook list itself. It SELECTS the exclusion
+  // columns so the row can render its badge, but must never filter on them:
+  // an excluded dive is still in the logbook and still shown.
   Future<List<DiveSummary>> getDiveSummaries({
     String? diverId,
     DiveFilterState filter = const DiveFilterState(),
@@ -2788,6 +2791,9 @@ class DiveRepository {
 
   /// Loads [DiveSummary] rows for [ids] (slim SELECT plus batched tags and
   /// dive types), ordered most recent first.
+  // stats-scope-exempt: hydrates rows for an already-chosen id set. It
+  // SELECTS the exclusion columns for the list badge and must not filter on
+  // them; whoever produced the ids decided what belongs.
   Future<List<DiveSummary>> _summariesForIds(
     List<String> ids, {
     Set<String> disabledSafetyRules = const {},

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1440,6 +1440,8 @@ class DiveRepository {
               weightingFeedbackKg: Value(dive.weightingFeedbackKg),
               // Favorite flag
               isFavorite: Value(dive.isFavorite),
+              excludedFromStats: Value(dive.excludedFromStats),
+              excludedFromGasStats: Value(dive.excludedFromGasStats),
               // CCR/SCR rebreather fields (v1.5)
               diveMode: Value(dive.diveMode.code),
               setpointLow: Value(dive.setpointLow),
@@ -1695,6 +1697,8 @@ class DiveRepository {
           weightingFeedbackKg: Value(dive.weightingFeedbackKg),
           // Favorite flag
           isFavorite: Value(dive.isFavorite),
+          excludedFromStats: Value(dive.excludedFromStats),
+          excludedFromGasStats: Value(dive.excludedFromGasStats),
           // CCR/SCR rebreather fields (v1.5)
           diveMode: Value(dive.diveMode.code),
           setpointLow: Value(dive.setpointLow),
@@ -2121,7 +2125,8 @@ class DiveRepository {
             'd.id, d.dive_number, d.name AS dive_name, '
             'd.dive_date_time, d.entry_time, '
             'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
-            'd.is_favorite, d.dive_type, d.dive_mode, '
+            'd.is_favorite, d.excluded_from_stats, d.excluded_from_gas_stats, '
+          'd.dive_type, d.dive_mode, '
             'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
             's.name AS site_name, s.country AS site_country, '
             's.region AS site_region, s.latitude AS site_latitude, '
@@ -2784,7 +2789,8 @@ class DiveRepository {
           'd.id, d.dive_number, d.name AS dive_name, '
           'd.dive_date_time, d.entry_time, '
           'd.max_depth, d.bottom_time, d.runtime, d.water_temp, d.rating, '
-          'd.is_favorite, d.dive_type, d.dive_mode, '
+          'd.is_favorite, d.excluded_from_stats, d.excluded_from_gas_stats, '
+          'd.dive_type, d.dive_mode, '
           'COALESCE(d.entry_time, d.dive_date_time) AS sort_timestamp, '
           's.name AS site_name, s.country AS site_country, '
           's.region AS site_region, s.latitude AS site_latitude, '
@@ -2847,6 +2853,8 @@ class DiveRepository {
         waterTemp: row.readNullable<double>('water_temp'),
         rating: row.readNullable<int>('rating'),
         isFavorite: row.read<int>('is_favorite') == 1,
+        excludedFromStats: row.read<int>('excluded_from_stats') == 1,
+        excludedFromGasStats: row.read<int>('excluded_from_gas_stats') == 1,
         diveMode: DiveMode.fromCode(row.read<String>('dive_mode')),
         diveTypeIds: diveTypesByDive[id] ?? [row.read<String>('dive_type')],
         tags: tagsByDive[id] ?? [],
@@ -3587,6 +3595,8 @@ class DiveRepository {
       equipment: equipment,
       weights: const [], // Weights not loaded for list views (use detail view)
       isFavorite: row.isFavorite,
+      excludedFromStats: row.excludedFromStats,
+      excludedFromGasStats: row.excludedFromGasStats,
       tags: tags,
       // CCR/SCR rebreather fields (v1.5)
       diveMode: DiveMode.fromCode(row.diveMode),
@@ -3969,6 +3979,8 @@ class DiveRepository {
       equipment: hydratedEquipmentItems,
       weights: weights,
       isFavorite: row.isFavorite,
+      excludedFromStats: row.excludedFromStats,
+      excludedFromGasStats: row.excludedFromGasStats,
       tags: tags,
       // CCR/SCR rebreather fields (v1.5)
       diveMode: DiveMode.fromCode(row.diveMode),

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -694,8 +694,7 @@ class Dive extends Equatable {
       weightingFeedbackKg: weightingFeedbackKg ?? this.weightingFeedbackKg,
       isFavorite: isFavorite ?? this.isFavorite,
       excludedFromStats: excludedFromStats ?? this.excludedFromStats,
-      excludedFromGasStats:
-          excludedFromGasStats ?? this.excludedFromGasStats,
+      excludedFromGasStats: excludedFromGasStats ?? this.excludedFromGasStats,
       tags: tags ?? this.tags,
       // CCR/SCR fields
       diveMode: diveMode ?? this.diveMode,

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -118,6 +118,15 @@ class Dive extends Equatable {
   final double? weightingFeedbackKg;
   // Favorites and tags (v1.1/v1.5)
   final bool isFavorite;
+
+  /// Excluded from every descriptive statistic, its count included (#526).
+  /// The dive stays fully visible and editable in the logbook.
+  final bool excludedFromStats;
+
+  /// Excluded from SAC/RMV and gas-mix aggregates only (#1272), for a dive
+  /// whose gas number is unrepresentative. Implied by [excludedFromStats];
+  /// the implication is applied in SQL by DiveStatsScope, not stored here.
+  final bool excludedFromGasStats;
   final List<Tag> tags;
 
   // Dive mode (v1.5) - OC, CCR, or SCR
@@ -233,6 +242,8 @@ class Dive extends Equatable {
     this.weightingFeedback,
     this.weightingFeedbackKg,
     this.isFavorite = false,
+    this.excludedFromStats = false,
+    this.excludedFromGasStats = false,
     this.tags = const [],
     // CCR/SCR fields (v1.5)
     this.diveMode = DiveMode.oc,
@@ -585,6 +596,8 @@ class Dive extends Equatable {
     WeightingFeedback? weightingFeedback,
     double? weightingFeedbackKg,
     bool? isFavorite,
+    bool? excludedFromStats,
+    bool? excludedFromGasStats,
     List<Tag>? tags,
     // CCR/SCR fields
     DiveMode? diveMode,
@@ -680,6 +693,9 @@ class Dive extends Equatable {
       weightingFeedback: weightingFeedback ?? this.weightingFeedback,
       weightingFeedbackKg: weightingFeedbackKg ?? this.weightingFeedbackKg,
       isFavorite: isFavorite ?? this.isFavorite,
+      excludedFromStats: excludedFromStats ?? this.excludedFromStats,
+      excludedFromGasStats:
+          excludedFromGasStats ?? this.excludedFromGasStats,
       tags: tags ?? this.tags,
       // CCR/SCR fields
       diveMode: diveMode ?? this.diveMode,
@@ -778,6 +794,8 @@ class Dive extends Equatable {
     weightingFeedback,
     weightingFeedbackKg,
     isFavorite,
+    excludedFromStats,
+    excludedFromGasStats,
     tags,
     // CCR/SCR fields
     diveMode,

--- a/lib/features/dive_log/domain/entities/dive_summary.dart
+++ b/lib/features/dive_log/domain/entities/dive_summary.dart
@@ -21,6 +21,13 @@ class DiveSummary extends Equatable {
   final double? waterTemp;
   final int? rating;
   final bool isFavorite;
+
+  /// Excluded from every descriptive statistic (#526). Surfaced in the
+  /// dive list so the diver can see which dives are not being counted.
+  final bool excludedFromStats;
+
+  /// Excluded from SAC/RMV and gas-mix aggregates only (#1272).
+  final bool excludedFromGasStats;
   final DiveMode diveMode;
   final List<String> diveTypeIds;
   final List<Tag> tags;
@@ -51,6 +58,8 @@ class DiveSummary extends Equatable {
     this.waterTemp,
     this.rating,
     this.isFavorite = false,
+    this.excludedFromStats = false,
+    this.excludedFromGasStats = false,
     this.diveMode = DiveMode.oc,
     this.diveTypeIds = const ['recreational'],
     this.tags = const [],
@@ -82,6 +91,8 @@ class DiveSummary extends Equatable {
       waterTemp: dive.waterTemp,
       rating: dive.rating,
       isFavorite: dive.isFavorite,
+      excludedFromStats: dive.excludedFromStats,
+      excludedFromGasStats: dive.excludedFromGasStats,
       diveMode: dive.diveMode,
       diveTypeIds: dive.diveTypeIds,
       tags: dive.tags,
@@ -133,6 +144,8 @@ class DiveSummary extends Equatable {
     double? waterTemp,
     int? rating,
     bool? isFavorite,
+    bool? excludedFromStats,
+    bool? excludedFromGasStats,
     DiveMode? diveMode,
     List<String>? diveTypeIds,
     List<Tag>? tags,
@@ -156,6 +169,9 @@ class DiveSummary extends Equatable {
       waterTemp: waterTemp ?? this.waterTemp,
       rating: rating ?? this.rating,
       isFavorite: isFavorite ?? this.isFavorite,
+      excludedFromStats: excludedFromStats ?? this.excludedFromStats,
+      excludedFromGasStats:
+          excludedFromGasStats ?? this.excludedFromGasStats,
       diveMode: diveMode ?? this.diveMode,
       diveTypeIds: diveTypeIds ?? this.diveTypeIds,
       tags: tags ?? this.tags,
@@ -182,6 +198,8 @@ class DiveSummary extends Equatable {
     waterTemp,
     rating,
     isFavorite,
+    excludedFromStats,
+    excludedFromGasStats,
     diveMode,
     diveTypeIds,
     tags,

--- a/lib/features/dive_log/domain/entities/dive_summary.dart
+++ b/lib/features/dive_log/domain/entities/dive_summary.dart
@@ -170,8 +170,7 @@ class DiveSummary extends Equatable {
       rating: rating ?? this.rating,
       isFavorite: isFavorite ?? this.isFavorite,
       excludedFromStats: excludedFromStats ?? this.excludedFromStats,
-      excludedFromGasStats:
-          excludedFromGasStats ?? this.excludedFromGasStats,
+      excludedFromGasStats: excludedFromGasStats ?? this.excludedFromGasStats,
       diveMode: diveMode ?? this.diveMode,
       diveTypeIds: diveTypeIds ?? this.diveTypeIds,
       tags: tags ?? this.tags,

--- a/lib/features/dive_log/domain/models/dive_filter_state.dart
+++ b/lib/features/dive_log/domain/models/dive_filter_state.dart
@@ -17,6 +17,14 @@ class DiveFilterState {
   final double? maxDepth;
   final bool? favoritesOnly;
 
+  /// When true, keep only dives the diver excluded from statistics, so
+  /// they can find and review them (#526). Null means this axis is off.
+  ///
+  /// This is a view filter for *finding* excluded dives. It plays no part
+  /// in enforcing the exclusion; that is DiveStatsScope's job and applies
+  /// unconditionally, whether or not this axis is set.
+  final bool? excludedFromStatsOnly;
+
   /// Decompression status, derived from the recorded profile signal: a
   /// deco-stop profile point, a `decoStopStart` event, or a positive ceiling
   /// on a profile carrying no deco-type data at all (mirroring
@@ -78,6 +86,7 @@ class DiveFilterState {
     this.minDepth,
     this.maxDepth,
     this.favoritesOnly,
+    this.excludedFromStatsOnly,
     this.decoOnly,
     this.noBuddyOnly,
     this.tagIds = const [],
@@ -110,6 +119,7 @@ class DiveFilterState {
       minDepth != null ||
       maxDepth != null ||
       favoritesOnly == true ||
+      excludedFromStatsOnly == true ||
       decoOnly != null ||
       noBuddyOnly == true ||
       tagIds.isNotEmpty ||
@@ -137,6 +147,7 @@ class DiveFilterState {
     double? minDepth,
     double? maxDepth,
     bool? favoritesOnly,
+    bool? excludedFromStatsOnly,
     bool? decoOnly,
     bool? noBuddyOnly,
     List<String>? tagIds,
@@ -166,6 +177,7 @@ class DiveFilterState {
     bool clearMinDepth = false,
     bool clearMaxDepth = false,
     bool clearFavoritesOnly = false,
+    bool clearExcludedFromStatsOnly = false,
     bool clearDecoOnly = false,
     bool clearNoBuddyOnly = false,
     bool clearTagIds = false,
@@ -198,6 +210,9 @@ class DiveFilterState {
       favoritesOnly: clearFavoritesOnly
           ? null
           : (favoritesOnly ?? this.favoritesOnly),
+      excludedFromStatsOnly: clearExcludedFromStatsOnly
+          ? null
+          : (excludedFromStatsOnly ?? this.excludedFromStatsOnly),
       decoOnly: clearDecoOnly ? null : (decoOnly ?? this.decoOnly),
       noBuddyOnly: clearNoBuddyOnly ? null : (noBuddyOnly ?? this.noBuddyOnly),
       tagIds: clearTagIds ? const [] : (tagIds ?? this.tagIds),
@@ -296,6 +311,9 @@ class DiveFilterState {
         return false;
       }
       if (favoritesOnly == true && !dive.isFavorite) {
+        return false;
+      }
+      if (excludedFromStatsOnly == true && !dive.excludedFromStats) {
         return false;
       }
       if (noBuddyOnly == true) {

--- a/lib/features/dive_log/domain/services/dive_merge_builder.dart
+++ b/lib/features/dive_log/domain/services/dive_merge_builder.dart
@@ -316,6 +316,11 @@ class DiveMergeBuilder {
       isPlanned: first.isPlanned,
       notes: _mergedNotes(sorted),
       isFavorite: sorted.any((d) => d.isFavorite),
+      // An explicit exclusion on any source survives the merge. Dropping it
+      // would silently re-admit a dive the diver deliberately took out of
+      // their statistics, which is the harder error to notice of the two.
+      excludedFromStats: sorted.any((d) => d.excludedFromStats),
+      excludedFromGasStats: sorted.any((d) => d.excludedFromGasStats),
       entryLocation: _firstNonNull(sorted, (d) => d.entryLocation),
       exitLocation: _lastNonNull(sorted, (d) => d.exitLocation),
       site: _firstNonNull(sorted, (d) => d.site),

--- a/lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart
+++ b/lib/features/dive_log/presentation/pages/bulk_edit_field_set.dart
@@ -11,6 +11,8 @@ enum BulkField {
   course,
   rating,
   isFavorite,
+  excludedFromStats,
+  excludedFromGasStats,
   waterType,
   visibility,
   currentDirection,
@@ -67,6 +69,8 @@ class BulkScalarInputs {
     this.courseId,
     this.rating,
     this.isFavorite,
+    this.excludedFromStats,
+    this.excludedFromGasStats,
     this.waterType,
     this.visibilityMeters,
     this.currentDirection,
@@ -105,6 +109,11 @@ class BulkScalarInputs {
   final String? courseId;
   final int? rating;
   final bool? isFavorite;
+
+  /// Statistics exclusion (#526 / #1272). Null means the diver never
+  /// touched the gate, so the field is left alone on every selected dive.
+  final bool? excludedFromStats;
+  final bool? excludedFromGasStats;
   final String? waterType;
 
   /// Measured visibility in meters. Replaces the pre-v144 bucket string:
@@ -157,6 +166,12 @@ DivesCompanion buildScalarCompanion(
       BulkField.trip => c.copyWith(tripId: Value(i.tripId)),
       BulkField.course => c.copyWith(courseId: Value(i.courseId)),
       BulkField.rating => c.copyWith(rating: Value(i.rating)),
+      BulkField.excludedFromStats => c.copyWith(
+        excludedFromStats: Value(i.excludedFromStats ?? false),
+      ),
+      BulkField.excludedFromGasStats => c.copyWith(
+        excludedFromGasStats: Value(i.excludedFromGasStats ?? false),
+      ),
       BulkField.isFavorite => c.copyWith(
         isFavorite: Value(i.isFavorite ?? false),
       ),

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -198,6 +198,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   List<String> _selectedDiveTypeIds = const ['recreational'];
   Visibility _selectedVisibility = Visibility.unknown;
   int _rating = 0;
+  // Statistics exclusion (#526 / #1272). Kept independent: unticking the
+  // master flag must restore the diver's own gas-only choice rather than
+  // having silently overwritten it.
+  bool _excludedFromStats = false;
+  bool _excludedFromGasStats = false;
+  bool _bulkExcludedFromStats = false;
+  bool _bulkExcludedFromGasStats = false;
   DiveSite? _selectedSite;
   Trip? _selectedTrip;
   DiveCenter? _selectedDiveCenter;
@@ -665,6 +672,8 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
               ? _seedDecimal(units.convertDepth(dive.visibilityMeters!), 0)
               : '';
           _rating = dive.rating ?? 0;
+          _excludedFromStats = dive.excludedFromStats;
+          _excludedFromGasStats = dive.excludedFromGasStats;
           _selectedSite = dive.site;
           _selectedTrip = dive.trip;
           _selectedDiveCenter = dive.diveCenter;
@@ -1057,6 +1066,23 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                   onChanged: (v) => setState(() => _bulkFavorite = v),
                 ),
               ),
+              _gatedRow(
+                BulkField.excludedFromStats,
+                FormRow.toggle(
+                  label: context.l10n.diveLog_bulkEdit_fieldExcludeFromStats,
+                  value: _bulkExcludedFromStats,
+                  onChanged: (v) => setState(() => _bulkExcludedFromStats = v),
+                ),
+              ),
+              _gatedRow(
+                BulkField.excludedFromGasStats,
+                FormRow.toggle(
+                  label: context.l10n.diveLog_bulkEdit_fieldExcludeFromGasStats,
+                  value: _bulkExcludedFromGasStats,
+                  onChanged: (v) =>
+                      setState(() => _bulkExcludedFromGasStats = v),
+                ),
+              ),
             ],
           ),
           _buildBulkConditionsSection(units),
@@ -1109,6 +1135,8 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       diverRoleId: _diverRoleId,
       rating: _rating > 0 ? _rating : null,
       isFavorite: _bulkFavorite,
+      excludedFromStats: _bulkExcludedFromStats,
+      excludedFromGasStats: _bulkExcludedFromGasStats,
       waterType: _waterType?.name,
       visibilityMeters: _visibilityMetersInput(units),
       currentDirection: _currentDirection?.name,
@@ -2022,6 +2050,16 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   Widget _buildTheDiveSection(UnitFormatter units) {
     final hasProfile = _existingDive?.profile.isNotEmpty == true;
     return TheDiveSection(
+      excludedFromStats: _excludedFromStats,
+      excludedFromGasStats: _excludedFromGasStats,
+      onExcludedFromStatsChanged: (v) {
+        _markDirty();
+        setState(() => _excludedFromStats = v);
+      },
+      onExcludedFromGasStatsChanged: (v) {
+        _markDirty();
+        setState(() => _excludedFromGasStats = v);
+      },
       depthSymbol: units.depthSymbol,
       nameController: _nameController,
       maxDepthController: _maxDepthController,
@@ -4879,6 +4917,8 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
             .toList(),
         // Preserve favorite status when editing
         isFavorite: _existingDive?.isFavorite ?? false,
+        excludedFromStats: _excludedFromStats,
+        excludedFromGasStats: _excludedFromGasStats,
         // Preserve dive profile data (time series from dive computer)
         profile: _existingDive?.profile ?? const [],
         // Preserve photo associations

--- a/lib/features/dive_log/presentation/pages/dive_list_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_list_page.dart
@@ -991,6 +991,30 @@ class DiveListTile extends ConsumerWidget {
                                   ),
                                 ),
                               ],
+                              // Statistics exclusion (#526 / #1272). Explains
+                              // why this dive is missing from the totals
+                              // without the diver having to open it.
+                              if (summary?.excludedFromStats == true ||
+                                  summary?.excludedFromGasStats == true) ...[
+                                const SizedBox(width: 6),
+                                Tooltip(
+                                  key: const Key('dive-excluded-badge'),
+                                  message: summary!.excludedFromStats
+                                      ? context
+                                            .l10n
+                                            .diveLog_badge_excludedFromStats
+                                      : context
+                                            .l10n
+                                            .diveLog_badge_excludedFromGasStats,
+                                  child: Icon(
+                                    summary!.excludedFromStats
+                                        ? Icons.bar_chart_outlined
+                                        : Icons.local_gas_station_outlined,
+                                    size: 16,
+                                    color: colorScheme.outline,
+                                  ),
+                                ),
+                              ],
                               if ((summary?.safetyFindingCount ?? 0) > 0 &&
                                   ref.watch(safetyReviewEnabledProvider)) ...[
                                 const SizedBox(width: 6),

--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -59,6 +59,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
   late double? _minDepth;
   late double? _maxDepth;
   late bool _favoritesOnly;
+  late bool _excludedFromStatsOnly;
   late List<String> _selectedTagIds;
   late List<int> _selectedWeekdays;
 
@@ -92,6 +93,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
     _minDepth = filter.minDepth;
     _maxDepth = filter.maxDepth;
     _favoritesOnly = filter.favoritesOnly ?? false;
+    _excludedFromStatsOnly = filter.excludedFromStatsOnly ?? false;
     _selectedTagIds = List.from(filter.tagIds);
     _selectedWeekdays = List.from(filter.weekdays);
     // Depth bounds live in meters; the fields show and accept the diver's
@@ -616,6 +618,18 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                         value: _favoritesOnly,
                         onChanged: (value) {
                           setState(() => _favoritesOnly = value);
+                        },
+                      ),
+
+                      // Statistics exclusion, so the diver can find the dives
+                      // they took out of their statistics (#526).
+                      SwitchListTile(
+                        key: const Key('filter-excluded-from-stats-only'),
+                        title: Text(context.l10n.diveLog_filter_excludedOnly),
+                        secondary: const Icon(Icons.bar_chart_outlined),
+                        value: _excludedFromStatsOnly,
+                        onChanged: (value) {
+                          setState(() => _excludedFromStatsOnly = value);
                         },
                       ),
                       const SizedBox(height: 24),
@@ -1199,6 +1213,7 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
       minDepth: _minDepth,
       maxDepth: _maxDepth,
       favoritesOnly: _favoritesOnly ? true : null,
+      excludedFromStatsOnly: _excludedFromStatsOnly ? true : null,
       tagIds: _selectedTagIds,
       weekdays: _selectedWeekdays,
       // v1.5 filters

--- a/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
@@ -38,6 +38,10 @@ class TheDiveSection extends StatelessWidget {
     this.surfaceIntervalRow,
     this.siteExtras,
     this.profileChild,
+    this.excludedFromStats = false,
+    this.excludedFromGasStats = false,
+    this.onExcludedFromStatsChanged,
+    this.onExcludedFromGasStatsChanged,
   });
 
   final String depthSymbol;
@@ -69,6 +73,13 @@ class TheDiveSection extends StatelessWidget {
   /// Existing profile block (points count, outlier chip, edit/draw
   /// buttons), stripped of its Card wrapper.
   final Widget? profileChild;
+
+  /// Statistics exclusion (#526 / #1272). The gas toggle renders inert while
+  /// [excludedFromStats] is on, because the master flag already implies it.
+  final bool excludedFromStats;
+  final bool excludedFromGasStats;
+  final ValueChanged<bool>? onExcludedFromStatsChanged;
+  final ValueChanged<bool>? onExcludedFromGasStatsChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -145,6 +156,22 @@ class TheDiveSection extends StatelessWidget {
         ),
         ?siteExtras,
         ?profileChild,
+        if (onExcludedFromStatsChanged != null)
+          FormRow.toggle(
+            key: const Key('dive-edit-exclude-from-stats'),
+            label: l10n.diveLog_edit_excludeFromStats,
+            value: excludedFromStats,
+            onChanged: onExcludedFromStatsChanged!,
+          ),
+        if (onExcludedFromGasStatsChanged != null)
+          FormRow.toggle(
+            key: const Key('dive-edit-exclude-from-gas-stats'),
+            label: l10n.diveLog_edit_excludeFromGasStats,
+            // Show the effective state: the master flag implies this one.
+            value: excludedFromStats || excludedFromGasStats,
+            onChanged: onExcludedFromGasStatsChanged!,
+            enabled: !excludedFromStats,
+          ),
       ],
     );
   }

--- a/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
@@ -162,6 +162,9 @@ class TheDiveSection extends StatelessWidget {
             label: l10n.diveLog_edit_excludeFromStats,
             value: excludedFromStats,
             onChanged: onExcludedFromStatsChanged!,
+            // The label alone does not say the dive count is affected, which
+            // is the part that surprises people later.
+            helpText: l10n.diveLog_edit_excludeFromStatsHelp,
           ),
         if (onExcludedFromGasStatsChanged != null)
           FormRow.toggle(
@@ -171,6 +174,7 @@ class TheDiveSection extends StatelessWidget {
             value: excludedFromStats || excludedFromGasStats,
             onChanged: onExcludedFromGasStatsChanged!,
             enabled: !excludedFromStats,
+            helpText: l10n.diveLog_edit_excludeFromGasStatsHelp,
           ),
       ],
     );

--- a/lib/features/dive_roles/data/repositories/dive_role_repository.dart
+++ b/lib/features/dive_roles/data/repositories/dive_role_repository.dart
@@ -237,6 +237,8 @@ class DiveRoleRepository {
       final result = await _db
           .customSelect(
             'SELECT '
+            // stats-scope-exempt: deletion guard, same reasoning as
+            // isDiveTypeInUse. Counts references, not statistics.
             '(SELECT COUNT(*) FROM dive_buddies WHERE role = ?1) + '
             '(SELECT COUNT(*) FROM dives WHERE diver_role = ?1) AS uses',
             variables: [Variable.withString(id)],

--- a/lib/features/dive_sites/data/repositories/site_repository_impl.dart
+++ b/lib/features/dive_sites/data/repositories/site_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/data/visibility/visibility_filter.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/performance/perf_timer.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/geocoding/place_lookup.dart';
@@ -868,7 +869,7 @@ class SiteRepository {
                MAX(dive_date_time) AS last_dived,
                MAX(max_depth) AS max_depth_reached
         FROM dives
-        WHERE site_id IS NOT NULL
+        WHERE site_id IS NOT NULL${DiveStatsScope.and(alias: 'dives')}
         GROUP BY site_id
       ''').get();
 

--- a/lib/features/dive_types/data/repositories/dive_type_repository.dart
+++ b/lib/features/dive_types/data/repositories/dive_type_repository.dart
@@ -3,6 +3,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
@@ -366,6 +367,7 @@ class DiveTypeRepository {
         FROM dive_types dt
         LEFT JOIN dive_dive_types ddt ON dt.id = ddt.dive_type_id
         LEFT JOIN dives d ON d.id = ddt.dive_id $diverJoinFilter
+                         ${DiveStatsScope.and(alias: 'd')}
         $whereClause
         GROUP BY dt.id
         ORDER BY dt.sort_order, dt.name
@@ -411,6 +413,9 @@ class DiveTypeRepository {
       final result = await _db
           .customSelect(
             '''
+        -- stats-scope-exempt: deletion guard. Must see EVERY referencing
+        -- dive, excluded ones included, or deleting this type would strand
+        -- a foreign key on a dive the diver still has.
         SELECT COUNT(*) as count FROM dive_dive_types WHERE dive_type_id = ?
       ''',
             variables: [Variable.withString(id)],

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
@@ -372,6 +373,7 @@ class DiverRepository {
           'UPDATE dive_profiles SET computer_id = NULL '
           'WHERE computer_id IN '
           '(SELECT id FROM dive_computers WHERE diver_id = ?) '
+          // stats-scope-exempt: reassignment cascade, not a statistic.
           'AND dive_id NOT IN (SELECT id FROM dives WHERE diver_id = ?)',
           [id, id],
         );
@@ -379,11 +381,14 @@ class DiverRepository {
           'UPDATE dive_data_sources SET computer_id = NULL '
           'WHERE computer_id IN '
           '(SELECT id FROM dive_computers WHERE diver_id = ?) '
+          // stats-scope-exempt: reassignment cascade, not a statistic.
           'AND dive_id NOT IN (SELECT id FROM dives WHERE diver_id = ?)',
           [id, id],
         );
 
         // Step 2: Delete dives (cascades: profiles, tanks, data_sources, etc.)
+        // stats-scope-exempt: deletion cascade. Deletes the diver's dives,
+        // excluded ones included.
         await _db.customStatement('DELETE FROM dives WHERE diver_id = ?', [id]);
 
         // Step 2b: Null out cross-diver FK references to sites/trips we're
@@ -397,6 +402,7 @@ class DiverRepository {
 
         final divesLosingSite = await _db
             .customSelect(
+              // stats-scope-exempt: deletion cascade cleanup.
               'SELECT id FROM dives WHERE site_id IN '
               '(SELECT id FROM dive_sites WHERE diver_id = ?)',
               variables: [Variable.withString(id)],
@@ -419,6 +425,7 @@ class DiverRepository {
 
         final divesLosingTrip = await _db
             .customSelect(
+              // stats-scope-exempt: deletion cascade cleanup.
               'SELECT id FROM dives WHERE trip_id IN '
               '(SELECT id FROM trips WHERE diver_id = ?)',
               variables: [Variable.withString(id)],
@@ -575,7 +582,8 @@ class DiverRepository {
     try {
       final result = await _db
           .customSelect(
-            'SELECT COUNT(*) as count FROM dives WHERE diver_id = ?',
+            'SELECT COUNT(*) as count FROM dives WHERE diver_id = ?'
+            "${DiveStatsScope.and(alias: 'dives')}",
             variables: [Variable.withString(diverId)],
           )
           .getSingle();
@@ -595,7 +603,9 @@ class DiverRepository {
     try {
       final result = await _db
           .customSelect(
-            'SELECT COALESCE(SUM(bottom_time), 0) as total FROM dives WHERE diver_id = ?',
+            'SELECT COALESCE(SUM(bottom_time), 0) as total '
+            'FROM dives WHERE diver_id = ?'
+            "${DiveStatsScope.and(alias: 'dives')}",
             variables: [Variable.withString(diverId)],
           )
           .getSingle();

--- a/lib/features/equipment/data/repositories/equipment_repository_impl.dart
+++ b/lib/features/equipment/data/repositories/equipment_repository_impl.dart
@@ -579,6 +579,12 @@ class EquipmentRepository {
   }
 
   /// Get dive count for equipment item
+  /// Deliberately does NOT apply DiveStatsScope. A dive the diver excluded
+  /// from statistics still physically happened: it cycled this gear and put
+  /// hours on it. Suppressing it here would push a real service interval
+  /// later than it should be, a safety-relevant error rather than a cosmetic
+  /// one. Do not "fix" this.
+  // stats-scope-exempt: gear wear is physical, not descriptive
   Future<int> getDiveCountForEquipment(String equipmentId) async {
     try {
       final result = await _db
@@ -606,6 +612,12 @@ class EquipmentRepository {
   /// (date, duration) samples of dives linked to this equipment via the
   /// dive_equipment junction or dive_tanks.equipment_id, for usage-based
   /// service clocks. Duration is COALESCE(runtime, bottom_time) seconds.
+  /// Deliberately does NOT apply DiveStatsScope. A dive the diver excluded
+  /// from statistics still physically happened: it cycled this gear and put
+  /// hours on it. Suppressing it here would push a real service interval
+  /// later than it should be, a safety-relevant error rather than a cosmetic
+  /// one. Do not "fix" this.
+  // stats-scope-exempt: gear wear is physical, not descriptive
   Future<List<DiveUsageSample>> getUsageSamplesForEquipment(
     String equipmentId, {
     DateTime? since,
@@ -659,6 +671,12 @@ class EquipmentRepository {
   }
 
   /// Get trip count for equipment item (unique trips from dives using this equipment)
+  /// Deliberately does NOT apply DiveStatsScope. A dive the diver excluded
+  /// from statistics still physically happened: it cycled this gear and put
+  /// hours on it. Suppressing it here would push a real service interval
+  /// later than it should be, a safety-relevant error rather than a cosmetic
+  /// one. Do not "fix" this.
+  // stats-scope-exempt: gear wear is physical, not descriptive
   Future<int> getTripCountForEquipment(String equipmentId) async {
     try {
       final result = await _db
@@ -685,6 +703,7 @@ class EquipmentRepository {
   }
 
   /// Get trip IDs for equipment item
+  // stats-scope-exempt: gear usage is physical, not descriptive
   Future<List<String>> getTripIdsForEquipment(String equipmentId) async {
     try {
       final result = await _db

--- a/lib/features/marine_life/data/repositories/seen_species_repository.dart
+++ b/lib/features/marine_life/data/repositories/seen_species_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/features/marine_life/domain/entities/seen_species.dart';
 import 'package:submersion/features/marine_life/domain/entities/species.dart'
@@ -39,7 +40,7 @@ class SeenSpeciesRepository {
       FROM species sp
       JOIN sightings s ON s.species_id = sp.id
       JOIN dives d ON d.id = s.dive_id
-      WHERE 1=1 $diverClause
+      WHERE 1=1 $diverClause${DiveStatsScope.and(alias: 'd')}
       GROUP BY sp.id
     ''',
           variables: [if (diverId != null) Variable.withString(diverId)],
@@ -67,7 +68,7 @@ class SeenSpeciesRepository {
       FROM sightings s
       JOIN dives d ON d.id = s.dive_id
       LEFT JOIN dive_sites ds ON ds.id = d.site_id
-      WHERE s.species_id = ? $diverClause
+      WHERE s.species_id = ? $diverClause${DiveStatsScope.and(alias: 'd')}
       ORDER BY d.dive_date_time DESC, s.id ASC
     ''',
           variables: [

--- a/lib/features/marine_life/data/repositories/species_repository.dart
+++ b/lib/features/marine_life/data/repositories/species_repository.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/marine_life/data/services/builtin_species_seed_version_store.dart';
@@ -684,7 +685,7 @@ class SpeciesRepository {
       FROM sightings s
       JOIN species sp ON s.species_id = sp.id
       JOIN dives d ON s.dive_id = d.id
-      WHERE d.site_id = ?
+      WHERE d.site_id = ?${DiveStatsScope.and(alias: 'd')}
       GROUP BY sp.id
       ORDER BY sighting_count DESC, sp.common_name ASC
     ''',

--- a/lib/features/statistics/data/dive_filter_sql.dart
+++ b/lib/features/statistics/data/dive_filter_sql.dart
@@ -129,6 +129,13 @@ import 'package:submersion/features/equipment/domain/constants/equipment_attribu
     conditions.add('is_favorite = 1');
   }
 
+  // Finds the dives the diver excluded. Enforcement of the exclusion is
+  // DiveStatsScope's job and is applied alongside this subquery, never
+  // inside it.
+  if (filter.excludedFromStatsOnly == true) {
+    conditions.add('excluded_from_stats = 1');
+  }
+
   if (filter.decoOnly != null) {
     conditions.add(
       decoSignalCondition(wantDeco: filter.decoOnly!, diveIdRef: 'dives.id'),

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 
 import 'package:submersion/core/constants/gas_model.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/deco/ascent_rate_calculator.dart';
 import 'package:submersion/core/domain/visibility/visibility_scale.dart';
 import 'package:submersion/core/services/database_service.dart';
@@ -176,15 +177,33 @@ class StatisticsRepository {
   /// sample while cutting anything an order of magnitude larger down to size.
   static const int _maxSampleGapFactor = 4;
 
-  /// Builds the `AND <alias>.id IN (<subquery>)` fragment + raw params for a
-  /// stats filter. Empty (no-op) when the filter has no active axes.
+  /// Builds the always-on statistics scope plus, when the diver has active
+  /// filter axes, the `AND <alias>.id IN (<subquery>)` fragment and its raw
+  /// params.
+  ///
+  /// The scope is emitted unconditionally and the user filter conditionally.
+  /// They are deliberately separate: [buildFilteredDiveIdSubquery] is the
+  /// diver's transient view filter and no-ops when nothing is selected, while
+  /// [DiveStatsScope] is a persistent property of the dive. Folding the scope
+  /// into the subquery would make the exclusion evaporate for every diver who
+  /// never opens the filter sheet.
+  ///
+  /// Pass `gas: true` for SAC/RMV and gas-mix aggregates, which additionally
+  /// drop per-dive gas exclusions and gauge-mode dives.
   ({String clause, List<Object?> params}) _diveFilter(
     DiveFilterState filter, {
     String alias = 'dives',
+    bool gas = false,
   }) {
+    final scope = DiveStatsScope.and(alias: alias, gas: gas);
     final f = buildFilteredDiveIdSubquery(filter);
-    if (f.subquery.isEmpty) return (clause: '', params: const <Object?>[]);
-    return (clause: 'AND $alias.id IN (${f.subquery})', params: f.params);
+    if (f.subquery.isEmpty) {
+      return (clause: scope, params: const <Object?>[]);
+    }
+    return (
+      clause: '$scope AND $alias.id IN (${f.subquery})',
+      params: f.params,
+    );
   }
 
   // ============================================================================
@@ -202,7 +221,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -218,7 +237,7 @@ class StatisticsRepository {
           t.he_percent
         FROM dives d
         JOIN dive_tanks t ON t.dive_id = d.id
-        WHERE d.dive_mode <> 'gauge' $diverFilter ${df.clause}
+        WHERE 1 = 1 $diverFilter ${df.clause}
           AND COALESCE(d.runtime, d.bottom_time) > 0
           AND d.avg_depth > 0
           AND t.start_pressure > t.end_pressure
@@ -313,7 +332,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -336,7 +355,7 @@ class StatisticsRepository {
           ORDER BY t2.tank_order, t2.rowid
           LIMIT 1
         )
-        WHERE d.dive_mode <> 'gauge' $diverFilter ${df.clause}
+        WHERE 1 = 1 $diverFilter ${df.clause}
           AND COALESCE(d.runtime, d.bottom_time) > 0
           AND d.avg_depth > 0
         ORDER BY d.dive_date_time
@@ -371,7 +390,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -384,7 +403,7 @@ class StatisticsRepository {
           COUNT(DISTINCT d.id) AS dive_count
         FROM dives d
         JOIN dive_tanks t ON t.dive_id = d.id
-        WHERE 1=1 AND d.dive_mode <> 'gauge' $diverFilter ${df.clause}
+        WHERE 1=1 $diverFilter ${df.clause}
         GROUP BY gas_type
         ORDER BY dive_count DESC
         ''', variables: params.map((p) => Variable(p)).toList()).get();
@@ -421,7 +440,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -444,7 +463,7 @@ class StatisticsRepository {
           AND d.avg_depth > 0
           AND t.start_pressure > t.end_pressure
           AND t.volume > 0
-          AND d.dive_mode <> 'gauge'
+         
           $diverFilter ${df.clause}
         ORDER BY d.dive_date_time
         ''', variables: params.map((p) => Variable(p)).toList()).get();
@@ -548,7 +567,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -576,7 +595,7 @@ class StatisticsRepository {
         LEFT JOIN dive_sites ds ON ds.id = d.site_id
         WHERE COALESCE(d.runtime, d.bottom_time) > 0
           AND d.avg_depth > 0
-          AND d.dive_mode <> 'gauge'
+         
           $diverFilter ${df.clause}
         ORDER BY sac ASC
         ''', variables: params.map((p) => Variable(p)).toList()).get();
@@ -618,7 +637,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -639,7 +658,7 @@ class StatisticsRepository {
           AND COALESCE(d.runtime, d.bottom_time) > 0
           AND d.avg_depth > 0
           AND t.volume > 0
-          AND d.dive_mode <> 'gauge'
+         
           $diverFilter ${df.clause}
         ''', variables: params.map((p) => Variable(p)).toList()).get();
 
@@ -701,7 +720,7 @@ class StatisticsRepository {
   }) async {
     try {
       final diverFilter = diverId != null ? 'AND d.diver_id = ?' : '';
-      final df = _diveFilter(filter, alias: 'd');
+      final df = _diveFilter(filter, alias: 'd', gas: true);
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
       final results = await _db.customSelect('''
@@ -720,7 +739,7 @@ class StatisticsRepository {
           AND t.end_pressure IS NOT NULL
           AND COALESCE(d.runtime, d.bottom_time) > 0
           AND d.avg_depth > 0
-          AND d.dive_mode <> 'gauge'
+         
           $diverFilter ${df.clause}
         GROUP BY t.tank_role
         HAVING avg_sac IS NOT NULL
@@ -938,7 +957,7 @@ class StatisticsRepository {
           MAX(max_depth) AS max_depth
         FROM dives
         WHERE dive_date_time >= ? AND dive_date_time < ?
-        $diverFilter
+        $diverFilter${DiveStatsScope.and(alias: 'dives')}
         ''',
             variables: [
               Variable<int>(startMs),
@@ -1259,6 +1278,7 @@ class StatisticsRepository {
         FROM dives
         WHERE site_id = ?
           AND entry_method IS NOT NULL AND entry_method != '' $diverFilter
+          ${DiveStatsScope.and(alias: 'dives')}
         GROUP BY entry_method, exit_method
         ORDER BY count DESC
         ''', variables: params.map((p) => Variable(p)).toList()).get();
@@ -1974,6 +1994,11 @@ class StatisticsRepository {
                     WHERE d2.diver_id = d.diver_id
                       AND d2.exit_time IS NOT NULL
                       AND d2.exit_time < d.entry_time
+                      -- The scope applies to the preceding dive as well: a
+                      -- surface interval measured from an excluded dive is
+                      -- as wrong as one measured to it. The user filter has
+                      -- never reached this inner alias.
+                      ${DiveStatsScope.and(alias: 'd2')}
                   )
                 ) / 1000.0
                 ELSE NULL
@@ -2495,6 +2520,7 @@ class StatisticsRepository {
       FROM dives d
       JOIN dive_sites ds ON d.site_id = ds.id
       WHERE LOWER(ds.name) = LOWER(?) AND d.diver_id = ?
+            ${DiveStatsScope.and(alias: 'd')}
     ''',
           variables: [
             Variable.withString(siteName),

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -2536,6 +2536,29 @@ class StatisticsRepository {
     );
   }
 
+  /// Counts the dives the diver has explicitly excluded from statistics, for
+  /// the Overview footnote.
+  ///
+  /// Deliberately counts only `excluded_from_stats`, not the whole
+  /// [DiveStatsScope]: this footnote exists to explain the diver's own choice
+  /// back to them. A planned dive is not something they chose to exclude, so
+  /// folding it in would make the number confusing rather than clarifying.
+  // stats-scope-exempt: counts the excluded, by definition
+  Future<int> countExcludedDives({String? diverId}) async {
+    final diverFilter = diverId != null ? 'AND diver_id = ?' : '';
+    final row = await _db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM dives '
+          'WHERE excluded_from_stats = 1 $diverFilter',
+          variables: diverId != null
+              ? [Variable<String>(diverId)]
+              : const <Variable<Object>>[],
+          readsFrom: {_db.dives},
+        )
+        .getSingle();
+    return row.read<int>('c');
+  }
+
   // ============================================================================
   // Helpers
   // ============================================================================

--- a/lib/features/statistics/presentation/pages/statistics_overview_page.dart
+++ b/lib/features/statistics/presentation/pages/statistics_overview_page.dart
@@ -113,6 +113,33 @@ class _OverviewBody extends ConsumerWidget {
           _TopSitesSection(sites: stats.topSites),
           const SizedBox(height: 16),
           _DistributionsSection(stats: stats, fmt: fmt),
+          // Explains why the statistics dive count and the logbook dive count
+          // differ, so the discrepancy never has to be discovered (#526).
+          ref
+              .watch(excludedDiveCountProvider)
+              .maybeWhen(
+                data: (count) => count == 0
+                    ? const SizedBox.shrink()
+                    : Padding(
+                        padding: const EdgeInsets.only(top: 16),
+                        child: Center(
+                          child: Text(
+                            key: const Key('statistics-excluded-footnote'),
+                            context.l10n.statistics_excludedDivesFootnote(
+                              count,
+                            ),
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                          ),
+                        ),
+                      ),
+                orElse: () => const SizedBox.shrink(),
+              ),
         ],
       ),
     );

--- a/lib/features/statistics/presentation/providers/statistics_providers.dart
+++ b/lib/features/statistics/presentation/providers/statistics_providers.dart
@@ -21,6 +21,19 @@ final statisticsRepositoryProvider = Provider<StatisticsRepository>((ref) {
   return StatisticsRepository(gasModel: ref.watch(gasModelProvider));
 });
 
+/// How many dives the diver has explicitly excluded from statistics.
+///
+/// Backs the Overview footnote, which exists so the statistics dive count and
+/// the logbook dive count differing is self-explaining rather than a support
+/// ticket six months later. Deliberately unaffected by the Statistics filter:
+/// it describes a persistent property of the logbook, not the current view.
+final excludedDiveCountProvider = FutureProvider<int>((ref) async {
+  final repository = ref.watch(statisticsRepositoryProvider);
+  final currentDiverId = ref.watch(currentDiverIdProvider);
+  ref.invalidateSelfWhen(repository.watchStatisticsChanges());
+  return repository.countExcludedDives(diverId: currentDiverId);
+});
+
 /// Overview totals scoped by the Statistics filter. Kept separate from
 /// diveStatisticsProvider so the home dashboard and dive-log summary (which
 /// read diveStatisticsProvider) stay unfiltered.

--- a/lib/features/tags/data/repositories/tag_repository.dart
+++ b/lib/features/tags/data/repositories/tag_repository.dart
@@ -587,6 +587,9 @@ class TagRepository {
     try {
       final result = await _db
           .customSelect(
+            // stats-scope-exempt: usage/deletion indicator. Must see every
+            // dive carrying the tag, excluded ones included, or removing the
+            // tag would strand a reference.
             'SELECT COUNT(*) as count FROM dive_tags WHERE tag_id = ?',
             variables: [Variable.withString(tagId)],
           )
@@ -609,6 +612,8 @@ class TagRepository {
       final placeholders = tagIds.map((_) => '?').join(',');
       final result = await _db
           .customSelect(
+            // stats-scope-exempt: merge preview. Tells the diver how many
+            // dives the merge will rewrite, which is every one of them.
             'SELECT COUNT(DISTINCT dive_id) as count FROM dive_tags WHERE tag_id IN ($placeholders)',
             variables: tagIds.map((id) => Variable.withString(id)).toList(),
           )

--- a/lib/features/trips/data/repositories/trip_repository.dart
+++ b/lib/features/trips/data/repositories/trip_repository.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/data/visibility/visibility_filter.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/sync_event_bus.dart';
@@ -257,6 +258,7 @@ class TripRepository {
   /// pre-existing, debounced-downstream behavior and is left as-is. This
   /// method's own notify is deferred until after the transaction commits so
   /// listeners never observe a rolled-back delete as "changed".
+  // stats-scope-exempt: deletion cascade
   Future<void> deleteTrip(String id) async {
     try {
       _log.info('Deleting trip: $id');
@@ -306,6 +308,8 @@ class TripRepository {
       if (diverId != null) Variable.withString(diverId),
     ];
     final results = await _db.customSelect('''
+      -- stats-scope-exempt: drives the trip's displayed dive list, which
+      -- shows excluded dives like the logbook does
       SELECT id FROM dives
       WHERE trip_id = ?
       $diverClause
@@ -329,7 +333,7 @@ class TripRepository {
       SELECT COUNT(*) as count
       FROM dives
       WHERE trip_id = ?
-      $diverClause
+      $diverClause${DiveStatsScope.and(alias: 'dives')}
     ''', variables: variables).getSingle();
 
     return result.data['count'] as int? ?? 0;
@@ -377,6 +381,7 @@ class TripRepository {
 
   /// Find dives within a trip's date range that are either unassigned
   /// or assigned to a different trip (excludes dives already on this trip).
+  // stats-scope-exempt: trip assignment candidates, a list the diver picks from
   Future<List<DiveCandidate>> findCandidateDivesForTrip({
     required String tripId,
     required DateTime startDate,
@@ -525,7 +530,7 @@ class TripRepository {
         AVG(max_depth) as avg_depth
       FROM dives
       WHERE trip_id = ?
-      $diverClause
+      $diverClause${DiveStatsScope.and(alias: 'dives')}
     ''', variables: variables).getSingle();
 
     return domain.TripWithStats(
@@ -584,9 +589,13 @@ class TripRepository {
     // Build the JOIN condition: always match trip_id, and also match
     // diver_id when a specific diver is requested so that stats on shared
     // trips reflect only that diver's dives.
+    // The statistics scope goes in the ON clause, not a WHERE: this is a
+    // LEFT JOIN and a WHERE would turn it inner, dropping every trip that
+    // has no in-scope dives instead of showing it with a zero count.
+    final scope = DiveStatsScope.and(alias: 'd');
     final joinClause = diverId != null
-        ? 'LEFT JOIN dives d ON d.trip_id = t.id AND d.diver_id = ?'
-        : 'LEFT JOIN dives d ON d.trip_id = t.id';
+        ? 'LEFT JOIN dives d ON d.trip_id = t.id AND d.diver_id = ?$scope'
+        : 'LEFT JOIN dives d ON d.trip_id = t.id$scope';
 
     // When diverId is provided, prepend its variable before the visibility
     // filter variables so the positional binding lines up with joinClause.

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{لم يتم تجاهل أي ملاحظة} =1{تم تجاهل ملاحظة واحدة} other{تم تجاهل {count} ملاحظات}}، {failed, plural, =1{تعذّر تحديث غطسة واحدة} other{تعذّر تحديث {failed} غطسات}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "تعذّرت قراءة قائمة الغطسات. لم يتم تغيير أي شيء.",
   "safetySettings_analyzeAll_failed": "تعذّر تحليل الغطسات.",
   "safetyReview_details": "التفاصيل",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "آخر 5 سنوات",
   "diveLog_filter_presetLast10Years": "آخر 10 سنوات",
   "statistics_trend_tooltip_lowest": "الأدنى",
-  "statistics_trend_tooltip_highest": "الأعلى"
+  "statistics_trend_tooltip_highest": "الأعلى",
+  "diveLog_edit_excludeFromStats": "استبعاد من الإحصائيات",
+  "diveLog_edit_excludeFromStatsHelp": "احتفظ بهذه الغطسة في سجلك، لكن استبعدها من كل الإحصائيات، بما في ذلك عدد غطساتك.",
+  "diveLog_edit_excludeFromGasStats": "استبعاد من إحصائيات الغاز",
+  "diveLog_edit_excludeFromGasStatsHelp": "استبعد هذه الغطسة من إحصائيات SAC وRMV وخليط الغاز فقط. مفيد عندما تكون قراءة الغاز غير ممثلة.",
+  "diveLog_badge_excludedFromStats": "مستبعدة من الإحصائيات",
+  "diveLog_badge_excludedFromGasStats": "مستبعدة من إحصائيات الغاز",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "استبعاد من الإحصائيات",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "استبعاد من إحصائيات الغاز",
+  "diveLog_filter_excludedOnly": "المستبعدة من الإحصائيات فقط",
+  "diveLog_edit_summary_excluded": "مستبعدة",
+  "statistics_excludedDivesFootnote": "{count, plural, zero{لا غطسات مستبعدة من الإحصائيات} one{غطسة واحدة مستبعدة من الإحصائيات} two{غطستان مستبعدتان من الإحصائيات} few{{count} غطسات مستبعدة من الإحصائيات} many{{count} غطسة مستبعدة من الإحصائيات} other{{count} غطسة مستبعدة من الإحصائيات}}"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Keine Beobachtungen ausgeblendet} =1{1 Beobachtung ausgeblendet} other{{count} Beobachtungen ausgeblendet}}, {failed, plural, =1{1 Tauchgang konnte nicht aktualisiert werden} other{{failed} Tauchgänge konnten nicht aktualisiert werden}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Die Tauchgangsliste konnte nicht gelesen werden. Es wurde nichts geändert.",
   "safetySettings_analyzeAll_failed": "Die Tauchgänge konnten nicht analysiert werden.",
   "safetyReview_details": "Details",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Letzte 5 Jahre",
   "diveLog_filter_presetLast10Years": "Letzte 10 Jahre",
   "statistics_trend_tooltip_lowest": "Niedrigster",
-  "statistics_trend_tooltip_highest": "Höchster"
+  "statistics_trend_tooltip_highest": "Höchster",
+  "diveLog_edit_excludeFromStats": "Von Statistiken ausschließen",
+  "diveLog_edit_excludeFromStatsHelp": "Behalte diesen Tauchgang im Logbuch, lasse ihn aber aus jeder Statistik heraus, einschließlich der Tauchgangszahl.",
+  "diveLog_edit_excludeFromGasStats": "Von Gasstatistiken ausschließen",
+  "diveLog_edit_excludeFromGasStatsHelp": "Lasse diesen Tauchgang nur aus AMV-, RMV- und Gasgemisch-Statistiken heraus. Nützlich, wenn der Gaswert nicht repräsentativ ist.",
+  "diveLog_badge_excludedFromStats": "Von Statistiken ausgeschlossen",
+  "diveLog_badge_excludedFromGasStats": "Von Gasstatistiken ausgeschlossen",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Von Statistiken ausschließen",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Von Gasstatistiken ausschließen",
+  "diveLog_filter_excludedOnly": "Nur von Statistiken ausgeschlossene",
+  "diveLog_edit_summary_excluded": "Ausgeschlossen",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 Tauchgang von Statistiken ausgeschlossen} other{{count} Tauchgänge von Statistiken ausgeschlossen}}"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -2204,7 +2204,13 @@
   "dashboard_recentDives_noProfileData": "No profile data for this dive",
   "dashboard_recentDives_profileLoadError": "Couldn't load the dive profile",
   "dashboard_recentDives_profileMinutes": "{minutes} min",
-  "@dashboard_recentDives_profileMinutes": {"placeholders": {"minutes": {"type": "int"}}},
+  "@dashboard_recentDives_profileMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "dashboard_recentDives_logFirst": "Log Your First Dive",
   "dashboard_recentDives_sectionTitle": "Recent Dives",
   "dashboard_recentDives_viewAll": "View All",
@@ -6936,16 +6942,26 @@
   "gasCalculators_blender_stepStart": "Start with {pressure} {gas}",
   "@gasCalculators_blender_stepStart": {
     "placeholders": {
-      "pressure": { "type": "String" },
-      "gas": { "type": "String" }
+      "pressure": {
+        "type": "String"
+      },
+      "gas": {
+        "type": "String"
+      }
     }
   },
   "gasCalculators_blender_stepFill": "Fill {gas} to {pressure} → {mix}",
   "@gasCalculators_blender_stepFill": {
     "placeholders": {
-      "gas": { "type": "String" },
-      "pressure": { "type": "String" },
-      "mix": { "type": "String" }
+      "gas": {
+        "type": "String"
+      },
+      "pressure": {
+        "type": "String"
+      },
+      "mix": {
+        "type": "String"
+      }
     }
   },
   "gasCalculators_blender_error_targetPressure": "Target pressure must be higher than the starting pressure.",
@@ -6956,7 +6972,9 @@
   "gasCalculators_blender_error_drainTo": "Too much gas in the cylinder for this blend. Drain to {pressure} first, then blend.",
   "@gasCalculators_blender_error_drainTo": {
     "placeholders": {
-      "pressure": { "type": "String" }
+      "pressure": {
+        "type": "String"
+      }
     }
   },
   "gasCalculators_blender_error_drainEmpty": "None of the gas in the cylinder can be used for this blend. Empty it first, then blend.",
@@ -7015,16 +7033,79 @@
   "gasCalculators_blender_fillAdded": "{mix} added to the bill",
   "gasCalculators_blender_billedIncomplete": "One or more lines have no price, so this total is incomplete.",
   "gasCalculators_blender_billedTotal": "Total",
-  "@gasCalculators_blender_clearBilledBody": {"placeholders": {"count": {"type": "int"}}},
-  "@gasCalculators_blender_editLine": {"placeholders": {"label": {"type": "String"}}},
-  "@gasCalculators_blender_deleteLine": {"placeholders": {"label": {"type": "String"}}},
-  "@gasCalculators_blender_fillAdded": {"placeholders": {"mix": {"type": "String"}}},
-  "@gasCalculators_blender_stepAdd": {"placeholders": {"gas": {"type": "String"}}},
-  "@gasCalculators_blender_settlesTo": {"placeholders": {"pressure": {"type": "String"}, "temperature": {"type": "String"}}},
-  "@gasCalculators_blender_templateSaved": {"placeholders": {"mix": {"type": "String"}}},
-  "@gasCalculators_blender_templateLimit": {"placeholders": {"count": {"type": "int"}}},
-  "@gasCalculators_blender_templateDelete": {"placeholders": {"mix": {"type": "String"}}},
-  "@gasCalculators_blender_unitPrice": {"placeholders": {"unit": {"type": "String"}}},
+  "@gasCalculators_blender_clearBilledBody": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@gasCalculators_blender_editLine": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_deleteLine": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_fillAdded": {
+    "placeholders": {
+      "mix": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_stepAdd": {
+    "placeholders": {
+      "gas": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_settlesTo": {
+    "placeholders": {
+      "pressure": {
+        "type": "String"
+      },
+      "temperature": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_templateSaved": {
+    "placeholders": {
+      "mix": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_templateLimit": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@gasCalculators_blender_templateDelete": {
+    "placeholders": {
+      "mix": {
+        "type": "String"
+      }
+    }
+  },
+  "@gasCalculators_blender_unitPrice": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
   "gasCalculators_tab_mod": "MOD",
   "gasCalculators_tab_rockBottom": "Rock Bottom",
   "gasCalculators_tankSize": "Tank Size",
@@ -7451,7 +7532,6 @@
       }
     }
   },
-  
   "media_siteMediaSection_unlinkSelectedSuccess": "Unlinked {count} items",
   "media_documentViewer_title": "Document",
   "media_documentViewer_unavailable": "This document is not available on this device",
@@ -7538,20 +7618,68 @@
   "media_photoPicker_files_autoMatchLabel": "Auto-match photos and videos to dives by date",
   "media_photoPicker_files_emptyHint": "Pick files or a folder to start.",
   "media_photoPicker_files_linkButton": "{count, plural, =1{Link 1 item} other{Link {count} items}}",
-  "@media_photoPicker_files_linkButton": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_linkButton": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_attachToSiteButton": "{count, plural, =1{Attach 1 item to this site} other{Attach {count} items to this site}}",
-  "@media_photoPicker_files_attachToSiteButton": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_attachToSiteButton": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_summary": "{fileCount, plural, =1{1 file} other{{fileCount} files}}, {diveCount, plural, =1{1 dive} other{{diveCount} dives}}, {unmatchedCount} unmatched",
-  "@media_photoPicker_files_summary": {"placeholders": {"fileCount": {"type": "int"}, "diveCount": {"type": "int"}, "unmatchedCount": {"type": "Object"}}},
+  "@media_photoPicker_files_summary": {
+    "placeholders": {
+      "fileCount": {
+        "type": "int"
+      },
+      "diveCount": {
+        "type": "int"
+      },
+      "unmatchedCount": {
+        "type": "Object"
+      }
+    }
+  },
   "media_photoPicker_files_itemCount": "{count, plural, =1{1 item} other{{count} items}}",
-  "@media_photoPicker_files_itemCount": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_itemCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_diveGroupTitle": "Dive {diveId}",
-  "@media_photoPicker_files_diveGroupTitle": {"placeholders": {"diveId": {"type": "String"}}},
+  "@media_photoPicker_files_diveGroupTitle": {
+    "placeholders": {
+      "diveId": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_groupCount": "{count, plural, =1{1 file} other{{count} files}}",
-  "@media_photoPicker_files_groupCount": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_groupCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_unmatchedGroupTitle": "Unmatched",
   "media_photoPicker_files_addAllToDive": "{count, plural, =1{Add 1 to this dive} other{Add all {count} to this dive}}",
-  "@media_photoPicker_files_addAllToDive": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_addAllToDive": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_addToDiveTooltip": "Add to this dive",
   "media_photoPicker_files_chooseDiveTooltip": "Choose a dive",
   "media_photoPicker_files_removeTooltip": "Remove from selection",
@@ -7560,23 +7688,68 @@
   "media_photoPicker_files_sourceFileDate": "from file date",
   "media_photoPicker_files_sourceNone": "no date found",
   "media_photoPicker_files_shiftedTime": "{shifted} (was {original})",
-  "@media_photoPicker_files_shiftedTime": {"placeholders": {"shifted": {"type": "String"}, "original": {"type": "String"}}},
+  "@media_photoPicker_files_shiftedTime": {
+    "placeholders": {
+      "shifted": {
+        "type": "String"
+      },
+      "original": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_reasonNoTimestamp": "No capture time could be read",
   "media_photoPicker_files_reasonBeforeDive": "{gap} before the nearest dive",
-  "@media_photoPicker_files_reasonBeforeDive": {"placeholders": {"gap": {"type": "String"}}},
+  "@media_photoPicker_files_reasonBeforeDive": {
+    "placeholders": {
+      "gap": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_reasonAfterDive": "{gap} after the nearest dive",
-  "@media_photoPicker_files_reasonAfterDive": {"placeholders": {"gap": {"type": "String"}}},
+  "@media_photoPicker_files_reasonAfterDive": {
+    "placeholders": {
+      "gap": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_reasonNoDives": "No dives to match against",
   "media_photoPicker_files_offsetLabel": "Shift capture times by",
   "media_photoPicker_files_offsetResetTooltip": "Reset to no shift",
   "media_photoPicker_files_offsetBackTooltip": "Shift {amount} earlier",
-  "@media_photoPicker_files_offsetBackTooltip": {"placeholders": {"amount": {"type": "String"}}},
+  "@media_photoPicker_files_offsetBackTooltip": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_offsetForwardTooltip": "Shift {amount} later",
-  "@media_photoPicker_files_offsetForwardTooltip": {"placeholders": {"amount": {"type": "String"}}},
+  "@media_photoPicker_files_offsetForwardTooltip": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      }
+    }
+  },
   "media_photoPicker_files_linkedCount": "{count, plural, =1{Linked 1 item} other{Linked {count} items}}",
-  "@media_photoPicker_files_linkedCount": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_linkedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_attachedToSiteCount": "{count, plural, =1{Attached 1 item to this site} other{Attached {count} items to this site}}",
-  "@media_photoPicker_files_attachedToSiteCount": {"placeholders": {"count": {"type": "int"}}},
+  "@media_photoPicker_files_attachedToSiteCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "media_photoPicker_files_undo": "Undo",
   "media_photoPicker_thumbnailAlreadyLinkedLabel": "Photo already linked to this dive",
   "media_perdixOverlay_labelCns": "CNS",
@@ -7992,17 +8165,6 @@
   "@media_import_review_chooseDive": {
     "description": "Review row menu: pick a dive"
   },
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
   "media_import_intro": "Photos are linked to a dive or a dive site as you import them.",
   "@media_import_intro": {
     "description": "Import section intro text"
@@ -8114,14 +8276,20 @@
   "media_sources_lastScanned": "Last scanned {date}",
   "@media_sources_lastScanned": {
     "placeholders": {
-      "date": { "type": "String" }
+      "date": {
+        "type": "String"
+      }
     }
   },
   "media_sources_scanResult": "{indexed} files indexed, {repaired} re-linked",
   "@media_sources_scanResult": {
     "placeholders": {
-      "indexed": { "type": "int" },
-      "repaired": { "type": "int" }
+      "indexed": {
+        "type": "int"
+      },
+      "repaired": {
+        "type": "int"
+      }
     }
   },
   "media_repairHistory_sourceFolder": "folder scan",
@@ -8147,7 +8315,9 @@
   "media_repairHistory_source": "via {source}",
   "@media_repairHistory_source": {
     "placeholders": {
-      "source": { "type": "String" }
+      "source": {
+        "type": "String"
+      }
     }
   },
   "media_missing_empty": "No missing files",
@@ -8293,8 +8463,6 @@
       }
     }
   },
-  
-  
   "media_library_filter_clear": "Clear filters",
   "media_library_filter_any": "Any",
   "@media_library_filter_any": {
@@ -8894,15 +9062,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{No observations dismissed} =1{1 observation dismissed} other{{count} observations dismissed}}, {failed, plural, =1{1 dive could not be updated} other{{failed} dives could not be updated}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Could not read your dive list. No dives were changed.",
   "safetySettings_analyzeAll_failed": "Could not analyze your dives.",
   "safetyReview_details": "Details",
@@ -12304,7 +12472,13 @@
   "universalImport_summary_noticeNoTankPressureTitle": "Tank pressure not recorded",
   "universalImport_summary_noticeNoTankPressureBody": "Air consumption and SAC cannot be calculated. You can add start and end pressure by editing the dive.",
   "universalImport_summary_noticeAffectedDives": "{count, plural, =1{Affects 1 dive} other{Affects {count} dives}}",
-  "@universalImport_summary_noticeAffectedDives": {"placeholders": {"count": {"type": "int"}}},
+  "@universalImport_summary_noticeAffectedDives": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "universalImport_summary_fileImported": "{count, plural, =1{1 dive imported} other{{count} dives imported}}",
   "universalImport_summary_fileNeedsIndividualImport": "Needs individual import",
   "universalImport_summary_fileUnsupported": "Unsupported format",
@@ -15595,7 +15769,13 @@
   "dive3d_metric_tts": "TTS",
   "@dive3d_metric_tts": {},
   "dive3d_axis_depth": "Depth ({unitSymbol})",
-  "@dive3d_axis_depth": {"placeholders": {"unitSymbol": {"type": "String"}}},
+  "@dive3d_axis_depth": {
+    "placeholders": {
+      "unitSymbol": {
+        "type": "String"
+      }
+    }
+  },
   "dive3d_axis_time": "Run time (min)",
   "@dive3d_axis_time": {},
   "dive3d_pose_menu": "Camera",
@@ -15613,7 +15793,13 @@
   "dive3d_readout_ceiling": "Ceiling",
   "@dive3d_readout_ceiling": {},
   "dive3d_readout_tank": "Tank {n}",
-  "@dive3d_readout_tank": {"placeholders": {"n": {"type": "int"}}},
+  "@dive3d_readout_tank": {
+    "placeholders": {
+      "n": {
+        "type": "int"
+      }
+    }
+  },
   "dive3d_scene_dive": "Dive",
   "@dive3d_scene_dive": {},
   "dive3d_scene_tissue": "Tissues",
@@ -16645,7 +16831,9 @@
   "@reef_species_showAll": {
     "description": "Expands the capped nearby-species chip list to its full length",
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "reef_species_showFewer": "Show fewer",
@@ -18596,100 +18784,609 @@
   "statistics_timePatterns_timeOfDay_morning": "Morning",
   "statistics_timePatterns_timeOfDay_night": "Night",
   "statistics_timePatterns_timeOfDay_semanticLabel": "Pie chart. Dives by time of day. {description}",
-  "@common_action_done": {"description": "Dismiss a finished operation"},
-  "@common_action_more": {"description": "Overflow menu tooltip"},
-  "@common_label_displayName": {"description": "Text field label for a user-chosen display name"},
-  "@common_relativeTime_daysAgo": {"description": "Relative past time in whole days (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_hoursAgo": {"description": "Relative past time in whole hours (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_inDays": {"description": "Relative future time in whole days (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_inHours": {"description": "Relative future time in whole hours (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_inLessThanMinute": {"description": "Relative future time, under one minute"},
-  "@common_relativeTime_inMinutes": {"description": "Relative future time in whole minutes (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_justNow": {"description": "Relative past time, under one minute"},
-  "@common_relativeTime_minutesAgo": {"description": "Relative past time in whole minutes (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_monthsAgo": {"description": "Relative past time in whole months (abbreviated)", "placeholders": {"count": {"type": "int"}}},
-  "@common_relativeTime_overdue": {"description": "Relative future time that is already in the past"},
-  "@media_cache_calculating": {"description": "Network Sources: cache size is still being measured"},
-  "@media_cache_cardTitle": {"description": "Network Sources: cache card header"},
-  "@media_cache_clearAction": {"description": "Network Sources: clear the network image cache action"},
-  "@media_cache_clearBody": {"description": "Network Sources: clear cache confirmation body"},
-  "@media_cache_clearConfirm": {"description": "Network Sources: confirm button on the clear cache dialog"},
-  "@media_cache_clearError": {"description": "Network Sources: clearing the cache threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_cache_clearTitle": {"description": "Network Sources: clear cache confirmation title"},
-  "@media_cache_cleared": {"description": "Network Sources: cache cleared confirmation"},
-  "@media_cache_diskCache": {"description": "Network Sources: on-disk network image cache row"},
-  "@media_cache_error": {"description": "Network Sources: measuring the cache size threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_credentials_actionTest": {"description": "Network Sources: probe a saved host with its credentials"},
-  "@media_credentials_authLabel": {"description": "Network Sources: saved host auth scheme (basic, bearer, ...)", "placeholders": {"authType": {"type": "String"}}},
-  "@media_credentials_deleteBody": {"description": "Network Sources: delete saved host confirmation body"},
-  "@media_credentials_deleteError": {"description": "Network Sources: removing a saved host threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_credentials_deleteTitle": {"description": "Network Sources: delete saved host confirmation title", "placeholders": {"host": {"type": "String"}}},
-  "@media_credentials_deleted": {"description": "Network Sources: saved host removed confirmation", "placeholders": {"host": {"type": "String"}}},
-  "@media_credentials_editTitle": {"description": "Network Sources: rename saved host dialog title", "placeholders": {"host": {"type": "String"}}},
-  "@media_credentials_emptySubtitle": {"description": "Network Sources: saved-hosts empty-state explanation"},
-  "@media_credentials_emptyTitle": {"description": "Network Sources: no per-host credentials stored"},
-  "@media_credentials_lastUsed": {"description": "Network Sources: relative time a saved host was last used", "placeholders": {"when": {"type": "String"}}},
-  "@media_credentials_loadError": {"description": "Network Sources: saved-hosts query failed"},
-  "@media_credentials_loading": {"description": "Network Sources: saved-hosts list is loading"},
-  "@media_credentials_saveError": {"description": "Network Sources: saving a host display name threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_credentials_savedHostsTitle": {"description": "Network Sources: saved-hosts card header"},
-  "@media_credentials_testError": {"description": "Network Sources: credential probe threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_credentials_testFailed": {"description": "Network Sources: credential probe was rejected", "placeholders": {"host": {"type": "String"}}},
-  "@media_credentials_testOk": {"description": "Network Sources: credential probe succeeded", "placeholders": {"host": {"type": "String"}}},
-  "@media_manifest_actionPollNow": {"description": "Network Sources: fetch a subscription immediately"},
-  "@media_manifest_cardTitle": {"description": "Network Sources: manifest subscriptions card header"},
-  "@media_manifest_deleteBody": {"description": "Network Sources: delete subscription confirmation body"},
-  "@media_manifest_deleteError": {"description": "Network Sources: deleting a subscription threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_manifest_deleteTitle": {"description": "Network Sources: delete subscription confirmation title", "placeholders": {"name": {"type": "String"}}},
-  "@media_manifest_editTitle": {"description": "Network Sources: edit subscription dialog title"},
-  "@media_manifest_emptySubtitle": {"description": "Network Sources: subscriptions empty-state explanation"},
-  "@media_manifest_emptyTitle": {"description": "Network Sources: no subscriptions configured"},
-  "@media_manifest_lastError": {"description": "Network Sources: the last poll of this subscription failed", "placeholders": {"error": {"type": "String"}}},
-  "@media_manifest_lastPolled": {"description": "Network Sources: relative time of the last successful poll", "placeholders": {"when": {"type": "String"}}},
-  "@media_manifest_loadError": {"description": "Network Sources: subscriptions query failed"},
-  "@media_manifest_loading": {"description": "Network Sources: subscriptions list is loading"},
-  "@media_manifest_neverPolled": {"description": "Network Sources: subscription has never been fetched"},
-  "@media_manifest_nextPoll": {"description": "Network Sources: relative time of the next scheduled poll", "placeholders": {"when": {"type": "String"}}},
-  "@media_manifest_notFound": {"description": "Network Sources: the polled subscription row no longer exists"},
-  "@media_manifest_pollError": {"description": "Network Sources: a manual poll threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_manifest_polled": {"description": "Network Sources: a manual poll finished", "placeholders": {"name": {"type": "String"}}},
-  "@media_manifest_polling": {"description": "Network Sources: a manual poll has started", "placeholders": {"name": {"type": "String"}}},
-  "@media_manifest_saveError": {"description": "Network Sources: saving subscription edits threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_manifest_updateError": {"description": "Network Sources: toggling a subscription active flag threw", "placeholders": {"error": {"type": "String"}}},
-  "@media_manifest_urlLabel": {"description": "Network Sources: manifest URL text field label"},
-  "@media_scan_failed": {"description": "Network scan dialog: the scan stream emitted an error", "placeholders": {"error": {"type": "String"}}},
-  "@media_scan_progressItems": {"description": "Network scan dialog: running item counter", "placeholders": {"done": {"type": "int"}, "total": {"type": "int"}}},
-  "@media_scan_progressReachability": {"description": "Network scan dialog: running reachable/unreachable counters", "placeholders": {"available": {"type": "int"}, "unreachable": {"type": "int"}}},
-  "@media_scan_summary": {"description": "Network scan dialog: final summary line", "placeholders": {"total": {"type": "int"}, "seconds": {"type": "String"}, "available": {"type": "int"}, "unreachable": {"type": "int"}}},
-  "@media_scan_summarySkipped": {"description": "Network scan dialog: summary line extended with the skipped-rows tail", "placeholders": {"base": {"type": "String"}, "count": {"type": "int"}}},
-  "@media_scan_title": {"description": "Network Sources: scan-all action label and scan dialog title"},
-  "@settings_mediaSources_androidUriTitle": {"description": "Media Sources: Android persistable URI gauge title"},
-  "@settings_mediaSources_androidUriUsage": {"description": "Media Sources: Android persistable URI gauge value", "placeholders": {"used": {"type": "int"}, "limit": {"type": "int"}}},
-  "@settings_mediaSources_counting": {"description": "Media Sources: local-file diagnostics still counting"},
-  "@settings_mediaSources_error": {"description": "Media Sources: a diagnostics provider failed", "placeholders": {"error": {"type": "String"}}},
-  "@settings_mediaSources_loading": {"description": "Media Sources: a diagnostics provider is still loading"},
-  "@settings_mediaSources_localFilesCounts": {"description": "Media Sources: local-file diagnostics counts", "placeholders": {"available": {"type": "int"}, "unavailable": {"type": "int"}}},
-  "@settings_mediaSources_photoLibrarySubtitle": {"description": "Media Sources: platform photo library row subtitle"},
-  "@settings_mediaSources_reverifyAll": {"description": "Media Sources: re-verify every local file action"},
-  "@settings_mediaSources_reverifyFailed": {"description": "Media Sources: the re-verify pass threw", "placeholders": {"error": {"type": "String"}}},
-  "@settings_mediaSources_reverifyResult": {"description": "Media Sources: how many rows the re-verify pass updated", "placeholders": {"count": {"type": "int"}}},
-  "@settings_mediaSources_checkAll": {"description": "Media Sources: verify every media row regardless of source type"},
-  "@settings_mediaSources_checkAllResult": {"description": "Media Sources: how many rows the check-all pass updated", "placeholders": {"count": {"type": "int"}}},
-  "@settings_mediaSources_checkAllBlocked": {"description": "Media Sources: the check-all pass reached none of the rows sources", "placeholders": {"count": {"type": "int"}}},
-  "@settings_mediaSources_title": {"description": "Media Sources settings page app bar title"},
-  "@settings_networkSources_scanDescription": {"description": "Network Sources: explanation under the scan-all button"},
-  "@statistics_conditions_entryMethod_semanticLabel": {"description": "Screen-reader summary of the entry method bar chart", "placeholders": {"description": {"type": "String", "example": "Boat Entry: 12 dives"}}},
-  "@statistics_conditions_visibility_semanticLabel": {"description": "Screen-reader summary of the visibility distribution pie chart", "placeholders": {"description": {"type": "String", "example": "Excellent: 40%"}}},
-  "@statistics_conditions_waterType_semanticLabel": {"description": "Screen-reader summary of the water type distribution pie chart", "placeholders": {"description": {"type": "String", "example": "Salt Water: 80%"}}},
-  "@statistics_progression_divesBySuitThickness_semanticLabel": {"description": "Screen-reader summary of the dives-by-suit-thickness bar chart", "placeholders": {"description": {"type": "String", "example": "5 mm: 12"}}},
-  "@statistics_progression_divesPerYear_countInYear": {"description": "One entry of the dives-per-year screen-reader summary", "placeholders": {"count": {"type": "int", "example": "42"}, "year": {"type": "String", "example": "2025"}}},
-  "@statistics_progression_divesPerYear_semanticLabel": {"description": "Screen-reader summary of the dives-per-year bar chart", "placeholders": {"description": {"type": "String", "example": "42 dives in 2025"}}},
-  "@statistics_summary_depthBucket_over": {"description": "Depth-distribution legend for the open-ended deepest bucket; unit is the diver's depth symbol", "placeholders": {"min": {"type": "String", "example": "30"}, "unit": {"type": "String", "example": "m"}}},
-  "@statistics_summary_depthBucket_range": {"description": "Depth-distribution legend for a closed depth bucket; unit is the diver's depth symbol", "placeholders": {"min": {"type": "String", "example": "10"}, "max": {"type": "String", "example": "20"}, "unit": {"type": "String", "example": "m"}}},
-  "@statistics_timePatterns_dayOfWeek_semanticLabel": {"description": "Screen-reader summary of the dives-by-day-of-week bar chart", "placeholders": {"description": {"type": "String", "example": "Mon: 3, Tue: 5"}}},
-  "@statistics_timePatterns_seasonal_semanticLabel": {"description": "Screen-reader summary of the dives-by-month bar chart", "placeholders": {"description": {"type": "String", "example": "Jan: 3, Feb: 5"}}},
-  "@statistics_timePatterns_surfaceInterval_statLabel": {"description": "Screen-reader label for one surface-interval statistic tile", "placeholders": {"label": {"type": "String", "example": "Average"}, "value": {"type": "String", "example": "1h 20m"}}},
-  "@statistics_timePatterns_timeOfDay_semanticLabel": {"description": "Screen-reader summary of the dives-by-time-of-day pie chart", "placeholders": {"description": {"type": "String", "example": "Morning: 40%"}}},
+  "@common_action_done": {
+    "description": "Dismiss a finished operation"
+  },
+  "@common_action_more": {
+    "description": "Overflow menu tooltip"
+  },
+  "@common_label_displayName": {
+    "description": "Text field label for a user-chosen display name"
+  },
+  "@common_relativeTime_daysAgo": {
+    "description": "Relative past time in whole days (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_hoursAgo": {
+    "description": "Relative past time in whole hours (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_inDays": {
+    "description": "Relative future time in whole days (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_inHours": {
+    "description": "Relative future time in whole hours (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_inLessThanMinute": {
+    "description": "Relative future time, under one minute"
+  },
+  "@common_relativeTime_inMinutes": {
+    "description": "Relative future time in whole minutes (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_justNow": {
+    "description": "Relative past time, under one minute"
+  },
+  "@common_relativeTime_minutesAgo": {
+    "description": "Relative past time in whole minutes (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_monthsAgo": {
+    "description": "Relative past time in whole months (abbreviated)",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@common_relativeTime_overdue": {
+    "description": "Relative future time that is already in the past"
+  },
+  "@media_cache_calculating": {
+    "description": "Network Sources: cache size is still being measured"
+  },
+  "@media_cache_cardTitle": {
+    "description": "Network Sources: cache card header"
+  },
+  "@media_cache_clearAction": {
+    "description": "Network Sources: clear the network image cache action"
+  },
+  "@media_cache_clearBody": {
+    "description": "Network Sources: clear cache confirmation body"
+  },
+  "@media_cache_clearConfirm": {
+    "description": "Network Sources: confirm button on the clear cache dialog"
+  },
+  "@media_cache_clearError": {
+    "description": "Network Sources: clearing the cache threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_cache_clearTitle": {
+    "description": "Network Sources: clear cache confirmation title"
+  },
+  "@media_cache_cleared": {
+    "description": "Network Sources: cache cleared confirmation"
+  },
+  "@media_cache_diskCache": {
+    "description": "Network Sources: on-disk network image cache row"
+  },
+  "@media_cache_error": {
+    "description": "Network Sources: measuring the cache size threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_actionTest": {
+    "description": "Network Sources: probe a saved host with its credentials"
+  },
+  "@media_credentials_authLabel": {
+    "description": "Network Sources: saved host auth scheme (basic, bearer, ...)",
+    "placeholders": {
+      "authType": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_deleteBody": {
+    "description": "Network Sources: delete saved host confirmation body"
+  },
+  "@media_credentials_deleteError": {
+    "description": "Network Sources: removing a saved host threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_deleteTitle": {
+    "description": "Network Sources: delete saved host confirmation title",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_deleted": {
+    "description": "Network Sources: saved host removed confirmation",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_editTitle": {
+    "description": "Network Sources: rename saved host dialog title",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_emptySubtitle": {
+    "description": "Network Sources: saved-hosts empty-state explanation"
+  },
+  "@media_credentials_emptyTitle": {
+    "description": "Network Sources: no per-host credentials stored"
+  },
+  "@media_credentials_lastUsed": {
+    "description": "Network Sources: relative time a saved host was last used",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_loadError": {
+    "description": "Network Sources: saved-hosts query failed"
+  },
+  "@media_credentials_loading": {
+    "description": "Network Sources: saved-hosts list is loading"
+  },
+  "@media_credentials_saveError": {
+    "description": "Network Sources: saving a host display name threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_savedHostsTitle": {
+    "description": "Network Sources: saved-hosts card header"
+  },
+  "@media_credentials_testError": {
+    "description": "Network Sources: credential probe threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_testFailed": {
+    "description": "Network Sources: credential probe was rejected",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_credentials_testOk": {
+    "description": "Network Sources: credential probe succeeded",
+    "placeholders": {
+      "host": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_actionPollNow": {
+    "description": "Network Sources: fetch a subscription immediately"
+  },
+  "@media_manifest_cardTitle": {
+    "description": "Network Sources: manifest subscriptions card header"
+  },
+  "@media_manifest_deleteBody": {
+    "description": "Network Sources: delete subscription confirmation body"
+  },
+  "@media_manifest_deleteError": {
+    "description": "Network Sources: deleting a subscription threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_deleteTitle": {
+    "description": "Network Sources: delete subscription confirmation title",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_editTitle": {
+    "description": "Network Sources: edit subscription dialog title"
+  },
+  "@media_manifest_emptySubtitle": {
+    "description": "Network Sources: subscriptions empty-state explanation"
+  },
+  "@media_manifest_emptyTitle": {
+    "description": "Network Sources: no subscriptions configured"
+  },
+  "@media_manifest_lastError": {
+    "description": "Network Sources: the last poll of this subscription failed",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_lastPolled": {
+    "description": "Network Sources: relative time of the last successful poll",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_loadError": {
+    "description": "Network Sources: subscriptions query failed"
+  },
+  "@media_manifest_loading": {
+    "description": "Network Sources: subscriptions list is loading"
+  },
+  "@media_manifest_neverPolled": {
+    "description": "Network Sources: subscription has never been fetched"
+  },
+  "@media_manifest_nextPoll": {
+    "description": "Network Sources: relative time of the next scheduled poll",
+    "placeholders": {
+      "when": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_notFound": {
+    "description": "Network Sources: the polled subscription row no longer exists"
+  },
+  "@media_manifest_pollError": {
+    "description": "Network Sources: a manual poll threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_polled": {
+    "description": "Network Sources: a manual poll finished",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_polling": {
+    "description": "Network Sources: a manual poll has started",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_saveError": {
+    "description": "Network Sources: saving subscription edits threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_updateError": {
+    "description": "Network Sources: toggling a subscription active flag threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_manifest_urlLabel": {
+    "description": "Network Sources: manifest URL text field label"
+  },
+  "@media_scan_failed": {
+    "description": "Network scan dialog: the scan stream emitted an error",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@media_scan_progressItems": {
+    "description": "Network scan dialog: running item counter",
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@media_scan_progressReachability": {
+    "description": "Network scan dialog: running reachable/unreachable counters",
+    "placeholders": {
+      "available": {
+        "type": "int"
+      },
+      "unreachable": {
+        "type": "int"
+      }
+    }
+  },
+  "@media_scan_summary": {
+    "description": "Network scan dialog: final summary line",
+    "placeholders": {
+      "total": {
+        "type": "int"
+      },
+      "seconds": {
+        "type": "String"
+      },
+      "available": {
+        "type": "int"
+      },
+      "unreachable": {
+        "type": "int"
+      }
+    }
+  },
+  "@media_scan_summarySkipped": {
+    "description": "Network scan dialog: summary line extended with the skipped-rows tail",
+    "placeholders": {
+      "base": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@media_scan_title": {
+    "description": "Network Sources: scan-all action label and scan dialog title"
+  },
+  "@settings_mediaSources_androidUriTitle": {
+    "description": "Media Sources: Android persistable URI gauge title"
+  },
+  "@settings_mediaSources_androidUriUsage": {
+    "description": "Media Sources: Android persistable URI gauge value",
+    "placeholders": {
+      "used": {
+        "type": "int"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_mediaSources_counting": {
+    "description": "Media Sources: local-file diagnostics still counting"
+  },
+  "@settings_mediaSources_error": {
+    "description": "Media Sources: a diagnostics provider failed",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_mediaSources_loading": {
+    "description": "Media Sources: a diagnostics provider is still loading"
+  },
+  "@settings_mediaSources_localFilesCounts": {
+    "description": "Media Sources: local-file diagnostics counts",
+    "placeholders": {
+      "available": {
+        "type": "int"
+      },
+      "unavailable": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_mediaSources_photoLibrarySubtitle": {
+    "description": "Media Sources: platform photo library row subtitle"
+  },
+  "@settings_mediaSources_reverifyAll": {
+    "description": "Media Sources: re-verify every local file action"
+  },
+  "@settings_mediaSources_reverifyFailed": {
+    "description": "Media Sources: the re-verify pass threw",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_mediaSources_reverifyResult": {
+    "description": "Media Sources: how many rows the re-verify pass updated",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_mediaSources_checkAll": {
+    "description": "Media Sources: verify every media row regardless of source type"
+  },
+  "@settings_mediaSources_checkAllResult": {
+    "description": "Media Sources: how many rows the check-all pass updated",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_mediaSources_checkAllBlocked": {
+    "description": "Media Sources: the check-all pass reached none of the rows sources",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_mediaSources_title": {
+    "description": "Media Sources settings page app bar title"
+  },
+  "@settings_networkSources_scanDescription": {
+    "description": "Network Sources: explanation under the scan-all button"
+  },
+  "@statistics_conditions_entryMethod_semanticLabel": {
+    "description": "Screen-reader summary of the entry method bar chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Boat Entry: 12 dives"
+      }
+    }
+  },
+  "@statistics_conditions_visibility_semanticLabel": {
+    "description": "Screen-reader summary of the visibility distribution pie chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Excellent: 40%"
+      }
+    }
+  },
+  "@statistics_conditions_waterType_semanticLabel": {
+    "description": "Screen-reader summary of the water type distribution pie chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Salt Water: 80%"
+      }
+    }
+  },
+  "@statistics_progression_divesBySuitThickness_semanticLabel": {
+    "description": "Screen-reader summary of the dives-by-suit-thickness bar chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "5 mm: 12"
+      }
+    }
+  },
+  "@statistics_progression_divesPerYear_countInYear": {
+    "description": "One entry of the dives-per-year screen-reader summary",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "42"
+      },
+      "year": {
+        "type": "String",
+        "example": "2025"
+      }
+    }
+  },
+  "@statistics_progression_divesPerYear_semanticLabel": {
+    "description": "Screen-reader summary of the dives-per-year bar chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "42 dives in 2025"
+      }
+    }
+  },
+  "@statistics_summary_depthBucket_over": {
+    "description": "Depth-distribution legend for the open-ended deepest bucket; unit is the diver's depth symbol",
+    "placeholders": {
+      "min": {
+        "type": "String",
+        "example": "30"
+      },
+      "unit": {
+        "type": "String",
+        "example": "m"
+      }
+    }
+  },
+  "@statistics_summary_depthBucket_range": {
+    "description": "Depth-distribution legend for a closed depth bucket; unit is the diver's depth symbol",
+    "placeholders": {
+      "min": {
+        "type": "String",
+        "example": "10"
+      },
+      "max": {
+        "type": "String",
+        "example": "20"
+      },
+      "unit": {
+        "type": "String",
+        "example": "m"
+      }
+    }
+  },
+  "@statistics_timePatterns_dayOfWeek_semanticLabel": {
+    "description": "Screen-reader summary of the dives-by-day-of-week bar chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Mon: 3, Tue: 5"
+      }
+    }
+  },
+  "@statistics_timePatterns_seasonal_semanticLabel": {
+    "description": "Screen-reader summary of the dives-by-month bar chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Jan: 3, Feb: 5"
+      }
+    }
+  },
+  "@statistics_timePatterns_surfaceInterval_statLabel": {
+    "description": "Screen-reader label for one surface-interval statistic tile",
+    "placeholders": {
+      "label": {
+        "type": "String",
+        "example": "Average"
+      },
+      "value": {
+        "type": "String",
+        "example": "1h 20m"
+      }
+    }
+  },
+  "@statistics_timePatterns_timeOfDay_semanticLabel": {
+    "description": "Screen-reader summary of the dives-by-time-of-day pie chart",
+    "placeholders": {
+      "description": {
+        "type": "String",
+        "example": "Morning: 40%"
+      }
+    }
+  },
   "columnConfig_displayOptions": "Display Options",
   "columnConfig_noExtraFields": "No extra fields configured. Add fields below.",
   "columnConfig_savePresetTitle": "Save Preset",
@@ -18879,34 +19576,326 @@
   "settings_troubleshootSync_wipeAll_title": "Wipe all sync data on this backend",
   "tableMode_tooltip_toggleDetailPane": "Toggle detail pane",
   "tableMode_tooltip_toggleProfilePanel": "Toggle profile panel",
-  "@diveLog_filterChip_dateRange": {"description": "Active-filter chip showing a closed date range.", "placeholders": {"end": {"type": "String"}, "start": {"type": "String"}}},
-  "@diveLog_filterChip_equipmentCount": {"description": "Active-filter chip when more than one equipment item is selected.", "placeholders": {"count": {"type": "int"}}},
-  "@diveLog_filter_sectionDepthRangeUnit": {"description": "Depth-range filter section header; {unit} is the diver's depth unit symbol (m or ft).", "placeholders": {"unit": {"type": "String"}}},
-  "@diveLog_listPage_semanticsDiveAtSite": {"description": "Screen-reader label for a dive row in the dive list.", "placeholders": {"diveNumber": {"type": "int"}, "siteName": {"type": "String"}}},
-  "@settings_fixDiveTimes_applied": {"description": "Snackbar after the offset is applied. hours is the signed offset as text; hoursAbs drives the hour/hours plural.", "placeholders": {"count": {"type": "int"}, "hours": {"type": "String"}, "hoursAbs": {"type": "int"}}},
-  "@settings_fixDiveTimes_apply": {"description": "Apply bar button label", "placeholders": {"count": {"type": "int"}}},
-  "@settings_fixDiveTimes_confirmBody": {"description": "Confirmation body. hours is the signed offset as text; hoursAbs drives the hour/hours plural.", "placeholders": {"count": {"type": "int"}, "hours": {"type": "String"}, "hoursAbs": {"type": "int"}}},
-  "@settings_fixDiveTimes_diveNumber": {"description": "List row title for a numbered dive", "placeholders": {"number": {"type": "int"}}},
-  "@settings_fixDiveTimes_loadError": {"description": "Snackbar shown when the dive list fails to load", "placeholders": {"error": {"type": "String"}}},
-  "@settings_fixDiveTimes_preview": {"description": "Preview banner. hours is the signed offset as text (e.g. +7); hoursAbs drives the hour/hours plural.", "placeholders": {"count": {"type": "int"}, "hours": {"type": "String"}, "hoursAbs": {"type": "int"}}},
-  "@settings_syncDevices_readError": {"description": "Shown when the sync backend listing could not be read.", "placeholders": {"error": {"example": "Network error", "type": "String"}}},
-  "@settings_syncDevices_removeDialog_bodyRisky": {"description": "Confirmation body when the peer is still an active syncer.", "placeholders": {"count": {"example": "42", "type": "int"}, "name": {"example": "Eric’s iPhone", "type": "String"}, "size": {"example": "1.4 MB", "type": "String"}}},
-  "@settings_syncDevices_removeDialog_bodySafe": {"description": "Confirmation body when the peer is safe to remove.", "placeholders": {"count": {"example": "42", "type": "int"}, "name": {"example": "Eric’s iPhone", "type": "String"}, "size": {"example": "1.4 MB", "type": "String"}}},
-  "@settings_syncDevices_removeDialog_title": {"placeholders": {"name": {"example": "Eric’s iPhone", "type": "String"}}},
-  "@settings_syncDevices_removeProgressTitle": {"placeholders": {"name": {"example": "Eric’s iPhone", "type": "String"}}},
-  "@settings_syncDevices_summary": {"description": "Totals header: how many devices, how many files, and their combined size. {size} is a preformatted size such as \"1.4 MB\".", "placeholders": {"deviceCount": {"example": "3", "type": "int"}, "fileCount": {"example": "412", "type": "int"}, "size": {"example": "1.4 MB", "type": "String"}}},
-  "@settings_syncDevices_summary_removable": {"description": "How many of the listed devices are safe to remove, and how much space they hold.", "placeholders": {"count": {"example": "2", "type": "int"}, "size": {"example": "900 KB", "type": "String"}}},
-  "@settings_syncDevices_tile_filesSize": {"description": "Device row subtitle when no timestamp is known.", "placeholders": {"count": {"example": "42", "type": "int"}, "size": {"example": "1.4 MB", "type": "String"}}},
-  "@settings_syncDevices_tile_filesSizeSeen": {"description": "Device row subtitle including the publish/modify timestamp.", "placeholders": {"count": {"example": "42", "type": "int"}, "size": {"example": "1.4 MB", "type": "String"}, "when": {"example": "Jan 3, 2026 4:15 PM", "type": "String"}}},
-  "@settings_syncDevices_unnamedDevice": {"description": "Title-case fallback name for a device that published no name. The mid-sentence lowercase form is settings_cloudSync_peerNeedsAdopt_unnamedDevice.", "placeholders": {"shortId": {"example": "a1b2c3", "type": "String"}}},
-  "@settings_syncDevices_nameWithId": {"description": "Device name qualified by its short id, used only when two devices published the same name (two phones of one model, or iOS 16+ handing out the model as the name).", "placeholders": {"name": {"example": "iPhone", "type": "String"}, "shortId": {"example": "a1b2c3d4", "type": "String"}}},
-  "@settings_syncMaintenance_progress_filesOfTotal": {"description": "Progress counter inside the sync maintenance dialog, e.g. \"12 of 400 files\".", "placeholders": {"done": {"example": "12", "type": "int"}, "total": {"example": "400", "type": "int"}}},
-  "@settings_syncMaintenance_removedFiles": {"description": "Snackbar after a fully successful cloud file removal.", "placeholders": {"count": {"example": "12", "type": "int"}}},
-  "@settings_syncMaintenance_removedFilesPartial": {"description": "Snackbar after a partially successful removal. {trouble} is an already localized clause built from the trouble_* keys.", "placeholders": {"count": {"example": "12", "type": "int"}, "trouble": {"example": "3 could not be deleted", "type": "String"}}},
-  "@settings_syncMaintenance_trouble_failed": {"description": "Clause spliced into the *Partial messages when some files could not be deleted.", "placeholders": {"count": {"example": "3", "type": "int"}}},
-  "@settings_syncMaintenance_wipedFiles": {"description": "Snackbar after a fully successful full-backend wipe.", "placeholders": {"count": {"example": "412", "type": "int"}}},
-  "@settings_syncMaintenance_wipedFilesPartial": {"description": "Snackbar after a partially successful wipe. {trouble} is an already localized clause built from the trouble_* keys.", "placeholders": {"count": {"example": "412", "type": "int"}, "trouble": {"example": "3 could not be deleted", "type": "String"}}},
-  "@settings_troubleshootSync_wipeAll_confirmBody": {"description": "Body of the typed-confirmation wipe dialog. {word} is the literal, never-translated sentinel the user must type (WIPE); it must match the hint and the button comparison exactly.", "placeholders": {"word": {"example": "WIPE", "type": "String"}}},
+  "@diveLog_filterChip_dateRange": {
+    "description": "Active-filter chip showing a closed date range.",
+    "placeholders": {
+      "end": {
+        "type": "String"
+      },
+      "start": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_filterChip_equipmentCount": {
+    "description": "Active-filter chip when more than one equipment item is selected.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@diveLog_filter_sectionDepthRangeUnit": {
+    "description": "Depth-range filter section header; {unit} is the diver's depth unit symbol (m or ft).",
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_listPage_semanticsDiveAtSite": {
+    "description": "Screen-reader label for a dive row in the dive list.",
+    "placeholders": {
+      "diveNumber": {
+        "type": "int"
+      },
+      "siteName": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_applied": {
+    "description": "Snackbar after the offset is applied. hours is the signed offset as text; hoursAbs drives the hour/hours plural.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "hours": {
+        "type": "String"
+      },
+      "hoursAbs": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_apply": {
+    "description": "Apply bar button label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_confirmBody": {
+    "description": "Confirmation body. hours is the signed offset as text; hoursAbs drives the hour/hours plural.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "hours": {
+        "type": "String"
+      },
+      "hoursAbs": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_diveNumber": {
+    "description": "List row title for a numbered dive",
+    "placeholders": {
+      "number": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_loadError": {
+    "description": "Snackbar shown when the dive list fails to load",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_fixDiveTimes_preview": {
+    "description": "Preview banner. hours is the signed offset as text (e.g. +7); hoursAbs drives the hour/hours plural.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "hours": {
+        "type": "String"
+      },
+      "hoursAbs": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_syncDevices_readError": {
+    "description": "Shown when the sync backend listing could not be read.",
+    "placeholders": {
+      "error": {
+        "example": "Network error",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_removeDialog_bodyRisky": {
+    "description": "Confirmation body when the peer is still an active syncer.",
+    "placeholders": {
+      "count": {
+        "example": "42",
+        "type": "int"
+      },
+      "name": {
+        "example": "Eric’s iPhone",
+        "type": "String"
+      },
+      "size": {
+        "example": "1.4 MB",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_removeDialog_bodySafe": {
+    "description": "Confirmation body when the peer is safe to remove.",
+    "placeholders": {
+      "count": {
+        "example": "42",
+        "type": "int"
+      },
+      "name": {
+        "example": "Eric’s iPhone",
+        "type": "String"
+      },
+      "size": {
+        "example": "1.4 MB",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_removeDialog_title": {
+    "placeholders": {
+      "name": {
+        "example": "Eric’s iPhone",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_removeProgressTitle": {
+    "placeholders": {
+      "name": {
+        "example": "Eric’s iPhone",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_summary": {
+    "description": "Totals header: how many devices, how many files, and their combined size. {size} is a preformatted size such as \"1.4 MB\".",
+    "placeholders": {
+      "deviceCount": {
+        "example": "3",
+        "type": "int"
+      },
+      "fileCount": {
+        "example": "412",
+        "type": "int"
+      },
+      "size": {
+        "example": "1.4 MB",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_summary_removable": {
+    "description": "How many of the listed devices are safe to remove, and how much space they hold.",
+    "placeholders": {
+      "count": {
+        "example": "2",
+        "type": "int"
+      },
+      "size": {
+        "example": "900 KB",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_tile_filesSize": {
+    "description": "Device row subtitle when no timestamp is known.",
+    "placeholders": {
+      "count": {
+        "example": "42",
+        "type": "int"
+      },
+      "size": {
+        "example": "1.4 MB",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_tile_filesSizeSeen": {
+    "description": "Device row subtitle including the publish/modify timestamp.",
+    "placeholders": {
+      "count": {
+        "example": "42",
+        "type": "int"
+      },
+      "size": {
+        "example": "1.4 MB",
+        "type": "String"
+      },
+      "when": {
+        "example": "Jan 3, 2026 4:15 PM",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_unnamedDevice": {
+    "description": "Title-case fallback name for a device that published no name. The mid-sentence lowercase form is settings_cloudSync_peerNeedsAdopt_unnamedDevice.",
+    "placeholders": {
+      "shortId": {
+        "example": "a1b2c3",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncDevices_nameWithId": {
+    "description": "Device name qualified by its short id, used only when two devices published the same name (two phones of one model, or iOS 16+ handing out the model as the name).",
+    "placeholders": {
+      "name": {
+        "example": "iPhone",
+        "type": "String"
+      },
+      "shortId": {
+        "example": "a1b2c3d4",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncMaintenance_progress_filesOfTotal": {
+    "description": "Progress counter inside the sync maintenance dialog, e.g. \"12 of 400 files\".",
+    "placeholders": {
+      "done": {
+        "example": "12",
+        "type": "int"
+      },
+      "total": {
+        "example": "400",
+        "type": "int"
+      }
+    }
+  },
+  "@settings_syncMaintenance_removedFiles": {
+    "description": "Snackbar after a fully successful cloud file removal.",
+    "placeholders": {
+      "count": {
+        "example": "12",
+        "type": "int"
+      }
+    }
+  },
+  "@settings_syncMaintenance_removedFilesPartial": {
+    "description": "Snackbar after a partially successful removal. {trouble} is an already localized clause built from the trouble_* keys.",
+    "placeholders": {
+      "count": {
+        "example": "12",
+        "type": "int"
+      },
+      "trouble": {
+        "example": "3 could not be deleted",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_syncMaintenance_trouble_failed": {
+    "description": "Clause spliced into the *Partial messages when some files could not be deleted.",
+    "placeholders": {
+      "count": {
+        "example": "3",
+        "type": "int"
+      }
+    }
+  },
+  "@settings_syncMaintenance_wipedFiles": {
+    "description": "Snackbar after a fully successful full-backend wipe.",
+    "placeholders": {
+      "count": {
+        "example": "412",
+        "type": "int"
+      }
+    }
+  },
+  "@settings_syncMaintenance_wipedFilesPartial": {
+    "description": "Snackbar after a partially successful wipe. {trouble} is an already localized clause built from the trouble_* keys.",
+    "placeholders": {
+      "count": {
+        "example": "412",
+        "type": "int"
+      },
+      "trouble": {
+        "example": "3 could not be deleted",
+        "type": "String"
+      }
+    }
+  },
+  "@settings_troubleshootSync_wipeAll_confirmBody": {
+    "description": "Body of the typed-confirmation wipe dialog. {word} is the literal, never-translated sentinel the user must type (WIPE); it must match the hint and the button comparison exactly.",
+    "placeholders": {
+      "word": {
+        "example": "WIPE",
+        "type": "String"
+      }
+    }
+  },
   "maps_regionDownload_title": "Download Region",
   "maps_regionDownload_nameRequired": "Please enter a name for this region",
   "maps_regionDownload_nameLabel": "Region Name",
@@ -19056,76 +20045,421 @@
   "universalImport_entityAction_consolidateBadge": "CONSOLIDATE",
   "diveCenters_import_quickSearch_egypt": "Egypt",
   "diveCenters_import_quickSearch_mexico": "Mexico",
-  "@maps_regionDownload_minZoom": {"placeholders": {"zoom": {"type": "int"}}},
-  "@maps_regionDownload_minZoomSemantics": {"placeholders": {"zoom": {"type": "int"}}},
-  "@maps_regionDownload_maxZoom": {"placeholders": {"zoom": {"type": "int"}}},
-  "@maps_regionDownload_maxZoomSemantics": {"placeholders": {"zoom": {"type": "int"}}},
-  "@maps_regionDownload_estimateSemantics": {"placeholders": {"count": {"type": "int"}, "size": {"type": "Object"}}},
-  "@maps_regionDownload_tileCount": {"placeholders": {"count": {"type": "int"}}},
-  "@diveLog_map_infoCard_minutes": {"placeholders": {"minutes": {"type": "int"}}},
-  "@trips_gallery_diveSection_subtitle": {"placeholders": {"date": {"type": "Object"}, "count": {"type": "int"}, "photoLabel": {"type": "Object"}}},
-  "@trips_picker_suggestedSemantics": {"placeholders": {"name": {"type": "Object"}}},
-  "@trips_picker_tileSemantics": {"placeholders": {"name": {"type": "Object"}, "startDate": {"type": "Object"}, "endDate": {"type": "Object"}}},
-  "@trips_picker_tileSemanticsSelected": {"placeholders": {"name": {"type": "Object"}, "startDate": {"type": "Object"}, "endDate": {"type": "Object"}}},
-  "@divePlanner_quickPlan_depthSemantics": {"placeholders": {"depth": {"type": "Object"}}},
-  "@divePlanner_quickPlan_bottomTimeSemantics": {"placeholders": {"minutes": {"type": "int"}}},
-  "@divePlanner_quickPlan_minutes": {"placeholders": {"minutes": {"type": "int"}}},
-  "@divePlanner_quickPlan_previewSemantics": {"placeholders": {"depth": {"type": "Object"}, "minutes": {"type": "int"}}},
-  "@divePlanner_quickPlan_previewDescent": {"placeholders": {"depth": {"type": "Object"}}},
-  "@divePlanner_quickPlan_previewBottomTime": {"placeholders": {"minutes": {"type": "int"}}},
-  "@divePlanner_semantics_sacRate": {"placeholders": {"value": {"type": "Object"}, "volumeSymbol": {"type": "Object"}}},
-  "@divePlanner_semantics_reservePressure": {"placeholders": {"pressureSymbol": {"type": "Object"}}},
-  "@divePlanner_semantics_altitudeGroup": {"placeholders": {"group": {"type": "Object"}}},
-  "@diveSites_import_detail_maxDepth": {"placeholders": {"depth": {"type": "Object"}}},
-  "@settings_cloudSync_provider_icloud_subtitle": {"description": "Subtitle of the iCloud provider tile on the Cloud Sync page."},
-  "@settings_debugLog_search_hint": {"description": "Hint text of the search field in the debug log viewer app bar."},
-  "@settings_debugLog_appBar_title": {"description": "App bar title of the debug log viewer page."},
-  "@settings_debugLog_disableDebugMode": {"description": "Overflow menu item that turns debug mode off."},
-  "@settings_debugLog_clearLogs": {"description": "Overflow menu item that erases the log file."},
-  "@settings_debugLog_empty": {"description": "Shown when every log entry is filtered out."},
-  "@settings_debugLog_loadError": {"description": "Shown when the log file cannot be read.", "placeholders": {"error": {"type": "Object"}}},
-  "@settings_debugLog_copiedSnack": {"description": "Snack bar confirming the visible log entries were copied."},
-  "@settings_debugLog_savedSnack": {"description": "Snack bar confirming where the log file was written.", "placeholders": {"path": {"type": "String"}}},
-  "@common_action_copy": {"description": "Generic Copy button label, sibling of common_action_share/save."},
-  "@settings_appearance_customGradient_title": {"description": "Title of the dialog for picking a two-colour card gradient."},
-  "@settings_appearance_customGradient_start": {"description": "Label of the gradient's first (start) colour well."},
-  "@settings_appearance_customGradient_end": {"description": "Label of the gradient's second (end) colour well."},
-  "@settings_appearance_customGradient_hue": {"description": "Label of the HSV hue slider."},
-  "@settings_appearance_customGradient_saturation": {"description": "Label of the HSV saturation slider."},
-  "@settings_appearance_customGradient_brightness": {"description": "Label of the HSV brightness (value) slider."},
-  "@settings_appearance_customGradient_preview": {"description": "Caption under the gradient preview bar."},
-  "@common_action_apply": {"description": "Generic Apply button label, sibling of common_action_save/cancel."},
-  "@settings_cloudSync_message_loadStateFailed": {"description": "Sync status detail when the stored sync state cannot be read.", "placeholders": {"error": {"type": "Object"}}},
-  "@settings_cloudSync_message_noProviderConfigured": {"description": "Sync status detail when no cloud backend has been chosen."},
-  "@settings_cloudSync_message_adopting": {"description": "Sync status detail while the replaced cloud library is being adopted."},
-  "@settings_cloudSync_message_adoptFailed": {"description": "Sync status detail when adopting the replaced cloud library failed."},
-  "@settings_cloudSync_message_firstSyncNeedsConfirm": {"description": "Sync status detail when an automatic sync deferred the first library merge."},
-  "@settings_cloudSync_message_startingSync": {"description": "Sync status detail at the start of a sync run."},
-  "@settings_cloudSync_message_replacePaused": {"description": "Sync status detail when another device replaced the cloud library."},
-  "@settings_cloudSync_message_encryptedPaused": {"description": "Sync status detail when the cloud library needs the encryption passphrase."},
-  "@settings_cloudSync_message_completedWithConflicts": {"description": "Sync status detail after a sync that produced conflicts."},
-  "@settings_cloudSync_message_completedSuccessfully": {"description": "Sync status detail after a clean sync."},
-  "@settings_cloudSync_message_syncFailed": {"description": "Sync status detail when the sync service reported a failure with no message."},
-  "@settings_cloudSync_message_phaseDefault": {"description": "Fallback name for the sync phase named inside settings_cloudSync_message_syncErrorDuring."},
-  "@settings_cloudSync_message_syncErrorDuring": {"description": "Sync status detail when a sync threw. {phase} is the previous, already localized status message.", "placeholders": {"phase": {"type": "String"}, "error": {"type": "Object"}}},
-  "@settings_section_debug_title": {"description": "Settings list row for the debug/diagnostics section."},
-  "@settings_section_debug_subtitle": {"description": "Subtitle of the debug settings row."},
-  "@settings_debugLog_minSeverityLabel": {"description": "Label before the minimum-severity dropdown in the debug log filter bar."},
-  "@settings_debugLog_shareSubject": {"description": "Subject line used when sharing the debug log file."},
-  "@settings_debugLog_saveDialogTitle": {"description": "Title of the system save dialog for the debug log file."},
-  "@universalImport_preset_signatureHeaders": {"description": "Count of CSV headers stored as the preset match signature.", "placeholders": {"count": {"type": "int"}}},
-  "@universalImport_preset_loadFailed": {"description": "Error shown when the saved CSV preset list cannot be read.", "placeholders": {"error": {"type": "String"}}},
-  "@universalImport_preset_deleteConfirm": {"description": "Confirmation body for deleting a user-saved CSV preset.", "placeholders": {"name": {"type": "String"}}},
-  "@universalImport_preset_headersMatched": {"description": "How well the current CSV headers match a preset signature.", "placeholders": {"matched": {"type": "int"}, "total": {"type": "int"}, "percent": {"type": "int"}}},
-  "@universalImport_preset_savedSnackbar": {"description": "Snackbar confirming a CSV column-mapping preset was saved.", "placeholders": {"name": {"type": "String"}}},
-  "@universalImport_counts_new": {"description": "Review bar fragment: how many items will be imported as new.", "placeholders": {"count": {"type": "int"}}},
-  "@universalImport_counts_merging": {"description": "Review bar fragment: how many items will be consolidated into existing records.", "placeholders": {"count": {"type": "int"}}},
-  "@universalImport_counts_replacing": {"description": "Review bar fragment: how many items will replace existing source data.", "placeholders": {"count": {"type": "int"}}},
-  "@universalImport_counts_skipped": {"description": "Review bar fragment: how many items will be skipped.", "placeholders": {"count": {"type": "int"}}},
-  "@universalImport_count_duplicates": {"description": "Header count of duplicate rows in an import review tab.", "placeholders": {"count": {"type": "int"}}},
-  "@diveImport_healthkit_fetchFailedBody": {"description": "Body text shown when reading dives from Apple Health throws.", "placeholders": {"error": {"type": "String"}}},
-  "@diveImport_healthkit_foundDives": {"description": "Result headline after fetching dives from Apple Health.", "placeholders": {"count": {"type": "int"}}},
-  "@importWizard_dc_knownComputerBody": {"description": "Badge body shown when the connected dive computer is already saved in the library.", "placeholders": {"name": {"type": "String"}}},
+  "@maps_regionDownload_minZoom": {
+    "placeholders": {
+      "zoom": {
+        "type": "int"
+      }
+    }
+  },
+  "@maps_regionDownload_minZoomSemantics": {
+    "placeholders": {
+      "zoom": {
+        "type": "int"
+      }
+    }
+  },
+  "@maps_regionDownload_maxZoom": {
+    "placeholders": {
+      "zoom": {
+        "type": "int"
+      }
+    }
+  },
+  "@maps_regionDownload_maxZoomSemantics": {
+    "placeholders": {
+      "zoom": {
+        "type": "int"
+      }
+    }
+  },
+  "@maps_regionDownload_estimateSemantics": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "size": {
+        "type": "Object"
+      }
+    }
+  },
+  "@maps_regionDownload_tileCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@diveLog_map_infoCard_minutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "@trips_gallery_diveSection_subtitle": {
+    "placeholders": {
+      "date": {
+        "type": "Object"
+      },
+      "count": {
+        "type": "int"
+      },
+      "photoLabel": {
+        "type": "Object"
+      }
+    }
+  },
+  "@trips_picker_suggestedSemantics": {
+    "placeholders": {
+      "name": {
+        "type": "Object"
+      }
+    }
+  },
+  "@trips_picker_tileSemantics": {
+    "placeholders": {
+      "name": {
+        "type": "Object"
+      },
+      "startDate": {
+        "type": "Object"
+      },
+      "endDate": {
+        "type": "Object"
+      }
+    }
+  },
+  "@trips_picker_tileSemanticsSelected": {
+    "placeholders": {
+      "name": {
+        "type": "Object"
+      },
+      "startDate": {
+        "type": "Object"
+      },
+      "endDate": {
+        "type": "Object"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_depthSemantics": {
+    "placeholders": {
+      "depth": {
+        "type": "Object"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_bottomTimeSemantics": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_minutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_previewSemantics": {
+    "placeholders": {
+      "depth": {
+        "type": "Object"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_previewDescent": {
+    "placeholders": {
+      "depth": {
+        "type": "Object"
+      }
+    }
+  },
+  "@divePlanner_quickPlan_previewBottomTime": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "@divePlanner_semantics_sacRate": {
+    "placeholders": {
+      "value": {
+        "type": "Object"
+      },
+      "volumeSymbol": {
+        "type": "Object"
+      }
+    }
+  },
+  "@divePlanner_semantics_reservePressure": {
+    "placeholders": {
+      "pressureSymbol": {
+        "type": "Object"
+      }
+    }
+  },
+  "@divePlanner_semantics_altitudeGroup": {
+    "placeholders": {
+      "group": {
+        "type": "Object"
+      }
+    }
+  },
+  "@diveSites_import_detail_maxDepth": {
+    "placeholders": {
+      "depth": {
+        "type": "Object"
+      }
+    }
+  },
+  "@settings_cloudSync_provider_icloud_subtitle": {
+    "description": "Subtitle of the iCloud provider tile on the Cloud Sync page."
+  },
+  "@settings_debugLog_search_hint": {
+    "description": "Hint text of the search field in the debug log viewer app bar."
+  },
+  "@settings_debugLog_appBar_title": {
+    "description": "App bar title of the debug log viewer page."
+  },
+  "@settings_debugLog_disableDebugMode": {
+    "description": "Overflow menu item that turns debug mode off."
+  },
+  "@settings_debugLog_clearLogs": {
+    "description": "Overflow menu item that erases the log file."
+  },
+  "@settings_debugLog_empty": {
+    "description": "Shown when every log entry is filtered out."
+  },
+  "@settings_debugLog_loadError": {
+    "description": "Shown when the log file cannot be read.",
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "@settings_debugLog_copiedSnack": {
+    "description": "Snack bar confirming the visible log entries were copied."
+  },
+  "@settings_debugLog_savedSnack": {
+    "description": "Snack bar confirming where the log file was written.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "@common_action_copy": {
+    "description": "Generic Copy button label, sibling of common_action_share/save."
+  },
+  "@settings_appearance_customGradient_title": {
+    "description": "Title of the dialog for picking a two-colour card gradient."
+  },
+  "@settings_appearance_customGradient_start": {
+    "description": "Label of the gradient's first (start) colour well."
+  },
+  "@settings_appearance_customGradient_end": {
+    "description": "Label of the gradient's second (end) colour well."
+  },
+  "@settings_appearance_customGradient_hue": {
+    "description": "Label of the HSV hue slider."
+  },
+  "@settings_appearance_customGradient_saturation": {
+    "description": "Label of the HSV saturation slider."
+  },
+  "@settings_appearance_customGradient_brightness": {
+    "description": "Label of the HSV brightness (value) slider."
+  },
+  "@settings_appearance_customGradient_preview": {
+    "description": "Caption under the gradient preview bar."
+  },
+  "@common_action_apply": {
+    "description": "Generic Apply button label, sibling of common_action_save/cancel."
+  },
+  "@settings_cloudSync_message_loadStateFailed": {
+    "description": "Sync status detail when the stored sync state cannot be read.",
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "@settings_cloudSync_message_noProviderConfigured": {
+    "description": "Sync status detail when no cloud backend has been chosen."
+  },
+  "@settings_cloudSync_message_adopting": {
+    "description": "Sync status detail while the replaced cloud library is being adopted."
+  },
+  "@settings_cloudSync_message_adoptFailed": {
+    "description": "Sync status detail when adopting the replaced cloud library failed."
+  },
+  "@settings_cloudSync_message_firstSyncNeedsConfirm": {
+    "description": "Sync status detail when an automatic sync deferred the first library merge."
+  },
+  "@settings_cloudSync_message_startingSync": {
+    "description": "Sync status detail at the start of a sync run."
+  },
+  "@settings_cloudSync_message_replacePaused": {
+    "description": "Sync status detail when another device replaced the cloud library."
+  },
+  "@settings_cloudSync_message_encryptedPaused": {
+    "description": "Sync status detail when the cloud library needs the encryption passphrase."
+  },
+  "@settings_cloudSync_message_completedWithConflicts": {
+    "description": "Sync status detail after a sync that produced conflicts."
+  },
+  "@settings_cloudSync_message_completedSuccessfully": {
+    "description": "Sync status detail after a clean sync."
+  },
+  "@settings_cloudSync_message_syncFailed": {
+    "description": "Sync status detail when the sync service reported a failure with no message."
+  },
+  "@settings_cloudSync_message_phaseDefault": {
+    "description": "Fallback name for the sync phase named inside settings_cloudSync_message_syncErrorDuring."
+  },
+  "@settings_cloudSync_message_syncErrorDuring": {
+    "description": "Sync status detail when a sync threw. {phase} is the previous, already localized status message.",
+    "placeholders": {
+      "phase": {
+        "type": "String"
+      },
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "@settings_section_debug_title": {
+    "description": "Settings list row for the debug/diagnostics section."
+  },
+  "@settings_section_debug_subtitle": {
+    "description": "Subtitle of the debug settings row."
+  },
+  "@settings_debugLog_minSeverityLabel": {
+    "description": "Label before the minimum-severity dropdown in the debug log filter bar."
+  },
+  "@settings_debugLog_shareSubject": {
+    "description": "Subject line used when sharing the debug log file."
+  },
+  "@settings_debugLog_saveDialogTitle": {
+    "description": "Title of the system save dialog for the debug log file."
+  },
+  "@universalImport_preset_signatureHeaders": {
+    "description": "Count of CSV headers stored as the preset match signature.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_preset_loadFailed": {
+    "description": "Error shown when the saved CSV preset list cannot be read.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@universalImport_preset_deleteConfirm": {
+    "description": "Confirmation body for deleting a user-saved CSV preset.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@universalImport_preset_headersMatched": {
+    "description": "How well the current CSV headers match a preset signature.",
+    "placeholders": {
+      "matched": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      },
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_preset_savedSnackbar": {
+    "description": "Snackbar confirming a CSV column-mapping preset was saved.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@universalImport_counts_new": {
+    "description": "Review bar fragment: how many items will be imported as new.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_counts_merging": {
+    "description": "Review bar fragment: how many items will be consolidated into existing records.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_counts_replacing": {
+    "description": "Review bar fragment: how many items will replace existing source data.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_counts_skipped": {
+    "description": "Review bar fragment: how many items will be skipped.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@universalImport_count_duplicates": {
+    "description": "Header count of duplicate rows in an import review tab.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@diveImport_healthkit_fetchFailedBody": {
+    "description": "Body text shown when reading dives from Apple Health throws.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveImport_healthkit_foundDives": {
+    "description": "Result headline after fetching dives from Apple Health.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@importWizard_dc_knownComputerBody": {
+    "description": "Badge body shown when the connected dive computer is already saved in the library.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "accessibility_shortcut_switchDiver": "Switch diver",
   "lock_recoveryCode_title": "Use recovery code",
   "lock_recoveryCode_body": "Enter the 8-word recovery code you saved when you set up the app password.",
@@ -19262,72 +20596,335 @@
   "diveLog_detail_errorLoadingSignature": "Error loading signature: {error}",
   "diveLog_profilePanel_selectDive": "Select a dive to view its profile",
   "diveLog_profilePanel_noProfileData": "No profile data for this dive",
-  "@lock_startFresh_body": {"description": "Body of the start-fresh confirmation dialog. {token} is the untranslated ASCII confirmation word the diver must type.", "placeholders": {"token": {"type": "Object", "example": "START FRESH"}}},
-  "@startup_migrating_progress": {"description": "Splash progress line during a schema migration", "placeholders": {"currentStep": {"type": "Object", "example": "3"}, "totalSteps": {"type": "Object", "example": "12"}}},
-  "@startup_recovery_sqliteCode": {"description": "Diagnostic line under the recovery screen. Object, not int, so the raw SQLite extended result code is never group-separated.", "placeholders": {"code": {"type": "Object", "example": "1032"}}},
-  "@startup_versionMismatch_body": {"description": "Explains a database written by a newer app build. Object, not int, so schema numbers are never group-separated.", "placeholders": {"databaseVersion": {"type": "Object", "example": "142"}, "appVersion": {"type": "Object", "example": "138"}}},
-  "@startup_error_title": {"description": "Terminal startup screen title when the failure could not be classified. Deliberately neutral: it must NOT claim the database upgrade failed, since most failures reach this screen without a migration having been attempted."},
-  "@startup_error_body": {"description": "Body for an unclassified terminal startup failure."},
-  "@startup_engineUnavailable_title": {"description": "Terminal startup screen title when the app's native database engine is missing or is not a SQLCipher build. The diver's database was never opened."},
-  "@startup_engineUnavailable_body": {"description": "Explains that an engine failure happens before the database is opened, so no dive data is at risk."},
-  "@startup_engineUnavailable_guidance": {"description": "Tells the diver that reinstalling or restoring cannot fix a broken app package, and asks them to report it."},
-  "@startup_migrationFailed_title": {"description": "Terminal startup screen title when the schema upgrade ladder genuinely failed. This is the ONLY class that may say the upgrade failed."},
-  "@startup_migrationFailed_body": {"description": "Explains a failed schema upgrade and points at the pre-migration safety copy."},
-  "@startup_dataUnreadable_title": {"description": "Terminal startup screen title when the database file was reached but is corrupt or unreadable."},
-  "@startup_dataUnreadable_body": {"description": "Explains a damaged database file and points at restoring a backup."},
-  "@startup_databaseBusy_title": {"description": "Terminal startup screen title when another connection held the database lock. Must NOT imply damage: the write never started."},
-  "@startup_databaseBusy_body": {"description": "Explains a lock, reassures that nothing was written, and gives the one action that fixes it: fully close and reopen the app."},
-  "@startup_failure_technicalDetails": {"description": "Label above the raw error text on the terminal startup failure screen."},
-  "@startup_failure_backupAvailable_title": {"description": "Heading of the recovery card offering a backup found on disk during a failed startup."},
-  "@startup_failure_backupAvailable_taken": {"description": "When the offered backup was taken.", "placeholders": {"timestamp": {"type": "Object", "example": "17 Aug 2026 12:00"}}},
-  "@startup_failure_backupAvailable_preMigration": {"description": "Extra line shown when the offered backup is the automatic pre-migration safety copy. Object, not int, so schema numbers are never group-separated.", "placeholders": {"fromVersion": {"type": "Object", "example": "141"}, "toVersion": {"type": "Object", "example": "142"}}},
-  "@startup_failure_restoreAction": {"description": "Button that swaps the offered backup in for the live database and restarts startup."},
-  "@startup_failure_restoring": {"description": "Progress label while the offered backup is being restored."},
-  "@startup_failure_restoreFailed": {"description": "Shown when the restore failed. Reassures the diver that the live database was rolled back untouched."},
-  "@startup_failure_backupsFolder": {"description": "Label before the filesystem path where backups are kept."},
-  "@startup_failure_showBackupsFolder": {"description": "Desktop-only button that opens the backups folder in the system file manager."},
-  "@startup_failure_downgrade_title": {"description": "Heading of the guided-downgrade section on a failed schema upgrade."},
-  "@startup_failure_downgrade_body": {"description": "Explains how to go back to the previous app version, and why Submersion never downgrades itself."},
-  "@startup_failure_downgrade_action": {"description": "Button opening the app's releases page so the diver can pick the previous version."},
-  "@universalImport_compare_sameFields": {"description": "Summary line listing the fields that match between the existing and incoming dive.", "placeholders": {"fields": {"type": "Object", "example": "date/time, max depth, duration"}}},
-  "@universalImport_compare_serial": {"description": "Dive computer serial number in a compact label", "placeholders": {"serial": {"type": "Object", "example": "A1B2C3"}}},
-  "@diveLog_tooltip_ndlOverMax": {"description": "Profile readout NDL value when the no-decompression limit is longer than the chart tracks (over one hour). NDL is a diving acronym and is not translated."},
-  "@diveLog_tooltip_interpolated": {"description": "Profile readout value carried over from the first sample rather than measured at the surface lead-in.", "placeholders": {"value": {"type": "String", "example": "21.5 C"}}},
-  "@enum_profileMetric_ascentRate_short": {"description": "Short form of the ascent-rate metric, shown on the chart axis."},
-  "@enum_profileMetric_cns_short": {"description": "Short form of the CNS metric, shown on the chart axis. Not translated."},
-  "@enum_profileMetric_otu_short": {"description": "Short form of the OTU metric, shown on the chart axis. Not translated."},
-  "@diveLog_profileEditor_depthPlusOneMeter": {"description": "Profile editor button: shift the selected segment 1 metre shallower. The shift is always exactly one metre because dive profiles are stored in metres, so keep the metric unit in the translation."},
-  "@diveLog_profileEditor_depthMinusOneMeter": {"description": "Profile editor button: shift the selected segment 1 metre deeper. The shift is always exactly one metre, so keep the metric unit."},
-  "@diveLog_profileEditor_smoothLight": {"description": "Profile editor smoothing strength: the weakest setting."},
-  "@diveLog_profileEditor_smoothMedium": {"description": "Profile editor smoothing strength: the middle setting."},
-  "@diveLog_profileEditor_smoothHeavy": {"description": "Profile editor smoothing strength: the strongest setting."},
-  "@diveLog_profileEditor_outliersDetected": {"description": "Number of suspect depth samples the profile editor found.", "placeholders": {"count": {"type": "int"}}},
-  "@diveLog_profileEditor_clearWaypoints": {"description": "Profile editor button: remove every drawn waypoint."},
-  "@diveLog_profileEditor_mode_smooth": {"description": "Profile editor mode and range action: smooth the depth curve."},
-  "@diveLog_profileEditor_saveFailed": {"description": "Snackbar shown when saving an edited dive profile fails.", "placeholders": {"error": {"type": "String"}}},
-  "@diveLog_profileEditor_errorLoadingDive": {"description": "Shown when the dive being edited cannot be loaded.", "placeholders": {"error": {"type": "String"}}},
-  "@diveLog_profileEditor_undo": {"description": "Tooltip for the profile editor's undo button."},
-  "@diveLog_profileEditor_mode_select": {"description": "Profile editor mode: select a range of the depth curve."},
-  "@diveLog_profileEditor_mode_outlier": {"description": "Profile editor mode: find and remove suspect depth samples."},
-  "@diveLog_profileEditor_mode_draw": {"description": "Profile editor mode: draw the depth curve by placing waypoints."},
-  "@diveLog_profileEditor_mode_trim": {"description": "Profile editor mode: trim samples off the ends of the profile."},
-  "@diveLog_sources_sectionTitle": {"description": "Header of the dive-detail section listing where a dive's data came from (dive computers, imported files, manual entry).", "placeholders": {"count": {"type": "int"}}},
-  "@diveLog_sources_badge_manual": {"description": "Badge on a dive whose data was typed in rather than downloaded."},
-  "@diveLog_sources_badge_viewing": {"description": "Badge on the data source currently being previewed on the chart."},
-  "@diveLog_sources_badge_secondary": {"description": "Badge on a data source that is not the dive's primary source."},
-  "@diveLog_sources_created": {"description": "When a manually entered dive record was created.", "placeholders": {"date": {"type": "String", "example": "12 Mar 2026"}}},
-  "@diveLog_sources_detail_serial": {"description": "Serial number of the dive computer a dive was downloaded from."},
-  "@diveLog_sources_detail_format": {"description": "File format a dive was imported from, e.g. UDDF or DL7."},
-  "@diveLog_sources_detail_imported": {"description": "Date a dive's data was imported into the app."},
-  "@diveLog_detail_semantics_viewDiveComputer": {"description": "Screen-reader label for the row that opens a linked dive computer.", "placeholders": {"name": {"type": "String", "example": "Perdix 2"}}},
-  "@diveLog_detail_semantics_viewTrip": {"description": "Screen-reader label for the row that opens the dive's trip.", "placeholders": {"name": {"type": "String", "example": "Red Sea 2026"}}},
-  "@diveLog_detail_semantics_viewDiveCenter": {"description": "Screen-reader label for the row that opens the dive's dive center.", "placeholders": {"name": {"type": "String"}}},
-  "@diveLog_detail_semantics_viewSpecies": {"description": "Screen-reader label for a marine life sighting that opens the species page. Uses the same localized species name shown on screen.", "placeholders": {"name": {"type": "String", "example": "Whale Shark"}}},
-  "@diveLog_detail_semantics_viewCourse": {"description": "Screen-reader label for the chip that opens the dive's course.", "placeholders": {"name": {"type": "String"}}},
-  "@diveLog_detail_serialNumber": {"description": "Serial number of the dive computer, shown under its name.", "placeholders": {"serial": {"type": "String", "example": "12345678"}}},
-  "@diveLog_detail_errorLoadingSignature": {"description": "Shown when the instructor signature attached to a dive fails to load.", "placeholders": {"error": {"type": "String"}}},
-  "@diveLog_profilePanel_selectDive": {"description": "Placeholder in the profile panel when no dive is highlighted."},
-  "@diveLog_profilePanel_noProfileData": {"description": "Placeholder in the profile panel when the highlighted dive has no depth samples."},
+  "@lock_startFresh_body": {
+    "description": "Body of the start-fresh confirmation dialog. {token} is the untranslated ASCII confirmation word the diver must type.",
+    "placeholders": {
+      "token": {
+        "type": "Object",
+        "example": "START FRESH"
+      }
+    }
+  },
+  "@startup_migrating_progress": {
+    "description": "Splash progress line during a schema migration",
+    "placeholders": {
+      "currentStep": {
+        "type": "Object",
+        "example": "3"
+      },
+      "totalSteps": {
+        "type": "Object",
+        "example": "12"
+      }
+    }
+  },
+  "@startup_recovery_sqliteCode": {
+    "description": "Diagnostic line under the recovery screen. Object, not int, so the raw SQLite extended result code is never group-separated.",
+    "placeholders": {
+      "code": {
+        "type": "Object",
+        "example": "1032"
+      }
+    }
+  },
+  "@startup_versionMismatch_body": {
+    "description": "Explains a database written by a newer app build. Object, not int, so schema numbers are never group-separated.",
+    "placeholders": {
+      "databaseVersion": {
+        "type": "Object",
+        "example": "142"
+      },
+      "appVersion": {
+        "type": "Object",
+        "example": "138"
+      }
+    }
+  },
+  "@startup_error_title": {
+    "description": "Terminal startup screen title when the failure could not be classified. Deliberately neutral: it must NOT claim the database upgrade failed, since most failures reach this screen without a migration having been attempted."
+  },
+  "@startup_error_body": {
+    "description": "Body for an unclassified terminal startup failure."
+  },
+  "@startup_engineUnavailable_title": {
+    "description": "Terminal startup screen title when the app's native database engine is missing or is not a SQLCipher build. The diver's database was never opened."
+  },
+  "@startup_engineUnavailable_body": {
+    "description": "Explains that an engine failure happens before the database is opened, so no dive data is at risk."
+  },
+  "@startup_engineUnavailable_guidance": {
+    "description": "Tells the diver that reinstalling or restoring cannot fix a broken app package, and asks them to report it."
+  },
+  "@startup_migrationFailed_title": {
+    "description": "Terminal startup screen title when the schema upgrade ladder genuinely failed. This is the ONLY class that may say the upgrade failed."
+  },
+  "@startup_migrationFailed_body": {
+    "description": "Explains a failed schema upgrade and points at the pre-migration safety copy."
+  },
+  "@startup_dataUnreadable_title": {
+    "description": "Terminal startup screen title when the database file was reached but is corrupt or unreadable."
+  },
+  "@startup_dataUnreadable_body": {
+    "description": "Explains a damaged database file and points at restoring a backup."
+  },
+  "@startup_databaseBusy_title": {
+    "description": "Terminal startup screen title when another connection held the database lock. Must NOT imply damage: the write never started."
+  },
+  "@startup_databaseBusy_body": {
+    "description": "Explains a lock, reassures that nothing was written, and gives the one action that fixes it: fully close and reopen the app."
+  },
+  "@startup_failure_technicalDetails": {
+    "description": "Label above the raw error text on the terminal startup failure screen."
+  },
+  "@startup_failure_backupAvailable_title": {
+    "description": "Heading of the recovery card offering a backup found on disk during a failed startup."
+  },
+  "@startup_failure_backupAvailable_taken": {
+    "description": "When the offered backup was taken.",
+    "placeholders": {
+      "timestamp": {
+        "type": "Object",
+        "example": "17 Aug 2026 12:00"
+      }
+    }
+  },
+  "@startup_failure_backupAvailable_preMigration": {
+    "description": "Extra line shown when the offered backup is the automatic pre-migration safety copy. Object, not int, so schema numbers are never group-separated.",
+    "placeholders": {
+      "fromVersion": {
+        "type": "Object",
+        "example": "141"
+      },
+      "toVersion": {
+        "type": "Object",
+        "example": "142"
+      }
+    }
+  },
+  "@startup_failure_restoreAction": {
+    "description": "Button that swaps the offered backup in for the live database and restarts startup."
+  },
+  "@startup_failure_restoring": {
+    "description": "Progress label while the offered backup is being restored."
+  },
+  "@startup_failure_restoreFailed": {
+    "description": "Shown when the restore failed. Reassures the diver that the live database was rolled back untouched."
+  },
+  "@startup_failure_backupsFolder": {
+    "description": "Label before the filesystem path where backups are kept."
+  },
+  "@startup_failure_showBackupsFolder": {
+    "description": "Desktop-only button that opens the backups folder in the system file manager."
+  },
+  "@startup_failure_downgrade_title": {
+    "description": "Heading of the guided-downgrade section on a failed schema upgrade."
+  },
+  "@startup_failure_downgrade_body": {
+    "description": "Explains how to go back to the previous app version, and why Submersion never downgrades itself."
+  },
+  "@startup_failure_downgrade_action": {
+    "description": "Button opening the app's releases page so the diver can pick the previous version."
+  },
+  "@universalImport_compare_sameFields": {
+    "description": "Summary line listing the fields that match between the existing and incoming dive.",
+    "placeholders": {
+      "fields": {
+        "type": "Object",
+        "example": "date/time, max depth, duration"
+      }
+    }
+  },
+  "@universalImport_compare_serial": {
+    "description": "Dive computer serial number in a compact label",
+    "placeholders": {
+      "serial": {
+        "type": "Object",
+        "example": "A1B2C3"
+      }
+    }
+  },
+  "@diveLog_tooltip_ndlOverMax": {
+    "description": "Profile readout NDL value when the no-decompression limit is longer than the chart tracks (over one hour). NDL is a diving acronym and is not translated."
+  },
+  "@diveLog_tooltip_interpolated": {
+    "description": "Profile readout value carried over from the first sample rather than measured at the surface lead-in.",
+    "placeholders": {
+      "value": {
+        "type": "String",
+        "example": "21.5 C"
+      }
+    }
+  },
+  "@enum_profileMetric_ascentRate_short": {
+    "description": "Short form of the ascent-rate metric, shown on the chart axis."
+  },
+  "@enum_profileMetric_cns_short": {
+    "description": "Short form of the CNS metric, shown on the chart axis. Not translated."
+  },
+  "@enum_profileMetric_otu_short": {
+    "description": "Short form of the OTU metric, shown on the chart axis. Not translated."
+  },
+  "@diveLog_profileEditor_depthPlusOneMeter": {
+    "description": "Profile editor button: shift the selected segment 1 metre shallower. The shift is always exactly one metre because dive profiles are stored in metres, so keep the metric unit in the translation."
+  },
+  "@diveLog_profileEditor_depthMinusOneMeter": {
+    "description": "Profile editor button: shift the selected segment 1 metre deeper. The shift is always exactly one metre, so keep the metric unit."
+  },
+  "@diveLog_profileEditor_smoothLight": {
+    "description": "Profile editor smoothing strength: the weakest setting."
+  },
+  "@diveLog_profileEditor_smoothMedium": {
+    "description": "Profile editor smoothing strength: the middle setting."
+  },
+  "@diveLog_profileEditor_smoothHeavy": {
+    "description": "Profile editor smoothing strength: the strongest setting."
+  },
+  "@diveLog_profileEditor_outliersDetected": {
+    "description": "Number of suspect depth samples the profile editor found.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@diveLog_profileEditor_clearWaypoints": {
+    "description": "Profile editor button: remove every drawn waypoint."
+  },
+  "@diveLog_profileEditor_mode_smooth": {
+    "description": "Profile editor mode and range action: smooth the depth curve."
+  },
+  "@diveLog_profileEditor_saveFailed": {
+    "description": "Snackbar shown when saving an edited dive profile fails.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_profileEditor_errorLoadingDive": {
+    "description": "Shown when the dive being edited cannot be loaded.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_profileEditor_undo": {
+    "description": "Tooltip for the profile editor's undo button."
+  },
+  "@diveLog_profileEditor_mode_select": {
+    "description": "Profile editor mode: select a range of the depth curve."
+  },
+  "@diveLog_profileEditor_mode_outlier": {
+    "description": "Profile editor mode: find and remove suspect depth samples."
+  },
+  "@diveLog_profileEditor_mode_draw": {
+    "description": "Profile editor mode: draw the depth curve by placing waypoints."
+  },
+  "@diveLog_profileEditor_mode_trim": {
+    "description": "Profile editor mode: trim samples off the ends of the profile."
+  },
+  "@diveLog_sources_sectionTitle": {
+    "description": "Header of the dive-detail section listing where a dive's data came from (dive computers, imported files, manual entry).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@diveLog_sources_badge_manual": {
+    "description": "Badge on a dive whose data was typed in rather than downloaded."
+  },
+  "@diveLog_sources_badge_viewing": {
+    "description": "Badge on the data source currently being previewed on the chart."
+  },
+  "@diveLog_sources_badge_secondary": {
+    "description": "Badge on a data source that is not the dive's primary source."
+  },
+  "@diveLog_sources_created": {
+    "description": "When a manually entered dive record was created.",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "12 Mar 2026"
+      }
+    }
+  },
+  "@diveLog_sources_detail_serial": {
+    "description": "Serial number of the dive computer a dive was downloaded from."
+  },
+  "@diveLog_sources_detail_format": {
+    "description": "File format a dive was imported from, e.g. UDDF or DL7."
+  },
+  "@diveLog_sources_detail_imported": {
+    "description": "Date a dive's data was imported into the app."
+  },
+  "@diveLog_detail_semantics_viewDiveComputer": {
+    "description": "Screen-reader label for the row that opens a linked dive computer.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Perdix 2"
+      }
+    }
+  },
+  "@diveLog_detail_semantics_viewTrip": {
+    "description": "Screen-reader label for the row that opens the dive's trip.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Red Sea 2026"
+      }
+    }
+  },
+  "@diveLog_detail_semantics_viewDiveCenter": {
+    "description": "Screen-reader label for the row that opens the dive's dive center.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_detail_semantics_viewSpecies": {
+    "description": "Screen-reader label for a marine life sighting that opens the species page. Uses the same localized species name shown on screen.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Whale Shark"
+      }
+    }
+  },
+  "@diveLog_detail_semantics_viewCourse": {
+    "description": "Screen-reader label for the chip that opens the dive's course.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_detail_serialNumber": {
+    "description": "Serial number of the dive computer, shown under its name.",
+    "placeholders": {
+      "serial": {
+        "type": "String",
+        "example": "12345678"
+      }
+    }
+  },
+  "@diveLog_detail_errorLoadingSignature": {
+    "description": "Shown when the instructor signature attached to a dive fails to load.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_profilePanel_selectDive": {
+    "description": "Placeholder in the profile panel when no dive is highlighted."
+  },
+  "@diveLog_profilePanel_noProfileData": {
+    "description": "Placeholder in the profile panel when the highlighted dive has no depth samples."
+  },
   "settings_export_progress_divesCsv": "Exporting dives to CSV...",
   "settings_export_progress_sitesCsv": "Exporting sites to CSV...",
   "settings_export_progress_equipmentCsv": "Exporting equipment to CSV...",
@@ -19436,33 +21033,234 @@
   "settings_cloudSync_launchCheck_updatesAvailable": "Updates available from cloud",
   "settings_cloudSync_launchCheck_upToDate": "Everything is up to date",
   "settings_cloudSync_launchCheck_failed": "Sync check failed: {error}",
-  "@settings_export_progress_templatePdf": {"placeholders": {"template": {"type": "String"}}},
-  "@settings_export_saveFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_export_backupFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_export_restoreFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_export_success_kml": {"placeholders": {"count": {"type": "int"}}},
-  "@settings_export_saved_kml": {"placeholders": {"count": {"type": "int"}}},
-  "@backup_operation_created": {"placeholders": {"size": {"type": "String"}}},
-  "@backup_operation_backupFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@backup_operation_restoreFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@backup_operation_deleteFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@backup_operation_exported": {"placeholders": {"size": {"type": "String"}}},
-  "@backup_operation_exportFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@backup_operation_upgrading": {"placeholders": {"step": {"type": "int"}, "total": {"type": "int"}}},
-  "@backup_restore_dialog_counts": {"placeholders": {"diveCount": {"type": "int"}, "siteCount": {"type": "int"}}},
-  "@backup_restore_preMigration_incompleteMetadata": {"placeholders": {"timestamp": {"type": "String"}, "appVersion": {"type": "String"}}},
-  "@backup_restore_preMigration_newerApp": {"placeholders": {"timestamp": {"type": "String"}, "appVersion": {"type": "String"}, "fromVersion": {"type": "int"}}},
-  "@backup_restore_preMigration_safe": {"placeholders": {"timestamp": {"type": "String"}, "appVersion": {"type": "String"}, "fromVersion": {"type": "int"}, "toVersion": {"type": "int"}}},
-  "@backup_restore_preMigration_warning": {"placeholders": {"timestamp": {"type": "String"}, "appVersion": {"type": "String"}, "fromVersion": {"type": "int"}, "toVersion": {"type": "int"}, "currentVersion": {"type": "int"}}},
-  "@settings_cloudSync_progress_uploadingLibrary": {"placeholders": {"uploaded": {"type": "int"}, "total": {"type": "int"}}},
-  "@settings_cloudSync_result_rebuildFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_cloudSync_result_libraryReplaceFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_cloudSync_result_adoptFailed": {"placeholders": {"error": {"type": "String"}}},
-  "@settings_cloudSync_result_recordsFailed": {"placeholders": {"count": {"type": "int"}}},
-  "@settings_cloudSync_launchCheck_unavailable": {"placeholders": {"provider": {"type": "String"}}},
-  "@settings_cloudSync_launchCheck_notSignedIn": {"placeholders": {"provider": {"type": "String"}}},
-  "@settings_cloudSync_launchCheck_localChanges": {"placeholders": {"count": {"type": "int"}}},
-  "@settings_cloudSync_launchCheck_failed": {"placeholders": {"error": {"type": "String"}}},
+  "@settings_export_progress_templatePdf": {
+    "placeholders": {
+      "template": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_export_saveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_export_backupFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_export_restoreFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_export_success_kml": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_export_saved_kml": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@backup_operation_created": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_backupFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_restoreFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_deleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_exported": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_exportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_operation_upgrading": {
+    "placeholders": {
+      "step": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@backup_restore_dialog_counts": {
+    "placeholders": {
+      "diveCount": {
+        "type": "int"
+      },
+      "siteCount": {
+        "type": "int"
+      }
+    }
+  },
+  "@backup_restore_preMigration_incompleteMetadata": {
+    "placeholders": {
+      "timestamp": {
+        "type": "String"
+      },
+      "appVersion": {
+        "type": "String"
+      }
+    }
+  },
+  "@backup_restore_preMigration_newerApp": {
+    "placeholders": {
+      "timestamp": {
+        "type": "String"
+      },
+      "appVersion": {
+        "type": "String"
+      },
+      "fromVersion": {
+        "type": "int"
+      }
+    }
+  },
+  "@backup_restore_preMigration_safe": {
+    "placeholders": {
+      "timestamp": {
+        "type": "String"
+      },
+      "appVersion": {
+        "type": "String"
+      },
+      "fromVersion": {
+        "type": "int"
+      },
+      "toVersion": {
+        "type": "int"
+      }
+    }
+  },
+  "@backup_restore_preMigration_warning": {
+    "placeholders": {
+      "timestamp": {
+        "type": "String"
+      },
+      "appVersion": {
+        "type": "String"
+      },
+      "fromVersion": {
+        "type": "int"
+      },
+      "toVersion": {
+        "type": "int"
+      },
+      "currentVersion": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_progress_uploadingLibrary": {
+    "placeholders": {
+      "uploaded": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_result_rebuildFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_cloudSync_result_libraryReplaceFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_cloudSync_result_adoptFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_cloudSync_result_recordsFailed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_launchCheck_unavailable": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_cloudSync_launchCheck_notSignedIn": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_cloudSync_launchCheck_localChanges": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_launchCheck_failed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "diveLog_detail_viewMap": "Map",
   "@diveLog_detail_viewMap": {},
   "diveLog_detail_view3d": "3D",
@@ -19503,11 +21301,17 @@
     }
   },
   "media_timeInDive_label": "Time in dive",
-  "@media_timeInDive_label": {"description": "Media info row label and Set-time dialog title: the moment in the dive a media item was taken."},
+  "@media_timeInDive_label": {
+    "description": "Media info row label and Set-time dialog title: the moment in the dive a media item was taken."
+  },
   "media_timeInDive_unknown": "Time in dive unknown",
-  "@media_timeInDive_unknown": {"description": "Viewer chip shown when a media item's capture time falls outside its dive; tapping it opens the Set-time dialog."},
+  "@media_timeInDive_unknown": {
+    "description": "Viewer chip shown when a media item's capture time falls outside its dive; tapping it opens the Set-time dialog."
+  },
   "media_timeInDive_setAction": "Set time in dive",
-  "@media_timeInDive_setAction": {"description": "Button and tooltip that opens the dialog to pin a media item to a moment in the dive."},
+  "@media_timeInDive_setAction": {
+    "description": "Button and tooltip that opens the dialog to pin a media item to a moment in the dive."
+  },
   "media_timeInDive_manual": "{time} (set manually)",
   "@media_timeInDive_manual": {
     "description": "Media info row value for a position the diver set themselves; {time} is a minutes:seconds offset.",
@@ -19518,9 +21322,13 @@
     }
   },
   "media_timeInDive_fieldLabel": "Time from dive start",
-  "@media_timeInDive_fieldLabel": {"description": "Set-time dialog: label of the minutes:seconds field."},
+  "@media_timeInDive_fieldLabel": {
+    "description": "Set-time dialog: label of the minutes:seconds field."
+  },
   "media_timeInDive_fieldHint": "mm:ss",
-  "@media_timeInDive_fieldHint": {"description": "Set-time dialog: placeholder showing the minutes:seconds format."},
+  "@media_timeInDive_fieldHint": {
+    "description": "Set-time dialog: placeholder showing the minutes:seconds format."
+  },
   "media_timeInDive_range": "Between 0:00 and {max}",
   "@media_timeInDive_range": {
     "description": "Set-time dialog: helper text under the field; {max} is the dive length as minutes:seconds.",
@@ -19540,11 +21348,17 @@
     }
   },
   "media_timeInDive_save": "Save",
-  "@media_timeInDive_save": {"description": "Set-time dialog: confirm button."},
+  "@media_timeInDive_save": {
+    "description": "Set-time dialog: confirm button."
+  },
   "media_timeInDive_cancel": "Cancel",
-  "@media_timeInDive_cancel": {"description": "Set-time dialog: dismiss button."},
+  "@media_timeInDive_cancel": {
+    "description": "Set-time dialog: dismiss button."
+  },
   "media_timeInDive_reset": "Reset to automatic",
-  "@media_timeInDive_reset": {"description": "Set-time dialog: button that removes the diver's pin so the position derives from the capture time again."},
+  "@media_timeInDive_reset": {
+    "description": "Set-time dialog: button that removes the diver's pin so the position derives from the capture time again."
+  },
   "media_info_backupSection": "Backup",
   "media_info_store": "Cloud store",
   "media_info_storeNotConnected": "No cloud store connected",
@@ -19661,15 +21475,45 @@
   "settings_dataSources_appleHealth_dataTypeWaterTemp": "Water Temperature - water temperature samples recorded during dives",
   "settings_dataSources_appleHealth_permissionManagedInHealth": "HealthKit access is managed in the Health app",
   "settings_dataSources_appleHealth_permissionUnsupported": "HealthKit is not available on this device",
-  "@diveImport_healthkit_accessGrantedHint": {"description": "Hint under the HealthKit access headline explaining that iOS will not confirm read access."},
-  "@diveImport_healthkit_foundNoDivesHint": {"description": "Hint shown when a HealthKit fetch returned zero dives."},
-  "@settings_dataSources_appleHealth_dataTypeDepth": {"description": "HealthKit data type disclosure: underwater depth."},
-  "@settings_dataSources_appleHealth_dataTypeWaterTemp": {"description": "HealthKit data type disclosure: water temperature."},
-  "@settings_dataSources_appleHealth_permissionManagedInHealth": {"description": "Permission row shown when the platform will not disclose read access."},
-  "@settings_dataSources_appleHealth_permissionUnsupported": {"description": "Permission row shown when HealthKit is unavailable on this device."},
-  "@settings_units_gasConsumption_sac_subtitle": {"placeholders": {"unit": {"type": "String"}}},
-  "@settings_units_gasConsumption_rmv_subtitle": {"placeholders": {"unit": {"type": "String"}}},
-  "@diveLog_detail_sacVolumeHint": {"placeholders": {"unit": {"type": "String"}}},
+  "@diveImport_healthkit_accessGrantedHint": {
+    "description": "Hint under the HealthKit access headline explaining that iOS will not confirm read access."
+  },
+  "@diveImport_healthkit_foundNoDivesHint": {
+    "description": "Hint shown when a HealthKit fetch returned zero dives."
+  },
+  "@settings_dataSources_appleHealth_dataTypeDepth": {
+    "description": "HealthKit data type disclosure: underwater depth."
+  },
+  "@settings_dataSources_appleHealth_dataTypeWaterTemp": {
+    "description": "HealthKit data type disclosure: water temperature."
+  },
+  "@settings_dataSources_appleHealth_permissionManagedInHealth": {
+    "description": "Permission row shown when the platform will not disclose read access."
+  },
+  "@settings_dataSources_appleHealth_permissionUnsupported": {
+    "description": "Permission row shown when HealthKit is unavailable on this device."
+  },
+  "@settings_units_gasConsumption_sac_subtitle": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "@settings_units_gasConsumption_rmv_subtitle": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "@diveLog_detail_sacVolumeHint": {
+    "placeholders": {
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
   "statistics_trend_aggregation_monthly": "Monthly average",
   "statistics_trend_aggregation_perDive": "Every dive",
   "statistics_trend_aggregation_tooltip": "How dives are grouped",
@@ -19693,5 +21537,54 @@
   "diveLog_filter_presetLast5Years": "Last 5 years",
   "diveLog_filter_presetLast10Years": "Last 10 years",
   "statistics_trend_tooltip_lowest": "Lowest",
-  "statistics_trend_tooltip_highest": "Highest"
+  "statistics_trend_tooltip_highest": "Highest",
+  "diveLog_edit_excludeFromStats": "Exclude from statistics",
+  "@diveLog_edit_excludeFromStats": {
+    "description": "Checkbox: exclude this dive from all statistics"
+  },
+  "diveLog_edit_excludeFromStatsHelp": "Keep this dive in your logbook, but leave it out of every statistic, including your dive count.",
+  "@diveLog_edit_excludeFromStatsHelp": {
+    "description": "Help text under the exclude-from-statistics checkbox"
+  },
+  "diveLog_edit_excludeFromGasStats": "Exclude from gas statistics",
+  "@diveLog_edit_excludeFromGasStats": {
+    "description": "Checkbox: exclude this dive from gas statistics only"
+  },
+  "diveLog_edit_excludeFromGasStatsHelp": "Leave this dive out of SAC, RMV and gas mix statistics only. Useful when the gas reading is not representative.",
+  "@diveLog_edit_excludeFromGasStatsHelp": {
+    "description": "Help text under the exclude-from-gas-statistics checkbox"
+  },
+  "diveLog_badge_excludedFromStats": "Excluded from statistics",
+  "@diveLog_badge_excludedFromStats": {
+    "description": "Tooltip on the excluded-from-statistics badge"
+  },
+  "diveLog_badge_excludedFromGasStats": "Excluded from gas statistics",
+  "@diveLog_badge_excludedFromGasStats": {
+    "description": "Tooltip on the excluded-from-gas-statistics badge"
+  },
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Excluded from statistics",
+  "@diveLog_bulkEdit_fieldExcludeFromStats": {
+    "description": "Bulk edit field label"
+  },
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Exclude from gas statistics",
+  "@diveLog_bulkEdit_fieldExcludeFromGasStats": {
+    "description": "Bulk edit field label"
+  },
+  "diveLog_filter_excludedOnly": "Excluded from statistics only",
+  "@diveLog_filter_excludedOnly": {
+    "description": "Filter axis: show only dives excluded from statistics"
+  },
+  "diveLog_edit_summary_excluded": "Excluded",
+  "@diveLog_edit_summary_excluded": {
+    "description": "Collapsed summary fragment: dive excluded from statistics"
+  },
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 dive excluded from statistics} other{{count} dives excluded from statistics}}",
+  "@statistics_excludedDivesFootnote": {
+    "description": "Overview footnote naming how many dives are excluded",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -21562,7 +21562,7 @@
   "@diveLog_badge_excludedFromGasStats": {
     "description": "Tooltip on the excluded-from-gas-statistics badge"
   },
-  "diveLog_bulkEdit_fieldExcludeFromStats": "Excluded from statistics",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Exclude from statistics",
   "@diveLog_bulkEdit_fieldExcludeFromStats": {
     "description": "Bulk edit field label"
   },

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{No se descartó ninguna observación} =1{1 observación descartada} other{{count} observaciones descartadas}}, {failed, plural, =1{no se pudo actualizar 1 inmersión} other{no se pudieron actualizar {failed} inmersiones}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "No se pudo leer la lista de inmersiones. No se cambió nada.",
   "safetySettings_analyzeAll_failed": "No se pudieron analizar las inmersiones.",
   "safetyReview_details": "Detalles",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Últimos 5 años",
   "diveLog_filter_presetLast10Years": "Últimos 10 años",
   "statistics_trend_tooltip_lowest": "Mínimo",
-  "statistics_trend_tooltip_highest": "Máximo"
+  "statistics_trend_tooltip_highest": "Máximo",
+  "diveLog_edit_excludeFromStats": "Excluir de las estadísticas",
+  "diveLog_edit_excludeFromStatsHelp": "Mantén esta inmersión en tu cuaderno, pero déjala fuera de todas las estadísticas, incluido tu número de inmersiones.",
+  "diveLog_edit_excludeFromGasStats": "Excluir de las estadísticas de gas",
+  "diveLog_edit_excludeFromGasStatsHelp": "Deja esta inmersión fuera solo de las estadísticas de SAC, RMV y mezcla de gas. Útil cuando el valor de gas no es representativo.",
+  "diveLog_badge_excludedFromStats": "Excluida de las estadísticas",
+  "diveLog_badge_excludedFromGasStats": "Excluida de las estadísticas de gas",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Excluir de las estadísticas",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Excluir de las estadísticas de gas",
+  "diveLog_filter_excludedOnly": "Solo las excluidas de las estadísticas",
+  "diveLog_edit_summary_excluded": "Excluida",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 inmersión excluida de las estadísticas} other{{count} inmersiones excluidas de las estadísticas}}"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Aucune observation ignorée} =1{1 observation ignorée} other{{count} observations ignorées}}, {failed, plural, =1{1 plongée n’a pas pu être mise à jour} other{{failed} plongées n’ont pas pu être mises à jour}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Impossible de lire la liste des plongées. Rien n’a été modifié.",
   "safetySettings_analyzeAll_failed": "Impossible d’analyser les plongées.",
   "safetyReview_details": "Détails",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "5 dernières années",
   "diveLog_filter_presetLast10Years": "10 dernières années",
   "statistics_trend_tooltip_lowest": "Minimum",
-  "statistics_trend_tooltip_highest": "Maximum"
+  "statistics_trend_tooltip_highest": "Maximum",
+  "diveLog_edit_excludeFromStats": "Exclure des statistiques",
+  "diveLog_edit_excludeFromStatsHelp": "Conservez cette plongée dans votre carnet, mais laissez-la en dehors de toutes les statistiques, y compris votre nombre de plongées.",
+  "diveLog_edit_excludeFromGasStats": "Exclure des statistiques de gaz",
+  "diveLog_edit_excludeFromGasStatsHelp": "Laissez cette plongée en dehors des seules statistiques SAC, RMV et mélange gazeux. Utile lorsque la valeur de gaz n'est pas représentative.",
+  "diveLog_badge_excludedFromStats": "Exclue des statistiques",
+  "diveLog_badge_excludedFromGasStats": "Exclue des statistiques de gaz",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Exclure des statistiques",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Exclure des statistiques de gaz",
+  "diveLog_filter_excludedOnly": "Uniquement les exclues des statistiques",
+  "diveLog_edit_summary_excluded": "Exclue",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 plongée exclue des statistiques} other{{count} plongées exclues des statistiques}}"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{לא בוצעה התעלמות מתצפיות} =1{בוצעה התעלמות מתצפית אחת} other{בוצעה התעלמות מ-{count} תצפיות}}, {failed, plural, =1{לא ניתן היה לעדכן צלילה אחת} other{לא ניתן היה לעדכן {failed} צלילות}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "לא ניתן לקרוא את רשימת הצלילות. דבר לא שונה.",
   "safetySettings_analyzeAll_failed": "לא ניתן לנתח את הצלילות.",
   "safetyReview_details": "פרטים",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "5 השנים האחרונות",
   "diveLog_filter_presetLast10Years": "10 השנים האחרונות",
   "statistics_trend_tooltip_lowest": "הנמוך ביותר",
-  "statistics_trend_tooltip_highest": "הגבוה ביותר"
+  "statistics_trend_tooltip_highest": "הגבוה ביותר",
+  "diveLog_edit_excludeFromStats": "החרג מהסטטיסטיקות",
+  "diveLog_edit_excludeFromStatsHelp": "השאר את הצלילה ביומן, אך החרג אותה מכל סטטיסטיקה, כולל מספר הצלילות שלך.",
+  "diveLog_edit_excludeFromGasStats": "החרג מסטטיסטיקות הגז",
+  "diveLog_edit_excludeFromGasStatsHelp": "החרג את הצלילה מסטטיסטיקות SAC, RMV ותערובת גז בלבד. שימושי כאשר ערך הגז אינו מייצג.",
+  "diveLog_badge_excludedFromStats": "מוחרגת מהסטטיסטיקות",
+  "diveLog_badge_excludedFromGasStats": "מוחרגת מסטטיסטיקות הגז",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "החרג מהסטטיסטיקות",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "החרג מסטטיסטיקות הגז",
+  "diveLog_filter_excludedOnly": "רק המוחרגות מהסטטיסטיקות",
+  "diveLog_edit_summary_excluded": "מוחרגת",
+  "statistics_excludedDivesFootnote": "{count, plural, one{צלילה אחת מוחרגת מהסטטיסטיקות} two{שתי צלילות מוחרגות מהסטטיסטיקות} many{{count} צלילות מוחרגות מהסטטיסטיקות} other{{count} צלילות מוחרגות מהסטטיסטיקות}}"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nem lett megfigyelés elvetve} =1{1 megfigyelés elvetve} other{{count} megfigyelés elvetve}}, {failed, plural, =1{1 merülést nem sikerült frissíteni} other{{failed} merülést nem sikerült frissíteni}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "A merüléslista nem olvasható. Semmi sem változott.",
   "safetySettings_analyzeAll_failed": "A merüléseket nem sikerült elemezni.",
   "safetyReview_details": "Részletek",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Elmúlt 5 év",
   "diveLog_filter_presetLast10Years": "Elmúlt 10 év",
   "statistics_trend_tooltip_lowest": "Legalacsonyabb",
-  "statistics_trend_tooltip_highest": "Legmagasabb"
+  "statistics_trend_tooltip_highest": "Legmagasabb",
+  "diveLog_edit_excludeFromStats": "Kizárás a statisztikákból",
+  "diveLog_edit_excludeFromStatsHelp": "Tartsd meg ezt a merülést a naplóban, de hagyd ki minden statisztikából, beleértve a merülésszámot is.",
+  "diveLog_edit_excludeFromGasStats": "Kizárás a gázstatisztikákból",
+  "diveLog_edit_excludeFromGasStatsHelp": "Csak a SAC-, RMV- és gázkeverék-statisztikákból hagyd ki ezt a merülést. Hasznos, ha a gázérték nem reprezentatív.",
+  "diveLog_badge_excludedFromStats": "Kizárva a statisztikákból",
+  "diveLog_badge_excludedFromGasStats": "Kizárva a gázstatisztikákból",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Kizárás a statisztikákból",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Kizárás a gázstatisztikákból",
+  "diveLog_filter_excludedOnly": "Csak a statisztikákból kizártak",
+  "diveLog_edit_summary_excluded": "Kizárva",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 merülés kizárva a statisztikákból} other{{count} merülés kizárva a statisztikákból}}"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nessuna osservazione ignorata} =1{1 osservazione ignorata} other{{count} osservazioni ignorate}}, {failed, plural, =1{1 immersione non è stata aggiornata} other{{failed} immersioni non sono state aggiornate}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Impossibile leggere l’elenco delle immersioni. Nulla è stato modificato.",
   "safetySettings_analyzeAll_failed": "Impossibile analizzare le immersioni.",
   "safetyReview_details": "Dettagli",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Ultimi 5 anni",
   "diveLog_filter_presetLast10Years": "Ultimi 10 anni",
   "statistics_trend_tooltip_lowest": "Minimo",
-  "statistics_trend_tooltip_highest": "Massimo"
+  "statistics_trend_tooltip_highest": "Massimo",
+  "diveLog_edit_excludeFromStats": "Escludi dalle statistiche",
+  "diveLog_edit_excludeFromStatsHelp": "Mantieni questa immersione nel logbook, ma lasciala fuori da ogni statistica, incluso il conteggio delle immersioni.",
+  "diveLog_edit_excludeFromGasStats": "Escludi dalle statistiche del gas",
+  "diveLog_edit_excludeFromGasStatsHelp": "Lascia questa immersione fuori solo dalle statistiche SAC, RMV e miscela di gas. Utile quando il valore del gas non è rappresentativo.",
+  "diveLog_badge_excludedFromStats": "Esclusa dalle statistiche",
+  "diveLog_badge_excludedFromGasStats": "Esclusa dalle statistiche del gas",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Escludi dalle statistiche",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Escludi dalle statistiche del gas",
+  "diveLog_filter_excludedOnly": "Solo quelle escluse dalle statistiche",
+  "diveLog_edit_summary_excluded": "Esclusa",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 immersione esclusa dalle statistiche} other{{count} immersioni escluse dalle statistiche}}"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -58523,7 +58523,7 @@ abstract class AppLocalizations {
   /// Bulk edit field label
   ///
   /// In en, this message translates to:
-  /// **'Excluded from statistics'**
+  /// **'Exclude from statistics'**
   String get diveLog_bulkEdit_fieldExcludeFromStats;
 
   /// Bulk edit field label

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -58483,6 +58483,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Highest'**
   String get statistics_trend_tooltip_highest;
+
+  /// Checkbox: exclude this dive from all statistics
+  ///
+  /// In en, this message translates to:
+  /// **'Exclude from statistics'**
+  String get diveLog_edit_excludeFromStats;
+
+  /// Help text under the exclude-from-statistics checkbox
+  ///
+  /// In en, this message translates to:
+  /// **'Keep this dive in your logbook, but leave it out of every statistic, including your dive count.'**
+  String get diveLog_edit_excludeFromStatsHelp;
+
+  /// Checkbox: exclude this dive from gas statistics only
+  ///
+  /// In en, this message translates to:
+  /// **'Exclude from gas statistics'**
+  String get diveLog_edit_excludeFromGasStats;
+
+  /// Help text under the exclude-from-gas-statistics checkbox
+  ///
+  /// In en, this message translates to:
+  /// **'Leave this dive out of SAC, RMV and gas mix statistics only. Useful when the gas reading is not representative.'**
+  String get diveLog_edit_excludeFromGasStatsHelp;
+
+  /// Tooltip on the excluded-from-statistics badge
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded from statistics'**
+  String get diveLog_badge_excludedFromStats;
+
+  /// Tooltip on the excluded-from-gas-statistics badge
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded from gas statistics'**
+  String get diveLog_badge_excludedFromGasStats;
+
+  /// Bulk edit field label
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded from statistics'**
+  String get diveLog_bulkEdit_fieldExcludeFromStats;
+
+  /// Bulk edit field label
+  ///
+  /// In en, this message translates to:
+  /// **'Exclude from gas statistics'**
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats;
+
+  /// Filter axis: show only dives excluded from statistics
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded from statistics only'**
+  String get diveLog_filter_excludedOnly;
+
+  /// Collapsed summary fragment: dive excluded from statistics
+  ///
+  /// In en, this message translates to:
+  /// **'Excluded'**
+  String get diveLog_edit_summary_excluded;
+
+  /// Overview footnote naming how many dives are excluded
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{1 dive excluded from statistics} other{{count} dives excluded from statistics}}'**
+  String statistics_excludedDivesFootnote(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -35196,4 +35196,52 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'الأعلى';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'استبعاد من الإحصائيات';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'احتفظ بهذه الغطسة في سجلك، لكن استبعدها من كل الإحصائيات، بما في ذلك عدد غطساتك.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats => 'استبعاد من إحصائيات الغاز';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'استبعد هذه الغطسة من إحصائيات SAC وRMV وخليط الغاز فقط. مفيد عندما تكون قراءة الغاز غير ممثلة.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'مستبعدة من الإحصائيات';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats => 'مستبعدة من إحصائيات الغاز';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats => 'استبعاد من الإحصائيات';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'استبعاد من إحصائيات الغاز';
+
+  @override
+  String get diveLog_filter_excludedOnly => 'المستبعدة من الإحصائيات فقط';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'مستبعدة';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count غطسة مستبعدة من الإحصائيات',
+      many: '$count غطسة مستبعدة من الإحصائيات',
+      few: '$count غطسات مستبعدة من الإحصائيات',
+      two: 'غطستان مستبعدتان من الإحصائيات',
+      one: 'غطسة واحدة مستبعدة من الإحصائيات',
+      zero: 'لا غطسات مستبعدة من الإحصائيات',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -35468,4 +35468,53 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Höchster';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Von Statistiken ausschließen';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Behalte diesen Tauchgang im Logbuch, lasse ihn aber aus jeder Statistik heraus, einschließlich der Tauchgangszahl.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Von Gasstatistiken ausschließen';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Lasse diesen Tauchgang nur aus AMV-, RMV- und Gasgemisch-Statistiken heraus. Nützlich, wenn der Gaswert nicht repräsentativ ist.';
+
+  @override
+  String get diveLog_badge_excludedFromStats =>
+      'Von Statistiken ausgeschlossen';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Von Gasstatistiken ausgeschlossen';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Von Statistiken ausschließen';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Von Gasstatistiken ausschließen';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Nur von Statistiken ausgeschlossene';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Ausgeschlossen';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Tauchgänge von Statistiken ausgeschlossen',
+      one: '1 Tauchgang von Statistiken ausgeschlossen',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -35003,4 +35003,50 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Highest';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Exclude from statistics';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Keep this dive in your logbook, but leave it out of every statistic, including your dive count.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats => 'Exclude from gas statistics';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Leave this dive out of SAC, RMV and gas mix statistics only. Useful when the gas reading is not representative.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Excluded from statistics';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Excluded from gas statistics';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Excluded from statistics';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Exclude from gas statistics';
+
+  @override
+  String get diveLog_filter_excludedOnly => 'Excluded from statistics only';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Excluded';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dives excluded from statistics',
+      one: '1 dive excluded from statistics',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -35027,7 +35027,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get diveLog_bulkEdit_fieldExcludeFromStats =>
-      'Excluded from statistics';
+      'Exclude from statistics';
 
   @override
   String get diveLog_bulkEdit_fieldExcludeFromGasStats =>

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -35581,4 +35581,52 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Máximo';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Excluir de las estadísticas';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Mantén esta inmersión en tu cuaderno, pero déjala fuera de todas las estadísticas, incluido tu número de inmersiones.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Excluir de las estadísticas de gas';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Deja esta inmersión fuera solo de las estadísticas de SAC, RMV y mezcla de gas. Útil cuando el valor de gas no es representativo.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Excluida de las estadísticas';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Excluida de las estadísticas de gas';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Excluir de las estadísticas';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Excluir de las estadísticas de gas';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Solo las excluidas de las estadísticas';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Excluida';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count inmersiones excluidas de las estadísticas',
+      one: '1 inmersión excluida de las estadísticas',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -35632,4 +35632,52 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Maximum';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Exclure des statistiques';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Conservez cette plongée dans votre carnet, mais laissez-la en dehors de toutes les statistiques, y compris votre nombre de plongées.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Exclure des statistiques de gaz';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Laissez cette plongée en dehors des seules statistiques SAC, RMV et mélange gazeux. Utile lorsque la valeur de gaz n\'est pas représentative.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Exclue des statistiques';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Exclue des statistiques de gaz';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Exclure des statistiques';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Exclure des statistiques de gaz';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Uniquement les exclues des statistiques';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Exclue';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count plongées exclues des statistiques',
+      one: '1 plongée exclue des statistiques',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -34842,4 +34842,50 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'הגבוה ביותר';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'החרג מהסטטיסטיקות';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'השאר את הצלילה ביומן, אך החרג אותה מכל סטטיסטיקה, כולל מספר הצלילות שלך.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats => 'החרג מסטטיסטיקות הגז';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'החרג את הצלילה מסטטיסטיקות SAC, RMV ותערובת גז בלבד. שימושי כאשר ערך הגז אינו מייצג.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'מוחרגת מהסטטיסטיקות';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats => 'מוחרגת מסטטיסטיקות הגז';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats => 'החרג מהסטטיסטיקות';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'החרג מסטטיסטיקות הגז';
+
+  @override
+  String get diveLog_filter_excludedOnly => 'רק המוחרגות מהסטטיסטיקות';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'מוחרגת';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count צלילות מוחרגות מהסטטיסטיקות',
+      many: '$count צלילות מוחרגות מהסטטיסטיקות',
+      two: 'שתי צלילות מוחרגות מהסטטיסטיקות',
+      one: 'צלילה אחת מוחרגת מהסטטיסטיקות',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -35402,4 +35402,50 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Legmagasabb';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Kizárás a statisztikákból';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Tartsd meg ezt a merülést a naplóban, de hagyd ki minden statisztikából, beleértve a merülésszámot is.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats => 'Kizárás a gázstatisztikákból';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Csak a SAC-, RMV- és gázkeverék-statisztikákból hagyd ki ezt a merülést. Hasznos, ha a gázérték nem reprezentatív.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Kizárva a statisztikákból';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Kizárva a gázstatisztikákból';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Kizárás a statisztikákból';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Kizárás a gázstatisztikákból';
+
+  @override
+  String get diveLog_filter_excludedOnly => 'Csak a statisztikákból kizártak';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Kizárva';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count merülés kizárva a statisztikákból',
+      one: '1 merülés kizárva a statisztikákból',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -35536,4 +35536,52 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Massimo';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Escludi dalle statistiche';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Mantieni questa immersione nel logbook, ma lasciala fuori da ogni statistica, incluso il conteggio delle immersioni.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Escludi dalle statistiche del gas';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Lascia questa immersione fuori solo dalle statistiche SAC, RMV e miscela di gas. Utile quando il valore del gas non è rappresentativo.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Esclusa dalle statistiche';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Esclusa dalle statistiche del gas';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Escludi dalle statistiche';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Escludi dalle statistiche del gas';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Solo quelle escluse dalle statistiche';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Esclusa';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count immersioni escluse dalle statistiche',
+      one: '1 immersione esclusa dalle statistiche',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -35298,4 +35298,52 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Hoogste';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Uitsluiten van statistieken';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Houd deze duik in je logboek, maar laat hem buiten elke statistiek, inclusief je duikaantal.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Uitsluiten van gasstatistieken';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Laat deze duik alleen buiten SAC-, RMV- en gasmengselstatistieken. Handig wanneer de gaswaarde niet representatief is.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Uitgesloten van statistieken';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Uitgesloten van gasstatistieken';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Uitsluiten van statistieken';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Uitsluiten van gasstatistieken';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Alleen uitgesloten van statistieken';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Uitgesloten';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count duiken uitgesloten van statistieken',
+      one: '1 duik uitgesloten van statistieken',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -35548,4 +35548,52 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => 'Máximo';
+
+  @override
+  String get diveLog_edit_excludeFromStats => 'Excluir das estatísticas';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      'Mantenha este mergulho no seu registo, mas deixe-o fora de todas as estatísticas, incluindo a sua contagem de mergulhos.';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats =>
+      'Excluir das estatísticas de gás';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      'Deixe este mergulho fora apenas das estatísticas de SAC, RMV e mistura de gás. Útil quando o valor de gás não é representativo.';
+
+  @override
+  String get diveLog_badge_excludedFromStats => 'Excluído das estatísticas';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats =>
+      'Excluído das estatísticas de gás';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats =>
+      'Excluir das estatísticas';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats =>
+      'Excluir das estatísticas de gás';
+
+  @override
+  String get diveLog_filter_excludedOnly =>
+      'Apenas os excluídos das estatísticas';
+
+  @override
+  String get diveLog_edit_summary_excluded => 'Excluído';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count mergulhos excluídos das estatísticas',
+      one: '1 mergulho excluído das estatísticas',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -33461,4 +33461,46 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get statistics_trend_tooltip_highest => '最高';
+
+  @override
+  String get diveLog_edit_excludeFromStats => '从统计中排除';
+
+  @override
+  String get diveLog_edit_excludeFromStatsHelp =>
+      '将此潜水保留在日志中，但将其排除在所有统计之外，包括潜水次数。';
+
+  @override
+  String get diveLog_edit_excludeFromGasStats => '从气体统计中排除';
+
+  @override
+  String get diveLog_edit_excludeFromGasStatsHelp =>
+      '仅将此潜水排除在 SAC、RMV 和气体混合统计之外。当气体数值不具代表性时很有用。';
+
+  @override
+  String get diveLog_badge_excludedFromStats => '已从统计中排除';
+
+  @override
+  String get diveLog_badge_excludedFromGasStats => '已从气体统计中排除';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromStats => '从统计中排除';
+
+  @override
+  String get diveLog_bulkEdit_fieldExcludeFromGasStats => '从气体统计中排除';
+
+  @override
+  String get diveLog_filter_excludedOnly => '仅显示已排除的潜水';
+
+  @override
+  String get diveLog_edit_summary_excluded => '已排除';
+
+  @override
+  String statistics_excludedDivesFootnote(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 次潜水已从统计中排除',
+    );
+    return '$_temp0';
+  }
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Geen observaties genegeerd} =1{1 observatie genegeerd} other{{count} observaties genegeerd}}, {failed, plural, =1{1 duik kon niet worden bijgewerkt} other{{failed} duiken konden niet worden bijgewerkt}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Kan de duiklijst niet lezen. Er is niets gewijzigd.",
   "safetySettings_analyzeAll_failed": "Kan de duiken niet analyseren.",
   "safetyReview_details": "Details",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Afgelopen 5 jaar",
   "diveLog_filter_presetLast10Years": "Afgelopen 10 jaar",
   "statistics_trend_tooltip_lowest": "Laagste",
-  "statistics_trend_tooltip_highest": "Hoogste"
+  "statistics_trend_tooltip_highest": "Hoogste",
+  "diveLog_edit_excludeFromStats": "Uitsluiten van statistieken",
+  "diveLog_edit_excludeFromStatsHelp": "Houd deze duik in je logboek, maar laat hem buiten elke statistiek, inclusief je duikaantal.",
+  "diveLog_edit_excludeFromGasStats": "Uitsluiten van gasstatistieken",
+  "diveLog_edit_excludeFromGasStatsHelp": "Laat deze duik alleen buiten SAC-, RMV- en gasmengselstatistieken. Handig wanneer de gaswaarde niet representatief is.",
+  "diveLog_badge_excludedFromStats": "Uitgesloten van statistieken",
+  "diveLog_badge_excludedFromGasStats": "Uitgesloten van gasstatistieken",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Uitsluiten van statistieken",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Uitsluiten van gasstatistieken",
+  "diveLog_filter_excludedOnly": "Alleen uitgesloten van statistieken",
+  "diveLog_edit_summary_excluded": "Uitgesloten",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 duik uitgesloten van statistieken} other{{count} duiken uitgesloten van statistieken}}"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{Nenhuma observação dispensada} =1{1 observação dispensada} other{{count} observações dispensadas}}, {failed, plural, =1{1 mergulho não pôde ser atualizado} other{{failed} mergulhos não puderam ser atualizados}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "Não foi possível ler a lista de mergulhos. Nada foi alterado.",
   "safetySettings_analyzeAll_failed": "Não foi possível analisar os mergulhos.",
   "safetyReview_details": "Detalhes",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "Últimos 5 anos",
   "diveLog_filter_presetLast10Years": "Últimos 10 anos",
   "statistics_trend_tooltip_lowest": "Mínimo",
-  "statistics_trend_tooltip_highest": "Máximo"
+  "statistics_trend_tooltip_highest": "Máximo",
+  "diveLog_edit_excludeFromStats": "Excluir das estatísticas",
+  "diveLog_edit_excludeFromStatsHelp": "Mantenha este mergulho no seu registo, mas deixe-o fora de todas as estatísticas, incluindo a sua contagem de mergulhos.",
+  "diveLog_edit_excludeFromGasStats": "Excluir das estatísticas de gás",
+  "diveLog_edit_excludeFromGasStatsHelp": "Deixe este mergulho fora apenas das estatísticas de SAC, RMV e mistura de gás. Útil quando o valor de gás não é representativo.",
+  "diveLog_badge_excludedFromStats": "Excluído das estatísticas",
+  "diveLog_badge_excludedFromGasStats": "Excluído das estatísticas de gás",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "Excluir das estatísticas",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "Excluir das estatísticas de gás",
+  "diveLog_filter_excludedOnly": "Apenas os excluídos das estatísticas",
+  "diveLog_edit_summary_excluded": "Excluído",
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 mergulho excluído das estatísticas} other{{count} mergulhos excluídos das estatísticas}}"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -7331,15 +7331,15 @@
   },
   "safetySettings_dismissAll_doneWithErrors": "{count, plural, =0{没有忽略任何观察} =1{已忽略 1 条观察} other{已忽略 {count} 条观察}}，{failed, plural, other{{failed} 次潜水无法更新}}",
   "@safetySettings_dismissAll_doneWithErrors": {
-  "placeholders": {
-    "count": {
-      "type": "int"
-    },
-    "failed": {
-      "type": "int"
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
     }
-  }
-},
+  },
   "safetySettings_dismissAll_failed": "无法读取潜水列表，未做任何更改。",
   "safetySettings_analyzeAll_failed": "无法分析潜水记录。",
   "safetyReview_details": "详情",
@@ -10386,5 +10386,16 @@
   "diveLog_filter_presetLast5Years": "最近 5 年",
   "diveLog_filter_presetLast10Years": "最近 10 年",
   "statistics_trend_tooltip_lowest": "最低",
-  "statistics_trend_tooltip_highest": "最高"
+  "statistics_trend_tooltip_highest": "最高",
+  "diveLog_edit_excludeFromStats": "从统计中排除",
+  "diveLog_edit_excludeFromStatsHelp": "将此潜水保留在日志中，但将其排除在所有统计之外，包括潜水次数。",
+  "diveLog_edit_excludeFromGasStats": "从气体统计中排除",
+  "diveLog_edit_excludeFromGasStatsHelp": "仅将此潜水排除在 SAC、RMV 和气体混合统计之外。当气体数值不具代表性时很有用。",
+  "diveLog_badge_excludedFromStats": "已从统计中排除",
+  "diveLog_badge_excludedFromGasStats": "已从气体统计中排除",
+  "diveLog_bulkEdit_fieldExcludeFromStats": "从统计中排除",
+  "diveLog_bulkEdit_fieldExcludeFromGasStats": "从气体统计中排除",
+  "diveLog_filter_excludedOnly": "仅显示已排除的潜水",
+  "diveLog_edit_summary_excluded": "已排除",
+  "statistics_excludedDivesFootnote": "{count, plural, other{{count} 次潜水已从统计中排除}}"
 }

--- a/lib/shared/widgets/forms/form_row.dart
+++ b/lib/shared/widgets/forms/form_row.dart
@@ -300,7 +300,7 @@ class _FormRowState extends State<FormRow> {
                 padding: EdgeInsets.only(
                   left: FormStyle.rowPadding.left,
                   right: FormStyle.rowPadding.right,
-                  bottom: FormStyle.rowPadding.vertical,
+                  bottom: FormStyle.rowPadding.bottom,
                 ),
                 child: Text(
                   help,

--- a/lib/shared/widgets/forms/form_row.dart
+++ b/lib/shared/widgets/forms/form_row.dart
@@ -45,6 +45,7 @@ class FormRow extends StatefulWidget {
     this.decoration,
     this.profileSuggestion,
   }) : _kind = _RowKind.text,
+       enabled = true,
        value = null,
        onTap = null,
        onClear = null,
@@ -62,6 +63,7 @@ class FormRow extends StatefulWidget {
     this.placeholder,
     this.onClear,
   }) : _kind = _RowKind.picker,
+       enabled = true,
        profileSuggestion = null,
        decoration = null,
        controller = null,
@@ -80,6 +82,7 @@ class FormRow extends StatefulWidget {
 
   const FormRow.display({super.key, required this.label, required this.value})
     : _kind = _RowKind.display,
+      enabled = true,
       profileSuggestion = null,
       decoration = null,
       controller = null,
@@ -99,11 +102,15 @@ class FormRow extends StatefulWidget {
       onIntChanged = null,
       child = null;
 
+  /// Set [enabled] to false to render the switch in its current position but
+  /// inert, for a value that is implied by another control rather than freely
+  /// chosen. Prefer this over silently overriding what the user picked.
   const FormRow.toggle({
     super.key,
     required this.label,
     required bool value,
     required ValueChanged<bool> onChanged,
+    this.enabled = true,
   }) : _kind = _RowKind.toggle,
        profileSuggestion = null,
        decoration = null,
@@ -132,6 +139,7 @@ class FormRow extends StatefulWidget {
     required ValueChanged<int> onChanged,
     this.onClear,
   }) : _kind = _RowKind.rating,
+       enabled = true,
        profileSuggestion = null,
        decoration = null,
        inputFormatters = null,
@@ -153,6 +161,7 @@ class FormRow extends StatefulWidget {
 
   const FormRow.custom({super.key, required this.label, required this.child})
     : _kind = _RowKind.custom,
+      enabled = true,
       profileSuggestion = null,
       decoration = null,
       controller = null,
@@ -171,6 +180,9 @@ class FormRow extends StatefulWidget {
       onBoolChanged = null,
       intValue = null,
       onIntChanged = null;
+
+  /// Toggle rows only: false renders the switch inert.
+  final bool enabled;
 
   final _RowKind _kind;
   final String label;
@@ -416,7 +428,7 @@ class _FormRowState extends State<FormRow> {
           context,
           trailing: Switch(
             value: widget.boolValue!,
-            onChanged: widget.onBoolChanged,
+            onChanged: widget.enabled ? widget.onBoolChanged : null,
           ),
         );
 

--- a/lib/shared/widgets/forms/form_row.dart
+++ b/lib/shared/widgets/forms/form_row.dart
@@ -46,6 +46,7 @@ class FormRow extends StatefulWidget {
     this.profileSuggestion,
   }) : _kind = _RowKind.text,
        enabled = true,
+       helpText = null,
        value = null,
        onTap = null,
        onClear = null,
@@ -64,6 +65,7 @@ class FormRow extends StatefulWidget {
     this.onClear,
   }) : _kind = _RowKind.picker,
        enabled = true,
+       helpText = null,
        profileSuggestion = null,
        decoration = null,
        controller = null,
@@ -83,6 +85,7 @@ class FormRow extends StatefulWidget {
   const FormRow.display({super.key, required this.label, required this.value})
     : _kind = _RowKind.display,
       enabled = true,
+      helpText = null,
       profileSuggestion = null,
       decoration = null,
       controller = null,
@@ -111,6 +114,7 @@ class FormRow extends StatefulWidget {
     required bool value,
     required ValueChanged<bool> onChanged,
     this.enabled = true,
+    this.helpText,
   }) : _kind = _RowKind.toggle,
        profileSuggestion = null,
        decoration = null,
@@ -140,6 +144,7 @@ class FormRow extends StatefulWidget {
     this.onClear,
   }) : _kind = _RowKind.rating,
        enabled = true,
+       helpText = null,
        profileSuggestion = null,
        decoration = null,
        inputFormatters = null,
@@ -162,6 +167,7 @@ class FormRow extends StatefulWidget {
   const FormRow.custom({super.key, required this.label, required this.child})
     : _kind = _RowKind.custom,
       enabled = true,
+      helpText = null,
       profileSuggestion = null,
       decoration = null,
       controller = null,
@@ -183,6 +189,10 @@ class FormRow extends StatefulWidget {
 
   /// Toggle rows only: false renders the switch inert.
   final bool enabled;
+
+  /// Optional explanatory line rendered under the row, for a control whose
+  /// label cannot carry the whole meaning on its own.
+  final String? helpText;
 
   final _RowKind _kind;
   final String label;
@@ -279,8 +289,30 @@ class _FormRowState extends State<FormRow> {
         ],
       ),
     );
-    if (onTap == null) return row;
-    return InkWell(onTap: onTap, child: row);
+    final help = widget.helpText;
+    final content = help == null
+        ? row
+        : Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              row,
+              Padding(
+                padding: EdgeInsets.only(
+                  left: FormStyle.rowPadding.left,
+                  right: FormStyle.rowPadding.right,
+                  bottom: FormStyle.rowPadding.vertical,
+                ),
+                child: Text(
+                  help,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          );
+    if (onTap == null) return content;
+    return InkWell(onTap: onTap, child: content);
   }
 
   @override

--- a/test/core/database/dive_stats_scope_census_test.dart
+++ b/test/core/database/dive_stats_scope_census_test.dart
@@ -94,14 +94,18 @@ List<String> _memberChunks(String source) {
       if (!_readsDives.hasMatch(chunk)) continue;
       scanned++;
 
-      // `_diveFilter` is StatisticsRepository's own wrapper, and it emits
-      // DiveStatsScope unconditionally, so calling it counts as applying the
-      // scope. This is the one indirection the census accepts; anything else
-      // has to name DiveStatsScope or the column outright.
+      // Only two things count as applying the scope: naming DiveStatsScope,
+      // or calling StatisticsRepository's own `_diveFilter` wrapper, which
+      // emits it unconditionally.
+      //
+      // A bare `excluded_from_stats` mention deliberately does NOT count.
+      // Hand-writing that one column satisfies the letter of the rule while
+      // silently missing `is_planned = 0` (and, on a gas query, the gas flag
+      // and the gauge-mode rule), which is exactly the partial-copy rot this
+      // census exists to prevent. Go through the helper or mark the query
+      // exempt; there is no third option.
       final applied =
-          chunk.contains('DiveStatsScope') ||
-          chunk.contains('excluded_from_stats') ||
-          chunk.contains('_diveFilter(');
+          chunk.contains('DiveStatsScope') || chunk.contains('_diveFilter(');
       final exempt = chunk.contains('stats-scope-exempt');
 
       if (!applied && !exempt) {

--- a/test/core/database/dive_stats_scope_census_test.dart
+++ b/test/core/database/dive_stats_scope_census_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Every source file holding aggregate SQL over `dives`.
+///
+/// A query in one of these files that neither applies `DiveStatsScope` nor
+/// carries an explicit `stats-scope-exempt` marker is a bug: someone added an
+/// aggregate without deciding whether an excluded dive should count.
+///
+/// This exists because the behavioural suite can only test the queries someone
+/// remembered to add to it. The rule it guards decayed once already: the
+/// gauge-mode exclusion was hand-copied into seven queries with nothing
+/// ensuring an eighth would get it.
+const _censusFiles = <String>[
+  'lib/features/statistics/data/repositories/statistics_repository.dart',
+  'lib/features/dive_log/data/repositories/dive_repository_impl.dart',
+  'lib/features/buddies/data/repositories/buddy_repository.dart',
+  'lib/features/dive_sites/data/repositories/site_repository_impl.dart',
+  'lib/features/trips/data/repositories/trip_repository.dart',
+  'lib/features/dive_centers/data/repositories/dive_center_repository.dart',
+  'lib/features/tags/data/repositories/tag_repository.dart',
+  'lib/features/dive_types/data/repositories/dive_type_repository.dart',
+  'lib/features/dive_roles/data/repositories/dive_role_repository.dart',
+  'lib/features/divers/data/repositories/diver_repository.dart',
+  'lib/features/marine_life/data/repositories/seen_species_repository.dart',
+  'lib/features/marine_life/data/repositories/species_repository.dart',
+  'lib/features/equipment/data/repositories/equipment_repository_impl.dart',
+  'lib/features/courses/data/repositories/course_repository.dart',
+  'lib/features/courses/data/repositories/course_requirement_repository.dart',
+];
+
+final _readsDives = RegExp(
+  r'\b(?:FROM|JOIN)\s+dives\b|\bFROM\s+dive_(?:buddies|tags|dive_types)\b',
+  caseSensitive: false,
+);
+
+/// Splits [source] into one chunk per class member.
+///
+/// Method granularity, not per-statement: the scope is threaded the way the
+/// surrounding code threads its filter, as a fragment built once at the top of
+/// a method and interpolated into several statements. A per-statement census
+/// would flag every one of those as unscoped.
+List<String> _memberChunks(String source) {
+  final starts = <int>[];
+  final lines = source.split('\n');
+  final offsets = <int>[];
+  var off = 0;
+  for (final l in lines) {
+    offsets.add(off);
+    off += l.length + 1;
+  }
+  // A member starts at exactly two spaces of indent with an identifier,
+  // annotation, or type. Anchoring on the leading character keeps
+  // continuation lines like `  }) async {` from splitting a method in half,
+  // which would hide the scope fragment built above the SQL.
+  final member = RegExp(r'^  [A-Za-z_@][^\n]*[({]\s*$');
+  final comment = RegExp(r'^\s*(///|//|@)');
+  for (var i = 0; i < lines.length; i++) {
+    if (!member.hasMatch(lines[i])) continue;
+    // Walk back over the member's own doc comment and annotations, so a
+    // `stats-scope-exempt` marker written above the signature belongs to the
+    // member it describes rather than to the one before it.
+    var start = i;
+    while (start > 0 && comment.hasMatch(lines[start - 1])) {
+      start--;
+    }
+    starts.add(offsets[start]);
+  }
+  if (starts.isEmpty) return [source];
+  final chunks = <String>[source.substring(0, starts.first)];
+  for (var i = 0; i < starts.length; i++) {
+    final end = i + 1 < starts.length ? starts[i + 1] : source.length;
+    chunks.add(source.substring(starts[i], end));
+  }
+  return chunks;
+}
+
+({int scanned, List<String> offenders}) _audit() {
+  final offenders = <String>[];
+  var scanned = 0;
+
+  for (final path in _censusFiles) {
+    final file = File(path);
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason:
+          '$path is in the census list but does not exist. If it moved, '
+          'update _censusFiles rather than deleting the entry.',
+    );
+
+    for (final chunk in _memberChunks(file.readAsStringSync())) {
+      if (!_readsDives.hasMatch(chunk)) continue;
+      scanned++;
+
+      // `_diveFilter` is StatisticsRepository's own wrapper, and it emits
+      // DiveStatsScope unconditionally, so calling it counts as applying the
+      // scope. This is the one indirection the census accepts; anything else
+      // has to name DiveStatsScope or the column outright.
+      final applied =
+          chunk.contains('DiveStatsScope') ||
+          chunk.contains('excluded_from_stats') ||
+          chunk.contains('_diveFilter(');
+      final exempt = chunk.contains('stats-scope-exempt');
+
+      if (!applied && !exempt) {
+        final signature = chunk.split('\n').first.trim();
+        final line = chunk
+            .split('\n')
+            .firstWhere((l) => _readsDives.hasMatch(l), orElse: () => '')
+            .trim();
+        offenders.add('  $path\n    in: $signature\n    sql: $line');
+      }
+    }
+  }
+  return (scanned: scanned, offenders: offenders);
+}
+
+void main() {
+  test('every dives aggregate applies the scope or is marked exempt', () {
+    final result = _audit();
+
+    expect(
+      result.offenders,
+      isEmpty,
+      reason:
+          'These queries read `dives` but neither apply DiveStatsScope nor '
+          'carry a `stats-scope-exempt` marker.\n\n'
+          'Decide which this query is:\n'
+          '  - Descriptive (a number the diver reads as a statistic): apply\n'
+          '    the scope, e.g. \${DiveStatsScope.and(alias: "d")}.\n'
+          '  - Operational (gear wear, course credit, a deletion guard, a\n'
+          '    displayed list): add a `// stats-scope-exempt: <reason>`\n'
+          '    comment saying why.\n\n'
+          'Offenders:\n${result.offenders.join('\n')}',
+    );
+  });
+
+  test('the census actually sees the queries it claims to guard', () {
+    // A census that silently matches nothing looks exactly like one that
+    // passes correctly. Pin the floor so a broken regex or a renamed file
+    // fails loudly instead of quietly guarding an empty set.
+    final result = _audit();
+    expect(
+      result.scanned,
+      greaterThan(25),
+      reason:
+          'the census matched only \${result.scanned} dives-reading members, '
+          'which is far fewer than this codebase has. The regex or the file '
+          'list is broken, and the guard above is passing vacuously.',
+    );
+  });
+}

--- a/test/core/database/dive_stats_scope_test.dart
+++ b/test/core/database/dive_stats_scope_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/dive_stats_scope.dart';
+
+void main() {
+  group('DiveStatsScope.predicate', () {
+    test('defaults to alias d and the two descriptive rules', () {
+      expect(
+        DiveStatsScope.predicate(),
+        'd.excluded_from_stats = 0 AND d.is_planned = 0',
+      );
+    });
+
+    test('honours a custom alias on every term', () {
+      expect(
+        DiveStatsScope.predicate(alias: 'd2'),
+        'd2.excluded_from_stats = 0 AND d2.is_planned = 0',
+      );
+    });
+
+    test('the gas variant adds the gas flag and the gauge-mode rule', () {
+      expect(
+        DiveStatsScope.predicate(gas: true),
+        'd.excluded_from_stats = 0 AND d.is_planned = 0 '
+        "AND d.excluded_from_gas_stats = 0 AND d.dive_mode <> 'gauge'",
+      );
+    });
+
+    test('the gas variant honours a custom alias on every term', () {
+      final sql = DiveStatsScope.predicate(alias: 'dives', gas: true);
+      expect(
+        sql.contains('d.'),
+        isFalse,
+        reason: 'no term may fall back to the default alias',
+      );
+      expect(sql, contains('dives.excluded_from_gas_stats = 0'));
+      expect(sql, contains("dives.dive_mode <> 'gauge'"));
+    });
+  });
+
+  group('DiveStatsScope.and', () {
+    test('prefixes the predicate for appending into an existing WHERE', () {
+      expect(
+        DiveStatsScope.and(),
+        ' AND d.excluded_from_stats = 0 AND d.is_planned = 0',
+      );
+    });
+
+    test('carries alias and gas through to the predicate', () {
+      expect(
+        DiveStatsScope.and(alias: 'x', gas: true),
+        ' AND ${DiveStatsScope.predicate(alias: 'x', gas: true)}',
+      );
+    });
+
+    test('never emits a bind placeholder', () {
+      expect(
+        DiveStatsScope.and(gas: true).contains('?'),
+        isFalse,
+        reason: 'callers must not have to thread params for the scope',
+      );
+    });
+  });
+}

--- a/test/core/database/migration_v178_stats_exclusion_test.dart
+++ b/test/core/database/migration_v178_stats_exclusion_test.dart
@@ -1,0 +1,100 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+/// Minimal pre-v178 shape: a dives table without either exclusion column,
+/// stamped at v175 so the upgrade to 178 runs.
+NativeDatabase _dbAt175() {
+  return NativeDatabase.memory(
+    setup: (rawDb) {
+      rawDb.execute('PRAGMA user_version = 175');
+      rawDb.execute('''
+        CREATE TABLE dives (
+          id TEXT NOT NULL PRIMARY KEY,
+          dive_date_time INTEGER NOT NULL,
+          is_planned INTEGER NOT NULL DEFAULT 0
+        )
+      ''');
+      rawDb.execute(
+        "INSERT INTO dives (id, dive_date_time) VALUES ('legacy', 0)",
+      );
+    },
+  );
+}
+
+Future<Set<String>> _diveColumns(AppDatabase db) async {
+  final cols = await db.customSelect("PRAGMA table_info('dives')").get();
+  return cols.map((c) => c.read<String>('name')).toSet();
+}
+
+void main() {
+  test('v178 adds both statistics-exclusion columns to an existing table',
+      () async {
+    final db = AppDatabase(_dbAt175());
+    addTearDown(db.close);
+
+    final names = await _diveColumns(db);
+    expect(names, contains('excluded_from_stats'));
+    expect(names, contains('excluded_from_gas_stats'));
+  });
+
+  test('pre-existing dives default to included', () async {
+    final db = AppDatabase(_dbAt175());
+    addTearDown(db.close);
+
+    final row = await db
+        .customSelect(
+          'SELECT excluded_from_stats, excluded_from_gas_stats '
+          "FROM dives WHERE id = 'legacy'",
+        )
+        .getSingle();
+    expect(row.read<int>('excluded_from_stats'), 0);
+    expect(row.read<int>('excluded_from_gas_stats'), 0);
+  });
+
+  test('fresh databases get both columns', () async {
+    final db = AppDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final names = await _diveColumns(db);
+    expect(names, contains('excluded_from_stats'));
+    expect(names, contains('excluded_from_gas_stats'));
+  });
+
+  test('the helper no-ops when dives is absent', () async {
+    // A minimal fixture with no dives table must not throw: the beforeOpen
+    // backstop runs the same assert on every open, including on the stripped
+    // databases other migration tests build.
+    final native = NativeDatabase.memory(
+      setup: (rawDb) => rawDb.execute('PRAGMA user_version = 175'),
+    );
+    final db = AppDatabase(native);
+    addTearDown(db.close);
+
+    await expectLater(db.customSelect('SELECT 1').get(), completes);
+  });
+
+  test('the backstop is idempotent across repeated opens', () async {
+    // Reopening the same file-backed schema re-runs beforeOpen. The assert
+    // must not attempt a second ALTER TABLE and fail with "duplicate column".
+    final db = AppDatabase(_dbAt175());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    await expectLater(
+      db.customSelect('SELECT excluded_from_stats FROM dives').get(),
+      completes,
+    );
+    final names = await _diveColumns(db);
+    expect(
+      names.where((n) => n == 'excluded_from_stats').length,
+      1,
+      reason: 'the column must be added exactly once',
+    );
+  });
+
+  test('v178 is present in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(178));
+    expect(AppDatabase.migrationVersions, contains(178));
+  });
+}

--- a/test/core/database/migration_v178_stats_exclusion_test.dart
+++ b/test/core/database/migration_v178_stats_exclusion_test.dart
@@ -28,15 +28,17 @@ Future<Set<String>> _diveColumns(AppDatabase db) async {
 }
 
 void main() {
-  test('v178 adds both statistics-exclusion columns to an existing table',
-      () async {
-    final db = AppDatabase(_dbAt175());
-    addTearDown(db.close);
+  test(
+    'v178 adds both statistics-exclusion columns to an existing table',
+    () async {
+      final db = AppDatabase(_dbAt175());
+      addTearDown(db.close);
 
-    final names = await _diveColumns(db);
-    expect(names, contains('excluded_from_stats'));
-    expect(names, contains('excluded_from_gas_stats'));
-  });
+      final names = await _diveColumns(db);
+      expect(names, contains('excluded_from_stats'));
+      expect(names, contains('excluded_from_gas_stats'));
+    },
+  );
 
   test('pre-existing dives default to included', () async {
     final db = AppDatabase(_dbAt175());

--- a/test/core/database/migration_v180_stats_exclusion_test.dart
+++ b/test/core/database/migration_v180_stats_exclusion_test.dart
@@ -2,12 +2,12 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
 
-/// Minimal pre-v178 shape: a dives table without either exclusion column,
-/// stamped at v175 so the upgrade to 178 runs.
-NativeDatabase _dbAt175() {
+/// Minimal pre-v180 shape: a dives table without either exclusion column,
+/// stamped at v179 so the upgrade to 180 runs.
+NativeDatabase _dbAt179() {
   return NativeDatabase.memory(
     setup: (rawDb) {
-      rawDb.execute('PRAGMA user_version = 175');
+      rawDb.execute('PRAGMA user_version = 179');
       rawDb.execute('''
         CREATE TABLE dives (
           id TEXT NOT NULL PRIMARY KEY,
@@ -29,9 +29,9 @@ Future<Set<String>> _diveColumns(AppDatabase db) async {
 
 void main() {
   test(
-    'v178 adds both statistics-exclusion columns to an existing table',
+    'v180 adds both statistics-exclusion columns to an existing table',
     () async {
-      final db = AppDatabase(_dbAt175());
+      final db = AppDatabase(_dbAt179());
       addTearDown(db.close);
 
       final names = await _diveColumns(db);
@@ -41,7 +41,7 @@ void main() {
   );
 
   test('pre-existing dives default to included', () async {
-    final db = AppDatabase(_dbAt175());
+    final db = AppDatabase(_dbAt179());
     addTearDown(db.close);
 
     final row = await db
@@ -68,7 +68,7 @@ void main() {
     // backstop runs the same assert on every open, including on the stripped
     // databases other migration tests build.
     final native = NativeDatabase.memory(
-      setup: (rawDb) => rawDb.execute('PRAGMA user_version = 175'),
+      setup: (rawDb) => rawDb.execute('PRAGMA user_version = 179'),
     );
     final db = AppDatabase(native);
     addTearDown(db.close);
@@ -79,7 +79,7 @@ void main() {
   test('the backstop is idempotent across repeated opens', () async {
     // Reopening the same file-backed schema re-runs beforeOpen. The assert
     // must not attempt a second ALTER TABLE and fail with "duplicate column".
-    final db = AppDatabase(_dbAt175());
+    final db = AppDatabase(_dbAt179());
     addTearDown(db.close);
     await db.customSelect('SELECT 1').get();
 
@@ -95,8 +95,8 @@ void main() {
     );
   });
 
-  test('v178 is present in the migration ladder', () {
-    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(178));
-    expect(AppDatabase.migrationVersions, contains(178));
+  test('v180 is present in the migration ladder', () {
+    expect(AppDatabase.currentSchemaVersion, greaterThanOrEqualTo(180));
+    expect(AppDatabase.migrationVersions, contains(180));
   });
 }

--- a/test/core/services/export/uddf/uddf_exclusion_roundtrip_test.dart
+++ b/test/core/services/export/uddf/uddf_exclusion_roundtrip_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_export_builders.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:xml/xml.dart';
+
+/// UDDF is hand-plumbed (unlike sync, which rides Drift's generated
+/// serializer), so the statistics-exclusion flags need an explicit test.
+///
+/// Each flag is exercised alone as well as together, so a bug that writes one
+/// flag into the other's element cannot pass by symmetry.
+void main() {
+  Dive makeDive({
+    bool excludedFromStats = false,
+    bool excludedFromGasStats = false,
+  }) => Dive(
+    id: 'dive-exclusion',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 3, 28, 10, 0),
+    bottomTime: const Duration(minutes: 45),
+    maxDepth: 25.0,
+    excludedFromStats: excludedFromStats,
+    excludedFromGasStats: excludedFromGasStats,
+  );
+
+  String exportOne(Dive dive) {
+    final builder = XmlBuilder();
+    builder.element(
+      'root',
+      nest: () {
+        UddfExportBuilders.buildDiveElement(
+          builder,
+          dive,
+          null,
+          const [],
+          const [],
+          const [],
+          const [],
+          null,
+          const [],
+        );
+      },
+    );
+    return builder.buildDocument().toXmlString();
+  }
+
+  bool? readFlag(String xml, String tag) {
+    final el = XmlDocument.parse(xml).findAllElements(tag).firstOrNull;
+    return el == null ? null : el.innerText.toLowerCase() == 'true';
+  }
+
+  test('an included dive writes neither exclusion element', () {
+    final xml = exportOne(makeDive());
+    expect(readFlag(xml, 'excludedfromstats'), isNull);
+    expect(readFlag(xml, 'excludedfromgasstats'), isNull);
+  });
+
+  test('the master flag alone writes only its own element', () {
+    final xml = exportOne(makeDive(excludedFromStats: true));
+    expect(readFlag(xml, 'excludedfromstats'), isTrue);
+    expect(
+      readFlag(xml, 'excludedfromgasstats'),
+      isNull,
+      reason:
+          'the master-implies-gas rule lives in SQL. Materialising it here '
+          'would lose the diver\'s own gas-only choice on re-import, so that '
+          'unticking the master flag would not restore it.',
+    );
+  });
+
+  test('the gas flag alone writes only its own element', () {
+    final xml = exportOne(makeDive(excludedFromGasStats: true));
+    expect(readFlag(xml, 'excludedfromstats'), isNull);
+    expect(readFlag(xml, 'excludedfromgasstats'), isTrue);
+  });
+
+  test('both flags write both elements', () {
+    final xml = exportOne(
+      makeDive(excludedFromStats: true, excludedFromGasStats: true),
+    );
+    expect(readFlag(xml, 'excludedfromstats'), isTrue);
+    expect(readFlag(xml, 'excludedfromgasstats'), isTrue);
+  });
+}

--- a/test/core/services/sync/sync_exclusion_flags_test.dart
+++ b/test/core/services/sync/sync_exclusion_flags_test.dart
@@ -1,0 +1,79 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// Regression guard for the statistics-exclusion flags crossing sync.
+///
+/// `SyncDataSerializer._exportDives` serialises via Drift's generated
+/// `toJson()`, so these flags ride along with no hand plumbing. That is
+/// precisely why this test exists: the serializer's own comment records that a
+/// hand-maintained map silently dropped bottomTime and GPS once before. If
+/// someone reintroduces a column allowlist, this fails instead of the flags
+/// quietly failing to reach the diver's other device.
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<Dive> insertAndRead({
+    required bool excludedFromStats,
+    required bool excludedFromGasStats,
+  }) async {
+    final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value('d1'),
+            diveDateTime: Value(at),
+            excludedFromStats: Value(excludedFromStats),
+            excludedFromGasStats: Value(excludedFromGasStats),
+            createdAt: Value(at),
+            updatedAt: Value(at),
+          ),
+        );
+    return (db.select(db.dives)..where((t) => t.id.equals('d1'))).getSingle();
+  }
+
+  test('both flags appear in the serialised payload', () async {
+    final row = await insertAndRead(
+      excludedFromStats: true,
+      excludedFromGasStats: true,
+    );
+    final json = row.toJson();
+    expect(json.containsKey('excludedFromStats'), isTrue);
+    expect(json.containsKey('excludedFromGasStats'), isTrue);
+    expect(json['excludedFromStats'], isTrue);
+    expect(json['excludedFromGasStats'], isTrue);
+  });
+
+  test('the flags survive a serialise/deserialise round trip', () async {
+    // Asymmetric on purpose: a bug that reads one flag into the other's slot
+    // would pass if both were set the same way.
+    final row = await insertAndRead(
+      excludedFromStats: false,
+      excludedFromGasStats: true,
+    );
+    final restored = Dive.fromJson(row.toJson());
+    expect(restored.excludedFromStats, isFalse);
+    expect(restored.excludedFromGasStats, isTrue);
+  });
+
+  test('an unflagged dive round-trips as included', () async {
+    final row = await insertAndRead(
+      excludedFromStats: false,
+      excludedFromGasStats: false,
+    );
+    final restored = Dive.fromJson(row.toJson());
+    expect(restored.excludedFromStats, isFalse);
+    expect(restored.excludedFromGasStats, isFalse);
+  });
+}

--- a/test/features/dive_log/dive_filter_excluded_axis_test.dart
+++ b/test/features/dive_log/dive_filter_excluded_axis_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/dive_filter_sql.dart';
+
+/// The excluded-dives axis has three implementations that must agree: the
+/// statistics SQL subquery, the paginated dive list's WHERE builder, and the
+/// in-memory apply() used by export/table/map views. A divergence between them
+/// is invisible until a diver notices two screens disagreeing, so this pins
+/// the two that can be exercised without a database and asserts the SQL one
+/// encodes the same rule.
+void main() {
+  final included = Dive(id: 'included', dateTime: DateTime(2026, 1, 1));
+  final excluded = Dive(
+    id: 'excluded',
+    dateTime: DateTime(2026, 1, 2),
+    excludedFromStats: true,
+  );
+  final gasExcluded = Dive(
+    id: 'gas-excluded',
+    dateTime: DateTime(2026, 1, 3),
+    excludedFromGasStats: true,
+  );
+
+  test('a null axis is inactive and filters nothing', () {
+    const filter = DiveFilterState();
+    expect(filter.hasActiveFilters, isFalse);
+    expect(filter.apply([included, excluded, gasExcluded]), hasLength(3));
+    expect(
+      buildFilteredDiveIdSubquery(filter).subquery,
+      isEmpty,
+      reason:
+          'an inactive filter must stay a no-op; the exclusion is '
+          'enforced by DiveStatsScope alongside this subquery, not inside it',
+    );
+  });
+
+  test('apply() keeps only excluded dives when the axis is true', () {
+    const filter = DiveFilterState(excludedFromStatsOnly: true);
+    expect(filter.hasActiveFilters, isTrue);
+    expect(
+      filter.apply([included, excluded, gasExcluded]).map((d) => d.id),
+      ['excluded'],
+      reason:
+          'the axis tracks the master flag only; a gas-excluded dive is '
+          'not "excluded from statistics"',
+    );
+  });
+
+  test('the SQL subquery encodes the same rule', () {
+    const filter = DiveFilterState(excludedFromStatsOnly: true);
+    final sql = buildFilteredDiveIdSubquery(filter);
+    expect(sql.subquery, contains('excluded_from_stats = 1'));
+    expect(
+      sql.subquery,
+      isNot(contains('excluded_from_gas_stats')),
+      reason: 'apply() does not consider the gas flag, so neither may SQL',
+    );
+    expect(sql.params, isEmpty);
+  });
+
+  test('copyWith can set and clear the axis', () {
+    const active = DiveFilterState(excludedFromStatsOnly: true);
+    expect(
+      active.copyWith(clearExcludedFromStatsOnly: true).excludedFromStatsOnly,
+      isNull,
+    );
+    expect(
+      const DiveFilterState()
+          .copyWith(excludedFromStatsOnly: true)
+          .excludedFromStatsOnly,
+      isTrue,
+    );
+  });
+
+  test('the axis composes with other axes rather than replacing them', () {
+    final favouriteAndExcluded = Dive(
+      id: 'both',
+      dateTime: DateTime(2026, 1, 4),
+      excludedFromStats: true,
+      isFavorite: true,
+    );
+    const filter = DiveFilterState(
+      excludedFromStatsOnly: true,
+      favoritesOnly: true,
+    );
+    expect(
+      filter.apply([included, excluded, favouriteAndExcluded]).map((d) => d.id),
+      ['both'],
+    );
+  });
+}

--- a/test/features/dive_log/dive_stats_exclusion_entity_test.dart
+++ b/test/features/dive_log/dive_stats_exclusion_entity_test.dart
@@ -16,7 +16,8 @@ void main() {
     expect(
       dive.copyWith(excludedFromStats: true).excludedFromGasStats,
       isFalse,
-      reason: 'the master flag must not write through to the gas flag; '
+      reason:
+          'the master flag must not write through to the gas flag; '
           'the implication lives in SQL, not in the entity',
     );
     expect(

--- a/test/features/dive_log/dive_stats_exclusion_entity_test.dart
+++ b/test/features/dive_log/dive_stats_exclusion_entity_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+void main() {
+  Dive makeDive() => Dive(id: 'd1', dateTime: DateTime(2026, 1, 1));
+
+  test('both exclusion flags default to false', () {
+    final dive = makeDive();
+    expect(dive.excludedFromStats, isFalse);
+    expect(dive.excludedFromGasStats, isFalse);
+  });
+
+  test('copyWith sets each flag independently', () {
+    final dive = makeDive();
+    expect(dive.copyWith(excludedFromStats: true).excludedFromStats, isTrue);
+    expect(
+      dive.copyWith(excludedFromStats: true).excludedFromGasStats,
+      isFalse,
+      reason: 'the master flag must not write through to the gas flag; '
+          'the implication lives in SQL, not in the entity',
+    );
+    expect(
+      dive.copyWith(excludedFromGasStats: true).excludedFromGasStats,
+      isTrue,
+    );
+    expect(
+      dive.copyWith(excludedFromGasStats: true).excludedFromStats,
+      isFalse,
+    );
+  });
+
+  test('copyWith preserves the flags when they are not passed', () {
+    final excluded = makeDive().copyWith(
+      excludedFromStats: true,
+      excludedFromGasStats: true,
+    );
+    final renamed = excluded.copyWith(notes: 'changed');
+    expect(renamed.excludedFromStats, isTrue);
+    expect(renamed.excludedFromGasStats, isTrue);
+  });
+
+  test('the flags participate in equality', () {
+    final a = makeDive();
+    expect(a, isNot(equals(a.copyWith(excludedFromStats: true))));
+    expect(a, isNot(equals(a.copyWith(excludedFromGasStats: true))));
+  });
+}

--- a/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
+++ b/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// The Dive section renders the two statistics-exclusion toggles. The one that
+/// matters is the gas toggle's behaviour while the master flag is on: it must
+/// read as checked and be inert, so the implication is visible rather than
+/// silently overriding what the diver picked.
+void main() {
+  Widget host({
+    required bool excludedFromStats,
+    required bool excludedFromGasStats,
+    ValueChanged<bool>? onStats,
+    ValueChanged<bool>? onGas,
+  }) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: TheDiveSection(
+            depthSymbol: 'm',
+            nameController: TextEditingController(),
+            maxDepthController: TextEditingController(),
+            avgDepthController: TextEditingController(),
+            bottomTimeController: TextEditingController(),
+            runtimeController: TextEditingController(),
+            diveNumberController: TextEditingController(),
+            entryText: '',
+            onEditEntry: () {},
+            exitText: null,
+            onEditExit: () {},
+            siteName: null,
+            onPickSite: () {},
+            excludedFromStats: excludedFromStats,
+            excludedFromGasStats: excludedFromGasStats,
+            onExcludedFromStatsChanged: onStats ?? (_) {},
+            onExcludedFromGasStatsChanged: onGas ?? (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  Switch switchAt(WidgetTester tester, Key key) {
+    return tester.widget<Switch>(
+      find.descendant(of: find.byKey(key), matching: find.byType(Switch)),
+    );
+  }
+
+  testWidgets('both toggles start off and are interactive', (tester) async {
+    await tester.pumpWidget(
+      host(excludedFromStats: false, excludedFromGasStats: false),
+    );
+    await tester.pumpAndSettle();
+
+    final stats = switchAt(tester, const Key('dive-edit-exclude-from-stats'));
+    final gas = switchAt(tester, const Key('dive-edit-exclude-from-gas-stats'));
+    expect(stats.value, isFalse);
+    expect(gas.value, isFalse);
+    expect(gas.onChanged, isNotNull);
+  });
+
+  testWidgets('the gas toggle reads checked and inert under the master flag', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(excludedFromStats: true, excludedFromGasStats: false),
+    );
+    await tester.pumpAndSettle();
+
+    final gas = switchAt(tester, const Key('dive-edit-exclude-from-gas-stats'));
+    expect(
+      gas.value,
+      isTrue,
+      reason:
+          'it must show the effective state: excluding a dive from all '
+          'statistics necessarily excludes it from the gas ones',
+    );
+    expect(
+      gas.onChanged,
+      isNull,
+      reason:
+          'inert rather than silently overridden, so the implication is '
+          'legible instead of surprising',
+    );
+  });
+
+  testWidgets('the gas toggle stands alone when the master flag is off', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      host(excludedFromStats: false, excludedFromGasStats: true),
+    );
+    await tester.pumpAndSettle();
+
+    final stats = switchAt(tester, const Key('dive-edit-exclude-from-stats'));
+    final gas = switchAt(tester, const Key('dive-edit-exclude-from-gas-stats'));
+    expect(stats.value, isFalse, reason: 'the gas flag must not imply master');
+    expect(gas.value, isTrue);
+    expect(gas.onChanged, isNotNull);
+  });
+
+  testWidgets('toggling the master flag reports the new value', (tester) async {
+    bool? reported;
+    await tester.pumpWidget(
+      host(
+        excludedFromStats: false,
+        excludedFromGasStats: false,
+        onStats: (v) => reported = v,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('dive-edit-exclude-from-stats')),
+        matching: find.byType(Switch),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(reported, isTrue);
+  });
+}

--- a/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
+++ b/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
@@ -123,4 +123,50 @@ void main() {
     await tester.pumpAndSettle();
     expect(reported, isTrue);
   });
+
+  testWidgets('each toggle renders its explanatory help text', (tester) async {
+    await tester.pumpWidget(
+      host(excludedFromStats: false, excludedFromGasStats: false),
+    );
+    await tester.pumpAndSettle();
+
+    // The labels alone do not say the dive count is affected, which is the
+    // part that surprises people months later.
+    expect(
+      find.textContaining('including your dive count'),
+      findsOneWidget,
+      reason: 'the master toggle must spell out that the count changes too',
+    );
+    expect(
+      find.textContaining('SAC, RMV and gas mix statistics only'),
+      findsOneWidget,
+      reason: 'the gas toggle must say it is narrower than the master flag',
+    );
+  });
+
+  testWidgets('the help text is a wrapping paragraph, not a fixed line', (
+    tester,
+  ) async {
+    // The help lines are long, so they must be free to wrap rather than being
+    // clipped to one line. Asserted on the widget rather than by measuring
+    // overflow: FormRow's own label is not Flexible, so under the test font
+    // (one fontSize-wide glyph per character) the ROW overflows at narrow
+    // widths independently of anything this feature added.
+    await tester.pumpWidget(
+      host(excludedFromStats: false, excludedFromGasStats: false),
+    );
+    await tester.pumpAndSettle();
+
+    final help = tester.widget<Text>(
+      find.textContaining('including your dive count'),
+    );
+    expect(
+      help.maxLines,
+      isNull,
+      reason:
+          'an unset maxLines lets the paragraph wrap to as many lines as '
+          'the locale needs; German and Hungarian run materially longer',
+    );
+    expect(help.overflow, anyOf(isNull, TextOverflow.clip));
+  });
 }

--- a/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_dive_edit_form_test.dart
@@ -72,10 +72,13 @@ void main() {
       await pumpBulk(tester);
 
       // 4 Logistics + 9 Conditions + 6 Weather + 6 Rebreather + 1 Buddies
-      // (my role, #1220) + 1 Notes gates.
+      // (my role, #1220) + 1 Notes + 2 statistics-exclusion gates (#526,
+      // #1272) = 29.
       // (dive type moved from a scalar gate to the collection lane, #414)
-      expect(find.byType(BulkFieldGate), findsNWidgets(27));
+      expect(find.byType(BulkFieldGate), findsNWidgets(29));
       expect(find.text('Favorite'), findsOneWidget);
+      expect(find.text('Exclude from statistics'), findsOneWidget);
+      expect(find.text('Exclude from gas statistics'), findsOneWidget);
       // Only the 3 owned collections (weights, tanks, sightings) still use a
       // mode selector; the 4 reference collections (tags, diveTypes,
       // equipment, buddies) use the tri-state membership editor.

--- a/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
+++ b/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -163,6 +164,79 @@ void main() {
       final records = await repository.getSacVolumeRecords();
       expect(records.best?.id, isNot('excluded'));
       expect(records.worst?.id, isNot('excluded'));
+    });
+  });
+
+  group('DiveRepository aggregates', () {
+    late DiveRepository diveRepo;
+
+    setUp(() {
+      diveRepo = DiveRepository();
+    });
+
+    test('getStatistics counts only dives in scope', () async {
+      final stats = await diveRepo.getStatistics();
+      expect(stats.totalDives, nonGasInScope);
+    });
+
+    test('getRecords never surfaces an excluded dive', () async {
+      // Make the excluded dive the deepest and the planned dive the longest,
+      // so a leak is unmissable rather than a tie broken the lucky way.
+      await db.customStatement(
+        "UPDATE dives SET max_depth = 99.0 WHERE id = 'excluded'",
+      );
+      await db.customStatement(
+        "UPDATE dives SET bottom_time = 99999 WHERE id = 'planned'",
+      );
+
+      final records = await diveRepo.getRecords();
+      expect(records.deepestDive?.diveId, isNot('excluded'));
+      expect(records.longestDive?.diveId, isNot('planned'));
+      expect(records.deepestDive?.diveId, isNotNull);
+    });
+
+    test('getPersonalRecordIds never surfaces an excluded dive', () async {
+      await db.customStatement(
+        "UPDATE dives SET max_depth = 99.0 WHERE id = 'excluded'",
+      );
+      final ids = await diveRepo.getPersonalRecordIds();
+      final winners = [
+        ids.deepestId,
+        ids.longestId,
+        ids.coldestId,
+        ids.warmestId,
+      ];
+      expect(winners, isNot(contains('excluded')));
+      expect(winners, isNot(contains('planned')));
+    });
+
+    test('countDivesSince counts only dives in scope', () async {
+      final count = await diveRepo.countDivesSince(DateTime.utc(2020));
+      expect(count, nonGasInScope);
+    });
+
+    test('getOnThisDayDiveIds skips excluded dives', () async {
+      final ids = await diveRepo.getOnThisDayDiveIds(
+        month: 1,
+        day: 1,
+        excludeYear: 2030,
+      );
+      expect(ids, isNot(contains('excluded')));
+      expect(ids, isNot(contains('planned')));
+      expect(ids, contains('included'));
+    });
+
+    test('getDiveCount deliberately still counts excluded dives', () async {
+      final count = await diveRepo.getDiveCount();
+      expect(
+        count,
+        5,
+        reason:
+            'the logbook list header counts what is in the logbook, and '
+            'an excluded dive is still in the logbook. If this ever starts '
+            'returning 3, someone applied DiveStatsScope where the design '
+            'deliberately does not.',
+      );
     });
   });
 }

--- a/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
+++ b/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
@@ -1,7 +1,11 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
+import 'package:submersion/features/dive_centers/data/repositories/dive_center_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_sites/data/repositories/site_repository_impl.dart';
+import 'package:submersion/features/divers/data/repositories/diver_repository.dart';
 import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -237,6 +241,99 @@ void main() {
             'returning 3, someone applied DiveStatsScope where the design '
             'deliberately does not.',
       );
+    });
+  });
+
+  group('per-entity descriptive counts', () {
+    setUp(() async {
+      // Link the included dive AND the out-of-scope dives to the same buddy,
+      // site and centre, so a leak shows up as 3 where 1 is correct.
+      final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+      await db
+          .into(db.buddies)
+          .insert(
+            BuddiesCompanion(
+              id: const Value('b1'),
+              name: const Value('Test Buddy'),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+      await db
+          .into(db.diveSites)
+          .insert(
+            DiveSitesCompanion(
+              id: const Value('s1'),
+              name: const Value('Test Site'),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+      for (final id in ['included', 'excluded', 'planned']) {
+        await db
+            .into(db.diveBuddies)
+            .insert(
+              DiveBuddiesCompanion(
+                id: Value('db-$id'),
+                diveId: Value(id),
+                buddyId: const Value('b1'),
+                createdAt: Value(at),
+              ),
+            );
+        await db.customStatement(
+          "UPDATE dives SET site_id = 's1' WHERE id = '$id'",
+        );
+      }
+    });
+
+    test('getDiveCountForBuddy ignores excluded and planned dives', () async {
+      expect(await BuddyRepository().getDiveCountForBuddy('b1'), 1);
+    });
+
+    test(
+      'getDiveAggregatesBySite ignores excluded and planned dives',
+      () async {
+        final agg = await SiteRepository().getDiveAggregatesBySite();
+        expect(agg['s1']?.diveCount, 1);
+      },
+    );
+
+    test('getDiveCountForDiver ignores excluded and planned dives', () async {
+      final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+      await db
+          .into(db.divers)
+          .insert(
+            DiversCompanion(
+              id: const Value('diver-1'),
+              name: const Value('Test Diver'),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+      await db.customStatement("UPDATE dives SET diver_id = 'diver-1'");
+      expect(
+        await DiverRepository().getDiveCountForDiver('diver-1'),
+        nonGasInScope,
+      );
+    });
+
+    test('getDiveCountForCenter ignores excluded and planned dives', () async {
+      final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+      await db
+          .into(db.diveCenters)
+          .insert(
+            DiveCentersCompanion(
+              id: const Value('c1'),
+              name: const Value('Test Centre'),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+      await db.customStatement(
+        "UPDATE dives SET dive_center_id = 'c1' "
+        "WHERE id IN ('included', 'excluded')",
+      );
+      expect(await DiveCenterRepository().getDiveCountForCenter('c1'), 1);
     });
   });
 }

--- a/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
+++ b/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
@@ -1,0 +1,168 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Behavioral guard for [DiveStatsScope]: proves every descriptive aggregate
+/// actually drops the dives it is supposed to, rather than merely that the
+/// predicate string is well formed.
+///
+/// The fixture seeds five dives, all identical apart from the flag under test,
+/// so a leak shows up as an inflated count rather than a subtle shift:
+///
+/// | id           | counted by non-gas aggregates | counted by gas aggregates |
+/// |--------------|-------------------------------|---------------------------|
+/// | included     | yes                           | yes                       |
+/// | excluded     | no (master flag)              | no                        |
+/// | gas-excluded | yes                           | no                        |
+/// | planned      | no                            | no                        |
+/// | gauge        | yes                           | no (gauge has no gas data)|
+///
+/// So a non-gas aggregate sees 3 dives and a gas aggregate sees 1.
+void main() {
+  late StatisticsRepository repository;
+  late AppDatabase db;
+
+  /// Dives in scope for a descriptive, non-gas aggregate.
+  const nonGasInScope = 3;
+
+  /// Dives in scope for a SAC/RMV or gas-mix aggregate.
+  const gasInScope = 1;
+
+  Future<void> insertDive(
+    String id, {
+    bool excludedFromStats = false,
+    bool excludedFromGasStats = false,
+    bool isPlanned = false,
+    String diveMode = 'oc',
+  }) async {
+    final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(at),
+            diveMode: Value(diveMode),
+            avgDepth: const Value(15.0),
+            maxDepth: const Value(30.0),
+            bottomTime: const Value(1800),
+            isPlanned: Value(isPlanned),
+            excludedFromStats: Value(excludedFromStats),
+            excludedFromGasStats: Value(excludedFromGasStats),
+            createdAt: Value(at),
+            updatedAt: Value(at),
+          ),
+        );
+    await db
+        .into(db.diveTanks)
+        .insert(
+          DiveTanksCompanion(
+            id: Value('tank-$id'),
+            diveId: Value(id),
+            startPressure: const Value(200.0),
+            endPressure: const Value(50.0),
+            volume: const Value(11.1),
+            o2Percent: const Value(21.0),
+            hePercent: const Value(0.0),
+            tankOrder: const Value(0),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = StatisticsRepository();
+
+    await insertDive('included');
+    await insertDive('excluded', excludedFromStats: true);
+    await insertDive('gas-excluded', excludedFromGasStats: true);
+    await insertDive('planned', isPlanned: true);
+    await insertDive('gauge', diveMode: 'gauge');
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  group('non-gas aggregates drop excluded and planned dives', () {
+    test('getDivesPerYear', () async {
+      final rows = await repository.getDivesPerYear();
+      final total = rows.fold<int>(0, (sum, r) => sum + r.count);
+      expect(total, nonGasInScope);
+    });
+
+    test('getCumulativeDiveCount', () async {
+      final rows = await repository.getCumulativeDiveCount();
+      expect(rows.last.value, nonGasInScope.toDouble());
+    });
+
+    test('getDepthProgressionTrend', () async {
+      final rows = await repository.getDepthProgressionTrend();
+      expect(rows, isNotEmpty);
+      // One monthly bucket; every seeded dive has the same max depth, so the
+      // assertion that bites is the count behind the average, checked above.
+      expect(rows.first.value, 30.0);
+    });
+
+    test('getDivesByDayOfWeek', () async {
+      final rows = await repository.getDivesByDayOfWeek();
+      final total = rows.fold<int>(0, (sum, r) => sum + r.count);
+      expect(total, nonGasInScope);
+    });
+
+    test('getDivesBySeason', () async {
+      final rows = await repository.getDivesBySeason();
+      final total = rows.fold<int>(0, (sum, r) => sum + r.count);
+      expect(total, nonGasInScope);
+    });
+  });
+
+  group('gas aggregates additionally drop gas-excluded and gauge dives', () {
+    test('getGasMixDistribution', () async {
+      final dist = await repository.getGasMixDistribution();
+      final total = dist.fold<int>(0, (sum, s) => sum + s.count);
+      expect(
+        total,
+        gasInScope,
+        reason:
+            'the gauge dive and the gas-excluded dive both drop out, on '
+            'top of the master-excluded and planned dives',
+      );
+    });
+
+    test('getSacVolumeTrend', () async {
+      final rows = await repository.getSacVolumeTrend();
+      expect(rows, isNotEmpty, reason: 'the included dive has tank volume');
+      // One month bucket holding exactly the in-scope dives.
+      expect(rows.length, 1);
+    });
+
+    test('getSacVolumeRecords', () async {
+      final records = await repository.getSacVolumeRecords();
+      expect(records.best, isNotNull);
+      expect(
+        records.best!.id,
+        'included',
+        reason: 'the only dive in scope for a gas aggregate',
+      );
+      expect(
+        records.worst?.id,
+        anyOf(isNull, 'included'),
+        reason:
+            'with a single dive in scope, best and worst are the same '
+            'dive or worst is unset; either way no excluded dive appears',
+      );
+    });
+  });
+
+  group('the master flag implies the gas flag', () {
+    test('a master-excluded dive is absent from gas aggregates too', () async {
+      final records = await repository.getSacVolumeRecords();
+      expect(records.best?.id, isNot('excluded'));
+      expect(records.worst?.id, isNot('excluded'));
+    });
+  });
+}

--- a/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
+++ b/test/features/statistics/data/repositories/dive_stats_scope_behavior_test.dart
@@ -104,8 +104,8 @@ void main() {
       expect(rows.last.value, nonGasInScope.toDouble());
     });
 
-    test('getDepthProgressionTrend', () async {
-      final rows = await repository.getDepthProgressionTrend();
+    test('getDepthPerDive', () async {
+      final rows = await repository.getDepthPerDive();
       expect(rows, isNotEmpty);
       // One monthly bucket; every seeded dive has the same max depth, so the
       // assertion that bites is the count behind the average, checked above.
@@ -138,8 +138,8 @@ void main() {
       );
     });
 
-    test('getSacVolumeTrend', () async {
-      final rows = await repository.getSacVolumeTrend();
+    test('getSacVolumePerDive', () async {
+      final rows = await repository.getSacVolumePerDive();
       expect(rows, isNotEmpty, reason: 'the included dive has tank volume');
       // One month bucket holding exactly the in-scope dives.
       expect(rows.length, 1);

--- a/test/features/statistics/excluded_dives_footnote_test.dart
+++ b/test/features/statistics/excluded_dives_footnote_test.dart
@@ -1,0 +1,67 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late StatisticsRepository repo;
+
+  Future<void> insert(
+    String id, {
+    bool excluded = false,
+    bool planned = false,
+    String? diverId,
+  }) async {
+    final at = DateTime.utc(2026, 1, 1).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: Value(at),
+            excludedFromStats: Value(excluded),
+            isPlanned: Value(planned),
+            diverId: Value(diverId),
+            createdAt: Value(at),
+            updatedAt: Value(at),
+          ),
+        );
+  }
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repo = StatisticsRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  test('counts zero when nothing is excluded', () async {
+    await insert('a');
+    expect(await repo.countExcludedDives(), 0);
+  });
+
+  test('counts only dives the diver excluded', () async {
+    await insert('a');
+    await insert('b', excluded: true);
+    await insert('c', excluded: true);
+    expect(await repo.countExcludedDives(), 2);
+  });
+
+  test('does not count planned dives', () async {
+    await insert('a');
+    await insert('planned', planned: true);
+    expect(
+      await repo.countExcludedDives(),
+      0,
+      reason:
+          'the footnote explains the diver\'s own choice back to them; a '
+          'planned dive is not something they chose to exclude, so counting '
+          'it here would confuse rather than clarify',
+    );
+  });
+}


### PR DESCRIPTION
Closes #526. Closes #1272.

## What this adds

Two per-dive flags, both defaulting to off:

- **Exclude from statistics** (#526). The dive stays in your logbook, fully visible and editable, but contributes to no statistic, its count included. For the 90-minute dive at 12 ft that is not an official dive by most agency standards.
- **Exclude from gas statistics** (#1272). Drops the dive from SAC, RMV and gas-mix figures only. For an otherwise ordinary dive whose gas number is unrepresentative, such as purging the tank to 500 psi for an end-of-dive weight check.

The master flag implies the gas one. That implication lives only in SQL: the two stay independent on the entity, so unticking the master flag restores your original gas-only choice rather than having silently overwritten it. The UI shows the implication by rendering the gas toggle checked and inert while the master flag is on.

Both are available in bulk edit, which is what makes #526 practical for someone with thirty pool sessions. A badge on the dive list explains why a dive is not counted, and a filter axis finds the dives you have excluded.

## Descriptive versus operational

Not every count of dives is a statistic. Descriptive counts honour the flags: the Statistics tab, records, career totals, the dashboard, and per-entity counts on buddy, site, trip, dive-centre, dive-type, diver and marine-life surfaces.

Three categories deliberately keep counting excluded dives, each with a doc comment saying why:

- **Gear service intervals.** A practice dive still cycled the regulator and put hours on it. Suppressing it would push a real service interval later than it should be, which is safety-relevant rather than cosmetic.
- **Course requirement progress.** You linked that dive to a requirement on purpose. Excluding it from your averages is not a retraction of course credit.
- **The logbook list header, deletion guards, and dedupe.** An excluded dive is still in your logbook, still referenced by the dive types and tags you would be deleting, and still already imported.

The census below surfaced two more that would have been actively dangerous to scope: `getNoFlyDiveInputs` and `getSurfaceInterval`. An excluded dive still off-gassed.

## How it is enforced, and how it stays enforced

A single `DiveStatsScope` predicate is the one place deciding which dives count. It is applied *alongside* `buildFilteredDiveIdSubquery`, never inside it: that function is your transient view filter and correctly no-ops when nothing is selected, while this scope is a persistent property of the dive. Folding them together would either make the exclusion evaporate for everyone who never opens the filter sheet, or silently scope the deliberately-unfiltered surfaces (dashboard quick stats, dive-log summary, species detail page).

Threading it through `StatisticsRepository._diveFilter` fixes 37 aggregates in one edit.

Two test layers, because correctness and completeness are different problems:

1. A **behavioural suite** seeds five dives differing only by flag and asserts every descriptive aggregate drops the right ones.
2. A **source census** asserts every member reading `dives` either applies the scope or carries a `stats-scope-exempt` marker with a reason. Verified in both directions: an unscoped probe query makes it fail, so it is not passing vacuously.

The census exists because this rule decayed once already. `dive_mode <> 'gauge'` was hand-copied into seven queries with nothing ensuring an eighth would get it. Those seven literals are now gone, replaced by the shared gas variant, and the pre-existing gauge test still passes unmodified.

## Behaviour change worth calling out

**Planned dives no longer count toward statistics.** A dive created in the planner but never logged was previously included in every total, average and record; no aggregate filtered on `is_planned`. Folding it into the same predicate fixes it in one line.

This changes existing divers' numbers on upgrade with no action on their part, so it needs a line in the release notes. Anyone who has used the planner will see their dive count and averages change to reflect only dives they actually made.

## Schema

Rung **v180**, two boolean columns on `dives`, both defaulting to included. Column-only with no backfill, so the `beforeOpen` backstop is safe to re-run. Renumbered from 178: main landed 178 and 179 while this branch was open, and a rung at or below the shipped version merges with no conflict marker and its `onUpgrade` step then never runs.

Sync carries the flags with no hand plumbing (Drift's generated `toJson`); UDDF is hand-plumbed and round-trip tested. Export deliberately does not materialise the master-implies-gas rule, or re-importing would lose your gas-only choice.

## Verification

- `flutter analyze` across the whole project: clean.
- Full suite: 21,863 tests. One failure, `media_share_helper_test.dart`, which passes when run alone: a known full-suite-only flake in unrelated media code.
- Localised in all eleven locales. German uses AMV rather than SAC, per the repo's own terminology test.

## Not done here

No release-notes file: those are compiled per release from the Projects board, not per PR. The `is_planned` change needs to reach the v1.7.8 notes.
