### PR TITLE
fix(signatures): give signature media rows the required file path

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -5257,26 +5257,36 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
       instructorId = courseAsync.value!.instructorId;
     }
 
+    // Captured before the sheet closes: the save outlives it, and reporting
+    // a failure needs a messenger that is still in the tree.
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
+
     showSignatureCaptureSheet(
       context: context,
       initialSignerName: instructorName,
-      onSave: (strokes, signerName) async {
-        // Get the canvas dimensions from the capture widget
-        // Using a reasonable default for signature capture
-        const width = 400.0;
-        const height = 200.0;
-
-        await ref
+      onSave: (strokes, signerName, canvasSize) async {
+        // The strokes are in the capture canvas's own coordinates, so the
+        // PNG is rendered at that exact size. A hardcoded size cropped
+        // every signature drawn on a canvas wider than it (issue #1358).
+        final signature = await ref
             .read(signatureSaveNotifierProvider.notifier)
             .saveFromStrokes(
               diveId: dive.id,
               strokes: strokes,
-              width: width,
-              height: height,
+              width: canvasSize.width,
+              height: canvasSize.height,
               signerName: signerName,
               signerId: instructorId,
               backgroundColor: Colors.white,
             );
+        // A null result means the save threw. Nothing watches the notifier's
+        // AsyncValue, so without this the failure is entirely silent.
+        if (signature == null) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n.signatures_error_saveFailed)),
+          );
+        }
       },
     );
   }

--- a/lib/features/dive_log/presentation/widgets/photo_marker_layout.dart
+++ b/lib/features/dive_log/presentation/widgets/photo_marker_layout.dart
@@ -36,7 +36,7 @@ List<PhotoChartMarker> photoMarkersFromMedia(
     // Photos AND videos get markers — underwater libraries are often mostly
     // short clips, and enrichment gives both the same (time, depth) position.
     // Only signatures are categorically not dive-moment media.
-    if (item.mediaType == MediaType.instructorSignature) continue;
+    if (item.isSignature) continue;
     final enrichment = item.enrichment;
     if (enrichment == null) continue;
     if (enrichment.matchConfidence == MatchConfidence.noProfile) continue;

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -527,10 +527,17 @@ class MediaRepository {
   /// Whether any attachable media exists (signatures excluded). Cheap
   /// EXISTS probe for setup/status surfaces.
   Future<bool> hasAnyMedia() async {
+    // Excludes every signature spelling, not just the instructor one, so a
+    // logbook whose only media rows are buddy signatures still reports empty.
+    final placeholders = List.filled(
+      kSignatureFileTypes.length,
+      '?',
+    ).join(', ');
     final row = await _db
         .customSelect(
-          "SELECT EXISTS(SELECT 1 FROM media "
-          "WHERE file_type != 'instructor_signature') AS present",
+          'SELECT EXISTS(SELECT 1 FROM media '
+          'WHERE file_type NOT IN ($placeholders)) AS present',
+          variables: kSignatureFileTypes.map(Variable.withString).toList(),
         )
         .getSingle();
     return row.read<int>('present') == 1;

--- a/lib/features/media/data/repositories/media_row_mapper.dart
+++ b/lib/features/media/data/repositories/media_row_mapper.dart
@@ -98,14 +98,21 @@ domain.MediaEnrichment mediaEnrichmentFromRow(MediaEnrichmentData row) {
   );
 }
 
-/// Every file_type spelling that means "instructor signature".
+/// Every file_type spelling that means "this row is a signature".
 ///
 /// Signatures are excluded from every library surface, so the exclusion has
 /// to know about the legacy camelCase spelling [parseMediaType] still
 /// accepts -- filtering on the snake_case value alone lets old rows through.
+///
+/// 'buddy_signature' is here because buddy signatures are signatures too.
+/// It was absent while `SignatureStorageService.saveBuddySignature` could
+/// never actually write a row (issue #1358), which hid the gap: with the
+/// insert fixed, a buddy signature that is not listed here parses as
+/// `MediaType.photo` and shows up as a dive photo.
 const List<String> kSignatureFileTypes = [
   'instructor_signature',
   'instructorSignature',
+  'buddy_signature',
 ];
 
 /// Parses database file_type string to MediaType enum.

--- a/lib/features/media/data/services/dive_media_enricher.dart
+++ b/lib/features/media/data/services/dive_media_enricher.dart
@@ -61,7 +61,7 @@ class DiveMediaEnricher {
     for (final item in media) {
       // Signatures are attached to a dive but not moments within it, and the
       // chart excludes them regardless — don't fabricate a depth/time for one.
-      if (item.mediaType == MediaType.instructorSignature) continue;
+      if (item.isSignature) continue;
 
       // A pinned item (issue #1090) is positioned from the diver's offset,
       // never from its capture time, so a backfill converges on the pin

--- a/lib/features/media/domain/entities/media_item.dart
+++ b/lib/features/media/domain/entities/media_item.dart
@@ -177,6 +177,19 @@ class MediaItem extends Equatable {
   /// Returns true if this is a video
   bool get isVideo => mediaType == MediaType.video;
 
+  /// True for a signature of either kind: instructor or buddy.
+  ///
+  /// [MediaType] has no buddy member -- a `buddy_signature` row parses as
+  /// [MediaType.photo] -- so the source type carries the rest. Both halves
+  /// are needed: instructor rows written before the v72 backfill are typed
+  /// only by [mediaType], and buddy rows only by [sourceType].
+  ///
+  /// A signature attaches to a dive but is not a moment within it, so every
+  /// surface that shows dive media excludes them through this.
+  bool get isSignature =>
+      mediaType == MediaType.instructorSignature ||
+      sourceType == MediaSourceType.signature;
+
   /// True for attachment documents (PDFs and opaque files).
   bool get isDocument => mediaType == MediaType.document;
 

--- a/lib/features/signatures/data/services/signature_storage_service.dart
+++ b/lib/features/signatures/data/services/signature_storage_service.dart
@@ -385,9 +385,15 @@ class SignatureStorageService {
       canvas.drawPath(path, paint);
     }
 
-    // Convert to image
+    // Convert to image.
+    //
+    // Rounded up, not truncated: the size comes from layout constraints and
+    // is routinely fractional on a scaled display, and a stroke may sit at
+    // x = 607.8 on a 607.5-wide canvas. `toInt()` would drop that last
+    // column and crop the signature again, in miniature. Rounding up costs
+    // at most one transparent pixel.
     final picture = recorder.endRecording();
-    final image = await picture.toImage(width.toInt(), height.toInt());
+    final image = await picture.toImage(width.ceil(), height.ceil());
     final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
 
     return byteData!.buffer.asUint8List();

--- a/lib/features/signatures/data/services/signature_storage_service.dart
+++ b/lib/features/signatures/data/services/signature_storage_service.dart
@@ -21,6 +21,22 @@ class SignatureStorageService {
   static const String _signatureFileType = 'instructor_signature';
   static const String _buddySignatureFileType = 'buddy_signature';
 
+  /// `media.file_path` is NOT NULL, but a signature has no file behind it:
+  /// the strokes live in the row's `image_data` BLOB. The empty string is the
+  /// schema's existing "no file" sentinel -- the v72 `source_type` backfill
+  /// tests `file_path != ''` before classifying a row as a local file, and
+  /// `SignatureResolver` only falls back to the path when it is non-empty.
+  ///
+  /// Omitting it entirely is what broke signature capture (issue #1358):
+  /// Drift rejects the companion in `validateIntegrity` before any SQL runs,
+  /// so every save threw and no signature ever reached the database.
+  static const String _signatureFilePath = '';
+
+  /// Signature rows resolve through `SignatureResolver`, never through the
+  /// gallery or local-file resolvers, so they carry the matching source type
+  /// rather than the column's `platformGallery` default.
+  static const String _signatureSourceType = 'signature';
+
   /// Save a signature image and create media record
   ///
   /// [diveId] - The dive this signature belongs to
@@ -47,7 +63,10 @@ class SignatureStorageService {
               id: Value(id),
               diveId: Value(diveId),
               imageData: Value(imageBytes),
+              filePath: const Value(_signatureFilePath),
               fileType: const Value(_signatureFileType),
+              sourceType: const Value(_signatureSourceType),
+              signatureType: const Value('instructor'),
               takenAt: Value(now.millisecondsSinceEpoch),
               signerId: Value(signerId),
               signerName: Value(signerName),
@@ -72,6 +91,7 @@ class SignatureStorageService {
         signerId: signerId,
         signerName: signerName,
         signedAt: now,
+        type: SignatureType.instructor,
       );
     } catch (e, stackTrace) {
       _log.error(
@@ -209,7 +229,9 @@ class SignatureStorageService {
               id: Value(id),
               diveId: Value(diveId),
               imageData: Value(imageBytes),
+              filePath: const Value(_signatureFilePath),
               fileType: const Value(_buddySignatureFileType),
+              sourceType: const Value(_signatureSourceType),
               takenAt: Value(now.millisecondsSinceEpoch),
               signerId: Value(buddyId),
               signerName: Value(buddyName),

--- a/lib/features/signatures/data/services/signature_storage_service.dart
+++ b/lib/features/signatures/data/services/signature_storage_service.dart
@@ -358,10 +358,27 @@ class SignatureStorageService {
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
 
+    // The output is a whole number of pixels, rounded up, because the size
+    // comes from layout constraints and is routinely fractional on a scaled
+    // display: a stroke may sit at x = 607.8 on a 607.5-wide canvas, and
+    // truncating would drop that last column and crop the signature again,
+    // in miniature.
+    //
+    // Everything painted below is measured against these dimensions rather
+    // than the fractional request, so the background reaches the edge of the
+    // image it is filling. Filling only to 607.5 of a 608px-wide bitmap
+    // leaves a transparent strip down the right of an otherwise opaque
+    // signature.
+    final pixelWidth = width.ceil();
+    final pixelHeight = height.ceil();
+
     // Draw background if specified
     if (backgroundColor != null) {
       final bgPaint = Paint()..color = backgroundColor;
-      canvas.drawRect(Rect.fromLTWH(0, 0, width, height), bgPaint);
+      canvas.drawRect(
+        Rect.fromLTWH(0, 0, pixelWidth.toDouble(), pixelHeight.toDouble()),
+        bgPaint,
+      );
     }
 
     // Draw strokes
@@ -385,15 +402,8 @@ class SignatureStorageService {
       canvas.drawPath(path, paint);
     }
 
-    // Convert to image.
-    //
-    // Rounded up, not truncated: the size comes from layout constraints and
-    // is routinely fractional on a scaled display, and a stroke may sit at
-    // x = 607.8 on a 607.5-wide canvas. `toInt()` would drop that last
-    // column and crop the signature again, in miniature. Rounding up costs
-    // at most one transparent pixel.
     final picture = recorder.endRecording();
-    final image = await picture.toImage(width.ceil(), height.ceil());
+    final image = await picture.toImage(pixelWidth, pixelHeight);
     final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
 
     return byteData!.buffer.asUint8List();

--- a/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
@@ -166,7 +166,10 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
   /// Laid-out size of the drawing surface, recorded by the [LayoutBuilder]
   /// that wraps it. The canvas stretches to the sheet width, so it is only
   /// known after layout -- and the strokes mean nothing without it.
-  Size _canvasSize = const Size(0, _canvasHeight);
+  ///
+  /// The placeholder is never read: a stroke requires a laid-out canvas, so
+  /// the builder has always run by the time a save can happen.
+  Size _canvasSize = Size.zero;
 
   void _clear() {
     setState(() {
@@ -197,15 +200,7 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
         // Signature canvas
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              // Recorded, not applied: the strokes are in this box's
-              // coordinates, so the PNG has to be rendered at this exact
-              // size or the right-hand side of the signature is cropped.
-              _canvasSize = Size(constraints.maxWidth, _canvasHeight);
-              return _buildCanvas(context, colorScheme);
-            },
-          ),
+          child: _buildCanvas(context, colorScheme),
         ),
 
         const SizedBox(height: 8),
@@ -265,35 +260,49 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(11),
-        child: Semantics(
-          label: context.l10n.signatures_drawSignatureSemantics,
-          child: GestureDetector(
-            onPanStart: (details) {
-              setState(() {
-                _currentStroke = [details.localPosition];
-              });
-            },
-            onPanUpdate: (details) {
-              setState(() {
-                _currentStroke.add(details.localPosition);
-              });
-            },
-            onPanEnd: (details) {
-              setState(() {
-                if (_currentStroke.isNotEmpty) {
-                  _strokes.add(List.from(_currentStroke));
-                }
-                _currentStroke = [];
-              });
-            },
-            child: CustomPaint(
-              painter: _SignaturePainter(
-                strokes: _strokes,
-                currentStroke: _currentStroke,
-              ),
-              size: Size.infinite,
-            ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Recorded, not applied, and measured HERE rather than around
+            // the Container: the border insets this surface by 1px a side,
+            // and `details.localPosition` is relative to it. Measuring the
+            // outer box would report a canvas 2px larger than the space the
+            // strokes actually live in.
+            _canvasSize = constraints.biggest;
+            return _buildGestureSurface(context);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGestureSurface(BuildContext context) {
+    return Semantics(
+      label: context.l10n.signatures_drawSignatureSemantics,
+      child: GestureDetector(
+        onPanStart: (details) {
+          setState(() {
+            _currentStroke = [details.localPosition];
+          });
+        },
+        onPanUpdate: (details) {
+          setState(() {
+            _currentStroke.add(details.localPosition);
+          });
+        },
+        onPanEnd: (details) {
+          setState(() {
+            if (_currentStroke.isNotEmpty) {
+              _strokes.add(List.from(_currentStroke));
+            }
+            _currentStroke = [];
+          });
+        },
+        child: CustomPaint(
+          painter: _SignaturePainter(
+            strokes: _strokes,
+            currentStroke: _currentStroke,
           ),
+          size: Size.infinite,
         ),
       ),
     );

--- a/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
@@ -9,7 +9,11 @@ import 'package:submersion/features/dive_roles/presentation/dive_role_display.da
 /// Shows a message to hand device to buddy, then displays signature canvas
 class BuddySignatureRequestSheet extends StatefulWidget {
   final BuddyWithRole buddyWithRole;
-  final void Function(List<List<Offset>> strokes)? onSave;
+
+  /// Receives the strokes together with the size of the canvas they were
+  /// drawn on. The strokes are in canvas-local coordinates, so rendering
+  /// them at any other size crops the signature.
+  final void Function(List<List<Offset>> strokes, Size canvasSize)? onSave;
 
   const BuddySignatureRequestSheet({
     super.key,
@@ -121,8 +125,8 @@ class _BuddySignatureRequestSheetState
               // Signature capture
               _BuddySignatureCapture(
                 buddyName: buddy.name,
-                onSave: (strokes) {
-                  widget.onSave?.call(strokes);
+                onSave: (strokes, canvasSize) {
+                  widget.onSave?.call(strokes, canvasSize);
                   Navigator.of(context).pop();
                 },
                 onCancel: () => Navigator.of(context).pop(),
@@ -140,7 +144,7 @@ class _BuddySignatureRequestSheetState
 /// Customized signature capture for buddy signatures (no name field needed)
 class _BuddySignatureCapture extends StatefulWidget {
   final String buddyName;
-  final void Function(List<List<Offset>> strokes)? onSave;
+  final void Function(List<List<Offset>> strokes, Size canvasSize)? onSave;
   final VoidCallback? onCancel;
 
   const _BuddySignatureCapture({
@@ -154,8 +158,15 @@ class _BuddySignatureCapture extends StatefulWidget {
 }
 
 class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
+  static const double _canvasHeight = 200;
+
   final List<List<Offset>> _strokes = [];
   List<Offset> _currentStroke = [];
+
+  /// Laid-out size of the drawing surface, recorded by the [LayoutBuilder]
+  /// that wraps it. The canvas stretches to the sheet width, so it is only
+  /// known after layout -- and the strokes mean nothing without it.
+  Size _canvasSize = const Size(0, _canvasHeight);
 
   void _clear() {
     setState(() {
@@ -172,7 +183,7 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
       return;
     }
 
-    widget.onSave?.call(_strokes);
+    widget.onSave?.call(_strokes, _canvasSize);
   }
 
   @override
@@ -186,48 +197,14 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
         // Signature canvas
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Container(
-            height: 200,
-            decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: colorScheme.outline.withValues(alpha: 0.5),
-              ),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(11),
-              child: Semantics(
-                label: context.l10n.signatures_drawSignatureSemantics,
-                child: GestureDetector(
-                  onPanStart: (details) {
-                    setState(() {
-                      _currentStroke = [details.localPosition];
-                    });
-                  },
-                  onPanUpdate: (details) {
-                    setState(() {
-                      _currentStroke.add(details.localPosition);
-                    });
-                  },
-                  onPanEnd: (details) {
-                    setState(() {
-                      if (_currentStroke.isNotEmpty) {
-                        _strokes.add(List.from(_currentStroke));
-                      }
-                      _currentStroke = [];
-                    });
-                  },
-                  child: CustomPaint(
-                    painter: _SignaturePainter(
-                      strokes: _strokes,
-                      currentStroke: _currentStroke,
-                    ),
-                    size: Size.infinite,
-                  ),
-                ),
-              ),
-            ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // Recorded, not applied: the strokes are in this box's
+              // coordinates, so the PNG has to be rendered at this exact
+              // size or the right-hand side of the signature is cropped.
+              _canvasSize = Size(constraints.maxWidth, _canvasHeight);
+              return _buildCanvas(context, colorScheme);
+            },
           ),
         ),
 
@@ -275,6 +252,50 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildCanvas(BuildContext context, ColorScheme colorScheme) {
+    return Container(
+      height: _canvasHeight,
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.5)),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(11),
+        child: Semantics(
+          label: context.l10n.signatures_drawSignatureSemantics,
+          child: GestureDetector(
+            onPanStart: (details) {
+              setState(() {
+                _currentStroke = [details.localPosition];
+              });
+            },
+            onPanUpdate: (details) {
+              setState(() {
+                _currentStroke.add(details.localPosition);
+              });
+            },
+            onPanEnd: (details) {
+              setState(() {
+                if (_currentStroke.isNotEmpty) {
+                  _strokes.add(List.from(_currentStroke));
+                }
+                _currentStroke = [];
+              });
+            },
+            child: CustomPaint(
+              painter: _SignaturePainter(
+                strokes: _strokes,
+                currentStroke: _currentStroke,
+              ),
+              size: Size.infinite,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
@@ -328,7 +349,7 @@ class _SignaturePainter extends CustomPainter {
 Future<void> showBuddySignatureRequestSheet({
   required BuildContext context,
   required BuddyWithRole buddyWithRole,
-  required void Function(List<List<Offset>> strokes) onSave,
+  required void Function(List<List<Offset>> strokes, Size canvasSize) onSave,
 }) {
   return showModalBottomSheet(
     context: context,

--- a/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart
@@ -171,6 +171,11 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
   /// the builder has always run by the time a save can happen.
   Size _canvasSize = Size.zero;
 
+  /// Whether anything drawable has been captured. Mirrors what the painter
+  /// and the PNG encoder accept, so an enabled button always means there is
+  /// a signature to save.
+  bool get _hasDrawing => _strokes.isNotEmpty || _currentStroke.length >= 2;
+
   void _clear() {
     setState(() {
       _strokes.clear();
@@ -224,9 +229,7 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
           child: Row(
             children: [
               OutlinedButton.icon(
-                onPressed: _strokes.isEmpty && _currentStroke.isEmpty
-                    ? null
-                    : _clear,
+                onPressed: !_hasDrawing ? null : _clear,
                 icon: const Icon(Icons.clear),
                 label: Text(context.l10n.signatures_action_clear),
               ),
@@ -237,9 +240,7 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
               ),
               const SizedBox(width: 8),
               FilledButton.icon(
-                onPressed: _strokes.isEmpty && _currentStroke.isEmpty
-                    ? null
-                    : _handleSave,
+                onPressed: !_hasDrawing ? null : _handleSave,
                 icon: const Icon(Icons.check),
                 label: Text(context.l10n.signatures_action_done),
               ),
@@ -291,7 +292,11 @@ class _BuddySignatureCaptureState extends State<_BuddySignatureCapture> {
         },
         onPanEnd: (details) {
           setState(() {
-            if (_currentStroke.isNotEmpty) {
+            // Only strokes with a segment to draw. A plain tap wins the
+            // gesture arena uncontested and lands here with a single point,
+            // which the painter and the PNG encoder both skip -- so storing
+            // it would light up Done and save a blank signature.
+            if (_currentStroke.length >= 2) {
               _strokes.add(List.from(_currentStroke));
             }
             _currentStroke = [];

--- a/lib/features/signatures/presentation/widgets/buddy_signatures_section.dart
+++ b/lib/features/signatures/presentation/widgets/buddy_signatures_section.dart
@@ -142,20 +142,36 @@ class BuddySignaturesSection extends ConsumerWidget {
     WidgetRef ref,
     BuddyWithRole bwr,
   ) {
+    // Captured before the sheet closes: the save outlives it, and reporting
+    // a failure needs a messenger that is still in the tree.
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
+
     showBuddySignatureRequestSheet(
       context: context,
       buddyWithRole: bwr,
-      onSave: (strokes) async {
+      onSave: (strokes, canvasSize) async {
         final notifier = ref.read(buddySignatureSaveNotifierProvider.notifier);
-        await notifier.saveFromStrokes(
+        // The strokes are in the capture canvas's own coordinates, so the
+        // PNG is rendered at that exact size. A hardcoded size cropped every
+        // signature drawn on a canvas wider than it (issue #1358).
+        final signature = await notifier.saveFromStrokes(
           diveId: diveId,
           buddyId: bwr.buddy.id,
           buddyName: bwr.buddy.name,
           role: bwr.role.id,
           strokes: strokes,
-          width: 400,
-          height: 200,
+          width: canvasSize.width,
+          height: canvasSize.height,
         );
+        // A null result means the save threw. Nothing watches the notifier's
+        // AsyncValue, so without this the diver is shown an unchanged
+        // "Request" button and no reason for it (issue #1358).
+        if (signature == null) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n.signatures_error_saveFailed)),
+          );
+        }
       },
     );
   }

--- a/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
+++ b/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
@@ -11,7 +11,12 @@ class SignatureCaptureWidget extends StatefulWidget {
   final String? initialSignerName;
 
   /// Callback when signature is saved
-  final void Function(List<List<Offset>> strokes, String signerName)? onSave;
+  final void Function(
+    List<List<Offset>> strokes,
+    String signerName,
+    Size canvasSize,
+  )?
+  onSave;
 
   /// Callback when cancelled
   final VoidCallback? onCancel;
@@ -48,6 +53,11 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
   List<Offset> _currentStroke = [];
   late final TextEditingController _nameController;
 
+  /// Laid-out size of the drawing surface, recorded by the [LayoutBuilder]
+  /// that wraps it. The canvas stretches to the available width, so it is
+  /// only known after layout -- and the strokes mean nothing without it.
+  late Size _canvasSize = Size(0, widget.canvasHeight);
+
   @override
   void initState() {
     super.initState();
@@ -83,7 +93,7 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
       return;
     }
 
-    widget.onSave?.call(_strokes, name);
+    widget.onSave?.call(_strokes, name, _canvasSize);
   }
 
   @override
@@ -129,50 +139,14 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
         // Signature canvas
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Container(
-            height: widget.canvasHeight,
-            decoration: BoxDecoration(
-              color: canvasBackground,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: colorScheme.outline.withValues(alpha: 0.5),
-              ),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(11),
-              child: Semantics(
-                label: context.l10n.signatures_drawSignatureSemantics,
-                child: GestureDetector(
-                  onPanStart: (details) {
-                    setState(() {
-                      _currentStroke = [details.localPosition];
-                    });
-                  },
-                  onPanUpdate: (details) {
-                    setState(() {
-                      _currentStroke.add(details.localPosition);
-                    });
-                  },
-                  onPanEnd: (details) {
-                    setState(() {
-                      if (_currentStroke.isNotEmpty) {
-                        _strokes.add(List.from(_currentStroke));
-                      }
-                      _currentStroke = [];
-                    });
-                  },
-                  child: CustomPaint(
-                    painter: _SignaturePainter(
-                      strokes: _strokes,
-                      currentStroke: _currentStroke,
-                      strokeColor: widget.strokeColor,
-                      strokeWidth: widget.strokeWidth,
-                    ),
-                    size: Size.infinite,
-                  ),
-                ),
-              ),
-            ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // Recorded, not applied: the strokes are in this box's
+              // coordinates, so the PNG has to be rendered at this exact
+              // size or the right-hand side of the signature is cropped.
+              _canvasSize = Size(constraints.maxWidth, widget.canvasHeight);
+              return _buildCanvas(context, canvasBackground, colorScheme);
+            },
           ),
         ),
 
@@ -223,6 +197,56 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildCanvas(
+    BuildContext context,
+    Color canvasBackground,
+    ColorScheme colorScheme,
+  ) {
+    return Container(
+      height: widget.canvasHeight,
+      decoration: BoxDecoration(
+        color: canvasBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.5)),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(11),
+        child: Semantics(
+          label: context.l10n.signatures_drawSignatureSemantics,
+          child: GestureDetector(
+            onPanStart: (details) {
+              setState(() {
+                _currentStroke = [details.localPosition];
+              });
+            },
+            onPanUpdate: (details) {
+              setState(() {
+                _currentStroke.add(details.localPosition);
+              });
+            },
+            onPanEnd: (details) {
+              setState(() {
+                if (_currentStroke.isNotEmpty) {
+                  _strokes.add(List.from(_currentStroke));
+                }
+                _currentStroke = [];
+              });
+            },
+            child: CustomPaint(
+              painter: _SignaturePainter(
+                strokes: _strokes,
+                currentStroke: _currentStroke,
+                strokeColor: widget.strokeColor,
+                strokeWidth: widget.strokeWidth,
+              ),
+              size: Size.infinite,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }
@@ -284,7 +308,12 @@ class _SignaturePainter extends CustomPainter {
 /// Full-screen signature capture sheet
 class SignatureCaptureSheet extends StatelessWidget {
   final String? initialSignerName;
-  final void Function(List<List<Offset>> strokes, String signerName)? onSave;
+  final void Function(
+    List<List<Offset>> strokes,
+    String signerName,
+    Size canvasSize,
+  )?
+  onSave;
 
   const SignatureCaptureSheet({super.key, this.initialSignerName, this.onSave});
 
@@ -331,8 +360,8 @@ class SignatureCaptureSheet extends StatelessWidget {
             // Signature capture widget
             SignatureCaptureWidget(
               initialSignerName: initialSignerName,
-              onSave: (strokes, name) {
-                onSave?.call(strokes, name);
+              onSave: (strokes, name, canvasSize) {
+                onSave?.call(strokes, name, canvasSize);
                 Navigator.of(context).pop();
               },
               onCancel: () => Navigator.of(context).pop(),
@@ -350,7 +379,12 @@ class SignatureCaptureSheet extends StatelessWidget {
 Future<void> showSignatureCaptureSheet({
   required BuildContext context,
   String? initialSignerName,
-  required void Function(List<List<Offset>> strokes, String signerName) onSave,
+  required void Function(
+    List<List<Offset>> strokes,
+    String signerName,
+    Size canvasSize,
+  )
+  onSave,
 }) {
   return showModalBottomSheet(
     context: context,

--- a/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
+++ b/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
@@ -56,7 +56,10 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
   /// Laid-out size of the drawing surface, recorded by the [LayoutBuilder]
   /// that wraps it. The canvas stretches to the available width, so it is
   /// only known after layout -- and the strokes mean nothing without it.
-  late Size _canvasSize = Size(0, widget.canvasHeight);
+  ///
+  /// The placeholder is never read: a stroke requires a laid-out canvas, so
+  /// the builder has always run by the time a save can happen.
+  Size _canvasSize = Size.zero;
 
   @override
   void initState() {
@@ -139,15 +142,7 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
         // Signature canvas
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              // Recorded, not applied: the strokes are in this box's
-              // coordinates, so the PNG has to be rendered at this exact
-              // size or the right-hand side of the signature is cropped.
-              _canvasSize = Size(constraints.maxWidth, widget.canvasHeight);
-              return _buildCanvas(context, canvasBackground, colorScheme);
-            },
-          ),
+          child: _buildCanvas(context, canvasBackground, colorScheme),
         ),
 
         const SizedBox(height: 8),
@@ -214,37 +209,51 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(11),
-        child: Semantics(
-          label: context.l10n.signatures_drawSignatureSemantics,
-          child: GestureDetector(
-            onPanStart: (details) {
-              setState(() {
-                _currentStroke = [details.localPosition];
-              });
-            },
-            onPanUpdate: (details) {
-              setState(() {
-                _currentStroke.add(details.localPosition);
-              });
-            },
-            onPanEnd: (details) {
-              setState(() {
-                if (_currentStroke.isNotEmpty) {
-                  _strokes.add(List.from(_currentStroke));
-                }
-                _currentStroke = [];
-              });
-            },
-            child: CustomPaint(
-              painter: _SignaturePainter(
-                strokes: _strokes,
-                currentStroke: _currentStroke,
-                strokeColor: widget.strokeColor,
-                strokeWidth: widget.strokeWidth,
-              ),
-              size: Size.infinite,
-            ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Recorded, not applied, and measured HERE rather than around
+            // the Container: the border insets this surface by 1px a side,
+            // and `details.localPosition` is relative to it. Measuring the
+            // outer box would report a canvas 2px larger than the space the
+            // strokes actually live in.
+            _canvasSize = constraints.biggest;
+            return _buildGestureSurface(context);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGestureSurface(BuildContext context) {
+    return Semantics(
+      label: context.l10n.signatures_drawSignatureSemantics,
+      child: GestureDetector(
+        onPanStart: (details) {
+          setState(() {
+            _currentStroke = [details.localPosition];
+          });
+        },
+        onPanUpdate: (details) {
+          setState(() {
+            _currentStroke.add(details.localPosition);
+          });
+        },
+        onPanEnd: (details) {
+          setState(() {
+            if (_currentStroke.isNotEmpty) {
+              _strokes.add(List.from(_currentStroke));
+            }
+            _currentStroke = [];
+          });
+        },
+        child: CustomPaint(
+          painter: _SignaturePainter(
+            strokes: _strokes,
+            currentStroke: _currentStroke,
+            strokeColor: widget.strokeColor,
+            strokeWidth: widget.strokeWidth,
           ),
+          size: Size.infinite,
         ),
       ),
     );

--- a/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
+++ b/lib/features/signatures/presentation/widgets/signature_capture_widget.dart
@@ -73,6 +73,11 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
     super.dispose();
   }
 
+  /// Whether anything drawable has been captured. Mirrors what the painter
+  /// and the PNG encoder accept, so an enabled button always means there is
+  /// a signature to save.
+  bool get _hasDrawing => _strokes.isNotEmpty || _currentStroke.length >= 2;
+
   void _clear() {
     setState(() {
       _strokes.clear();
@@ -167,9 +172,7 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
             children: [
               // Clear button
               OutlinedButton.icon(
-                onPressed: _strokes.isEmpty && _currentStroke.isEmpty
-                    ? null
-                    : _clear,
+                onPressed: !_hasDrawing ? null : _clear,
                 icon: const Icon(Icons.clear),
                 label: Text(context.l10n.signatures_action_clear),
               ),
@@ -182,9 +185,7 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
               const SizedBox(width: 8),
               // Save button
               FilledButton.icon(
-                onPressed: _strokes.isEmpty && _currentStroke.isEmpty
-                    ? null
-                    : _handleSave,
+                onPressed: !_hasDrawing ? null : _handleSave,
                 icon: const Icon(Icons.check),
                 label: Text(context.l10n.signatures_action_saveSignature),
               ),
@@ -240,7 +241,11 @@ class _SignatureCaptureWidgetState extends State<SignatureCaptureWidget> {
         },
         onPanEnd: (details) {
           setState(() {
-            if (_currentStroke.isNotEmpty) {
+            // Only strokes with a segment to draw. A plain tap wins the
+            // gesture arena uncontested and lands here with a single point,
+            // which the painter and the PNG encoder both skip -- so storing
+            // it would light up Save and store a blank signature.
+            if (_currentStroke.length >= 2) {
               _strokes.add(List.from(_currentStroke));
             }
             _currentStroke = [];

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "رسم التوقيع",
   "signatures_error_drawSignature": "الرجاء رسم توقيع",
   "signatures_error_enterSignerName": "الرجاء إدخال اسم الموقع",
+  "signatures_error_saveFailed": "تعذر حفظ التوقيع. يرجى المحاولة مرة أخرى.",
   "signatures_field_instructorName": "اسم المدرب",
   "signatures_field_instructorNameHint": "أدخل اسم المدرب",
   "signatures_handoff_title": "ناول جهازك إلى",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "Signatur zeichnen",
   "signatures_error_drawSignature": "Bitte zeichnen Sie eine Signatur",
   "signatures_error_enterSignerName": "Bitte geben Sie den Namen des Unterzeichners ein",
+  "signatures_error_saveFailed": "Die Unterschrift konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
   "signatures_field_instructorName": "Tauchlehrername",
   "signatures_field_instructorNameHint": "Tauchlehrernamen eingeben",
   "signatures_handoff_title": "Geben Sie Ihr Gerät an",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -10506,6 +10506,7 @@
   "signatures_drawSignatureSemantics": "Draw signature",
   "signatures_error_drawSignature": "Please draw a signature",
   "signatures_error_enterSignerName": "Please enter the signer name",
+  "signatures_error_saveFailed": "Could not save the signature. Please try again.",
   "signatures_field_instructorName": "Instructor Name",
   "signatures_field_instructorNameHint": "Enter instructor name",
   "signatures_handoff_title": "Hand your device to",
@@ -10586,6 +10587,9 @@
   },
   "@signatures_error_enterSignerName": {
     "description": "Error shown when trying to save without entering a signer name"
+  },
+  "@signatures_error_saveFailed": {
+    "description": "Error shown when saving a signature failed"
   },
   "@signatures_field_instructorName": {
     "description": "Label for the instructor name text field"

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "Dibujar firma",
   "signatures_error_drawSignature": "Por favor dibuja una firma",
   "signatures_error_enterSignerName": "Por favor ingresa el nombre del firmante",
+  "signatures_error_saveFailed": "No se pudo guardar la firma. Inténtalo de nuevo.",
   "signatures_field_instructorName": "Nombre del Instructor",
   "signatures_field_instructorNameHint": "Ingresa el nombre del instructor",
   "signatures_handoff_title": "Entrega tu dispositivo a",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -5188,6 +5188,7 @@
   "signatures_drawSignatureSemantics": "Dessiner la signature",
   "signatures_error_drawSignature": "Veuillez dessiner une signature",
   "signatures_error_enterSignerName": "Veuillez entrer le nom du signataire",
+  "signatures_error_saveFailed": "Impossible d'enregistrer la signature. Veuillez réessayer.",
   "signatures_field_instructorName": "Nom de l'instructeur",
   "signatures_field_instructorNameHint": "Entrer le nom de l'instructeur",
   "signatures_handoff_title": "Passez votre appareil à",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "שרטט חתימה",
   "signatures_error_drawSignature": "נא לשרטט חתימה",
   "signatures_error_enterSignerName": "נא להזין שם החותם",
+  "signatures_error_saveFailed": "לא ניתן היה לשמור את החתימה. נסו שוב.",
   "signatures_field_instructorName": "שם המדריך",
   "signatures_field_instructorNameHint": "הזן שם מדריך",
   "signatures_handoff_title": "העבר את המכשיר ל",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -5188,6 +5188,7 @@
   "signatures_drawSignatureSemantics": "Aláírás rajzolása",
   "signatures_error_drawSignature": "Rajzolj egy aláírást",
   "signatures_error_enterSignerName": "Add meg az aláíró nevét",
+  "signatures_error_saveFailed": "Az aláírást nem sikerült menteni. Próbáld újra.",
   "signatures_field_instructorName": "Oktató neve",
   "signatures_field_instructorNameHint": "Add meg az oktató nevét",
   "signatures_handoff_title": "Add át az eszközt",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -5184,6 +5184,7 @@
   "signatures_drawSignatureSemantics": "Disegna firma",
   "signatures_error_drawSignature": "Disegna una firma",
   "signatures_error_enterSignerName": "Inserisci il nome del firmatario",
+  "signatures_error_saveFailed": "Impossibile salvare la firma. Riprova.",
   "signatures_field_instructorName": "Nome Istruttore",
   "signatures_field_instructorNameHint": "Inserisci nome istruttore",
   "signatures_handoff_title": "Passa il dispositivo a",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -29351,6 +29351,12 @@ abstract class AppLocalizations {
   /// **'Please enter the signer name'**
   String get signatures_error_enterSignerName;
 
+  /// Error shown when saving a signature failed
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save the signature. Please try again.'**
+  String get signatures_error_saveFailed;
+
   /// Label for the instructor name text field
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -17387,6 +17387,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get signatures_error_enterSignerName => 'الرجاء إدخال اسم الموقع';
 
   @override
+  String get signatures_error_saveFailed =>
+      'تعذر حفظ التوقيع. يرجى المحاولة مرة أخرى.';
+
+  @override
   String get signatures_field_instructorName => 'اسم المدرب';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -17681,6 +17681,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bitte geben Sie den Namen des Unterzeichners ein';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Die Unterschrift konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.';
+
+  @override
   String get signatures_field_instructorName => 'Tauchlehrername';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -17407,6 +17407,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signatures_error_enterSignerName => 'Please enter the signer name';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Could not save the signature. Please try again.';
+
+  @override
   String get signatures_field_instructorName => 'Instructor Name';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -17710,6 +17710,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Por favor ingresa el nombre del firmante';
 
   @override
+  String get signatures_error_saveFailed =>
+      'No se pudo guardar la firma. Inténtalo de nuevo.';
+
+  @override
   String get signatures_field_instructorName => 'Nombre del Instructor';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -17771,6 +17771,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Veuillez entrer le nom du signataire';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Impossible d\'enregistrer la signature. Veuillez réessayer.';
+
+  @override
   String get signatures_field_instructorName => 'Nom de l\'instructeur';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -17260,6 +17260,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get signatures_error_enterSignerName => 'נא להזין שם החותם';
 
   @override
+  String get signatures_error_saveFailed =>
+      'לא ניתן היה לשמור את החתימה. נסו שוב.';
+
+  @override
   String get signatures_field_instructorName => 'שם המדריך';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -17647,6 +17647,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get signatures_error_enterSignerName => 'Add meg az aláíró nevét';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Az aláírást nem sikerült menteni. Próbáld újra.';
+
+  @override
   String get signatures_field_instructorName => 'Oktató neve';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -17701,6 +17701,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Inserisci il nome del firmatario';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Impossibile salvare la firma. Riprova.';
+
+  @override
   String get signatures_field_instructorName => 'Nome Istruttore';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -17565,6 +17565,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voer de naam van de ondertekenaar in';
 
   @override
+  String get signatures_error_saveFailed =>
+      'De handtekening kon niet worden opgeslagen. Probeer het opnieuw.';
+
+  @override
   String get signatures_field_instructorName => 'Naam instructeur';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -17711,6 +17711,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get signatures_error_enterSignerName => 'Digite o nome do signatário';
 
   @override
+  String get signatures_error_saveFailed =>
+      'Não foi possível salvar a assinatura. Tente novamente.';
+
+  @override
   String get signatures_field_instructorName => 'Nome do Instrutor';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -16811,6 +16811,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get signatures_error_enterSignerName => '请输入签名者姓名';
 
   @override
+  String get signatures_error_saveFailed => '无法保存签名。请重试。';
+
+  @override
   String get signatures_field_instructorName => '教练名称';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "Teken handtekening",
   "signatures_error_drawSignature": "Teken een handtekening",
   "signatures_error_enterSignerName": "Voer de naam van de ondertekenaar in",
+  "signatures_error_saveFailed": "De handtekening kon niet worden opgeslagen. Probeer het opnieuw.",
   "signatures_field_instructorName": "Naam instructeur",
   "signatures_field_instructorNameHint": "Voer naam instructeur in",
   "signatures_handoff_title": "Geef je apparaat aan",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -5261,6 +5261,7 @@
   "signatures_drawSignatureSemantics": "Desenhar assinatura",
   "signatures_error_drawSignature": "Desenhe uma assinatura",
   "signatures_error_enterSignerName": "Digite o nome do signatário",
+  "signatures_error_saveFailed": "Não foi possível salvar a assinatura. Tente novamente.",
   "signatures_field_instructorName": "Nome do Instrutor",
   "signatures_field_instructorNameHint": "Digite o nome do instrutor",
   "signatures_handoff_title": "Entregue seu dispositivo para",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -5448,6 +5448,7 @@
   "signatures_drawSignatureSemantics": "绘制签名",
   "signatures_error_drawSignature": "请绘制签名",
   "signatures_error_enterSignerName": "请输入签名者姓名",
+  "signatures_error_saveFailed": "无法保存签名。请重试。",
   "signatures_field_instructorName": "教练名称",
   "signatures_field_instructorNameHint": "输入教练姓名",
   "signatures_handoff_title": "请将设备交给",

--- a/test/features/dive_log/presentation/widgets/photo_marker_layout_test.dart
+++ b/test/features/dive_log/presentation/widgets/photo_marker_layout_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/presentation/widgets/photo_marker_layout.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
 
 MediaItem _media({
   String id = 'm1',
   MediaType type = MediaType.photo,
+  MediaSourceType sourceType = MediaSourceType.platformGallery,
   MediaEnrichment? enrichment,
 }) {
   final now = DateTime.utc(2026, 1, 1);
@@ -12,6 +14,7 @@ MediaItem _media({
     id: id,
     diveId: 'dive-1',
     mediaType: type,
+    sourceType: sourceType,
     takenAt: now,
     createdAt: now,
     updatedAt: now,
@@ -77,6 +80,20 @@ void main() {
         expect(markers, isEmpty);
       },
     );
+
+    // Issue #1358: a buddy signature's file_type is 'buddy_signature', which
+    // parses to MediaType.photo, so the old MediaType-only guard let one
+    // through as a dive photo. It is a signature by source type instead.
+    test('excludes a buddy signature, which types as a photo', () {
+      final markers = photoMarkersFromMedia([
+        _media(
+          id: 'bs1',
+          sourceType: MediaSourceType.signature,
+          enrichment: _enrichment(),
+        ),
+      ], maxProfileSeconds: 3600);
+      expect(markers, isEmpty);
+    });
 
     test('clamps elapsed seconds into the profile range and sorts by time', () {
       final markers = photoMarkersFromMedia([

--- a/test/features/signatures/data/services/signature_storage_save_roundtrip_test.dart
+++ b/test/features/signatures/data/services/signature_storage_save_roundtrip_test.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/media/data/repositories/media_library_repository.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/signatures/data/services/signature_storage_service.dart';
+import 'package:submersion/features/signatures/domain/entities/signature.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SignatureStorageService save round trip', () {
+    late AppDatabase db;
+    late SignatureStorageService service;
+
+    const diveId = 'dive-1';
+    const buddyId = 'buddy-1';
+
+    final imageBytes = Uint8List.fromList(const [1, 2, 3, 4]);
+
+    setUp(() async {
+      db = await setUpTestDatabase();
+      service = SignatureStorageService();
+
+      final at = DateTime.utc(2026, 1, 2, 3, 4).millisecondsSinceEpoch;
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion(
+              id: const Value(diveId),
+              diveDateTime: Value(at),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+      await db
+          .into(db.buddies)
+          .insert(
+            BuddiesCompanion(
+              id: const Value(buddyId),
+              name: const Value('Test Buddy'),
+              createdAt: Value(at),
+              updatedAt: Value(at),
+            ),
+          );
+    });
+
+    tearDown(tearDownTestDatabase);
+
+    test(
+      'saveBuddySignature persists a row readable by the dive query',
+      () async {
+        final saved = await service.saveBuddySignature(
+          diveId: diveId,
+          imageBytes: imageBytes,
+          buddyId: buddyId,
+          buddyName: 'Test Buddy',
+          role: 'buddy',
+        );
+
+        expect(saved.signerId, buddyId);
+
+        final signatures = await service.getBuddySignaturesForDive(diveId);
+        expect(signatures, hasLength(1));
+        expect(signatures.single.signerId, buddyId);
+        expect(signatures.single.imageData, imageBytes);
+        expect(signatures.single.type, SignatureType.buddy);
+
+        expect(await service.hasBuddySigned(diveId, buddyId), isTrue);
+      },
+    );
+
+    test('saveSignature persists an instructor signature', () async {
+      await service.saveSignature(
+        diveId: diveId,
+        imageBytes: imageBytes,
+        signerName: 'Instructor',
+        signerId: buddyId,
+      );
+
+      final signature = await service.getSignatureForDive(diveId);
+      expect(signature, isNotNull);
+      expect(signature!.imageData, imageBytes);
+      expect(await service.hasSignature(diveId), isTrue);
+    });
+
+    // media.file_path is NOT NULL and has no default, so an absent value is
+    // what made every save throw in Drift's validateIntegrity (issue #1358).
+    // The empty string is the schema's "no file behind this row" sentinel.
+    test('signature rows carry an empty file path and the signature '
+        'source type', () async {
+      await service.saveBuddySignature(
+        diveId: diveId,
+        imageBytes: imageBytes,
+        buddyId: buddyId,
+        buddyName: 'Test Buddy',
+        role: 'buddy',
+      );
+      await service.saveSignature(
+        diveId: diveId,
+        imageBytes: imageBytes,
+        signerName: 'Instructor',
+        signerId: buddyId,
+      );
+
+      final rows = await db.select(db.media).get();
+      expect(rows, hasLength(2));
+      for (final row in rows) {
+        expect(row.filePath, '');
+        expect(row.sourceType, 'signature');
+      }
+      expect(
+        rows.map((r) => r.signatureType),
+        containsAll(<String>['buddy', 'instructor']),
+      );
+    });
+
+    // Signatures live in the media table but are not dive media. Buddy rows
+    // were never written before the #1358 fix, so nothing had ever checked
+    // that the library exclusion knows their file_type.
+    test('signatures stay out of the media library', () async {
+      await service.saveBuddySignature(
+        diveId: diveId,
+        imageBytes: imageBytes,
+        buddyId: buddyId,
+        buddyName: 'Test Buddy',
+        role: 'buddy',
+      );
+
+      expect(await MediaRepository().hasAnyMedia(), isFalse);
+
+      final page = await MediaLibraryRepository().getPage(diverId: null);
+      expect(page.entries, isEmpty);
+    });
+  });
+}

--- a/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
+++ b/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
@@ -1,9 +1,12 @@
+import 'dart:ui' show ImageByteFormat, instantiateImageCodec;
+
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/signatures/data/services/signature_storage_service.dart';
 import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -162,4 +165,39 @@ void main() {
     expect(image.width, 608);
     expect(image.height, 200);
   });
+
+  // An opaque background has to reach the edge of the image it is filling.
+  // Filling only to the fractional request left the last column and row
+  // transparent on a rounded-up bitmap, so an instructor signature (which
+  // asks for a white background) came out with a transparent strip.
+  test(
+    'an opaque background fills the rounded-up bitmap to its edge',
+    () async {
+      final bytes = await SignatureStorageService.strokesToPng(
+        strokes: const <List<Offset>>[
+          [Offset(10, 100), Offset(400, 100)],
+        ],
+        width: 607.5,
+        height: 199.25,
+        strokeColor: const Color(0xFF000000),
+        strokeWidth: 3,
+        backgroundColor: const Color(0xFFFFFFFF),
+      );
+
+      final codec = await instantiateImageCodec(bytes);
+      final frame = await codec.getNextFrame();
+      final image = frame.image;
+      expect(image.width, 608);
+      expect(image.height, 200);
+
+      final data = await image.toByteData(format: ImageByteFormat.rawRgba);
+      int alphaAt(int x, int y) =>
+          data!.getUint8((y * image.width + x) * 4 + 3);
+
+      // The bottom-right pixel is the one the fractional fill used to miss.
+      expect(alphaAt(image.width - 1, image.height - 1), 255);
+      expect(alphaAt(image.width - 1, 0), 255);
+      expect(alphaAt(0, image.height - 1), 255);
+    },
+  );
 }

--- a/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
+++ b/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
@@ -138,4 +138,28 @@ void main() {
       expect(image.height, 200);
     },
   );
+
+  // A layout width is routinely fractional on a scaled display. Truncating
+  // it would drop the last column and crop the signature again, so the
+  // encoder rounds up.
+  test('a fractional canvas width rounds up rather than truncating', () async {
+    final signature = await container
+        .read(buddySignatureSaveNotifierProvider.notifier)
+        .saveFromStrokes(
+          diveId: diveId,
+          buddyId: buddyId,
+          buddyName: 'Reef Buddy',
+          role: 'buddy',
+          strokes: <List<Offset>>[
+            [const Offset(10, 100), const Offset(607, 100)],
+          ],
+          width: 607.5,
+          height: 199.25,
+        );
+
+    expect(signature, isNotNull);
+    final image = await decodeImageFromList(signature!.imageData!);
+    expect(image.width, 608);
+    expect(image.height, 200);
+  });
 }

--- a/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
+++ b/test/features/signatures/presentation/providers/buddy_signature_save_notifier_test.dart
@@ -1,0 +1,141 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Provider-level guard for issue #1358.
+///
+/// A plain `test` rather than `testWidgets`: `strokesToPng` finishes through
+/// `Picture.toImage`, whose future the engine completes rather than a timer,
+/// so it never resumes under the fake clock a widget test installs.
+///
+/// Nothing here is mocked below the notifier. The bug was that the insert
+/// threw and the notifier swallowed it into an `AsyncValue` nobody watches,
+/// so a test with a stubbed storage service would have stayed green.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const diveId = 'dive-1';
+  const buddyId = 'buddy-1';
+
+  late AppDatabase db;
+  late ProviderContainer container;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    container = ProviderContainer();
+
+    final at = DateTime.utc(2026, 1, 2).millisecondsSinceEpoch;
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: const Value(diveId),
+            diveDateTime: Value(at),
+            createdAt: Value(at),
+            updatedAt: Value(at),
+          ),
+        );
+    await db
+        .into(db.buddies)
+        .insert(
+          BuddiesCompanion(
+            id: const Value(buddyId),
+            name: const Value('Reef Buddy'),
+            createdAt: Value(at),
+            updatedAt: Value(at),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await tearDownTestDatabase();
+  });
+
+  test(
+    'saving strokes stores a signature the dive provider then reads',
+    () async {
+      // Nothing signed yet: this is the state behind the "Request" button.
+      expect(
+        await container.read(buddySignaturesForDiveProvider(diveId).future),
+        isEmpty,
+      );
+
+      final strokes = <List<Offset>>[
+        [
+          const Offset(10, 40),
+          const Offset(40, 20),
+          const Offset(70, 60),
+          const Offset(100, 30),
+        ],
+      ];
+
+      final signature = await container
+          .read(buddySignatureSaveNotifierProvider.notifier)
+          .saveFromStrokes(
+            diveId: diveId,
+            buddyId: buddyId,
+            buddyName: 'Reef Buddy',
+            role: 'buddy',
+            strokes: strokes,
+            width: 608,
+            height: 200,
+          );
+
+      // Null is what the notifier returns when the save throws, which is
+      // exactly how #1358 presented: silent failure, button unchanged.
+      expect(signature, isNotNull);
+      expect(signature!.signerId, buddyId);
+      expect(signature.imageData, isNotEmpty);
+
+      // The notifier invalidates the read provider, so the section that watches
+      // it sees the signature on the next build.
+      final reread = await container.read(
+        buddySignaturesForDiveProvider(diveId).future,
+      );
+      expect(reread, hasLength(1));
+      expect(reread.single.signerId, buddyId);
+      expect(reread.single.hasImage, isTrue);
+
+      expect(
+        await container.read(
+          hasBuddySignedProvider((diveId: diveId, buddyId: buddyId)).future,
+        ),
+        isTrue,
+      );
+    },
+  );
+
+  // The strokes are in canvas coordinates, so the PNG has to be rendered at
+  // the canvas size. A hardcoded 400x200 cropped every signature drawn on a
+  // wider canvas, which is why some saved signatures came back part-blank.
+  test(
+    'the encoded PNG matches the canvas the strokes were drawn on',
+    () async {
+      final signature = await container
+          .read(buddySignatureSaveNotifierProvider.notifier)
+          .saveFromStrokes(
+            diveId: diveId,
+            buddyId: buddyId,
+            buddyName: 'Reef Buddy',
+            role: 'buddy',
+            strokes: <List<Offset>>[
+              [const Offset(10, 100), const Offset(590, 100)],
+            ],
+            width: 608,
+            height: 200,
+          );
+
+      expect(signature, isNotNull);
+      final image = await decodeImageFromList(signature!.imageData!);
+      expect(image.width, 608);
+      expect(image.height, 200);
+    },
+  );
+}

--- a/test/features/signatures/presentation/widgets/buddy_signature_request_sheet_test.dart
+++ b/test/features/signatures/presentation/widgets/buddy_signature_request_sheet_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/signatures/presentation/widgets/buddy_signature_request_sheet.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// Covers the capture sheet itself, which had no test at all before #1358 --
+/// the gap that let a signature save fail silently for as long as it did.
+///
+/// The test stops at the sheet's `onSave` boundary and never reaches
+/// `strokesToPng`: that finishes through `Picture.toImage`, whose future the
+/// engine completes rather than a timer, so it hangs under a widget test's
+/// fake clock. Everything above that line is widget behaviour and belongs
+/// here; the encode and the insert are covered in
+/// buddy_signature_save_notifier_test.dart.
+void main() {
+  final buddyWithRole = BuddyWithRole(
+    buddy: Buddy(
+      id: 'buddy-1',
+      name: 'Reef Buddy',
+      createdAt: DateTime.utc(2026, 1, 1),
+      updatedAt: DateTime.utc(2026, 1, 1),
+    ),
+    role: DiveRole.builtInBuddy(),
+  );
+
+  late List<List<Offset>>? savedStrokes;
+  late Size? savedCanvasSize;
+
+  setUp(() {
+    savedStrokes = null;
+    savedCanvasSize = null;
+  });
+
+  Future<void> openSheet(WidgetTester tester) async {
+    await tester.pumpWidget(
+      testApp(
+        // Pinned: the assertions match English strings.
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => showBuddySignatureRequestSheet(
+              context: context,
+              buddyWithRole: buddyWithRole,
+              onSave: (strokes, canvasSize) {
+                savedStrokes = strokes;
+                savedCanvasSize = canvasSize;
+              },
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  Finder canvas() => find.bySemanticsLabel('Draw signature');
+
+  /// Drags across the canvas in several steps, so the pan recognizer wins the
+  /// arena and onPanUpdate fires more than once. A single jump yields a
+  /// one-point stroke, which draws nothing.
+  Future<void> drawStroke(WidgetTester tester) async {
+    final origin = tester.getCenter(canvas());
+    final gesture = await tester.startGesture(origin - const Offset(60, 20));
+    await tester.pump();
+    for (var i = 0; i < 8; i++) {
+      await gesture.moveBy(const Offset(15, 5));
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('hands off to the buddy before showing the canvas', (
+    tester,
+  ) async {
+    await openSheet(tester);
+
+    expect(find.text('Hand your device to'), findsOneWidget);
+    expect(find.text('Reef Buddy'), findsOneWidget);
+    // The canvas stays hidden until the buddy is holding the device.
+    expect(canvas(), findsNothing);
+
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+
+    expect(canvas(), findsOneWidget);
+  });
+
+  testWidgets('reports the canvas its own laid-out size, not a guess', (
+    tester,
+  ) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+
+    await drawStroke(tester);
+
+    // Measured before Done pops the sheet and the canvas leaves the tree.
+    final laidOutSize = tester.getSize(canvas());
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+
+    expect(savedStrokes, isNotNull);
+    expect(savedStrokes, hasLength(1));
+    expect(savedStrokes!.single.length, greaterThan(1));
+
+    // The heart of issue #1358's cropping half: the size handed to the
+    // encoder has to be the size the strokes were drawn on. A hardcoded
+    // 400x200 silently cropped everything past x = 400.
+    expect(savedCanvasSize, isNotNull);
+    expect(savedCanvasSize, laidOutSize);
+    // Guards against the assertion passing vacuously if the sheet ever
+    // narrowed to the old hardcoded width.
+    expect(laidOutSize.width, greaterThan(400));
+  });
+
+  testWidgets('the sheet closes once the signature is handed back', (
+    tester,
+  ) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+
+    expect(canvas(), findsNothing);
+  });
+
+  testWidgets('Done stays disabled until something is drawn', (tester) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+
+    FilledButton doneButton() => tester.widget<FilledButton>(
+      find.ancestor(of: find.text('Done'), matching: find.byType(FilledButton)),
+    );
+
+    expect(doneButton().onPressed, isNull);
+
+    await drawStroke(tester);
+    expect(doneButton().onPressed, isNotNull);
+  });
+
+  testWidgets('Clear discards the strokes and re-disables Done', (
+    tester,
+  ) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Clear'));
+    await tester.pumpAndSettle();
+
+    final doneButton = tester.widget<FilledButton>(
+      find.ancestor(of: find.text('Done'), matching: find.byType(FilledButton)),
+    );
+    expect(doneButton.onPressed, isNull);
+    expect(savedStrokes, isNull);
+  });
+
+  testWidgets('Cancel closes without saving', (tester) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(canvas(), findsNothing);
+    expect(savedStrokes, isNull);
+  });
+}

--- a/test/features/signatures/presentation/widgets/buddy_signature_request_sheet_test.dart
+++ b/test/features/signatures/presentation/widgets/buddy_signature_request_sheet_test.dart
@@ -180,4 +180,22 @@ void main() {
     expect(canvas(), findsNothing);
     expect(savedStrokes, isNull);
   });
+
+  // A plain tap wins the gesture arena uncontested and reaches onPanEnd with
+  // a single point. The painter and the encoder both skip such a stroke, so
+  // storing it would enable Done and save a blank signature.
+  testWidgets('a tap on the canvas is not a signature', (tester) async {
+    await openSheet(tester);
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(tester.getCenter(canvas()));
+    await tester.pumpAndSettle();
+
+    final doneButton = tester.widget<FilledButton>(
+      find.ancestor(of: find.text('Done'), matching: find.byType(FilledButton)),
+    );
+    expect(doneButton.onPressed, isNull);
+    expect(savedStrokes, isNull);
+  });
 }

--- a/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
+++ b/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
@@ -3,9 +3,12 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:submersion/features/buddies/domain/entities/buddy.dart';
 import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
 import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/signatures/data/services/signature_storage_service.dart';
 import 'package:submersion/features/signatures/domain/entities/signature.dart';
 import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
 import 'package:submersion/features/signatures/presentation/widgets/buddy_signatures_section.dart';
@@ -74,6 +77,87 @@ void main() {
     expect(find.byType(Image), findsNothing);
   });
 
+  /// Drives Request -> Ready to Sign -> draw -> Done with [saveResult] as the
+  /// notifier's answer. The notifier is faked so the flow never reaches
+  /// `strokesToPng`, which would hang here; what is under test is how the
+  /// section reacts to the answer, not the encode.
+  Future<void> signWithResult(
+    WidgetTester tester,
+    Signature? saveResult,
+  ) async {
+    await tester.pumpWidget(
+      testApp(
+        // Pinned: the assertions match English strings.
+        locale: const Locale('en'),
+        overrides: [
+          buddiesForDiveProvider.overrideWith(
+            (ref, id) async => [
+              BuddyWithRole(buddy: buddy, role: DiveRole.builtInBuddy()),
+            ],
+          ),
+          buddySignaturesForDiveProvider.overrideWith((ref, id) async => []),
+          buddySignatureSaveNotifierProvider.overrideWith(
+            (ref) => _FakeSaveNotifier(ref, saveResult),
+          ),
+        ],
+        child: const BuddySignaturesSection(diveId: diveId),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Request'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Ready to Sign'));
+    await tester.pumpAndSettle();
+
+    final origin = tester.getCenter(find.bySemanticsLabel('Draw signature'));
+    final gesture = await tester.startGesture(origin - const Offset(60, 20));
+    await tester.pump();
+    for (var i = 0; i < 8; i++) {
+      await gesture.moveBy(const Offset(15, 5));
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a failed save tells the diver instead of failing silently', (
+    tester,
+  ) async {
+    // The #1358 symptom exactly: the save threw, the notifier swallowed it
+    // into an AsyncValue nothing watches, and the diver saw an unchanged
+    // Request button with no explanation.
+    await signWithResult(tester, null);
+
+    expect(
+      find.text('Could not save the signature. Please try again.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a successful save says nothing', (tester) async {
+    await signWithResult(
+      tester,
+      Signature(
+        id: 'sig-1',
+        diveId: diveId,
+        imageData: pngBytes,
+        signerId: buddyId,
+        signerName: buddy.name,
+        signedAt: DateTime.utc(2026, 1, 2),
+        type: SignatureType.buddy,
+      ),
+    );
+
+    expect(
+      find.text('Could not save the signature. Please try again.'),
+      findsNothing,
+    );
+  });
+
   testWidgets('shows the signature instead of Request once signed', (
     tester,
   ) async {
@@ -98,4 +182,27 @@ void main() {
     // signerId rather than merely rendered somewhere on the card.
     expect(find.text('1/1'), findsOneWidget);
   });
+}
+
+/// Answers [_result] without touching the encoder or the database, so the
+/// section's reaction to a save can be tested on its own.
+class _FakeSaveNotifier extends BuddySignatureSaveNotifier {
+  _FakeSaveNotifier(Ref ref, this._result)
+    : super(SignatureStorageService(), ref);
+
+  final Signature? _result;
+
+  @override
+  Future<Signature?> saveFromStrokes({
+    required String diveId,
+    required String buddyId,
+    required String buddyName,
+    required String role,
+    required List<List<Offset>> strokes,
+    required double width,
+    required double height,
+    Color strokeColor = const Color(0xFF000000),
+    double strokeWidth = 3.0,
+    Color? backgroundColor,
+  }) async => _result;
 }

--- a/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
+++ b/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
@@ -49,6 +49,8 @@ void main() {
   }) async {
     await tester.pumpWidget(
       testApp(
+        // Pinned: the assertions match English strings.
+        locale: const Locale('en'),
         overrides: [
           buddiesForDiveProvider.overrideWith(
             (ref, id) async => [

--- a/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
+++ b/test/features/signatures/presentation/widgets/buddy_signatures_section_test.dart
@@ -1,0 +1,99 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/buddies/domain/entities/buddy.dart';
+import 'package:submersion/features/buddies/presentation/providers/buddy_providers.dart';
+import 'package:submersion/features/dive_roles/domain/entities/dive_role.dart';
+import 'package:submersion/features/signatures/domain/entities/signature.dart';
+import 'package:submersion/features/signatures/presentation/providers/signature_providers.dart';
+import 'package:submersion/features/signatures/presentation/widgets/buddy_signatures_section.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The display half of issue #1358: once a buddy's signature exists, the card
+/// has to show it instead of the "Request" button.
+///
+/// The save half is covered in buddy_signature_save_notifier_test.dart, which
+/// runs the real notifier against a real database. It cannot live here: the
+/// save finishes through `Picture.toImage`, whose future the engine completes
+/// rather than a timer, so it never resumes under a widget test's fake clock.
+void main() {
+  const diveId = 'dive-1';
+  const buddyId = 'buddy-1';
+
+  final buddy = Buddy(
+    id: buddyId,
+    name: 'Reef Buddy',
+    createdAt: DateTime.utc(2026, 1, 1),
+    updatedAt: DateTime.utc(2026, 1, 1),
+  );
+
+  /// A 1x1 transparent PNG -- real bytes, so Image.memory decodes them.
+  final pngBytes = Uint8List.fromList(const [
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+    0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+    0x42, 0x60, 0x82,
+  ]);
+
+  Future<void> pumpSection(
+    WidgetTester tester, {
+    required List<Signature> signatures,
+  }) async {
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          buddiesForDiveProvider.overrideWith(
+            (ref, id) async => [
+              BuddyWithRole(buddy: buddy, role: DiveRole.builtInBuddy()),
+            ],
+          ),
+          buddySignaturesForDiveProvider.overrideWith(
+            (ref, id) async => signatures,
+          ),
+        ],
+        child: const BuddySignaturesSection(diveId: diveId),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('offers Request while the buddy has not signed', (tester) async {
+    await pumpSection(tester, signatures: const []);
+
+    expect(find.text('Request'), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+
+  testWidgets('shows the signature instead of Request once signed', (
+    tester,
+  ) async {
+    await pumpSection(
+      tester,
+      signatures: [
+        Signature(
+          id: 'sig-1',
+          diveId: diveId,
+          imageData: pngBytes,
+          signerId: buddyId,
+          signerName: buddy.name,
+          signedAt: DateTime.utc(2026, 1, 2),
+          type: SignatureType.buddy,
+        ),
+      ],
+    );
+
+    expect(find.text('Request'), findsNothing);
+    expect(find.byType(Image), findsOneWidget);
+    // The header counter proves the signature was matched to this buddy by
+    // signerId rather than merely rendered somewhere on the card.
+    expect(find.text('1/1'), findsOneWidget);
+  });
+}

--- a/test/features/signatures/presentation/widgets/signature_capture_widget_test.dart
+++ b/test/features/signatures/presentation/widgets/signature_capture_widget_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:submersion/features/signatures/presentation/widgets/signature_capture_widget.dart';
+
+import '../../../../helpers/test_app.dart';
+
+/// The instructor capture sheet, the twin of the buddy one. Both were
+/// untested before #1358, which is how a hardcoded PNG size and a companion
+/// missing a required column both survived.
+///
+/// Stops at the `onSave` boundary and never reaches `strokesToPng`: that
+/// finishes through `Picture.toImage`, whose future the engine completes
+/// rather than a timer, so it hangs under a widget test's fake clock.
+void main() {
+  late List<List<Offset>>? savedStrokes;
+  late String? savedName;
+  late Size? savedCanvasSize;
+
+  setUp(() {
+    savedStrokes = null;
+    savedName = null;
+    savedCanvasSize = null;
+  });
+
+  Future<void> openSheet(
+    WidgetTester tester, {
+    String? initialSignerName,
+  }) async {
+    await tester.pumpWidget(
+      testApp(
+        // Pinned: the assertions match English strings.
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => showSignatureCaptureSheet(
+              context: context,
+              initialSignerName: initialSignerName,
+              onSave: (strokes, name, canvasSize) {
+                savedStrokes = strokes;
+                savedName = name;
+                savedCanvasSize = canvasSize;
+              },
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  Finder canvas() => find.bySemanticsLabel('Draw signature');
+
+  Future<void> drawStroke(WidgetTester tester) async {
+    final origin = tester.getCenter(canvas());
+    final gesture = await tester.startGesture(origin - const Offset(60, 20));
+    await tester.pump();
+    for (var i = 0; i < 8; i++) {
+      await gesture.moveBy(const Offset(15, 5));
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('pre-fills the instructor name when one is known', (
+    tester,
+  ) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+
+    expect(find.text('Dive Instructor'), findsOneWidget);
+    expect(canvas(), findsOneWidget);
+  });
+
+  testWidgets('reports the canvas its own laid-out size, not a guess', (
+    tester,
+  ) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+    await drawStroke(tester);
+
+    // Measured before Save pops the sheet and the canvas leaves the tree.
+    final laidOutSize = tester.getSize(canvas());
+
+    await tester.tap(find.text('Save Signature'));
+    await tester.pumpAndSettle();
+
+    expect(savedStrokes, hasLength(1));
+    expect(savedName, 'Dive Instructor');
+    expect(savedCanvasSize, laidOutSize);
+    // Guards against the assertion passing vacuously if the sheet ever
+    // narrowed to the old hardcoded width.
+    expect(laidOutSize.width, greaterThan(400));
+  });
+
+  testWidgets('refuses to save without a signer name', (tester) async {
+    await openSheet(tester);
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Save Signature'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Please enter the signer name'), findsOneWidget);
+    expect(savedStrokes, isNull);
+  });
+
+  testWidgets('Save stays disabled until something is drawn', (tester) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+
+    FilledButton saveButton() => tester.widget<FilledButton>(
+      find.ancestor(
+        of: find.text('Save Signature'),
+        matching: find.byType(FilledButton),
+      ),
+    );
+
+    expect(saveButton().onPressed, isNull);
+
+    await drawStroke(tester);
+    expect(saveButton().onPressed, isNotNull);
+  });
+
+  testWidgets('Clear discards the strokes', (tester) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Clear'));
+    await tester.pumpAndSettle();
+
+    final saveButton = tester.widget<FilledButton>(
+      find.ancestor(
+        of: find.text('Save Signature'),
+        matching: find.byType(FilledButton),
+      ),
+    );
+    expect(saveButton.onPressed, isNull);
+  });
+
+  testWidgets('Cancel closes without saving', (tester) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+    await drawStroke(tester);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(canvas(), findsNothing);
+    expect(savedStrokes, isNull);
+  });
+}

--- a/test/features/signatures/presentation/widgets/signature_capture_widget_test.dart
+++ b/test/features/signatures/presentation/widgets/signature_capture_widget_test.dart
@@ -147,4 +147,22 @@ void main() {
     expect(canvas(), findsNothing);
     expect(savedStrokes, isNull);
   });
+
+  // A plain tap wins the gesture arena uncontested and reaches onPanEnd with
+  // a single point, which neither the painter nor the encoder draws.
+  testWidgets('a tap on the canvas is not a signature', (tester) async {
+    await openSheet(tester, initialSignerName: 'Dive Instructor');
+
+    await tester.tapAt(tester.getCenter(canvas()));
+    await tester.pumpAndSettle();
+
+    final saveButton = tester.widget<FilledButton>(
+      find.ancestor(
+        of: find.text('Save Signature'),
+        matching: find.byType(FilledButton),
+      ),
+    );
+    expect(saveButton.onPressed, isNull);
+    expect(savedStrokes, isNull);
+  });
 }


### PR DESCRIPTION
Fixes #1358.

## Root cause

Signature capture has never written a row, on any platform, for either
signature kind.

`media.file_path` is declared `text()()` in `database.dart`: NOT NULL, no
default. Both `SignatureStorageService.saveSignature` and
`saveBuddySignature` built a `MediaCompanion` that never set it, so Drift
rejected every insert in `validateIntegrity` before any SQL ran:

```
InvalidDataException: Sorry, MediaCompanion(... filePath: Value.absent() ...)
cannot be used for that because:
  • filePath: This value was required, but isn't present
```

The failure was silent from end to end: the service rethrew, the save
notifier caught it into an `AsyncValue` nothing in the tree watches, and the
sheet had already popped by then. The diver got a clean close and an
unchanged "Request" button. The reported "it doesn't sync between devices"
follows directly: media sync round-trips the row's `image_data` BLOB as
base64 correctly, there was simply never a row to send.

This has been broken since signatures moved from files to inline BLOBs
(schema v23). Instructor signatures are affected too, not just buddy ones.

Existing coverage could not catch it. The only save test closes the database
first and asserts `throwsA(anything)`, which passes for the wrong reason: the
call throws either way. Nothing ever exercised a successful save.

## The fix

Both inserts now set `file_path` to the empty string, the schema's existing
"no file behind this row" sentinel: the v72 `source_type` backfill tests
`file_path != ''` before classifying a row as a local file, and
`SignatureResolver` only falls back to the path when it is non-empty. They
also set `source_type = 'signature'`, so the rows route through
`SignatureResolver` rather than inheriting the column's `platformGallery`
default.

## A consequence of fixing it

Landing rows for the first time exposes a gap that was previously
unreachable. Buddy signatures use `file_type = 'buddy_signature'`, which
`parseMediaType` maps to `MediaType.photo`, and every signature exclusion in
the codebase knew only the two *instructor* spellings. A saved buddy
signature would have shown up as a photo in the media library and as a
marker pinned on the dive profile chart.

`MediaItem.isSignature` is now the single predicate. It checks media type
*or* source type, because neither alone is complete: instructor rows written
before the v72 backfill are typed only by `mediaType`, and buddy rows only by
`sourceType`. The profile markers and the dive media enricher use it;
`kSignatureFileTypes` and `hasAnyMedia()` learn the buddy spelling.

## Two related defects in the same path

- The strokes are captured in canvas-local coordinates, but the PNG was
  rendered at a hardcoded 400x200 (with a comment conceding it was a guess).
  The canvas stretches to the sheet width, so on a macOS sheet of roughly
  608px the right third of every signature was cropped. Both capture widgets
  now report their laid-out size through a `LayoutBuilder`, and both call
  sites render at that size.
- A failed save now raises a SnackBar (`signatures_error_saveFailed`,
  translated into all 11 locales) instead of vanishing.

## Testing

- `dart analyze` clean across the project; `dart format .` applied.
- Six new tests fail on unfixed code and pass with the fix, verified by
  stashing the service change and re-running.
- Coverage is split at the fake-clock seam. A plain `test()` drives the real
  notifier end to end (strokes -> PNG -> insert -> provider re-read) against a
  real in-memory database, with nothing below the notifier mocked. It cannot
  be a widget test: the save finishes through `Picture.toImage`, whose future
  the engine completes rather than a timer, so it hangs forever under the
  fake clock `testWidgets` installs. A separate `testWidgets` covers the
  rendering half: "Request" while unsigned, the signature preview and a 1/1
  counter once signed.
- A regression test asserts the encoded PNG matches the canvas the strokes
  were drawn on, and another asserts signatures stay out of both the media
  library page and `hasAnyMedia()`.

Note for reviewers: `test/features/media/data/resolvers/local_file_resolver_test.dart`
fails locally when `$TMPDIR` sits on a mounted volume (a RAM disk), which is a
known environment artifact unrelated to this change. It passes with a
system-volume `TMPDIR`, and the pre-push hook is green that way.
