### PR TITLE
Statistics: give MultiTrendLineChart a shared ChartAxis (#1354)

### DIFF
--- a/lib/features/statistics/presentation/widgets/stat_charts.dart
+++ b/lib/features/statistics/presentation/widgets/stat_charts.dart
@@ -621,10 +621,12 @@ class MultiTrendLineChart extends StatelessWidget {
     ];
     final colors = seriesColors ?? defaultColors;
 
-    final allValues = dataSeries.expand((s) => s.map((d) => d.value)).toList();
-    final minY = allValues.reduce((a, b) => a < b ? a : b);
-    final maxY = allValues.reduce((a, b) => a > b ? a : b);
-    final padding = (maxY - minY) * 0.1;
+    // Every series shares one axis, and that axis drives the bounds, the grid
+    // lines and the labels together, so the numbers sit on the lines instead
+    // of on fl_chart's own separate sequence (issues #219, #1354).
+    final axis = ChartAxis.forTrend(
+      dataSeries.expand((s) => s.map((d) => d.value)),
+    );
 
     final longestSeries = dataSeries.reduce(
       (a, b) => a.length > b.length ? a : b,
@@ -640,8 +642,8 @@ class MultiTrendLineChart extends StatelessWidget {
             height: height - 30,
             child: LineChart(
               LineChartData(
-                minY: minY - padding,
-                maxY: maxY + padding,
+                minY: axis.min,
+                maxY: axis.max,
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
                     getTooltipItems: (touchedSpots) {
@@ -689,7 +691,11 @@ class MultiTrendLineChart extends StatelessWidget {
                   leftTitles: AxisTitles(
                     sideTitles: SideTitles(
                       showTitles: true,
-                      reservedSize: 40,
+                      // Matches the sibling trend chart: a unit-formatted
+                      // temperature such as 85.5 F wrapped onto two lines in
+                      // the narrower gutter this chart used to reserve.
+                      reservedSize: 50,
+                      interval: axis.interval,
                       getTitlesWidget: (value, meta) {
                         return Text(
                           valueFormatter?.call(value) ??
@@ -715,6 +721,7 @@ class MultiTrendLineChart extends StatelessWidget {
                 gridData: FlGridData(
                   show: true,
                   drawVerticalLine: false,
+                  horizontalInterval: axis.interval,
                   getDrawingHorizontalLine: (value) => FlLine(
                     color: Theme.of(context).colorScheme.outlineVariant,
                     strokeWidth: 1,

--- a/test/features/statistics/presentation/widgets/stat_charts_axis_test.dart
+++ b/test/features/statistics/presentation/widgets/stat_charts_axis_test.dart
@@ -157,4 +157,154 @@ void main() {
       expect(_isOnTick(data.maxY, interval), isTrue);
     });
   });
+
+  group('MultiTrendLineChart axis', () {
+    // Issue #1354: the seasonal water temperature chart was the one chart in
+    // the statistics feature that never adopted ChartAxis. It picked its own
+    // padded bounds and left both intervals null, so the left labels landed on
+    // fl_chart's own sequence, wide of the grid lines and each other.
+    List<TrendDataPoint> series(List<double> values) => [
+      for (final (index, value) in values.indexed)
+        TrendDataPoint(
+          date: DateTime(2024, index + 1),
+          value: value,
+          label: 'M${index + 1}',
+        ),
+    ];
+
+    final seasonalTemps = [
+      series(const [8.4, 9.1, 11.6, 14.2, 18.9, 22.3]),
+      series(const [11.2, 12.0, 14.4, 17.1, 21.8, 25.6]),
+      series(const [14.0, 15.3, 17.2, 20.5, 24.7, 28.9]),
+    ];
+
+    testWidgets('grid lines and left labels share one interval', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: seasonalTemps,
+          seriesLabels: const ['Min', 'Avg', 'Max'],
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final gridInterval = data.gridData.horizontalInterval;
+      final labelInterval = data.titlesData.leftTitles.sideTitles.interval;
+
+      expect(gridInterval, isNotNull);
+      expect(labelInterval, isNotNull);
+      expect(labelInterval, gridInterval);
+    });
+
+    testWidgets('axis bounds sit on the shared interval', (tester) async {
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: seasonalTemps,
+          seriesLabels: const ['Min', 'Avg', 'Max'],
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final interval = data.gridData.horizontalInterval!;
+
+      expect(_isOnTick(data.minY, interval), isTrue);
+      expect(_isOnTick(data.maxY, interval), isTrue);
+    });
+
+    testWidgets('every rendered left label lands on a grid line', (
+      tester,
+    ) async {
+      final labelledValues = <double>[];
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: seasonalTemps,
+          seriesLabels: const ['Min', 'Avg', 'Max'],
+          valueFormatter: (value) {
+            labelledValues.add(value);
+            return value.toStringAsFixed(1);
+          },
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+      final interval = data.gridData.horizontalInterval!;
+
+      expect(labelledValues, isNotEmpty);
+      for (final value in labelledValues) {
+        expect(
+          _isOnTick(value, interval),
+          isTrue,
+          reason: '$value is not a multiple of the $interval grid interval',
+        );
+      }
+    });
+
+    testWidgets('spans every series, not just the first', (tester) async {
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: seasonalTemps,
+          seriesLabels: const ['Min', 'Avg', 'Max'],
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+
+      expect(data.minY, lessThanOrEqualTo(8.4));
+      expect(data.maxY, greaterThanOrEqualTo(28.9));
+    });
+
+    testWidgets('survives a flat series', (tester) async {
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: [
+            series(const [15.0, 15.0]),
+          ],
+          seriesLabels: const ['Avg'],
+        ),
+      );
+
+      final data = tester.widget<LineChart>(find.byType(LineChart)).data;
+
+      expect(data.maxY, greaterThan(data.minY));
+      expect(data.gridData.horizontalInterval, greaterThan(0));
+    });
+
+    testWidgets('reserves the same label width as the sibling trend chart', (
+      tester,
+    ) async {
+      // A unit-formatted temperature such as "85.5\u00b0F" wrapped onto two
+      // lines in the narrower gutter this chart used to reserve.
+      await _pump(
+        tester,
+        MultiTrendLineChart(
+          dataSeries: seasonalTemps,
+          seriesLabels: const ['Min', 'Avg', 'Max'],
+        ),
+      );
+      final multi = tester
+          .widget<LineChart>(find.byType(LineChart))
+          .data
+          .titlesData
+          .leftTitles
+          .sideTitles
+          .reservedSize;
+
+      await _pump(tester, TrendLineChart(data: _sacTrend));
+      final single = tester
+          .widget<LineChart>(find.byType(LineChart))
+          .data
+          .titlesData
+          .leftTitles
+          .sideTitles
+          .reservedSize;
+
+      expect(multi, single);
+    });
+  });
 }


### PR DESCRIPTION
Fixes #1354.

## The bug

`MultiTrendLineChart` was the last chart in the statistics feature that never adopted `ChartAxis`. It picked its own y bounds inline and left both tick intervals null:

```dart
final minY = allValues.reduce((a, b) => a < b ? a : b);
final maxY = allValues.reduce((a, b) => a > b ? a : b);
final padding = (maxY - minY) * 0.1;
```

fl_chart then spaced grid lines by `FlGridData.horizontalInterval` and side titles by `SideTitles.interval`, each falling back independently to its own heuristic. Two heuristics over the same axis produce two tick sequences, so the left labels landed on arbitrary values, wide of the lines. Those arbitrary values are also longer strings than round ones, and in the 40px gutter this chart reserved, a unit-formatted `85.5°F` wrapped onto two lines and its neighbour ran into it.

Seen on macOS on Statistics > Conditions > Seasonal Water Temperature.

## The fix

Derive the bounds, the grid spacing and the label spacing from one `ChartAxis.forTrend`, the way `TrendLineChart` and `CategoryBarChart` have since #219, and widen the label gutter to the 50px its siblings reserve.

Adopting `ChartAxis` also closes a latent degenerate case that the issue did not mention: `padding` is zero for a flat series, so a chart whose values never move rendered with `minY == maxY`. `ChartAxis.forTrend` gives a flat series a band of its own.

## Scope

`MultiTrendLineChart` has exactly one consumer, the seasonal water temperature chart at `statistics_conditions_page.dart:278`, so the blast radius is limited to that chart. No API change: the widget's constructor is untouched.

## Tests

Six new cases in `stat_charts_axis_test.dart`, mirroring the `TrendLineChart` group that already guards #219:

- grid lines and left labels share one interval
- axis bounds sit on that shared interval
- every rendered left label lands on a grid line
- the axis spans every series, not just the first
- a flat series still yields `maxY > minY` and a positive interval
- the label gutter is as wide as the sibling trend chart's

All five of the first-listed behaviours failed against `main` before the change. `flutter test test/features/statistics/` is green at 403 tests; `flutter analyze` is clean; `flutter build macos --debug` succeeds.

An on-screen macOS smoke of the seasonal chart has not been run, so the label wrapping is guarded by the reserved-width test rather than observed directly.