### PR TITLE
fix(dive): open the bulk tag Browse picker above its dialog (#1366)

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -2615,12 +2615,22 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
   /// Opens the previously-used-tag picker (#1171) over [selected], so tagging
   /// stays consistent without having to recall earlier spellings. Reports the
   /// merged list (existing plus newly picked) through [onPicked].
+  ///
+  /// [host] is the context the sheet is pushed from, so it decides which
+  /// navigator owns the picker. It defaults to the page, which is right when
+  /// Browse sits on the form itself. A caller whose Browse action lives inside
+  /// a dialog must pass that dialog's context instead: `showDialog` defaults
+  /// to the root navigator while `showModalBottomSheet` defaults to the
+  /// nearest one, which under the app's `ShellRoute` is the shell navigator
+  /// sitting *below* the dialog. Pushed from the page, the picker would open
+  /// behind the dialog with the dialog's barrier eating every tap (#1366).
   void _showTagPickerFor({
     required List<Tag> selected,
     required ValueChanged<List<Tag>> onPicked,
+    BuildContext? host,
   }) {
     showModalBottomSheet<void>(
-      context: context,
+      context: host ?? context,
       isScrollControlled: true,
       builder: (sheetContext) => DraggableScrollableSheet(
         initialChildSize: 0.7,
@@ -3557,7 +3567,10 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
           ),
           actions: [
             TextButton(
+              // `ctx` is inside the dialog route, so the picker lands on the
+              // same (root) navigator and opens above the dialog (#1366).
               onPressed: () => _showTagPickerFor(
+                host: ctx,
                 selected: picked,
                 onPicked: (tags) => setSt(() => picked = tags),
               ),

--- a/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
+++ b/test/features/dive_log/presentation/pages/bulk_membership_wiring_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/constants/enums.dart';
 import 'package:submersion/core/database/database.dart' hide Buddy, Dive;
-import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/buddies/data/repositories/buddy_repository.dart';
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/widgets/buddy_picker.dart';
@@ -19,9 +18,9 @@ import 'package:submersion/features/equipment/data/repositories/equipment_reposi
 import 'package:submersion/features/equipment/domain/entities/equipment_item.dart';
 import 'package:submersion/features/tags/presentation/widgets/tag_picker_sheet.dart';
 import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
-import 'package:submersion/l10n/arb/app_localizations.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
 import '../../../../helpers/test_database.dart';
 
 /// Covers the bulk tri-state membership wiring in DiveEditPage: loading members
@@ -89,10 +88,20 @@ void main() {
       Dive(id: id, dateTime: DateTime(2026, 1, 1), notes: ''),
     );
 
+    /// Hosted in the shell shape rather than straight under `MaterialApp.home`.
+    /// Every add-affordance below is a dialog, a sheet, or a sheet opened from
+    /// a dialog, and `showDialog` defaults to the root navigator while
+    /// `showModalBottomSheet` defaults to the nearest one. Under `home` those
+    /// are the same object, so a sheet pushed onto the wrong navigator still
+    /// lands on top and the test sees nothing wrong; under the app's real
+    /// `ShellRoute` it opens *behind* the dialog instead (#1366).
     Future<void> pump(WidgetTester tester, List<String> ids) async {
       final overrides = await getBaseOverrides();
       await tester.pumpWidget(
-        ProviderScope(
+        testAppInShell(
+          // Every assertion below matches an English label, so pin the
+          // locale instead of inheriting the ambient platform one.
+          locale: const Locale('en'),
           overrides: [
             ...overrides,
             diveRepositoryProvider.overrideWithValue(repository),
@@ -100,17 +109,8 @@ void main() {
               (ref) => DiveListNotifier(repository, ref),
             ),
             customTankPresetsProvider.overrideWith((ref) async => []),
-          ].cast(),
-          child: MaterialApp(
-            // Every assertion below matches an English label, so pin the
-            // locale instead of inheriting the ambient platform one.
-            locale: const Locale('en'),
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: DiveEditPage(bulkDiveIds: ids, embedded: true),
-            ),
-          ),
+          ],
+          child: DiveEditPage(bulkDiveIds: ids, embedded: true),
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
Fixes #1366.

## The bug

In bulk-edit mode, Tags > Add opens an `AlertDialog`, and its Browse action opened the previously-used-tag picker **behind** that dialog. Neither panel could be moved, and the dialog's full-screen `ModalBarrier` absorbed every tap aimed at the picker, so the sheet was visible but completely unreachable.

Two Flutter modal helpers have opposite navigator defaults:

| Helper | `useRootNavigator` default |
| --- | --- |
| `showDialog` | `true` (root navigator) |
| `showModalBottomSheet` | `false` (nearest navigator) |

The app wraps everything in a `ShellRoute` that declares no `navigatorKey`, so GoRouter builds its own navigator for the shell, and that navigator sits below the root one in the overlay stack. `_bulkAddTags` shows its dialog on the root navigator, but its Browse action called `_showTagPickerFor`, which pushed the sheet with `context`: the page `State`'s context, which resolves to the shell navigator. Hence the sheet under the dialog.

This is the push-side twin of the pop bug fixed in #1312, and unlike that one it is not master-detail-specific: the shell navigator exists on every layout, so it reproduces on desktop too.

## The fix

`_showTagPickerFor` gains an optional `host` context that decides which navigator owns the picker. It defaults to the page, which stays correct for the single-dive form where Browse sits on the form itself and the sheet should remain inside the shell chrome. `_bulkAddTags` passes the dialog builder's own `ctx`, so the picker lands on the same (root) navigator and opens above the dialog.

The sibling bulk dialogs were never affected and are unchanged. Buddies and Dive Types push their pickers from `BuddyPicker` / `DiveTypeMultiSelectField`, which are rendered as the dialog's `content`; `Navigator.of` walks the widget tree, and a dialog route's subtree already lives under the root navigator's overlay, so their "nearest navigator" is the root one. Only a `State` helper reached from a dialog action escapes back to the page's context.

## Tests

A test named "the bulk tag dialog can browse previously used tags" already existed, and it passed with the bug present. It pumped under `MaterialApp.home`, where the local and root navigator are the same object, so a sheet pushed onto the wrong navigator still lands on top. That is exactly the blind spot `test/helpers/test_app.dart` documents.

Rather than add a parallel test, this repoints that file's `pump` helper at `testAppInShell`, which nests a single-route navigator to reproduce the real shell shape. All 11 tests in the file now run against the correct navigator topology, which also guards the buddy, equipment, dive-type and equipment-set add affordances.

Verification:

- Without the production fix, exactly one test fails: the tag browse one. `tap()` reports "would not hit test on the specified widget", with `_RenderTheater` and `RenderAbsorbPointer` (the dialog's overlay) in the hit-test path instead of the tag row.
- With the fix, 9/9 in that file pass, and the other dialog and sheet tests in it pass unchanged under the shell shape.
- Full blast radius (every test referencing `DiveEditPage`, plus `test/features/tags`): 174 passed, 1 skipped.
- `flutter analyze`: no issues. `dart format .` clean.

Two imports (`core/providers/provider.dart`, `app_localizations.dart`) became unused once `testAppInShell` took over supplying `ProviderScope` and the l10n delegates, and were dropped.