### PR TITLE
fix(dive_log): stop the table presets provider seeding itself in a loop

### DIFF
--- a/lib/features/dive_log/data/repositories/view_config_repository.dart
+++ b/lib/features/dive_log/data/repositories/view_config_repository.dart
@@ -196,13 +196,42 @@ class ViewConfigRepository {
     }
   }
 
-  /// Upserts built-in table presets for [diverId]. Idempotent: safe to call
-  /// on every load. Uses insertOnConflictUpdate so presets are refreshed if
-  /// the built-in definitions change, but createdAt is preserved by using a
-  /// fixed stable timestamp per preset ID.
+  /// Seeds the built-in table presets for [diverId], refreshing them if the
+  /// built-in definitions have changed.
+  ///
+  /// Idempotent in the strict sense: a row that already matches its built-in
+  /// definition is left alone, so a repeat call issues no write at all. That
+  /// matters because drift raises a `field_presets` update for every write
+  /// statement it executes, changed rows or not, and the presets provider
+  /// listens to that stream while seeding from inside its own build. An
+  /// unconditional upsert therefore made the provider invalidate itself on its
+  /// own write and rebuild without end (issue #1355).
+  ///
+  /// [createdAt] carries over from the stored row so a refresh preserves the
+  /// original creation time, which is also the preset list's sort key.
   Future<void> ensureBuiltInPresets(String diverId) async {
+    final builtIns = domain.FieldPreset.builtInTablePresets();
+    if (builtIns.isEmpty) return;
+
+    final ids = builtIns.map((p) => p.id).toList();
+    final rows = await (_db.select(
+      _db.fieldPresets,
+    )..where((r) => r.id.isIn(ids))).get();
+    final existing = {for (final row in rows) row.id: row};
+
     final now = DateTime.now().millisecondsSinceEpoch;
-    for (final preset in domain.FieldPreset.builtInTablePresets()) {
+    for (final preset in builtIns) {
+      final row = existing[preset.id];
+      final configJson = jsonEncode(preset.configJson);
+      final unchanged =
+          row != null &&
+          row.diverId == diverId &&
+          row.viewMode == preset.viewMode.name &&
+          row.name == preset.name &&
+          row.configJson == configJson &&
+          row.isBuiltIn;
+      if (unchanged) continue;
+
       await _db
           .into(_db.fieldPresets)
           .insertOnConflictUpdate(
@@ -211,9 +240,9 @@ class ViewConfigRepository {
               diverId: diverId,
               viewMode: preset.viewMode.name,
               name: preset.name,
-              configJson: jsonEncode(preset.configJson),
+              configJson: configJson,
               isBuiltIn: const Value(true),
-              createdAt: now,
+              createdAt: row?.createdAt ?? now,
             ),
           );
     }

--- a/lib/features/dive_log/presentation/providers/view_config_providers.dart
+++ b/lib/features/dive_log/presentation/providers/view_config_providers.dart
@@ -337,6 +337,24 @@ final detailedCardConfigProvider =
 // Table presets provider
 // ---------------------------------------------------------------------------
 
+// no-tick: this provider caches no row that could go stale -- it holds a write,
+// and re-running it re-runs that write. A tick here would restore exactly the
+// loop it exists to break. The rows it seeds are read by tablePresetsProvider
+// below, which does subscribe, so a preset arriving by sync still shows up.
+/// Seeds the built-in table presets for a diver, once per container.
+///
+/// Deliberately separate from [tablePresetsProvider]: that provider ticks on
+/// every `field_presets` write, and a seeding write inside its own build would
+/// invalidate the build that issued it. Holding the seed in its own provider
+/// means a self-invalidation replays the read and not the write, so the pair
+/// settles after one pass however many times the tick fires (issue #1355).
+final _builtInTablePresetsSeedProvider = FutureProvider.family<void, String>((
+  ref,
+  diverId,
+) async {
+  await ref.watch(viewConfigRepositoryProvider).ensureBuiltInPresets(diverId);
+});
+
 /// Loads all field presets for a diver (built-in + user-saved).
 final tablePresetsProvider =
     FutureProvider.family<List<domain.FieldPreset>, String>((
@@ -345,6 +363,6 @@ final tablePresetsProvider =
     ) async {
       final repo = ref.watch(viewConfigRepositoryProvider);
       ref.invalidateSelfWhen(repo.watchPresetsChanges());
-      await repo.ensureBuiltInPresets(diverId);
+      await ref.watch(_builtInTablePresetsSeedProvider(diverId).future);
       return repo.getPresetsForMode(diverId, ListViewMode.table);
     });

--- a/test/features/dive_log/presentation/providers/table_presets_provider_loop_test.dart
+++ b/test/features/dive_log/presentation/providers/table_presets_provider_loop_test.dart
@@ -1,0 +1,146 @@
+/// Regression coverage for issue #1355: opening the Dive List Fields page
+/// pinned a CPU core and froze the app.
+///
+/// `tablePresetsProvider` subscribes to `watchPresetsChanges()` and then, in
+/// the same build, calls `ensureBuiltInPresets()`. The seeding write landed on
+/// `field_presets`, the tick fired, the provider invalidated itself, and the
+/// rebuild seeded again -- an unbounded write/invalidate loop for as long as
+/// anything listened to the provider.
+library;
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart' hide FieldPreset;
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/features/dive_log/data/repositories/view_config_repository.dart';
+import 'package:submersion/features/dive_log/presentation/providers/view_config_providers.dart';
+
+/// Counts how many times the provider reaches the seeding write.
+class _CountingViewConfigRepository extends ViewConfigRepository {
+  _CountingViewConfigRepository(super.db);
+
+  int ensureCalls = 0;
+
+  @override
+  Future<void> ensureBuiltInPresets(String diverId) {
+    ensureCalls++;
+    return super.ensureBuiltInPresets(diverId);
+  }
+}
+
+void main() {
+  late AppDatabase db;
+  late _CountingViewConfigRepository repository;
+  const diverId = 'diver-1355';
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = _CountingViewConfigRepository(db);
+    DatabaseService.instance.setTestDatabase(db);
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: const Value(diverId),
+            name: const Value('Test Diver'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    DatabaseService.instance.resetForTesting();
+    await db.close();
+  });
+
+  test('tablePresetsProvider settles instead of re-seeding forever', () async {
+    final container = ProviderContainer(
+      overrides: [viewConfigRepositoryProvider.overrideWithValue(repository)],
+    );
+    addTearDown(container.dispose);
+
+    // A listener keeps the provider active, exactly like the open page.
+    container.listen(
+      tablePresetsProvider(diverId),
+      (_, _) {},
+      fireImmediately: true,
+    );
+
+    await container.read(tablePresetsProvider(diverId).future);
+    // Let every queued invalidation drain.
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    // One seeding pass, plus at most one rebuild from the seeding write
+    // itself. Anything beyond that is the runaway loop.
+    expect(repository.ensureCalls, lessThanOrEqualTo(2));
+  });
+
+  test('two live divers settle instead of trading writes', () async {
+    // The provider family is not autoDispose, so switching divers leaves both
+    // instances alive. The built-in preset row carries one global id, so each
+    // diver's seed rewrites the other's -- a real change, which a per-build
+    // seed would bounce back and forth forever.
+    const otherDiverId = 'diver-1355-b';
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await db
+        .into(db.divers)
+        .insert(
+          DiversCompanion(
+            id: const Value(otherDiverId),
+            name: const Value('Second Diver'),
+            createdAt: Value(now),
+            updatedAt: Value(now),
+          ),
+        );
+
+    final container = ProviderContainer(
+      overrides: [viewConfigRepositoryProvider.overrideWithValue(repository)],
+    );
+    addTearDown(container.dispose);
+
+    for (final id in [diverId, otherDiverId]) {
+      container.listen(
+        tablePresetsProvider(id),
+        (_, _) {},
+        fireImmediately: true,
+      );
+    }
+
+    await container.read(tablePresetsProvider(diverId).future);
+    await container.read(tablePresetsProvider(otherDiverId).future);
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    // One seeding pass per diver; neither reacts to the other's write by
+    // seeding again.
+    expect(repository.ensureCalls, lessThanOrEqualTo(2));
+  });
+
+  test('ensureBuiltInPresets does not rewrite unchanged built-ins', () async {
+    await repository.ensureBuiltInPresets(diverId);
+    final seeded = await db.select(db.fieldPresets).get();
+    expect(seeded, isNotEmpty);
+
+    var ticks = 0;
+    final sub = repository.watchPresetsChanges().listen((_) => ticks++);
+    addTearDown(sub.cancel);
+    // Drop the tick drift emits on subscribe.
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    ticks = 0;
+
+    await repository.ensureBuiltInPresets(diverId);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(ticks, isZero, reason: 'a no-op reseed must not fire a table tick');
+    final after = await db.select(db.fieldPresets).get();
+    expect(
+      after.map((r) => r.createdAt).toList(),
+      equals(seeded.map((r) => r.createdAt).toList()),
+      reason: 'createdAt must survive a reseed',
+    );
+  });
+}

--- a/test/features/dive_log/presentation/providers/table_presets_provider_loop_test.dart
+++ b/test/features/dive_log/presentation/providers/table_presets_provider_loop_test.dart
@@ -6,6 +6,10 @@
 /// `field_presets`, the tick fired, the provider invalidated itself, and the
 /// rebuild seeded again -- an unbounded write/invalidate loop for as long as
 /// anything listened to the provider.
+///
+/// Every settle here is `pumpEventQueue()` rather than a wall-clock delay: the
+/// loop is driven by queued events, so draining the queue is both the exact
+/// thing that lets it run and a bound the runaway case cannot outlast.
 library;
 
 import 'package:drift/drift.dart' hide isNull, isNotNull;
@@ -35,22 +39,25 @@ void main() {
   late _CountingViewConfigRepository repository;
   const diverId = 'diver-1355';
 
-  setUp(() async {
-    db = AppDatabase(NativeDatabase.memory());
-    repository = _CountingViewConfigRepository(db);
-    DatabaseService.instance.setTestDatabase(db);
-
+  Future<void> insertDiver(String id, String name) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await db
         .into(db.divers)
         .insert(
           DiversCompanion(
-            id: const Value(diverId),
-            name: const Value('Test Diver'),
+            id: Value(id),
+            name: Value(name),
             createdAt: Value(now),
             updatedAt: Value(now),
           ),
         );
+  }
+
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    repository = _CountingViewConfigRepository(db);
+    DatabaseService.instance.setTestDatabase(db);
+    await insertDiver(diverId, 'Test Diver');
   });
 
   tearDown(() async {
@@ -71,13 +78,23 @@ void main() {
       fireImmediately: true,
     );
 
-    await container.read(tablePresetsProvider(diverId).future);
-    // Let every queued invalidation drain.
-    await Future<void>.delayed(const Duration(milliseconds: 300));
+    // Drain every queued rebuild. Asserting the count BEFORE awaiting the
+    // provider's future is deliberate: under the loop that future never
+    // completes, and a count is a far clearer failure than a timeout.
+    await pumpEventQueue();
 
-    // One seeding pass, plus at most one rebuild from the seeding write
-    // itself. Anything beyond that is the runaway loop.
-    expect(repository.ensureCalls, lessThanOrEqualTo(2));
+    expect(
+      repository.ensureCalls,
+      lessThanOrEqualTo(2),
+      reason:
+          'one seeding pass, plus at most one rebuild from the seeding write '
+          'itself. Anything beyond that is the runaway loop.',
+    );
+
+    // Settling must not have cost the presets themselves.
+    expect(await container.read(tablePresetsProvider(diverId).future), [
+      isA<FieldPreset>().having((p) => p.isBuiltIn, 'isBuiltIn', isTrue),
+    ]);
   });
 
   test('two live divers settle instead of trading writes', () async {
@@ -86,17 +103,7 @@ void main() {
     // diver's seed rewrites the other's -- a real change, which a per-build
     // seed would bounce back and forth forever.
     const otherDiverId = 'diver-1355-b';
-    final now = DateTime.now().millisecondsSinceEpoch;
-    await db
-        .into(db.divers)
-        .insert(
-          DiversCompanion(
-            id: const Value(otherDiverId),
-            name: const Value('Second Diver'),
-            createdAt: Value(now),
-            updatedAt: Value(now),
-          ),
-        );
+    await insertDiver(otherDiverId, 'Second Diver');
 
     final container = ProviderContainer(
       overrides: [viewConfigRepositoryProvider.overrideWithValue(repository)],
@@ -111,13 +118,15 @@ void main() {
       );
     }
 
-    await container.read(tablePresetsProvider(diverId).future);
-    await container.read(tablePresetsProvider(otherDiverId).future);
-    await Future<void>.delayed(const Duration(milliseconds: 300));
+    await pumpEventQueue();
 
-    // One seeding pass per diver; neither reacts to the other's write by
-    // seeding again.
-    expect(repository.ensureCalls, lessThanOrEqualTo(2));
+    expect(
+      repository.ensureCalls,
+      lessThanOrEqualTo(2),
+      reason:
+          'one seeding pass per diver; neither may react to the other write '
+          'by seeding again',
+    );
   });
 
   test('ensureBuiltInPresets does not rewrite unchanged built-ins', () async {
@@ -128,17 +137,21 @@ void main() {
     var ticks = 0;
     final sub = repository.watchPresetsChanges().listen((_) => ticks++);
     addTearDown(sub.cancel);
-    // Drop the tick drift emits on subscribe.
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    ticks = 0;
+    await pumpEventQueue();
+    // Whatever the subscription itself delivered is the baseline; only the
+    // delta across the reseed is under test.
+    final before = ticks;
 
     await repository.ensureBuiltInPresets(diverId);
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    await pumpEventQueue();
 
-    expect(ticks, isZero, reason: 'a no-op reseed must not fire a table tick');
-    final after = await db.select(db.fieldPresets).get();
     expect(
-      after.map((r) => r.createdAt).toList(),
+      ticks,
+      equals(before),
+      reason: 'a no-op reseed must not fire a table tick',
+    );
+    expect(
+      (await db.select(db.fieldPresets).get()).map((r) => r.createdAt).toList(),
       equals(seeded.map((r) => r.createdAt).toList()),
       reason: 'createdAt must survive a reseed',
     );


### PR DESCRIPTION
Fixes #1355.

## Symptom

Opening **Appearance > Dives > Dive List Fields** pinned a CPU core and made the app unresponsive. The reporter noted it "seems to be in some kind of loop", which is exactly right: the page was not doing slow work, it was spinning.

## Root cause

`tablePresetsProvider` did two incompatible things in a single build:

```dart
final repo = ref.watch(viewConfigRepositoryProvider);
ref.invalidateSelfWhen(repo.watchPresetsChanges());  // subscribe to field_presets
await repo.ensureBuiltInPresets(diverId);            // WRITE to field_presets
```

Drift's `InsertStatement.insert` calls `notifyUpdates` after every write statement it executes, changed rows or not, so the seeding write always fired the tick the build had just subscribed to. `invalidateSelf()` reran the build, which seeded again, and nothing bounded it.

`_TableColumnConfigSection` is the only consumer, and it is what `ColumnConfigPage` renders for dives in table mode, which is the default mode when the page opens. So the loop started the moment Dive List Fields opened, matching the reported steps exactly.

The self-invalidation came in with 969e60c835a (the #974 tick sweep) and has shipped since v1.7.3, consistent with the reported 1.7.7.

`ensureBuiltInPresets` compounded it by passing `createdAt: DateTime.now()` on every call, making each pass a genuine row change too. That churned the preset list's sort key (`getPresetsForMode` orders by `createdAt`) on every load, which the method's own docstring already claimed did not happen.

## Fix

Two changes, closing two different ways the cycle can form.

**`ensureBuiltInPresets` only writes when something actually changed.** It reads the stored rows first and skips a row that already matches its built-in definition, carrying `createdAt` over from the stored row rather than restamping it. Steady state now issues no write statement at all, so the tick never fires.

**Seeding moved into its own cached provider.** A self-invalidation then replays the read and not the write. This covers the case where the write genuinely *is* a change: the built-in preset row carries one global id (`builtin_standard`) with a per-diver `diverId` column, and the provider family is not `autoDispose`, so switching divers leaves two live instances that would otherwise rewrite each other's row indefinitely. The seed provider carries a documented `// no-tick:` marker for `provider_change_tick_test`, since re-running it re-runs a write rather than refreshing a cached row.

## Testing

New regression coverage in `table_presets_provider_loop_test.dart`:

- `tablePresetsProvider` settles for one diver
- it settles with two live divers
- a no-op reseed fires no table tick and preserves `createdAt`

Against the unfixed code the first test does not fail an expectation, it **times out after 30 seconds**: `await container.read(tablePresetsProvider(id).future)` never resolves, because the provider never stops rebuilding. With the fix all three pass in under a second.

Full local suite green, plus `dart format` and `flutter analyze lib test` clean.

## Noted, not fixed here

The built-in preset row uses a single global id with a per-diver `diverId` column, so with more than one diver only the most recent seeder sees "Standard" in their preset dropdown. That is a pre-existing data-model problem rather than part of this freeze, so it is left alone here; the second half of this fix just makes sure it can no longer manifest as a loop.
