### PR TITLE
feat(marine-life): reach the online species lookup from the species picker

### DIFF
--- a/lib/features/dive_log/presentation/widgets/pickers/species_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/species_picker_sheet.dart
@@ -216,13 +216,19 @@ class _SpeciesPickerSheetState extends ConsumerState<SpeciesPickerSheet> {
         // no way to reach the online lookup at all. This footer is the door
         // that is always open.
         const Divider(height: 1),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: TextButton.icon(
-            key: const ValueKey('species_picker_lookup_online'),
-            icon: const Icon(Icons.travel_explore),
-            label: Text(context.l10n.marineLife_lookup_button),
-            onPressed: _lookUpOnline,
+        // Neither host passes useSafeArea, and the sheet is bottom-anchored,
+        // so without this the button sits under the home indicator. The list
+        // above could be scrolled clear of it; a fixed footer cannot.
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: TextButton.icon(
+              key: const ValueKey('species_picker_lookup_online'),
+              icon: const Icon(Icons.travel_explore),
+              label: Text(context.l10n.marineLife_lookup_button),
+              onPressed: _lookUpOnline,
+            ),
           ),
         ),
       ],

--- a/lib/features/dive_log/presentation/widgets/pickers/species_picker_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/pickers/species_picker_sheet.dart
@@ -211,8 +211,57 @@ class _SpeciesPickerSheetState extends ConsumerState<SpeciesPickerSheet> {
             ),
           ),
         ),
+        // The empty state's "Add ..." button only appears when the catalog
+        // answers nothing, so a diver whose search has one near-miss hit had
+        // no way to reach the online lookup at all. This footer is the door
+        // that is always open.
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: TextButton.icon(
+            key: const ValueKey('species_picker_lookup_online'),
+            icon: const Icon(Icons.travel_explore),
+            label: Text(context.l10n.marineLife_lookup_button),
+            onPressed: _lookUpOnline,
+          ),
+        ),
       ],
     );
+  }
+
+  /// The always-available online path. Unlike the empty state, the diver has
+  /// not committed to creating anything, so a dismissed sheet must create
+  /// nothing; with no query typed there is also no name to fall back on, so
+  /// the sheet's "create without lookup" escape is withheld.
+  Future<void> _lookUpOnline() async {
+    final query = _searchQuery.trim();
+    final outcome = await showSpeciesLookupSheet(
+      context,
+      initialQuery: query,
+      allowCreateWithout: query.isNotEmpty,
+    );
+    if (!mounted || outcome == null) return;
+    await _createFromOutcome(outcome, fallbackName: query);
+  }
+
+  /// Turns a lookup outcome into a species and opens the sighting dialog.
+  /// [fallbackName] is what a "create without lookup" is named.
+  Future<void> _createFromOutcome(
+    SpeciesLookupOutcome outcome, {
+    required String fallbackName,
+  }) async {
+    final repository = ref.read(speciesRepositoryProvider);
+    final species = switch (outcome) {
+      SpeciesLookupChosen(:final result) => await _speciesFromLookup(
+        repository,
+        result,
+      ),
+      SpeciesLookupCreateWithout() => await repository.getOrCreateSpecies(
+        commonName: fallbackName,
+        category: SpeciesCategory.other,
+      ),
+    };
+    if (mounted) _showSightingDetails(species);
   }
 
   Widget _buildCategoryChip(SpeciesCategory? category, String label) {
@@ -315,16 +364,14 @@ class _SpeciesPickerSheetState extends ConsumerState<SpeciesPickerSheet> {
   /// lookup" (or a dismissed sheet) keeps the old name-only creation, so an
   /// offline diver loses nothing.
   Future<void> _addCustomSpecies(String name) async {
-    final result = await showSpeciesLookupSheet(context, initialQuery: name);
+    final outcome = await showSpeciesLookupSheet(context, initialQuery: name);
     if (!mounted) return;
-    final repository = ref.read(speciesRepositoryProvider);
-    final species = result == null
-        ? await repository.getOrCreateSpecies(
-            commonName: name,
-            category: SpeciesCategory.other,
-          )
-        : await _speciesFromLookup(repository, result);
-    if (mounted) _showSightingDetails(species);
+    // The diver already tapped "Add <name>", so dismissing the lookup is not
+    // a reason to abandon the species they asked for.
+    await _createFromOutcome(
+      outcome ?? const SpeciesLookupCreateWithout(),
+      fallbackName: name,
+    );
   }
 
   Future<Species> _speciesFromLookup(

--- a/lib/features/marine_life/domain/entities/species_lookup.dart
+++ b/lib/features/marine_life/domain/entities/species_lookup.dart
@@ -137,6 +137,25 @@ class SpeciesLookupResult extends Equatable {
   ];
 }
 
+/// What the lookup sheet was closed with. Dismissal is the absence of an
+/// outcome (a null future), so a caller can tell "the diver backed out" from
+/// "the diver asked to skip the lookup" instead of guessing from a bare null.
+sealed class SpeciesLookupOutcome {
+  const SpeciesLookupOutcome();
+}
+
+/// The diver picked a taxon and it resolved.
+class SpeciesLookupChosen extends SpeciesLookupOutcome {
+  final SpeciesLookupResult result;
+
+  const SpeciesLookupChosen(this.result);
+}
+
+/// The diver asked to create the species from the typed name alone.
+class SpeciesLookupCreateWithout extends SpeciesLookupOutcome {
+  const SpeciesLookupCreateWithout();
+}
+
 enum SpeciesLookupErrorKind { offline, timeout, server, malformed }
 
 /// One message per kind in the sheet; nothing retries silently.

--- a/lib/features/marine_life/presentation/pages/species_edit_page.dart
+++ b/lib/features/marine_life/presentation/pages/species_edit_page.dart
@@ -220,7 +220,7 @@ class _SpeciesEditPageState extends ConsumerState<SpeciesEditPage> {
       context,
       initialQuery: _commonNameController.text.trim(),
     );
-    if (result != null && mounted) _applyLookup(result);
+    if (result is SpeciesLookupChosen && mounted) _applyLookup(result.result);
   }
 
   /// Fills what the lookup knows and leaves the description alone; the

--- a/lib/features/marine_life/presentation/widgets/species_lookup_sheet.dart
+++ b/lib/features/marine_life/presentation/widgets/species_lookup_sheet.dart
@@ -6,13 +6,18 @@ import 'package:submersion/features/marine_life/presentation/providers/species_l
 import 'package:submersion/l10n/arb/app_localizations.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Opens the lookup sheet. Resolves to the chosen species' fields, or null
-/// when the diver dismisses it or asks to create the species without a
-/// lookup (callers keep their offline path for that).
-Future<SpeciesLookupResult?> showSpeciesLookupSheet(
+/// Opens the lookup sheet. Resolves to a [SpeciesLookupChosen] when the
+/// diver picked a taxon, a [SpeciesLookupCreateWithout] when they asked to
+/// skip the lookup, and null when they dismissed the sheet.
+///
+/// Set [allowCreateWithout] to false when the caller has no name to fall
+/// back on, so the sheet does not offer to create a species out of an empty
+/// string.
+Future<SpeciesLookupOutcome?> showSpeciesLookupSheet(
   BuildContext context, {
   String initialQuery = '',
-}) => showModalBottomSheet<SpeciesLookupResult>(
+  bool allowCreateWithout = true,
+}) => showModalBottomSheet<SpeciesLookupOutcome>(
   context: context,
   isScrollControlled: true,
   useSafeArea: true,
@@ -23,6 +28,7 @@ Future<SpeciesLookupResult?> showSpeciesLookupSheet(
     expand: false,
     builder: (_, controller) => SpeciesLookupSheet(
       initialQuery: initialQuery,
+      allowCreateWithout: allowCreateWithout,
       scrollController: controller,
     ),
   ),
@@ -33,11 +39,13 @@ Future<SpeciesLookupResult?> showSpeciesLookupSheet(
 /// offline boat is a single clear message rather than a stream of errors.
 class SpeciesLookupSheet extends ConsumerStatefulWidget {
   final String initialQuery;
+  final bool allowCreateWithout;
   final ScrollController? scrollController;
 
   const SpeciesLookupSheet({
     super.key,
     required this.initialQuery,
+    this.allowCreateWithout = true,
     this.scrollController,
   });
 
@@ -95,7 +103,7 @@ class _SpeciesLookupSheetState extends ConsumerState<SpeciesLookupSheet> {
       final result = await ref
           .read(speciesLookupServiceProvider)
           .resolve(hit.taxonId, locale: ref.read(speciesLookupLocaleProvider));
-      if (mounted) Navigator.of(context).pop(result);
+      if (mounted) Navigator.of(context).pop(SpeciesLookupChosen(result));
     } on SpeciesLookupException catch (e) {
       if (mounted) {
         setState(() {
@@ -144,12 +152,15 @@ class _SpeciesLookupSheetState extends ConsumerState<SpeciesLookupSheet> {
         const SizedBox(height: 16),
         ..._body(l10n, theme),
         const SizedBox(height: 16),
-        OutlinedButton(
-          key: const ValueKey('lookup_create_without'),
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(l10n.marineLife_lookup_createWithout),
-        ),
-        const SizedBox(height: 8),
+        if (widget.allowCreateWithout) ...[
+          OutlinedButton(
+            key: const ValueKey('lookup_create_without'),
+            onPressed: () =>
+                Navigator.of(context).pop(const SpeciesLookupCreateWithout()),
+            child: Text(l10n.marineLife_lookup_createWithout),
+          ),
+          const SizedBox(height: 8),
+        ],
         Text(
           l10n.marineLife_lookup_attribution,
           textAlign: TextAlign.center,

--- a/lib/features/reef/presentation/widgets/nearby_species_tier.dart
+++ b/lib/features/reef/presentation/widgets/nearby_species_tier.dart
@@ -235,11 +235,15 @@ class _NearbySpeciesTierState extends ConsumerState<NearbySpeciesTier> {
       result = null;
     }
     if (!mounted) return;
-    result ??= await showSpeciesLookupSheet(
-      context,
-      initialQuery: scientificName,
-    );
-    if (result == null || !mounted) return;
+    if (result == null) {
+      final outcome = await showSpeciesLookupSheet(
+        context,
+        initialQuery: scientificName,
+      );
+      if (outcome is! SpeciesLookupChosen) return;
+      result = outcome.result;
+    }
+    if (!mounted) return;
 
     final repository = ref.read(speciesRepositoryProvider);
     final species =

--- a/test/features/dive_log/presentation/widgets/pickers/species_picker_sheet_lookup_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/species_picker_sheet_lookup_test.dart
@@ -88,21 +88,51 @@ class _RecordingRepository extends Fake implements SpeciesRepository {
   }
 }
 
+const _lookupFooter = ValueKey('species_picker_lookup_online');
+
+/// A catalog that answers "sail" locally, so the lookup footer is exercised
+/// on the path the empty state never reaches.
+const _catalog = [
+  Species(
+    id: 'sp_sailfin_blenny',
+    commonName: 'Sailfin Blenny',
+    scientificName: 'Emblemaria pandionis',
+    category: SpeciesCategory.fish,
+    isBuiltIn: true,
+  ),
+  Species(
+    id: 'sp_sailfin_tang',
+    commonName: 'Sailfin Tang',
+    scientificName: 'Zebrasoma veliferum',
+    category: SpeciesCategory.fish,
+    isBuiltIn: true,
+  ),
+];
+
 Future<void> _pump(
   WidgetTester tester, {
   required _RecordingRepository repository,
+  List<Species> catalog = const [],
 }) async {
   tester.view.physicalSize = const Size(900, 1800);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
+  List<Species> matching(String query) => catalog
+      .where(
+        (s) => s.commonName.toLowerCase().contains(query.trim().toLowerCase()),
+      )
+      .toList();
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        allSpeciesProvider.overrideWith((ref) async => const []),
+        allSpeciesProvider.overrideWith((ref) async => catalog),
         speciesByCategoryProvider.overrideWith(
-          (ref, category) async => const [],
+          (ref, category) async =>
+              catalog.where((s) => s.category == category).toList(),
         ),
-        speciesSearchProvider.overrideWith((ref, query) async => const []),
+        speciesSearchProvider.overrideWith(
+          (ref, query) async => matching(query),
+        ),
         speciesRepositoryProvider.overrideWithValue(repository),
         speciesLookupServiceProvider.overrideWithValue(_FakeLookup()),
         speciesLookupLocaleProvider.overrideWithValue('en'),
@@ -114,6 +144,51 @@ Future<void> _pump(
           body: SpeciesPickerSheet(
             scrollController: ScrollController(),
             onSpeciesSelected: (_, _, _) {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Pumps the sheet into a short fixed box, the way DraggableScrollableSheet
+/// does at its minimum size. Kept wide on purpose: the test font draws every
+/// glyph as wide as the font size, so a narrow surface overflows the title
+/// row for reasons that have nothing to do with the height under test.
+Future<void> _pumpConstrained(
+  WidgetTester tester, {
+  required double height,
+}) async {
+  tester.view.physicalSize = Size(900, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        allSpeciesProvider.overrideWith((ref) async => _catalog),
+        speciesByCategoryProvider.overrideWith(
+          (ref, category) async => const [],
+        ),
+        speciesSearchProvider.overrideWith((ref, query) async => const []),
+        speciesRepositoryProvider.overrideWithValue(_RecordingRepository()),
+        speciesLookupServiceProvider.overrideWithValue(_FakeLookup()),
+        speciesLookupLocaleProvider.overrideWithValue('en'),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              height: height,
+              width: 900,
+              child: SpeciesPickerSheet(
+                scrollController: ScrollController(),
+                onSpeciesSelected: (_, _, _) {},
+              ),
+            ),
           ),
         ),
       ),
@@ -182,5 +257,128 @@ void main() {
     expect(repository.nameOnlyCreations, 1);
     expect(repository.created, isEmpty);
     expect(find.byType(AlertDialog), findsOneWidget);
+  });
+
+  testWidgets('the online lookup is offered even when the catalog matches '
+      'the query', (tester) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    // The empty state's "Add ..." button is the pre-existing door and it is
+    // shut here, because the catalog answered the search.
+    await tester.enterText(find.byType(TextField).first, 'sail');
+    await tester.pumpAndSettle();
+    expect(find.text('Sailfin Blenny'), findsOneWidget);
+    expect(find.textContaining('Add "'), findsNothing);
+
+    expect(find.byKey(_lookupFooter), findsOneWidget);
+  });
+
+  testWidgets('the online lookup is offered before anything is typed', (
+    tester,
+  ) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    expect(find.byKey(_lookupFooter), findsOneWidget);
+  });
+
+  testWidgets('the footer carries the current query into the lookup and '
+      'creates the chosen species', (tester) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    await tester.enterText(find.byType(TextField).first, 'whale');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_lookupFooter));
+    await tester.pumpAndSettle();
+
+    // The sheet opens pre-filled, so the diver does not retype the name.
+    expect(find.text('Look up a species'), findsOneWidget);
+    expect(
+      tester.widget<TextField>(find.byType(TextField).last).controller?.text,
+      'whale',
+    );
+
+    await tester.tap(find.text('Look up'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Whale Shark'));
+    await tester.pumpAndSettle();
+
+    expect(repository.created.single['scientificName'], 'Rhincodon typus');
+    expect(repository.nameOnlyCreations, 0);
+    expect(find.byType(AlertDialog), findsOneWidget);
+  });
+
+  testWidgets('browsing the lookup with an empty query offers no '
+      'create-without escape and creates nothing when dismissed', (
+    tester,
+  ) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    await tester.tap(find.byKey(_lookupFooter));
+    await tester.pumpAndSettle();
+    expect(find.text('Look up a species'), findsOneWidget);
+
+    // With no name to fall back on, "Create without lookup" would mint a
+    // nameless species, so it must not be offered at all.
+    expect(find.text('Create without lookup'), findsNothing);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Look up a species'), findsNothing);
+    expect(repository.created, isEmpty);
+    expect(repository.nameOnlyCreations, 0);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('dismissing the lookup opened from the footer with a query '
+      'creates nothing', (tester) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    await tester.enterText(find.byType(TextField).first, 'whale');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_lookupFooter));
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(repository.created, isEmpty);
+    expect(repository.nameOnlyCreations, 0);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('Create without lookup from the footer keeps the name-only '
+      'path', (tester) async {
+    final repository = _RecordingRepository();
+    await _pump(tester, repository: repository, catalog: _catalog);
+
+    await tester.enterText(find.byType(TextField).first, 'whale');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(_lookupFooter));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create without lookup'));
+    await tester.pumpAndSettle();
+
+    expect(repository.nameOnlyCreations, 1);
+    expect(repository.created, isEmpty);
+    expect(find.byType(AlertDialog), findsOneWidget);
+  });
+
+  testWidgets('the footer survives a short sheet, since it sits below the '
+      'scrolling list rather than inside it', (tester) async {
+    await _pumpConstrained(tester, height: 320);
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(_lookupFooter), findsOneWidget);
+    // Off-screen would still be "found", so check it can actually be hit.
+    final box = tester.getRect(find.byKey(_lookupFooter));
+    expect(box.bottom, lessThanOrEqualTo(320));
+    expect(box.height, greaterThan(0));
+    // The list is the part that gives, not the footer.
+    expect(find.byType(ListView), findsWidgets);
   });
 }

--- a/test/features/dive_log/presentation/widgets/pickers/species_picker_sheet_lookup_test.dart
+++ b/test/features/dive_log/presentation/widgets/pickers/species_picker_sheet_lookup_test.dart
@@ -197,6 +197,58 @@ Future<void> _pumpConstrained(
   await tester.pumpAndSettle();
 }
 
+/// Pumps the sheet bottom-anchored under a home-indicator-sized inset, the
+/// way both hosts present it: showModalBottomSheet without useSafeArea.
+Future<void> _pumpWithBottomInset(
+  WidgetTester tester, {
+  required double inset,
+}) async {
+  tester.view.physicalSize = const Size(900, 800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        allSpeciesProvider.overrideWith((ref) async => _catalog),
+        speciesByCategoryProvider.overrideWith(
+          (ref, category) async => const [],
+        ),
+        speciesSearchProvider.overrideWith((ref, query) async => const []),
+        speciesRepositoryProvider.overrideWithValue(_RecordingRepository()),
+        speciesLookupServiceProvider.overrideWithValue(_FakeLookup()),
+        speciesLookupLocaleProvider.overrideWithValue('en'),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          // The override sits inside the body so it is the sheet's nearest
+          // MediaQuery, whatever the Scaffold did with the real padding.
+          body: Builder(
+            builder: (context) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(padding: EdgeInsets.only(bottom: inset)),
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: SizedBox(
+                  height: 560,
+                  width: 900,
+                  child: SpeciesPickerSheet(
+                    scrollController: ScrollController(),
+                    onSpeciesSelected: (_, _, _) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
 Future<void> _typeAndAdd(WidgetTester tester) async {
   await tester.enterText(find.byType(TextField).first, 'whale');
   await tester.pumpAndSettle();
@@ -380,5 +432,17 @@ void main() {
     expect(box.height, greaterThan(0));
     // The list is the part that gives, not the footer.
     expect(find.byType(ListView), findsWidgets);
+  });
+
+  testWidgets('the footer clears the bottom inset, since neither host passes '
+      'useSafeArea', (tester) async {
+    const inset = 34.0;
+    await _pumpWithBottomInset(tester, inset: inset);
+
+    final footer = tester.getRect(find.byKey(_lookupFooter));
+    // The sheet is bottom-anchored, so its own bottom edge is the screen
+    // edge; the button has to stop short of the home indicator.
+    expect(footer.bottom, lessThanOrEqualTo(800 - inset));
+    expect(footer.height, greaterThan(0));
   });
 }

--- a/test/features/marine_life/presentation/widgets/species_lookup_sheet_test.dart
+++ b/test/features/marine_life/presentation/widgets/species_lookup_sheet_test.dart
@@ -62,12 +62,13 @@ class _FakeLookup implements SpeciesLookupService {
 }
 
 /// Opens the sheet from a button so the popped value can be captured.
-Future<SpeciesLookupResult? Function()> _open(
+Future<SpeciesLookupOutcome? Function()> _open(
   WidgetTester tester,
   _FakeLookup service, {
   String initialQuery = '',
+  bool allowCreateWithout = true,
 }) async {
-  SpeciesLookupResult? popped;
+  SpeciesLookupOutcome? popped;
   var closed = false;
   await tester.pumpWidget(
     testApp(
@@ -82,6 +83,7 @@ Future<SpeciesLookupResult? Function()> _open(
             popped = await showSpeciesLookupSheet(
               context,
               initialQuery: initialQuery,
+              allowCreateWithout: allowCreateWithout,
             );
             closed = true;
           },
@@ -141,7 +143,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(service.resolved, [52188]);
-    expect(read(), _resolved);
+    expect(
+      read(),
+      isA<SpeciesLookupChosen>().having((o) => o.result, 'result', _resolved),
+    );
   });
 
   testWidgets('shows the empty state for a query with no hits', (tester) async {
@@ -169,13 +174,33 @@ void main() {
     expect(service.queries, hasLength(2));
   });
 
-  testWidgets('Create without lookup pops with null', (tester) async {
+  testWidgets('Create without lookup pops its own outcome, distinct from a '
+      'dismissal', (tester) async {
     final service = _FakeLookup();
     final read = await _open(tester, service, initialQuery: 'whale');
 
     await tester.tap(find.text('Create without lookup'));
     await tester.pumpAndSettle();
 
+    expect(read(), isA<SpeciesLookupCreateWithout>());
+  });
+
+  testWidgets('dismissing the sheet pops null', (tester) async {
+    final service = _FakeLookup();
+    final read = await _open(tester, service, initialQuery: 'whale');
+
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+
     expect(read(), isNull);
+  });
+
+  testWidgets('the create-without escape is withheld when the caller has no '
+      'name to fall back on', (tester) async {
+    final service = _FakeLookup();
+    await _open(tester, service, allowCreateWithout: false);
+
+    expect(find.text('Create without lookup'), findsNothing);
+    expect(find.byKey(const ValueKey('lookup_create_without')), findsNothing);
   });
 }


### PR DESCRIPTION
## Problem

The iNaturalist lookup added in #1343 was already wired into `SpeciesPickerSheet`, but behind exactly one door: the zero-result empty state's `Add "<query>"` button, whose label says nothing about searching online.

So with an empty search box, or with any query matching even one of the 685 catalog rows, there was no way to reach the online lookup at all. Reported from the media viewer's "Species in this photo" sheet, which opens this same picker via `media_species_sheet.dart` `_pickOther`.

## Change

**A persistent "Look up online" footer** under the results list, always visible, carrying whatever is currently typed into the lookup as its initial query. It reuses `Icons.travel_explore` and the existing `marineLife_lookup_button` string from `species_edit_page`, so it adds **no new ARB keys** across the 11 locales.

**A sealed `SpeciesLookupOutcome`** replacing the sheet's nullable return. The old contract popped a bare `null` for two different things: "the diver dismissed the sheet" and "the diver tapped Create without lookup". That was harmless while the only caller was the empty state, where the diver has already committed to adding the species and both outcomes mean the same name-only creation. Behind an always-visible button it is not: dismissing the sheet out of curiosity would silently create a species.

| Entry point | Chose a taxon | "Create without lookup" | Dismissed |
| --- | --- | --- | --- |
| Empty state `Add "X"` | create from lookup | name-only species | name-only species (unchanged) |
| New footer, with a query | create from lookup | name-only species | nothing |
| New footer, empty box | create from lookup | button hidden | nothing |

`allowCreateWithout` remains as a UX guard rather than a disambiguation crutch: with an empty search box there is no name to fall back on, so offering that escape would create an empty-named species.

The two other call sites (`species_edit_page`, `nearby_species_tier`) already treated `null` as "do nothing", so both are one-line changes with no behaviour change.

## Notes

- No schema change, no new strings, no new network surface. The lookup stays explicit: nothing is sent until the diver taps "Look up".
- A species created this way is a normal custom catalog row (`isBuiltIn: false`, hlc-stamped, syncs to the diver's other devices). It does not enter the bundled asset; that remains the `species-suggestion` GitHub issue path on the species detail page.

## Testing

- 10 tests on the picker, 6 new: the footer is offered with matches present and before anything is typed; it carries the query into the sheet; dismissal creates nothing with and without a query; "Create without lookup" still takes the name-only path; and the footer survives a short sheet, since it sits below the scrolling list rather than inside it.
- 3 new tests on the sheet contract: create-without pops its own outcome distinct from a dismissal, dismissal pops null, and the escape is withheld when the caller has no name.
- `flutter analyze` clean, `dart format` clean, 5533 pass / 9 skipped across `marine_life`, `reef`, `dive_log`, `media`, `l10n`.

## Manual verification

- [ ] macOS: open a dive photo, Species in this photo, Other species, confirm the footer renders and opens the lookup