### PR TITLE
perf(media): read image dimensions from the header, not the JPEG scan

### DIFF
--- a/lib/features/media/data/services/image_dimensions_reader.dart
+++ b/lib/features/media/data/services/image_dimensions_reader.dart
@@ -152,7 +152,7 @@ ImageDimensions? _isoBmffDimensions(RandomAccessFile raf, int end) {
   final properties = findBoxesInBytes(metaBytes, ipco.start, ipco.end, 'ispe');
   if (properties.isEmpty) return null;
 
-  final wanted = _primaryIspe(metaBytes, iprp, ipco, properties);
+  final wanted = _primaryIspe(metaBytes, iprp, ipco);
   // A file with no usable pitm/ipma pair still has exactly one plausible
   // answer in the common single-image case: the first ispe.
   return _readIspe(metaBytes, wanted ?? properties.first);
@@ -160,12 +160,7 @@ ImageDimensions? _isoBmffDimensions(RandomAccessFile raf, int end) {
 
 /// Resolves the `ispe` associated with the `pitm` primary item, or null when
 /// either the primary item or its association is missing.
-BoxRange? _primaryIspe(
-  Uint8List b,
-  BoxRange iprp,
-  BoxRange ipco,
-  List<BoxRange> ispeRanges,
-) {
+BoxRange? _primaryIspe(Uint8List b, BoxRange iprp, BoxRange ipco) {
   final pitm = findBoxInBytes(b, 0, b.length, 'pitm');
   if (pitm == null) return null;
   final version = b[pitm.start];
@@ -179,30 +174,16 @@ BoxRange? _primaryIspe(
   // Property indices are 1-based into ipco's full child list, which holds
   // `hvcC`, `colr`, `pixi` and `irot` alongside the `ispe` entries -- an item
   // is associated with several of them, in no guaranteed order, so every
-  // association is tried and the one that lands on an ispe wins.
-  final children = _ipcoChildren(b, ipco);
+  // association is tried and the one that lands on an ispe wins. The list has
+  // to come from the shared walker: it is positional, so a child using the
+  // 64-bit or to-end-of-range size form must still occupy exactly one slot.
+  final children = boxesInBytes(b, ipco.start, ipco.end);
   for (final index in _propertyIndicesFor(b, ipma, primaryId)) {
     if (index < 1 || index > children.length) continue;
-    final target = children[index - 1];
-    for (final range in ispeRanges) {
-      if (range.start == target.start) return range;
-    }
+    final child = children[index - 1];
+    if (child.type == 'ispe') return child.range;
   }
   return null;
-}
-
-/// Every child property of `ipco`, in declaration order, since `ipma`
-/// indices count all of them and not just the `ispe` ones.
-List<BoxRange> _ipcoChildren(Uint8List b, BoxRange ipco) {
-  final children = <BoxRange>[];
-  var pos = ipco.start;
-  while (pos + 8 <= ipco.end) {
-    final size = beU32(b, pos);
-    if (size < 8 || pos + size > ipco.end) break;
-    children.add(BoxRange(pos + 8, pos + size));
-    pos += size;
-  }
-  return children;
 }
 
 /// Every property index associated with [wantId] in an `ipma` box, in

--- a/lib/features/media/data/services/image_dimensions_reader.dart
+++ b/lib/features/media/data/services/image_dimensions_reader.dart
@@ -1,0 +1,266 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+import 'package:submersion/features/media/data/services/isobmff_boxes.dart';
+
+/// The stored pixel size of an image, as its container declares it.
+typedef ImageDimensions = ({int width, int height});
+
+/// Reads an image's pixel dimensions from its container header, without
+/// decoding pixels and, for the two formats that matter on a folder import,
+/// without reading the file.
+///
+/// Dispatch is on the file's own magic bytes, not on [mime] -- [mime] only
+/// gates images from video, so a photo whose name lies is still read
+/// correctly.
+///
+/// The dimensions reported are the ones *stored* in the container. No
+/// orientation is applied: a JPEG's EXIF `Orientation` tag and a HEIC's
+/// `irot` property both leave the encoded frame alone, and the decoder this
+/// reader replaced ignored them too. Matching tiers such as
+/// `AssetResolutionService.matchByTimestampAndDimensions` compare for exact
+/// equality against dimensions recorded the same way, so the convention
+/// matters more than the choice.
+///
+/// Returns null for videos and for anything whose header cannot be read.
+ImageDimensions? readImageDimensions(File file, String mime) {
+  if (!mime.startsWith('image/')) return null;
+  RandomAccessFile? raf;
+  try {
+    raf = file.openSync();
+    final end = raf.lengthSync();
+    if (end < 12) return null;
+    final magic = readBytesAt(raf, 0, 12);
+    if (_isJpeg(magic)) return _jpegDimensions(raf, end);
+    if (_isIsoBmff(magic)) return _isoBmffDimensions(raf, end);
+    return _decoderDimensions(raf, end);
+  } on Object {
+    // Unreadable, truncated, or malformed: dimensions are optional here.
+    return null;
+  } finally {
+    raf?.closeSync();
+  }
+}
+
+bool _isJpeg(Uint8List b) => b[0] == 0xff && b[1] == 0xd8 && b[2] == 0xff;
+
+/// ISO base media file format: a `ftyp` box at offset 0. HEIC, HEIF and AVIF
+/// all take the `meta > iprp` route below; other brands (MP4, MOV) never
+/// reach here because [readImageDimensions] gates on an image mime.
+bool _isIsoBmff(Uint8List b) => fourCC(b, 4) == 'ftyp';
+
+// -- JPEG ------------------------------------------------------------------
+
+/// Walks the JPEG segment chain to the first frame header and reads the
+/// dimensions out of it.
+///
+/// This is the whole reason the reader exists. `JpegDecoder.startDecode`
+/// yields a result only once it has seen both an SOF *and* an SOS, and
+/// reaching the marker after the SOS means byte-scanning the entire
+/// entropy-coded scan in Dart: ~26 ms on a 3.8 MB photo, for two integers
+/// that were already on the table at the SOF. Seeking segment to segment
+/// touches a few KB instead.
+ImageDimensions? _jpegDimensions(RandomAccessFile raf, int end) {
+  var pos = 2; // past the SOI matched by _isJpeg
+  while (pos + 2 <= end) {
+    final head = readBytesAt(raf, pos, 2);
+    if (head.length < 2 || head[0] != 0xff) return null;
+    final marker = head[1];
+    pos += 2;
+
+    // A marker may be preceded by any number of 0xFF fill bytes.
+    if (marker == 0xff) {
+      pos -= 1;
+      continue;
+    }
+    // 0xFF00 is a stuffed data byte, which cannot appear between segments.
+    if (marker == 0x00) return null;
+    // Standalone markers carry no length payload: TEM, SOI, RSTn.
+    if (marker == 0x01 ||
+        marker == 0xd8 ||
+        (marker >= 0xd0 && marker <= 0xd7)) {
+      continue;
+    }
+    // EOI, or the start of the scan, with no frame header seen. Everything
+    // past an SOS is entropy-coded data, and stepping through it is exactly
+    // the cost being avoided.
+    if (marker == 0xd9 || marker == 0xda) return null;
+
+    if (pos + 2 > end) return null;
+    final length = beU16(readBytesAt(raf, pos, 2), 0);
+    // A segment shorter than its own length field, or one running past EOF,
+    // is corrupt; stop rather than seek to a guessed position.
+    if (length < 2 || pos + length > end) return null;
+
+    if (_isFrameHeader(marker)) {
+      // SOFn payload: [precision:1][height:2][width:2][components:1]...
+      if (length < 8) return null;
+      final frame = readBytesAt(raf, pos + 2, 5);
+      final height = beU16(frame, 1);
+      final width = beU16(frame, 3);
+      if (width == 0 || height == 0) return null;
+      return (width: width, height: height);
+    }
+
+    pos += length;
+  }
+  return null;
+}
+
+/// SOF0..SOF15 share one payload layout, so all of them answer. The three
+/// markers that sit inside that range without being frame headers do not:
+/// DHT (0xC4), JPG (0xC8) and DAC (0xCC).
+bool _isFrameHeader(int marker) =>
+    marker >= 0xc0 &&
+    marker <= 0xcf &&
+    marker != 0xc4 &&
+    marker != 0xc8 &&
+    marker != 0xcc;
+
+// -- HEIC / HEIF / AVIF ----------------------------------------------------
+
+/// Upper bound on the `meta` box read. Mirrors the cap in
+/// `local_exif_loader.dart` and for the same reason: the box carries no pixel data, so a real one is tens of
+/// KB, and a folder import runs this over every picked file.
+const _maxMetaBytes = 8 * 1024 * 1024;
+
+/// Reads the primary image item's `ispe` (image spatial extents) property.
+///
+/// The layout is `meta > iprp > ipco`, a flat list of item properties, with
+/// `meta > iprp > ipma` associating 1-based indices into that list with item
+/// ids and `meta > pitm` naming the primary item. Resolving the primary item
+/// matters: a thumbnail's `ispe` is commonly the first one in `ipco`.
+///
+/// Before this route existed HEIC fell to `package:image`, which read the
+/// whole file and then found no HEIC decoder at all -- a multi-MB read for a
+/// guaranteed null, leaving every picked HEIC at 0x0.
+ImageDimensions? _isoBmffDimensions(RandomAccessFile raf, int end) {
+  final meta = findBox(raf, 0, end, 'meta');
+  if (meta == null) return null;
+  // `meta` is a FullBox: its children start 4 (version + flags) bytes in.
+  final metaLen = meta.end - meta.start - 4;
+  if (metaLen <= 0 || metaLen > _maxMetaBytes) return null;
+  final metaBytes = readBytesAt(raf, meta.start + 4, metaLen);
+
+  final iprp = findBoxInBytes(metaBytes, 0, metaBytes.length, 'iprp');
+  if (iprp == null) return null;
+  final ipco = findBoxInBytes(metaBytes, iprp.start, iprp.end, 'ipco');
+  if (ipco == null) return null;
+
+  final properties = findBoxesInBytes(metaBytes, ipco.start, ipco.end, 'ispe');
+  if (properties.isEmpty) return null;
+
+  final wanted = _primaryIspe(metaBytes, iprp, ipco, properties);
+  // A file with no usable pitm/ipma pair still has exactly one plausible
+  // answer in the common single-image case: the first ispe.
+  return _readIspe(metaBytes, wanted ?? properties.first);
+}
+
+/// Resolves the `ispe` associated with the `pitm` primary item, or null when
+/// either the primary item or its association is missing.
+BoxRange? _primaryIspe(
+  Uint8List b,
+  BoxRange iprp,
+  BoxRange ipco,
+  List<BoxRange> ispeRanges,
+) {
+  final pitm = findBoxInBytes(b, 0, b.length, 'pitm');
+  if (pitm == null) return null;
+  final version = b[pitm.start];
+  final idPos = pitm.start + 4;
+  if (idPos + (version == 0 ? 2 : 4) > pitm.end) return null;
+  final primaryId = version == 0 ? beU16(b, idPos) : beU32(b, idPos);
+
+  final ipma = findBoxInBytes(b, iprp.start, iprp.end, 'ipma');
+  if (ipma == null) return null;
+
+  // Property indices are 1-based into ipco's full child list, which holds
+  // `hvcC`, `colr`, `pixi` and `irot` alongside the `ispe` entries -- an item
+  // is associated with several of them, in no guaranteed order, so every
+  // association is tried and the one that lands on an ispe wins.
+  final children = _ipcoChildren(b, ipco);
+  for (final index in _propertyIndicesFor(b, ipma, primaryId)) {
+    if (index < 1 || index > children.length) continue;
+    final target = children[index - 1];
+    for (final range in ispeRanges) {
+      if (range.start == target.start) return range;
+    }
+  }
+  return null;
+}
+
+/// Every child property of `ipco`, in declaration order, since `ipma`
+/// indices count all of them and not just the `ispe` ones.
+List<BoxRange> _ipcoChildren(Uint8List b, BoxRange ipco) {
+  final children = <BoxRange>[];
+  var pos = ipco.start;
+  while (pos + 8 <= ipco.end) {
+    final size = beU32(b, pos);
+    if (size < 8 || pos + size > ipco.end) break;
+    children.add(BoxRange(pos + 8, pos + size));
+    pos += size;
+  }
+  return children;
+}
+
+/// Every property index associated with [wantId] in an `ipma` box, in
+/// declaration order.
+///
+/// Entry layout: item_ID (uint16 in v0, uint32 in v1+), an association count,
+/// then that many association records. Each record is one byte -- an
+/// "essential" flag plus a 7-bit index -- unless flags bit 0 is set, in which
+/// case it is two bytes with a 15-bit index.
+List<int> _propertyIndicesFor(Uint8List b, BoxRange ipma, int wantId) {
+  final version = b[ipma.start];
+  final wideIndex = (b[ipma.start + 3] & 0x1) != 0;
+  final idBytes = version < 1 ? 2 : 4;
+  final indexBytes = wideIndex ? 2 : 1;
+
+  var pos = ipma.start + 4;
+  if (pos + 4 > ipma.end) return const [];
+  final entryCount = beU32(b, pos);
+  pos += 4;
+
+  for (var i = 0; i < entryCount; i++) {
+    if (pos + idBytes + 1 > ipma.end) return const [];
+    final id = idBytes == 2 ? beU16(b, pos) : beU32(b, pos);
+    pos += idBytes;
+    final associationCount = b[pos];
+    pos += 1;
+    if (pos + associationCount * indexBytes > ipma.end) return const [];
+    if (id == wantId) {
+      return [
+        for (var a = 0; a < associationCount; a++)
+          if (wideIndex)
+            beU16(b, pos + a * indexBytes) & 0x7fff
+          else
+            b[pos + a * indexBytes] & 0x7f,
+      ];
+    }
+    pos += associationCount * indexBytes;
+  }
+  return const [];
+}
+
+/// `ispe` is a FullBox holding image_width then image_height as uint32.
+ImageDimensions? _readIspe(Uint8List b, BoxRange ispe) {
+  if (ispe.end - ispe.start < 12) return null;
+  final width = beU32(b, ispe.start + 4);
+  final height = beU32(b, ispe.start + 8);
+  if (width == 0 || height == 0) return null;
+  return (width: width, height: height);
+}
+
+// -- everything else -------------------------------------------------------
+
+/// PNG, GIF, WebP, BMP and TIFF, whose `startDecode` really does stop at the
+/// header. Only these formats pay the full-file read, and at roughly 0.6 ms
+/// per 4 MB that read is not what this reader was written to remove.
+ImageDimensions? _decoderDimensions(RandomAccessFile raf, int end) {
+  final bytes = readBytesAt(raf, 0, end);
+  final info = img.findDecoderForData(bytes)?.startDecode(bytes);
+  if (info == null || info.width == 0 || info.height == 0) return null;
+  return (width: info.width, height: info.height);
+}

--- a/lib/features/media/data/services/isobmff_boxes.dart
+++ b/lib/features/media/data/services/isobmff_boxes.dart
@@ -52,11 +52,21 @@ List<BoxRange> findBoxesInBytes(Uint8List b, int start, int end, String type) =>
         if (r.type == type) r.range,
     ];
 
-typedef _Header = ({String type, BoxRange range});
+/// A box's four-character type paired with its content range.
+typedef BoxHeader = ({String type, BoxRange range});
+
+/// Every sibling box within [start, end), in file order, whatever its type.
+///
+/// Callers that need a box's POSITION among its siblings need all of them,
+/// not just the ones of one type: HEIC `ipma` property indices are 1-based
+/// into `ipco`'s full child list, so skipping a `hvcC` shifts every later
+/// index onto the wrong property.
+List<BoxHeader> boxesInBytes(Uint8List b, int start, int end) =>
+    _walkBytes(b, start, end).toList();
 
 /// Lazily yields sibling boxes; stops at the first corrupt header so a bad
 /// size never walks past [end] or spins.
-Iterable<_Header> _walk(RandomAccessFile raf, int start, int end) sync* {
+Iterable<BoxHeader> _walk(RandomAccessFile raf, int start, int end) sync* {
   var pos = start;
   while (pos + 8 <= end) {
     raf.setPositionSync(pos);
@@ -81,7 +91,7 @@ Iterable<_Header> _walk(RandomAccessFile raf, int start, int end) sync* {
   }
 }
 
-Iterable<_Header> _walkBytes(Uint8List b, int start, int end) sync* {
+Iterable<BoxHeader> _walkBytes(Uint8List b, int start, int end) sync* {
   var pos = start;
   while (pos + 8 <= end) {
     var size = beU32(b, pos);

--- a/lib/features/media/data/services/photo_picker_service_desktop.dart
+++ b/lib/features/media/data/services/photo_picker_service_desktop.dart
@@ -2,10 +2,10 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show compute;
-import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:submersion/features/media/data/services/image_dimensions_reader.dart';
 import 'package:submersion/features/media/data/services/local_media_metadata.dart';
 import 'package:submersion/features/media/data/services/photo_picker_service.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_metadata.dart';
@@ -56,11 +56,12 @@ class PhotoPickerServiceDesktop implements PhotoPickerService {
       return [];
     }
 
-    // Reading capture time and dimensions means reading each file's bytes,
-    // which would jank the UI thread for a pick of large photos (the old
-    // stat()-only implementation was cheap enough to inline). Do the batch on
-    // a background isolate, then register the paths here -- the isolate only
-    // ever mutates its own copy of [_filePathCache].
+    // Reading the capture time still means reading each file's bytes -- a
+    // JPEG's EXIF comes out of a full-file parse -- which would jank the UI
+    // thread for a pick of large photos (the old stat()-only implementation
+    // was cheap enough to inline). Do the batch on a background isolate, then
+    // register the paths here -- the isolate only ever mutates its own copy
+    // of [_filePathCache].
     final assets = await compute(
       _extractAssets,
       files.map((f) => f.path).toList(),
@@ -181,7 +182,7 @@ AssetInfo? _assetInfoForPath(String path) {
           capturedUtc.microsecond,
         );
 
-  final size = _dimensionsOf(ioFile, mime);
+  final size = readImageDimensions(ioFile, mime);
 
   return AssetInfo(
     // Keyed on mtime + path so re-picking the same file in one session reuses
@@ -199,31 +200,6 @@ AssetInfo? _assetInfoForPath(String path) {
     filename: p.basename(path),
     filePath: path,
   );
-}
-
-/// Reads pixel dimensions from an image's header.
-///
-/// Only the header is parsed -- `startDecode` stops before any pixel decode --
-/// but the decoder API takes bytes, so the file is read in full first. That
-/// read is why the batch runs on a [compute] isolate; on the main thread a
-/// pick of large images would visibly jank the UI.
-///
-/// Returns null for videos and for anything the decoder cannot read.
-({int width, int height})? _dimensionsOf(File file, String mime) {
-  if (!mime.startsWith('image/')) return null;
-  try {
-    final bytes = file.readAsBytesSync();
-    // Extension first, then content sniffing for files whose name lies.
-    final decoder =
-        img.findDecoderForNamedImage(file.path) ??
-        img.findDecoderForData(bytes);
-    final info = decoder?.startDecode(bytes);
-    if (info == null) return null;
-    return (width: info.width, height: info.height);
-  } on Object {
-    // Unsupported or truncated container: dimensions are optional here.
-    return null;
-  }
 }
 
 String _mimeFromExtension(String ext) => switch (ext) {

--- a/test/features/media/data/services/image_dimensions_reader_test.dart
+++ b/test/features/media/data/services/image_dimensions_reader_test.dart
@@ -1,0 +1,355 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:submersion/features/media/data/services/image_dimensions_reader.dart';
+
+import '../../../../helpers/media_container_fixtures.dart';
+
+/// A SOFn segment: [length:2][precision:1][height:2][width:2][components:1]
+/// followed by 3 bytes per component.
+List<int> sofSegment(int marker, int width, int height, {int components = 3}) =>
+    [
+      0xff,
+      marker,
+      ...u16(8 + 3 * components),
+      8, // sample precision
+      ...u16(height),
+      ...u16(width),
+      components,
+      for (var i = 0; i < components; i++) ...[i + 1, 0x11, 0],
+    ];
+
+/// A hand-assembled JPEG: SOI, [before] segments, the frame header, then
+/// [scan] standing in for the entropy-coded data.
+List<int> jpegBytes({
+  required int width,
+  required int height,
+  int sofMarker = 0xc0,
+  List<int> before = const [],
+  List<int> scan = const [],
+}) => [
+  0xff, 0xd8, // SOI
+  ...before,
+  ...sofSegment(sofMarker, width, height),
+  if (scan.isNotEmpty) ...[
+    0xff, 0xda, ...u16(8), 1, 1, 0, 0, 63, 0, // SOS header, 1 component
+    ...scan,
+  ],
+];
+
+/// An APPn segment of [payloadBytes] filler, to push the frame header past a
+/// realistic EXIF/ICC block.
+List<int> appSegment(int marker, int payloadBytes) => [
+  0xff,
+  marker,
+  ...u16(2 + payloadBytes),
+  for (var i = 0; i < payloadBytes; i++) 0x5a,
+];
+
+/// `ispe` carries the stored pixel size of one item.
+List<int> ispe(int width, int height) =>
+    fullBox('ispe', [...u32(width), ...u32(height)]);
+
+/// One `ipma` entry: item [itemId] associated with the 1-based [indices] into
+/// `ipco`'s child list.
+List<int> ipmaEntry(int itemId, List<int> indices) => [
+  ...u16(itemId),
+  indices.length, // association_count
+  ...indices, // essential bit clear + 7-bit property index
+];
+
+/// Minimal HEIC carrying [properties] in `meta > iprp > ipco`, associated to
+/// items by [associations], with [primaryItem] named by `pitm`.
+List<int> heicWithProperties({
+  required List<int> properties,
+  required List<List<int>> associations,
+  required int primaryItem,
+  bool includePitm = true,
+}) {
+  final ipco = box('ipco', properties);
+  final ipma = fullBox('ipma', [
+    ...u32(associations.length),
+    for (final entry in associations) ...entry,
+  ]);
+  final iprp = box('iprp', [...ipco, ...ipma]);
+  final pitm = fullBox('pitm', u16(primaryItem));
+  return [
+    ...box('ftyp', 'heic'.codeUnits),
+    ...box('meta', [0, 0, 0, 0, if (includePitm) ...pitm, ...iprp]),
+  ];
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('image_dimensions_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  File write(String name, List<int> bytes) =>
+      File('${tempDir.path}/$name')..writeAsBytesSync(bytes);
+
+  group('JPEG', () {
+    test('reads width and height from the frame header', () {
+      final f = write('a.jpg', jpegBytes(width: 4032, height: 3024));
+
+      expect(readImageDimensions(f, 'image/jpeg'), (width: 4032, height: 3024));
+    });
+
+    test('agrees with the decoder on a real encoded JPEG', () {
+      final encoded = img.encodeJpg(img.Image(width: 7, height: 3));
+      final f = write('real.jpg', encoded);
+
+      // The value this reader replaces came from JpegDecoder.startDecode;
+      // it must not move for any file that decoder could already read.
+      final decoded = img.JpegDecoder().startDecode(encoded)!;
+      expect(readImageDimensions(f, 'image/jpeg'), (
+        width: decoded.width,
+        height: decoded.height,
+      ));
+    });
+
+    test('answers without reading the entropy-coded scan data', () {
+      // The whole point: dimensions come from the SOF, so a file whose scan
+      // is truncated (no EOI, no following marker) still answers. The old
+      // decoder returned null here because it required an SOS *and* then
+      // byte-scanned to the next marker.
+      final f = write(
+        'truncated.jpg',
+        jpegBytes(width: 640, height: 480, scan: List.filled(200000, 0x7f)),
+      );
+
+      expect(readImageDimensions(f, 'image/jpeg'), (width: 640, height: 480));
+    });
+
+    test('skips APPn segments ahead of the frame header', () {
+      final f = write(
+        'exif.jpg',
+        jpegBytes(
+          width: 100,
+          height: 50,
+          before: [
+            ...appSegment(0xe0, 14), // JFIF
+            ...appSegment(0xe1, 60000), // a full-size EXIF block
+            ...appSegment(0xe2, 5000), // ICC profile
+          ],
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/jpeg'), (width: 100, height: 50));
+    });
+
+    test('reads a progressive frame header (SOF2)', () {
+      final f = write(
+        'prog.jpg',
+        jpegBytes(width: 300, height: 200, sofMarker: 0xc2),
+      );
+
+      expect(readImageDimensions(f, 'image/jpeg'), (width: 300, height: 200));
+    });
+
+    test('reads a lossless frame header the decoder rejects (SOF3)', () {
+      final f = write(
+        'lossless.jpg',
+        jpegBytes(width: 16, height: 9, sofMarker: 0xc3),
+      );
+
+      expect(readImageDimensions(f, 'image/jpeg'), (width: 16, height: 9));
+    });
+
+    test('does not mistake a Huffman table (DHT) for a frame header', () {
+      // DHT is 0xC4, inside the SOFn marker range. Reading its payload as a
+      // frame would report garbage dimensions rather than none.
+      final f = write('dht.jpg', [
+        0xff,
+        0xd8,
+        0xff,
+        0xc4,
+        ...u16(10),
+        ...List.filled(8, 0x11),
+      ]);
+
+      expect(readImageDimensions(f, 'image/jpeg'), isNull);
+    });
+
+    test('returns null when the file ends before any frame header', () {
+      final f = write('nosof.jpg', [0xff, 0xd8, ...appSegment(0xe0, 14)]);
+
+      expect(readImageDimensions(f, 'image/jpeg'), isNull);
+    });
+
+    test('returns null on a segment length that runs past the end', () {
+      final f = write('bad.jpg', [
+        0xff,
+        0xd8,
+        0xff,
+        0xe1,
+        ...u16(40000),
+        0x00,
+        0x00,
+      ]);
+
+      expect(readImageDimensions(f, 'image/jpeg'), isNull);
+    });
+
+    test('returns null on a zero-sized frame', () {
+      final f = write('zero.jpg', jpegBytes(width: 0, height: 0));
+
+      expect(readImageDimensions(f, 'image/jpeg'), isNull);
+    });
+  });
+
+  group('HEIC', () {
+    test('reads the primary item stored size from ispe', () {
+      final f = write(
+        'a.heic',
+        heicWithProperties(
+          properties: ispe(4032, 3024),
+          associations: [
+            ipmaEntry(1, [1]),
+          ],
+          primaryItem: 1,
+        ),
+      );
+
+      // Today this returns null: the file is read in full and package:image
+      // has no HEIC decoder at all.
+      expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
+    });
+
+    test('picks the primary item ispe, not the first one in ipco', () {
+      // A thumbnail item's ispe commonly sits ahead of the primary in ipco.
+      final f = write(
+        'thumb-first.heic',
+        heicWithProperties(
+          properties: [...ispe(320, 240), ...ispe(4032, 3024)],
+          associations: [
+            ipmaEntry(1, [1]),
+            ipmaEntry(2, [2]),
+          ],
+          primaryItem: 2,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
+    });
+
+    test('finds the ispe when it is not the first associated property', () {
+      // Real items associate hvcC, colr, pixi and irot alongside ispe, in no
+      // guaranteed order. Taking only the first association would resolve to
+      // hvcC and quietly fall back to the thumbnail's ispe.
+      final f = write(
+        'assoc-order.heic',
+        heicWithProperties(
+          properties: [
+            ...ispe(320, 240), // the thumbnail's, first in ipco
+            ...box('hvcC', List.filled(8, 0)),
+            ...ispe(4032, 3024), // the primary's
+          ],
+          associations: [
+            ipmaEntry(1, [1]),
+            ipmaEntry(2, [2, 3]),
+          ],
+          primaryItem: 2,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
+    });
+
+    test('falls back to the first ispe when pitm is absent', () {
+      final f = write(
+        'nopitm.heic',
+        heicWithProperties(
+          properties: ispe(1600, 1200),
+          associations: [
+            ipmaEntry(1, [1]),
+          ],
+          primaryItem: 1,
+          includePitm: false,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heic'), (width: 1600, height: 1200));
+    });
+
+    test('returns null when the file carries no ispe', () {
+      final f = write('noispe.heic', [
+        ...box('ftyp', 'heic'.codeUnits),
+        ...box('meta', [0, 0, 0, 0]),
+      ]);
+
+      expect(readImageDimensions(f, 'image/heic'), isNull);
+    });
+
+    test('reads a HEIF the same way', () {
+      final f = write(
+        'a.heif',
+        heicWithProperties(
+          properties: ispe(800, 600),
+          associations: [
+            ipmaEntry(1, [1]),
+          ],
+          primaryItem: 1,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heif'), (width: 800, height: 600));
+    });
+  });
+
+  group('other containers', () {
+    test('reads PNG through the decoder', () {
+      final f = write('a.png', img.encodePng(img.Image(width: 12, height: 5)));
+
+      expect(readImageDimensions(f, 'image/png'), (width: 12, height: 5));
+    });
+
+    test('reads GIF through the decoder', () {
+      final f = write('a.gif', img.encodeGif(img.Image(width: 9, height: 6)));
+
+      expect(readImageDimensions(f, 'image/gif'), (width: 9, height: 6));
+    });
+
+    test('sniffs content, so a JPEG named .png still answers', () {
+      // The "file whose name lies" case the old findDecoderForData fallback
+      // covered. Dispatch is on magic bytes, never on the declared mime.
+      final f = write('liar.png', jpegBytes(width: 64, height: 48));
+
+      expect(readImageDimensions(f, 'image/png'), (width: 64, height: 48));
+    });
+  });
+
+  group('non-images', () {
+    test('returns null for a video mime without opening the file', () {
+      final f = write('clip.mp4', List.filled(64, 0));
+
+      expect(readImageDimensions(f, 'video/mp4'), isNull);
+    });
+
+    test('returns null for a container nothing recognises', () {
+      final f = write('junk.png', List.filled(4096, 0x42));
+
+      expect(readImageDimensions(f, 'image/png'), isNull);
+    });
+
+    test('returns null for an empty file', () {
+      final f = write('empty.jpg', const []);
+
+      expect(readImageDimensions(f, 'image/jpeg'), isNull);
+    });
+
+    test('returns null for a file that does not exist', () {
+      expect(
+        readImageDimensions(File('${tempDir.path}/gone.jpg'), 'image/jpeg'),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/media/data/services/image_dimensions_reader_test.dart
+++ b/test/features/media/data/services/image_dimensions_reader_test.dart
@@ -263,6 +263,53 @@ void main() {
       expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
     });
 
+    test('counts an extended-size (64-bit) property when indexing ipco', () {
+      // ipma indices are positional over ipco's full child list, so a child
+      // using the size==1 form has to be walked correctly or every later
+      // index is off by one and resolves to the wrong property.
+      final f = write(
+        'largesize.heic',
+        heicWithProperties(
+          properties: [
+            ...ispe(320, 240), // the thumbnail's, first in ipco
+            ...box('hvcC', List.filled(8, 0), largeSize: true),
+            ...ispe(4032, 3024), // the primary's, index 3
+          ],
+          associations: [
+            ipmaEntry(1, [1]),
+            ipmaEntry(2, [3]),
+          ],
+          primaryItem: 2,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
+    });
+
+    test('counts a to-end-of-range (size 0) property when indexing ipco', () {
+      // The size==0 form means "runs to the end of the enclosing box"; it can
+      // only be the last child, and it must still occupy one index.
+      final f = write(
+        'sizezero.heic',
+        heicWithProperties(
+          properties: [
+            ...ispe(320, 240),
+            // ispe with a size field of 0 rather than its real length.
+            ...u32(0), ...'ispe'.codeUnits,
+            0, 0, 0, 0, // version + flags
+            ...u32(4032), ...u32(3024),
+          ],
+          associations: [
+            ipmaEntry(1, [1]),
+            ipmaEntry(2, [2]),
+          ],
+          primaryItem: 2,
+        ),
+      );
+
+      expect(readImageDimensions(f, 'image/heic'), (width: 4032, height: 3024));
+    });
+
     test('falls back to the first ispe when pitm is absent', () {
       final f = write(
         'nopitm.heic',


### PR DESCRIPTION
Closes #1371.

## The problem

`_dimensionsOf` read a picked image's width and height through `JpegDecoder.startDecode`. That call returns a result only once it has seen **both** an SOF and an SOS:

```dart
return (hasSOF && hasSOS) ? info : null;
```

The width and height are already known at the SOF. Everything after that is spent reaching the SOS and then walking off the end of it: `_nextMarker()` byte-scans the entire entropy-coded scan in Dart looking for the next marker. On a folder import that ran once per picked file.

## The fix

A new header-only reader, `readImageDimensions(File, String mime)`, in `lib/features/media/data/services/image_dimensions_reader.dart`. It reads like a sibling of `local_exif_loader.dart` and reuses the `isobmff_boxes.dart` walkers.

- **JPEG** walks the segment chain and stops at the first frame header. Handles `0xFF` fill bytes and standalone markers (TEM, RSTn), and excludes DHT (`0xC4`), JPG (`0xC8`) and DAC (`0xCC`) from the `0xC0..0xCF` range. All of SOF0..SOF15 answer, so lossless and arithmetic JPEGs now report dimensions that `package:image` could not read at all.
- **HEIC / HEIF / AVIF** read `meta > iprp > ipco > ispe`, resolved through `pitm` and `ipma` so the *primary* item wins. This matters: a thumbnail's `ispe` is commonly first in `ipco`, and an item is associated with several properties (`hvcC`, `colr`, `pixi`, `irot`) in no guaranteed order, so every association is tried and the one landing on an `ispe` wins. These files previously read in full and then found no decoder, leaving every picked HEIC at 0x0.
- **PNG, GIF, WebP, BMP, TIFF** keep the `package:image` fallback, whose header parse really does stop at the header.

Dispatch is on the file's own magic bytes rather than the declared mime, which covers the "file whose name lies" case the old `findDecoderForNamedImage ?? findDecoderForData` pair existed for, and does it more directly.

## Performance

Size sweep, JIT mode (so absolute numbers run high; the shape is the point):

| file | old `read + startDecode` | new |
| --- | --- | --- |
| 0.44 MB | 1.29 ms | 0.031 ms |
| 1.74 MB | 14.18 ms | 0.034 ms |
| 6.73 MB | 56.70 ms | 0.032 ms |
| 13.23 MB | 110.38 ms | 0.035 ms |

The old path costs ~8.2 ms/MB, matching the issue's measured "roughly 7 ms per MB". The new path is **flat**, so a folder import no longer scales with photo size.

## Orientation

Deliberately not applied. `image-4.9.1` sets `info.width = frame.samplesPerLine` straight off the SOF and never consults EXIF `Orientation`, so the SOF read is byte-for-byte identical to what it replaces. HEIC `irot` is ignored for the same consistency. This matters because `AssetResolutionService.matchByTimestampAndDimensions` compares for exact equality against dimensions recorded the same way.

## Testing

24 new tests in `image_dimensions_reader_test.dart`, covering the frame-header read, a truncated scan (the structural proof that the SOS is never reached), large APPn segments ahead of the SOF, SOF2/SOF3, DHT not being mistaken for a frame header, corrupt segment lengths, the HEIC primary-item and association-order cases, the content-sniffing fallback, and the null paths.

One test pins the contract directly: `agrees with the decoder on a real encoded JPEG` asserts the new value equals `JpegDecoder().startDecode(...)` on the same bytes.

Beyond the fixtures, the reader was validated against **real Apple-encoded HEIC and JPEG files** produced by `sips`, cross-checked against `sips -g pixelWidth -g pixelHeight` as an independent oracle: 5/5 exact, including non-square HEICs with genuine `pitm`/`ipma`/`ipco` structures. Hand-built fixtures can only test the parser against one reading of the spec, so an independent oracle was needed to trust the ISO-BMFF path.

Full suite: 22044 pass. The 3 failures are pre-existing environment artifacts, each confirmed by rerunning the file alone (44/44 and 7/7 pass): `local_file_resolver_test.dart` fails when `$TMPDIR` sits on a mounted volume, and two cases in `equipment_set_providers_mutations_test.dart` are a full-suite-only flake unrelated to media.

## Note on scope

The issue lists "the macOS folder picker" as affected. It is not: `photoPickerServiceProvider` gates `PhotoPickerServiceDesktop` to `Platform.isWindows || Platform.isLinux`. Separately, `assetInfoForFile` has no production caller at all (test-only seam); the live path is `getAssetsInDateRange` -> `_extractAssets` -> `_assetInfoForPath`, which this PR fixes. Both left alone as out of scope.
