### PR TITLE
fix(dive): compare filter dates as calendar days against wall-clock-UTC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,10 +248,11 @@ jobs:
         # must equal (shard count + 1) for the scripts job -- Codecov holds the
         # patch/project status until every partial lcov arrives (see codecov.yml).
         # It is also bounded by the account-wide concurrent-job cap: this workflow
-        # already fans out ~9-10 non-test jobs (analyze + 5 builds + scripts +
-        # integration) that share the pool AND gate ci-success, so oversharding
-        # queues the builds and makes total CI slower, not faster. 8 keeps us
-        # under the cap while roughly halving test wall-clock.
+        # already fans out ~10-11 non-test jobs (analyze + 5 builds + scripts +
+        # timezone + integration) that share the pool AND gate ci-success, so
+        # oversharding queues the builds and makes total CI slower, not
+        # faster. 8 keeps us under the cap while roughly halving test
+        # wall-clock.
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       TOTAL_SHARDS: 8
@@ -337,6 +338,96 @@ jobs:
           # Per-shard flag so Codecov merges the partial reports for this commit.
           flags: shard-${{ matrix.shard }}
           fail_ci_if_error: false  # Enable after configuring repo on codecov.io
+
+  # Replays the timezone-sensitive tests under a non-UTC zone. The runners are
+  # UTC, where a device's UTC offset is zero and a whole class of frame bug
+  # cannot reproduce: `dives.dive_date_time` holds a wall clock flagged as UTC
+  # while the filter's dates are built LOCAL, so mixing the two frames shifts
+  # the day boundary by exactly that offset and stays invisible here
+  # (issue #1368).
+  #
+  # Two zones, because they fail differently: America/New_York is a whole hour
+  # WEST of UTC (a boundary pulls dives out), Australia/Adelaide is a HALF hour
+  # EAST (a boundary pulls extra dives in, and the half hour catches rounding a
+  # whole-hour offset hides). Both observe DST, so a `Duration(days: 1)` added
+  # to a local date lands 23 or 25 hours out at a transition.
+  #
+  # Scoped to a hand-maintained file list rather than the whole suite: an
+  # unscoped `flutter test --tags ...` still compiles every test file, which is
+  # the dominant cost. Add any new test whose result depends on the machine's
+  # zone here.
+  timezone-tests:
+    name: Timezone Tests
+    needs: codegen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Read Flutter version
+        id: flutter-ver
+        run: echo "version=$(cat ${{ env.FLUTTER_VERSION_FILE }})" >> "$GITHUB_OUTPUT"
+
+      - uses: subosito/flutter-action@v2
+        id: setup-flutter
+        with:
+          flutter-version: ${{ steps.flutter-ver.outputs.version }}
+          channel: 'stable'
+
+      - name: Cache Flutter SDK
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.setup-flutter.outputs.CACHE-PATH }}
+          key: ${{ steps.setup-flutter.outputs.CACHE-KEY }}
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.pub-cache
+            ${{ github.workspace }}/.dart_tool
+          key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            pub-${{ runner.os }}-
+
+      - name: Disable Swift Package Manager (project uses CocoaPods)
+        run: flutter config --no-enable-swift-package-manager
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Download generated code
+        uses: actions/download-artifact@v8
+        with:
+          name: generated-code
+
+      - name: Unpack generated code
+        run: tar -xzf generated-code.tar.gz
+
+      - name: Run zone-sensitive tests under non-UTC zones
+        run: |
+          set -euo pipefail
+          files=(
+            test/features/dive_log/dive_filter_date_boundary_test.dart
+            test/features/dive_log/domain/models/dive_filter_state_test.dart
+            test/features/dive_log/data/repositories/dive_records_filter_test.dart
+            test/features/dive_log/data/repositories/dive_repository_weekday_filter_test.dart
+            test/features/statistics/data/dive_filter_sql_test.dart
+          )
+          # Guard against a rename silently emptying the list: with no paths,
+          # `flutter test` would run the ENTIRE suite twice and look green.
+          for f in "${files[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Listed test file is missing: $f"
+              exit 1
+            fi
+          done
+          for zone in America/New_York Australia/Adelaide; do
+            echo "::group::TZ=$zone"
+            TZ="$zone" flutter test "${files[@]}"
+            echo "::endgroup::"
+          done
 
   # Unit-tests the dependency-free Python guard scripts (e.g. the issue #318
   # ProGuard keep-rule checker). No Flutter/codegen needed, so it runs in
@@ -1082,6 +1173,7 @@ jobs:
       - codegen
       - analyze
       - test
+      - timezone-tests
       - integration-test
       - build-ios
       - build-macos

--- a/lib/core/util/wall_clock_utc.dart
+++ b/lib/core/util/wall_clock_utc.dart
@@ -14,6 +14,9 @@
 ///   but should match wall-clock-UTC dive times.
 /// * [fromWallClockUtc] — the inverse, for reading a stored wall-clock-UTC
 ///   value back into the local `DateTime` the UI works in.
+/// * [wallClockUtcDayStart] gives the start of a calendar day in
+///   wall-clock-UTC, for comparing a date the user picked against stored
+///   wall-clock values.
 library;
 
 /// Matches a trailing `Z` or `+hh:mm` / `-hh:mm` / `+hhmm` / `-hhmm` offset
@@ -90,3 +93,16 @@ DateTime fromWallClockUtc(DateTime wallClockUtc) {
     wallClockUtc.millisecond,
   );
 }
+
+/// Start of [date]'s calendar day in wall-clock-UTC, discarding any
+/// time-of-day component and any timezone offset [date] carries.
+///
+/// This is the bridge a date the diver *picked* has to cross before it can be
+/// compared against a stored wall-clock-UTC timestamp (issue #1368). Pickers
+/// and preset builders produce LOCAL `DateTime`s, whose
+/// `millisecondsSinceEpoch` is local midnight shifted by the device's UTC
+/// offset; comparing that raw against wall-clock-UTC values moved the day
+/// boundary by that offset. Reading only the calendar components makes the
+/// result identical whichever flavor the caller holds.
+DateTime wallClockUtcDayStart(DateTime date) =>
+    DateTime.utc(date.year, date.month, date.day);

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -2367,14 +2367,19 @@ class DiveRepository {
     List<String> clauses,
     List<Variable<Object>> args,
   ) {
-    if (filter.startDate != null) {
+    // Bounds come pre-normalized to the wall-clock-as-UTC frame the column
+    // stores, so a locally-built filter date lands on the right day boundary
+    // whatever the device's UTC offset is (issue #1368). Half-open, matching
+    // buildFilteredDiveIdSubquery and DiveFilterState.apply.
+    final startBoundMs = filter.startDateBoundMs;
+    if (startBoundMs != null) {
       clauses.add('d.dive_date_time >= ?');
-      args.add(Variable(filter.startDate!.millisecondsSinceEpoch));
+      args.add(Variable(startBoundMs));
     }
-    if (filter.endDate != null) {
-      final endOfDay = filter.endDate!.add(const Duration(days: 1));
+    final endBoundMs = filter.endDateBoundMs;
+    if (endBoundMs != null) {
       clauses.add('d.dive_date_time < ?');
-      args.add(Variable(endOfDay.millisecondsSinceEpoch));
+      args.add(Variable(endBoundMs));
     }
     if (filter.diveTypeId != null) {
       clauses.add(

--- a/lib/features/dive_log/domain/models/dive_filter_state.dart
+++ b/lib/features/dive_log/domain/models/dive_filter_state.dart
@@ -1,4 +1,5 @@
 import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/util/wall_clock_utc.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/equipment/domain/constants/equipment_attribute_catalog.dart';
 
@@ -7,7 +8,19 @@ import 'package:submersion/features/equipment/domain/constants/equipment_attribu
 /// Used by both the provider layer (UI filter state) and the repository layer
 /// (SQL WHERE clause generation for paginated queries).
 class DiveFilterState {
+  /// Inclusive first day of the range, treated as a CALENDAR DATE: only the
+  /// year/month/day are read, and any time-of-day or timezone flag the value
+  /// carries is discarded.
+  ///
+  /// Producers build these locally (the filter sheet's presets, and
+  /// `showAppDatePicker` by construction) while `dives.dive_date_time` holds a
+  /// wall clock flagged as UTC. Comparing the two frames raw shifted the day
+  /// boundary by the device's UTC offset (issue #1368), so every comparison
+  /// site goes through [startDateBoundMs] / [endDateBoundMs] instead.
   final DateTime? startDate;
+
+  /// Inclusive last day of the range. See [startDate] for the calendar-date
+  /// semantics; the whole of this day is kept.
   final DateTime? endDate;
   final String? diveTypeId;
   final String? siteId;
@@ -108,6 +121,29 @@ class DiveFilterState {
     this.equipmentAttrMin,
     this.equipmentAttrMax,
   });
+
+  /// Inclusive lower bound for `dives.dive_date_time`, in the wall-clock-as-UTC
+  /// epoch milliseconds that column stores. Null when [startDate] is unset.
+  ///
+  /// Every date comparison, in SQL and in [apply], binds this value, so the
+  /// three implementations of the axis cannot drift apart.
+  int? get startDateBoundMs {
+    final date = startDate;
+    if (date == null) return null;
+    return wallClockUtcDayStart(date).millisecondsSinceEpoch;
+  }
+
+  /// EXCLUSIVE upper bound for `dives.dive_date_time`: the start of the day
+  /// after [endDate], so the whole of the end day is inside the range. Null
+  /// when [endDate] is unset.
+  int? get endDateBoundMs {
+    final date = endDate;
+    if (date == null) return null;
+    // UTC has no DST, so adding a day here is exact.
+    return wallClockUtcDayStart(
+      date,
+    ).add(const Duration(days: 1)).millisecondsSinceEpoch;
+  }
 
   bool get hasActiveFilters =>
       startDate != null ||
@@ -276,13 +312,26 @@ class DiveFilterState {
   /// axis intersect this result with `decoFilteredDiveIdsProvider`, which
   /// resolves it through the same SQL condition the paginated list uses.
   List<Dive> apply(List<Dive> dives) {
+    final startBound = startDateBoundMs;
+    final endBound = endDateBoundMs;
     return dives.where((dive) {
-      if (startDate != null && dive.dateTime.isBefore(startDate!)) {
-        return false;
-      }
-      if (endDate != null &&
-          dive.dateTime.isAfter(endDate!.add(const Duration(days: 1)))) {
-        return false;
+      if (startBound != null || endBound != null) {
+        // Compare CALENDAR DAYS, not instants. Reducing the dive to the start
+        // of its own day makes this identical to the SQL half-open range
+        // (`>= startBound AND < endBound`), because both bounds are themselves
+        // day starts: a timestamp satisfies them exactly when its day does.
+        // Going through the day start also keeps the comparison honest for a
+        // caller holding a local-flagged entity, since only the digits the
+        // diver sees are read.
+        final diveDay = wallClockUtcDayStart(
+          dive.dateTime,
+        ).millisecondsSinceEpoch;
+        if (startBound != null && diveDay < startBound) {
+          return false;
+        }
+        if (endBound != null && diveDay >= endBound) {
+          return false;
+        }
       }
       if (diveTypeId != null && !dive.diveTypeIds.contains(diveTypeId)) {
         return false;

--- a/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_filter_sheet.dart
@@ -226,6 +226,13 @@ class _DiveFilterSheetState extends ConsumerState<DiveFilterSheet> {
                         style: Theme.of(context).textTheme.titleMedium,
                       ),
                       const SizedBox(height: 8),
+                      // These presets, and the two date buttons below, hand
+                      // DiveFilterState LOCAL DateTimes. That is deliberate:
+                      // the filter reads them as CALENDAR DATES and normalizes
+                      // to the wall-clock-as-UTC frame the dive rows use, so
+                      // there is nothing to gain by building them with
+                      // DateTime.utc here (issue #1368). Only year/month/day
+                      // are ever read.
                       Wrap(
                         spacing: 8,
                         children: [

--- a/lib/features/statistics/data/dive_filter_sql.dart
+++ b/lib/features/statistics/data/dive_filter_sql.dart
@@ -15,17 +15,20 @@ import 'package:submersion/features/equipment/domain/constants/equipment_attribu
   final conditions = <String>[];
   final params = <Object?>[];
 
-  // Date range. dive_date_time is epoch MILLISECONDS (wall-clock-as-UTC).
-  if (filter.startDate != null) {
+  // Date range. dive_date_time is epoch MILLISECONDS (wall-clock-as-UTC), and
+  // the bounds are already normalized to that frame by DiveFilterState, so the
+  // two sides of the comparison agree on where a day starts (issue #1368).
+  // Half-open: the end bound is the start of the day AFTER endDate, which
+  // keeps the whole end day and matches apply() and the paginated list.
+  final startBoundMs = filter.startDateBoundMs;
+  if (startBoundMs != null) {
     conditions.add('dive_date_time >= ?');
-    params.add(filter.startDate!.millisecondsSinceEpoch);
+    params.add(startBoundMs);
   }
-  if (filter.endDate != null) {
-    // apply() keeps dives up to endDate + 1 day (inclusive of the end day).
-    conditions.add('dive_date_time <= ?');
-    params.add(
-      filter.endDate!.add(const Duration(days: 1)).millisecondsSinceEpoch,
-    );
+  final endBoundMs = filter.endDateBoundMs;
+  if (endBoundMs != null) {
+    conditions.add('dive_date_time < ?');
+    params.add(endBoundMs);
   }
 
   // Dive type: membership against the many-to-many junction.

--- a/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
+++ b/test/features/dive_log/data/repositories/dive_ordered_ids_test.dart
@@ -80,13 +80,18 @@ void main() {
   });
 
   test('applies filter where-clause', () async {
-    await insertDive('a', 2000);
-    await insertDive('c', 500); // before the filter window
+    // The date axis is a CALENDAR DATE range (issue #1368), so the window is
+    // expressed in days, not milliseconds. Rows carry a wall clock flagged as
+    // UTC, matching the column; the filter date is LOCAL, as the pickers
+    // build it.
+    await insertDive('a', DateTime.utc(2026, 6, 15).millisecondsSinceEpoch);
+    await insertDive(
+      'c',
+      DateTime.utc(2026, 5, 1).millisecondsSinceEpoch,
+    ); // before the filter window
 
     final ids = await repository.getOrderedDiveIds(
-      filter: DiveFilterState(
-        startDate: DateTime.fromMillisecondsSinceEpoch(1000),
-      ),
+      filter: DiveFilterState(startDate: DateTime(2026, 6, 1)),
     );
 
     expect(ids, ['a']);

--- a/test/features/dive_log/data/repositories/dive_records_filter_test.dart
+++ b/test/features/dive_log/data/repositories/dive_records_filter_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/util/wall_clock_utc.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
 
@@ -65,7 +66,13 @@ void main() {
           DivesCompanion(
             id: Value(id),
             diverId: Value(diverId),
-            diveDateTime: Value(date.millisecondsSinceEpoch),
+            // dive_date_time holds a wall clock flagged as UTC (the digits
+            // on the computer face, stored verbatim), so the fixture has to
+            // write the same frame the app does. Passing a LOCAL DateTime's
+            // raw epoch would shift the stored wall clock by the machine's
+            // UTC offset and quietly move these dives to another day under
+            // any non-UTC zone (issue #1368).
+            diveDateTime: Value(asWallClockUtc(date).millisecondsSinceEpoch),
             siteId: Value(siteId),
             maxDepth: Value(maxDepth),
             waterTemp: Value(waterTemp),

--- a/test/features/dive_log/data/repositories/dive_repository_weekday_filter_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_weekday_filter_test.dart
@@ -6,6 +6,12 @@ import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dar
 
 import '../../../../helpers/test_database.dart';
 
+/// Dives reach the DB through `createDive`, which writes
+/// `dive.dateTime.millisecondsSinceEpoch` verbatim into the wall-clock-as-UTC
+/// `dive_date_time` column. The fixtures therefore build UTC-flagged dives, as
+/// the app does: a LOCAL DateTime here would store a wall clock shifted by the
+/// machine's UTC offset and land on a different weekday under some zones
+/// (issue #1368). Filter dates stay LOCAL, which is what the pickers produce.
 void main() {
   late DiveRepository repository;
 
@@ -18,9 +24,9 @@ void main() {
   test('SQL filter matches ANY selected weekday', () async {
     // 28 days apart (4 whole weeks) guarantees the same weekday regardless
     // of which actual day of the week these calendar dates land on.
-    final mondayA = DateTime(2026, 6, 8);
-    final mondayB = DateTime(2026, 7, 6);
-    final tuesday = DateTime(2026, 6, 9);
+    final mondayA = DateTime.utc(2026, 6, 8);
+    final mondayB = DateTime.utc(2026, 7, 6);
+    final tuesday = DateTime.utc(2026, 6, 9);
     await repository.createDive(domain.Dive(id: 'd1', dateTime: mondayA));
     await repository.createDive(domain.Dive(id: 'd2', dateTime: mondayB));
     await repository.createDive(domain.Dive(id: 'd3', dateTime: tuesday));
@@ -33,9 +39,9 @@ void main() {
   });
 
   test('SQL filter ANDs weekday with date range', () async {
-    final mondayInRange = DateTime(2026, 6, 8);
-    final mondayOutOfRange = DateTime(2026, 7, 6);
-    final tuesdayInRange = DateTime(2026, 6, 9);
+    final mondayInRange = DateTime.utc(2026, 6, 8);
+    final mondayOutOfRange = DateTime.utc(2026, 7, 6);
+    final tuesdayInRange = DateTime.utc(2026, 6, 9);
     await repository.createDive(domain.Dive(id: 'd1', dateTime: mondayInRange));
     await repository.createDive(
       domain.Dive(id: 'd2', dateTime: mondayOutOfRange),
@@ -55,8 +61,8 @@ void main() {
   });
 
   test('in-memory apply() matches by weekday membership', () {
-    final monday = DateTime(2026, 6, 8);
-    final tuesday = DateTime(2026, 6, 9);
+    final monday = DateTime.utc(2026, 6, 8);
+    final tuesday = DateTime.utc(2026, 6, 9);
     final dives = [
       domain.Dive(id: 'a', dateTime: monday),
       domain.Dive(id: 'b', dateTime: tuesday),

--- a/test/features/dive_log/dive_filter_date_boundary_test.dart
+++ b/test/features/dive_log/dive_filter_date_boundary_test.dart
@@ -1,0 +1,215 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/dive_filter_sql.dart';
+
+import '../../helpers/test_database.dart';
+
+/// Issue #1368: `dives.dive_date_time` holds a wall clock flagged as UTC,
+/// while every producer of a filter date builds a LOCAL `DateTime` (the
+/// presets in the filter sheet, and `showAppDatePicker` by construction).
+/// Comparing the two frames put the day boundary off by the device's UTC
+/// offset, so a dive within that offset of a boundary was silently in or out
+/// of the range.
+///
+/// The date axis has three implementations that must agree: the statistics
+/// SQL subquery, the paginated dive list's WHERE builder, and the in-memory
+/// `apply()` used by export/table/map views. This pins all three against the
+/// same fixtures.
+///
+/// CI runs in UTC, where the offset is zero and the original bug cannot
+/// reproduce, so the boundary-getter group deliberately feeds filter dates
+/// that CARRY a time-of-day: that is the shape a non-zero offset produces,
+/// and it fails under UTC too. The `.github/workflows/ci.yaml` timezone job
+/// additionally replays this file under a whole-hour and a half-hour zone.
+void main() {
+  late AppDatabase db;
+  late DiveRepository repository;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+  tearDown(() async => tearDownTestDatabase());
+
+  // Wall clocks, as the entity and the column carry them. The four fixtures
+  // straddle the two boundaries of a 2026-01-01..2026-06-30 range by less
+  // than any real UTC offset.
+  final justInsideStart = DateTime.utc(2026, 1, 1, 2, 0);
+  final justBeforeStart = DateTime.utc(2025, 12, 31, 22, 0);
+  final justInsideEnd = DateTime.utc(2026, 6, 30, 23, 30);
+  final justAfterEnd = DateTime.utc(2026, 7, 1, 0, 0);
+
+  // The dates a producer hands the filter: LOCAL midnights, exactly what the
+  // presets and the date picker build.
+  final rangeStart = DateTime(2026, 1, 1);
+  final rangeEnd = DateTime(2026, 6, 30);
+
+  DiveFilterState rangeFilter() =>
+      DiveFilterState(startDate: rangeStart, endDate: rangeEnd);
+
+  List<domain.Dive> allDives() => [
+    domain.Dive(id: 'just-inside-start', dateTime: justInsideStart),
+    domain.Dive(id: 'just-before-start', dateTime: justBeforeStart),
+    domain.Dive(id: 'just-inside-end', dateTime: justInsideEnd),
+    domain.Dive(id: 'just-after-end', dateTime: justAfterEnd),
+  ];
+
+  Future<void> seedDives() async {
+    for (final dive in allDives()) {
+      await repository.createDive(dive);
+    }
+  }
+
+  Future<Set<String>> subqueryIdsMatching(DiveFilterState filter) async {
+    final f = buildFilteredDiveIdSubquery(filter);
+    final sql = f.subquery.isEmpty ? 'SELECT id FROM dives' : f.subquery;
+    final rows = await db
+        .customSelect(sql, variables: f.params.map((p) => Variable(p)).toList())
+        .get();
+    return rows.map((r) => r.read<String>('id')).toSet();
+  }
+
+  group('boundary getters', () {
+    test('a null date leaves its bound null', () {
+      const filter = DiveFilterState();
+      expect(filter.startDateBoundMs, isNull);
+      expect(filter.endDateBoundMs, isNull);
+    });
+
+    test('startDateBoundMs is the start of the calendar day', () {
+      expect(
+        DiveFilterState(startDate: rangeStart).startDateBoundMs,
+        DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+      );
+    });
+
+    test('startDateBoundMs discards a time-of-day component', () {
+      // A local midnight west of UTC arrives here as an instant with a
+      // non-zero UTC time-of-day. That component is the bug: it must not
+      // reach the comparison.
+      expect(
+        DiveFilterState(
+          startDate: DateTime.utc(2026, 1, 1, 5, 0),
+        ).startDateBoundMs,
+        DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+      );
+      expect(
+        DiveFilterState(
+          startDate: DateTime.utc(2026, 1, 1, 23, 59, 59, 999),
+        ).startDateBoundMs,
+        DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+      );
+    });
+
+    test('endDateBoundMs is exclusive: the start of the day AFTER endDate', () {
+      expect(
+        DiveFilterState(endDate: rangeEnd).endDateBoundMs,
+        DateTime.utc(2026, 7, 1).millisecondsSinceEpoch,
+      );
+    });
+
+    test('endDateBoundMs discards a time-of-day component', () {
+      expect(
+        DiveFilterState(
+          endDate: DateTime.utc(2026, 6, 30, 13, 30),
+        ).endDateBoundMs,
+        DateTime.utc(2026, 7, 1).millisecondsSinceEpoch,
+      );
+    });
+  });
+
+  group('apply()', () {
+    test('keeps the whole start day and excludes the day before', () {
+      final ids = rangeFilter().apply(allDives()).map((d) => d.id).toSet();
+      expect(
+        ids,
+        contains('just-inside-start'),
+        reason: '02:00 on the start day is inside a range starting that day',
+      );
+      expect(
+        ids,
+        isNot(contains('just-before-start')),
+        reason: '22:00 the previous day is outside it',
+      );
+    });
+
+    test('keeps the whole end day and excludes the day after', () {
+      final ids = rangeFilter().apply(allDives()).map((d) => d.id).toSet();
+      expect(
+        ids,
+        contains('just-inside-end'),
+        reason: '23:30 on the end day is inside a range ending that day',
+      );
+      expect(
+        ids,
+        isNot(contains('just-after-end')),
+        reason: 'midnight the following day is outside it',
+      );
+    });
+
+    test('a local-frame dive is matched on its calendar day too', () {
+      // apply() is public and takes whatever entities a caller holds, so it
+      // compares calendar days rather than instants: a dive whose DateTime
+      // was built local reads the same digits the diver sees.
+      final localDive = domain.Dive(
+        id: 'local',
+        dateTime: DateTime(2026, 1, 1, 2, 0),
+      );
+      expect(rangeFilter().apply([localDive]).map((d) => d.id), ['local']);
+    });
+  });
+
+  group('statistics SQL subquery', () {
+    test('matches apply() on both boundaries', () async {
+      await seedDives();
+      expect(await subqueryIdsMatching(rangeFilter()), {
+        'just-inside-start',
+        'just-inside-end',
+      });
+    });
+
+    test('binds the shared bounds, half-open', () {
+      final f = buildFilteredDiveIdSubquery(rangeFilter());
+      expect(f.subquery, contains('dive_date_time >= ?'));
+      expect(
+        f.subquery,
+        contains('dive_date_time < ?'),
+        reason: 'the end bound is the exclusive start of the following day',
+      );
+      expect(f.params.take(2), [
+        DateTime.utc(2026, 1, 1).millisecondsSinceEpoch,
+        DateTime.utc(2026, 7, 1).millisecondsSinceEpoch,
+      ]);
+    });
+  });
+
+  group('paginated dive list SQL', () {
+    test('matches apply() on both boundaries', () async {
+      await seedDives();
+      final results = await repository.getDiveSummaries(filter: rangeFilter());
+      expect(results.map((d) => d.id).toSet(), {
+        'just-inside-start',
+        'just-inside-end',
+      });
+    });
+  });
+
+  test('all three paths agree on an open-ended range', () async {
+    await seedDives();
+    final filter = DiveFilterState(startDate: rangeStart);
+    final expected = {'just-inside-start', 'just-inside-end', 'just-after-end'};
+    expect(filter.apply(allDives()).map((d) => d.id).toSet(), expected);
+    expect(await subqueryIdsMatching(filter), expected);
+    expect(
+      (await repository.getDiveSummaries(
+        filter: filter,
+      )).map((d) => d.id).toSet(),
+      expected,
+    );
+  });
+}

--- a/test/features/statistics/data/dive_filter_sql_test.dart
+++ b/test/features/statistics/data/dive_filter_sql_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/util/wall_clock_utc.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as dive_entity;
@@ -39,8 +40,16 @@ void main() {
         .insert(
           DivesCompanion(
             id: Value(id),
+            // dive_date_time holds a wall clock flagged as UTC (the digits
+            // on the computer face, stored verbatim), so the fixture has to
+            // write the same frame the app does. Passing a LOCAL DateTime's
+            // raw epoch would shift the stored wall clock by the machine's
+            // UTC offset and quietly move these dives to another day under
+            // any non-UTC zone (issue #1368).
             diveDateTime: Value(
-              (date ?? DateTime(2026, 6, 1)).millisecondsSinceEpoch,
+              asWallClockUtc(
+                date ?? DateTime(2026, 6, 1),
+              ).millisecondsSinceEpoch,
             ),
             siteId: Value(siteId),
             diveCenterId: Value(diveCenterId),
@@ -465,7 +474,9 @@ void main() {
             .insert(
               DivesCompanion(
                 id: Value(id),
-                diveDateTime: Value(date.millisecondsSinceEpoch),
+                diveDateTime: Value(
+                  asWallClockUtc(date).millisecondsSinceEpoch,
+                ),
                 bottomTime: Value(bt),
                 createdAt: Value(now),
                 updatedAt: Value(now),
@@ -476,7 +487,8 @@ void main() {
           .map(
             (c) => dive_entity.Dive(
               id: c.$1,
-              dateTime: c.$2,
+              // Entities carry the same wall-clock-UTC value the rows do.
+              dateTime: asWallClockUtc(c.$2),
               bottomTime: Duration(seconds: c.$3),
             ),
           )


### PR DESCRIPTION
## Summary

Fixes #1368.

`dives.dive_date_time` stores a wall clock flagged as UTC. Every producer of a filter date builds a **local** `DateTime` (the presets in the filter sheet, and `showAppDatePicker` by construction), and all three comparison sites bound that raw instant against the column. The effective day boundary therefore sat at the device's UTC offset rather than at midnight.

At UTC-5, "This year" resolved to 05:00 UTC on 1 January and silently dropped any dive logged before then. East of UTC the error ran the other way and pulled in part of 31 December. A dive within the offset of a boundary was in or out of every filtered statistic, and of the dive list, with nothing on screen to say so.

Investigating turned up a second, independent defect the issue did not mention: **the three sites had already drifted on the end bound.** `apply()` and the statistics subquery kept dives up to and *including* `endDate + 1 day`, while the paginated list used a strict `<`. A dive logged at exactly 00:00 on the day after `endDate` appeared in Statistics but not in the dive list. All three are half-open now.

## Changes

- `DiveFilterState.startDate` / `endDate` are now documented and treated as **calendar dates**: only year/month/day are read, and any time-of-day or UTC flag is discarded.
- Two derived bounds in the frame the column actually uses: `startDateBoundMs` (inclusive) and `endDateBoundMs` (exclusive, the start of the day after `endDate`).
- All three comparison sites bind those same integers, so they cannot drift apart:
  - `DiveFilterState.apply()` (export, table and map views)
  - `buildFilteredDiveIdSubquery` (statistics)
  - `DiveRepository._buildFilterWhereClauses` (paginated dive list)
- New `wallClockUtcDayStart` in `lib/core/util/wall_clock_utc.dart`, joining the family that already owns this convention. Its library docstring already named filter bounds as a consumer.
- A note in the filter sheet explaining why the presets deliberately stay local, so nobody "fixes" them into the instant frame.
- New CI job `timezone-tests`, wired into the `ci-success` gate.

### Why `apply()` compares calendar days

Reducing the dive to the start of its own day makes it identical to the SQL half-open range, because both bounds are themselves day starts: a timestamp satisfies them exactly when its day start does. Going through the day start also keeps the comparison honest for a caller holding a local-flagged entity, since only the digits the diver sees are read.

## Behavior change worth reviewing deliberately

**The date axis is now day-granular, not instant-granular.** A filter carrying a time-of-day previously narrowed the range to that instant; it now rounds out to the whole calendar day.

Nothing in `lib/` ever set a time-of-day (the presets and both date pickers all produce midnight), so no shipping surface changes. But `dive_ordered_ids_test` was filtering a **half-second** window (`fromMillisecondsSinceEpoch(1000)` against a dive at epoch ms 500), which only means anything under instant semantics, so it is rewritten in days. That test failing was the correct signal.

## Testing

CI runners are UTC, where a device's offset is zero and this class of frame bug cannot reproduce. Two things address that:

1. **New `timezone-tests` job** replays the zone-sensitive files under `America/New_York` (a whole hour west, so a boundary pulls dives out) and `Australia/Adelaide` (a half hour east, so it pulls extra dives in, and the half hour catches rounding a whole-hour offset hides). Both observe DST, which also matters: `Duration(days: 1)` added to a *local* date lands 23 or 25 hours out at a transition. It needs `codegen`, so docs-only changes skip it like the other test jobs. Scoped to a hand-maintained file list with an existence guard, rather than an unscoped `--tags` run that would still compile every test file.

2. **New `test/features/dive_log/dive_filter_date_boundary_test.dart`**, 12 cases pinning both boundaries across all three paths. Confirmed to fail before this change: **6 cases under `America/New_York`**, and **3 under `TZ=UTC`** from the half-open drift, which CI could have caught on its own.

The boundary-getter cases deliberately feed filter dates that *carry* a time-of-day. That is the shape a non-zero offset produces, so those assertions bite under UTC too rather than passing trivially.

### Fixtures that could never fail

Three existing fixtures wrote `localDateTime.millisecondsSinceEpoch` into the wall-clock-UTC column, so they were keyed the same wrong way as the bug and the two wrongs cancelled. Under `Australia/Adelaide` the weekday tests broke on that alone, independently of this change. They now write the frame the app writes, matching what 1d491ccbec9 did for the exclusion fixtures.

### Results

| Check | Result |
| --- | --- |
| `flutter test` (full suite) | 22036 passed, 20 skipped, 0 failed |
| `flutter analyze` | No issues found |
| `dart format .` | Clean |
| New boundary test | Green under UTC, America/New_York, Australia/Adelaide, Pacific/Kiritimati |
| Date and weekday tests (96 cases) | Green under all three zones after rekeying |

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [ ] Manual testing on: not yet run in the app. The change is exercised end to end by the SQL-backed and in-memory tests across four zones; a macOS pass over the dive list and Statistics date presets would still be worth doing before merge.
