### PR TITLE
feat: profile series codec (packed sample storage, part 1)

### DIFF
--- a/docs/superpowers/plans/2026-08-29-profile-series-codec.md
+++ b/docs/superpowers/plans/2026-08-29-profile-series-codec.md
@@ -1,0 +1,2456 @@
+# Profile Series Codec Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship PR 1 of the packed-series program: a pure-Dart, lossless, versioned codec that packs a dive's profile samples (and a tank's pressure samples) into one zlib-compressed columnar blob and back, together with the summary scalars the series tables will store.
+
+**Architecture:** A small byte-level reader/writer (`byte_io.dart`) provides varints, zigzag signed varints, float64, and presence-bitmapped columns. `ProfileSeriesCodec` walks a fixed, versioned field table over a `ProfileSample` value type, writes one column block per field, and zlib-compresses the result; decoding reverses it strictly and throws `ProfileSeriesCodecException` on anything malformed. `TankPressureSeriesCodec` is the two-field sibling. Nothing in this PR touches the database, the repositories, or sync; the codec is consumed in PR 2.
+
+**Tech Stack:** Dart 3 (records, switch expressions), `dart:typed_data`, `dart:io` `ZLibCodec`, `package:equatable`, `flutter_test`, Drift's generated table metadata (test only).
+
+**Spec:** `docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md`, sections 3 (architecture), 5 (codec v1), 10 (codec tests), 11 (delivery: this is PR 1).
+
+## Global Constraints
+
+- Work only inside the worktree `/Users/ericgriffin/repos/submersion-app/submersion/.claude/worktrees/profile-sample-storage` on branch `worktree-profile-sample-storage`. Every command below assumes `cd` into that directory first; the shell's working directory does not persist between commands.
+- Never use an em-dash (U+2014) or an en-dash as punctuation anywhere: code, comments, tests, commit messages, this plan. Rewrite with a colon, comma, or two sentences.
+- No emojis in code, comments, or documentation.
+- Lints in force: `package:flutter_lints/flutter.yaml` plus `prefer_const_constructors`, `prefer_const_declarations`, `prefer_final_fields`, `prefer_final_locals`, `avoid_print`, `require_trailing_commas`, `always_use_package_imports`. All imports of project files use the `package:submersion/...` form.
+- Codec files under `lib/` import nothing from Drift or Flutter. Allowed: `dart:*`, `package:equatable`, `package:meta`, and the domain entity file `package:submersion/features/dive_log/domain/entities/dive.dart`.
+- Codec v1 constants, verbatim from the spec: version byte `1`; real fields are float64 little-endian (lossless, never float32 or fixed point); integer fields are delta-encoded zigzag varints with the delta reset to 0 at the start of each block and taken from the last present value; presence modes are `0` absent, `1` all present, `2` bitmap (LSB-first within each byte); the whole body is zlib level 6. The 28-field table order is fixed in Task 4 and must not be reordered.
+- Run tests per file (`flutter test <one file>`), never a whole directory; the Bash tool times out on directories. Never pipe `flutter test` through `grep` or `tail`: the exit code you see would be the pipe's, not the test run's.
+- Before every commit run `dart format .` from the worktree root (the whole project, not a subdirectory) and `flutter analyze`. CI fails on a single unformatted file.
+- Commit messages: conventional prefix (`feat:`, `test:`, `docs:`), no `Co-Authored-By` trailer, no session URL.
+- Files stay small: none of the new files should exceed 400 lines.
+
+---
+
+## File structure
+
+Create:
+
+| file | responsibility |
+|---|---|
+| `lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart` | the one exception type every decoder throws |
+| `lib/features/dive_log/domain/codecs/byte_io.dart` | `ByteWriter`, `ByteReader`, varint/zigzag/float64, presence-bitmapped column blocks |
+| `lib/features/dive_log/domain/codecs/profile_sample.dart` | `ProfileSample`, the 28-field value type the codec packs, with conversions to and from `DiveProfilePoint` |
+| `lib/features/dive_log/domain/codecs/profile_series_summary.dart` | `ProfileSeriesSummary` and its computation from a sample list |
+| `lib/features/dive_log/domain/codecs/profile_series_codec.dart` | `ProfileField`, `ProfileFieldKind`, the v1 field table, `EncodedProfileSeries`, `ProfileSeriesCodec` |
+| `lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart` | `TankPressureSample`, `TankPressureSeriesSummary`, `EncodedTankPressureSeries`, `TankPressureSeriesCodec` |
+| `test/features/dive_log/domain/codecs/byte_io_test.dart` | |
+| `test/features/dive_log/domain/codecs/profile_sample_test.dart` | |
+| `test/features/dive_log/domain/codecs/profile_series_summary_test.dart` | |
+| `test/features/dive_log/domain/codecs/profile_series_codec_test.dart` | round trips, malformed input, forward tolerance |
+| `test/features/dive_log/domain/codecs/profile_series_field_table_test.dart` | the field table enumerated against Drift's `dive_profiles` columns |
+| `test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart` | |
+
+Modify: nothing. This PR adds files only.
+
+---
+
+### Task 1: Exception type and byte reader/writer
+
+**Files:**
+- Create: `lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart`
+- Create: `lib/features/dive_log/domain/codecs/byte_io.dart`
+- Test: `test/features/dive_log/domain/codecs/byte_io_test.dart`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `class ProfileSeriesCodecException implements Exception { const ProfileSeriesCodecException(String message); final String message; }`
+  - `class ByteWriter { int get length; void writeByte(int); void writeVarUint(int); void writeVarInt(int); void writeFloat64(double); void writeBytes(List<int>); Uint8List takeBytes(); }`
+  - `class ByteReader { ByteReader(Uint8List bytes); int get offset; int get remaining; bool get isAtEnd; int readByte(); int readVarUint(); int readVarInt(); double readFloat64(); Uint8List readBytes(int count); }`
+  - `extension ColumnWriter on ByteWriter { bool writePresence(List<Object?> values); void writeColumn<T extends Object>(List<T?> values, void Function(T value) writeValue); }`
+  - `extension ColumnReader on ByteReader { List<bool> readPresence(int count); List<T?> readColumn<T extends Object>(int count, T Function() readValue); }`
+  - Constants `kPresenceAbsent = 0`, `kPresenceAll = 1`, `kPresenceBitmap = 2`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/domain/codecs/byte_io_test.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// The raw IEEE-754 bits, so -0.0 and NaN payloads compare exactly.
+int bitsOf(double value) =>
+    (ByteData(8)..setFloat64(0, value, Endian.little)).getInt64(
+      0,
+      Endian.little,
+    );
+
+void main() {
+  group('varuint', () {
+    for (final value in [
+      0,
+      1,
+      127,
+      128,
+      255,
+      300,
+      16383,
+      16384,
+      1 << 31,
+      (1 << 62) - 1,
+    ]) {
+      test('round-trips $value', () {
+        final writer = ByteWriter()..writeVarUint(value);
+        expect(ByteReader(writer.takeBytes()).readVarUint(), value);
+      });
+    }
+
+    test('127 fits in one byte and 128 needs two', () {
+      expect((ByteWriter()..writeVarUint(127)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarUint(128)).takeBytes(), hasLength(2));
+    });
+  });
+
+  group('varint (zigzag)', () {
+    for (final value in [
+      0,
+      -1,
+      1,
+      -2,
+      2,
+      -64,
+      63,
+      -65,
+      64,
+      -1000000,
+      1000000,
+      -(1 << 40),
+      1 << 40,
+    ]) {
+      test('round-trips $value', () {
+        final writer = ByteWriter()..writeVarInt(value);
+        expect(ByteReader(writer.takeBytes()).readVarInt(), value);
+      });
+    }
+
+    test('small negatives stay one byte', () {
+      expect((ByteWriter()..writeVarInt(-1)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarInt(-64)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarInt(-65)).takeBytes(), hasLength(2));
+    });
+  });
+
+  group('float64', () {
+    for (final value in [
+      0.0,
+      -0.0,
+      1.5,
+      18.3,
+      -273.15,
+      double.maxFinite,
+      double.minPositive,
+      double.infinity,
+      double.negativeInfinity,
+    ]) {
+      test('round-trips $value bit-exactly', () {
+        final writer = ByteWriter()..writeFloat64(value);
+        final bytes = writer.takeBytes();
+        expect(bytes, hasLength(8));
+        expect(bitsOf(ByteReader(bytes).readFloat64()), bitsOf(value));
+      });
+    }
+
+    test('NaN round-trips as NaN', () {
+      final writer = ByteWriter()..writeFloat64(double.nan);
+      expect(ByteReader(writer.takeBytes()).readFloat64().isNaN, isTrue);
+    });
+
+    test('two consecutive floats do not alias each other', () {
+      final writer = ByteWriter()
+        ..writeFloat64(1.0)
+        ..writeFloat64(2.0);
+      final reader = ByteReader(writer.takeBytes());
+      expect(reader.readFloat64(), 1.0);
+      expect(reader.readFloat64(), 2.0);
+    });
+  });
+
+  group('reader bounds', () {
+    test('reading past the end throws', () {
+      final reader = ByteReader(Uint8List.fromList([0x01]));
+      reader.readByte();
+      expect(reader.isAtEnd, isTrue);
+      expect(reader.readByte, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('a float needs eight bytes', () {
+      final reader = ByteReader(Uint8List.fromList([0, 0, 0, 0]));
+      expect(reader.readFloat64, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('an unterminated varint throws', () {
+      final reader = ByteReader(Uint8List.fromList([0x80, 0x80]));
+      expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('a varint longer than 64 bits throws', () {
+      final reader = ByteReader(Uint8List.fromList(List.filled(11, 0x80)));
+      expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('readBytes past the end throws', () {
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3]));
+      expect(
+        () => reader.readBytes(4),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('offset and remaining track consumption', () {
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3]));
+      reader.readByte();
+      expect(reader.offset, 1);
+      expect(reader.remaining, 2);
+    });
+  });
+
+  group('columns', () {
+    // Note: `writer` is declared on its own line in every case below. Dart
+    // rejects a closure that names the variable being initialised
+    // ("referenced before declaration"), so the cascade form cannot be used.
+
+    test('an all-null column costs exactly one byte', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>([null, null, null], writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes, [kPresenceAbsent]);
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(3, reader.readVarInt), [null, null, null]);
+      expect(reader.isAtEnd, isTrue);
+    });
+
+    test('a fully present column carries no bitmap', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>([5, 6, 7], writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes.first, kPresenceAll);
+      expect(bytes, hasLength(4));
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(3, reader.readVarInt), [5, 6, 7]);
+    });
+
+    test('a mixed column uses a bitmap and round-trips across a byte edge', () {
+      // Nine values force a two-byte bitmap.
+      final values = <int?>[1, null, 3, null, null, 6, 7, null, 9];
+      final writer = ByteWriter();
+      writer.writeColumn<int>(values, writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes.first, kPresenceBitmap);
+      // mode + 2 bitmap bytes + 5 one-byte values
+      expect(bytes, hasLength(8));
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(9, reader.readVarInt), values);
+      expect(reader.isAtEnd, isTrue);
+    });
+
+    test('float columns round-trip through the same presence logic', () {
+      final values = <double?>[1.5, null, -2.25];
+      final writer = ByteWriter();
+      writer.writeColumn<double>(values, writer.writeFloat64);
+      final reader = ByteReader(writer.takeBytes());
+      expect(reader.readColumn<double>(3, reader.readFloat64), values);
+    });
+
+    test('an unknown presence mode throws', () {
+      final reader = ByteReader(Uint8List.fromList([7]));
+      expect(
+        () => reader.readColumn<int>(1, reader.readVarInt),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an empty column writes only the absent marker', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>(const [], writer.writeVarInt);
+      expect(writer.takeBytes(), [kPresenceAbsent]);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/codecs/byte_io_test.dart`
+Expected: compilation failure, `Error: Couldn't resolve the package 'submersion/features/dive_log/domain/codecs/byte_io.dart'` (or "Target of URI doesn't exist").
+
+- [ ] **Step 3: Create the exception type**
+
+Create `lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart`:
+
+```dart
+/// Thrown when a packed series blob cannot be decoded.
+///
+/// Decoders never guess. An unknown version byte, a truncated payload,
+/// trailing bytes, or a block that disagrees with its field table all end
+/// here rather than in a partial sample list.
+class ProfileSeriesCodecException implements Exception {
+  const ProfileSeriesCodecException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'ProfileSeriesCodecException: $message';
+}
+```
+
+- [ ] **Step 4: Create the byte reader and writer**
+
+Create `lib/features/dive_log/domain/codecs/byte_io.dart`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// Presence mode for a column block: every value is null, no payload.
+const int kPresenceAbsent = 0;
+
+/// Presence mode for a column block: every value is present, no bitmap.
+const int kPresenceAll = 1;
+
+/// Presence mode for a column block: a bitmap of `ceil(n / 8)` bytes
+/// (LSB-first within each byte) precedes the present values.
+const int kPresenceBitmap = 2;
+
+/// Append-only little-endian byte sink for the series codecs.
+class ByteWriter {
+  // copy: true (the default) matters: writeFloat64 hands the builder a view
+  // of a reused scratch buffer, and a non-copying builder would alias every
+  // float written to the same eight bytes.
+  final BytesBuilder _builder = BytesBuilder();
+  final ByteData _scratch = ByteData(8);
+
+  int get length => _builder.length;
+
+  void writeByte(int value) {
+    assert(value >= 0 && value <= 0xFF, 'not a byte: $value');
+    _builder.addByte(value);
+  }
+
+  /// Unsigned LEB128 varint: seven bits per byte, high bit set on all but
+  /// the last byte.
+  void writeVarUint(int value) {
+    assert(value >= 0, 'varuint cannot encode $value');
+    var remaining = value;
+    while (remaining >= 0x80) {
+      _builder.addByte((remaining & 0x7F) | 0x80);
+      remaining >>= 7;
+    }
+    _builder.addByte(remaining);
+  }
+
+  /// Zigzag-mapped signed varint, so small negatives stay small: 0, -1, 1,
+  /// -2, 2 map to 0, 1, 2, 3, 4.
+  void writeVarInt(int value) => writeVarUint((value << 1) ^ (value >> 63));
+
+  /// IEEE-754 binary64, little-endian, bit-exact.
+  void writeFloat64(double value) {
+    _scratch.setFloat64(0, value, Endian.little);
+    _builder.add(_scratch.buffer.asUint8List(0, 8));
+  }
+
+  void writeBytes(List<int> bytes) => _builder.add(bytes);
+
+  /// Returns everything written and resets the writer.
+  Uint8List takeBytes() => _builder.takeBytes();
+}
+
+/// Strict forward-only reader over a byte buffer. Every read that would run
+/// past the end throws [ProfileSeriesCodecException].
+class ByteReader {
+  ByteReader(Uint8List bytes)
+    : _bytes = bytes,
+      _data = ByteData.sublistView(bytes);
+
+  final Uint8List _bytes;
+  final ByteData _data;
+  int _offset = 0;
+
+  int get offset => _offset;
+  int get remaining => _bytes.length - _offset;
+  bool get isAtEnd => _offset >= _bytes.length;
+
+  int readByte() {
+    _ensure(1);
+    return _bytes[_offset++];
+  }
+
+  int readVarUint() {
+    var result = 0;
+    var shift = 0;
+    while (true) {
+      final byte = readByte();
+      result |= (byte & 0x7F) << shift;
+      if ((byte & 0x80) == 0) return result;
+      shift += 7;
+      if (shift > 63) {
+        throw const ProfileSeriesCodecException('varint longer than 64 bits');
+      }
+    }
+  }
+
+  int readVarInt() {
+    final zigzag = readVarUint();
+    return (zigzag >>> 1) ^ -(zigzag & 1);
+  }
+
+  double readFloat64() {
+    _ensure(8);
+    final value = _data.getFloat64(_offset, Endian.little);
+    _offset += 8;
+    return value;
+  }
+
+  Uint8List readBytes(int count) {
+    _ensure(count);
+    final view = Uint8List.sublistView(_bytes, _offset, _offset + count);
+    _offset += count;
+    return view;
+  }
+
+  void _ensure(int count) {
+    if (count < 0 || _offset + count > _bytes.length) {
+      throw ProfileSeriesCodecException(
+        'unexpected end of data: needed $count byte(s) at offset $_offset '
+        'of ${_bytes.length}',
+      );
+    }
+  }
+}
+
+/// Column blocks: a presence mode byte, an optional bitmap, then only the
+/// present values in order.
+extension ColumnWriter on ByteWriter {
+  /// Writes the presence mode and, when needed, the bitmap. Returns whether
+  /// any value is present, so the caller knows whether to write payload.
+  bool writePresence(List<Object?> values) {
+    var presentCount = 0;
+    for (final value in values) {
+      if (value != null) presentCount++;
+    }
+    if (presentCount == 0) {
+      writeByte(kPresenceAbsent);
+      return false;
+    }
+    if (presentCount == values.length) {
+      writeByte(kPresenceAll);
+      return true;
+    }
+    writeByte(kPresenceBitmap);
+    final bitmap = Uint8List((values.length + 7) >> 3);
+    for (var i = 0; i < values.length; i++) {
+      if (values[i] != null) bitmap[i >> 3] |= 1 << (i & 7);
+    }
+    writeBytes(bitmap);
+    return true;
+  }
+
+  /// Writes one column: presence, then [writeValue] for each present value
+  /// in order. [writeValue] may keep state between calls (delta encoding).
+  void writeColumn<T extends Object>(
+    List<T?> values,
+    void Function(T value) writeValue,
+  ) {
+    if (!writePresence(values)) return;
+    for (final value in values) {
+      if (value != null) writeValue(value);
+    }
+  }
+}
+
+extension ColumnReader on ByteReader {
+  /// Reads a presence block for [count] values.
+  List<bool> readPresence(int count) {
+    final mode = readByte();
+    switch (mode) {
+      case kPresenceAbsent:
+        return List<bool>.filled(count, false);
+      case kPresenceAll:
+        return List<bool>.filled(count, true);
+      case kPresenceBitmap:
+        final bitmap = readBytes((count + 7) >> 3);
+        return [
+          for (var i = 0; i < count; i++)
+            ((bitmap[i >> 3] >> (i & 7)) & 1) == 1,
+        ];
+      default:
+        throw ProfileSeriesCodecException('unknown presence mode $mode');
+    }
+  }
+
+  /// Reads one column of [count] values, calling [readValue] once per
+  /// present value in order. [readValue] may keep state between calls.
+  List<T?> readColumn<T extends Object>(int count, T Function() readValue) {
+    final present = readPresence(count);
+    return [for (final isPresent in present) isPresent ? readValue() : null];
+  }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/byte_io_test.dart`
+Expected: all tests pass (around 45 cases).
+
+- [ ] **Step 6: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart lib/features/dive_log/domain/codecs/byte_io.dart test/features/dive_log/domain/codecs/byte_io_test.dart
+git commit -m "feat: byte reader and writer for the profile series codec"
+```
+
+---
+
+### Task 2: ProfileSample value type
+
+**Files:**
+- Create: `lib/features/dive_log/domain/codecs/profile_sample.dart`
+- Test: `test/features/dive_log/domain/codecs/profile_sample_test.dart`
+
+**Interfaces:**
+- Consumes: `DiveProfilePoint` from `package:submersion/features/dive_log/domain/entities/dive.dart` (27 fields, no `pressure`).
+- Produces: `class ProfileSample extends Equatable` with 28 fields matching the `dive_profiles` sample columns: `int timestamp`, `double depth`, `double? pressure`, `double? temperature`, `int? heartRate`, `double? ascentRate`, `double? ceiling`, `int? ndl`, `double? setpoint`, `double? ppO2`, `double? o2Sensor1` to `o2Sensor6`, `double? cns`, `int? tts`, `int? rbt`, `int? decoType`, `String? heartRateSource`, `double? heading`, `int? o2SensorMv1` to `o2SensorMv6`. Plus `factory ProfileSample.fromPoint(DiveProfilePoint point, {double? pressure})` and `DiveProfilePoint toPoint()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/domain/codecs/profile_sample_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+void main() {
+  const point = DiveProfilePoint(
+    timestamp: 120,
+    depth: 18.3,
+    temperature: 21.5,
+    heartRate: 88,
+    heading: 270.0,
+    setpoint: 1.2,
+    ppO2: 1.19,
+    o2Sensor1: 1.18,
+    o2Sensor2: 1.2,
+    o2Sensor3: 1.21,
+    o2Sensor4: 1.17,
+    o2Sensor5: 1.22,
+    o2Sensor6: 1.19,
+    o2SensorMv1: 51,
+    o2SensorMv2: 52,
+    o2SensorMv3: 53,
+    o2SensorMv4: 50,
+    o2SensorMv5: 54,
+    o2SensorMv6: 52,
+    heartRateSource: 'appleWatch',
+    cns: 12.5,
+    ndl: 1800,
+    ceiling: 3.0,
+    ascentRate: -9.0,
+    rbt: 1500,
+    decoType: 2,
+    tts: 900,
+  );
+
+  test('fromPoint then toPoint is the identity on every point field', () {
+    final sample = ProfileSample.fromPoint(point);
+    expect(sample.toPoint(), point);
+  });
+
+  test('fromPoint carries the legacy per-sample pressure separately', () {
+    final sample = ProfileSample.fromPoint(point, pressure: 180.5);
+    expect(sample.pressure, 180.5);
+    // DiveProfilePoint has no pressure field, so it cannot survive toPoint.
+    expect(sample.toPoint(), point);
+  });
+
+  test('a minimal point maps with every optional field null', () {
+    const minimal = DiveProfilePoint(timestamp: 0, depth: 0.0);
+    final sample = ProfileSample.fromPoint(minimal);
+    expect(sample.timestamp, 0);
+    expect(sample.depth, 0.0);
+    expect(sample.pressure, isNull);
+    expect(sample.temperature, isNull);
+    expect(sample.heartRateSource, isNull);
+    expect(sample.o2SensorMv6, isNull);
+    expect(sample.toPoint(), minimal);
+  });
+
+  test('value equality covers every field', () {
+    final a = ProfileSample.fromPoint(point, pressure: 1.0);
+    final b = ProfileSample.fromPoint(point, pressure: 1.0);
+    final c = ProfileSample.fromPoint(point, pressure: 2.0);
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    expect(a, isNot(c));
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_sample_test.dart`
+Expected: compilation failure, `profile_sample.dart` not found.
+
+- [ ] **Step 3: Create the value type**
+
+Create `lib/features/dive_log/domain/codecs/profile_sample.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+/// One profile sample exactly as the `dive_profiles` table stores it, minus
+/// the identity columns (`id`, `dive_id`, `computer_id`, `source_id`,
+/// `is_primary`) that live on the series row.
+///
+/// This is the codec's input and output type. It differs from
+/// [DiveProfilePoint] in one field: the legacy per-sample [pressure]
+/// column, which the v59 migration moved to tank pressure profiles but
+/// which older rows still populate. The codec is lossless over the stored
+/// row, so the field rides along; [toPoint] drops it, as every read path
+/// does today.
+class ProfileSample extends Equatable {
+  const ProfileSample({
+    required this.timestamp,
+    required this.depth,
+    this.pressure,
+    this.temperature,
+    this.heartRate,
+    this.ascentRate,
+    this.ceiling,
+    this.ndl,
+    this.setpoint,
+    this.ppO2,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
+    this.cns,
+    this.tts,
+    this.rbt,
+    this.decoType,
+    this.heartRateSource,
+    this.heading,
+    this.o2SensorMv1,
+    this.o2SensorMv2,
+    this.o2SensorMv3,
+    this.o2SensorMv4,
+    this.o2SensorMv5,
+    this.o2SensorMv6,
+  });
+
+  factory ProfileSample.fromPoint(DiveProfilePoint point, {double? pressure}) {
+    return ProfileSample(
+      timestamp: point.timestamp,
+      depth: point.depth,
+      pressure: pressure,
+      temperature: point.temperature,
+      heartRate: point.heartRate,
+      ascentRate: point.ascentRate,
+      ceiling: point.ceiling,
+      ndl: point.ndl,
+      setpoint: point.setpoint,
+      ppO2: point.ppO2,
+      o2Sensor1: point.o2Sensor1,
+      o2Sensor2: point.o2Sensor2,
+      o2Sensor3: point.o2Sensor3,
+      o2Sensor4: point.o2Sensor4,
+      o2Sensor5: point.o2Sensor5,
+      o2Sensor6: point.o2Sensor6,
+      cns: point.cns,
+      tts: point.tts,
+      rbt: point.rbt,
+      decoType: point.decoType,
+      heartRateSource: point.heartRateSource,
+      heading: point.heading,
+      o2SensorMv1: point.o2SensorMv1,
+      o2SensorMv2: point.o2SensorMv2,
+      o2SensorMv3: point.o2SensorMv3,
+      o2SensorMv4: point.o2SensorMv4,
+      o2SensorMv5: point.o2SensorMv5,
+      o2SensorMv6: point.o2SensorMv6,
+    );
+  }
+
+  /// Seconds from dive start.
+  final int timestamp;
+
+  /// Metres.
+  final double depth;
+
+  /// Legacy per-sample pressure in bar; null on every row written after the
+  /// v59 migration.
+  final double? pressure;
+  final double? temperature;
+  final int? heartRate;
+  final double? ascentRate;
+  final double? ceiling;
+  final int? ndl;
+  final double? setpoint;
+  final double? ppO2;
+  final double? o2Sensor1;
+  final double? o2Sensor2;
+  final double? o2Sensor3;
+  final double? o2Sensor4;
+  final double? o2Sensor5;
+  final double? o2Sensor6;
+  final double? cns;
+  final int? tts;
+  final int? rbt;
+  final int? decoType;
+  final String? heartRateSource;
+  final double? heading;
+  final int? o2SensorMv1;
+  final int? o2SensorMv2;
+  final int? o2SensorMv3;
+  final int? o2SensorMv4;
+  final int? o2SensorMv5;
+  final int? o2SensorMv6;
+
+  /// The domain point. Drops [pressure], which [DiveProfilePoint] does not
+  /// carry.
+  DiveProfilePoint toPoint() {
+    return DiveProfilePoint(
+      timestamp: timestamp,
+      depth: depth,
+      temperature: temperature,
+      heartRate: heartRate,
+      heading: heading,
+      setpoint: setpoint,
+      ppO2: ppO2,
+      o2Sensor1: o2Sensor1,
+      o2Sensor2: o2Sensor2,
+      o2Sensor3: o2Sensor3,
+      o2Sensor4: o2Sensor4,
+      o2Sensor5: o2Sensor5,
+      o2Sensor6: o2Sensor6,
+      o2SensorMv1: o2SensorMv1,
+      o2SensorMv2: o2SensorMv2,
+      o2SensorMv3: o2SensorMv3,
+      o2SensorMv4: o2SensorMv4,
+      o2SensorMv5: o2SensorMv5,
+      o2SensorMv6: o2SensorMv6,
+      heartRateSource: heartRateSource,
+      cns: cns,
+      ndl: ndl,
+      ceiling: ceiling,
+      ascentRate: ascentRate,
+      rbt: rbt,
+      decoType: decoType,
+      tts: tts,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    timestamp,
+    depth,
+    pressure,
+    temperature,
+    heartRate,
+    ascentRate,
+    ceiling,
+    ndl,
+    setpoint,
+    ppO2,
+    o2Sensor1,
+    o2Sensor2,
+    o2Sensor3,
+    o2Sensor4,
+    o2Sensor5,
+    o2Sensor6,
+    cns,
+    tts,
+    rbt,
+    decoType,
+    heartRateSource,
+    heading,
+    o2SensorMv1,
+    o2SensorMv2,
+    o2SensorMv3,
+    o2SensorMv4,
+    o2SensorMv5,
+    o2SensorMv6,
+  ];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_sample_test.dart`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_log/domain/codecs/profile_sample.dart test/features/dive_log/domain/codecs/profile_sample_test.dart
+git commit -m "feat: ProfileSample value type for the series codec"
+```
+
+---
+
+### Task 3: ProfileSeriesSummary
+
+**Files:**
+- Create: `lib/features/dive_log/domain/codecs/profile_series_summary.dart`
+- Test: `test/features/dive_log/domain/codecs/profile_series_summary_test.dart`
+
+**Interfaces:**
+- Consumes: `ProfileSample` (Task 2).
+- Produces: `class ProfileSeriesSummary extends Equatable` with `int sampleCount`, `int startTimestamp`, `int endTimestamp`, `double maxDepth`, `double firstDepth`, `double lastDepth`, `bool hasDecoType`, `bool hasDecoStop`, `bool hasPositiveCeiling`, and `factory ProfileSeriesSummary.of(List<ProfileSample> samples)` which throws `ArgumentError` on an empty list. Constant `kDecoTypeDecoStop = 2`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/features/dive_log/domain/codecs/profile_series_summary_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+void main() {
+  test('summarises a plain no-deco series', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0),
+      ProfileSample(timestamp: 10, depth: 5.2),
+      ProfileSample(timestamp: 20, depth: 18.7),
+      ProfileSample(timestamp: 30, depth: 12.1),
+      ProfileSample(timestamp: 40, depth: 0.3),
+    ];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(
+      summary,
+      const ProfileSeriesSummary(
+        sampleCount: 5,
+        startTimestamp: 0,
+        endTimestamp: 40,
+        maxDepth: 18.7,
+        firstDepth: 0.0,
+        lastDepth: 0.3,
+        hasDecoType: false,
+        hasDecoStop: false,
+        hasPositiveCeiling: false,
+      ),
+    );
+  });
+
+  test('a recorded deco type without a stop sets only hasDecoType', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, decoType: 0),
+      ProfileSample(timestamp: 10, depth: 20.0, decoType: 1),
+    ];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(summary.hasDecoType, isTrue);
+    expect(summary.hasDecoStop, isFalse);
+  });
+
+  test('deco type 2 on any sample sets hasDecoStop', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, decoType: 0),
+      ProfileSample(timestamp: 10, depth: 6.0, decoType: kDecoTypeDecoStop),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasDecoStop, isTrue);
+  });
+
+  test('a positive ceiling on any sample sets hasPositiveCeiling', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, ceiling: 0.0),
+      ProfileSample(timestamp: 10, depth: 30.0, ceiling: 3.0),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasPositiveCeiling, isTrue);
+  });
+
+  test('a zero or null ceiling does not count as positive', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, ceiling: 0.0),
+      ProfileSample(timestamp: 10, depth: 30.0),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasPositiveCeiling, isFalse);
+  });
+
+  test('a single sample is its own start, end, first, last and max', () {
+    const samples = [ProfileSample(timestamp: 7, depth: 4.4)];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(summary.sampleCount, 1);
+    expect(summary.startTimestamp, 7);
+    expect(summary.endTimestamp, 7);
+    expect(summary.maxDepth, 4.4);
+    expect(summary.firstDepth, 4.4);
+    expect(summary.lastDepth, 4.4);
+  });
+
+  test('an empty series is a caller error', () {
+    expect(() => ProfileSeriesSummary.of(const []), throwsArgumentError);
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_series_summary_test.dart`
+Expected: compilation failure, `profile_series_summary.dart` not found.
+
+- [ ] **Step 3: Create the summary**
+
+Create `lib/features/dive_log/domain/codecs/profile_series_summary.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+
+/// The `deco_type` value that marks a mandatory decompression stop
+/// (0 = NDL, 1 = safety stop, 2 = deco stop, 3 = deep stop).
+const int kDecoTypeDecoStop = 2;
+
+/// The scalars a `dive_profile_series` row stores next to its blob.
+///
+/// These exist so the SQL consumers that only need a predicate or a span
+/// (deco classification, runtime fallback, quality neighbours) never decode
+/// a blob. They are computed from the same sample list the codec packs, so
+/// a scalar can never disagree with its blob.
+class ProfileSeriesSummary extends Equatable {
+  const ProfileSeriesSummary({
+    required this.sampleCount,
+    required this.startTimestamp,
+    required this.endTimestamp,
+    required this.maxDepth,
+    required this.firstDepth,
+    required this.lastDepth,
+    required this.hasDecoType,
+    required this.hasDecoStop,
+    required this.hasPositiveCeiling,
+  });
+
+  /// Computes the summary of a non-empty, timestamp-ordered series.
+  factory ProfileSeriesSummary.of(List<ProfileSample> samples) {
+    if (samples.isEmpty) {
+      throw ArgumentError.value(
+        samples,
+        'samples',
+        'a series needs at least one sample',
+      );
+    }
+    var maxDepth = samples.first.depth;
+    var hasDecoType = false;
+    var hasDecoStop = false;
+    var hasPositiveCeiling = false;
+    for (final sample in samples) {
+      if (sample.depth > maxDepth) maxDepth = sample.depth;
+      final decoType = sample.decoType;
+      if (decoType != null) {
+        hasDecoType = true;
+        if (decoType == kDecoTypeDecoStop) hasDecoStop = true;
+      }
+      final ceiling = sample.ceiling;
+      if (ceiling != null && ceiling > 0) hasPositiveCeiling = true;
+    }
+    return ProfileSeriesSummary(
+      sampleCount: samples.length,
+      startTimestamp: samples.first.timestamp,
+      endTimestamp: samples.last.timestamp,
+      maxDepth: maxDepth,
+      firstDepth: samples.first.depth,
+      lastDepth: samples.last.depth,
+      hasDecoType: hasDecoType,
+      hasDecoStop: hasDecoStop,
+      hasPositiveCeiling: hasPositiveCeiling,
+    );
+  }
+
+  final int sampleCount;
+
+  /// Seconds from dive start of the first sample.
+  final int startTimestamp;
+
+  /// Seconds from dive start of the last sample.
+  final int endTimestamp;
+
+  /// Metres.
+  final double maxDepth;
+  final double firstDepth;
+  final double lastDepth;
+
+  /// Any sample carries a `deco_type`.
+  final bool hasDecoType;
+
+  /// Any sample carries `deco_type == 2`.
+  final bool hasDecoStop;
+
+  /// Any sample carries `ceiling > 0`.
+  final bool hasPositiveCeiling;
+
+  @override
+  List<Object?> get props => [
+    sampleCount,
+    startTimestamp,
+    endTimestamp,
+    maxDepth,
+    firstDepth,
+    lastDepth,
+    hasDecoType,
+    hasDecoStop,
+    hasPositiveCeiling,
+  ];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_series_summary_test.dart`
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_log/domain/codecs/profile_series_summary.dart test/features/dive_log/domain/codecs/profile_series_summary_test.dart
+git commit -m "feat: ProfileSeriesSummary scalars for series rows"
+```
+
+---
+
+### Task 4: ProfileSeriesCodec
+
+**Files:**
+- Create: `lib/features/dive_log/domain/codecs/profile_series_codec.dart`
+- Test: `test/features/dive_log/domain/codecs/profile_series_codec_test.dart`
+
+**Interfaces:**
+- Consumes: `ByteWriter`, `ByteReader`, `ColumnWriter`, `ColumnReader` (Task 1); `ProfileSample` (Task 2); `ProfileSeriesSummary` (Task 3); `ProfileSeriesCodecException` (Task 1).
+- Produces:
+  - `enum ProfileFieldKind { deltaInt, float64, runLengthString }`
+  - `class ProfileField { const ProfileField(String name, ProfileFieldKind kind); final String name; final ProfileFieldKind kind; }`
+  - `class EncodedProfileSeries { final Uint8List bytes; final int codecVersion; final ProfileSeriesSummary summary; }`
+  - `class ProfileSeriesCodec { const ProfileSeriesCodec({Map<int, List<ProfileField>> fieldTables}); static const int version = 1; static const List<ProfileField> fieldTableV1; EncodedProfileSeries encode(List<ProfileSample> samples, {int version = 1}); List<ProfileSample> decode(Uint8List bytes); }`
+  - PR 2 calls `const ProfileSeriesCodec().encode(samples)` and `.decode(bytes)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/domain/codecs/profile_series_codec_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+/// A fully populated sample: every one of the 28 fields present.
+ProfileSample fullSample(int i) => ProfileSample(
+  timestamp: i * 10,
+  depth: 10.0 + i * 0.5,
+  pressure: 200.0 - i,
+  temperature: 20.0 - i * 0.01,
+  heartRate: 80 + (i % 7),
+  ascentRate: -3.0 + i * 0.1,
+  ceiling: i > 5 ? 3.0 : 0.0,
+  ndl: 1800 - i * 15,
+  setpoint: 1.2,
+  ppO2: 1.19 + i * 0.001,
+  o2Sensor1: 1.18,
+  o2Sensor2: 1.20,
+  o2Sensor3: 1.21,
+  o2Sensor4: 1.17,
+  o2Sensor5: 1.22,
+  o2Sensor6: 1.19,
+  cns: 12.5 + i,
+  tts: 900 + i * 3,
+  rbt: 1500 - i * 2,
+  decoType: i > 5 ? 2 : 0,
+  heartRateSource: i < 4 ? 'diveComputer' : 'appleWatch',
+  heading: (i * 37) % 360 * 1.0,
+  o2SensorMv1: 51 + i,
+  o2SensorMv2: 52 - i,
+  o2SensorMv3: 53,
+  o2SensorMv4: 50,
+  o2SensorMv5: 54,
+  o2SensorMv6: 52,
+);
+
+/// Depth and timestamp only, like a manually entered profile.
+ProfileSample minimalSample(int i) =>
+    ProfileSample(timestamp: i * 30, depth: 5.0 * (i % 4));
+
+void main() {
+  const codec = ProfileSeriesCodec();
+
+  group('round trips', () {
+    test('every field present', () {
+      final samples = [for (var i = 0; i < 12; i++) fullSample(i)];
+      final encoded = codec.encode(samples);
+      expect(encoded.codecVersion, 1);
+      expect(codec.decode(encoded.bytes), samples);
+    });
+
+    test('every optional field null', () {
+      final samples = [for (var i = 0; i < 12; i++) minimalSample(i)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('mixed presence within one column', () {
+      final samples = [
+        for (var i = 0; i < 20; i++)
+          ProfileSample(
+            timestamp: i,
+            depth: 1.0 * i,
+            temperature: i.isEven ? 20.0 : null,
+            ndl: i % 3 == 0 ? 600 - i : null,
+            heartRateSource: i % 5 == 0 ? 'garmin' : null,
+          ),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('a single sample', () {
+      final samples = [fullSample(0)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('duplicate timestamps survive in insertion order', () {
+      const samples = [
+        ProfileSample(timestamp: 10, depth: 5.0),
+        ProfileSample(timestamp: 10, depth: 5.5),
+        ProfileSample(timestamp: 10, depth: 5.0, temperature: 19.0),
+        ProfileSample(timestamp: 20, depth: 6.0),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('integer fields that decrease encode negative deltas correctly', () {
+      final samples = [
+        for (var i = 0; i < 50; i++)
+          ProfileSample(
+            timestamp: i,
+            depth: 1.0,
+            ndl: 3000 - i * 60,
+            rbt: 2000 - i * 45,
+            heartRate: 100 - i,
+            o2SensorMv1: -5 + i,
+          ),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('float64 fields are bit-exact', () {
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 0.1 + 0.2, temperature: -0.0),
+        ProfileSample(timestamp: 1, depth: double.maxFinite, cns: 1e-300),
+      ];
+      final decoded = codec.decode(codec.encode(samples).bytes);
+      expect(decoded[0].depth, samples[0].depth);
+      expect(decoded[0].temperature!.isNegative, isTrue);
+      expect(decoded[1].depth, double.maxFinite);
+      expect(decoded[1].cns, 1e-300);
+    });
+
+    test('the largest realistic series: 20,000 samples at one second', () {
+      final random = Random(42);
+      var depth = 0.0;
+      final samples = <ProfileSample>[];
+      for (var i = 0; i < 20000; i++) {
+        depth = max(0.0, depth + (random.nextDouble() - 0.5) * 0.3);
+        samples.add(
+          ProfileSample(
+            timestamp: i,
+            depth: depth,
+            temperature: 8.0 + (i ~/ 600) * 0.1,
+            ndl: max(0, 3600 - i ~/ 2),
+            cns: i / 400.0,
+            decoType: i > 15000 ? 2 : 0,
+          ),
+        );
+      }
+      final encoded = codec.encode(samples);
+      expect(codec.decode(encoded.bytes), samples);
+      // 20,000 samples of six fields. Row storage today costs roughly 300
+      // bytes per sample; the packed blob must land far below even the raw
+      // columnar size (8 bytes per float64 field per sample).
+      expect(encoded.bytes.length, lessThan(20000 * 3 * 8));
+    });
+  });
+
+  group('summary', () {
+    test('encode returns the summary of the packed samples', () {
+      final samples = [for (var i = 0; i < 12; i++) fullSample(i)];
+      final encoded = codec.encode(samples);
+      expect(encoded.summary, ProfileSeriesSummary.of(samples));
+      expect(encoded.summary.sampleCount, 12);
+      expect(encoded.summary.hasDecoStop, isTrue);
+      expect(encoded.summary.hasPositiveCeiling, isTrue);
+    });
+  });
+
+  group('caller errors', () {
+    test('an empty series cannot be encoded', () {
+      expect(() => codec.encode(const []), throwsArgumentError);
+    });
+
+    test('timestamps must be non-decreasing', () {
+      const samples = [
+        ProfileSample(timestamp: 10, depth: 1.0),
+        ProfileSample(timestamp: 9, depth: 1.0),
+      ];
+      expect(() => codec.encode(samples), throwsArgumentError);
+    });
+
+    test('an unregistered version cannot be encoded', () {
+      expect(
+        () => codec.encode([fullSample(0)], version: 9),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('malformed input', () {
+    Uint8List validBytes() =>
+        codec.encode([for (var i = 0; i < 8; i++) fullSample(i)]).bytes;
+
+    /// Re-compresses a tampered body so the failure is in the codec, not
+    /// in zlib.
+    Uint8List recompress(List<int> body) =>
+        Uint8List.fromList(ZLibCodec(level: 6).encode(body));
+
+    Uint8List inflate(Uint8List bytes) => Uint8List.fromList(zlib.decode(bytes));
+
+    test('bytes that are not a zlib stream', () {
+      expect(
+        () => codec.decode(Uint8List.fromList([1, 2, 3, 4, 5])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an empty blob', () {
+      expect(
+        () => codec.decode(Uint8List(0)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an unknown version byte', () {
+      final body = inflate(validBytes());
+      body[0] = 42;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('version'),
+          ),
+        ),
+      );
+    });
+
+    test('a truncated body', () {
+      final body = inflate(validBytes());
+      final truncated = body.sublist(0, body.length ~/ 2);
+      expect(
+        () => codec.decode(recompress(truncated)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('trailing bytes after the last block', () {
+      final body = inflate(validBytes());
+      final padded = Uint8List.fromList([...body, 0, 0, 0]);
+      expect(
+        () => codec.decode(recompress(padded)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('trailing'),
+          ),
+        ),
+      );
+    });
+
+    test('a blob whose timestamp column is marked absent', () {
+      // Header is version (1 byte) then count varint (8 fits in 1 byte);
+      // byte 2 is the timestamp block's presence mode.
+      final body = inflate(validBytes());
+      expect(body[2], isNot(0));
+      body[2] = 0;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a sample count larger than the payload', () {
+      final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...huge,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a string run longer than the present values', () {
+      // A three-field table keeps the body small enough to address by hand:
+      // [version][count 3][timestamp: mode, 3 deltas][depth: mode, 3 floats]
+      // [heart_rate_source: mode, run count, run length, byte length, 'a'].
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 1, depth: 2.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 2, depth: 3.0, heartRateSource: 'a'),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      const runLengthOffset = 1 + 1 + (1 + 3) + (1 + 24) + 1 + 1;
+      expect(body[runLengthOffset], 3);
+      body[runLengthOffset] = 5;
+      expect(
+        () => small.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+  });
+
+  group('forward tolerance', () {
+    // A hypothetical older format that never recorded heading.
+    final withoutHeading = [
+      for (final field in ProfileSeriesCodec.fieldTableV1)
+        if (field.name != 'heading') field,
+    ];
+
+    test('a newer decoder reads an older version with missing fields null', () {
+      final legacy = ProfileSeriesCodec(fieldTables: {7: withoutHeading});
+      final modern = ProfileSeriesCodec(
+        fieldTables: {
+          7: withoutHeading,
+          ProfileSeriesCodec.version: ProfileSeriesCodec.fieldTableV1,
+        },
+      );
+      final samples = [for (var i = 0; i < 6; i++) fullSample(i)];
+      final bytes = legacy.encode(samples, version: 7).bytes;
+      final decoded = modern.decode(bytes);
+      expect(decoded, hasLength(6));
+      for (var i = 0; i < 6; i++) {
+        expect(decoded[i].heading, isNull);
+        expect(decoded[i], samples[i].copyWithoutHeading());
+      }
+    });
+
+    test('a decoder that does not know the version refuses it', () {
+      final legacy = ProfileSeriesCodec(fieldTables: {7: withoutHeading});
+      final bytes = legacy.encode([fullSample(0)], version: 7).bytes;
+      expect(
+        () => codec.decode(bytes),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('every field table must carry timestamp and depth', () {
+      final noDepth = [
+        for (final field in ProfileSeriesCodec.fieldTableV1)
+          if (field.name != 'depth') field,
+      ];
+      expect(
+        () => ProfileSeriesCodec(fieldTables: {1: noDepth}).encode([
+          fullSample(0),
+        ]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('field table', () {
+    test('v1 has 28 entries with unique names', () {
+      final names = ProfileSeriesCodec.fieldTableV1.map((f) => f.name);
+      expect(names, hasLength(28));
+      expect(names.toSet(), hasLength(28));
+    });
+
+    test('v1 begins with timestamp and depth', () {
+      expect(ProfileSeriesCodec.fieldTableV1[0].name, 'timestamp');
+      expect(ProfileSeriesCodec.fieldTableV1[1].name, 'depth');
+    });
+  });
+}
+
+extension on ProfileSample {
+  ProfileSample copyWithoutHeading() => ProfileSample(
+    timestamp: timestamp,
+    depth: depth,
+    pressure: pressure,
+    temperature: temperature,
+    heartRate: heartRate,
+    ascentRate: ascentRate,
+    ceiling: ceiling,
+    ndl: ndl,
+    setpoint: setpoint,
+    ppO2: ppO2,
+    o2Sensor1: o2Sensor1,
+    o2Sensor2: o2Sensor2,
+    o2Sensor3: o2Sensor3,
+    o2Sensor4: o2Sensor4,
+    o2Sensor5: o2Sensor5,
+    o2Sensor6: o2Sensor6,
+    cns: cns,
+    tts: tts,
+    rbt: rbt,
+    decoType: decoType,
+    heartRateSource: heartRateSource,
+    o2SensorMv1: o2SensorMv1,
+    o2SensorMv2: o2SensorMv2,
+    o2SensorMv3: o2SensorMv3,
+    o2SensorMv4: o2SensorMv4,
+    o2SensorMv5: o2SensorMv5,
+    o2SensorMv6: o2SensorMv6,
+  );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_series_codec_test.dart`
+Expected: compilation failure, `profile_series_codec.dart` not found.
+
+- [ ] **Step 3: Create the codec**
+
+Create `lib/features/dive_log/domain/codecs/profile_series_codec.dart`:
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+/// How a field's column block is written.
+enum ProfileFieldKind {
+  /// Zigzag varint of the difference from the previous present value; the
+  /// previous value starts at 0 for each block.
+  deltaInt,
+
+  /// IEEE-754 binary64, little-endian.
+  float64,
+
+  /// Runs of identical strings: run count, then (length, UTF-8 length,
+  /// UTF-8 bytes) per run, covering the present values only.
+  runLengthString,
+}
+
+/// One entry of a field table. [name] is the `dive_profiles` column name.
+class ProfileField {
+  const ProfileField(this.name, this.kind);
+
+  final String name;
+  final ProfileFieldKind kind;
+}
+
+/// The bytes and scalars a `dive_profile_series` row stores.
+class EncodedProfileSeries {
+  const EncodedProfileSeries({
+    required this.bytes,
+    required this.codecVersion,
+    required this.summary,
+  });
+
+  final Uint8List bytes;
+  final int codecVersion;
+  final ProfileSeriesSummary summary;
+}
+
+/// Packs a series of [ProfileSample]s into one zlib-compressed columnar blob
+/// and back. Lossless.
+///
+/// Layout of the uncompressed body: a version byte, the sample count as a
+/// varint, then one column block per entry of that version's field table in
+/// table order. See `byte_io.dart` for the block format.
+///
+/// Versioning: a later codec appends fields under a new version byte. The
+/// decoder selects the field table by the blob's version byte, so an older
+/// blob decodes under a newer codec with its missing fields null. A version
+/// this codec does not know is refused.
+class ProfileSeriesCodec {
+  const ProfileSeriesCodec({
+    this.fieldTables = const {version: fieldTableV1},
+  });
+
+  /// The version new blobs are written with.
+  static const int version = 1;
+
+  /// Codec v1: every `dive_profiles` sample column, in this order. Never
+  /// reorder or remove an entry; append under a new version instead.
+  static const List<ProfileField> fieldTableV1 = [
+    ProfileField('timestamp', ProfileFieldKind.deltaInt),
+    ProfileField('depth', ProfileFieldKind.float64),
+    ProfileField('pressure', ProfileFieldKind.float64),
+    ProfileField('temperature', ProfileFieldKind.float64),
+    ProfileField('heart_rate', ProfileFieldKind.deltaInt),
+    ProfileField('ascent_rate', ProfileFieldKind.float64),
+    ProfileField('ceiling', ProfileFieldKind.float64),
+    ProfileField('ndl', ProfileFieldKind.deltaInt),
+    ProfileField('setpoint', ProfileFieldKind.float64),
+    ProfileField('pp_o2', ProfileFieldKind.float64),
+    ProfileField('o2_sensor1', ProfileFieldKind.float64),
+    ProfileField('o2_sensor2', ProfileFieldKind.float64),
+    ProfileField('o2_sensor3', ProfileFieldKind.float64),
+    ProfileField('o2_sensor4', ProfileFieldKind.float64),
+    ProfileField('o2_sensor5', ProfileFieldKind.float64),
+    ProfileField('o2_sensor6', ProfileFieldKind.float64),
+    ProfileField('cns', ProfileFieldKind.float64),
+    ProfileField('tts', ProfileFieldKind.deltaInt),
+    ProfileField('rbt', ProfileFieldKind.deltaInt),
+    ProfileField('deco_type', ProfileFieldKind.deltaInt),
+    ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+    ProfileField('heading', ProfileFieldKind.float64),
+    ProfileField('o2_sensor_mv1', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv2', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv3', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv4', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv5', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv6', ProfileFieldKind.deltaInt),
+  ];
+
+  /// Field table per version byte this codec can read.
+  final Map<int, List<ProfileField>> fieldTables;
+
+  // ZLibCodec has no const constructor, so this is `final`, not `const`.
+  static final ZLibCodec _zlib = ZLibCodec(level: 6);
+
+  /// Encodes a non-empty, timestamp-ordered series.
+  ///
+  /// Throws [ArgumentError] on an empty list, on decreasing timestamps, on
+  /// an unregistered [version], or on a field table without `timestamp` and
+  /// `depth`. These are caller bugs, not data faults.
+  EncodedProfileSeries encode(
+    List<ProfileSample> samples, {
+    int version = ProfileSeriesCodec.version,
+  }) {
+    final table = fieldTables[version];
+    if (table == null) {
+      throw ArgumentError.value(version, 'version', 'no field table');
+    }
+    _requireTimestampAndDepth(table);
+    final summary = ProfileSeriesSummary.of(samples);
+    for (var i = 1; i < samples.length; i++) {
+      if (samples[i].timestamp < samples[i - 1].timestamp) {
+        throw ArgumentError.value(
+          samples,
+          'samples',
+          'timestamps must be non-decreasing (sample $i)',
+        );
+      }
+    }
+
+    final writer = ByteWriter()
+      ..writeByte(version)
+      ..writeVarUint(samples.length);
+    for (final field in table) {
+      final column = [for (final sample in samples) _fieldOf(sample, field.name)];
+      _writeColumn(writer, field.kind, column);
+    }
+    return EncodedProfileSeries(
+      bytes: Uint8List.fromList(_zlib.encode(writer.takeBytes())),
+      codecVersion: version,
+      summary: summary,
+    );
+  }
+
+  /// Decodes a blob written by [encode] under any registered version.
+  ///
+  /// Throws [ProfileSeriesCodecException] on anything malformed: not a zlib
+  /// stream, an unknown version, a truncated block, trailing bytes, or a
+  /// sample without timestamp or depth.
+  List<ProfileSample> decode(Uint8List bytes) {
+    final Uint8List body;
+    try {
+      body = Uint8List.fromList(_zlib.decode(bytes));
+    } catch (e) {
+      throw ProfileSeriesCodecException('not a zlib stream: $e');
+    }
+    if (body.isEmpty) {
+      throw const ProfileSeriesCodecException('empty body');
+    }
+    final reader = ByteReader(body);
+    final blobVersion = reader.readByte();
+    final table = fieldTables[blobVersion];
+    if (table == null) {
+      throw ProfileSeriesCodecException('unknown codec version $blobVersion');
+    }
+    final count = reader.readVarUint();
+    // Every sample carries at least a one-byte timestamp delta, so a count
+    // the remaining payload cannot hold is corruption, not a large series.
+    // Guarding here keeps a bogus count from sizing 28 column lists.
+    if (count > reader.remaining) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the ${reader.remaining} remaining '
+        'byte(s)',
+      );
+    }
+    final columns = <String, List<Object?>>{};
+    for (final field in table) {
+      columns[field.name] = _readColumn(reader, field.kind, count);
+    }
+    if (!reader.isAtEnd) {
+      throw ProfileSeriesCodecException(
+        '${reader.remaining} trailing byte(s) after the last block',
+      );
+    }
+    return _samplesFrom(columns, count);
+  }
+
+  static void _requireTimestampAndDepth(List<ProfileField> table) {
+    final names = {for (final field in table) field.name};
+    if (!names.contains('timestamp') || !names.contains('depth')) {
+      throw ArgumentError.value(
+        table,
+        'fieldTables',
+        'every field table must carry timestamp and depth',
+      );
+    }
+  }
+
+  static Object? _fieldOf(ProfileSample s, String name) => switch (name) {
+    'timestamp' => s.timestamp,
+    'depth' => s.depth,
+    'pressure' => s.pressure,
+    'temperature' => s.temperature,
+    'heart_rate' => s.heartRate,
+    'ascent_rate' => s.ascentRate,
+    'ceiling' => s.ceiling,
+    'ndl' => s.ndl,
+    'setpoint' => s.setpoint,
+    'pp_o2' => s.ppO2,
+    'o2_sensor1' => s.o2Sensor1,
+    'o2_sensor2' => s.o2Sensor2,
+    'o2_sensor3' => s.o2Sensor3,
+    'o2_sensor4' => s.o2Sensor4,
+    'o2_sensor5' => s.o2Sensor5,
+    'o2_sensor6' => s.o2Sensor6,
+    'cns' => s.cns,
+    'tts' => s.tts,
+    'rbt' => s.rbt,
+    'deco_type' => s.decoType,
+    'heart_rate_source' => s.heartRateSource,
+    'heading' => s.heading,
+    'o2_sensor_mv1' => s.o2SensorMv1,
+    'o2_sensor_mv2' => s.o2SensorMv2,
+    'o2_sensor_mv3' => s.o2SensorMv3,
+    'o2_sensor_mv4' => s.o2SensorMv4,
+    'o2_sensor_mv5' => s.o2SensorMv5,
+    'o2_sensor_mv6' => s.o2SensorMv6,
+    _ => throw ArgumentError.value(name, 'name', 'not a profile sample field'),
+  };
+
+  static void _writeColumn(
+    ByteWriter writer,
+    ProfileFieldKind kind,
+    List<Object?> column,
+  ) {
+    switch (kind) {
+      case ProfileFieldKind.deltaInt:
+        var previous = 0;
+        writer.writeColumn<int>(column.cast<int?>(), (value) {
+          writer.writeVarInt(value - previous);
+          previous = value;
+        });
+      case ProfileFieldKind.float64:
+        writer.writeColumn<double>(column.cast<double?>(), writer.writeFloat64);
+      case ProfileFieldKind.runLengthString:
+        _writeStringColumn(writer, column.cast<String?>());
+    }
+  }
+
+  static List<Object?> _readColumn(
+    ByteReader reader,
+    ProfileFieldKind kind,
+    int count,
+  ) {
+    switch (kind) {
+      case ProfileFieldKind.deltaInt:
+        var previous = 0;
+        return reader.readColumn<int>(count, () {
+          previous += reader.readVarInt();
+          return previous;
+        });
+      case ProfileFieldKind.float64:
+        return reader.readColumn<double>(count, reader.readFloat64);
+      case ProfileFieldKind.runLengthString:
+        return _readStringColumn(reader, count);
+    }
+  }
+
+  static void _writeStringColumn(ByteWriter writer, List<String?> values) {
+    if (!writer.writePresence(values)) return;
+    final runs = <(String, int)>[];
+    for (final value in values) {
+      if (value == null) continue;
+      if (runs.isNotEmpty && runs.last.$1 == value) {
+        runs[runs.length - 1] = (value, runs.last.$2 + 1);
+      } else {
+        runs.add((value, 1));
+      }
+    }
+    writer.writeVarUint(runs.length);
+    for (final (value, length) in runs) {
+      final encoded = utf8.encode(value);
+      writer
+        ..writeVarUint(length)
+        ..writeVarUint(encoded.length)
+        ..writeBytes(encoded);
+    }
+  }
+
+  static List<String?> _readStringColumn(ByteReader reader, int count) {
+    final present = reader.readPresence(count);
+    var presentCount = 0;
+    for (final isPresent in present) {
+      if (isPresent) presentCount++;
+    }
+    if (presentCount == 0) return List<String?>.filled(count, null);
+    final runCount = reader.readVarUint();
+    final values = <String>[];
+    for (var run = 0; run < runCount; run++) {
+      final length = reader.readVarUint();
+      if (values.length + length > presentCount) {
+        throw ProfileSeriesCodecException(
+          'string run $run of length $length overruns the $presentCount '
+          'present values',
+        );
+      }
+      final byteLength = reader.readVarUint();
+      final String value;
+      try {
+        value = utf8.decode(reader.readBytes(byteLength));
+      } on FormatException catch (e) {
+        throw ProfileSeriesCodecException(
+          'invalid UTF-8 in string run $run: ${e.message}',
+        );
+      }
+      for (var i = 0; i < length; i++) {
+        values.add(value);
+      }
+    }
+    if (values.length != presentCount) {
+      throw ProfileSeriesCodecException(
+        'string runs cover ${values.length} of $presentCount present values',
+      );
+    }
+    var next = 0;
+    return [for (final isPresent in present) isPresent ? values[next++] : null];
+  }
+
+  static List<ProfileSample> _samplesFrom(
+    Map<String, List<Object?>> columns,
+    int count,
+  ) {
+    List<T?> column<T>(String name) {
+      final values = columns[name];
+      if (values == null) return List<T?>.filled(count, null);
+      return values.cast<T?>();
+    }
+
+    final timestamps = column<int>('timestamp');
+    final depths = column<double>('depth');
+    final pressures = column<double>('pressure');
+    final temperatures = column<double>('temperature');
+    final heartRates = column<int>('heart_rate');
+    final ascentRates = column<double>('ascent_rate');
+    final ceilings = column<double>('ceiling');
+    final ndls = column<int>('ndl');
+    final setpoints = column<double>('setpoint');
+    final ppO2s = column<double>('pp_o2');
+    final o2Sensor1s = column<double>('o2_sensor1');
+    final o2Sensor2s = column<double>('o2_sensor2');
+    final o2Sensor3s = column<double>('o2_sensor3');
+    final o2Sensor4s = column<double>('o2_sensor4');
+    final o2Sensor5s = column<double>('o2_sensor5');
+    final o2Sensor6s = column<double>('o2_sensor6');
+    final cnss = column<double>('cns');
+    final ttss = column<int>('tts');
+    final rbts = column<int>('rbt');
+    final decoTypes = column<int>('deco_type');
+    final heartRateSources = column<String>('heart_rate_source');
+    final headings = column<double>('heading');
+    final mv1s = column<int>('o2_sensor_mv1');
+    final mv2s = column<int>('o2_sensor_mv2');
+    final mv3s = column<int>('o2_sensor_mv3');
+    final mv4s = column<int>('o2_sensor_mv4');
+    final mv5s = column<int>('o2_sensor_mv5');
+    final mv6s = column<int>('o2_sensor_mv6');
+
+    return [
+      for (var i = 0; i < count; i++)
+        ProfileSample(
+          timestamp:
+              timestamps[i] ??
+              (throw ProfileSeriesCodecException(
+                'sample $i has no timestamp',
+              )),
+          depth:
+              depths[i] ??
+              (throw ProfileSeriesCodecException('sample $i has no depth')),
+          pressure: pressures[i],
+          temperature: temperatures[i],
+          heartRate: heartRates[i],
+          ascentRate: ascentRates[i],
+          ceiling: ceilings[i],
+          ndl: ndls[i],
+          setpoint: setpoints[i],
+          ppO2: ppO2s[i],
+          o2Sensor1: o2Sensor1s[i],
+          o2Sensor2: o2Sensor2s[i],
+          o2Sensor3: o2Sensor3s[i],
+          o2Sensor4: o2Sensor4s[i],
+          o2Sensor5: o2Sensor5s[i],
+          o2Sensor6: o2Sensor6s[i],
+          cns: cnss[i],
+          tts: ttss[i],
+          rbt: rbts[i],
+          decoType: decoTypes[i],
+          heartRateSource: heartRateSources[i],
+          heading: headings[i],
+          o2SensorMv1: mv1s[i],
+          o2SensorMv2: mv2s[i],
+          o2SensorMv3: mv3s[i],
+          o2SensorMv4: mv4s[i],
+          o2SensorMv5: mv5s[i],
+          o2SensorMv6: mv6s[i],
+        ),
+    ];
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_series_codec_test.dart`
+Expected: all tests pass, including the 20,000-sample case. If the size assertion in "the largest realistic series" fails, the encoder is writing a bitmap or payload it should not; do not loosen the bound, find the block that grew.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_log/domain/codecs/profile_series_codec.dart test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+git commit -m "feat: ProfileSeriesCodec, lossless columnar packing of profile samples"
+```
+
+---
+
+### Task 5: Field table enumerated against the Drift table
+
+**Files:**
+- Test: `test/features/dive_log/domain/codecs/profile_series_field_table_test.dart`
+
+**Interfaces:**
+- Consumes: `ProfileSeriesCodec.fieldTableV1` (Task 4); `AppDatabase` and its `diveProfiles` table from `package:submersion/core/database/database.dart`; `NativeDatabase.memory()` from `package:drift/native.dart`; `DriftSqlType` from `package:drift/drift.dart`.
+- Produces: nothing; this task is the guard the spec's risk list names ("a sample field the field table forgot fails the test, not the user").
+
+- [ ] **Step 1: Write the test**
+
+Create `test/features/dive_log/domain/codecs/profile_series_field_table_test.dart`:
+
+```dart
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+
+/// Columns of `dive_profiles` that identify the series, not the sample.
+/// They live on the series row and are never packed.
+const identityColumns = {
+  'id',
+  'dive_id',
+  'computer_id',
+  'source_id',
+  'is_primary',
+};
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  test('codec v1 covers every dive_profiles sample column, and only those', () {
+    final tableColumns = {
+      for (final column in db.diveProfiles.$columns) column.$name,
+    };
+    final expected = tableColumns.difference(identityColumns);
+    final actual = {
+      for (final field in ProfileSeriesCodec.fieldTableV1) field.name,
+    };
+    expect(
+      actual,
+      expected,
+      reason:
+          'A dive_profiles column was added or removed without a codec '
+          'version. Append the field under a new version in '
+          'ProfileSeriesCodec; never edit fieldTableV1.',
+    );
+  });
+
+  test('each field kind matches its column type', () {
+    final typeByName = {
+      for (final column in db.diveProfiles.$columns) column.$name: column.type,
+    };
+    for (final field in ProfileSeriesCodec.fieldTableV1) {
+      final type = typeByName[field.name];
+      final expectedKind = switch (type) {
+        DriftSqlType.int => ProfileFieldKind.deltaInt,
+        DriftSqlType.double => ProfileFieldKind.float64,
+        DriftSqlType.string => ProfileFieldKind.runLengthString,
+        _ => fail('unexpected column type $type for ${field.name}'),
+      };
+      expect(field.kind, expectedKind, reason: field.name);
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/profile_series_field_table_test.dart`
+Expected: 2 tests pass. If the first fails, the set difference in the failure output names the column the field table is missing or has extra; that is a real finding, resolve it in the field table only if the column genuinely is a sample column, otherwise add it to `identityColumns` with a comment.
+
+- [ ] **Step 3: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
+git commit -m "test: pin the codec field table to the dive_profiles columns"
+```
+
+---
+
+### Task 6: TankPressureSeriesCodec
+
+**Files:**
+- Create: `lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart`
+- Test: `test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart`
+
+**Interfaces:**
+- Consumes: `ByteWriter`, `ByteReader`, `ColumnWriter`, `ColumnReader`, `ProfileSeriesCodecException` (Task 1).
+- Produces:
+  - `class TankPressureSample extends Equatable { const TankPressureSample({required int timestamp, required double pressure}); }`
+  - `class TankPressureSeriesSummary extends Equatable { int sampleCount; int startTimestamp; int endTimestamp; factory TankPressureSeriesSummary.of(List<TankPressureSample>); }`
+  - `class EncodedTankPressureSeries { Uint8List bytes; int codecVersion; TankPressureSeriesSummary summary; }`
+  - `class TankPressureSeriesCodec { const TankPressureSeriesCodec(); static const int version = 1; EncodedTankPressureSeries encode(List<TankPressureSample> samples); List<TankPressureSample> decode(Uint8List bytes); }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
+
+void main() {
+  const codec = TankPressureSeriesCodec();
+
+  List<TankPressureSample> descending(int count) => [
+    for (var i = 0; i < count; i++)
+      TankPressureSample(timestamp: i * 10, pressure: 210.0 - i * 0.3),
+  ];
+
+  group('round trips', () {
+    test('a typical series', () {
+      final samples = descending(200);
+      final encoded = codec.encode(samples);
+      expect(encoded.codecVersion, 1);
+      expect(codec.decode(encoded.bytes), samples);
+    });
+
+    test('a single sample', () {
+      const samples = [TankPressureSample(timestamp: 0, pressure: 200.0)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('duplicate timestamps survive in insertion order', () {
+      const samples = [
+        TankPressureSample(timestamp: 5, pressure: 200.0),
+        TankPressureSample(timestamp: 5, pressure: 199.0),
+        TankPressureSample(timestamp: 6, pressure: 198.5),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('pressures are bit-exact', () {
+      const samples = [
+        TankPressureSample(timestamp: 0, pressure: 0.1 + 0.2),
+        TankPressureSample(timestamp: 1, pressure: 1e-300),
+      ];
+      final decoded = codec.decode(codec.encode(samples).bytes);
+      expect(decoded[0].pressure, 0.1 + 0.2);
+      expect(decoded[1].pressure, 1e-300);
+    });
+
+    test('20,000 samples pack below raw columnar size', () {
+      final samples = descending(20000);
+      final encoded = codec.encode(samples);
+      expect(codec.decode(encoded.bytes), samples);
+      // Raw columnar is one varint byte plus eight float bytes per sample.
+      // Any compression at all lands below this; the bound is deterministic.
+      expect(encoded.bytes.length, lessThan(20000 * 9));
+    });
+  });
+
+  group('summary', () {
+    test('encode returns the summary of the packed samples', () {
+      final samples = descending(10);
+      final encoded = codec.encode(samples);
+      expect(encoded.summary, TankPressureSeriesSummary.of(samples));
+      expect(encoded.summary.sampleCount, 10);
+      expect(encoded.summary.startTimestamp, 0);
+      expect(encoded.summary.endTimestamp, 90);
+    });
+  });
+
+  group('caller errors', () {
+    test('an empty series cannot be encoded', () {
+      expect(() => codec.encode(const []), throwsArgumentError);
+    });
+
+    test('an empty summary is a caller error', () {
+      expect(() => TankPressureSeriesSummary.of(const []), throwsArgumentError);
+    });
+
+    test('timestamps must be non-decreasing', () {
+      const samples = [
+        TankPressureSample(timestamp: 10, pressure: 1.0),
+        TankPressureSample(timestamp: 9, pressure: 1.0),
+      ];
+      expect(() => codec.encode(samples), throwsArgumentError);
+    });
+  });
+
+  group('malformed input', () {
+    Uint8List validBytes() => codec.encode(descending(8)).bytes;
+    Uint8List recompress(List<int> body) =>
+        Uint8List.fromList(ZLibCodec(level: 6).encode(body));
+    Uint8List inflate(Uint8List bytes) => Uint8List.fromList(zlib.decode(bytes));
+
+    test('bytes that are not a zlib stream', () {
+      expect(
+        () => codec.decode(Uint8List.fromList([9, 9, 9])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an unknown version byte', () {
+      final body = inflate(validBytes());
+      body[0] = 2;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a truncated body', () {
+      final body = inflate(validBytes());
+      expect(
+        () => codec.decode(recompress(body.sublist(0, body.length - 3))),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('trailing bytes', () {
+      final body = inflate(validBytes());
+      expect(
+        () => codec.decode(recompress([...body, 0])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a sample count larger than the payload', () {
+      final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...huge,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart`
+Expected: compilation failure, `tank_pressure_series_codec.dart` not found.
+
+- [ ] **Step 3: Create the codec**
+
+Create `lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart`:
+
+```dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// One tank pressure reading as `tank_pressure_profiles` stores it, minus
+/// the identity columns (`id`, `dive_id`, `tank_id`, `computer_id`) that
+/// live on the series row.
+class TankPressureSample extends Equatable {
+  const TankPressureSample({required this.timestamp, required this.pressure});
+
+  /// Seconds from dive start.
+  final int timestamp;
+
+  /// Bar.
+  final double pressure;
+
+  @override
+  List<Object?> get props => [timestamp, pressure];
+}
+
+/// The scalars a `tank_pressure_series` row stores next to its blob.
+class TankPressureSeriesSummary extends Equatable {
+  const TankPressureSeriesSummary({
+    required this.sampleCount,
+    required this.startTimestamp,
+    required this.endTimestamp,
+  });
+
+  /// Computes the summary of a non-empty, timestamp-ordered series.
+  factory TankPressureSeriesSummary.of(List<TankPressureSample> samples) {
+    if (samples.isEmpty) {
+      throw ArgumentError.value(
+        samples,
+        'samples',
+        'a series needs at least one sample',
+      );
+    }
+    return TankPressureSeriesSummary(
+      sampleCount: samples.length,
+      startTimestamp: samples.first.timestamp,
+      endTimestamp: samples.last.timestamp,
+    );
+  }
+
+  final int sampleCount;
+  final int startTimestamp;
+  final int endTimestamp;
+
+  @override
+  List<Object?> get props => [sampleCount, startTimestamp, endTimestamp];
+}
+
+/// The bytes and scalars a `tank_pressure_series` row stores.
+class EncodedTankPressureSeries {
+  const EncodedTankPressureSeries({
+    required this.bytes,
+    required this.codecVersion,
+    required this.summary,
+  });
+
+  final Uint8List bytes;
+  final int codecVersion;
+  final TankPressureSeriesSummary summary;
+}
+
+/// Packs a tank's pressure readings into one zlib-compressed columnar blob
+/// and back. Lossless.
+///
+/// Body: version byte, sample count varint, a delta-zigzag-varint timestamp
+/// column, a float64 pressure column. Both columns are always fully present
+/// (the fields are non-nullable), so each costs one presence byte.
+class TankPressureSeriesCodec {
+  const TankPressureSeriesCodec();
+
+  static const int version = 1;
+
+  // ZLibCodec has no const constructor, so this is `final`, not `const`.
+  static final ZLibCodec _zlib = ZLibCodec(level: 6);
+
+  /// Encodes a non-empty, timestamp-ordered series. Throws [ArgumentError]
+  /// on an empty list or on decreasing timestamps.
+  EncodedTankPressureSeries encode(List<TankPressureSample> samples) {
+    final summary = TankPressureSeriesSummary.of(samples);
+    for (var i = 1; i < samples.length; i++) {
+      if (samples[i].timestamp < samples[i - 1].timestamp) {
+        throw ArgumentError.value(
+          samples,
+          'samples',
+          'timestamps must be non-decreasing (sample $i)',
+        );
+      }
+    }
+    final writer = ByteWriter()
+      ..writeByte(version)
+      ..writeVarUint(samples.length);
+    var previous = 0;
+    writer.writeColumn<int>([for (final s in samples) s.timestamp], (value) {
+      writer.writeVarInt(value - previous);
+      previous = value;
+    });
+    writer.writeColumn<double>(
+      [for (final s in samples) s.pressure],
+      writer.writeFloat64,
+    );
+    return EncodedTankPressureSeries(
+      bytes: Uint8List.fromList(_zlib.encode(writer.takeBytes())),
+      codecVersion: version,
+      summary: summary,
+    );
+  }
+
+  /// Decodes a blob written by [encode]. Throws
+  /// [ProfileSeriesCodecException] on anything malformed.
+  List<TankPressureSample> decode(Uint8List bytes) {
+    final Uint8List body;
+    try {
+      body = Uint8List.fromList(_zlib.decode(bytes));
+    } catch (e) {
+      throw ProfileSeriesCodecException('not a zlib stream: $e');
+    }
+    if (body.isEmpty) {
+      throw const ProfileSeriesCodecException('empty body');
+    }
+    final reader = ByteReader(body);
+    final blobVersion = reader.readByte();
+    if (blobVersion != version) {
+      throw ProfileSeriesCodecException('unknown codec version $blobVersion');
+    }
+    final count = reader.readVarUint();
+    // Every sample carries at least a one-byte timestamp delta, so a count
+    // the remaining payload cannot hold is corruption, not a large series.
+    if (count > reader.remaining) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the ${reader.remaining} remaining '
+        'byte(s)',
+      );
+    }
+    var previous = 0;
+    final timestamps = reader.readColumn<int>(count, () {
+      previous += reader.readVarInt();
+      return previous;
+    });
+    final pressures = reader.readColumn<double>(count, reader.readFloat64);
+    if (!reader.isAtEnd) {
+      throw ProfileSeriesCodecException(
+        '${reader.remaining} trailing byte(s) after the last block',
+      );
+    }
+    return [
+      for (var i = 0; i < count; i++)
+        TankPressureSample(
+          timestamp:
+              timestamps[i] ??
+              (throw ProfileSeriesCodecException(
+                'sample $i has no timestamp',
+              )),
+          pressure:
+              pressures[i] ??
+              (throw ProfileSeriesCodecException(
+                'sample $i has no pressure',
+              )),
+        ),
+    ];
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart`
+Expected: all tests pass.
+
+- [ ] **Step 5: Format, analyze, commit**
+
+```bash
+dart format .
+flutter analyze
+git add lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
+git commit -m "feat: TankPressureSeriesCodec"
+```
+
+---
+
+### Task 7: Verification and PR
+
+**Files:**
+- No new files. This task proves the branch is green and opens the PR.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: an open PR against `main` titled `feat: profile series codec (packed sample storage, part 1)`.
+
+- [ ] **Step 1: Run every codec test file individually**
+
+Run each of these; every one must report `All tests passed!`:
+
+```bash
+flutter test test/features/dive_log/domain/codecs/byte_io_test.dart
+flutter test test/features/dive_log/domain/codecs/profile_sample_test.dart
+flutter test test/features/dive_log/domain/codecs/profile_series_summary_test.dart
+flutter test test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+flutter test test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
+flutter test test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
+```
+
+- [ ] **Step 2: Confirm format and analyze are clean project-wide**
+
+```bash
+dart format --output=none --set-exit-if-changed .
+flutter analyze
+```
+
+Expected: both exit 0. `flutter analyze` must report `No issues found!`; an "info" level finding still fails CI.
+
+- [ ] **Step 3: Confirm the codec files import nothing from Drift or Flutter**
+
+```bash
+grep -l "package:drift\|package:flutter" lib/features/dive_log/domain/codecs/*.dart
+```
+
+Expected: no output (exit 1 from grep is the success case here).
+
+- [ ] **Step 4: Run the full suite once in the background**
+
+```bash
+flutter test --reporter compact > /private/tmp/claude-501/-Users-ericgriffin-repos-submersion-app-submersion/5b0068b6-136c-4277-89c4-30a25ed89d1c/scratchpad/full-suite-pr1.log 2>&1; echo "exit=$?" >> /private/tmp/claude-501/-Users-ericgriffin-repos-submersion-app-submersion/5b0068b6-136c-4277-89c4-30a25ed89d1c/scratchpad/full-suite-pr1.log
+```
+
+Run with `run_in_background: true` and a 600000 ms timeout. When it finishes, read the last 30 lines of the log. Expected: `exit=0` and a summary line with zero failures. Do not start a second suite run while this one is going; overlapping runs fake lone failures. If a single unrelated test fails, rerun that one file alone before concluding anything.
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin worktree-profile-sample-storage
+gh pr create --title "feat: profile series codec (packed sample storage, part 1)" --body-file /private/tmp/claude-501/-Users-ericgriffin-repos-submersion-app-submersion/5b0068b6-136c-4277-89c4-30a25ed89d1c/scratchpad/pr1-body.md
+```
+
+Write the body file first with exactly this content (no attribution line, no session URL):
+
+```markdown
+## Summary
+
+Part 1 of the packed profile sample storage program
+(`docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md`).
+Adds a pure-Dart, lossless, versioned codec that packs a series of profile
+samples (or a tank's pressure readings) into one zlib-compressed columnar
+blob, plus the summary scalars the series tables will store. Nothing in
+this PR touches the database, repositories, or sync; part 2 adopts it.
+
+## Why
+
+On a 40-dive database the two row-per-sample tables and their indexes are
+25.4 of 28.1 MB (90%). Measured on that data, this codec packs
+`dive_profiles` 74x and `tank_pressure_profiles` 129x, lossless.
+
+## What is in it
+
+- `byte_io.dart`: varint, zigzag varint, float64, presence-bitmapped
+  column blocks.
+- `ProfileSample`: the 28 sample columns of `dive_profiles` as a value
+  type, with `DiveProfilePoint` conversions.
+- `ProfileSeriesSummary`: the scalars that keep the deco, runtime, and
+  quality predicates in SQL.
+- `ProfileSeriesCodec`: versioned field table, encode/decode, strict
+  failure on anything malformed, forward tolerance for older versions.
+- `TankPressureSeriesCodec`: the two-field sibling.
+- A test that pins the field table to the live `dive_profiles` column
+  list, so a column added without a codec version fails CI.
+
+## Test plan
+
+- Round trips: every field present, every optional field null, mixed
+  presence, duplicate timestamps, decreasing integers, float64
+  bit-exactness, 20,000 samples.
+- Malformed input: non-zlib bytes, empty, unknown version, truncated,
+  trailing bytes, absent required column.
+- Forward tolerance: a newer decoder reads an older version with the
+  missing field null; an unknown version is refused.
+- Full suite green locally.
+```
+
+- [ ] **Step 6: Report**
+
+Reply with the PR URL, the measured blob size from the 20,000-sample test (print `encoded.bytes.length` once while verifying, then remove the print), and any test that needed a rerun and why.
+
+---
+
+## Self-review
+
+**Spec coverage.** Section 5's layout (version byte, count varint, per-field blocks, three presence modes, delta zigzag ints with reset per block and delta from last present value, float64 reals, run-length strings, zlib level 6, 28-field table in the stated order): Tasks 1 and 4. Section 5's versioning and strict failure: Task 4 (`fieldTables` keyed by version byte, `ProfileSeriesCodecException` on unknown version, truncation, trailing bytes, missing required column). Section 5's "summary scalars computed by the encoder and returned alongside the bytes": Task 3 and `EncodedProfileSeries` in Task 4. Section 4's scalar set for `dive_profile_series` (sample_count, start_timestamp, end_timestamp, max_depth, first_depth, last_depth, has_deco_type, has_deco_stop, has_positive_ceiling): Task 3, one for one. Section 4's scalar set for `tank_pressure_series`: Task 6. Section 10's codec tests (property round trips, largest series, bit-exactness, forward tolerance, the three malformed cases, the field-table-versus-Drift guard): Tasks 4, 5, 6. Section 11's PR 1 scope (codec, exception, summary, tests; no schema or behaviour change): all tasks; Task 7 verifies no Drift or Flutter import leaked into `lib/`. Section 3's layering ("pure Dart, same layering as `track_point_codec.dart`"): files live under `lib/features/dive_log/domain/codecs/`.
+
+Deliberately not in this plan, by spec: the repository, migration packer, sync shim, and benchmark fixture are PR 2.
+
+**Placeholder scan.** Every code step carries the full file or test. No "similar to", no "add handling". The one open-ended instruction, Task 5 step 2's "resolve it in the field table only if the column genuinely is a sample column", is a decision rule, not a placeholder.
+
+## Post-review amendments (2026-08-29)
+
+The whole-branch review after Task 7 added the following on top of the tasks
+above. They are recorded here so the plan matches the branch.
+
+- `byte_io.dart`: `readVarUint` rejects a tenth byte whose payload reaches
+  bit 63 (the value would wrap negative and escape the count guard as a
+  `RangeError`); `ByteWriter.length` removed as dead API.
+- `profile_series_codec.dart`: `_validateTable` also rejects duplicate field
+  names and runs on decode as well as encode; `decode` rejects a zero sample
+  count. `ProfileFieldKind`, `ProfileField`, and the v1 table moved to
+  `profile_field_table.dart` (top-level `kProfileFieldTableV1`;
+  `ProfileSeriesCodec.fieldTableV1` forwards to it) to keep every file under
+  400 lines.
+- `tank_pressure_series_codec.dart`: `decode` rejects a zero sample count.
+- Tests: absent-timestamp and absent-depth (and absent-pressure) bodies
+  built on a two-field table so the tampering stays aligned and reaches the
+  `no timestamp` / `no depth` / `no pressure` guards; malformed UTF-8 in a
+  string run; duplicate field name refused on both sides; zero count; the
+  tank table column pin; `props` length 28; and
+  `profile_series_golden_test.dart`, which freezes the v1 wire format as
+  hard-coded bytes for both codecs.
+- Deferred to PR 2 or later (recorded in the review): narrow the `catch (e)`
+  around zlib decode to `on FormatException`; a decode-side monotonic
+  timestamp re-check; `ProfileSample.copyWith`; a version-dispatch note on
+  the tank codec; a bounded inflate for peer-received blobs; the spec section
+  10 summary-scalar SQL equivalence test belongs to PR 2.
+
+**Type consistency.** `ProfileSeriesCodecException(String message)` with a `message` field is used by Tasks 1, 4, 6 and matched by `.having((e) => e.message, ...)` in tests. `ByteWriter.writeColumn<T extends Object>(List<T?>, void Function(T))` and `ByteReader.readColumn<T extends Object>(int, T Function())` are called with `int` and `double` in Tasks 1, 4, 6. `writePresence` returns `bool` and `readPresence` returns `List<bool>`, used by the string column in Task 4. `ProfileSeriesSummary.of(List<ProfileSample>)` is used in Task 4's encode and asserted in its test. `EncodedProfileSeries.bytes`, `.codecVersion`, `.summary` and the tank equivalents match between implementation and tests. `ProfileSeriesCodec.fieldTableV1` and `.version` are referenced by Tasks 4 and 5 with those exact names. `kDecoTypeDecoStop` is defined in Task 3 and used in its test.

--- a/docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md
+++ b/docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md
@@ -184,6 +184,13 @@ Layout:
    `dart:io` compression is already used by `track_point_codec.dart` and
    `sync_envelope.dart`.
 
+Varints are canonical: every value has exactly one encoding, the shortest
+one. LEB128 otherwise allows padding a value with continuation bytes that
+carry no payload, which would give one series several valid byte forms and
+make byte comparison of two blobs meaningless. The reader refuses any
+varint whose terminating byte carries a zero payload, unless that byte is
+the whole varint (the encoding of zero).
+
 Field table (dive profile), with encoding:
 
 | field | encoding |
@@ -412,8 +419,8 @@ Codec:
   bit-exactness.
 - A version-1 blob decoded under a hypothetical later field table yields
   the new fields null.
-- An unknown version, a truncated payload, and a malformed block each throw
-  `ProfileSeriesCodecException`.
+- An unknown version, a truncated payload, a malformed block, and a
+  non-canonical (padded) varint each throw `ProfileSeriesCodecException`.
 
 Summary scalars:
 

--- a/docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md
+++ b/docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md
@@ -1,0 +1,488 @@
+# Profile Sample Storage: Packed Series
+
+Design for replacing the row-per-sample `dive_profiles` and
+`tank_pressure_profiles` tables with one compressed, columnar BLOB row per
+series. Approved in brainstorming on 2026-08-28. Companion issues: #1375
+(cache and tombstone retention) and #1376 (backup retention defaults and
+raw-data discard) cover the rest of the on-device storage findings and are
+independent of this design.
+
+## 1. Why
+
+Measured on a 40-dive development database (28.07 MB, schema v179):
+
+| btree | size |
+|---|---:|
+| `dive_profiles` | 9.99 MB |
+| `tank_pressure_profiles` | 5.30 MB |
+| `idx_tank_pressure_dive_tank` | 3.42 MB |
+| `sqlite_autoindex_dive_profiles_1` | 2.48 MB |
+| `idx_dive_profiles_dive_id` | 2.19 MB |
+| `sqlite_autoindex_tank_pressure_profiles_1` | 2.04 MB |
+| subtotal | 25.41 MB (90.5% of the file) |
+| the other 244 btrees | 2.66 MB |
+
+Both tables hold one row per sample, and every row carries three or four
+36-character UUID strings (`id`, `dive_id`, `computer_id`, `source_id`, or
+`tank_id`), each mirrored again in the primary-key autoindex and the
+secondary index. `tank_pressure_profiles` spends 4.32 MB of UUID text to
+carry 0.48 MB of timestamps and pressures.
+
+Per-dive cost is 332 KB (a 1,032-dive fixture measured 2026-07-10 with 6 of
+the intended indexes) to 719 KB (the current schema with all 70 indexes). A
+1,000-dive logbook is therefore 300 to 700 MB, and backup retention (3
+pre-migration plus 10 manual copies by default) multiplies that by up to 14x
+on disk.
+
+Fragmentation is not the problem: `freelist_count` is 0 and `VACUUM INTO`
+recovers 4.3%. Periodic compaction was considered and rejected; the only
+`VACUUM` in this design is the one-time pass after the migration drops the
+old tables.
+
+Packing each series into a columnar, zlib-compressed BLOB was measured on the
+same database (lossless, float64 for real fields):
+
+| table | today | packed | factor |
+|---|---:|---:|---:|
+| `dive_profiles` and its indexes | 14.66 MB | 0.20 MB | 74x |
+| `tank_pressure_profiles` and its indexes | 10.75 MB | 0.08 MB | 129x |
+
+50,883 sample rows become 40 series rows. Sync payloads shrink by the same
+factor, and a dive edit stops shipping any samples at all.
+
+Alternatives measured and rejected: `WITHOUT ROWID` (14.66 to 14.03 MB; the
+fat TEXT key bloats every secondary index) and UUID text to 16-byte BLOB
+re-encoding (42 to 46%, still row-per-sample, still a sync protocol change).
+
+## 2. Goals and non-goals
+
+Goals:
+
+- Order-of-magnitude reduction in the bytes the two sample tables occupy,
+  on disk and on the sync wire.
+- No behaviour change above the repository layer. `DiveProfilePoint`, the
+  chart, the analysis pipeline, and every provider keep their contracts.
+- Every source-scoped operation (manual edit, restore, primary swap,
+  reparse, split, merge, consolidation) becomes a single-row operation.
+- Per-series last-writer-wins in sync, replacing the clockless per-sample
+  blind upsert.
+- Adding a sample field never again requires an `ALTER TABLE` over a
+  million rows.
+
+Non-goals:
+
+- Lossy downsampling or decimation at rest. The codec is lossless.
+- A natural-key uniqueness constraint on series. One data source
+  legitimately owns two series (its original and a manual edit), and
+  convergence across devices already rests on the dive-level match gate.
+- A dual-format sync bridge. The compatibility floor rises; older peers
+  hold until they upgrade.
+- Periodic or scheduled compaction.
+
+## 3. Architecture
+
+Two new tables, `dive_profile_series` and `tank_pressure_series`, replace
+`dive_profiles` and `tank_pressure_profiles`. A series row carries the
+identity columns exactly as they exist per row today, a small set of summary
+scalars, a codec version, and one BLOB holding every sample of the series.
+
+Three new units:
+
+- `ProfileSeriesCodec` (pure Dart, no Drift or Flutter imports, the same
+  layering as `lib/features/gps_log/domain/track_point_codec.dart`). Encodes
+  a sample list to bytes and back, and computes the summary scalars from the
+  samples it packs, so a scalar can never disagree with its blob.
+- `ProfileSeriesRepository`. Owns every read and write of series rows. The
+  only place that encodes or decodes in production code outside the
+  migration packer and the sync tolerance shim.
+- `ProfileSeries` and `TankPressureSeries` domain entities: identity,
+  summary, and the decoded sample list.
+
+`DiveRepository` and `TankPressureRepository` keep their public signatures
+(`getDiveProfile`, `getMergedProfile`, `getProfilesByDataSource`,
+`getDiveForAnalysis`, `getBatchProfileSummaries`, `getTankPressures`,
+`getPressuresForTank`) and delegate to the series repository.
+
+The existing per-row `computer_id`, `source_id`, `is_primary` triple is
+already a series identity: every operation that touches those columns
+filters a whole group and never a single sample. Lifting the triple onto the
+series row is the whole conceptual change.
+
+## 4. Schema
+
+### `dive_profile_series`
+
+| column | type | notes |
+|---|---|---|
+| `id` | TEXT PK | uuid v4 for new writes; deterministic for migrated rows (section 8) |
+| `dive_id` | TEXT NOT NULL | FK `dives(id)` ON DELETE CASCADE |
+| `computer_id` | TEXT | FK `dive_computers(id)` ON DELETE SET NULL |
+| `source_id` | TEXT | FK `dive_data_sources(id)` ON DELETE SET NULL |
+| `is_primary` | INTEGER NOT NULL DEFAULT 1 | CHECK 0 or 1 |
+| `sample_count` | INTEGER NOT NULL | |
+| `start_timestamp` | INTEGER NOT NULL | seconds from dive start, first sample |
+| `end_timestamp` | INTEGER NOT NULL | seconds from dive start, last sample |
+| `max_depth` | REAL NOT NULL | metres |
+| `first_depth` | REAL NOT NULL | metres |
+| `last_depth` | REAL NOT NULL | metres |
+| `has_deco_type` | INTEGER NOT NULL | any sample with `deco_type` not null |
+| `has_deco_stop` | INTEGER NOT NULL | any sample with `deco_type = 2` |
+| `has_positive_ceiling` | INTEGER NOT NULL | any sample with `ceiling > 0` |
+| `codec_version` | INTEGER NOT NULL | |
+| `samples` | BLOB NOT NULL | codec output |
+| `created_at` | INTEGER NOT NULL | |
+| `updated_at` | INTEGER NOT NULL | |
+| `hlc` | TEXT | sync clock, same shape as `dives.hlc` |
+
+Index: `idx_dive_profile_series_dive_primary` on `(dive_id, is_primary)`.
+
+### `tank_pressure_series`
+
+| column | type | notes |
+|---|---|---|
+| `id` | TEXT PK | as above |
+| `dive_id` | TEXT NOT NULL | FK `dives(id)` ON DELETE CASCADE |
+| `tank_id` | TEXT NOT NULL | FK `dive_tanks(id)` ON DELETE CASCADE |
+| `computer_id` | TEXT | FK `dive_computers(id)` ON DELETE SET NULL |
+| `sample_count` | INTEGER NOT NULL | |
+| `start_timestamp` | INTEGER NOT NULL | |
+| `end_timestamp` | INTEGER NOT NULL | |
+| `codec_version` | INTEGER NOT NULL | |
+| `samples` | BLOB NOT NULL | |
+| `created_at` | INTEGER NOT NULL | |
+| `updated_at` | INTEGER NOT NULL | |
+| `hlc` | TEXT | |
+
+Index: `idx_tank_pressure_series_dive_tank` on `(dive_id, tank_id)`.
+
+The summary scalars are exactly the set the nine SQL consumers in section 9
+need. Nothing speculative is stored; anything else decodes.
+
+Both tables replace the two entries `idx_dive_profiles_dive_id` and
+`idx_tank_pressure_dive_tank` in `kPerformanceIndexes`
+(`lib/core/database/performance_indexes.dart`) with their own indexes. The
+old entries must be removed, or the `beforeOpen` heal would try to index a
+dropped table.
+
+## 5. Codec v1
+
+Columnar, versioned, lossless.
+
+Layout:
+
+1. Header: one version byte (`1`), then `sample_count` as an unsigned
+   varint.
+2. One block per field, in the fixed field-table order below (28 fields
+   for a dive profile: every `dive_profiles` column except `id`,
+   `dive_id`, `computer_id`, `source_id`, and `is_primary`). Each block
+   begins with a presence mode byte: `0` absent (every value null; no
+   payload), `1` all present, `2` bitmap (a presence bitmap of
+   `ceil(n / 8)` bytes precedes the payload; only present values are
+   written).
+3. The concatenation of header and blocks is zlib-compressed with
+   `dart:io`'s `ZLibCodec` at level 6. No web build exists in CI, and
+   `dart:io` compression is already used by `track_point_codec.dart` and
+   `sync_envelope.dart`.
+
+Field table (dive profile), with encoding:
+
+| field | encoding |
+|---|---|
+| `timestamp` | delta from previous value, zigzag varint; the first delta is from 0 |
+| `depth` | float64 little-endian |
+| `pressure` (legacy per-sample column, still populated on older rows) | float64 |
+| `temperature` | float64 |
+| `heart_rate` | delta zigzag varint |
+| `ascent_rate` | float64 |
+| `ceiling` | float64 |
+| `ndl` | delta zigzag varint |
+| `setpoint` | float64 |
+| `pp_o2` | float64 |
+| `o2_sensor1` to `o2_sensor6` | float64 each |
+| `cns` | float64 |
+| `tts` | delta zigzag varint |
+| `rbt` | delta zigzag varint |
+| `deco_type` | delta zigzag varint |
+| `heart_rate_source` | run-length over the present values: a run count varint, then per run a length varint, a UTF-8 byte-length varint, and the bytes |
+| `heading` | float64 |
+| `o2_sensor_mv1` to `o2_sensor_mv6` | delta zigzag varint each |
+
+Field table (tank pressure): `timestamp` (delta zigzag varint), `pressure`
+(float64).
+
+Delta encoding of integer fields resets its "previous value" to 0 at the
+start of each field block and skips null entries (the delta is from the last
+present value). A zero timestamp delta is legal, so samples that share a
+timestamp are representable in insertion order.
+
+Real fields are float64 rather than fixed point because the measured 74x
+already exceeds the target and fixed point would be lossy for depths that
+libdivecomputer reports as doubles. float32 was measured (101x) and rejected
+for the same reason.
+
+Versioning: a later codec appends fields to the table under a new version
+byte. A decoder for version N reads a version M < N blob with the missing
+fields null. Decoders never guess: an unknown version byte, a truncated
+payload, or a block count that disagrees with the field table throws
+`ProfileSeriesCodecException` rather than returning a partial list.
+
+Summary scalars are computed by the encoder from the sample list it packs
+and returned alongside the bytes, so the repository writes both from one
+call.
+
+## 6. Read and write paths
+
+### Writes
+
+The thirteen sites that mint sample rows today reduce to this repository
+API:
+
+- `insertSeries(ProfileSeriesDraft)`: encode, compute summaries, mint a v4
+  id, insert one row.
+- `replaceSeriesOwnedBy(diveId, {computerId, sourceId}, samples)`: delete
+  the matching series rows, insert the replacement. Used by reparse,
+  re-download, and consolidation.
+- `demoteAll(diveId)` and `promote(diveId, {computerId, sourceId})`: the
+  `is_primary` flips, each a single-row `UPDATE`.
+- `deleteSeriesOwnedBy(diveId, {computerId, sourceId})` and
+  `deleteSeriesForDive(diveId)`.
+- The tank-pressure equivalents keyed by `(diveId, tankId, computerId)`.
+
+Semantics preserved exactly:
+
+- Manual edit (`saveEditedProfile`): demote every series for the dive, then
+  insert a new primary series with `computer_id` null and the primary
+  source's `source_id`.
+- Restore (`restoreOriginalProfile`): delete series where `is_primary` and
+  `computer_id IS NULL`, then re-promote the primary computer's series (or
+  every remaining series for a single-computer dive).
+- Split and merge: encode their rebased sample lists into new series rows;
+  originals are deleted as today.
+- Consolidation undo: `DiveMergeSnapshot` captures series rows instead of
+  sample rows and re-inserts them by series id with `insertOrReplace`.
+- Primary-source swap: `markRecordPending` once per series instead of once
+  per sample.
+
+Exact-duplicate dedupe (`_dropDuplicateSamples`, whole-row equality) moves
+from read time to encode time in the repository and into the migration
+packer. Samples that share a timestamp but differ are kept in insertion
+order.
+
+### Reads
+
+Every existing read method selects series rows for the dive and decodes.
+Merge order across sources and the promote tiebreaker are reproduced in Dart
+over decoded lists. `getBatchProfileSummaries` decodes one series per dive
+and downsamples, replacing the load-every-row path.
+
+Decoding one series (at most a few thousand samples) is on the order of a
+millisecond and runs on the isolate that receives the row. Whole-library
+aggregations (section 9) decode on a worker isolate via `compute`.
+
+### Domain
+
+`DiveProfilePoint` is unchanged. `TankPressurePoint.id` is removed: it
+appears only in Equatable `props`, no widget or exporter reads it, and
+`estimated_tank_pressure_synthesizer.dart` already fabricates non-uuid
+values for it.
+
+## 7. Sync
+
+`diveProfileSeries` and `tankPressureSeries` register in
+`SyncDataSerializer._baseTables` with `blob: true`, export by their own
+`hlc > since` (the `_exportGpsTracks` pattern, `samples` riding as base64
+through `_syncBlobSerializer`), and register as HLC-bearing with
+`updated_at` in `SyncService`. Apply is `insertOnConflictUpdate` by series
+id with last-writer-wins by HLC. `parentRefs` lists `dives`,
+`dive_computers`, `dive_data_sources`, and (for tank series) `dive_tanks`, so
+`sync_parent_refs_completeness_test` stays green.
+
+`diveProfiles` and `tankPressureProfiles` leave `_baseTables`, `SyncData`,
+`hlcBearing`, `parentRefs`, and the `fetchRecord`, `upsertRecord`,
+`upsertRecords`, `deleteRecord`, and `recordIdsFor` switches.
+
+Deleting a series logs one `deletion_log` row for the series id. The three
+per-sample tombstone amplifiers named in #1375 (tank-pressure delete, split,
+safety-review recompute over samples) disappear as a consequence.
+
+`minimumCompatibleSchemaVersion` rises to the new rung: the migration
+removes two synced entities and replaces them, which the floor's own rules
+classify as breaking. The floor is one-directional, so receiving-side
+tolerance for older peers' payloads is added in the serializer's established
+pattern: legacy `diveProfiles` and `tankPressureProfiles` arrays that still
+arrive are grouped by identity tuple and packed into series on apply, using
+the same packer the migration uses. This is a read-side shim, not a
+dual-write; older peers hold until they upgrade and then migrate their own
+rows.
+
+The `cross_version_roundtrip_test` projection is extended to cover the new
+boundary, as the floor's doc comment requires.
+
+## 8. Migration and one-time compaction
+
+### The rung
+
+One new ladder rung at the next free schema version. At the time of
+writing `origin/main` is at 179 and 180 is the next free rung, but at least
+one sibling worktree also needs to move onto it; the number is claimed at
+implementation time and re-checked against `origin/main` immediately before
+the PR opens.
+
+Steps, in order:
+
+1. Create both series tables and their indexes.
+2. Pack profiles. For each distinct `dive_id`, select that dive's rows
+   ordered by `(computer_id, source_id, is_primary, timestamp, rowid)`,
+   group by the identity tuple in Dart, drop exact duplicates, encode, and
+   insert one series row per group. Memory is bounded by one dive's samples
+   (the largest observed series is 4,631 samples), never by the table.
+3. Pack tank pressures the same way, grouped by
+   `(dive_id, tank_id, computer_id)`.
+4. Drop `dive_profiles` and `tank_pressure_profiles`.
+5. Purge `deletion_log` and `sync_records` rows whose entity type is
+   `diveProfiles` or `tankPressureProfiles`.
+
+Migrated series rows take `created_at` and `updated_at` from the migration
+time and an `hlc` minted by the local clock, so the first sync after
+upgrade publishes them.
+
+### Fleet convergence
+
+Every device runs this migration independently. A random series id per
+device would let sync union two primary series per dive, the exact shape of
+the duplicate dive-types bug (#1360). Migrated series ids are therefore
+deterministic: uuid v5 over the identity tuple
+`dive_id | computer_id | source_id | is_primary` (with the literal `null`
+for absent members). Two devices holding the same synced sample rows
+produce the same series id and converge on upsert. Only the migration
+derives ids this way; writes after it mint v4, because a fresh download or
+edit genuinely is a new series.
+
+### Safety net
+
+The existing pre-migration backup (`_runPreMigrationBackup` in
+`startup_page.dart`, retain 3) runs before the ladder as it does today. The
+rung runs under Drift's migration handling like every other rung; a failure
+leaves the old tables intact for the retry.
+
+### Compaction
+
+Dropping the tables returns roughly 90% of the pages to the freelist, but
+the file does not shrink until `VACUUM`. The seam is
+`DatabaseService._runUpgradeLadder`: it reads `PRAGMA user_version` before
+constructing the migrator, and if that value was below the pack rung, it
+executes `VACUUM` on the same synchronous connection after the ladder
+completes (the forcing `SELECT 1` has returned) and before `close()`. That
+point is outside any migration transaction, on the one exclusive
+main-isolate connection, before the background executor opens the file, and
+works under SQLCipher.
+
+Non-fatal by design: a `VACUUM` that fails (for example `SQLITE_BUSY` from
+another connection) logs and moves on with a correct but large file. No
+marker is persisted; the decision comes from the pre-ladder `user_version`.
+
+## 9. The nine SQL consumers
+
+| consumer | today | after |
+|---|---|---|
+| deco classification signals (`statistics_repository.dart`) | `MAX(deco_type IS NOT NULL)`, `MAX(deco_type = 2)`, `MAX(ceiling > 0)` over rows | `has_deco_type`, `has_deco_stop`, `has_positive_ceiling`; stays SQL |
+| `decoSignalCondition` (`statistics/data/dive_filter_sql.dart`) and `getDiveIdsWithDecoSignal` | `EXISTS` over rows plus `dive_profile_events` | same flags plus events; stays SQL |
+| `had_deco` in the recent-dives query (`dive_repository_impl.dart`) | `EXISTS(deco_type = 2 OR ceiling > 0)` | `has_deco_stop OR has_positive_ceiling`; stays SQL |
+| profile span in `_effectiveRuntimeSql` and `_diveTimesSelect` | `MAX(ts) - MIN(ts)` over rows | `MAX(end_timestamp) - MIN(start_timestamp)` over the dive's series; stays SQL |
+| quality neighbour first and last depth (`quality_context_builder.dart`) | two correlated `ORDER BY ts LIMIT 1` subqueries | `first_depth`, `last_depth`; stays SQL |
+| quality prefilters (`quality_prefilters.dart`) | `EXISTS` on both sample tables | `EXISTS` on both series tables; stays SQL |
+| source ownership and promote-by-predicate (`_sourceOwnsProfiles` and neighbours) | row predicates with a bound-variable-limit workaround | series-row predicates; the workaround becomes unnecessary |
+| sustained ascent and descent rates (`statistics_repository.dart`) | windowed `AVG(depth)` and `LAG` over every primary row in scope | decode primary series in scope on a worker isolate; same window and threshold constants |
+| time-at-depth buckets (`statistics_repository.dart`) | `LEAD` intervals with a cadence cap, tiebreak `ORDER BY at, sample_id` | same algorithm in Dart over decoded series; tiebreak is stored order |
+
+Only the last two leave SQL, and both are whole-library aggregations that
+the statistics page already awaits asynchronously. The two Dart aggregations
+carry a benchmark gate (section 10).
+
+Historical backfills in older rungs (v132, v146, v177) run before the pack
+rung and are untouched. Any future backfill that needs samples decodes.
+
+## 10. Testing and benchmark gates
+
+Codec:
+
+- Round-trip property tests over generated sample lists: every field null,
+  every field present, mixed presence, duplicate timestamps, negative
+  deltas, the largest realistic series (20,000 samples at 1 s), float64
+  bit-exactness.
+- A version-1 blob decoded under a hypothetical later field table yields
+  the new fields null.
+- An unknown version, a truncated payload, and a malformed block each throw
+  `ProfileSeriesCodecException`.
+
+Summary scalars:
+
+- Equivalence tests run today's SQL expressions over a row fixture, pack
+  it, and assert the scalars match, proving the section 9 substitutions.
+
+Migration (following the `test/core/database/migration_v*` precedent):
+
+- A pre-rung fixture with exact duplicates, null `source_id`, null
+  `computer_id`, a multi-source dive, and a manual-edit series.
+- Asserts: decoded samples equal the originals minus exact duplicates; the
+  old tables are gone; the retired tombstones and pending records are
+  purged; two independently migrated copies of the same fixture produce
+  identical series ids (the #1360 test).
+- `query_plan_test` and `performance_indexes_test` updated for the removed
+  and added indexes.
+
+Sync:
+
+- Export-to-JSON-to-apply round trips for both entities on a second
+  database.
+- The legacy-array tolerance shim applied to a v179-shaped payload.
+- `sync_parent_refs_completeness_test`; the `cross_version_roundtrip_test`
+  projection extended.
+- One tombstone per deleted series.
+
+Behaviour:
+
+- Existing tests for manual edit, restore, primary swap, split, merge, and
+  consolidation undo run unchanged against the new storage. Of the 53 test
+  files that reference the old tables, those asserting on raw rows are
+  ported.
+- The two statistics aggregations that move to Dart get golden values
+  captured from the SQL versions before the change.
+
+Benchmarks, gated in the second PR, on a synthesized 1,000-dive fixture (a
+`tools/` script replicates the 40-dive development database with fresh ids;
+the 2026-07-10 real fixture is no longer on this machine):
+
+- per-dive detail hydrate
+- `getBatchProfileSummaries` for 50 dives
+- both statistics aggregations
+- migration wall time
+- post-`VACUUM` file size and `VACUUM` time
+
+Gate: nothing slower than today; numbers reported in the PR description.
+
+## 11. Delivery
+
+Two stacked PRs on `worktree-profile-sample-storage`:
+
+1. Codec only: `ProfileSeriesCodec`, its exception type, the summary
+   computation, and the codec tests. Pure Dart, no schema change, no
+   behaviour change.
+2. Schema, `ProfileSeriesRepository`, the repository ports, the migration
+   rung with compaction, the sync changes and tolerance shim, the SQL
+   consumer substitutions, the fixture script, and the benchmark results.
+
+## 12. Risks and mitigations
+
+- Migration time on a large phone database: bounded per-dive memory and a
+  benchmark on the 1,000-dive fixture; the startup screen already shows
+  migration progress.
+- Statistics regressions from moving two aggregations to Dart: golden-value
+  tests plus the benchmark gate.
+- Schema rung collision with sibling worktrees: claim at implementation
+  time, re-check before the PR opens.
+- A sample field the field table forgot: the codec tests enumerate the
+  field table against the Drift column list for `DiveProfiles` so a missing
+  column fails the test, not the user.
+- Deterministic migrated ids colliding with a v4 id: uuid v5 and v4 occupy
+  disjoint version nibbles, so a collision is impossible by construction.

--- a/lib/features/dive_log/domain/codecs/bounded_inflate.dart
+++ b/lib/features/dive_log/domain/codecs/bounded_inflate.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// The largest sample count either series codec will encode or decode.
+///
+/// 262,144 samples is over 72 hours at one hertz, where the longest dive the
+/// round-trip tests call realistic is 20,000 samples. The cap is not a claim
+/// about plausible dives but a bound on allocation: the profile decoder
+/// sizes one list per field from this count, and decoding a full series was
+/// measured to retain about 200 MB (the reference arrays, the boxed doubles
+/// and ints inside the nullable columns, the per-column presence lists, and
+/// the [ProfileSample] objects, which are all live at once). A declared
+/// count costs one varint, so it must not size anything unbounded.
+///
+/// Encode enforces the same cap. A blob this codec would refuse to read must
+/// never be written, because part 2 drops the source rows once a series is
+/// packed.
+const int kMaxSeriesSampleCount = 1 << 18;
+
+/// The largest uncompressed body either series codec will inflate.
+///
+/// This is the outer bound against unbounded inflation, not the binding
+/// guard. For the profile codec [kMaxSeriesSampleCount] binds first: a
+/// maximal series is roughly 37 MB of body, so this leaves headroom rather
+/// than sitting on the real limit. Sizing it snugly would trade that
+/// headroom for the risk of refusing a legitimate series, which for packed
+/// storage means data that cannot be read back.
+const int kMaxSeriesBodyBytes = 64 * 1024 * 1024;
+
+/// The largest compressed blob either series codec will accept.
+///
+/// zlib output for a body under [kMaxSeriesBodyBytes] cannot exceed it by
+/// more than stream overhead even for incompressible input, so matching the
+/// two can never refuse a blob the body cap would have accepted. Without
+/// this, arbitrary bytes appended after a complete zlib stream are copied
+/// whole into the native filter and then silently discarded: a 64 MiB pad
+/// was measured returning a five byte body, no error, and a 135 MB spike.
+const int kMaxSeriesBlobBytes = kMaxSeriesBodyBytes;
+
+/// Inflates a zlib stream, refusing anything that expands past [maxBytes].
+///
+/// The decoder runs chunked, so a compression bomb is abandoned at the first
+/// chunk over the cap rather than after the whole body is in memory.
+///
+/// Throws [ProfileSeriesCodecException] if [bytes] is longer than
+/// [maxBlobBytes], is not a zlib stream, or inflates past [maxBytes].
+/// Errors that are not malformed input, an [ArgumentError] from a bad cap
+/// among them, are left to surface.
+///
+/// Not a completeness check. zlib accepts a truncated stream, returning the
+/// bytes it managed to inflate with no error, and a stream missing only its
+/// four byte adler-32 trailer returns its body in full, so the checksum is
+/// never verified. Both were measured. Callers must frame their own payload;
+/// the series codecs do, by refusing a body whose column blocks do not span
+/// it exactly.
+Uint8List inflateBounded(
+  Uint8List bytes, {
+  int maxBytes = kMaxSeriesBodyBytes,
+  int maxBlobBytes = kMaxSeriesBlobBytes,
+}) {
+  if (maxBytes < 0) {
+    throw ArgumentError.value(maxBytes, 'maxBytes', 'must not be negative');
+  }
+  if (maxBlobBytes < 0) {
+    throw ArgumentError.value(
+      maxBlobBytes,
+      'maxBlobBytes',
+      'must not be negative',
+    );
+  }
+  // Before the conversion, not inside the sink: the filter copies the whole
+  // input natively before it emits a first chunk, so a sink-side check
+  // never sees an oversized blob.
+  if (bytes.length > maxBlobBytes) {
+    throw ProfileSeriesCodecException(
+      'blob of ${bytes.length} byte(s) exceeds the $maxBlobBytes allowed',
+    );
+  }
+  final sink = _BoundedByteSink(maxBytes);
+  try {
+    final input = ZLibCodec().decoder.startChunkedConversion(sink);
+    input
+      ..add(bytes)
+      ..close();
+  } on FormatException catch (e) {
+    throw ProfileSeriesCodecException('not a zlib stream: ${e.message}');
+  }
+  return sink.takeBytes();
+}
+
+/// Collects inflated chunks and throws as soon as they pass [_maxBytes].
+class _BoundedByteSink implements Sink<List<int>> {
+  _BoundedByteSink(this._maxBytes);
+
+  final int _maxBytes;
+  final BytesBuilder _builder = BytesBuilder(copy: false);
+
+  @override
+  void add(List<int> chunk) {
+    if (_builder.length + chunk.length > _maxBytes) {
+      // Thrown from inside the zlib filter's own add, which unwinds it.
+      throw ProfileSeriesCodecException(
+        'inflated body exceeds the $_maxBytes byte(s) allowed',
+      );
+    }
+    _builder.add(chunk);
+  }
+
+  @override
+  void close() {}
+
+  Uint8List takeBytes() => _builder.takeBytes();
+}

--- a/lib/features/dive_log/domain/codecs/byte_io.dart
+++ b/lib/features/dive_log/domain/codecs/byte_io.dart
@@ -1,0 +1,187 @@
+import 'dart:typed_data';
+
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// Presence mode for a column block: every value is null, no payload.
+const int kPresenceAbsent = 0;
+
+/// Presence mode for a column block: every value is present, no bitmap.
+const int kPresenceAll = 1;
+
+/// Presence mode for a column block: a bitmap of `ceil(n / 8)` bytes
+/// (LSB-first within each byte) precedes the present values.
+const int kPresenceBitmap = 2;
+
+/// Append-only little-endian byte sink for the series codecs.
+class ByteWriter {
+  // copy: true (the default) matters: writeFloat64 hands the builder a view
+  // of a reused scratch buffer, and a non-copying builder would alias every
+  // float written to the same eight bytes.
+  final BytesBuilder _builder = BytesBuilder();
+  final ByteData _scratch = ByteData(8);
+
+  int get length => _builder.length;
+
+  void writeByte(int value) {
+    assert(value >= 0 && value <= 0xFF, 'not a byte: $value');
+    _builder.addByte(value);
+  }
+
+  /// Unsigned LEB128 varint: seven bits per byte, high bit set on all but
+  /// the last byte.
+  void writeVarUint(int value) {
+    assert(value >= 0, 'varuint cannot encode $value');
+    var remaining = value;
+    while (remaining >= 0x80) {
+      _builder.addByte((remaining & 0x7F) | 0x80);
+      remaining >>= 7;
+    }
+    _builder.addByte(remaining);
+  }
+
+  /// Zigzag-mapped signed varint, so small negatives stay small: 0, -1, 1,
+  /// -2, 2 map to 0, 1, 2, 3, 4.
+  void writeVarInt(int value) => writeVarUint((value << 1) ^ (value >> 63));
+
+  /// IEEE-754 binary64, little-endian, bit-exact.
+  void writeFloat64(double value) {
+    _scratch.setFloat64(0, value, Endian.little);
+    _builder.add(_scratch.buffer.asUint8List(0, 8));
+  }
+
+  void writeBytes(List<int> bytes) => _builder.add(bytes);
+
+  /// Returns everything written and resets the writer.
+  Uint8List takeBytes() => _builder.takeBytes();
+}
+
+/// Strict forward-only reader over a byte buffer. Every read that would run
+/// past the end throws [ProfileSeriesCodecException].
+class ByteReader {
+  ByteReader(Uint8List bytes)
+    : _bytes = bytes,
+      _data = ByteData.sublistView(bytes);
+
+  final Uint8List _bytes;
+  final ByteData _data;
+  int _offset = 0;
+
+  int get offset => _offset;
+  int get remaining => _bytes.length - _offset;
+  bool get isAtEnd => _offset >= _bytes.length;
+
+  int readByte() {
+    _ensure(1);
+    return _bytes[_offset++];
+  }
+
+  int readVarUint() {
+    var result = 0;
+    var shift = 0;
+    while (true) {
+      final byte = readByte();
+      result |= (byte & 0x7F) << shift;
+      if ((byte & 0x80) == 0) return result;
+      shift += 7;
+      if (shift > 63) {
+        throw const ProfileSeriesCodecException('varint longer than 64 bits');
+      }
+    }
+  }
+
+  int readVarInt() {
+    final zigzag = readVarUint();
+    return (zigzag >>> 1) ^ -(zigzag & 1);
+  }
+
+  double readFloat64() {
+    _ensure(8);
+    final value = _data.getFloat64(_offset, Endian.little);
+    _offset += 8;
+    return value;
+  }
+
+  Uint8List readBytes(int count) {
+    _ensure(count);
+    final view = Uint8List.sublistView(_bytes, _offset, _offset + count);
+    _offset += count;
+    return view;
+  }
+
+  void _ensure(int count) {
+    if (count < 0 || _offset + count > _bytes.length) {
+      throw ProfileSeriesCodecException(
+        'unexpected end of data: needed $count byte(s) at offset $_offset '
+        'of ${_bytes.length}',
+      );
+    }
+  }
+}
+
+/// Column blocks: a presence mode byte, an optional bitmap, then only the
+/// present values in order.
+extension ColumnWriter on ByteWriter {
+  /// Writes the presence mode and, when needed, the bitmap. Returns whether
+  /// any value is present, so the caller knows whether to write payload.
+  bool writePresence(List<Object?> values) {
+    var presentCount = 0;
+    for (final value in values) {
+      if (value != null) presentCount++;
+    }
+    if (presentCount == 0) {
+      writeByte(kPresenceAbsent);
+      return false;
+    }
+    if (presentCount == values.length) {
+      writeByte(kPresenceAll);
+      return true;
+    }
+    writeByte(kPresenceBitmap);
+    final bitmap = Uint8List((values.length + 7) >> 3);
+    for (var i = 0; i < values.length; i++) {
+      if (values[i] != null) bitmap[i >> 3] |= 1 << (i & 7);
+    }
+    writeBytes(bitmap);
+    return true;
+  }
+
+  /// Writes one column: presence, then [writeValue] for each present value
+  /// in order. [writeValue] may keep state between calls (delta encoding).
+  void writeColumn<T extends Object>(
+    List<T?> values,
+    void Function(T value) writeValue,
+  ) {
+    if (!writePresence(values)) return;
+    for (final value in values) {
+      if (value != null) writeValue(value);
+    }
+  }
+}
+
+extension ColumnReader on ByteReader {
+  /// Reads a presence block for [count] values.
+  List<bool> readPresence(int count) {
+    final mode = readByte();
+    switch (mode) {
+      case kPresenceAbsent:
+        return List<bool>.filled(count, false);
+      case kPresenceAll:
+        return List<bool>.filled(count, true);
+      case kPresenceBitmap:
+        final bitmap = readBytes((count + 7) >> 3);
+        return [
+          for (var i = 0; i < count; i++)
+            ((bitmap[i >> 3] >> (i & 7)) & 1) == 1,
+        ];
+      default:
+        throw ProfileSeriesCodecException('unknown presence mode $mode');
+    }
+  }
+
+  /// Reads one column of [count] values, calling [readValue] once per
+  /// present value in order. [readValue] may keep state between calls.
+  List<T?> readColumn<T extends Object>(int count, T Function() readValue) {
+    final present = readPresence(count);
+    return [for (final isPresent in present) isPresent ? readValue() : null];
+  }
+}

--- a/lib/features/dive_log/domain/codecs/byte_io.dart
+++ b/lib/features/dive_log/domain/codecs/byte_io.dart
@@ -20,8 +20,6 @@ class ByteWriter {
   final BytesBuilder _builder = BytesBuilder();
   final ByteData _scratch = ByteData(8);
 
-  int get length => _builder.length;
-
   void writeByte(int value) {
     assert(value >= 0 && value <= 0xFF, 'not a byte: $value');
     _builder.addByte(value);
@@ -80,6 +78,9 @@ class ByteReader {
     var shift = 0;
     while (true) {
       final byte = readByte();
+      if (shift == 63 && (byte & 0x7F) != 0) {
+        throw const ProfileSeriesCodecException('varint overflows 63 bits');
+      }
       result |= (byte & 0x7F) << shift;
       if ((byte & 0x80) == 0) return result;
       shift += 7;

--- a/lib/features/dive_log/domain/codecs/byte_io.dart
+++ b/lib/features/dive_log/domain/codecs/byte_io.dart
@@ -102,6 +102,13 @@ class ByteReader {
     return _bytes[_offset++];
   }
 
+  /// Accepts only the minimal encoding of a value. LEB128 lets any value be
+  /// padded with continuation bytes carrying no payload, so `0x80 0x00` and
+  /// `0x00` would otherwise both decode to zero and one series would have
+  /// several valid byte forms. A terminating byte of zero is canonical only
+  /// as the whole varint, which is what `shift > 0` tests. That also refuses
+  /// the ten-byte form the bit-63 guard below cannot reach, since its tenth
+  /// byte must carry a zero payload to get that far.
   int readVarUint() {
     var result = 0;
     var shift = 0;
@@ -111,7 +118,14 @@ class ByteReader {
         throw const ProfileSeriesCodecException('varint overflows 63 bits');
       }
       result |= (byte & 0x7F) << shift;
-      if ((byte & 0x80) == 0) return result;
+      if ((byte & 0x80) == 0) {
+        if (shift > 0 && (byte & 0x7F) == 0) {
+          throw const ProfileSeriesCodecException(
+            'non-canonical varint: padded with an empty terminating byte',
+          );
+        }
+        return result;
+      }
       shift += 7;
       if (shift > 63) {
         throw const ProfileSeriesCodecException('varint longer than 64 bits');

--- a/lib/features/dive_log/domain/codecs/byte_io.dart
+++ b/lib/features/dive_log/domain/codecs/byte_io.dart
@@ -12,6 +12,12 @@ const int kPresenceAll = 1;
 /// (LSB-first within each byte) precedes the present values.
 const int kPresenceBitmap = 2;
 
+/// The most negative value [ByteWriter.writeVarInt] can zigzag-map.
+const int minVarInt = -(1 << 62);
+
+/// The most positive value [ByteWriter.writeVarInt] can zigzag-map.
+const int maxVarInt = (1 << 62) - 1;
+
 /// Append-only little-endian byte sink for the series codecs.
 class ByteWriter {
   // copy: true (the default) matters: writeFloat64 hands the builder a view
@@ -20,15 +26,27 @@ class ByteWriter {
   final BytesBuilder _builder = BytesBuilder();
   final ByteData _scratch = ByteData(8);
 
+  /// Throws [ArgumentError] outside 0 .. 255. Like [writeVarUint], this is
+  /// not an assert: `addByte` keeps the low eight bits, so a release build
+  /// would silently write 44 for 300 and the blob would decode under the
+  /// wrong version.
   void writeByte(int value) {
-    assert(value >= 0 && value <= 0xFF, 'not a byte: $value');
+    if (value < 0 || value > 0xFF) {
+      throw ArgumentError.value(value, 'value', 'not a byte');
+    }
     _builder.addByte(value);
   }
 
   /// Unsigned LEB128 varint: seven bits per byte, high bit set on all but
   /// the last byte.
+  ///
+  /// Throws [ArgumentError] on a negative value. The check is not an assert
+  /// because a release build would otherwise emit one truncated byte for it
+  /// and produce a blob no reader can make sense of.
   void writeVarUint(int value) {
-    assert(value >= 0, 'varuint cannot encode $value');
+    if (value < 0) {
+      throw ArgumentError.value(value, 'value', 'varuint cannot encode');
+    }
     var remaining = value;
     while (remaining >= 0x80) {
       _builder.addByte((remaining & 0x7F) | 0x80);
@@ -39,7 +57,18 @@ class ByteWriter {
 
   /// Zigzag-mapped signed varint, so small negatives stay small: 0, -1, 1,
   /// -2, 2 map to 0, 1, 2, 3, 4.
-  void writeVarInt(int value) => writeVarUint((value << 1) ^ (value >> 63));
+  ///
+  /// Dart's int is 64-bit two's complement, so `value << 1` wraps into the
+  /// sign bit outside [minVarInt] .. [maxVarInt] and the mapping would hand
+  /// [writeVarUint] a negative. Throws [ArgumentError] rather than encode a
+  /// value the reader, which refuses a payload reaching bit 63, could not
+  /// read back.
+  void writeVarInt(int value) {
+    if (value < minVarInt || value > maxVarInt) {
+      throw ArgumentError.value(value, 'value', 'varint out of zigzag range');
+    }
+    writeVarUint((value << 1) ^ (value >> 63));
+  }
 
   /// IEEE-754 binary64, little-endian, bit-exact.
   void writeFloat64(double value) {
@@ -110,7 +139,10 @@ class ByteReader {
   }
 
   void _ensure(int count) {
-    if (count < 0 || _offset + count > _bytes.length) {
+    // Subtract rather than add: `_offset + count` overflows into a negative
+    // for a count near 2^63, which a crafted length varint can reach, and
+    // the guard would pass it straight to a RangeError.
+    if (count < 0 || count > _bytes.length - _offset) {
       throw ProfileSeriesCodecException(
         'unexpected end of data: needed $count byte(s) at offset $_offset '
         'of ${_bytes.length}',

--- a/lib/features/dive_log/domain/codecs/profile_field_table.dart
+++ b/lib/features/dive_log/domain/codecs/profile_field_table.dart
@@ -1,0 +1,54 @@
+/// How a field's column block is written.
+enum ProfileFieldKind {
+  /// Zigzag varint of the difference from the previous present value; the
+  /// previous value starts at 0 for each block.
+  deltaInt,
+
+  /// IEEE-754 binary64, little-endian.
+  float64,
+
+  /// Runs of identical strings: run count, then (length, UTF-8 length,
+  /// UTF-8 bytes) per run, covering the present values only.
+  runLengthString,
+}
+
+/// One entry of a field table. [name] is the `dive_profiles` column name.
+class ProfileField {
+  const ProfileField(this.name, this.kind);
+
+  final String name;
+  final ProfileFieldKind kind;
+}
+
+/// Codec v1: every `dive_profiles` sample column, in this order. Never
+/// reorder or remove an entry; append under a new version instead.
+const List<ProfileField> kProfileFieldTableV1 = [
+  ProfileField('timestamp', ProfileFieldKind.deltaInt),
+  ProfileField('depth', ProfileFieldKind.float64),
+  ProfileField('pressure', ProfileFieldKind.float64),
+  ProfileField('temperature', ProfileFieldKind.float64),
+  ProfileField('heart_rate', ProfileFieldKind.deltaInt),
+  ProfileField('ascent_rate', ProfileFieldKind.float64),
+  ProfileField('ceiling', ProfileFieldKind.float64),
+  ProfileField('ndl', ProfileFieldKind.deltaInt),
+  ProfileField('setpoint', ProfileFieldKind.float64),
+  ProfileField('pp_o2', ProfileFieldKind.float64),
+  ProfileField('o2_sensor1', ProfileFieldKind.float64),
+  ProfileField('o2_sensor2', ProfileFieldKind.float64),
+  ProfileField('o2_sensor3', ProfileFieldKind.float64),
+  ProfileField('o2_sensor4', ProfileFieldKind.float64),
+  ProfileField('o2_sensor5', ProfileFieldKind.float64),
+  ProfileField('o2_sensor6', ProfileFieldKind.float64),
+  ProfileField('cns', ProfileFieldKind.float64),
+  ProfileField('tts', ProfileFieldKind.deltaInt),
+  ProfileField('rbt', ProfileFieldKind.deltaInt),
+  ProfileField('deco_type', ProfileFieldKind.deltaInt),
+  ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+  ProfileField('heading', ProfileFieldKind.float64),
+  ProfileField('o2_sensor_mv1', ProfileFieldKind.deltaInt),
+  ProfileField('o2_sensor_mv2', ProfileFieldKind.deltaInt),
+  ProfileField('o2_sensor_mv3', ProfileFieldKind.deltaInt),
+  ProfileField('o2_sensor_mv4', ProfileFieldKind.deltaInt),
+  ProfileField('o2_sensor_mv5', ProfileFieldKind.deltaInt),
+  ProfileField('o2_sensor_mv6', ProfileFieldKind.deltaInt),
+];

--- a/lib/features/dive_log/domain/codecs/profile_sample.dart
+++ b/lib/features/dive_log/domain/codecs/profile_sample.dart
@@ -1,0 +1,179 @@
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+/// One profile sample exactly as the `dive_profiles` table stores it, minus
+/// the identity columns (`id`, `dive_id`, `computer_id`, `source_id`,
+/// `is_primary`) that live on the series row.
+///
+/// This is the codec's input and output type. It differs from
+/// [DiveProfilePoint] in one field: the legacy per-sample [pressure]
+/// column, which the v59 migration moved to tank pressure profiles but
+/// which older rows still populate. The codec is lossless over the stored
+/// row, so the field rides along; [toPoint] drops it, as every read path
+/// does today.
+class ProfileSample extends Equatable {
+  const ProfileSample({
+    required this.timestamp,
+    required this.depth,
+    this.pressure,
+    this.temperature,
+    this.heartRate,
+    this.ascentRate,
+    this.ceiling,
+    this.ndl,
+    this.setpoint,
+    this.ppO2,
+    this.o2Sensor1,
+    this.o2Sensor2,
+    this.o2Sensor3,
+    this.o2Sensor4,
+    this.o2Sensor5,
+    this.o2Sensor6,
+    this.cns,
+    this.tts,
+    this.rbt,
+    this.decoType,
+    this.heartRateSource,
+    this.heading,
+    this.o2SensorMv1,
+    this.o2SensorMv2,
+    this.o2SensorMv3,
+    this.o2SensorMv4,
+    this.o2SensorMv5,
+    this.o2SensorMv6,
+  });
+
+  factory ProfileSample.fromPoint(DiveProfilePoint point, {double? pressure}) {
+    return ProfileSample(
+      timestamp: point.timestamp,
+      depth: point.depth,
+      pressure: pressure,
+      temperature: point.temperature,
+      heartRate: point.heartRate,
+      ascentRate: point.ascentRate,
+      ceiling: point.ceiling,
+      ndl: point.ndl,
+      setpoint: point.setpoint,
+      ppO2: point.ppO2,
+      o2Sensor1: point.o2Sensor1,
+      o2Sensor2: point.o2Sensor2,
+      o2Sensor3: point.o2Sensor3,
+      o2Sensor4: point.o2Sensor4,
+      o2Sensor5: point.o2Sensor5,
+      o2Sensor6: point.o2Sensor6,
+      cns: point.cns,
+      tts: point.tts,
+      rbt: point.rbt,
+      decoType: point.decoType,
+      heartRateSource: point.heartRateSource,
+      heading: point.heading,
+      o2SensorMv1: point.o2SensorMv1,
+      o2SensorMv2: point.o2SensorMv2,
+      o2SensorMv3: point.o2SensorMv3,
+      o2SensorMv4: point.o2SensorMv4,
+      o2SensorMv5: point.o2SensorMv5,
+      o2SensorMv6: point.o2SensorMv6,
+    );
+  }
+
+  /// Seconds from dive start.
+  final int timestamp;
+
+  /// Metres.
+  final double depth;
+
+  /// Legacy per-sample pressure in bar; null on every row written after the
+  /// v59 migration.
+  final double? pressure;
+  final double? temperature;
+  final int? heartRate;
+  final double? ascentRate;
+  final double? ceiling;
+  final int? ndl;
+  final double? setpoint;
+  final double? ppO2;
+  final double? o2Sensor1;
+  final double? o2Sensor2;
+  final double? o2Sensor3;
+  final double? o2Sensor4;
+  final double? o2Sensor5;
+  final double? o2Sensor6;
+  final double? cns;
+  final int? tts;
+  final int? rbt;
+  final int? decoType;
+  final String? heartRateSource;
+  final double? heading;
+  final int? o2SensorMv1;
+  final int? o2SensorMv2;
+  final int? o2SensorMv3;
+  final int? o2SensorMv4;
+  final int? o2SensorMv5;
+  final int? o2SensorMv6;
+
+  /// The domain point. Drops [pressure], which [DiveProfilePoint] does not
+  /// carry.
+  DiveProfilePoint toPoint() {
+    return DiveProfilePoint(
+      timestamp: timestamp,
+      depth: depth,
+      temperature: temperature,
+      heartRate: heartRate,
+      heading: heading,
+      setpoint: setpoint,
+      ppO2: ppO2,
+      o2Sensor1: o2Sensor1,
+      o2Sensor2: o2Sensor2,
+      o2Sensor3: o2Sensor3,
+      o2Sensor4: o2Sensor4,
+      o2Sensor5: o2Sensor5,
+      o2Sensor6: o2Sensor6,
+      o2SensorMv1: o2SensorMv1,
+      o2SensorMv2: o2SensorMv2,
+      o2SensorMv3: o2SensorMv3,
+      o2SensorMv4: o2SensorMv4,
+      o2SensorMv5: o2SensorMv5,
+      o2SensorMv6: o2SensorMv6,
+      heartRateSource: heartRateSource,
+      cns: cns,
+      ndl: ndl,
+      ceiling: ceiling,
+      ascentRate: ascentRate,
+      rbt: rbt,
+      decoType: decoType,
+      tts: tts,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    timestamp,
+    depth,
+    pressure,
+    temperature,
+    heartRate,
+    ascentRate,
+    ceiling,
+    ndl,
+    setpoint,
+    ppO2,
+    o2Sensor1,
+    o2Sensor2,
+    o2Sensor3,
+    o2Sensor4,
+    o2Sensor5,
+    o2Sensor6,
+    cns,
+    tts,
+    rbt,
+    decoType,
+    heartRateSource,
+    heading,
+    o2SensorMv1,
+    o2SensorMv2,
+    o2SensorMv3,
+    o2SensorMv4,
+    o2SensorMv5,
+    o2SensorMv6,
+  ];
+}

--- a/lib/features/dive_log/domain/codecs/profile_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec.dart
@@ -1,0 +1,387 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+/// How a field's column block is written.
+enum ProfileFieldKind {
+  /// Zigzag varint of the difference from the previous present value; the
+  /// previous value starts at 0 for each block.
+  deltaInt,
+
+  /// IEEE-754 binary64, little-endian.
+  float64,
+
+  /// Runs of identical strings: run count, then (length, UTF-8 length,
+  /// UTF-8 bytes) per run, covering the present values only.
+  runLengthString,
+}
+
+/// One entry of a field table. [name] is the `dive_profiles` column name.
+class ProfileField {
+  const ProfileField(this.name, this.kind);
+
+  final String name;
+  final ProfileFieldKind kind;
+}
+
+/// The bytes and scalars a `dive_profile_series` row stores.
+class EncodedProfileSeries {
+  const EncodedProfileSeries({
+    required this.bytes,
+    required this.codecVersion,
+    required this.summary,
+  });
+
+  final Uint8List bytes;
+  final int codecVersion;
+  final ProfileSeriesSummary summary;
+}
+
+/// Packs a series of [ProfileSample]s into one zlib-compressed columnar blob
+/// and back. Lossless.
+///
+/// Layout of the uncompressed body: a version byte, the sample count as a
+/// varint, then one column block per entry of that version's field table in
+/// table order. See `byte_io.dart` for the block format.
+///
+/// Versioning: a later codec appends fields under a new version byte. The
+/// decoder selects the field table by the blob's version byte, so an older
+/// blob decodes under a newer codec with its missing fields null. A version
+/// this codec does not know is refused.
+class ProfileSeriesCodec {
+  const ProfileSeriesCodec({this.fieldTables = const {version: fieldTableV1}});
+
+  /// The version new blobs are written with.
+  static const int version = 1;
+
+  /// Codec v1: every `dive_profiles` sample column, in this order. Never
+  /// reorder or remove an entry; append under a new version instead.
+  static const List<ProfileField> fieldTableV1 = [
+    ProfileField('timestamp', ProfileFieldKind.deltaInt),
+    ProfileField('depth', ProfileFieldKind.float64),
+    ProfileField('pressure', ProfileFieldKind.float64),
+    ProfileField('temperature', ProfileFieldKind.float64),
+    ProfileField('heart_rate', ProfileFieldKind.deltaInt),
+    ProfileField('ascent_rate', ProfileFieldKind.float64),
+    ProfileField('ceiling', ProfileFieldKind.float64),
+    ProfileField('ndl', ProfileFieldKind.deltaInt),
+    ProfileField('setpoint', ProfileFieldKind.float64),
+    ProfileField('pp_o2', ProfileFieldKind.float64),
+    ProfileField('o2_sensor1', ProfileFieldKind.float64),
+    ProfileField('o2_sensor2', ProfileFieldKind.float64),
+    ProfileField('o2_sensor3', ProfileFieldKind.float64),
+    ProfileField('o2_sensor4', ProfileFieldKind.float64),
+    ProfileField('o2_sensor5', ProfileFieldKind.float64),
+    ProfileField('o2_sensor6', ProfileFieldKind.float64),
+    ProfileField('cns', ProfileFieldKind.float64),
+    ProfileField('tts', ProfileFieldKind.deltaInt),
+    ProfileField('rbt', ProfileFieldKind.deltaInt),
+    ProfileField('deco_type', ProfileFieldKind.deltaInt),
+    ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+    ProfileField('heading', ProfileFieldKind.float64),
+    ProfileField('o2_sensor_mv1', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv2', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv3', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv4', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv5', ProfileFieldKind.deltaInt),
+    ProfileField('o2_sensor_mv6', ProfileFieldKind.deltaInt),
+  ];
+
+  /// Field table per version byte this codec can read.
+  final Map<int, List<ProfileField>> fieldTables;
+
+  static final ZLibCodec _zlib = ZLibCodec(level: 6);
+
+  /// Encodes a non-empty, timestamp-ordered series.
+  ///
+  /// Throws [ArgumentError] on an empty list, on decreasing timestamps, on
+  /// an unregistered [version], or on a field table without `timestamp` and
+  /// `depth`. These are caller bugs, not data faults.
+  EncodedProfileSeries encode(
+    List<ProfileSample> samples, {
+    int version = ProfileSeriesCodec.version,
+  }) {
+    final table = fieldTables[version];
+    if (table == null) {
+      throw ArgumentError.value(version, 'version', 'no field table');
+    }
+    _requireTimestampAndDepth(table);
+    final summary = ProfileSeriesSummary.of(samples);
+    for (var i = 1; i < samples.length; i++) {
+      if (samples[i].timestamp < samples[i - 1].timestamp) {
+        throw ArgumentError.value(
+          samples,
+          'samples',
+          'timestamps must be non-decreasing (sample $i)',
+        );
+      }
+    }
+
+    final writer = ByteWriter()
+      ..writeByte(version)
+      ..writeVarUint(samples.length);
+    for (final field in table) {
+      final column = [
+        for (final sample in samples) _fieldOf(sample, field.name),
+      ];
+      _writeColumn(writer, field.kind, column);
+    }
+    return EncodedProfileSeries(
+      bytes: Uint8List.fromList(_zlib.encode(writer.takeBytes())),
+      codecVersion: version,
+      summary: summary,
+    );
+  }
+
+  /// Decodes a blob written by [encode] under any registered version.
+  ///
+  /// Throws [ProfileSeriesCodecException] on anything malformed: not a zlib
+  /// stream, an unknown version, a truncated block, trailing bytes, or a
+  /// sample without timestamp or depth.
+  List<ProfileSample> decode(Uint8List bytes) {
+    final Uint8List body;
+    try {
+      body = Uint8List.fromList(_zlib.decode(bytes));
+    } catch (e) {
+      throw ProfileSeriesCodecException('not a zlib stream: $e');
+    }
+    if (body.isEmpty) {
+      throw const ProfileSeriesCodecException('empty body');
+    }
+    final reader = ByteReader(body);
+    final blobVersion = reader.readByte();
+    final table = fieldTables[blobVersion];
+    if (table == null) {
+      throw ProfileSeriesCodecException('unknown codec version $blobVersion');
+    }
+    final count = reader.readVarUint();
+    final columns = <String, List<Object?>>{};
+    for (final field in table) {
+      columns[field.name] = _readColumn(reader, field.kind, count);
+    }
+    if (!reader.isAtEnd) {
+      throw ProfileSeriesCodecException(
+        '${reader.remaining} trailing byte(s) after the last block',
+      );
+    }
+    return _samplesFrom(columns, count);
+  }
+
+  static void _requireTimestampAndDepth(List<ProfileField> table) {
+    final names = {for (final field in table) field.name};
+    if (!names.contains('timestamp') || !names.contains('depth')) {
+      throw ArgumentError.value(
+        table,
+        'fieldTables',
+        'every field table must carry timestamp and depth',
+      );
+    }
+  }
+
+  static Object? _fieldOf(ProfileSample s, String name) => switch (name) {
+    'timestamp' => s.timestamp,
+    'depth' => s.depth,
+    'pressure' => s.pressure,
+    'temperature' => s.temperature,
+    'heart_rate' => s.heartRate,
+    'ascent_rate' => s.ascentRate,
+    'ceiling' => s.ceiling,
+    'ndl' => s.ndl,
+    'setpoint' => s.setpoint,
+    'pp_o2' => s.ppO2,
+    'o2_sensor1' => s.o2Sensor1,
+    'o2_sensor2' => s.o2Sensor2,
+    'o2_sensor3' => s.o2Sensor3,
+    'o2_sensor4' => s.o2Sensor4,
+    'o2_sensor5' => s.o2Sensor5,
+    'o2_sensor6' => s.o2Sensor6,
+    'cns' => s.cns,
+    'tts' => s.tts,
+    'rbt' => s.rbt,
+    'deco_type' => s.decoType,
+    'heart_rate_source' => s.heartRateSource,
+    'heading' => s.heading,
+    'o2_sensor_mv1' => s.o2SensorMv1,
+    'o2_sensor_mv2' => s.o2SensorMv2,
+    'o2_sensor_mv3' => s.o2SensorMv3,
+    'o2_sensor_mv4' => s.o2SensorMv4,
+    'o2_sensor_mv5' => s.o2SensorMv5,
+    'o2_sensor_mv6' => s.o2SensorMv6,
+    _ => throw ArgumentError.value(name, 'name', 'not a profile sample field'),
+  };
+
+  static void _writeColumn(
+    ByteWriter writer,
+    ProfileFieldKind kind,
+    List<Object?> column,
+  ) {
+    switch (kind) {
+      case ProfileFieldKind.deltaInt:
+        var previous = 0;
+        writer.writeColumn<int>(column.cast<int?>(), (value) {
+          writer.writeVarInt(value - previous);
+          previous = value;
+        });
+      case ProfileFieldKind.float64:
+        writer.writeColumn<double>(column.cast<double?>(), writer.writeFloat64);
+      case ProfileFieldKind.runLengthString:
+        _writeStringColumn(writer, column.cast<String?>());
+    }
+  }
+
+  static List<Object?> _readColumn(
+    ByteReader reader,
+    ProfileFieldKind kind,
+    int count,
+  ) {
+    switch (kind) {
+      case ProfileFieldKind.deltaInt:
+        var previous = 0;
+        return reader.readColumn<int>(count, () {
+          previous += reader.readVarInt();
+          return previous;
+        });
+      case ProfileFieldKind.float64:
+        return reader.readColumn<double>(count, reader.readFloat64);
+      case ProfileFieldKind.runLengthString:
+        return _readStringColumn(reader, count);
+    }
+  }
+
+  static void _writeStringColumn(ByteWriter writer, List<String?> values) {
+    if (!writer.writePresence(values)) return;
+    final runs = <(String, int)>[];
+    for (final value in values) {
+      if (value == null) continue;
+      if (runs.isNotEmpty && runs.last.$1 == value) {
+        runs[runs.length - 1] = (value, runs.last.$2 + 1);
+      } else {
+        runs.add((value, 1));
+      }
+    }
+    writer.writeVarUint(runs.length);
+    for (final (value, length) in runs) {
+      final encoded = utf8.encode(value);
+      writer
+        ..writeVarUint(length)
+        ..writeVarUint(encoded.length)
+        ..writeBytes(encoded);
+    }
+  }
+
+  static List<String?> _readStringColumn(ByteReader reader, int count) {
+    final present = reader.readPresence(count);
+    var presentCount = 0;
+    for (final isPresent in present) {
+      if (isPresent) presentCount++;
+    }
+    if (presentCount == 0) return List<String?>.filled(count, null);
+    final runCount = reader.readVarUint();
+    final values = <String>[];
+    for (var run = 0; run < runCount; run++) {
+      final length = reader.readVarUint();
+      final byteLength = reader.readVarUint();
+      final String value;
+      try {
+        value = utf8.decode(reader.readBytes(byteLength));
+      } on FormatException catch (e) {
+        throw ProfileSeriesCodecException(
+          'invalid UTF-8 in string run $run: ${e.message}',
+        );
+      }
+      for (var i = 0; i < length; i++) {
+        values.add(value);
+      }
+    }
+    if (values.length != presentCount) {
+      throw ProfileSeriesCodecException(
+        'string runs cover ${values.length} of $presentCount present values',
+      );
+    }
+    var next = 0;
+    return [for (final isPresent in present) isPresent ? values[next++] : null];
+  }
+
+  static List<ProfileSample> _samplesFrom(
+    Map<String, List<Object?>> columns,
+    int count,
+  ) {
+    List<T?> column<T>(String name) {
+      final values = columns[name];
+      if (values == null) return List<T?>.filled(count, null);
+      return values.cast<T?>();
+    }
+
+    final timestamps = column<int>('timestamp');
+    final depths = column<double>('depth');
+    final pressures = column<double>('pressure');
+    final temperatures = column<double>('temperature');
+    final heartRates = column<int>('heart_rate');
+    final ascentRates = column<double>('ascent_rate');
+    final ceilings = column<double>('ceiling');
+    final ndls = column<int>('ndl');
+    final setpoints = column<double>('setpoint');
+    final ppO2s = column<double>('pp_o2');
+    final o2Sensor1s = column<double>('o2_sensor1');
+    final o2Sensor2s = column<double>('o2_sensor2');
+    final o2Sensor3s = column<double>('o2_sensor3');
+    final o2Sensor4s = column<double>('o2_sensor4');
+    final o2Sensor5s = column<double>('o2_sensor5');
+    final o2Sensor6s = column<double>('o2_sensor6');
+    final cnss = column<double>('cns');
+    final ttss = column<int>('tts');
+    final rbts = column<int>('rbt');
+    final decoTypes = column<int>('deco_type');
+    final heartRateSources = column<String>('heart_rate_source');
+    final headings = column<double>('heading');
+    final mv1s = column<int>('o2_sensor_mv1');
+    final mv2s = column<int>('o2_sensor_mv2');
+    final mv3s = column<int>('o2_sensor_mv3');
+    final mv4s = column<int>('o2_sensor_mv4');
+    final mv5s = column<int>('o2_sensor_mv5');
+    final mv6s = column<int>('o2_sensor_mv6');
+
+    return [
+      for (var i = 0; i < count; i++)
+        ProfileSample(
+          timestamp:
+              timestamps[i] ??
+              (throw ProfileSeriesCodecException('sample $i has no timestamp')),
+          depth:
+              depths[i] ??
+              (throw ProfileSeriesCodecException('sample $i has no depth')),
+          pressure: pressures[i],
+          temperature: temperatures[i],
+          heartRate: heartRates[i],
+          ascentRate: ascentRates[i],
+          ceiling: ceilings[i],
+          ndl: ndls[i],
+          setpoint: setpoints[i],
+          ppO2: ppO2s[i],
+          o2Sensor1: o2Sensor1s[i],
+          o2Sensor2: o2Sensor2s[i],
+          o2Sensor3: o2Sensor3s[i],
+          o2Sensor4: o2Sensor4s[i],
+          o2Sensor5: o2Sensor5s[i],
+          o2Sensor6: o2Sensor6s[i],
+          cns: cnss[i],
+          tts: ttss[i],
+          rbt: rbts[i],
+          decoType: decoTypes[i],
+          heartRateSource: heartRateSources[i],
+          heading: headings[i],
+          o2SensorMv1: mv1s[i],
+          o2SensorMv2: mv2s[i],
+          o2SensorMv3: mv3s[i],
+          o2SensorMv4: mv4s[i],
+          o2SensorMv5: mv5s[i],
+          o2SensorMv6: mv6s[i],
+        ),
+    ];
+  }
+}

--- a/lib/features/dive_log/domain/codecs/profile_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec.dart
@@ -160,6 +160,15 @@ class ProfileSeriesCodec {
       throw ProfileSeriesCodecException('unknown codec version $blobVersion');
     }
     final count = reader.readVarUint();
+    // Every sample carries at least a one-byte timestamp delta, so a count
+    // the remaining payload cannot hold is corruption, not a large series.
+    // Guarding here keeps a bogus count from sizing 28 column lists.
+    if (count > reader.remaining) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the ${reader.remaining} remaining '
+        'byte(s)',
+      );
+    }
     final columns = <String, List<Object?>>{};
     for (final field in table) {
       columns[field.name] = _readColumn(reader, field.kind, count);
@@ -285,6 +294,12 @@ class ProfileSeriesCodec {
     final values = <String>[];
     for (var run = 0; run < runCount; run++) {
       final length = reader.readVarUint();
+      if (values.length + length > presentCount) {
+        throw ProfileSeriesCodecException(
+          'string run $run of length $length overruns the $presentCount '
+          'present values',
+        );
+      }
       final byteLength = reader.readVarUint();
       final String value;
       try {

--- a/lib/features/dive_log/domain/codecs/profile_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:submersion/features/dive_log/domain/codecs/bounded_inflate.dart';
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_field_table.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
@@ -48,9 +49,17 @@ class ProfileSeriesCodec {
 
   /// Encodes a non-empty, timestamp-ordered series.
   ///
-  /// Throws [ArgumentError] on an empty list, on decreasing timestamps, on
-  /// an unregistered [version], or on a field table without `timestamp` and
-  /// `depth`. These are caller bugs, not data faults.
+  /// Throws [ArgumentError] on an empty list, on more than
+  /// [kMaxSeriesSampleCount] samples, on decreasing timestamps, on an
+  /// unregistered [version], or on a field table without `timestamp` and
+  /// `depth`.
+  ///
+  /// Most of those are caller bugs, but not all: a deltaInt field whose
+  /// difference from the previous sample leaves the zigzag varint range
+  /// (`minVarInt` .. `maxVarInt`) also throws [ArgumentError], and that is
+  /// data. A caller packing rows it did not produce, the part 2 migration
+  /// among them, has to handle the throw per series rather than treat it as
+  /// a bug that cannot happen.
   EncodedProfileSeries encode(
     List<ProfileSample> samples, {
     int version = ProfileSeriesCodec.version,
@@ -60,6 +69,16 @@ class ProfileSeriesCodec {
       throw ArgumentError.value(version, 'version', 'no field table');
     }
     _validateTable(table);
+    // Refuse to write what decode would refuse to read. Part 2 drops the
+    // source rows once a series is packed, so a blob over the cap would be
+    // unrecoverable while its summary scalars kept the dive looking whole.
+    if (samples.length > kMaxSeriesSampleCount) {
+      throw ArgumentError.value(
+        samples.length,
+        'samples',
+        'more than the maximum $kMaxSeriesSampleCount samples',
+      );
+    }
     final summary = ProfileSeriesSummary.of(samples);
     for (var i = 1; i < samples.length; i++) {
       if (samples[i].timestamp < samples[i - 1].timestamp) {
@@ -90,15 +109,11 @@ class ProfileSeriesCodec {
   /// Decodes a blob written by [encode] under any registered version.
   ///
   /// Throws [ProfileSeriesCodecException] on anything malformed: not a zlib
-  /// stream, an unknown version, a truncated block, trailing bytes, or a
-  /// sample without timestamp or depth.
+  /// stream, a body or sample count over the codec limits, an unknown
+  /// version, a truncated block, trailing bytes, or a sample without
+  /// timestamp or depth.
   List<ProfileSample> decode(Uint8List bytes) {
-    final Uint8List body;
-    try {
-      body = Uint8List.fromList(_zlib.decode(bytes));
-    } catch (e) {
-      throw ProfileSeriesCodecException('not a zlib stream: $e');
-    }
+    final body = inflateBounded(bytes);
     if (body.isEmpty) {
       throw const ProfileSeriesCodecException('empty body');
     }
@@ -113,9 +128,17 @@ class ProfileSeriesCodec {
     if (count == 0) {
       throw const ProfileSeriesCodecException('empty series');
     }
+    // The count sizes one list per field, so it needs a hard cap of its
+    // own: the payload guard below bounds it only by the body, and a body
+    // at the inflate cap admits a count near 67 million, which for 28
+    // columns is about 15 GB of references before any value is read.
+    if (count > kMaxSeriesSampleCount) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the maximum $kMaxSeriesSampleCount',
+      );
+    }
     // Every sample carries at least a one-byte timestamp delta, so a count
     // the remaining payload cannot hold is corruption, not a large series.
-    // Guarding here keeps a bogus count from sizing 28 column lists.
     if (count > reader.remaining) {
       throw ProfileSeriesCodecException(
         'sample count $count exceeds the ${reader.remaining} remaining '
@@ -152,7 +175,25 @@ class ProfileSeriesCodec {
         'every field table must carry timestamp and depth',
       );
     }
+    // A field's kind is frozen with its name: the column readers and
+    // _samplesFrom both cast on it, and cast() is lazy, so a mismatch would
+    // otherwise escape as a TypeError from inside a presence loop or from a
+    // ProfileSample argument, far from the table that caused it.
+    for (final field in table) {
+      final frozen = _frozenKinds[field.name];
+      if (frozen != null && frozen != field.kind) {
+        throw ArgumentError.value(
+          table,
+          'fieldTables',
+          '${field.name} is ${frozen.name} in v1, not ${field.kind.name}',
+        );
+      }
+    }
   }
+
+  static final Map<String, ProfileFieldKind> _frozenKinds = {
+    for (final field in kProfileFieldTableV1) field.name: field.kind,
+  };
 
   static Object? _fieldOf(ProfileSample s, String name) => switch (name) {
     'timestamp' => s.timestamp,
@@ -253,10 +294,25 @@ class ProfileSeriesCodec {
     }
     if (presentCount == 0) return List<String?>.filled(count, null);
     final runCount = reader.readVarUint();
+    if (runCount > presentCount) {
+      throw ProfileSeriesCodecException(
+        '$runCount string runs for $presentCount present values',
+      );
+    }
     final values = <String>[];
     for (var run = 0; run < runCount; run++) {
       final length = reader.readVarUint();
-      if (values.length + length > presentCount) {
+      // The encoder never emits an empty run, and accepting one would make
+      // the format non-canonical: padding runs would decode to the same
+      // samples from different bytes, so any hash of the blob would
+      // disagree with the decoder about identity.
+      if (length == 0) {
+        throw ProfileSeriesCodecException('string run $run is empty');
+      }
+      // Subtract rather than add: `values.length + length` overflows into a
+      // negative for a length near 2^63, which one varint can declare, and
+      // the append loop below would then run unbounded.
+      if (length > presentCount - values.length) {
         throw ProfileSeriesCodecException(
           'string run $run of length $length overruns the $presentCount '
           'present values',

--- a/lib/features/dive_log/domain/codecs/profile_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec.dart
@@ -110,7 +110,7 @@ class ProfileSeriesCodec {
     if (table == null) {
       throw ArgumentError.value(version, 'version', 'no field table');
     }
-    _requireTimestampAndDepth(table);
+    _validateTable(table);
     final summary = ProfileSeriesSummary.of(samples);
     for (var i = 1; i < samples.length; i++) {
       if (samples[i].timestamp < samples[i - 1].timestamp) {
@@ -159,7 +159,11 @@ class ProfileSeriesCodec {
     if (table == null) {
       throw ProfileSeriesCodecException('unknown codec version $blobVersion');
     }
+    _validateTable(table);
     final count = reader.readVarUint();
+    if (count == 0) {
+      throw const ProfileSeriesCodecException('empty series');
+    }
     // Every sample carries at least a one-byte timestamp delta, so a count
     // the remaining payload cannot hold is corruption, not a large series.
     // Guarding here keeps a bogus count from sizing 28 column lists.
@@ -181,8 +185,17 @@ class ProfileSeriesCodec {
     return _samplesFrom(columns, count);
   }
 
-  static void _requireTimestampAndDepth(List<ProfileField> table) {
-    final names = {for (final field in table) field.name};
+  static void _validateTable(List<ProfileField> table) {
+    final names = <String>{};
+    for (final field in table) {
+      if (!names.add(field.name)) {
+        throw ArgumentError.value(
+          table,
+          'fieldTables',
+          'duplicate field ${field.name}',
+        );
+      }
+    }
     if (!names.contains('timestamp') || !names.contains('depth')) {
       throw ArgumentError.value(
         table,

--- a/lib/features/dive_log/domain/codecs/profile_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec.dart
@@ -3,31 +3,10 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_field_table.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
-
-/// How a field's column block is written.
-enum ProfileFieldKind {
-  /// Zigzag varint of the difference from the previous present value; the
-  /// previous value starts at 0 for each block.
-  deltaInt,
-
-  /// IEEE-754 binary64, little-endian.
-  float64,
-
-  /// Runs of identical strings: run count, then (length, UTF-8 length,
-  /// UTF-8 bytes) per run, covering the present values only.
-  runLengthString,
-}
-
-/// One entry of a field table. [name] is the `dive_profiles` column name.
-class ProfileField {
-  const ProfileField(this.name, this.kind);
-
-  final String name;
-  final ProfileFieldKind kind;
-}
 
 /// The bytes and scalars a `dive_profile_series` row stores.
 class EncodedProfileSeries {
@@ -59,38 +38,8 @@ class ProfileSeriesCodec {
   /// The version new blobs are written with.
   static const int version = 1;
 
-  /// Codec v1: every `dive_profiles` sample column, in this order. Never
-  /// reorder or remove an entry; append under a new version instead.
-  static const List<ProfileField> fieldTableV1 = [
-    ProfileField('timestamp', ProfileFieldKind.deltaInt),
-    ProfileField('depth', ProfileFieldKind.float64),
-    ProfileField('pressure', ProfileFieldKind.float64),
-    ProfileField('temperature', ProfileFieldKind.float64),
-    ProfileField('heart_rate', ProfileFieldKind.deltaInt),
-    ProfileField('ascent_rate', ProfileFieldKind.float64),
-    ProfileField('ceiling', ProfileFieldKind.float64),
-    ProfileField('ndl', ProfileFieldKind.deltaInt),
-    ProfileField('setpoint', ProfileFieldKind.float64),
-    ProfileField('pp_o2', ProfileFieldKind.float64),
-    ProfileField('o2_sensor1', ProfileFieldKind.float64),
-    ProfileField('o2_sensor2', ProfileFieldKind.float64),
-    ProfileField('o2_sensor3', ProfileFieldKind.float64),
-    ProfileField('o2_sensor4', ProfileFieldKind.float64),
-    ProfileField('o2_sensor5', ProfileFieldKind.float64),
-    ProfileField('o2_sensor6', ProfileFieldKind.float64),
-    ProfileField('cns', ProfileFieldKind.float64),
-    ProfileField('tts', ProfileFieldKind.deltaInt),
-    ProfileField('rbt', ProfileFieldKind.deltaInt),
-    ProfileField('deco_type', ProfileFieldKind.deltaInt),
-    ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
-    ProfileField('heading', ProfileFieldKind.float64),
-    ProfileField('o2_sensor_mv1', ProfileFieldKind.deltaInt),
-    ProfileField('o2_sensor_mv2', ProfileFieldKind.deltaInt),
-    ProfileField('o2_sensor_mv3', ProfileFieldKind.deltaInt),
-    ProfileField('o2_sensor_mv4', ProfileFieldKind.deltaInt),
-    ProfileField('o2_sensor_mv5', ProfileFieldKind.deltaInt),
-    ProfileField('o2_sensor_mv6', ProfileFieldKind.deltaInt),
-  ];
+  /// Codec v1 field table. See [kProfileFieldTableV1].
+  static const List<ProfileField> fieldTableV1 = kProfileFieldTableV1;
 
   /// Field table per version byte this codec can read.
   final Map<int, List<ProfileField>> fieldTables;

--- a/lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_codec_exception.dart
@@ -1,0 +1,13 @@
+/// Thrown when a packed series blob cannot be decoded.
+///
+/// Decoders never guess. An unknown version byte, a truncated payload,
+/// trailing bytes, or a block that disagrees with its field table all end
+/// here rather than in a partial sample list.
+class ProfileSeriesCodecException implements Exception {
+  const ProfileSeriesCodecException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'ProfileSeriesCodecException: $message';
+}

--- a/lib/features/dive_log/domain/codecs/profile_series_summary.dart
+++ b/lib/features/dive_log/domain/codecs/profile_series_summary.dart
@@ -1,0 +1,97 @@
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+
+/// The `deco_type` value that marks a mandatory decompression stop
+/// (0 = NDL, 1 = safety stop, 2 = deco stop, 3 = deep stop).
+const int kDecoTypeDecoStop = 2;
+
+/// The scalars a `dive_profile_series` row stores next to its blob.
+///
+/// These exist so the SQL consumers that only need a predicate or a span
+/// (deco classification, runtime fallback, quality neighbours) never decode
+/// a blob. They are computed from the same sample list the codec packs, so
+/// a scalar can never disagree with its blob.
+class ProfileSeriesSummary extends Equatable {
+  const ProfileSeriesSummary({
+    required this.sampleCount,
+    required this.startTimestamp,
+    required this.endTimestamp,
+    required this.maxDepth,
+    required this.firstDepth,
+    required this.lastDepth,
+    required this.hasDecoType,
+    required this.hasDecoStop,
+    required this.hasPositiveCeiling,
+  });
+
+  /// Computes the summary of a non-empty, timestamp-ordered series.
+  factory ProfileSeriesSummary.of(List<ProfileSample> samples) {
+    if (samples.isEmpty) {
+      throw ArgumentError.value(
+        samples,
+        'samples',
+        'a series needs at least one sample',
+      );
+    }
+    var maxDepth = samples.first.depth;
+    var hasDecoType = false;
+    var hasDecoStop = false;
+    var hasPositiveCeiling = false;
+    for (final sample in samples) {
+      if (sample.depth > maxDepth) maxDepth = sample.depth;
+      final decoType = sample.decoType;
+      if (decoType != null) {
+        hasDecoType = true;
+        if (decoType == kDecoTypeDecoStop) hasDecoStop = true;
+      }
+      final ceiling = sample.ceiling;
+      if (ceiling != null && ceiling > 0) hasPositiveCeiling = true;
+    }
+    return ProfileSeriesSummary(
+      sampleCount: samples.length,
+      startTimestamp: samples.first.timestamp,
+      endTimestamp: samples.last.timestamp,
+      maxDepth: maxDepth,
+      firstDepth: samples.first.depth,
+      lastDepth: samples.last.depth,
+      hasDecoType: hasDecoType,
+      hasDecoStop: hasDecoStop,
+      hasPositiveCeiling: hasPositiveCeiling,
+    );
+  }
+
+  final int sampleCount;
+
+  /// Seconds from dive start of the first sample.
+  final int startTimestamp;
+
+  /// Seconds from dive start of the last sample.
+  final int endTimestamp;
+
+  /// Metres.
+  final double maxDepth;
+  final double firstDepth;
+  final double lastDepth;
+
+  /// Any sample carries a `deco_type`.
+  final bool hasDecoType;
+
+  /// Any sample carries `deco_type == 2`.
+  final bool hasDecoStop;
+
+  /// Any sample carries `ceiling > 0`.
+  final bool hasPositiveCeiling;
+
+  @override
+  List<Object?> get props => [
+    sampleCount,
+    startTimestamp,
+    endTimestamp,
+    maxDepth,
+    firstDepth,
+    lastDepth,
+    hasDecoType,
+    hasDecoStop,
+    hasPositiveCeiling,
+  ];
+}

--- a/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// One tank pressure reading as `tank_pressure_profiles` stores it, minus
+/// the identity columns (`id`, `dive_id`, `tank_id`, `computer_id`) that
+/// live on the series row.
+class TankPressureSample extends Equatable {
+  const TankPressureSample({required this.timestamp, required this.pressure});
+
+  /// Seconds from dive start.
+  final int timestamp;
+
+  /// Bar.
+  final double pressure;
+
+  @override
+  List<Object?> get props => [timestamp, pressure];
+}
+
+/// The scalars a `tank_pressure_series` row stores next to its blob.
+class TankPressureSeriesSummary extends Equatable {
+  const TankPressureSeriesSummary({
+    required this.sampleCount,
+    required this.startTimestamp,
+    required this.endTimestamp,
+  });
+
+  /// Computes the summary of a non-empty, timestamp-ordered series.
+  factory TankPressureSeriesSummary.of(List<TankPressureSample> samples) {
+    if (samples.isEmpty) {
+      throw ArgumentError.value(
+        samples,
+        'samples',
+        'a series needs at least one sample',
+      );
+    }
+    return TankPressureSeriesSummary(
+      sampleCount: samples.length,
+      startTimestamp: samples.first.timestamp,
+      endTimestamp: samples.last.timestamp,
+    );
+  }
+
+  final int sampleCount;
+  final int startTimestamp;
+  final int endTimestamp;
+
+  @override
+  List<Object?> get props => [sampleCount, startTimestamp, endTimestamp];
+}
+
+/// The bytes and scalars a `tank_pressure_series` row stores.
+class EncodedTankPressureSeries {
+  const EncodedTankPressureSeries({
+    required this.bytes,
+    required this.codecVersion,
+    required this.summary,
+  });
+
+  final Uint8List bytes;
+  final int codecVersion;
+  final TankPressureSeriesSummary summary;
+}
+
+/// Packs a tank's pressure readings into one zlib-compressed columnar blob
+/// and back. Lossless.
+///
+/// Body: version byte, sample count varint, a delta-zigzag-varint timestamp
+/// column, a float64 pressure column. Both columns are always fully present
+/// (the fields are non-nullable), so each costs one presence byte.
+class TankPressureSeriesCodec {
+  const TankPressureSeriesCodec();
+
+  static const int version = 1;
+
+  // ZLibCodec has no const constructor, so this is `final`, not `const`.
+  static final ZLibCodec _zlib = ZLibCodec(level: 6);
+
+  /// Encodes a non-empty, timestamp-ordered series. Throws [ArgumentError]
+  /// on an empty list or on decreasing timestamps.
+  EncodedTankPressureSeries encode(List<TankPressureSample> samples) {
+    final summary = TankPressureSeriesSummary.of(samples);
+    for (var i = 1; i < samples.length; i++) {
+      if (samples[i].timestamp < samples[i - 1].timestamp) {
+        throw ArgumentError.value(
+          samples,
+          'samples',
+          'timestamps must be non-decreasing (sample $i)',
+        );
+      }
+    }
+    final writer = ByteWriter()
+      ..writeByte(version)
+      ..writeVarUint(samples.length);
+    var previous = 0;
+    writer.writeColumn<int>([for (final s in samples) s.timestamp], (value) {
+      writer.writeVarInt(value - previous);
+      previous = value;
+    });
+    writer.writeColumn<double>([
+      for (final s in samples) s.pressure,
+    ], writer.writeFloat64);
+    return EncodedTankPressureSeries(
+      bytes: Uint8List.fromList(_zlib.encode(writer.takeBytes())),
+      codecVersion: version,
+      summary: summary,
+    );
+  }
+
+  /// Decodes a blob written by [encode]. Throws
+  /// [ProfileSeriesCodecException] on anything malformed.
+  List<TankPressureSample> decode(Uint8List bytes) {
+    final Uint8List body;
+    try {
+      body = Uint8List.fromList(_zlib.decode(bytes));
+    } catch (e) {
+      throw ProfileSeriesCodecException('not a zlib stream: $e');
+    }
+    if (body.isEmpty) {
+      throw const ProfileSeriesCodecException('empty body');
+    }
+    final reader = ByteReader(body);
+    final blobVersion = reader.readByte();
+    if (blobVersion != version) {
+      throw ProfileSeriesCodecException('unknown codec version $blobVersion');
+    }
+    final count = reader.readVarUint();
+    // Every sample carries at least a one-byte timestamp delta, so a count
+    // the remaining payload cannot hold is corruption, not a large series.
+    if (count > reader.remaining) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the ${reader.remaining} remaining '
+        'byte(s)',
+      );
+    }
+    var previous = 0;
+    final timestamps = reader.readColumn<int>(count, () {
+      previous += reader.readVarInt();
+      return previous;
+    });
+    final pressures = reader.readColumn<double>(count, reader.readFloat64);
+    if (!reader.isAtEnd) {
+      throw ProfileSeriesCodecException(
+        '${reader.remaining} trailing byte(s) after the last block',
+      );
+    }
+    return [
+      for (var i = 0; i < count; i++)
+        TankPressureSample(
+          timestamp:
+              timestamps[i] ??
+              (throw ProfileSeriesCodecException('sample $i has no timestamp')),
+          pressure:
+              pressures[i] ??
+              (throw ProfileSeriesCodecException('sample $i has no pressure')),
+        ),
+    ];
+  }
+}

--- a/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
+import 'package:submersion/features/dive_log/domain/codecs/bounded_inflate.dart';
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
 
@@ -81,8 +82,18 @@ class TankPressureSeriesCodec {
   static final ZLibCodec _zlib = ZLibCodec(level: 6);
 
   /// Encodes a non-empty, timestamp-ordered series. Throws [ArgumentError]
-  /// on an empty list or on decreasing timestamps.
+  /// on an empty list, on more than [kMaxSeriesSampleCount] samples, or on
+  /// decreasing timestamps.
   EncodedTankPressureSeries encode(List<TankPressureSample> samples) {
+    // Refuse to write what decode would refuse to read; see the profile
+    // codec for why an unreadable blob is worse than a refused encode.
+    if (samples.length > kMaxSeriesSampleCount) {
+      throw ArgumentError.value(
+        samples.length,
+        'samples',
+        'more than the maximum $kMaxSeriesSampleCount samples',
+      );
+    }
     final summary = TankPressureSeriesSummary.of(samples);
     for (var i = 1; i < samples.length; i++) {
       if (samples[i].timestamp < samples[i - 1].timestamp) {
@@ -114,12 +125,7 @@ class TankPressureSeriesCodec {
   /// Decodes a blob written by [encode]. Throws
   /// [ProfileSeriesCodecException] on anything malformed.
   List<TankPressureSample> decode(Uint8List bytes) {
-    final Uint8List body;
-    try {
-      body = Uint8List.fromList(_zlib.decode(bytes));
-    } catch (e) {
-      throw ProfileSeriesCodecException('not a zlib stream: $e');
-    }
+    final body = inflateBounded(bytes);
     if (body.isEmpty) {
       throw const ProfileSeriesCodecException('empty body');
     }
@@ -131,6 +137,13 @@ class TankPressureSeriesCodec {
     final count = reader.readVarUint();
     if (count == 0) {
       throw const ProfileSeriesCodecException('empty series');
+    }
+    // The count sizes both column lists, so cap it before the payload guard
+    // below, which a body at the inflate cap would leave far too generous.
+    if (count > kMaxSeriesSampleCount) {
+      throw ProfileSeriesCodecException(
+        'sample count $count exceeds the maximum $kMaxSeriesSampleCount',
+      );
     }
     // Every sample carries at least a one-byte timestamp delta, so a count
     // the remaining payload cannot hold is corruption, not a large series.

--- a/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
+++ b/lib/features/dive_log/domain/codecs/tank_pressure_series_codec.dart
@@ -129,6 +129,9 @@ class TankPressureSeriesCodec {
       throw ProfileSeriesCodecException('unknown codec version $blobVersion');
     }
     final count = reader.readVarUint();
+    if (count == 0) {
+      throw const ProfileSeriesCodecException('empty series');
+    }
     // Every sample carries at least a one-byte timestamp delta, so a count
     // the remaining payload cannot hold is corruption, not a large series.
     if (count > reader.remaining) {

--- a/test/features/dive_log/domain/codecs/bounded_inflate_test.dart
+++ b/test/features/dive_log/domain/codecs/bounded_inflate_test.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/bounded_inflate.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+void main() {
+  final zlibCodec = ZLibCodec(level: 6);
+
+  Uint8List deflate(List<int> body) =>
+      Uint8List.fromList(zlibCodec.encode(body));
+
+  group('inflateBounded', () {
+    test('returns the body of a stream under the cap', () {
+      final body = List<int>.generate(5000, (i) => i % 251);
+      expect(inflateBounded(deflate(body), maxBytes: 1 << 20), body);
+    });
+
+    test('accepts a body of exactly maxBytes', () {
+      final body = List<int>.filled(4096, 9);
+      expect(inflateBounded(deflate(body), maxBytes: 4096), hasLength(4096));
+    });
+
+    test('refuses a body one byte over maxBytes', () {
+      final body = List<int>.filled(4097, 9);
+      expect(
+        () => inflateBounded(deflate(body), maxBytes: 4096),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds the 4096 byte'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses a zlib bomb without inflating it whole', () {
+      // A gigabyte of zeros, deflated a mebibyte at a time so the fixture
+      // itself never costs a gigabyte. Asserting on memory rather than the
+      // clock is deliberate: zlib inflates a gigabyte in well under a
+      // second, so a time bound cannot tell a chunked abort from a decoder
+      // that buffered the lot and checked its length afterwards.
+      final bomb = _deflateZeros(mebibytes: 1024);
+      expect(bomb.length, lessThan(2 << 20));
+
+      final before = ProcessInfo.currentRss;
+      expect(
+        () => inflateBounded(bomb, maxBytes: 64 * 1024),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+      final grew = ProcessInfo.currentRss - before;
+      // Buffering the whole body would need 1 GiB. The threshold is loose
+      // enough for GC noise and still an order of magnitude under that.
+      expect(grew, lessThan(128 * 1024 * 1024));
+    });
+
+    test('refuses a blob longer than maxBlobBytes', () {
+      // Bytes after a complete zlib stream are copied into the native
+      // filter and then discarded, so without this cap an arbitrarily long
+      // pad drives peak memory and still returns a body and no error.
+      final padded = Uint8List(4096)..setRange(0, 8, deflate([1, 2, 3]));
+      expect(
+        () => inflateBounded(padded, maxBlobBytes: 512),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds the 512 allowed'),
+          ),
+        ),
+      );
+    });
+
+    test('the blob cap cannot refuse what the body cap would accept', () {
+      // Deflate never expands a body past the stream overhead, so matching
+      // the two caps adds no false refusal.
+      expect(kMaxSeriesBlobBytes, greaterThanOrEqualTo(kMaxSeriesBodyBytes));
+    });
+
+    test('a truncated stream returns a short body rather than throwing', () {
+      // Pinned, not endorsed: zlib reports no error for a lost tail, and
+      // dropping only the adler-32 trailer returns the body in full, so the
+      // checksum is never verified. The codecs catch this downstream by
+      // requiring the column blocks to span the body exactly.
+      final full = deflate(List<int>.generate(300, (i) => i % 251));
+      expect(inflateBounded(full.sublist(0, full.length ~/ 2)), hasLength(135));
+      expect(inflateBounded(full.sublist(0, full.length - 4)), hasLength(300));
+    });
+
+    test('refuses bytes that are not a zlib stream', () {
+      expect(
+        () => inflateBounded(Uint8List.fromList([1, 2, 3, 4, 5])),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('not a zlib stream'),
+          ),
+        ),
+      );
+    });
+
+    test('returns an empty body for empty input', () {
+      // zlib accepts zero bytes as zero output rather than as corruption.
+      // Ruling on an empty body is the codecs' job, not the inflater's.
+      expect(inflateBounded(Uint8List(0)), isEmpty);
+    });
+
+    test('lets a programming error surface instead of wrapping it', () {
+      expect(
+        () => inflateBounded(deflate([1, 2, 3]), maxBytes: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('limits', () {
+    test('the body cap comfortably clears a maximal profile series', () {
+      // A maximal series is kMaxSeriesSampleCount samples at roughly 140
+      // uncompressed bytes each. The body cap is the outer bound against
+      // unbounded inflation, so it must sit above that with headroom, not
+      // on it: refusing a legitimate series means unreadable stored data.
+      const maximalBody = kMaxSeriesSampleCount * 140;
+      expect(kMaxSeriesBodyBytes, greaterThan(maximalBody));
+    });
+
+    test('the sample cap is the guard that binds for profiles', () {
+      // 28 columns of references alone is 8 bytes per sample per column,
+      // and the boxed values, presence lists and ProfileSample objects cost
+      // several times that again. If the body cap ever bound first, this
+      // arithmetic would stop describing the real ceiling.
+      expect(kMaxSeriesSampleCount * 28 * 8, lessThan(kMaxSeriesBodyBytes * 4));
+    });
+  });
+}
+
+/// Deflates [mebibytes] MiB of zeros without ever holding them.
+Uint8List _deflateZeros({required int mebibytes}) {
+  final chunks = <List<int>>[];
+  final sink = ZLibCodec(
+    level: 6,
+  ).encoder.startChunkedConversion(_Collect(chunks));
+  final block = Uint8List(1024 * 1024);
+  for (var i = 0; i < mebibytes; i++) {
+    sink.add(block);
+  }
+  sink.close();
+  return Uint8List.fromList([for (final c in chunks) ...c]);
+}
+
+class _Collect implements Sink<List<int>> {
+  _Collect(this.chunks);
+
+  final List<List<int>> chunks;
+
+  @override
+  void add(List<int> data) => chunks.add(data);
+
+  @override
+  void close() {}
+}

--- a/test/features/dive_log/domain/codecs/byte_io_test.dart
+++ b/test/features/dive_log/domain/codecs/byte_io_test.dart
@@ -1,0 +1,202 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+
+/// The raw IEEE-754 bits, so -0.0 and NaN payloads compare exactly.
+int bitsOf(double value) => (ByteData(
+  8,
+)..setFloat64(0, value, Endian.little)).getInt64(0, Endian.little);
+
+void main() {
+  group('varuint', () {
+    for (final value in [
+      0,
+      1,
+      127,
+      128,
+      255,
+      300,
+      16383,
+      16384,
+      1 << 31,
+      (1 << 62) - 1,
+    ]) {
+      test('round-trips $value', () {
+        final writer = ByteWriter()..writeVarUint(value);
+        expect(ByteReader(writer.takeBytes()).readVarUint(), value);
+      });
+    }
+
+    test('127 fits in one byte and 128 needs two', () {
+      expect((ByteWriter()..writeVarUint(127)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarUint(128)).takeBytes(), hasLength(2));
+    });
+  });
+
+  group('varint (zigzag)', () {
+    for (final value in [
+      0,
+      -1,
+      1,
+      -2,
+      2,
+      -64,
+      63,
+      -65,
+      64,
+      -1000000,
+      1000000,
+      -(1 << 40),
+      1 << 40,
+    ]) {
+      test('round-trips $value', () {
+        final writer = ByteWriter()..writeVarInt(value);
+        expect(ByteReader(writer.takeBytes()).readVarInt(), value);
+      });
+    }
+
+    test('small negatives stay one byte', () {
+      expect((ByteWriter()..writeVarInt(-1)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarInt(-64)).takeBytes(), hasLength(1));
+      expect((ByteWriter()..writeVarInt(-65)).takeBytes(), hasLength(2));
+    });
+  });
+
+  group('float64', () {
+    for (final value in [
+      0.0,
+      -0.0,
+      1.5,
+      18.3,
+      -273.15,
+      double.maxFinite,
+      double.minPositive,
+      double.infinity,
+      double.negativeInfinity,
+    ]) {
+      test('round-trips $value bit-exactly', () {
+        final writer = ByteWriter()..writeFloat64(value);
+        final bytes = writer.takeBytes();
+        expect(bytes, hasLength(8));
+        expect(bitsOf(ByteReader(bytes).readFloat64()), bitsOf(value));
+      });
+    }
+
+    test('NaN round-trips as NaN', () {
+      final writer = ByteWriter()..writeFloat64(double.nan);
+      expect(ByteReader(writer.takeBytes()).readFloat64().isNaN, isTrue);
+    });
+
+    test('two consecutive floats do not alias each other', () {
+      final writer = ByteWriter()
+        ..writeFloat64(1.0)
+        ..writeFloat64(2.0);
+      final reader = ByteReader(writer.takeBytes());
+      expect(reader.readFloat64(), 1.0);
+      expect(reader.readFloat64(), 2.0);
+    });
+  });
+
+  group('reader bounds', () {
+    test('reading past the end throws', () {
+      final reader = ByteReader(Uint8List.fromList([0x01]));
+      reader.readByte();
+      expect(reader.isAtEnd, isTrue);
+      expect(reader.readByte, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('a float needs eight bytes', () {
+      final reader = ByteReader(Uint8List.fromList([0, 0, 0, 0]));
+      expect(reader.readFloat64, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('an unterminated varint throws', () {
+      final reader = ByteReader(Uint8List.fromList([0x80, 0x80]));
+      expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('a varint longer than 64 bits throws', () {
+      final reader = ByteReader(Uint8List.fromList(List.filled(11, 0x80)));
+      expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('readBytes past the end throws', () {
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3]));
+      expect(
+        () => reader.readBytes(4),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('offset and remaining track consumption', () {
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3]));
+      reader.readByte();
+      expect(reader.offset, 1);
+      expect(reader.remaining, 2);
+    });
+  });
+
+  group('columns', () {
+    // Note: `writer` is declared on its own line in every case below. Dart
+    // rejects a closure that names the variable being initialised
+    // ("referenced before declaration"), so the cascade form cannot be used.
+
+    test('an all-null column costs exactly one byte', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>([null, null, null], writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes, [kPresenceAbsent]);
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(3, reader.readVarInt), [null, null, null]);
+      expect(reader.isAtEnd, isTrue);
+    });
+
+    test('a fully present column carries no bitmap', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>([5, 6, 7], writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes.first, kPresenceAll);
+      expect(bytes, hasLength(4));
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(3, reader.readVarInt), [5, 6, 7]);
+    });
+
+    test('a mixed column uses a bitmap and round-trips across a byte edge', () {
+      // Nine values force a two-byte bitmap.
+      final values = <int?>[1, null, 3, null, null, 6, 7, null, 9];
+      final writer = ByteWriter();
+      writer.writeColumn<int>(values, writer.writeVarInt);
+      final bytes = writer.takeBytes();
+      expect(bytes.first, kPresenceBitmap);
+      // mode + 2 bitmap bytes + 5 one-byte values
+      expect(bytes, hasLength(8));
+      final reader = ByteReader(bytes);
+      expect(reader.readColumn<int>(9, reader.readVarInt), values);
+      expect(reader.isAtEnd, isTrue);
+    });
+
+    test('float columns round-trip through the same presence logic', () {
+      final values = <double?>[1.5, null, -2.25];
+      final writer = ByteWriter();
+      writer.writeColumn<double>(values, writer.writeFloat64);
+      final reader = ByteReader(writer.takeBytes());
+      expect(reader.readColumn<double>(3, reader.readFloat64), values);
+    });
+
+    test('an unknown presence mode throws', () {
+      final reader = ByteReader(Uint8List.fromList([7]));
+      expect(
+        () => reader.readColumn<int>(1, reader.readVarInt),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an empty column writes only the absent marker', () {
+      final writer = ByteWriter();
+      writer.writeColumn<int>(const [], writer.writeVarInt);
+      expect(writer.takeBytes(), [kPresenceAbsent]);
+    });
+  });
+}

--- a/test/features/dive_log/domain/codecs/byte_io_test.dart
+++ b/test/features/dive_log/domain/codecs/byte_io_test.dart
@@ -246,6 +246,39 @@ void main() {
       expect(() => ByteWriter().writeVarUint(-1), throwsArgumentError);
     });
 
+    test('writeVarUint has no upper-bound gap against the reader', () {
+      // The reader refuses a varint whose payload reaches bit 63, which
+      // raises the question of whether the writer can emit one. It cannot:
+      // 2^63-1 is the largest Dart int, it encodes in nine bytes, and the
+      // guard needs a tenth. So the writer's accepted range (0 .. 2^63-1)
+      // is exactly the reader's decodable range, and no upper bound on the
+      // writer would exclude anything reachable.
+      const maxDartInt = 9223372036854775807;
+      for (final value in [1 << 62, maxDartInt - 1, maxDartInt]) {
+        final bytes = (ByteWriter()..writeVarUint(value)).takeBytes();
+        expect(bytes, hasLength(9));
+        expect(ByteReader(bytes).readVarUint(), value);
+      }
+      // The tenth byte the guard exists for cannot come from the writer,
+      // only from a crafted blob.
+      final crafted = Uint8List.fromList([
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x80,
+        0x01,
+      ]);
+      expect(
+        () => ByteReader(crafted).readVarUint(),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
     test('writeVarInt round-trips the extremes of the zigzag range', () {
       for (final value in [(1 << 62) - 1, -(1 << 62)]) {
         final writer = ByteWriter()..writeVarInt(value);

--- a/test/features/dive_log/domain/codecs/byte_io_test.dart
+++ b/test/features/dive_log/domain/codecs/byte_io_test.dart
@@ -117,9 +117,25 @@ void main() {
       expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
     });
 
-    test('a varint longer than 64 bits throws', () {
+    test('eleven continuation bytes throw', () {
       final reader = ByteReader(Uint8List.fromList(List.filled(11, 0x80)));
       expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('a ten-byte varint whose payload reaches bit 63 throws', () {
+      // Nine continuation bytes, then a terminating byte carrying bit 63.
+      final reader = ByteReader(
+        Uint8List.fromList([...List.filled(9, 0x80), 0x01]),
+      );
+      expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
+    });
+
+    test('the largest 63-bit varint still decodes', () {
+      // 2^63 - 1: eight bytes of 0xFF then 0x7F.
+      final reader = ByteReader(
+        Uint8List.fromList([...List.filled(8, 0xFF), 0x7F]),
+      );
+      expect(reader.readVarUint(), (1 << 63) - 1);
     });
 
     test('readBytes past the end throws', () {

--- a/test/features/dive_log/domain/codecs/byte_io_test.dart
+++ b/test/features/dive_log/domain/codecs/byte_io_test.dart
@@ -130,6 +130,30 @@ void main() {
       expect(reader.readVarUint, throwsA(isA<ProfileSeriesCodecException>()));
     });
 
+    test('a padded varint is refused as non-canonical', () {
+      // Every one of these decodes to a value the writer encodes in fewer
+      // bytes, so accepting them would give one series several valid byte
+      // forms. The ten-byte case is only the longest instance of that.
+      final padded = <String, List<int>>{
+        'zero in two bytes': [0x80, 0x00],
+        'one in three bytes': [0x81, 0x80, 0x00],
+        'zero in ten bytes': [...List.filled(9, 0x80), 0x00],
+      };
+      for (final entry in padded.entries) {
+        final reader = ByteReader(Uint8List.fromList(entry.value));
+        expect(
+          reader.readVarUint,
+          throwsA(isA<ProfileSeriesCodecException>()),
+          reason: entry.key,
+        );
+      }
+    });
+
+    test('a single zero byte is canonical and decodes', () {
+      // The one varint that ends in a zero byte legitimately.
+      expect(ByteReader(Uint8List.fromList([0x00])).readVarUint(), 0);
+    });
+
     test('the largest 63-bit varint still decodes', () {
       // 2^63 - 1: eight bytes of 0xFF then 0x7F.
       final reader = ByteReader(

--- a/test/features/dive_log/domain/codecs/byte_io_test.dart
+++ b/test/features/dive_log/domain/codecs/byte_io_test.dart
@@ -215,4 +215,59 @@ void main() {
       expect(writer.takeBytes(), [kPresenceAbsent]);
     });
   });
+
+  group('reader bounds against overflow', () {
+    test('a length near 2^63 is refused, not passed to sublistView', () {
+      // _ensure adding _offset to count would wrap negative here, and the
+      // guard would fall through to a RangeError from Uint8List.sublistView
+      // instead of the exception decode() documents.
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3, 4]))..readByte();
+      expect(
+        () => reader.readBytes(maxVarInt * 2 + 1),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a length one past the end is still refused', () {
+      final reader = ByteReader(Uint8List.fromList([1, 2, 3, 4]))..readByte();
+      expect(
+        () => reader.readBytes(4),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+      expect(reader.readBytes(3), [2, 3, 4]);
+    });
+  });
+
+  group('writer range', () {
+    // The reader refuses a varint whose payload reaches bit 63. The writer
+    // has to refuse the same values, or a release build (where asserts are
+    // stripped) would emit one truncated byte and call it an encoding.
+    test('writeVarUint refuses a negative value', () {
+      expect(() => ByteWriter().writeVarUint(-1), throwsArgumentError);
+    });
+
+    test('writeVarInt round-trips the extremes of the zigzag range', () {
+      for (final value in [(1 << 62) - 1, -(1 << 62)]) {
+        final writer = ByteWriter()..writeVarInt(value);
+        expect(ByteReader(writer.takeBytes()).readVarInt(), value);
+      }
+    });
+
+    test('writeByte refuses values outside a byte', () {
+      // addByte keeps the low eight bits, so without the check a release
+      // build writes 44 for 300 and the blob claims a version it is not.
+      for (final value in [-1, 256, 300]) {
+        expect(() => ByteWriter().writeByte(value), throwsArgumentError);
+      }
+      expect((ByteWriter()..writeByte(255)).takeBytes(), [255]);
+    });
+
+    test('writeVarInt refuses values whose zigzag overflows', () {
+      // (value << 1) runs into the sign bit here, so the zigzag mapping
+      // would silently produce a negative varuint.
+      for (final value in [1 << 62, -(1 << 62) - 1, 1 << 63]) {
+        expect(() => ByteWriter().writeVarInt(value), throwsArgumentError);
+      }
+    });
+  });
 }

--- a/test/features/dive_log/domain/codecs/profile_sample_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_sample_test.dart
@@ -64,5 +64,6 @@ void main() {
     expect(a, b);
     expect(a.hashCode, b.hashCode);
     expect(a, isNot(c));
+    expect(a.props, hasLength(28));
   });
 }

--- a/test/features/dive_log/domain/codecs/profile_sample_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_sample_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+
+void main() {
+  const point = DiveProfilePoint(
+    timestamp: 120,
+    depth: 18.3,
+    temperature: 21.5,
+    heartRate: 88,
+    heading: 270.0,
+    setpoint: 1.2,
+    ppO2: 1.19,
+    o2Sensor1: 1.18,
+    o2Sensor2: 1.2,
+    o2Sensor3: 1.21,
+    o2Sensor4: 1.17,
+    o2Sensor5: 1.22,
+    o2Sensor6: 1.19,
+    o2SensorMv1: 51,
+    o2SensorMv2: 52,
+    o2SensorMv3: 53,
+    o2SensorMv4: 50,
+    o2SensorMv5: 54,
+    o2SensorMv6: 52,
+    heartRateSource: 'appleWatch',
+    cns: 12.5,
+    ndl: 1800,
+    ceiling: 3.0,
+    ascentRate: -9.0,
+    rbt: 1500,
+    decoType: 2,
+    tts: 900,
+  );
+
+  test('fromPoint then toPoint is the identity on every point field', () {
+    final sample = ProfileSample.fromPoint(point);
+    expect(sample.toPoint(), point);
+  });
+
+  test('fromPoint carries the legacy per-sample pressure separately', () {
+    final sample = ProfileSample.fromPoint(point, pressure: 180.5);
+    expect(sample.pressure, 180.5);
+    // DiveProfilePoint has no pressure field, so it cannot survive toPoint.
+    expect(sample.toPoint(), point);
+  });
+
+  test('a minimal point maps with every optional field null', () {
+    const minimal = DiveProfilePoint(timestamp: 0, depth: 0.0);
+    final sample = ProfileSample.fromPoint(minimal);
+    expect(sample.timestamp, 0);
+    expect(sample.depth, 0.0);
+    expect(sample.pressure, isNull);
+    expect(sample.temperature, isNull);
+    expect(sample.heartRateSource, isNull);
+    expect(sample.o2SensorMv6, isNull);
+    expect(sample.toPoint(), minimal);
+  });
+
+  test('value equality covers every field', () {
+    final a = ProfileSample.fromPoint(point, pressure: 1.0);
+    final b = ProfileSample.fromPoint(point, pressure: 1.0);
+    final c = ProfileSample.fromPoint(point, pressure: 2.0);
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    expect(a, isNot(c));
+  });
+}

--- a/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
@@ -1,0 +1,347 @@
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+/// A fully populated sample: every one of the 28 fields present.
+ProfileSample fullSample(int i) => ProfileSample(
+  timestamp: i * 10,
+  depth: 10.0 + i * 0.5,
+  pressure: 200.0 - i,
+  temperature: 20.0 - i * 0.01,
+  heartRate: 80 + (i % 7),
+  ascentRate: -3.0 + i * 0.1,
+  ceiling: i > 5 ? 3.0 : 0.0,
+  ndl: 1800 - i * 15,
+  setpoint: 1.2,
+  ppO2: 1.19 + i * 0.001,
+  o2Sensor1: 1.18,
+  o2Sensor2: 1.20,
+  o2Sensor3: 1.21,
+  o2Sensor4: 1.17,
+  o2Sensor5: 1.22,
+  o2Sensor6: 1.19,
+  cns: 12.5 + i,
+  tts: 900 + i * 3,
+  rbt: 1500 - i * 2,
+  decoType: i > 5 ? 2 : 0,
+  heartRateSource: i < 4 ? 'diveComputer' : 'appleWatch',
+  heading: (i * 37) % 360 * 1.0,
+  o2SensorMv1: 51 + i,
+  o2SensorMv2: 52 - i,
+  o2SensorMv3: 53,
+  o2SensorMv4: 50,
+  o2SensorMv5: 54,
+  o2SensorMv6: 52,
+);
+
+/// Depth and timestamp only, like a manually entered profile.
+ProfileSample minimalSample(int i) =>
+    ProfileSample(timestamp: i * 30, depth: 5.0 * (i % 4));
+
+void main() {
+  const codec = ProfileSeriesCodec();
+
+  group('round trips', () {
+    test('every field present', () {
+      final samples = [for (var i = 0; i < 12; i++) fullSample(i)];
+      final encoded = codec.encode(samples);
+      expect(encoded.codecVersion, 1);
+      expect(codec.decode(encoded.bytes), samples);
+    });
+
+    test('every optional field null', () {
+      final samples = [for (var i = 0; i < 12; i++) minimalSample(i)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('mixed presence within one column', () {
+      final samples = [
+        for (var i = 0; i < 20; i++)
+          ProfileSample(
+            timestamp: i,
+            depth: 1.0 * i,
+            temperature: i.isEven ? 20.0 : null,
+            ndl: i % 3 == 0 ? 600 - i : null,
+            heartRateSource: i % 5 == 0 ? 'garmin' : null,
+          ),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('a single sample', () {
+      final samples = [fullSample(0)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('duplicate timestamps survive in insertion order', () {
+      const samples = [
+        ProfileSample(timestamp: 10, depth: 5.0),
+        ProfileSample(timestamp: 10, depth: 5.5),
+        ProfileSample(timestamp: 10, depth: 5.0, temperature: 19.0),
+        ProfileSample(timestamp: 20, depth: 6.0),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('integer fields that decrease encode negative deltas correctly', () {
+      final samples = [
+        for (var i = 0; i < 50; i++)
+          ProfileSample(
+            timestamp: i,
+            depth: 1.0,
+            ndl: 3000 - i * 60,
+            rbt: 2000 - i * 45,
+            heartRate: 100 - i,
+            o2SensorMv1: -5 + i,
+          ),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('float64 fields are bit-exact', () {
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 0.1 + 0.2, temperature: -0.0),
+        ProfileSample(timestamp: 1, depth: double.maxFinite, cns: 1e-300),
+      ];
+      final decoded = codec.decode(codec.encode(samples).bytes);
+      expect(decoded[0].depth, samples[0].depth);
+      expect(decoded[0].temperature!.isNegative, isTrue);
+      expect(decoded[1].depth, double.maxFinite);
+      expect(decoded[1].cns, 1e-300);
+    });
+
+    test('the largest realistic series: 20,000 samples at one second', () {
+      final random = Random(42);
+      var depth = 0.0;
+      final samples = <ProfileSample>[];
+      for (var i = 0; i < 20000; i++) {
+        depth = max(0.0, depth + (random.nextDouble() - 0.5) * 0.3);
+        samples.add(
+          ProfileSample(
+            timestamp: i,
+            depth: depth,
+            temperature: 8.0 + (i ~/ 600) * 0.1,
+            ndl: max(0, 3600 - i ~/ 2),
+            cns: i / 400.0,
+            decoType: i > 15000 ? 2 : 0,
+          ),
+        );
+      }
+      final encoded = codec.encode(samples);
+      expect(codec.decode(encoded.bytes), samples);
+      // 20,000 samples of six fields. Row storage today costs roughly 300
+      // bytes per sample; the packed blob must land far below even the raw
+      // columnar size (8 bytes per float64 field per sample).
+      expect(encoded.bytes.length, lessThan(20000 * 3 * 8));
+    });
+  });
+
+  group('summary', () {
+    test('encode returns the summary of the packed samples', () {
+      final samples = [for (var i = 0; i < 12; i++) fullSample(i)];
+      final encoded = codec.encode(samples);
+      expect(encoded.summary, ProfileSeriesSummary.of(samples));
+      expect(encoded.summary.sampleCount, 12);
+      expect(encoded.summary.hasDecoStop, isTrue);
+      expect(encoded.summary.hasPositiveCeiling, isTrue);
+    });
+  });
+
+  group('caller errors', () {
+    test('an empty series cannot be encoded', () {
+      expect(() => codec.encode(const []), throwsArgumentError);
+    });
+
+    test('timestamps must be non-decreasing', () {
+      const samples = [
+        ProfileSample(timestamp: 10, depth: 1.0),
+        ProfileSample(timestamp: 9, depth: 1.0),
+      ];
+      expect(() => codec.encode(samples), throwsArgumentError);
+    });
+
+    test('an unregistered version cannot be encoded', () {
+      expect(
+        () => codec.encode([fullSample(0)], version: 9),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('malformed input', () {
+    Uint8List validBytes() =>
+        codec.encode([for (var i = 0; i < 8; i++) fullSample(i)]).bytes;
+
+    /// Re-compresses a tampered body so the failure is in the codec, not
+    /// in zlib.
+    Uint8List recompress(List<int> body) =>
+        Uint8List.fromList(ZLibCodec(level: 6).encode(body));
+
+    Uint8List inflate(Uint8List bytes) =>
+        Uint8List.fromList(zlib.decode(bytes));
+
+    test('bytes that are not a zlib stream', () {
+      expect(
+        () => codec.decode(Uint8List.fromList([1, 2, 3, 4, 5])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an empty blob', () {
+      expect(
+        () => codec.decode(Uint8List(0)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an unknown version byte', () {
+      final body = inflate(validBytes());
+      body[0] = 42;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('version'),
+          ),
+        ),
+      );
+    });
+
+    test('a truncated body', () {
+      final body = inflate(validBytes());
+      final truncated = body.sublist(0, body.length ~/ 2);
+      expect(
+        () => codec.decode(recompress(truncated)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('trailing bytes after the last block', () {
+      final body = inflate(validBytes());
+      final padded = Uint8List.fromList([...body, 0, 0, 0]);
+      expect(
+        () => codec.decode(recompress(padded)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('trailing'),
+          ),
+        ),
+      );
+    });
+
+    test('a blob whose timestamp column is marked absent', () {
+      // Header is version (1 byte) then count varint (8 fits in 1 byte);
+      // byte 2 is the timestamp block's presence mode.
+      final body = inflate(validBytes());
+      expect(body[2], isNot(0));
+      body[2] = 0;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+  });
+
+  group('forward tolerance', () {
+    // A hypothetical older format that never recorded heading.
+    final withoutHeading = [
+      for (final field in ProfileSeriesCodec.fieldTableV1)
+        if (field.name != 'heading') field,
+    ];
+
+    test('a newer decoder reads an older version with missing fields null', () {
+      final legacy = ProfileSeriesCodec(fieldTables: {7: withoutHeading});
+      final modern = ProfileSeriesCodec(
+        fieldTables: {
+          7: withoutHeading,
+          ProfileSeriesCodec.version: ProfileSeriesCodec.fieldTableV1,
+        },
+      );
+      final samples = [for (var i = 0; i < 6; i++) fullSample(i)];
+      final bytes = legacy.encode(samples, version: 7).bytes;
+      final decoded = modern.decode(bytes);
+      expect(decoded, hasLength(6));
+      for (var i = 0; i < 6; i++) {
+        expect(decoded[i].heading, isNull);
+        expect(decoded[i], samples[i].copyWithoutHeading());
+      }
+    });
+
+    test('a decoder that does not know the version refuses it', () {
+      final legacy = ProfileSeriesCodec(fieldTables: {7: withoutHeading});
+      final bytes = legacy.encode([fullSample(0)], version: 7).bytes;
+      expect(
+        () => codec.decode(bytes),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('every field table must carry timestamp and depth', () {
+      final noDepth = [
+        for (final field in ProfileSeriesCodec.fieldTableV1)
+          if (field.name != 'depth') field,
+      ];
+      expect(
+        () => ProfileSeriesCodec(
+          fieldTables: {1: noDepth},
+        ).encode([fullSample(0)]),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('field table', () {
+    test('v1 has 28 entries with unique names', () {
+      final names = ProfileSeriesCodec.fieldTableV1.map((f) => f.name);
+      expect(names, hasLength(28));
+      expect(names.toSet(), hasLength(28));
+    });
+
+    test('v1 begins with timestamp and depth', () {
+      expect(ProfileSeriesCodec.fieldTableV1[0].name, 'timestamp');
+      expect(ProfileSeriesCodec.fieldTableV1[1].name, 'depth');
+    });
+  });
+}
+
+extension on ProfileSample {
+  ProfileSample copyWithoutHeading() => ProfileSample(
+    timestamp: timestamp,
+    depth: depth,
+    pressure: pressure,
+    temperature: temperature,
+    heartRate: heartRate,
+    ascentRate: ascentRate,
+    ceiling: ceiling,
+    ndl: ndl,
+    setpoint: setpoint,
+    ppO2: ppO2,
+    o2Sensor1: o2Sensor1,
+    o2Sensor2: o2Sensor2,
+    o2Sensor3: o2Sensor3,
+    o2Sensor4: o2Sensor4,
+    o2Sensor5: o2Sensor5,
+    o2Sensor6: o2Sensor6,
+    cns: cns,
+    tts: tts,
+    rbt: rbt,
+    decoType: decoType,
+    heartRateSource: heartRateSource,
+    o2SensorMv1: o2SensorMv1,
+    o2SensorMv2: o2SensorMv2,
+    o2SensorMv3: o2SensorMv3,
+    o2SensorMv4: o2SensorMv4,
+    o2SensorMv5: o2SensorMv5,
+    o2SensorMv6: o2SensorMv6,
+  );
+}

--- a/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_field_table.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';

--- a/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/bounded_inflate.dart';
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_field_table.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
@@ -172,6 +173,38 @@ void main() {
       expect(
         () => codec.encode([fullSample(0)], version: 9),
         throwsArgumentError,
+      );
+    });
+  });
+
+  group('encode limits', () {
+    test('refuses more samples than decode would accept', () {
+      // encode and decode have to agree: part 2 drops the source rows once
+      // a series is packed, so a blob decode refuses is unrecoverable.
+      final tooMany = [
+        for (var i = 0; i < kMaxSeriesSampleCount + 1; i++) minimalSample(i),
+      ];
+      expect(() => codec.encode(tooMany), throwsArgumentError);
+    });
+
+    test('a field table may not change a v1 field kind', () {
+      // cast() is lazy, so without this the mismatch escapes as a TypeError
+      // from inside a presence loop rather than as a table error.
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('cns', ProfileFieldKind.deltaInt),
+      ];
+      const wrong = ProfileSeriesCodec(fieldTables: {9: table});
+      expect(
+        () => wrong.encode([fullSample(0)], version: 9),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('cns is float64 in v1'),
+          ),
+        ),
       );
     });
   });
@@ -350,7 +383,33 @@ void main() {
 
     test('a sample count larger than the payload', () {
       final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a three-byte varint for 200,000:
+      // under the hard cap, so this exercises the payload-size guard.
+      expect(body[1], 8, reason: 'the count must still be one byte here');
+      const overPayload = [0xC0, 0x9A, 0x0C];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...overPayload,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('remaining'),
+          ),
+        ),
+      );
+    });
+
+    test('a sample count over the hard cap', () {
+      final body = inflate(validBytes());
       // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      // The cap is checked before the payload guard, so no crafted body has
+      // to be large enough to make the count plausible.
+      expect(body[1], 8, reason: 'the count must still be one byte here');
       const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
       final tampered = Uint8List.fromList([
         body[0],
@@ -359,7 +418,124 @@ void main() {
       ]);
       expect(
         () => codec.decode(recompress(tampered)),
-        throwsA(isA<ProfileSeriesCodecException>()),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum $kMaxSeriesSampleCount'),
+          ),
+        ),
+      );
+    });
+
+    test('a sample count of exactly the cap clears the cap guard', () {
+      // Pins which side of the boundary the cap sits on: this count is
+      // legal, so it must fall through to the payload guard instead. An
+      // off-by-one to >= would make every maximal series undecodable.
+      final body = inflate(validBytes());
+      expect(body[1], 8, reason: 'the count must still be one byte here');
+      final atCap = ByteWriter()..writeVarUint(kMaxSeriesSampleCount);
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...atCap.takeBytes(),
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('remaining'),
+          ),
+        ),
+      );
+    });
+
+    test('a sample count one past the cap is refused by the cap', () {
+      final body = inflate(validBytes());
+      expect(body[1], 8, reason: 'the count must still be one byte here');
+      final pastCap = ByteWriter()..writeVarUint(kMaxSeriesSampleCount + 1);
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...pastCap.takeBytes(),
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum $kMaxSeriesSampleCount'),
+          ),
+        ),
+      );
+    });
+
+    test('a string run length near 2^63 does not overrun the guard', () {
+      // values.length + length would wrap negative and let the append loop
+      // run unbounded, which no sample-count cap can see: the declared
+      // count here is a legitimate 3.
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 1, depth: 2.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 2, depth: 3.0, heartRateSource: 'a'),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      const runLengthOffset = 1 + 1 + (1 + 3) + (1 + 24) + 1 + 1;
+      expect(body[runLengthOffset], 3);
+      final huge = ByteWriter()..writeVarUint(maxVarInt * 2 + 1);
+      final tampered = Uint8List.fromList([
+        ...body.sublist(0, runLengthOffset),
+        ...huge.takeBytes(),
+        ...body.sublist(runLengthOffset + 1),
+      ]);
+      expect(
+        () => small.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('overruns'),
+          ),
+        ),
+      );
+    });
+
+    test('a zero-length string run is refused', () {
+      // Accepting one would make the format non-canonical: padding runs
+      // decode to the same samples from different bytes.
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 1, depth: 2.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 2, depth: 3.0, heartRateSource: 'a'),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      const runLengthOffset = 1 + 1 + (1 + 3) + (1 + 24) + 1 + 1;
+      expect(body[runLengthOffset], 3);
+      body[runLengthOffset] = 0;
+      expect(
+        () => small.decode(recompress(body)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('empty'),
+          ),
+        ),
       );
     });
 

--- a/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
@@ -239,15 +240,110 @@ void main() {
       );
     });
 
-    test('a blob whose timestamp column is marked absent', () {
-      // Header is version (1 byte) then count varint (8 fits in 1 byte);
-      // byte 2 is the timestamp block's presence mode.
-      final body = inflate(validBytes());
-      expect(body[2], isNot(0));
-      body[2] = 0;
+    test('a body whose timestamp column is absent', () {
+      // [version 9][count 3][timestamp: mode, 3 deltas][depth: mode, 3 floats]
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.5),
+        ProfileSample(timestamp: 10, depth: 2.5),
+        ProfileSample(timestamp: 20, depth: 3.5),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      expect(body[2], kPresenceAll);
+      // Mark the timestamp column absent and drop its three delta bytes.
+      final tampered = Uint8List.fromList([
+        body[0],
+        body[1],
+        kPresenceAbsent,
+        ...body.sublist(6),
+      ]);
+      expect(
+        () => small.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('no timestamp'),
+          ),
+        ),
+      );
+    });
+
+    test('a body whose depth column is absent', () {
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.5),
+        ProfileSample(timestamp: 10, depth: 2.5),
+        ProfileSample(timestamp: 20, depth: 3.5),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      // Depth block starts after version, count, timestamp mode, 3 deltas.
+      const depthMode = 6;
+      expect(body[depthMode], kPresenceAll);
+      final tampered = Uint8List.fromList([
+        ...body.sublist(0, depthMode),
+        kPresenceAbsent,
+      ]);
+      expect(
+        () => small.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('no depth'),
+          ),
+        ),
+      );
+    });
+
+    test('malformed UTF-8 in a string run', () {
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 1, depth: 2.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 2, depth: 3.0, heartRateSource: 'a'),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      const firstStringByte = 1 + 1 + (1 + 3) + (1 + 24) + 1 + 1 + 1 + 1;
+      expect(body[firstStringByte], 0x61);
+      body[firstStringByte] = 0xFF;
+      expect(
+        () => small.decode(recompress(body)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('UTF-8'),
+          ),
+        ),
+      );
+    });
+
+    test('a zero sample count', () {
+      // [version 1][count 0] then 28 absent blocks.
+      final body = Uint8List.fromList([1, 0, ...List.filled(28, 0)]);
       expect(
         () => codec.decode(recompress(body)),
-        throwsA(isA<ProfileSeriesCodecException>()),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('empty'),
+          ),
+        ),
       );
     });
 
@@ -337,6 +433,17 @@ void main() {
         ).encode([fullSample(0)]),
         throwsArgumentError,
       );
+    });
+
+    test('a field table with a duplicate name is refused on both sides', () {
+      final duplicated = [
+        ...ProfileSeriesCodec.fieldTableV1,
+        const ProfileField('depth', ProfileFieldKind.float64),
+      ];
+      final bad = ProfileSeriesCodec(fieldTables: {1: duplicated});
+      expect(() => bad.encode([fullSample(0)]), throwsArgumentError);
+      final bytes = codec.encode([fullSample(0)]).bytes;
+      expect(() => bad.decode(bytes), throwsArgumentError);
     });
   });
 

--- a/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_codec_test.dart
@@ -250,6 +250,46 @@ void main() {
         throwsA(isA<ProfileSeriesCodecException>()),
       );
     });
+
+    test('a sample count larger than the payload', () {
+      final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...huge,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a string run longer than the present values', () {
+      // A three-field table keeps the body small enough to address by hand:
+      // [version][count 3][timestamp: mode, 3 deltas][depth: mode, 3 floats]
+      // [heart_rate_source: mode, run count, run length, byte length, 'a'].
+      const table = [
+        ProfileField('timestamp', ProfileFieldKind.deltaInt),
+        ProfileField('depth', ProfileFieldKind.float64),
+        ProfileField('heart_rate_source', ProfileFieldKind.runLengthString),
+      ];
+      const small = ProfileSeriesCodec(fieldTables: {9: table});
+      const samples = [
+        ProfileSample(timestamp: 0, depth: 1.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 1, depth: 2.0, heartRateSource: 'a'),
+        ProfileSample(timestamp: 2, depth: 3.0, heartRateSource: 'a'),
+      ];
+      final body = inflate(small.encode(samples, version: 9).bytes);
+      const runLengthOffset = 1 + 1 + (1 + 3) + (1 + 24) + 1 + 1;
+      expect(body[runLengthOffset], 3);
+      body[runLengthOffset] = 5;
+      expect(
+        () => small.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
   });
 
   group('forward tolerance', () {

--- a/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
@@ -56,4 +56,12 @@ void main() {
       expect(field.kind, expectedKind, reason: field.name);
     }
   });
+
+  test('the tank codec covers every tank_pressure_profiles sample column', () {
+    const tankIdentity = {'id', 'dive_id', 'tank_id', 'computer_id'};
+    final tableColumns = {
+      for (final column in db.tankPressureProfiles.$columns) column.$name,
+    };
+    expect(tableColumns.difference(tankIdentity), {'timestamp', 'pressure'});
+  });
 }

--- a/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_field_table.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
 
 /// Columns of `dive_profiles` that identify the series, not the sample.

--- a/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_field_table_test.dart
@@ -1,0 +1,59 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+
+/// Columns of `dive_profiles` that identify the series, not the sample.
+/// They live on the series row and are never packed.
+const identityColumns = {
+  'id',
+  'dive_id',
+  'computer_id',
+  'source_id',
+  'is_primary',
+};
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  test('codec v1 covers every dive_profiles sample column, and only those', () {
+    final tableColumns = {
+      for (final column in db.diveProfiles.$columns) column.$name,
+    };
+    final expected = tableColumns.difference(identityColumns);
+    final actual = {
+      for (final field in ProfileSeriesCodec.fieldTableV1) field.name,
+    };
+    expect(
+      actual,
+      expected,
+      reason:
+          'A dive_profiles column was added or removed without a codec '
+          'version. Append the field under a new version in '
+          'ProfileSeriesCodec; never edit fieldTableV1.',
+    );
+  });
+
+  test('each field kind matches its column type', () {
+    final typeByName = {
+      for (final column in db.diveProfiles.$columns) column.$name: column.type,
+    };
+    for (final field in ProfileSeriesCodec.fieldTableV1) {
+      final type = typeByName[field.name];
+      final expectedKind = switch (type) {
+        DriftSqlType.int => ProfileFieldKind.deltaInt,
+        DriftSqlType.double => ProfileFieldKind.float64,
+        DriftSqlType.string => ProfileFieldKind.runLengthString,
+        _ => fail('unexpected column type $type for ${field.name}'),
+      };
+      expect(field.kind, expectedKind, reason: field.name);
+    }
+  });
+}

--- a/test/features/dive_log/domain/codecs/profile_series_golden_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_golden_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
+
+/// Freezes the codecs' v1 wire format.
+///
+/// These golden bodies are captured once from a known-good encode and pasted
+/// in as literals. They exist so a reordered field table or a changed delta
+/// convention fails a test even though round trips through the same codec
+/// stay green: a round trip alone cannot tell a stable format from a
+/// silently-changed one, because it always decodes with the same encoder
+/// that wrote it.
+///
+/// A future change that alters a golden body is a codec version bump, never
+/// an edit to the literal.
+void main() {
+  const codec = ProfileSeriesCodec();
+  const tankCodec = TankPressureSeriesCodec();
+
+  Uint8List inflate(Uint8List bytes) => Uint8List.fromList(zlib.decode(bytes));
+
+  Uint8List recompress(List<int> body) =>
+      Uint8List.fromList(ZLibCodec(level: 6).encode(body));
+
+  const samples = [
+    ProfileSample(
+      timestamp: 0,
+      depth: 1.5,
+      pressure: 0.25,
+      temperature: 0.5,
+      heartRate: 1,
+      ascentRate: 0.75,
+      ceiling: 1.0,
+      ndl: 2,
+      setpoint: 1.25,
+      ppO2: 1.75,
+      o2Sensor1: 2.25,
+      o2Sensor2: 2.75,
+      o2Sensor3: 3.25,
+      o2Sensor4: 3.75,
+      o2Sensor5: 4.25,
+      o2Sensor6: 4.75,
+      cns: 5.25,
+      tts: 3,
+      rbt: 4,
+      decoType: 5,
+      heartRateSource: 'a',
+      heading: 5.75,
+      o2SensorMv1: 6,
+      o2SensorMv2: 7,
+      o2SensorMv3: 8,
+      o2SensorMv4: 9,
+      o2SensorMv5: 10,
+      o2SensorMv6: 11,
+    ),
+    ProfileSample(
+      timestamp: 10,
+      depth: 2.5,
+      pressure: 10.25,
+      temperature: 10.5,
+      heartRate: 101,
+      ascentRate: 10.75,
+      ceiling: 11.0,
+      ndl: 102,
+      setpoint: 11.25,
+      ppO2: 11.75,
+      o2Sensor1: 12.25,
+      o2Sensor2: 12.75,
+      o2Sensor3: 13.25,
+      o2Sensor4: 13.75,
+      o2Sensor5: 14.25,
+      o2Sensor6: 14.75,
+      cns: 15.25,
+      tts: 103,
+      rbt: 104,
+      decoType: 105,
+      heartRateSource: 'b',
+      heading: 15.75,
+      o2SensorMv1: 106,
+      o2SensorMv2: 107,
+      o2SensorMv3: 108,
+      o2SensorMv4: 109,
+      o2SensorMv5: 110,
+      o2SensorMv6: 111,
+    ),
+  ];
+
+  // Captured from a known-good encode of `samples` above. The first bytes,
+  // hand-verified:
+  //   [0]  1   version
+  //   [1]  2   sample count
+  //   [2]  1   timestamp presence mode (kPresenceAll)
+  //   [3]  0   zigzag delta of timestamp 0 (0 - 0 = 0 -> 0)
+  //   [4]  20  zigzag delta of timestamp 10 (10 - 0 = 10 -> 20)
+  //   [5]  1   depth presence mode (kPresenceAll)
+  //   [6..13]  00 00 00 00 00 00 F8 3F: float64 1.5, little-endian
+  //   [14..21] 00 00 00 00 00 00 04 40: float64 2.5, little-endian
+  // [22] onward is the pressure column (presence mode, then two float64s),
+  // followed by the remaining 25 columns in field-table order.
+  const goldenBody = <int>[
+    1, 2, 1, 0, 20, 1, //
+    0, 0, 0, 0, 0, 0, 248, 63, //
+    0, 0, 0, 0, 0, 0, 4, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 208, 63, //
+    0, 0, 0, 0, 0, 128, 36, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 224, 63, //
+    0, 0, 0, 0, 0, 0, 37, 64, //
+    1, 2, 200, 1, 1, //
+    0, 0, 0, 0, 0, 0, 232, 63, //
+    0, 0, 0, 0, 0, 128, 37, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 240, 63, //
+    0, 0, 0, 0, 0, 0, 38, 64, //
+    1, 4, 200, 1, 1, //
+    0, 0, 0, 0, 0, 0, 244, 63, //
+    0, 0, 0, 0, 0, 128, 38, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 252, 63, //
+    0, 0, 0, 0, 0, 128, 39, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 2, 64, //
+    0, 0, 0, 0, 0, 128, 40, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 6, 64, //
+    0, 0, 0, 0, 0, 128, 41, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 10, 64, //
+    0, 0, 0, 0, 0, 128, 42, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 14, 64, //
+    0, 0, 0, 0, 0, 128, 43, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 17, 64, //
+    0, 0, 0, 0, 0, 128, 44, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 19, 64, //
+    0, 0, 0, 0, 0, 128, 45, 64, //
+    1, //
+    0, 0, 0, 0, 0, 0, 21, 64, //
+    0, 0, 0, 0, 0, 128, 46, 64, //
+    1, 6, 200, 1, 1, 8, 200, 1, 1, 10, 200, 1, //
+    1, 2, 1, 1, 97, 1, 1, 98, //
+    1, //
+    0, 0, 0, 0, 0, 0, 23, 64, //
+    0, 0, 0, 0, 0, 128, 47, 64, //
+    1, 12, 200, 1, 1, 14, 200, 1, 1, 16, 200, 1, //
+    1, 18, 200, 1, 1, 20, 200, 1, 1, 22, 200, 1,
+  ];
+
+  const tankSamples = [
+    TankPressureSample(timestamp: 0, pressure: 200.0),
+    TankPressureSample(timestamp: 10, pressure: 190.5),
+    TankPressureSample(timestamp: 20, pressure: 181.0),
+  ];
+
+  // [1]        version
+  // [3]        sample count
+  // [1, 0, 20, 20]   timestamp: mode, then zigzag deltas 0, 10, 10
+  // [1]        pressure presence mode
+  // 24 bytes   three float64 pressures, little-endian
+  const tankGoldenBody = <int>[
+    1, 3, 1, 0, 20, 20, //
+    1, //
+    0, 0, 0, 0, 0, 0, 105, 64, //
+    0, 0, 0, 0, 0, 208, 103, 64, //
+    0, 0, 0, 0, 0, 160, 102, 64,
+  ];
+
+  group('profile series codec v1', () {
+    test('encoding freezes to the golden body', () {
+      final encoded = codec.encode(samples);
+      expect(inflate(encoded.bytes), goldenBody);
+    });
+
+    test('the golden body decodes to the source samples', () {
+      expect(codec.decode(recompress(goldenBody)), samples);
+    });
+  });
+
+  group('tank pressure series codec v1', () {
+    test('encoding freezes to the golden body', () {
+      final encoded = tankCodec.encode(tankSamples);
+      expect(inflate(encoded.bytes), tankGoldenBody);
+    });
+
+    test('the golden body decodes to the source samples', () {
+      expect(tankCodec.decode(recompress(tankGoldenBody)), tankSamples);
+    });
+  });
+}

--- a/test/features/dive_log/domain/codecs/profile_series_summary_test.dart
+++ b/test/features/dive_log/domain/codecs/profile_series_summary_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_summary.dart';
+
+void main() {
+  test('summarises a plain no-deco series', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0),
+      ProfileSample(timestamp: 10, depth: 5.2),
+      ProfileSample(timestamp: 20, depth: 18.7),
+      ProfileSample(timestamp: 30, depth: 12.1),
+      ProfileSample(timestamp: 40, depth: 0.3),
+    ];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(
+      summary,
+      const ProfileSeriesSummary(
+        sampleCount: 5,
+        startTimestamp: 0,
+        endTimestamp: 40,
+        maxDepth: 18.7,
+        firstDepth: 0.0,
+        lastDepth: 0.3,
+        hasDecoType: false,
+        hasDecoStop: false,
+        hasPositiveCeiling: false,
+      ),
+    );
+  });
+
+  test('a recorded deco type without a stop sets only hasDecoType', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, decoType: 0),
+      ProfileSample(timestamp: 10, depth: 20.0, decoType: 1),
+    ];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(summary.hasDecoType, isTrue);
+    expect(summary.hasDecoStop, isFalse);
+  });
+
+  test('deco type 2 on any sample sets hasDecoStop', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, decoType: 0),
+      ProfileSample(timestamp: 10, depth: 6.0, decoType: kDecoTypeDecoStop),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasDecoStop, isTrue);
+  });
+
+  test('a positive ceiling on any sample sets hasPositiveCeiling', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, ceiling: 0.0),
+      ProfileSample(timestamp: 10, depth: 30.0, ceiling: 3.0),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasPositiveCeiling, isTrue);
+  });
+
+  test('a zero or null ceiling does not count as positive', () {
+    const samples = [
+      ProfileSample(timestamp: 0, depth: 0.0, ceiling: 0.0),
+      ProfileSample(timestamp: 10, depth: 30.0),
+    ];
+    expect(ProfileSeriesSummary.of(samples).hasPositiveCeiling, isFalse);
+  });
+
+  test('a single sample is its own start, end, first, last and max', () {
+    const samples = [ProfileSample(timestamp: 7, depth: 4.4)];
+    final summary = ProfileSeriesSummary.of(samples);
+    expect(summary.sampleCount, 1);
+    expect(summary.startTimestamp, 7);
+    expect(summary.endTimestamp, 7);
+    expect(summary.maxDepth, 4.4);
+    expect(summary.firstDepth, 4.4);
+    expect(summary.lastDepth, 4.4);
+  });
+
+  test('an empty series is a caller error', () {
+    expect(() => ProfileSeriesSummary.of(const []), throwsArgumentError);
+  });
+}

--- a/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/bounded_inflate.dart';
 import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
 import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
@@ -85,6 +86,15 @@ void main() {
     });
   });
 
+  group('encode limits', () {
+    test('refuses more samples than decode would accept', () {
+      expect(
+        () => codec.encode(descending(kMaxSeriesSampleCount + 1)),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('malformed input', () {
     Uint8List validBytes() => codec.encode(descending(8)).bytes;
     Uint8List recompress(List<int> body) =>
@@ -126,7 +136,31 @@ void main() {
 
     test('a sample count larger than the payload', () {
       final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a three-byte varint for 200,000:
+      // under the hard cap, so this exercises the payload-size guard.
+      expect(body[1], 8, reason: 'the count must still be one byte here');
+      const overPayload = [0xC0, 0x9A, 0x0C];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...overPayload,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('remaining'),
+          ),
+        ),
+      );
+    });
+
+    test('a sample count over the hard cap', () {
+      final body = inflate(validBytes());
       // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      expect(body[1], 8, reason: 'the count must still be one byte here');
       const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
       final tampered = Uint8List.fromList([
         body[0],
@@ -135,7 +169,13 @@ void main() {
       ]);
       expect(
         () => codec.decode(recompress(tampered)),
-        throwsA(isA<ProfileSeriesCodecException>()),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum $kMaxSeriesSampleCount'),
+          ),
+        ),
       );
     });
 

--- a/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/byte_io.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
 import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
 
@@ -135,6 +136,61 @@ void main() {
       expect(
         () => codec.decode(recompress(tampered)),
         throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a body whose timestamp column is absent', () {
+      final body = inflate(codec.encode(descending(3)).bytes);
+      expect(body[2], kPresenceAll);
+      final tampered = Uint8List.fromList([
+        body[0],
+        body[1],
+        kPresenceAbsent,
+        ...body.sublist(6),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('no timestamp'),
+          ),
+        ),
+      );
+    });
+
+    test('a body whose pressure column is absent', () {
+      final body = inflate(codec.encode(descending(3)).bytes);
+      const pressureMode = 6;
+      expect(body[pressureMode], kPresenceAll);
+      final tampered = Uint8List.fromList([
+        ...body.sublist(0, pressureMode),
+        kPresenceAbsent,
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('no pressure'),
+          ),
+        ),
+      );
+    });
+
+    test('a zero sample count', () {
+      final body = Uint8List.fromList([1, 0, 0, 0]);
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(
+          isA<ProfileSeriesCodecException>().having(
+            (e) => e.message,
+            'message',
+            contains('empty'),
+          ),
+        ),
       );
     });
   });

--- a/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
+++ b/test/features/dive_log/domain/codecs/tank_pressure_series_codec_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec_exception.dart';
+import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
+
+void main() {
+  const codec = TankPressureSeriesCodec();
+
+  List<TankPressureSample> descending(int count) => [
+    for (var i = 0; i < count; i++)
+      TankPressureSample(timestamp: i * 10, pressure: 210.0 - i * 0.3),
+  ];
+
+  group('round trips', () {
+    test('a typical series', () {
+      final samples = descending(200);
+      final encoded = codec.encode(samples);
+      expect(encoded.codecVersion, 1);
+      expect(codec.decode(encoded.bytes), samples);
+    });
+
+    test('a single sample', () {
+      const samples = [TankPressureSample(timestamp: 0, pressure: 200.0)];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('duplicate timestamps survive in insertion order', () {
+      const samples = [
+        TankPressureSample(timestamp: 5, pressure: 200.0),
+        TankPressureSample(timestamp: 5, pressure: 199.0),
+        TankPressureSample(timestamp: 6, pressure: 198.5),
+      ];
+      expect(codec.decode(codec.encode(samples).bytes), samples);
+    });
+
+    test('pressures are bit-exact', () {
+      const samples = [
+        TankPressureSample(timestamp: 0, pressure: 0.1 + 0.2),
+        TankPressureSample(timestamp: 1, pressure: 1e-300),
+      ];
+      final decoded = codec.decode(codec.encode(samples).bytes);
+      expect(decoded[0].pressure, 0.1 + 0.2);
+      expect(decoded[1].pressure, 1e-300);
+    });
+
+    test('20,000 samples pack below raw columnar size', () {
+      final samples = descending(20000);
+      final encoded = codec.encode(samples);
+      expect(codec.decode(encoded.bytes), samples);
+      // Raw columnar is one varint byte plus eight float bytes per sample.
+      // Any compression at all lands below this; the bound is deterministic.
+      expect(encoded.bytes.length, lessThan(20000 * 9));
+    });
+  });
+
+  group('summary', () {
+    test('encode returns the summary of the packed samples', () {
+      final samples = descending(10);
+      final encoded = codec.encode(samples);
+      expect(encoded.summary, TankPressureSeriesSummary.of(samples));
+      expect(encoded.summary.sampleCount, 10);
+      expect(encoded.summary.startTimestamp, 0);
+      expect(encoded.summary.endTimestamp, 90);
+    });
+  });
+
+  group('caller errors', () {
+    test('an empty series cannot be encoded', () {
+      expect(() => codec.encode(const []), throwsArgumentError);
+    });
+
+    test('an empty summary is a caller error', () {
+      expect(() => TankPressureSeriesSummary.of(const []), throwsArgumentError);
+    });
+
+    test('timestamps must be non-decreasing', () {
+      const samples = [
+        TankPressureSample(timestamp: 10, pressure: 1.0),
+        TankPressureSample(timestamp: 9, pressure: 1.0),
+      ];
+      expect(() => codec.encode(samples), throwsArgumentError);
+    });
+  });
+
+  group('malformed input', () {
+    Uint8List validBytes() => codec.encode(descending(8)).bytes;
+    Uint8List recompress(List<int> body) =>
+        Uint8List.fromList(ZLibCodec(level: 6).encode(body));
+    Uint8List inflate(Uint8List bytes) =>
+        Uint8List.fromList(zlib.decode(bytes));
+
+    test('bytes that are not a zlib stream', () {
+      expect(
+        () => codec.decode(Uint8List.fromList([9, 9, 9])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('an unknown version byte', () {
+      final body = inflate(validBytes());
+      body[0] = 2;
+      expect(
+        () => codec.decode(recompress(body)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a truncated body', () {
+      final body = inflate(validBytes());
+      expect(
+        () => codec.decode(recompress(body.sublist(0, body.length - 3))),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('trailing bytes', () {
+      final body = inflate(validBytes());
+      expect(
+        () => codec.decode(recompress([...body, 0])),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+
+    test('a sample count larger than the payload', () {
+      final body = inflate(validBytes());
+      // Replace the one-byte count (8) with a five-byte varint for 2^32.
+      const huge = [0x80, 0x80, 0x80, 0x80, 0x10];
+      final tampered = Uint8List.fromList([
+        body[0],
+        ...huge,
+        ...body.sublist(2),
+      ]);
+      expect(
+        () => codec.decode(recompress(tampered)),
+        throwsA(isA<ProfileSeriesCodecException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Part 1 of the packed profile sample storage program
(`docs/superpowers/specs/2026-08-28-profile-sample-storage-design.md`).
Adds a pure-Dart, lossless, versioned codec that packs a series of profile
samples (or a tank's pressure readings) into one zlib-compressed columnar
blob, plus the summary scalars the series tables will store. Nothing in
this PR touches the database, repositories, or sync; part 2 adopts it.

## Why

On a 40-dive database the two row-per-sample tables and their indexes are
25.4 of 28.1 MB (90%). Measured on that data, this codec packs
`dive_profiles` 74x and `tank_pressure_profiles` 129x, lossless (float64).
A synthetic 20,000-sample profile series packs to 195,925 bytes.

## What is in it

- `byte_io.dart`: varint, zigzag varint, float64, presence-bitmapped
  column blocks; strict reader that throws on any read past the end.
- `ProfileSample`: the 28 sample columns of `dive_profiles` as a value
  type, with `DiveProfilePoint` conversions.
- `ProfileSeriesSummary`: the scalars that keep the deco, runtime, and
  quality predicates in SQL.
- `profile_field_table.dart`: the frozen v1 field table.
- `ProfileSeriesCodec`: encode/decode over a versioned field table; strict
  failure on anything malformed (unknown version, truncation, trailing
  bytes, oversized or zero count, run overrun, malformed UTF-8, missing
  timestamp or depth); forward tolerance for older versions.
- `TankPressureSeriesCodec`: the two-field sibling.
- A test that pins the field table to the live `dive_profiles` column
  list (and the tank table to its two sample columns), so a column added
  without a codec version fails CI.
- A golden-bytes test that freezes the v1 wire format for both codecs.

## Test plan

- Round trips: every field present, every optional field null, mixed
  presence, duplicate timestamps, decreasing integers, float64
  bit-exactness, 20,000 samples.
- Malformed input: non-zlib bytes, empty, unknown version, truncated,
  trailing bytes, oversized count, zero count, absent timestamp, depth,
  and pressure columns, string run overrun, malformed UTF-8.
- Forward tolerance: a newer decoder reads an older version with the
  missing field null; an unknown version is refused; a field table with a
  duplicate name is refused on both sides.
- Golden bytes: hard-coded uncompressed bodies for both codecs, encode and
  decode directions.
- 114 codec tests across seven files; `dart format` and `flutter analyze`
  clean; full suite run once locally (the two failures were the documented
  wordlist-split and mounted-TMPDIR flakes, both green rerun alone).
