### PR TITLE
refactor(dive): move the statistics-exclusion toggles into their own collapsible group

### DIFF
--- a/docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md
+++ b/docs/superpowers/specs/2026-08-28-exclude-dive-from-statistics-design.md
@@ -240,12 +240,19 @@ requires an explicit release note.
 
 ## Section 3: UI and localization
 
-**Dive edit form.** Two checkboxes at the end of `_buildTheDiveSection`
-(`dive_edit_page.dart:2025`), under a small "Statistics" label. That section
-holds dive number, date, site, and depth, so a flag about how the dive is
-counted belongs there rather than in Experience (rating, notes, sightings,
-tags). The collapsed section summary picks up an "Excluded" marker when either
-flag is set.
+**Dive edit form.** A collapsible "Statistics" group at the bottom of the
+form (`_buildStatisticsSection`, rendered after the contextual groups and
+before the AddSectionRow), holding the two toggles.
+
+The toggles first shipped as two rows at the end of `_buildTheDiveSection`,
+on the reasoning that the group holding dive number, date, site and depth is
+where a flag about how the dive is counted belongs. In practice they read as
+clutter inside an always-expanded group of core facts, so they moved into
+their own collapsible group instead, matching the other expandable ones. The
+group is collapsed unless the dive is already excluded, and its header carries
+the state: an "Excluded" or "Gas excluded" summary, or the fainter "Counted in
+every statistic" hint. Nothing in the group is a validated field, so it does
+not join the sections `_saveDive` force-expands before `Form.validate()`.
 
 The gas checkbox renders disabled and checked while the master flag is on, so
 the implication is visible rather than surprising.

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -67,6 +67,7 @@ import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/
 import 'package:submersion/features/cylinder_configs/domain/entities/cylinder_config.dart';
 import 'package:submersion/features/cylinder_configs/domain/services/dive_tank_config_adapter.dart';
 import 'package:submersion/features/cylinder_configs/presentation/widgets/apply_configuration_menu.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/statistics_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/tank_row.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/trip_section.dart';
@@ -903,6 +904,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                 _buildExperienceSection(),
                 if (_showCourseSection) _buildCourseGroupSection(),
                 if (_showCustomFieldsSection) _buildCustomFieldsGroupSection(),
+                _buildStatisticsSection(),
                 AddSectionRow(
                   entries: [
                     if (!_showCourseSection)
@@ -2050,16 +2052,6 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   Widget _buildTheDiveSection(UnitFormatter units) {
     final hasProfile = _existingDive?.profile.isNotEmpty == true;
     return TheDiveSection(
-      excludedFromStats: _excludedFromStats,
-      excludedFromGasStats: _excludedFromGasStats,
-      onExcludedFromStatsChanged: (v) {
-        _markDirty();
-        setState(() => _excludedFromStats = v);
-      },
-      onExcludedFromGasStatsChanged: (v) {
-        _markDirty();
-        setState(() => _excludedFromGasStats = v);
-      },
       depthSymbol: units.depthSymbol,
       nameController: _nameController,
       maxDepthController: _maxDepthController,
@@ -2525,6 +2517,42 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
       child: _customFieldsChild(),
     );
   }
+
+  Widget _buildStatisticsSection() {
+    return StatisticsSection(
+      // Collapsed unless this dive is already excluded, so the setting stays
+      // out of the way of the dives that are just dives.
+      expanded: _isExpanded(
+        'statistics',
+        defaultValue: _excludedFromStats || _excludedFromGasStats,
+      ),
+      onToggle: () => _toggleSection(
+        'statistics',
+        defaultValue: _excludedFromStats || _excludedFromGasStats,
+      ),
+      excludedFromStats: _excludedFromStats,
+      excludedFromGasStats: _excludedFromGasStats,
+      onExcludedFromStatsChanged: (v) {
+        _markDirty();
+        setState(() {
+          _excludedFromStats = v;
+          _pinStatisticsOpen();
+        });
+      },
+      onExcludedFromGasStatsChanged: (v) {
+        _markDirty();
+        setState(() {
+          _excludedFromGasStats = v;
+          _pinStatisticsOpen();
+        });
+      },
+    );
+  }
+
+  /// The section's default expansion follows the two flags, so clearing the
+  /// last one would otherwise shut the group under the diver's finger. Once
+  /// they have touched a toggle, expansion is theirs to decide.
+  void _pinStatisticsOpen() => _expanded['statistics'] = true;
 
   Widget _buildExperienceSection() {
     return ExperienceSection(

--- a/lib/features/dive_log/presentation/widgets/edit_sections/statistics_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/statistics_section.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/widgets/forms/form_row.dart';
+import 'package:submersion/shared/widgets/forms/form_section.dart';
+
+/// Last group of the dive form: the statistics-exclusion toggles (#526 /
+/// #1272). Collapsed by default because most dives are never excluded, so the
+/// header carries the state instead: a summary naming the exclusion, or the
+/// fainter "counted" hint when there is none.
+///
+/// Nothing in here is a validated field, so unlike the other collapsible
+/// groups it does not need force-expanding before `Form.validate()`; the two
+/// flags live on the page, not in the collapsed subtree.
+class StatisticsSection extends StatelessWidget {
+  const StatisticsSection({
+    super.key,
+    required this.expanded,
+    required this.onToggle,
+    required this.excludedFromStats,
+    required this.excludedFromGasStats,
+    required this.onExcludedFromStatsChanged,
+    required this.onExcludedFromGasStatsChanged,
+  });
+
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  /// The gas toggle renders inert while [excludedFromStats] is on, because
+  /// the master flag already implies it.
+  final bool excludedFromStats;
+  final bool excludedFromGasStats;
+  final ValueChanged<bool> onExcludedFromStatsChanged;
+  final ValueChanged<bool> onExcludedFromGasStatsChanged;
+
+  bool get _isExcluded => excludedFromStats || excludedFromGasStats;
+
+  /// Header text for the collapsed group. The master flag wins: it already
+  /// implies the gas one, so naming both would read as two separate settings.
+  String _summary(AppLocalizations l10n) {
+    if (excludedFromStats) return l10n.diveLog_edit_summary_excluded;
+    if (excludedFromGasStats) return l10n.diveLog_edit_summary_gasExcluded;
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return FormSection(
+      label: l10n.diveLog_edit_group_statistics,
+      icon: Icons.bar_chart_outlined,
+      expanded: expanded,
+      onToggle: onToggle,
+      // An exclusion has to be readable with the group shut, or the only
+      // trace of it is behind a closed section.
+      summary: _summary(l10n),
+      isEmpty: !_isExcluded,
+      emptyInvitation: l10n.diveLog_edit_statisticsIncludedHint,
+      children: [
+        FormRow.toggle(
+          key: const Key('dive-edit-exclude-from-stats'),
+          label: l10n.diveLog_edit_excludeFromStats,
+          value: excludedFromStats,
+          onChanged: onExcludedFromStatsChanged,
+          // The label alone does not say the dive count is affected, which
+          // is the part that surprises people later.
+          helpText: l10n.diveLog_edit_excludeFromStatsHelp,
+        ),
+        FormRow.toggle(
+          key: const Key('dive-edit-exclude-from-gas-stats'),
+          label: l10n.diveLog_edit_excludeFromGasStats,
+          // Show the effective state: the master flag implies this one.
+          value: excludedFromStats || excludedFromGasStats,
+          onChanged: onExcludedFromGasStatsChanged,
+          enabled: !excludedFromStats,
+          helpText: l10n.diveLog_edit_excludeFromGasStatsHelp,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart
@@ -38,10 +38,6 @@ class TheDiveSection extends StatelessWidget {
     this.surfaceIntervalRow,
     this.siteExtras,
     this.profileChild,
-    this.excludedFromStats = false,
-    this.excludedFromGasStats = false,
-    this.onExcludedFromStatsChanged,
-    this.onExcludedFromGasStatsChanged,
   });
 
   final String depthSymbol;
@@ -73,13 +69,6 @@ class TheDiveSection extends StatelessWidget {
   /// Existing profile block (points count, outlier chip, edit/draw
   /// buttons), stripped of its Card wrapper.
   final Widget? profileChild;
-
-  /// Statistics exclusion (#526 / #1272). The gas toggle renders inert while
-  /// [excludedFromStats] is on, because the master flag already implies it.
-  final bool excludedFromStats;
-  final bool excludedFromGasStats;
-  final ValueChanged<bool>? onExcludedFromStatsChanged;
-  final ValueChanged<bool>? onExcludedFromGasStatsChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -156,26 +145,6 @@ class TheDiveSection extends StatelessWidget {
         ),
         ?siteExtras,
         ?profileChild,
-        if (onExcludedFromStatsChanged != null)
-          FormRow.toggle(
-            key: const Key('dive-edit-exclude-from-stats'),
-            label: l10n.diveLog_edit_excludeFromStats,
-            value: excludedFromStats,
-            onChanged: onExcludedFromStatsChanged!,
-            // The label alone does not say the dive count is affected, which
-            // is the part that surprises people later.
-            helpText: l10n.diveLog_edit_excludeFromStatsHelp,
-          ),
-        if (onExcludedFromGasStatsChanged != null)
-          FormRow.toggle(
-            key: const Key('dive-edit-exclude-from-gas-stats'),
-            label: l10n.diveLog_edit_excludeFromGasStats,
-            // Show the effective state: the master flag implies this one.
-            value: excludedFromStats || excludedFromGasStats,
-            onChanged: onExcludedFromGasStatsChanged!,
-            enabled: !excludedFromStats,
-            helpText: l10n.diveLog_edit_excludeFromGasStatsHelp,
-          ),
       ],
     );
   }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "استبعاد من إحصائيات الغاز",
   "diveLog_filter_excludedOnly": "المستبعدة من الإحصائيات فقط",
   "diveLog_edit_summary_excluded": "مستبعدة",
-  "statistics_excludedDivesFootnote": "{count, plural, zero{لا غطسات مستبعدة من الإحصائيات} one{غطسة واحدة مستبعدة من الإحصائيات} two{غطستان مستبعدتان من الإحصائيات} few{{count} غطسات مستبعدة من الإحصائيات} many{{count} غطسة مستبعدة من الإحصائيات} other{{count} غطسة مستبعدة من الإحصائيات}}"
+  "statistics_excludedDivesFootnote": "{count, plural, zero{لا غطسات مستبعدة من الإحصائيات} one{غطسة واحدة مستبعدة من الإحصائيات} two{غطستان مستبعدتان من الإحصائيات} few{{count} غطسات مستبعدة من الإحصائيات} many{{count} غطسة مستبعدة من الإحصائيات} other{{count} غطسة مستبعدة من الإحصائيات}}",
+  "diveLog_edit_group_statistics": "الإحصائيات",
+  "diveLog_edit_summary_gasExcluded": "الغاز مستبعد",
+  "diveLog_edit_statisticsIncludedHint": "محتسبة في كل الإحصائيات"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Von Gasstatistiken ausschließen",
   "diveLog_filter_excludedOnly": "Nur von Statistiken ausgeschlossene",
   "diveLog_edit_summary_excluded": "Ausgeschlossen",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 Tauchgang von Statistiken ausgeschlossen} other{{count} Tauchgänge von Statistiken ausgeschlossen}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 Tauchgang von Statistiken ausgeschlossen} other{{count} Tauchgänge von Statistiken ausgeschlossen}}",
+  "diveLog_edit_group_statistics": "Statistiken",
+  "diveLog_edit_summary_gasExcluded": "Gas ausgeschlossen",
+  "diveLog_edit_statisticsIncludedHint": "In allen Statistiken enthalten"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -21598,5 +21598,17 @@
         "type": "int"
       }
     }
+  },
+  "diveLog_edit_group_statistics": "Statistics",
+  "@diveLog_edit_group_statistics": {
+    "description": "Collapsible dive-form group holding the statistics-exclusion toggles"
+  },
+  "diveLog_edit_summary_gasExcluded": "Gas excluded",
+  "@diveLog_edit_summary_gasExcluded": {
+    "description": "Collapsed Statistics group summary when only gas statistics are excluded"
+  },
+  "diveLog_edit_statisticsIncludedHint": "Counted in every statistic",
+  "@diveLog_edit_statisticsIncludedHint": {
+    "description": "Collapsed Statistics group hint when the dive is not excluded"
   }
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Excluir de las estadísticas de gas",
   "diveLog_filter_excludedOnly": "Solo las excluidas de las estadísticas",
   "diveLog_edit_summary_excluded": "Excluida",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 inmersión excluida de las estadísticas} other{{count} inmersiones excluidas de las estadísticas}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 inmersión excluida de las estadísticas} other{{count} inmersiones excluidas de las estadísticas}}",
+  "diveLog_edit_group_statistics": "Estadísticas",
+  "diveLog_edit_summary_gasExcluded": "Gas excluido",
+  "diveLog_edit_statisticsIncludedHint": "Incluida en todas las estadísticas"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Exclure des statistiques de gaz",
   "diveLog_filter_excludedOnly": "Uniquement les exclues des statistiques",
   "diveLog_edit_summary_excluded": "Exclue",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 plongée exclue des statistiques} other{{count} plongées exclues des statistiques}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 plongée exclue des statistiques} other{{count} plongées exclues des statistiques}}",
+  "diveLog_edit_group_statistics": "Statistiques",
+  "diveLog_edit_summary_gasExcluded": "Gaz exclu",
+  "diveLog_edit_statisticsIncludedHint": "Comptée dans toutes les statistiques"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "החרג מסטטיסטיקות הגז",
   "diveLog_filter_excludedOnly": "רק המוחרגות מהסטטיסטיקות",
   "diveLog_edit_summary_excluded": "מוחרגת",
-  "statistics_excludedDivesFootnote": "{count, plural, one{צלילה אחת מוחרגת מהסטטיסטיקות} two{שתי צלילות מוחרגות מהסטטיסטיקות} many{{count} צלילות מוחרגות מהסטטיסטיקות} other{{count} צלילות מוחרגות מהסטטיסטיקות}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{צלילה אחת מוחרגת מהסטטיסטיקות} two{שתי צלילות מוחרגות מהסטטיסטיקות} many{{count} צלילות מוחרגות מהסטטיסטיקות} other{{count} צלילות מוחרגות מהסטטיסטיקות}}",
+  "diveLog_edit_group_statistics": "סטטיסטיקות",
+  "diveLog_edit_summary_gasExcluded": "הגז הוחרג",
+  "diveLog_edit_statisticsIncludedHint": "נכללת בכל הסטטיסטיקות"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Kizárás a gázstatisztikákból",
   "diveLog_filter_excludedOnly": "Csak a statisztikákból kizártak",
   "diveLog_edit_summary_excluded": "Kizárva",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 merülés kizárva a statisztikákból} other{{count} merülés kizárva a statisztikákból}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 merülés kizárva a statisztikákból} other{{count} merülés kizárva a statisztikákból}}",
+  "diveLog_edit_group_statistics": "Statisztikák",
+  "diveLog_edit_summary_gasExcluded": "Gáz kizárva",
+  "diveLog_edit_statisticsIncludedHint": "Minden statisztikában szerepel"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Escludi dalle statistiche del gas",
   "diveLog_filter_excludedOnly": "Solo quelle escluse dalle statistiche",
   "diveLog_edit_summary_excluded": "Esclusa",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 immersione esclusa dalle statistiche} other{{count} immersioni escluse dalle statistiche}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 immersione esclusa dalle statistiche} other{{count} immersioni escluse dalle statistiche}}",
+  "diveLog_edit_group_statistics": "Statistiche",
+  "diveLog_edit_summary_gasExcluded": "Gas escluso",
+  "diveLog_edit_statisticsIncludedHint": "Inclusa in tutte le statistiche"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -58561,6 +58561,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, one{1 dive excluded from statistics} other{{count} dives excluded from statistics}}'**
   String statistics_excludedDivesFootnote(int count);
+
+  /// Collapsible dive-form group holding the statistics-exclusion toggles
+  ///
+  /// In en, this message translates to:
+  /// **'Statistics'**
+  String get diveLog_edit_group_statistics;
+
+  /// Collapsed Statistics group summary when only gas statistics are excluded
+  ///
+  /// In en, this message translates to:
+  /// **'Gas excluded'**
+  String get diveLog_edit_summary_gasExcluded;
+
+  /// Collapsed Statistics group hint when the dive is not excluded
+  ///
+  /// In en, this message translates to:
+  /// **'Counted in every statistic'**
+  String get diveLog_edit_statisticsIncludedHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -35258,4 +35258,13 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'الإحصائيات';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'الغاز مستبعد';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint => 'محتسبة في كل الإحصائيات';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -35531,4 +35531,14 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statistiken';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gas ausgeschlossen';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'In allen Statistiken enthalten';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -35063,4 +35063,14 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statistics';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gas excluded';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Counted in every statistic';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -35643,4 +35643,14 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Estadísticas';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gas excluido';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Incluida en todas las estadísticas';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -35694,4 +35694,14 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statistiques';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gaz exclu';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Comptée dans toutes les statistiques';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -34902,4 +34902,13 @@ class AppLocalizationsHe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'סטטיסטיקות';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'הגז הוחרג';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint => 'נכללת בכל הסטטיסטיקות';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -35462,4 +35462,14 @@ class AppLocalizationsHu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statisztikák';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gáz kizárva';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Minden statisztikában szerepel';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -35598,4 +35598,14 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statistiche';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gas escluso';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Inclusa in tutte le statistiche';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -35360,4 +35360,14 @@ class AppLocalizationsNl extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Statistieken';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gas uitgesloten';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Meegeteld in alle statistieken';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -35610,4 +35610,14 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => 'Estatísticas';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => 'Gás excluído';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint =>
+      'Incluído em todas as estatísticas';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -33517,4 +33517,13 @@ class AppLocalizationsZh extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get diveLog_edit_group_statistics => '统计';
+
+  @override
+  String get diveLog_edit_summary_gasExcluded => '已排除气体';
+
+  @override
+  String get diveLog_edit_statisticsIncludedHint => '计入所有统计';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Uitsluiten van gasstatistieken",
   "diveLog_filter_excludedOnly": "Alleen uitgesloten van statistieken",
   "diveLog_edit_summary_excluded": "Uitgesloten",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 duik uitgesloten van statistieken} other{{count} duiken uitgesloten van statistieken}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 duik uitgesloten van statistieken} other{{count} duiken uitgesloten van statistieken}}",
+  "diveLog_edit_group_statistics": "Statistieken",
+  "diveLog_edit_summary_gasExcluded": "Gas uitgesloten",
+  "diveLog_edit_statisticsIncludedHint": "Meegeteld in alle statistieken"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "Excluir das estatísticas de gás",
   "diveLog_filter_excludedOnly": "Apenas os excluídos das estatísticas",
   "diveLog_edit_summary_excluded": "Excluído",
-  "statistics_excludedDivesFootnote": "{count, plural, one{1 mergulho excluído das estatísticas} other{{count} mergulhos excluídos das estatísticas}}"
+  "statistics_excludedDivesFootnote": "{count, plural, one{1 mergulho excluído das estatísticas} other{{count} mergulhos excluídos das estatísticas}}",
+  "diveLog_edit_group_statistics": "Estatísticas",
+  "diveLog_edit_summary_gasExcluded": "Gás excluído",
+  "diveLog_edit_statisticsIncludedHint": "Incluído em todas as estatísticas"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -10399,5 +10399,8 @@
   "diveLog_bulkEdit_fieldExcludeFromGasStats": "从气体统计中排除",
   "diveLog_filter_excludedOnly": "仅显示已排除的潜水",
   "diveLog_edit_summary_excluded": "已排除",
-  "statistics_excludedDivesFootnote": "{count, plural, other{{count} 次潜水已从统计中排除}}"
+  "statistics_excludedDivesFootnote": "{count, plural, other{{count} 次潜水已从统计中排除}}",
+  "diveLog_edit_group_statistics": "统计",
+  "diveLog_edit_summary_gasExcluded": "已排除气体",
+  "diveLog_edit_statisticsIncludedHint": "计入所有统计"
 }

--- a/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
+++ b/test/features/dive_log/presentation/dive_exclusion_toggles_test.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/statistics_section.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
-/// The Dive section renders the two statistics-exclusion toggles. The one that
-/// matters is the gas toggle's behaviour while the master flag is on: it must
-/// read as checked and be inert, so the implication is visible rather than
-/// silently overriding what the diver picked.
+/// The Statistics section is the collapsible group at the bottom of the dive
+/// form that owns the two exclusion toggles. Two things matter: the collapsed
+/// header has to say whether this dive is excluded (otherwise the exclusion is
+/// invisible), and the gas toggle has to read as checked and inert while the
+/// master flag is on, so the implication is visible rather than silently
+/// overriding what the diver picked.
 void main() {
   Widget host({
     required bool excludedFromStats,
     required bool excludedFromGasStats,
+    bool expanded = true,
+    VoidCallback? onToggle,
     ValueChanged<bool>? onStats,
     ValueChanged<bool>? onGas,
   }) {
@@ -20,20 +24,9 @@ void main() {
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
         body: SingleChildScrollView(
-          child: TheDiveSection(
-            depthSymbol: 'm',
-            nameController: TextEditingController(),
-            maxDepthController: TextEditingController(),
-            avgDepthController: TextEditingController(),
-            bottomTimeController: TextEditingController(),
-            runtimeController: TextEditingController(),
-            diveNumberController: TextEditingController(),
-            entryText: '',
-            onEditEntry: () {},
-            exitText: null,
-            onEditExit: () {},
-            siteName: null,
-            onPickSite: () {},
+          child: StatisticsSection(
+            expanded: expanded,
+            onToggle: onToggle ?? () {},
             excludedFromStats: excludedFromStats,
             excludedFromGasStats: excludedFromGasStats,
             onExcludedFromStatsChanged: onStats ?? (_) {},
@@ -168,5 +161,73 @@ void main() {
           'the locale needs; German and Hungarian run materially longer',
     );
     expect(help.overflow, anyOf(isNull, TextOverflow.clip));
+  });
+
+  group('collapsed', () {
+    testWidgets('hides the toggles but keeps the header tappable', (
+      tester,
+    ) async {
+      var toggled = 0;
+      await tester.pumpWidget(
+        host(
+          excludedFromStats: false,
+          excludedFromGasStats: false,
+          expanded: false,
+          onToggle: () => toggled++,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('dive-edit-exclude-from-stats')),
+        findsNothing,
+        reason: 'a collapsed FormSection does not mount its children',
+      );
+      await tester.tap(find.text('Statistics'));
+      await tester.pumpAndSettle();
+      expect(toggled, 1);
+    });
+
+    testWidgets('says the dive is counted when nothing is excluded', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        host(
+          excludedFromStats: false,
+          excludedFromGasStats: false,
+          expanded: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Counted in every statistic'), findsOneWidget);
+    });
+
+    testWidgets('names the exclusion so it is not hidden by collapsing', (
+      tester,
+    ) async {
+      // Without this the only trace of an excluded dive would be behind a
+      // closed section, which is how a diver loses track of why a count is
+      // off months later.
+      await tester.pumpWidget(
+        host(
+          excludedFromStats: true,
+          excludedFromGasStats: false,
+          expanded: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Excluded'), findsOneWidget);
+
+      await tester.pumpWidget(
+        host(
+          excludedFromStats: false,
+          excludedFromGasStats: true,
+          expanded: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Gas excluded'), findsOneWidget);
+    });
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_edit_statistics_section_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_statistics_section_test.dart
@@ -35,8 +35,11 @@ void main() {
   }) => Dive(
     id: 'dive-stats',
     diveNumber: 1,
-    dateTime: DateTime(2026, 3, 28, 10, 0),
-    entryTime: DateTime(2026, 3, 28, 10, 5),
+    // Dives round-trip through the repository as UTC-flagged wall clocks
+    // (`fromMillisecondsSinceEpoch(..., isUtc: true)`), so a local DateTime
+    // would come back shifted by the machine's offset.
+    dateTime: DateTime.utc(2026, 3, 28, 10, 0),
+    entryTime: DateTime.utc(2026, 3, 28, 10, 5),
     bottomTime: const Duration(minutes: 40),
     maxDepth: 20.0,
     excludedFromStats: excludedFromStats,
@@ -128,6 +131,37 @@ void main() {
     await pumpEditPage(tester, created.id);
 
     expect(masterToggle(), findsOneWidget);
+  });
+
+  testWidgets('the gas flag reaches page state on its own', (tester) async {
+    // The narrower flag has its own handler on the page, and it is the one a
+    // diver reaches for when only the gas reading is unrepresentative.
+    final created = await repository.createDive(buildDive());
+    await pumpEditPage(tester, created.id);
+
+    final header = find.text('Statistics');
+    await tester.ensureVisible(header.first);
+    await tester.pumpAndSettle();
+    await tester.tap(header.first);
+    await tester.pumpAndSettle();
+
+    final gas = find.byKey(const Key('dive-edit-exclude-from-gas-stats'));
+    final gasSwitch = find.descendant(of: gas, matching: find.byType(Switch));
+    await tester.ensureVisible(gasSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(gasSwitch);
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<Switch>(gasSwitch).value, isTrue);
+    expect(
+      tester
+          .widget<Switch>(
+            find.descendant(of: masterToggle(), matching: find.byType(Switch)),
+          )
+          .value,
+      isFalse,
+      reason: 'the gas flag must not imply the master one',
+    );
   });
 
   testWidgets('clearing the last flag does not shut the group', (tester) async {

--- a/test/features/dive_log/presentation/pages/dive_edit_statistics_section_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_statistics_section_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/statistics_section.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/the_dive_section.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// The statistics-exclusion toggles live in their own collapsible group at the
+/// bottom of the dive form rather than inside The Dive. What this covers is
+/// the part a widget test of the section alone cannot: where the group sits,
+/// when it opens itself, and that it does not shut under the diver's finger.
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive({
+    bool excludedFromStats = false,
+    bool excludedFromGasStats = false,
+  }) => Dive(
+    id: 'dive-stats',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 3, 28, 10, 0),
+    entryTime: DateTime(2026, 3, 28, 10, 5),
+    bottomTime: const Duration(minutes: 40),
+    maxDepth: 20.0,
+    excludedFromStats: excludedFromStats,
+    excludedFromGasStats: excludedFromGasStats,
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  Future<void> pumpEditPage(WidgetTester tester, String diveId) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final base = await getBaseOverrides();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DiveEditPage(diveId: diveId, embedded: true)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder masterToggle() =>
+      find.byKey(const Key('dive-edit-exclude-from-stats'));
+
+  testWidgets('the toggles are no longer part of The Dive', (tester) async {
+    final created = await repository.createDive(buildDive());
+    await pumpEditPage(tester, created.id);
+
+    expect(find.byType(StatisticsSection), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(TheDiveSection),
+        matching: masterToggle(),
+      ),
+      findsNothing,
+      reason:
+          'The Dive is always expanded, so a flag about how the dive is '
+          'counted would sit permanently among the core facts',
+    );
+  });
+
+  testWidgets('an ordinary dive keeps the group shut until asked', (
+    tester,
+  ) async {
+    final created = await repository.createDive(buildDive());
+    await pumpEditPage(tester, created.id);
+
+    expect(masterToggle(), findsNothing);
+    expect(find.text('Counted in every statistic'), findsOneWidget);
+
+    final header = find.text('Statistics');
+    await tester.ensureVisible(header.first);
+    await tester.pumpAndSettle();
+    await tester.tap(header.first);
+    await tester.pumpAndSettle();
+
+    expect(masterToggle(), findsOneWidget);
+  });
+
+  testWidgets('an already-excluded dive opens the group on load', (
+    tester,
+  ) async {
+    // Otherwise the one setting the diver came back to change is the one
+    // hidden behind a closed section.
+    final created = await repository.createDive(
+      buildDive(excludedFromStats: true),
+    );
+    await pumpEditPage(tester, created.id);
+
+    expect(masterToggle(), findsOneWidget);
+  });
+
+  testWidgets('clearing the last flag does not shut the group', (tester) async {
+    // The default expansion follows the flags, so without pinning, switching
+    // the exclusion off would collapse the group under the diver's finger.
+    final created = await repository.createDive(
+      buildDive(excludedFromStats: true),
+    );
+    await pumpEditPage(tester, created.id);
+
+    final toggle = find.descendant(
+      of: masterToggle(),
+      matching: find.byType(Switch),
+    );
+    await tester.ensureVisible(toggle);
+    await tester.pumpAndSettle();
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    expect(masterToggle(), findsOneWidget);
+    expect(
+      tester
+          .widget<Switch>(
+            find.descendant(of: masterToggle(), matching: find.byType(Switch)),
+          )
+          .value,
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## What

The statistics-exclusion toggles (#526 / #1272) shipped at the end of The Dive
section. That group is always expanded, so a setting most divers never touch
sat permanently among the core facts: dive number, entry, exit, depth, site.

They now live in a collapsible **Statistics** group at the bottom of the dive
edit form, matching the other expandable groups.

## Behaviour

- **Collapsed by default**, so the setting stays out of the way of the dives
  that are just dives.
- **Opens itself when the dive is already excluded.** Otherwise the one setting
  the diver came back to change would be the one hidden behind a closed section.
- **The header carries the state either way:** an "Excluded" or "Gas excluded"
  summary, or the fainter "Counted in every statistic" hint. An exclusion has to
  be readable with the group shut, or the only trace of it is behind a closed
  section.
- **Touching a toggle pins the group open.** The default expansion follows the
  two flags, so without the pin, clearing the last flag would flip the default
  back to false and shut the group under the diver's finger. There is a
  regression test for exactly this; it fails without the pin.
- The gas toggle still renders checked and inert while the master flag is on.
- Placement is bottom-of-form in both layouts: `ResponsiveFormColumns`
  (`splitIndex: 2`) puts everything after the first two groups in the right
  column on wide windows, and in the single scroll on phones.

Bulk edit is unchanged; it keeps its own gated `BulkField` rows.

## Implementation notes

Nothing in the new group is a validated field, so unlike the other collapsible
groups it does not join the set `_saveDive` force-expands before
`Form.validate()`. The flags live on the page, not in the collapsed subtree.

Three new l10n keys across all eleven locales. A fourth was not needed:
`diveLog_edit_summary_excluded` was already present in every locale but
referenced nowhere in `lib/`, added by #1374 for a collapsed-section summary
that could not materialize while the toggles lived in an always-expanded group.

## Testing

- `test/features/dive_log/presentation/dive_exclusion_toggles_test.dart`
  retargeted at `StatisticsSection`, plus collapsed-state cases (children not
  mounted, header tappable, summary and hint text).
- New `test/.../pages/dive_edit_statistics_section_test.dart` covers what a
  section-only test cannot: the toggles are gone from `TheDiveSection`, an
  ordinary dive keeps the group shut until asked, an excluded dive opens it on
  load, and clearing the last flag does not shut it.
- `flutter analyze` clean; full suite 21897 passed / 20 skipped. The single
  failure in the local full-suite run was `local_file_resolver_test.dart`'s
  system-volume probe, an artifact of a `$TMPDIR` on a RAM disk locally; that
  file passes 37/37 with `TMPDIR` on the system volume and is untouched here.
