### PR TITLE
fix(marine-life): save a species without the autoDispose list notifier

### DIFF
--- a/lib/features/marine_life/presentation/pages/species_edit_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_edit_page.dart
@@ -240,17 +240,20 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
     setState(() => _isSaving = true);
 
     try {
-      final notifier = ref.read(speciesListNotifierProvider.notifier);
+      // Write through the repository, not through the species list notifier.
+      // That notifier is autoDispose and this page never watches it, so a
+      // `read` of it would be disposed at the end of the frame while the save
+      // was still in flight. The list refreshes off the `species` table tick.
+      final repository = ref.read(speciesRepositoryProvider);
       final commonName = _commonNameController.text.trim();
       final scientificName = _scientificNameController.text.trim();
       final taxonomyClass = _taxonomyClassController.text.trim();
       final description = _descriptionController.text.trim();
 
       if (widget.isEditing) {
-        final repository = ref.read(speciesRepositoryProvider);
         final existing = await repository.getSpeciesById(widget.speciesId!);
         if (existing != null) {
-          await notifier.updateSpecies(
+          await repository.updateSpecies(
             existing.copyWith(
               commonName: commonName,
               scientificName: scientificName.isEmpty ? null : scientificName,
@@ -261,7 +264,7 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
           );
         }
       } else {
-        await notifier.addSpecies(
+        await repository.createSpecies(
           commonName: commonName,
           scientificName: scientificName.isEmpty ? null : scientificName,
           category: _category,

--- a/lib/features/marine_life/presentation/pages/species_edit_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_edit_page.dart
@@ -4,6 +4,7 @@ import 'package:submersion/core/providers/provider.dart';
 
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/marine_life/domain/entities/species_lookup.dart';
 import 'package:submersion/features/marine_life/presentation/species_display.dart';
 import 'package:submersion/features/marine_life/presentation/widgets/species_lookup_sheet.dart';
@@ -253,13 +254,20 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
       if (widget.isEditing) {
         final existing = await repository.getSpeciesById(widget.speciesId!);
         if (existing != null) {
+          // Built by hand rather than with copyWith, which reads a null as
+          // "keep this value" and so could never blank an optional field the
+          // diver had cleared. Everything the form does not show is carried
+          // over from the stored row.
           await repository.updateSpecies(
-            existing.copyWith(
+            Species(
+              id: existing.id,
               commonName: commonName,
               scientificName: scientificName.isEmpty ? null : scientificName,
               category: _category,
               taxonomyClass: taxonomyClass.isEmpty ? null : taxonomyClass,
               description: description.isEmpty ? null : description,
+              photoPath: existing.photoPath,
+              isBuiltIn: existing.isBuiltIn,
             ),
           );
         }

--- a/lib/features/marine_life/presentation/pages/species_edit_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_edit_page.dart
@@ -253,24 +253,38 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
 
       if (widget.isEditing) {
         final existing = await repository.getSpeciesById(widget.speciesId!);
-        if (existing != null) {
-          // Built by hand rather than with copyWith, which reads a null as
-          // "keep this value" and so could never blank an optional field the
-          // diver had cleared. Everything the form does not show is carried
-          // over from the stored row.
-          await repository.updateSpecies(
-            Species(
-              id: existing.id,
-              commonName: commonName,
-              scientificName: scientificName.isEmpty ? null : scientificName,
-              category: _category,
-              taxonomyClass: taxonomyClass.isEmpty ? null : taxonomyClass,
-              description: description.isEmpty ? null : description,
-              photoPath: existing.photoPath,
-              isBuiltIn: existing.isBuiltIn,
-            ),
-          );
+        if (existing == null) {
+          // The row went away while the editor was open, e.g. a sync applied
+          // a deletion from another device. Say so instead of reporting an
+          // update that never happened.
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  context.l10n.marineLife_speciesEdit_notFoundMessage,
+                ),
+                backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+            );
+          }
+          return;
         }
+        // Built by hand rather than with copyWith, which reads a null as
+        // "keep this value" and so could never blank an optional field the
+        // diver had cleared. Everything the form does not show is carried
+        // over from the stored row.
+        await repository.updateSpecies(
+          Species(
+            id: existing.id,
+            commonName: commonName,
+            scientificName: scientificName.isEmpty ? null : scientificName,
+            category: _category,
+            taxonomyClass: taxonomyClass.isEmpty ? null : taxonomyClass,
+            description: description.isEmpty ? null : description,
+            photoPath: existing.photoPath,
+            isBuiltIn: existing.isBuiltIn,
+          ),
+        );
       } else {
         await repository.createSpecies(
           commonName: commonName,

--- a/lib/features/marine_life/presentation/providers/species_providers.dart
+++ b/lib/features/marine_life/presentation/providers/species_providers.dart
@@ -189,6 +189,12 @@ class SpeciesListNotifier extends StateNotifier<AsyncValue<List<Species>>> {
     // Reload when the `species` table changes (e.g. a sync writes rows
     // directly), not just on local mutations. _loadSpecies() updates in place
     // without a loading flash, so it doubles as the silent reload.
+    //
+    // The same tick refreshes allSpeciesProvider, speciesByCategoryProvider
+    // and speciesSearchProvider through their own invalidateSelfWhen, so the
+    // mutations below invalidate nothing by hand. A manual invalidate here
+    // would touch this Ref after an await, which throws once this autoDispose
+    // provider has been disposed mid-write.
     final tableChangeSub = _repository.watchSpeciesChanges().listen(
       (_) => _loadSpecies(),
     );
@@ -219,20 +225,17 @@ class SpeciesListNotifier extends StateNotifier<AsyncValue<List<Species>>> {
       description: description,
     );
     await _loadSpecies();
-    _invalidateRelatedProviders();
     return species;
   }
 
   Future<void> updateSpecies(Species species) async {
     await _repository.updateSpecies(species);
     await _loadSpecies();
-    _invalidateRelatedProviders();
   }
 
   Future<void> deleteSpecies(String id) async {
     await _repository.deleteSpecies(id);
     await _loadSpecies();
-    _invalidateRelatedProviders();
   }
 
   Future<bool> isSpeciesInUse(String id) async {
@@ -242,13 +245,6 @@ class SpeciesListNotifier extends StateNotifier<AsyncValue<List<Species>>> {
   Future<void> resetBuiltInSpecies() async {
     await _repository.resetBuiltInSpecies();
     await _loadSpecies();
-    _invalidateRelatedProviders();
-  }
-
-  void _invalidateRelatedProviders() {
-    _ref.invalidate(allSpeciesProvider);
-    _ref.invalidate(speciesByCategoryProvider);
-    _ref.invalidate(speciesSearchProvider);
   }
 }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -4039,6 +4039,7 @@
   "marineLife_speciesEdit_editTitle": "تعديل النوع",
   "marineLife_speciesEdit_errorLoading": "خطأ في تحميل النوع: {error}",
   "marineLife_speciesEdit_errorSaving": "خطأ في حفظ النوع: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "لم يعد هذا النوع موجودًا.",
   "marineLife_speciesEdit_saveButton": "حفظ",
   "marineLife_speciesEdit_scientificNameHint": "مثال: Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "الاسم العلمي",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -4039,6 +4039,7 @@
   "marineLife_speciesEdit_editTitle": "Art bearbeiten",
   "marineLife_speciesEdit_errorLoading": "Fehler beim Laden der Art: {error}",
   "marineLife_speciesEdit_errorSaving": "Fehler beim Speichern der Art: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Diese Art existiert nicht mehr.",
   "marineLife_speciesEdit_saveButton": "Speichern",
   "marineLife_speciesEdit_scientificNameHint": "z.B. Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Wissenschaftlicher Name",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -7161,6 +7161,7 @@
   "marineLife_speciesEdit_editTitle": "Edit Species",
   "marineLife_speciesEdit_errorLoading": "Error loading species: {error}",
   "marineLife_speciesEdit_errorSaving": "Error saving species: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "This species no longer exists.",
   "marineLife_speciesEdit_saveButton": "Save",
   "marineLife_speciesEdit_scientificNameHint": "e.g., Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Scientific Name",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -4039,6 +4039,7 @@
   "marineLife_speciesEdit_editTitle": "Editar especie",
   "marineLife_speciesEdit_errorLoading": "Error al cargar especie: {error}",
   "marineLife_speciesEdit_errorSaving": "Error al guardar especie: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Esta especie ya no existe.",
   "marineLife_speciesEdit_saveButton": "Guardar",
   "marineLife_speciesEdit_scientificNameHint": "ej., Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Nombre cientifico",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -3966,6 +3966,7 @@
   "marineLife_speciesEdit_editTitle": "Modifier l'espece",
   "marineLife_speciesEdit_errorLoading": "Erreur lors du chargement de l'espece : {error}",
   "marineLife_speciesEdit_errorSaving": "Erreur lors de l'enregistrement de l'espece : {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Cette espèce n'existe plus.",
   "marineLife_speciesEdit_saveButton": "Enregistrer",
   "marineLife_speciesEdit_scientificNameHint": "ex. Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Nom scientifique",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -3966,6 +3966,7 @@
   "marineLife_speciesEdit_editTitle": "ערוך מין",
   "marineLife_speciesEdit_errorLoading": "שגיאה בטעינת מין: {error}",
   "marineLife_speciesEdit_errorSaving": "שגיאה בשמירת מין: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "מין זה כבר אינו קיים.",
   "marineLife_speciesEdit_saveButton": "שמירה",
   "marineLife_speciesEdit_scientificNameHint": "לדוגמה, Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "שם מדעי",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -3966,6 +3966,7 @@
   "marineLife_speciesEdit_editTitle": "Faj szerkesztese",
   "marineLife_speciesEdit_errorLoading": "Hiba a faj betoltesekor: {error}",
   "marineLife_speciesEdit_errorSaving": "Hiba a faj mentesekor: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Ez a faj már nem létezik.",
   "marineLife_speciesEdit_saveButton": "Mentes",
   "marineLife_speciesEdit_scientificNameHint": "pl. Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Tudomanyos nev",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -3966,6 +3966,7 @@
   "marineLife_speciesEdit_editTitle": "Modifica specie",
   "marineLife_speciesEdit_errorLoading": "Errore nel caricamento della specie: {error}",
   "marineLife_speciesEdit_errorSaving": "Errore nel salvataggio della specie: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Questa specie non esiste più.",
   "marineLife_speciesEdit_saveButton": "Salva",
   "marineLife_speciesEdit_scientificNameHint": "es. Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Nome scientifico",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -21323,6 +21323,12 @@ abstract class AppLocalizations {
   /// **'Error saving species: {error}'**
   String marineLife_speciesEdit_errorSaving(Object error);
 
+  /// No description provided for @marineLife_speciesEdit_notFoundMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This species no longer exists.'**
+  String get marineLife_speciesEdit_notFoundMessage;
+
   /// No description provided for @marineLife_speciesEdit_saveButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -12374,6 +12374,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'لم يعد هذا النوع موجودًا.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'حفظ';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -12593,6 +12593,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Diese Art existiert nicht mehr.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Speichern';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -12396,6 +12396,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'This species no longer exists.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Save';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -12596,6 +12596,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Esta especie ya no existe.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Guardar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -12645,6 +12645,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Cette espèce n\'existe plus.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Enregistrer';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -12290,6 +12290,9 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage => 'מין זה כבר אינו קיים.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'שמירה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -12563,6 +12563,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Ez a faj már nem létezik.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Mentes';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -12612,6 +12612,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Questa specie non esiste più.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Salva';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -12512,6 +12512,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Deze soort bestaat niet meer.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Opslaan';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -12610,6 +12610,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage =>
+      'Esta espécie já não existe.';
+
+  @override
   String get marineLife_speciesEdit_saveButton => 'Salvar';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -12002,6 +12002,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get marineLife_speciesEdit_notFoundMessage => '该物种已不存在。';
+
+  @override
   String get marineLife_speciesEdit_saveButton => '保存';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -4039,6 +4039,7 @@
   "marineLife_speciesEdit_editTitle": "Soort bewerken",
   "marineLife_speciesEdit_errorLoading": "Fout bij laden van soort: {error}",
   "marineLife_speciesEdit_errorSaving": "Fout bij opslaan van soort: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Deze soort bestaat niet meer.",
   "marineLife_speciesEdit_saveButton": "Opslaan",
   "marineLife_speciesEdit_scientificNameHint": "bijv. Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Wetenschappelijke naam",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -4039,6 +4039,7 @@
   "marineLife_speciesEdit_editTitle": "Editar Especie",
   "marineLife_speciesEdit_errorLoading": "Erro ao carregar especie: {error}",
   "marineLife_speciesEdit_errorSaving": "Erro ao salvar especie: {error}",
+  "marineLife_speciesEdit_notFoundMessage": "Esta espécie já não existe.",
   "marineLife_speciesEdit_saveButton": "Salvar",
   "marineLife_speciesEdit_scientificNameHint": "ex., Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "Nome Cientifico",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -4193,6 +4193,7 @@
   "marineLife_speciesEdit_editTitle": "编辑物种",
   "marineLife_speciesEdit_errorLoading": "加载物种出错：{error}",
   "marineLife_speciesEdit_errorSaving": "保存物种出错：{error}",
+  "marineLife_speciesEdit_notFoundMessage": "该物种已不存在。",
   "marineLife_speciesEdit_saveButton": "保存",
   "marineLife_speciesEdit_scientificNameHint": "例如 Amphiprion ocellaris",
   "marineLife_speciesEdit_scientificNameLabel": "学名",

--- a/test/features/marine_life/presentation/pages/species_edit_page_test.dart
+++ b/test/features/marine_life/presentation/pages/species_edit_page_test.dart
@@ -1,10 +1,16 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/marine_life/data/repositories/species_repository.dart';
 import 'package:submersion/features/marine_life/data/services/species_lookup_service.dart';
+import 'package:submersion/features/marine_life/domain/entities/species.dart';
 import 'package:submersion/features/marine_life/domain/entities/species_lookup.dart';
 import 'package:submersion/features/marine_life/presentation/pages/species_edit_page.dart';
 import 'package:submersion/features/marine_life/presentation/providers/species_lookup_providers.dart';
+import 'package:submersion/features/marine_life/presentation/providers/species_providers.dart';
 
 import '../../../../helpers/test_app.dart';
 
@@ -35,6 +41,58 @@ class _FakeLookup implements SpeciesLookupService {
     category: SpeciesCategory.shark,
     taxonomyClass: 'Chondrichthyes',
   );
+}
+
+/// Records what the editor writes, and can hold a write open across a frame,
+/// which is when Riverpod disposes an autoDispose provider nothing listens to.
+class _FakeSpeciesRepository extends Fake implements SpeciesRepository {
+  _FakeSpeciesRepository(this._stored);
+
+  final List<Species> _stored;
+  final _changes = StreamController<void>.broadcast();
+  final List<Species> updated = [];
+  final List<String> created = [];
+
+  /// Completed by the test to release the in-flight write.
+  Completer<void>? gate;
+
+  @override
+  Stream<void> watchSpeciesChanges() => _changes.stream;
+
+  @override
+  Future<List<Species>> getAllSpecies() async => List.of(_stored);
+
+  @override
+  Future<Species?> getSpeciesById(String id) async =>
+      _stored.where((s) => s.id == id).firstOrNull;
+
+  @override
+  Future<void> updateSpecies(Species species) async {
+    await gate?.future;
+    updated.add(species);
+  }
+
+  @override
+  Future<Species> createSpecies({
+    required String commonName,
+    String? scientificName,
+    required SpeciesCategory category,
+    String? taxonomyClass,
+    String? description,
+  }) async {
+    await gate?.future;
+    created.add(commonName);
+    return Species(
+      id: 'new-1',
+      commonName: commonName,
+      scientificName: scientificName,
+      category: category,
+      taxonomyClass: taxonomyClass,
+      description: description,
+    );
+  }
+
+  void dispose() => _changes.close();
 }
 
 void main() {
@@ -74,5 +132,89 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Shark'), findsOneWidget);
+  });
+
+  group('saving', () {
+    const existing = Species(
+      id: 's1',
+      commonName: 'Map Puffer',
+      scientificName: 'Arothron mappa',
+      category: SpeciesCategory.fish,
+    );
+
+    late _FakeSpeciesRepository repository;
+
+    setUp(() => repository = _FakeSpeciesRepository([existing]));
+    tearDown(() => repository.dispose());
+
+    /// Mirrors the real route shape: the editor sits on its own route above
+    /// the species page, so nothing on screen watches
+    /// speciesListNotifierProvider while the save runs.
+    Widget host({bool editing = true}) => testAppRouter(
+      overrides: [speciesRepositoryProvider.overrideWithValue(repository)],
+      locale: const Locale('en'),
+      router: GoRouter(
+        initialLocation: editing ? '/species/edit' : '/species/new',
+        routes: [
+          GoRoute(
+            path: '/species',
+            builder: (context, state) =>
+                const Scaffold(body: Center(child: Text('species list'))),
+            routes: [
+              GoRoute(
+                path: 'new',
+                builder: (context, state) => const SpeciesEditPage(),
+              ),
+              GoRoute(
+                path: 'edit',
+                builder: (context, state) =>
+                    const SpeciesEditPage(speciesId: 's1'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    testWidgets('an edit saves while nothing listens to the species list', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextFormField).first,
+        'Map Pufferfish',
+      );
+      repository.gate = Completer<void>();
+      await tester.tap(find.text('Save'));
+      // End the frame so Riverpod disposes anything unlistened before the
+      // write returns.
+      await tester.pump();
+      repository.gate!.complete();
+      await tester.pumpAndSettle();
+
+      expect(repository.updated.single.commonName, 'Map Pufferfish');
+      expect(find.textContaining('Error saving species'), findsNothing);
+      expect(find.text('species list'), findsOneWidget);
+    });
+
+    testWidgets('a new species saves while nothing listens to the list', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host(editing: false));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).first, 'Map Puffer');
+      repository.gate = Completer<void>();
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+      repository.gate!.complete();
+      await tester.pumpAndSettle();
+
+      expect(repository.created, ['Map Puffer']);
+      expect(find.textContaining('Error saving species'), findsNothing);
+      expect(find.text('species list'), findsOneWidget);
+    });
   });
 }

--- a/test/features/marine_life/presentation/pages/species_edit_page_test.dart
+++ b/test/features/marine_life/presentation/pages/species_edit_page_test.dart
@@ -56,6 +56,10 @@ class _FakeSpeciesRepository extends Fake implements SpeciesRepository {
   /// Completed by the test to release the in-flight write.
   Completer<void>? gate;
 
+  /// Drops the row on the next read, standing in for a sync that deleted the
+  /// species from another device while the editor was open.
+  bool deleteOnNextRead = false;
+
   @override
   Stream<void> watchSpeciesChanges() => _changes.stream;
 
@@ -63,8 +67,14 @@ class _FakeSpeciesRepository extends Fake implements SpeciesRepository {
   Future<List<Species>> getAllSpecies() async => List.of(_stored);
 
   @override
-  Future<Species?> getSpeciesById(String id) async =>
-      _stored.where((s) => s.id == id).firstOrNull;
+  Future<Species?> getSpeciesById(String id) async {
+    if (deleteOnNextRead) {
+      _stored.removeWhere((s) => s.id == id);
+      deleteOnNextRead = false;
+      return null;
+    }
+    return _stored.where((s) => s.id == id).firstOrNull;
+  }
 
   @override
   Future<void> updateSpecies(Species species) async {
@@ -241,5 +251,27 @@ void main() {
       expect(saved.id, 's1');
       expect(saved.photoPath, '/photos/map-puffer.jpg');
     });
+
+    testWidgets(
+      'reports a species deleted under the editor instead of a save',
+      (tester) async {
+        await tester.pumpWidget(host());
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.byType(TextFormField).first,
+          'Map Pufferfish',
+        );
+        repository.deleteOnNextRead = true;
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+
+        expect(repository.updated, isEmpty);
+        expect(find.text('This species no longer exists.'), findsOneWidget);
+        expect(find.textContaining('updated'), findsNothing);
+        // The editor stays put so the diver does not lose what they typed.
+        expect(find.text('species list'), findsNothing);
+      },
+    );
   });
 }

--- a/test/features/marine_life/presentation/pages/species_edit_page_test.dart
+++ b/test/features/marine_life/presentation/pages/species_edit_page_test.dart
@@ -140,6 +140,9 @@ void main() {
       commonName: 'Map Puffer',
       scientificName: 'Arothron mappa',
       category: SpeciesCategory.fish,
+      taxonomyClass: 'Actinopterygii',
+      description: 'Large pale pufferfish.',
+      photoPath: '/photos/map-puffer.jpg',
     );
 
     late _FakeSpeciesRepository repository;
@@ -215,6 +218,28 @@ void main() {
       expect(repository.created, ['Map Puffer']);
       expect(find.textContaining('Error saving species'), findsNothing);
       expect(find.text('species list'), findsOneWidget);
+    });
+
+    testWidgets('clearing the optional fields blanks them on the row', (
+      tester,
+    ) async {
+      await tester.pumpWidget(host());
+      await tester.pumpAndSettle();
+
+      final fields = find.byType(TextFormField);
+      await tester.enterText(fields.at(1), '');
+      await tester.enterText(fields.at(2), '');
+      await tester.enterText(fields.at(3), '');
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final saved = repository.updated.single;
+      expect(saved.scientificName, isNull);
+      expect(saved.taxonomyClass, isNull);
+      expect(saved.description, isNull);
+      // Fields the editor does not show survive the write.
+      expect(saved.id, 's1');
+      expect(saved.photoPath, '/photos/map-puffer.jpg');
     });
   });
 }


### PR DESCRIPTION
## The bug

Saving from the species editor fails with:

> Error saving species: Cannot use the Ref of StateNotifierProvider<SpeciesListNotifier, AsyncValue<List<Species>>>#388cf after it has been disposed.

It happens on both the add and the edit path, and it has nothing to do with the online lookup that surfaced it.

## Root cause

`SpeciesEditPage._save()` reached for the list notifier to do its write:

```dart
final notifier = ref.read(speciesListNotifierProvider.notifier);
await notifier.updateSpecies(...);
```

`speciesListNotifierProvider` is a `StateNotifierProvider.autoDispose`, and the only widget that watches it is `SpeciesManagePage`. The editor is its own route (`/species/:speciesId/edit`), so while you stand on it nothing in the tree is listening. A `ref.read` creates no lasting subscription, so Riverpod builds the notifier for that single read and disposes it at the end of the frame. The database write outlives it, and coming back from the await `SpeciesListNotifier` called `_ref.invalidate(...)` on a dead `Ref`.

The row was written before the throw, so the species actually saved: the diver just saw an error and the page never popped.

## The fix

1. **`species_edit_page.dart`** writes through `speciesRepositoryProvider`, a keep-alive `Provider`, the same one `_loadSpecies()` on that page already uses. No UI-scoped provider lifetime wrapped around a database write.

2. **`species_providers.dart`** drops `_invalidateRelatedProviders()`. It was redundant: `allSpeciesProvider`, `speciesByCategoryProvider` and `speciesSearchProvider` each already call `ref.invalidateSelfWhen(repository.watchSpeciesChanges())`, and that is a Drift `tableUpdates` stream on `species`, so every write ticks them. Removing it also takes the after-await `Ref` use out of `deleteSpecies` and `resetBuiltInSpecies`, where the manage page could reach the same crash by navigating away mid-delete. A comment on the tick subscription records why nothing is invalidated by hand, so it does not come back.

## Tests

`test/features/marine_life/presentation/pages/species_edit_page_test.dart` gains a `saving` group (the existing lookup test is untouched). Both new cases mount the editor under a `GoRouter` in the app's real route shape, with nothing watching the list provider, and gate the repository write on a `Completer` so the disposal frame falls in the middle of the save. Both reproduce the exact error message before the fix and pass after.

## Verification

- `flutter analyze`: no issues
- Full suite: 22017 passed. The single failure, `local_file_resolver_test.dart` "a path on the system volume is never probed at all", is the known local `$TMPDIR`-on-a-RAM-disk environment issue and passes when rerun with a system-volume `TMPDIR`.

## Second fix: clearing an optional field

`existing.copyWith(scientificName: null)` reads a null as "keep this value", so blanking Scientific Name, Taxonomy Class or Description in the editor silently wrote the old value back. A wrong scientific name could never be removed once saved.

The update now builds the `Species` by hand so a cleared field reaches the row as NULL, and carries `photoPath` and `isBuiltIn` (which the form does not show) over from the stored row. Covered by a third test that blanks all three fields and asserts both the nulls and that the unshown fields survive.

## Third fix: a species deleted under the open editor (from review)

The edit path skipped the write when `getSpeciesById` came back null, then showed the "updated" snackbar and popped anyway, so a sync applying a deletion from another device while the editor was open ended in a success message with no write behind it.

The null branch now reports `marineLife_speciesEdit_notFoundMessage` ("This species no longer exists.", translated into all ten non-English locales) and returns, leaving the editor on screen so the diver keeps what they typed. Covered by a fourth test that drops the row between the page load and the Save tap.
