### PR TITLE
fix: iCloud media uploads stall at Waiting after a second device connects

### DIFF
--- a/lib/core/services/media_store/icloud_media_object_store.dart
+++ b/lib/core/services/media_store/icloud_media_object_store.dart
@@ -95,10 +95,17 @@ class ICloudMediaObjectStore implements MediaObjectStore {
     TransferProgressCallback? onProgress,
   }) async {
     final path = await _pathFor(key);
+    // A false answer means iCloud KNOWS the file: the placeholder is on disk,
+    // startDownloadingUbiquitousItem succeeded, and the native poll ran out
+    // waiting for the bytes. A key the container has never held does not get
+    // here (the native side answers true for a non-ubiquitous path and the
+    // exists() check below reports it absent). Reporting the slow download
+    // as notFound made StoreMarkerStore.ensure mint a fresh store id over a
+    // marker another device had already written (issue #1356).
     if (!await _platform.ensureDownloaded(path)) {
       throw MediaStoreException(
-        'not found: $key',
-        kind: MediaStoreErrorKind.notFound,
+        'still downloading from iCloud: $key',
+        kind: MediaStoreErrorKind.transient,
       );
     }
     final file = File(path);

--- a/lib/core/services/media_store/icloud_media_object_store.dart
+++ b/lib/core/services/media_store/icloud_media_object_store.dart
@@ -38,7 +38,17 @@ class ICloudMediaObjectStore implements MediaObjectStore {
   @override
   Future<StoreObjectInfo?> head(String key) async {
     final path = await _pathFor(key);
-    if (!await _platform.ensureDownloaded(path)) return null;
+    // Same distinction getFile draws below, and it matters more here: null
+    // means "not in the store" to every caller, and the upload pipeline
+    // answers that by uploading. Reporting a placeholder still coming down
+    // as absent re-uploads the whole library from the second device, and
+    // lets the dedup stamp fall back to this device's local byte count.
+    if (!await _platform.ensureDownloaded(path)) {
+      throw MediaStoreException(
+        'still downloading from iCloud: $key',
+        kind: MediaStoreErrorKind.transient,
+      );
+    }
     final file = File(path);
     if (!await file.exists()) return null;
     final stat = await file.stat();

--- a/lib/core/services/media_store/icloud_media_platform.dart
+++ b/lib/core/services/media_store/icloud_media_platform.dart
@@ -90,8 +90,13 @@ class DirectoryICloudMediaPlatform implements ICloudMediaPlatform {
     return true;
   }
 
+  /// Always true, matching the native answer for a path that is not a
+  /// ubiquitous item: a plain directory has nothing to download, and a
+  /// missing file is reported by the adapter's own exists() check. A false
+  /// answer is reserved for a placeholder whose download did not finish, so
+  /// a fake that wants that case overrides this explicitly.
   @override
-  Future<bool> ensureDownloaded(String path) => File(path).exists();
+  Future<bool> ensureDownloaded(String path) async => true;
 
   @override
   Future<void> refreshFolder(String path) async {}

--- a/lib/core/services/media_store/store_marker.dart
+++ b/lib/core/services/media_store/store_marker.dart
@@ -69,6 +69,23 @@ class StoreMarkerStore {
   Future<({StoreMarker marker, bool created})> ensure() async {
     final existing = await read();
     if (existing != null) return (marker: existing, created: false);
+    // Confirm the absence before minting, because [read] cannot tell "this
+    // store has no marker" from "this device cannot see it yet". On iCloud a
+    // marker another device wrote has no local entry at all until the
+    // container's metadata reaches this device, and the native download
+    // check answers "nothing to do" for a path it has never heard of - so
+    // the read fails as absent and minting overwrites the other device's
+    // marker, splitting one store into two (issue #1356).
+    //
+    // A listing is the one call that makes an adapter go and look: the
+    // iCloud adapter refreshes the container folder before enumerating it.
+    // It costs one request, on the mint path only.
+    if (await _markerVisibleInListing()) {
+      final afterListing = await read();
+      if (afterListing != null) {
+        return (marker: afterListing, created: false);
+      }
+    }
     final marker = StoreMarker(
       storeId: const Uuid().v4(),
       formatVersion: 1,
@@ -90,5 +107,20 @@ class StoreMarkerStore {
       if (await tmp.exists()) await tmp.delete();
     }
     return (marker: marker, created: true);
+  }
+
+  /// Whether a listing can see the marker this device failed to read.
+  ///
+  /// Never blocks a first connect: a store that cannot serve the listing
+  /// answers the same as one that has no marker, which is the state a first
+  /// connect is entitled to assume.
+  Future<bool> _markerVisibleInListing() async {
+    try {
+      return await _store
+          .list(StoreKeys.markerKey)
+          .any((object) => object.key == StoreKeys.markerKey);
+    } on Object {
+      return false;
+    }
   }
 }

--- a/lib/features/media/data/repositories/media_repository.dart
+++ b/lib/features/media/data/repositories/media_repository.dart
@@ -1932,6 +1932,42 @@ class MediaRepository {
     ];
   }
 
+  /// SQLite's default bound-parameter ceiling is 999 on older builds; a
+  /// library backfill can queue far more rows than that.
+  static const int _labelChunk = 500;
+
+  /// A display label (file name, else caption) for each of [ids] that has
+  /// one. Ids with neither, or with no row, are absent.
+  ///
+  /// selectOnly projection, one query per chunk: the Transfers page names
+  /// every queued row, and hydrating a full MediaItem per row would drag the
+  /// imageData BLOB in for each and pin it in a provider cache.
+  Future<Map<String, String>> getDisplayLabels(Iterable<String> ids) async {
+    final all = ids.toSet().toList();
+    if (all.isEmpty) return const {};
+    final id = _db.media.id;
+    final name = _db.media.originalFilename;
+    final caption = _db.media.caption;
+    final labels = <String, String>{};
+    for (var start = 0; start < all.length; start += _labelChunk) {
+      final end = (start + _labelChunk).clamp(0, all.length);
+      final query = _db.selectOnly(_db.media)
+        ..addColumns([id, name, caption])
+        ..where(id.isIn(all.sublist(start, end)));
+      for (final row in await query.get()) {
+        final label = _firstNonBlank(row.read(name), row.read(caption));
+        if (label != null) labels[row.read(id)!] = label;
+      }
+    }
+    return labels;
+  }
+
+  static String? _firstNonBlank(String? first, String? second) {
+    if (first != null && first.isNotEmpty) return first;
+    if (second != null && second.isNotEmpty) return second;
+    return null;
+  }
+
   /// Clears a stale thumb stamp (verify sweep reverse repair). Mirrors
   /// [clearRemoteUploaded].
   Future<void> clearRemoteThumbUploaded(String mediaId) async {

--- a/lib/features/media_store/data/media_store_preflight.dart
+++ b/lib/features/media_store/data/media_store_preflight.dart
@@ -1,4 +1,3 @@
-import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
 import 'package:submersion/core/services/media_store/store_marker.dart';
@@ -12,48 +11,33 @@ import 'package:submersion/core/services/media_store/store_marker.dart';
 /// land while a drain is running, and the rest of that drain must stop.
 ///
 /// A marker that is present but not the attached one means the store was
-/// wiped and re-minted, or repointed. The spec's answer is to suspend and let
-/// the user decide; [adoptMarker], when supplied, is the one exception. On
-/// iCloud the container is fixed per Apple ID, so a foreign marker can only be
-/// the app's own two-device race (issue #1356), and the runtime passes an
-/// adopter that re-attaches this device to it. A missing marker is never
-/// adopted: there is nothing to adopt, and minting is the connect flow's job.
+/// wiped and re-minted, or repointed, and this check deliberately does NOT
+/// resolve that on its own. Adopting the store the container happens to hold
+/// looked attractive for iCloud, where the container is fixed per Apple ID,
+/// but `media` rows carry no store id: their `remoteUploadedAt` stamps would
+/// survive an adoption and keep reading "backed up" while pointing at
+/// objects the new store never held. Spec section 13 makes adopt one of
+/// three GUIDED choices (adopt / rebuild / detach) for that reason. Until
+/// those exist, suspending and telling the user is the honest answer.
 class MediaStorePreflight {
   MediaStorePreflight({
     required MediaStoreAttachState attachState,
     required MediaObjectStore store,
     required String attachedStoreId,
-    Future<void> Function(StoreMarker marker)? adoptMarker,
   }) : _attachState = attachState,
        _store = store,
-       _attachedStoreId = attachedStoreId,
-       _adoptMarker = adoptMarker;
+       _attachedStoreId = attachedStoreId;
 
   final MediaStoreAttachState _attachState;
   final MediaObjectStore _store;
-  final Future<void> Function(StoreMarker marker)? _adoptMarker;
-  final _log = LoggerService.forClass(MediaStorePreflight);
-  String _attachedStoreId;
-
-  /// The store this check holds the runtime to: the id it was built with,
-  /// or the marker it adopted since.
-  String get attachedStoreId => _attachedStoreId;
+  final String _attachedStoreId;
 
   /// Whether the drain may proceed. Throws when the marker cannot be read;
-  /// the worker treats that the same as a false answer.
+  /// the worker separates that from a determinate refusal.
   Future<bool> call() async {
     final currentId = await _attachState.attachedStoreId();
     if (currentId == null || currentId != _attachedStoreId) return false;
     final marker = await StoreMarkerStore(store: _store).read();
-    if (marker == null) return false;
-    if (marker.storeId == currentId) return true;
-    final adopt = _adoptMarker;
-    if (adopt == null) return false;
-    _log.info(
-      'Adopting media store marker ${marker.storeId} in place of $currentId',
-    );
-    await adopt(marker);
-    _attachedStoreId = marker.storeId;
-    return true;
+    return marker != null && marker.storeId == currentId;
   }
 }

--- a/lib/features/media_store/data/media_store_preflight.dart
+++ b/lib/features/media_store/data/media_store_preflight.dart
@@ -1,0 +1,59 @@
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
+import 'package:submersion/core/services/media_store/store_marker.dart';
+
+/// The admission check [MediaStoreWorker] runs before every transfer (design
+/// spec section 13): this device must still be attached to the store the
+/// runtime was built for, and the store must still carry that store's
+/// marker. A false answer suspends the drain.
+///
+/// Attach state is re-read on every call, not captured: a disconnect can
+/// land while a drain is running, and the rest of that drain must stop.
+///
+/// A marker that is present but not the attached one means the store was
+/// wiped and re-minted, or repointed. The spec's answer is to suspend and let
+/// the user decide; [adoptMarker], when supplied, is the one exception. On
+/// iCloud the container is fixed per Apple ID, so a foreign marker can only be
+/// the app's own two-device race (issue #1356), and the runtime passes an
+/// adopter that re-attaches this device to it. A missing marker is never
+/// adopted: there is nothing to adopt, and minting is the connect flow's job.
+class MediaStorePreflight {
+  MediaStorePreflight({
+    required MediaStoreAttachState attachState,
+    required MediaObjectStore store,
+    required String attachedStoreId,
+    Future<void> Function(StoreMarker marker)? adoptMarker,
+  }) : _attachState = attachState,
+       _store = store,
+       _attachedStoreId = attachedStoreId,
+       _adoptMarker = adoptMarker;
+
+  final MediaStoreAttachState _attachState;
+  final MediaObjectStore _store;
+  final Future<void> Function(StoreMarker marker)? _adoptMarker;
+  final _log = LoggerService.forClass(MediaStorePreflight);
+  String _attachedStoreId;
+
+  /// The store this check holds the runtime to: the id it was built with,
+  /// or the marker it adopted since.
+  String get attachedStoreId => _attachedStoreId;
+
+  /// Whether the drain may proceed. Throws when the marker cannot be read;
+  /// the worker treats that the same as a false answer.
+  Future<bool> call() async {
+    final currentId = await _attachState.attachedStoreId();
+    if (currentId == null || currentId != _attachedStoreId) return false;
+    final marker = await StoreMarkerStore(store: _store).read();
+    if (marker == null) return false;
+    if (marker.storeId == currentId) return true;
+    final adopt = _adoptMarker;
+    if (adopt == null) return false;
+    _log.info(
+      'Adopting media store marker ${marker.storeId} in place of $currentId',
+    );
+    await adopt(marker);
+    _attachedStoreId = marker.storeId;
+    return true;
+  }
+}

--- a/lib/features/media_store/data/media_store_service.dart
+++ b/lib/features/media_store/data/media_store_service.dart
@@ -262,29 +262,6 @@ class MediaStoreService {
     _icloudStoreFactory,
   );
 
-  /// Re-attaches this device to [storeId], the marker its iCloud container
-  /// actually holds, keeping the account it connected through.
-  ///
-  /// The runtime's preflight calls this when the container carries a marker
-  /// this device did not attach to. On iCloud that cannot mean a repointed
-  /// bucket (the container is fixed per Apple ID); it means two devices each
-  /// minted an identity, the second overwriting the first's marker before
-  /// it had downloaded (issue #1356). Adopting the container's marker is
-  /// exactly what the manual disconnect-and-reconnect workaround did.
-  Future<void> adoptICloudStore(String storeId) async {
-    final accountId = await _attachState.attachedAccountId();
-    await _attachState.setAttached(
-      storeId,
-      providerType: CloudProviderType.icloud,
-      accountId: accountId,
-    );
-    await _storesRepository.upsertActive(
-      storeId: storeId,
-      providerType: CloudProviderType.icloud.name,
-      displayHint: _icloudDisplayHint,
-    );
-  }
-
   /// Shared managed-provider flow: no credentials-store write - managed
   /// providers keep credentials in their own auth stores.
   Future<MediaStoreConnectResult> _connectManaged(

--- a/lib/features/media_store/data/media_store_service.dart
+++ b/lib/features/media_store/data/media_store_service.dart
@@ -253,9 +253,37 @@ class MediaStoreService {
     _googleDriveStoreFactory,
   );
 
+  static const String _icloudDisplayHint = 'iCloud';
+
   /// Connects through the signed-in Apple ID's iCloud container.
-  Future<MediaStoreConnectResult> connectICloud() =>
-      _connectManaged(CloudProviderType.icloud, 'iCloud', _icloudStoreFactory);
+  Future<MediaStoreConnectResult> connectICloud() => _connectManaged(
+    CloudProviderType.icloud,
+    _icloudDisplayHint,
+    _icloudStoreFactory,
+  );
+
+  /// Re-attaches this device to [storeId], the marker its iCloud container
+  /// actually holds, keeping the account it connected through.
+  ///
+  /// The runtime's preflight calls this when the container carries a marker
+  /// this device did not attach to. On iCloud that cannot mean a repointed
+  /// bucket (the container is fixed per Apple ID); it means two devices each
+  /// minted an identity, the second overwriting the first's marker before
+  /// it had downloaded (issue #1356). Adopting the container's marker is
+  /// exactly what the manual disconnect-and-reconnect workaround did.
+  Future<void> adoptICloudStore(String storeId) async {
+    final accountId = await _attachState.attachedAccountId();
+    await _attachState.setAttached(
+      storeId,
+      providerType: CloudProviderType.icloud,
+      accountId: accountId,
+    );
+    await _storesRepository.upsertActive(
+      storeId: storeId,
+      providerType: CloudProviderType.icloud.name,
+      displayHint: _icloudDisplayHint,
+    );
+  }
 
   /// Shared managed-provider flow: no credentials-store write - managed
   /// providers keep credentials in their own auth stores.

--- a/lib/features/media_store/data/media_store_service.dart
+++ b/lib/features/media_store/data/media_store_service.dart
@@ -99,11 +99,13 @@ class MediaStoreService {
     required MediaStoresRepository storesRepository,
     ConnectedAccountsRepository? accountsRepository,
     AccountCredentialsStore? accountCredentials,
+    List<Duration>? markerRetryBackoff,
     MediaObjectStore Function(S3Config config)? storeFactory,
     Future<MediaObjectStore?> Function()? dropboxStoreFactory,
     Future<MediaObjectStore?> Function()? googleDriveStoreFactory,
     Future<MediaObjectStore?> Function()? icloudStoreFactory,
-  }) : _credentials = credentials,
+  }) : _markerRetryBackoff = markerRetryBackoff ?? defaultMarkerRetryBackoff,
+       _credentials = credentials,
        _attachState = attachState,
        _storesRepository = storesRepository,
        _accounts = accountsRepository ?? ConnectedAccountsRepository(),
@@ -119,6 +121,21 @@ class MediaStoreService {
            icloudStoreFactory ??
            (() => buildMediaObjectStore(CloudProviderType.icloud));
 
+  /// How long to wait between attempts at the identity marker when the store
+  /// answers that it cannot serve it yet.
+  ///
+  /// Connecting is a deliberate foreground action the user is watching, and
+  /// on iCloud the container's copy of `store.json` may still be coming down
+  /// when they tap Connect. Failing on the first attempt would refuse a
+  /// connect that succeeds seconds later, which is the shape issue #1356
+  /// leaves behind now that an unreadable marker is no longer mistaken for
+  /// an absent one.
+  static const List<Duration> defaultMarkerRetryBackoff = [
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+  ];
+
+  final List<Duration> _markerRetryBackoff;
   final MediaStoreCredentialsStore _credentials;
   final MediaStoreAttachState _attachState;
   final MediaStoresRepository _storesRepository;
@@ -198,7 +215,7 @@ class MediaStoreService {
     _validate(config);
     final built = _buildS3Store(config);
     try {
-      final ensured = await StoreMarkerStore(store: built.store).ensure();
+      final ensured = await _ensureMarker(built.store);
       // Reuse the given account (only when it really is an S3 account:
       // attaching S3 credentials under another kind's keychain key would
       // corrupt that account), else resolve the endpoint to its
@@ -276,7 +293,7 @@ class MediaStoreService {
         kind: MediaStoreErrorKind.auth,
       );
     }
-    final ensured = await StoreMarkerStore(store: store).ensure();
+    final ensured = await _ensureMarker(store);
     // Ensure an account row for the kind (single-instance for managed
     // providers). Dropbox adopts the sync-era auth blob when the
     // per-account key is still empty: a user who linked Dropbox sync
@@ -314,6 +331,26 @@ class MediaStoreService {
       storeId: ensured.marker.storeId,
       createdNewStore: ensured.created,
     );
+  }
+
+  /// Reads or creates the store's identity marker, waiting out a store that
+  /// says it cannot serve it yet. Only [MediaStoreErrorKind.transient] is
+  /// retried: an auth or fatal answer will not improve by asking again.
+  Future<({StoreMarker marker, bool created})> _ensureMarker(
+    MediaObjectStore store,
+  ) async {
+    final markers = StoreMarkerStore(store: store);
+    for (var attempt = 0; ; attempt++) {
+      try {
+        return await markers.ensure();
+      } on MediaStoreException catch (e) {
+        if (e.kind != MediaStoreErrorKind.transient ||
+            attempt >= _markerRetryBackoff.length) {
+          rethrow;
+        }
+        await Future<void>.delayed(_markerRetryBackoff[attempt]);
+      }
+    }
   }
 
   /// Detaches this device. Credentials and attach state are cleared; the

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -23,13 +23,15 @@ class MediaStoreWorker {
     Future<WorkerGate> Function(MediaTransferQueueEntry entry)? gate,
     Duration entryBudget = defaultEntryBudget,
     Duration preflightBudget = defaultPreflightBudget,
+    Duration preflightRetryWindow = defaultPreflightRetryWindow,
   }) : _queue = queue,
        _pipeline = pipeline,
        _deleteProcessor = deleteProcessor,
        _preflight = preflight,
        _gate = gate,
        _entryBudget = entryBudget,
-       _preflightBudget = preflightBudget;
+       _preflightBudget = preflightBudget,
+       _preflightRetryWindow = preflightRetryWindow;
 
   final MediaTransferQueueRepository _queue;
   final MediaUploadPipeline _pipeline;
@@ -66,12 +68,28 @@ class MediaStoreWorker {
   /// stall here wedges the drain without a single row being touched.
   static const Duration defaultPreflightBudget = Duration(seconds: 30);
 
+  /// How long a drain the preflight suspended waits before trying again.
+  ///
+  /// A suspended drain leaves its due rows untouched, which is right for the
+  /// rows (no attempt burned, no backoff written) but left the queue with
+  /// nothing to wake it: [MediaTransferQueueRepository.earliestPendingWakeup]
+  /// deliberately skips rows that are already due. Every retry then hung on
+  /// an external trigger re-running the same check, and on desktop, where
+  /// the app sits in one process for days, the rows read "Waiting" for as
+  /// long (issue #1356). The preflight is one small GET, so a periodic retry
+  /// costs almost nothing, and it is what lets a marker that was merely slow
+  /// to download from iCloud clear on its own.
+  static const Duration defaultPreflightRetryWindow = Duration(minutes: 10);
+
   final Duration _entryBudget;
   final Duration _preflightBudget;
+  final Duration _preflightRetryWindow;
 
   final _log = LoggerService.forClass(MediaStoreWorker);
   bool _running = false;
   bool _disposed = false;
+  bool _suspended = false;
+  final _suspensionChanges = StreamController<bool>.broadcast();
   Future<void>? _activeDrain;
   Timer? _wakeup;
   Duration? _wakeupDelay;
@@ -86,6 +104,21 @@ class MediaStoreWorker {
   /// [enqueueAndKick] fires the drain in the background, so callers (and tests)
   /// that need to observe completion await this instead of racing it.
   Future<void>? get activeDrain => _activeDrain;
+
+  /// Whether the most recent preflight suspended the drain. The queue's rows
+  /// carry no trace of a suspension (they are left exactly as they were), so
+  /// without this the only record was a log line and the settings page could
+  /// not tell "paused" from "queued" (issue #1356).
+  bool get isSuspended => _suspended;
+
+  /// Emits on every change of [isSuspended].
+  Stream<bool> get suspensionChanges => _suspensionChanges.stream;
+
+  void _setSuspended(bool value) {
+    if (_suspended == value) return;
+    _suspended = value;
+    if (!_suspensionChanges.isClosed) _suspensionChanges.add(value);
+  }
 
   Future<void> drain() async {
     if (_disposed || _running) return;
@@ -133,7 +166,7 @@ class MediaStoreWorker {
       }
     } finally {
       _running = false;
-      await _armWakeup(drainedToEmpty: drainedToEmpty);
+      await _armWakeup(drainedToEmpty: drainedToEmpty, suspended: _suspended);
     }
   }
 
@@ -197,7 +230,10 @@ class MediaStoreWorker {
     final preflight = _preflight;
     if (preflight == null) return true;
     try {
-      if (await preflight().timeout(_preflightBudget)) return true;
+      if (await preflight().timeout(_preflightBudget)) {
+        _setSuspended(false);
+        return true;
+      }
       _log.warning('Media store preflight failed; drain suspended');
     } on Object catch (e, stackTrace) {
       _log.warning(
@@ -206,6 +242,7 @@ class MediaStoreWorker {
         stackTrace: stackTrace,
       );
     }
+    _setSuspended(true);
     return false;
   }
 
@@ -224,7 +261,16 @@ class MediaStoreWorker {
   ///
   /// [drainedToEmpty] says the drain looked and found nothing due. That is
   /// what makes the already-due branch below safe; see it for why.
-  Future<void> _armWakeup({required bool drainedToEmpty}) async {
+  ///
+  /// [suspended] says the preflight stopped the drain. Its due rows are
+  /// still due, so the immediate branch must not take them (it would spin
+  /// against a check that keeps failing); they get the
+  /// [defaultPreflightRetryWindow] instead, and only while there is
+  /// anything left to retry for.
+  Future<void> _armWakeup({
+    required bool drainedToEmpty,
+    required bool suspended,
+  }) async {
     _wakeup?.cancel();
     _wakeup = null;
     _wakeupDelay = null;
@@ -237,6 +283,15 @@ class MediaStoreWorker {
       // One clock reading for both the query and the delay, so the timer
       // cannot be handed a negative duration by the query's own latency.
       final now = DateTime.now();
+      if (suspended) {
+        final anythingPending =
+            await _queue.nextPending(now) != null ||
+            await _queue.earliestPendingWakeup(now) != null;
+        if (!anythingPending) return;
+        _wakeupDelay = _preflightRetryWindow;
+        _wakeup = Timer(_preflightRetryWindow, () => unawaited(drain()));
+        return;
+      }
       // The drain asked "what is due?" against its own clock reading, and
       // earliestPendingWakeup asks "what is not due yet?" against this one.
       // Those are complements only if no time passed in between, so a row
@@ -246,8 +301,9 @@ class MediaStoreWorker {
       // straight back to a fresh drain.
       //
       // Only when the drain reached an empty queue. A drain that declined to
-      // run (offline, failed preflight) left its due row behind deliberately,
-      // and re-kicking that would spin against a drain that keeps declining.
+      // run (offline, or the preflight case handled above) left its due row
+      // behind deliberately, and re-kicking that would spin against a drain
+      // that keeps declining.
       // A drain that emptied the queue cannot: every loop exit consumes its
       // entry, so the next drain either takes this row or is itself a decline.
       if (drainedToEmpty && await _queue.nextPending(now) != null) {
@@ -280,6 +336,7 @@ class MediaStoreWorker {
     _wakeup?.cancel();
     _wakeup = null;
     _wakeupDelay = null;
+    _suspensionChanges.close();
   }
 
   Future<void> enqueueAndKick(String mediaId) async {

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -111,8 +111,22 @@ class MediaStoreWorker {
   /// not tell "paused" from "queued" (issue #1356).
   bool get isSuspended => _suspended;
 
-  /// Emits on every change of [isSuspended].
-  Stream<bool> get suspensionChanges => _suspensionChanges.stream;
+  /// The current value on subscribe, then every change.
+  ///
+  /// Emitting the current value is load-bearing, not a convenience: the
+  /// runtime fires its first drain before any reader can subscribe, and
+  /// [_setSuspended] never repeats a value it has already sent. A reader
+  /// that sampled [isSuspended] and then subscribed would silently lose a
+  /// flip that landed in between, and nothing would ever re-send it.
+  Stream<bool> get suspensionChanges => Stream<bool>.multi((controller) {
+    controller.add(_suspended);
+    final subscription = _suspensionChanges.stream.listen(
+      controller.add,
+      onError: controller.addError,
+      onDone: controller.close,
+    );
+    controller.onCancel = subscription.cancel;
+  });
 
   void _setSuspended(bool value) {
     if (_suspended == value) return;
@@ -234,15 +248,23 @@ class MediaStoreWorker {
         _setSuspended(false);
         return true;
       }
+      // A determinate refusal: this device has detached, or the store no
+      // longer carries the marker it attached to. Only this answer is
+      // reported as a suspension, because only this one is about the store.
       _log.warning('Media store preflight failed; drain suspended');
+      _setSuspended(true);
     } on Object catch (e, stackTrace) {
+      // Could not determine, which is not the same thing and must not be
+      // dressed up as a store problem. Being offline lands here on every
+      // provider - the marker read goes to the network, and drain() runs
+      // this check BEFORE the gate that owns offline - and an ordinary
+      // offline moment must not tell the user their store is broken.
       _log.warning(
         'Media store preflight could not run; drain suspended',
         error: e,
         stackTrace: stackTrace,
       );
     }
-    _setSuspended(true);
     return false;
   }
 
@@ -284,12 +306,26 @@ class MediaStoreWorker {
       // cannot be handed a negative duration by the query's own latency.
       final now = DateTime.now();
       if (suspended) {
-        final anythingPending =
-            await _queue.nextPending(now) != null ||
-            await _queue.earliestPendingWakeup(now) != null;
-        if (!anythingPending) return;
-        _wakeupDelay = _preflightRetryWindow;
-        _wakeup = Timer(_preflightRetryWindow, () => unawaited(drain()));
+        // Always arm, even with an empty queue. A suspension is cleared only
+        // from inside a passing preflight, so a drain that armed nothing
+        // here could never clear one in this process: the loop checks the
+        // preflight before asking what is due, so the final iteration of an
+        // emptying drain can record a suspension with nothing left to carry
+        // a timer, and the notice would then stand forever over a queue with
+        // nothing in it.
+        //
+        // Never later than a row's own backoff. That timer is the one this
+        // branch replaces, and a row deferred for thirty seconds must not
+        // wait out the retry window because an unrelated check failed.
+        final due = await _queue.earliestPendingWakeup(now);
+        final backoff = due?.difference(now);
+        final delay = backoff != null && backoff > Duration.zero
+            ? (backoff < _preflightRetryWindow
+                  ? backoff
+                  : _preflightRetryWindow)
+            : _preflightRetryWindow;
+        _wakeupDelay = delay;
+        _wakeup = Timer(delay, () => unawaited(drain()));
         return;
       }
       // The drain asked "what is due?" against its own clock reading, and

--- a/lib/features/media_store/data/media_store_worker.dart
+++ b/lib/features/media_store/data/media_store_worker.dart
@@ -142,11 +142,20 @@ class MediaStoreWorker {
     // stopped the drain, an exception out of the pipeline - leaves work
     // behind on purpose, and must not arm the immediate wakeup below.
     var drainedToEmpty = false;
+    // Whether the preflight stopped this drain, for ANY reason. Separate from
+    // the user-visible [isSuspended], which speaks only for a determinate
+    // refusal: a preflight that could not answer (offline) still leaves due
+    // rows behind with nothing to pick them up, so scheduling has to know
+    // about it even though the UI must not.
+    var preflightBlocked = false;
     try {
       while (true) {
         // Re-checked per entry, not once per drain: a store wipe or user
         // disconnect mid-drain must suspend the rest of the queue.
-        if (!await _preflightPasses()) return;
+        if (!await _preflightPasses()) {
+          preflightBlocked = true;
+          return;
+        }
         final entry = await _queue.nextPending(DateTime.now());
         if (entry == null) {
           drainedToEmpty = true;
@@ -180,7 +189,10 @@ class MediaStoreWorker {
       }
     } finally {
       _running = false;
-      await _armWakeup(drainedToEmpty: drainedToEmpty, suspended: _suspended);
+      await _armWakeup(
+        drainedToEmpty: drainedToEmpty,
+        preflightBlocked: preflightBlocked,
+      );
     }
   }
 
@@ -284,14 +296,13 @@ class MediaStoreWorker {
   /// [drainedToEmpty] says the drain looked and found nothing due. That is
   /// what makes the already-due branch below safe; see it for why.
   ///
-  /// [suspended] says the preflight stopped the drain. Its due rows are
-  /// still due, so the immediate branch must not take them (it would spin
+  /// [preflightBlocked] says the preflight stopped the drain. Its due rows
+  /// are still due, so the immediate branch must not take them (it would spin
   /// against a check that keeps failing); they get the
-  /// [defaultPreflightRetryWindow] instead, and only while there is
-  /// anything left to retry for.
+  /// [defaultPreflightRetryWindow] instead.
   Future<void> _armWakeup({
     required bool drainedToEmpty,
-    required bool suspended,
+    required bool preflightBlocked,
   }) async {
     _wakeup?.cancel();
     _wakeup = null;
@@ -305,14 +316,15 @@ class MediaStoreWorker {
       // One clock reading for both the query and the delay, so the timer
       // cannot be handed a negative duration by the query's own latency.
       final now = DateTime.now();
-      if (suspended) {
-        // Always arm, even with an empty queue. A suspension is cleared only
-        // from inside a passing preflight, so a drain that armed nothing
-        // here could never clear one in this process: the loop checks the
-        // preflight before asking what is due, so the final iteration of an
-        // emptying drain can record a suspension with nothing left to carry
-        // a timer, and the notice would then stand forever over a queue with
-        // nothing in it.
+      if (preflightBlocked) {
+        // Always arm, even with an empty queue. A blocked preflight is
+        // re-run only by a drain, and a suspension is cleared only by one
+        // that passes, so a drain that armed nothing here could never
+        // recover in this process. Both halves need it: an offline blip
+        // would otherwise strand every due row until an unrelated trigger,
+        // and the final iteration of an emptying drain can record a
+        // suspension with nothing left to carry a timer, leaving the notice
+        // standing forever over a queue with nothing in it.
         //
         // Never later than a row's own backoff. That timer is the one this
         // branch replaces, and a row deferred for thirty seconds must not

--- a/lib/features/media_store/presentation/pages/media_storage_page.dart
+++ b/lib/features/media_store/presentation/pages/media_storage_page.dart
@@ -24,6 +24,24 @@ import 'package:submersion/core/utils/log_failure.dart';
 /// set and validation, its own keychain entry and default prefix, and a
 /// connect flow that adopts or creates the bucket's store identity
 /// marker. Managed providers (iCloud/Drive/Dropbox) arrive in Phase 4.
+/// User-facing text for a failed CONNECT.
+///
+/// A transient answer is the store saying "not yet", not "no": on iCloud it
+/// is a container whose copy of `store.json` has not finished coming down,
+/// and the raw message is a developer string naming an object key. Every
+/// other kind carries a message written to be read.
+///
+/// Connect only. Test Connection and Verify Library keep the raw text: they
+/// are diagnostics, and "wait a moment and try connecting again" answers a
+/// question neither of them asked.
+///
+/// Top-level and l10n-only so it can be tested without a host platform.
+String mediaStoreErrorMessage(AppLocalizations l10n, MediaStoreException e) {
+  return e.kind == MediaStoreErrorKind.transient
+      ? l10n.settings_mediaStorage_error_notReady
+      : e.message;
+}
+
 class MediaStoragePage extends ConsumerStatefulWidget {
   const MediaStoragePage({super.key});
 
@@ -282,7 +300,7 @@ class _MediaStoragePageState extends ConsumerState<MediaStoragePage> {
       _showSnack(l10n.settings_mediaStorage_saved);
       await Navigator.maybePop(context);
     } on MediaStoreException catch (e) {
-      _showSnack(e.message, isError: true);
+      _showSnack(mediaStoreErrorMessage(l10n, e), isError: true);
     } catch (e) {
       _showSnack(
         '${l10n.settings_s3Config_error_secureStorage}: $e',
@@ -379,7 +397,7 @@ class _MediaStoragePageState extends ConsumerState<MediaStoragePage> {
       _showSnack(l10n.settings_mediaStorage_saved);
       await Navigator.maybePop(context);
     } on MediaStoreException catch (e) {
-      _showSnack(e.message, isError: true);
+      _showSnack(mediaStoreErrorMessage(l10n, e), isError: true);
     } finally {
       if (mounted) setState(() => _busy = false);
     }

--- a/lib/features/media_store/presentation/pages/transfers_page.dart
+++ b/lib/features/media_store/presentation/pages/transfers_page.dart
@@ -6,6 +6,7 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart';
 import 'package:submersion/features/media_store/presentation/widgets/transfers_view.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/bulk_action.dart';
@@ -126,10 +127,23 @@ class _TransfersPageState extends ConsumerState<TransfersPage> {
                     ),
                   ],
                 ),
-          body: TransfersView(
-            isSelectionMode: _isSelectionMode,
-            selectedIds: _selectedIds,
-            onToggle: _selection.toggle,
+          // The notice lives here rather than inside TransfersView: this
+          // page builds the runtime deliberately (see initState), while the
+          // Media console embeds the bare view, and watching the runtime
+          // from there would construct it - and kick a drain, a queue
+          // reclaim and the opportunistic verify sweep - just because a tab
+          // was selected.
+          body: Column(
+            children: [
+              const MediaTransfersSuspendedNotice(),
+              Expanded(
+                child: TransfersView(
+                  isSelectionMode: _isSelectionMode,
+                  selectedIds: _selectedIds,
+                  onToggle: _selection.toggle,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -234,18 +234,41 @@ final mediaTransferEntriesProvider =
 final mediaTransferLabelsProvider = FutureProvider<Map<String, String>>((
   ref,
 ) async {
-  final key = ref.watch(
+  final queued = ref.watch(
     mediaTransferEntriesProvider.select((entries) {
       final rows = entries.value;
-      if (rows == null) return null;
-      return (rows.map((e) => e.mediaId).toSet().toList()..sort()).join('\n');
+      return rows == null ? null : _QueuedMediaIds(rows.map((e) => e.mediaId));
     }),
   );
-  if (key == null || key.isEmpty) return const {};
+  if (queued == null || queued.ids.isEmpty) return const {};
   final repository = ref.watch(mediaRepositoryProvider);
   ref.invalidateSelfWhen(repository.watchMediaChanges());
-  return repository.getDisplayLabels(key.split('\n'));
+  return repository.getDisplayLabels(queued.ids);
 });
+
+/// The set of media ids the transfer queue names, as a value: `select`
+/// compares successive results with `==`, and a List or Set compares by
+/// identity, so a fresh collection per emission would defeat the point.
+class _QueuedMediaIds {
+  _QueuedMediaIds(Iterable<String> ids)
+    : ids = List.unmodifiable(ids.toSet().toList()..sort());
+
+  final List<String> ids;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! _QueuedMediaIds || other.ids.length != ids.length) {
+      return false;
+    }
+    for (var i = 0; i < ids.length; i++) {
+      if (ids[i] != other.ids[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(ids);
+}
 
 /// Whether this device has any media store attached. Deliberately not
 /// mediaStoreRuntimeProvider: that constructs the full runtime and kicks a

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -231,20 +231,21 @@ final mediaTransferEntriesProvider =
 /// A lookup per visible row was the first shape; it hydrated a full
 /// MediaItem (imageData BLOB included) into a non-autoDispose family per
 /// row and re-ran for every visible row on every media write.
-final mediaTransferLabelsProvider = FutureProvider<Map<String, String>>((
-  ref,
-) async {
-  final queued = ref.watch(
-    mediaTransferEntriesProvider.select((entries) {
-      final rows = entries.value;
-      return rows == null ? null : _QueuedMediaIds(rows.map((e) => e.mediaId));
-    }),
-  );
-  if (queued == null || queued.ids.isEmpty) return const {};
-  final repository = ref.watch(mediaRepositoryProvider);
-  ref.invalidateSelfWhen(repository.watchMediaChanges());
-  return repository.getDisplayLabels(queued.ids);
-});
+final mediaTransferLabelsProvider =
+    FutureProvider.autoDispose<Map<String, String>>((ref) async {
+      final queued = ref.watch(
+        mediaTransferEntriesProvider.select((entries) {
+          final rows = entries.value;
+          return rows == null
+              ? null
+              : _QueuedMediaIds(rows.map((e) => e.mediaId));
+        }),
+      );
+      if (queued == null || queued.ids.isEmpty) return const {};
+      final repository = ref.watch(mediaRepositoryProvider);
+      ref.invalidateSelfWhen(repository.watchMediaChanges());
+      return repository.getDisplayLabels(queued.ids);
+    });
 
 /// The set of media ids the transfer queue names, as a value: `select`
 /// compares successive results with `==`, and a List or Set compares by
@@ -392,21 +393,13 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         store: store,
         mediaRepository: mediaRepository,
       );
-      // Read now, not inside the adopter: the adopter runs from a drain
-      // that can outlive this provider's ref.
-      final service = ref.read(mediaStoreServiceProvider);
+      // Suspend all transfers when this device detached or when the store no
+      // longer carries the marker this device attached to (wiped or
+      // repointed; spec section 13).
       final preflight = MediaStorePreflight(
         attachState: attachState,
         store: store,
         attachedStoreId: attachedId,
-        // Suspend all transfers when this device detached or when the bucket
-        // no longer carries the store this device attached to (wiped or
-        // repointed; spec section 13). iCloud alone adopts a foreign marker:
-        // its container is fixed per Apple ID, so the only way to find one
-        // there is the two-device race in issue #1356.
-        adoptMarker: providerType == CloudProviderType.icloud
-            ? (marker) => service.adoptICloudStore(marker.storeId)
-            : null,
       );
       final worker = MediaStoreWorker(
         queue: MediaTransferQueueRepository(),
@@ -518,7 +511,8 @@ final mediaTransfersSuspendedProvider = StreamProvider<bool>((ref) async* {
     yield false;
     return;
   }
-  yield worker.isSuspended;
+  // suspensionChanges opens with the current value, so there is no window
+  // between sampling it and subscribing.
   yield* worker.suspensionChanges;
 });
 

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -222,6 +222,31 @@ final mediaTransferEntriesProvider =
       (ref) => ref.watch(mediaTransferQueueRepositoryProvider).watchEntries(),
     );
 
+/// Display labels (file name, else caption) for every media row the transfer
+/// queue names, in one lean query.
+///
+/// Keyed on the SET of media ids, not the rows: progress ticks and state
+/// changes re-emit the rows many times per transfer without changing which
+/// media the queue names, and none of those should touch the media table.
+/// A lookup per visible row was the first shape; it hydrated a full
+/// MediaItem (imageData BLOB included) into a non-autoDispose family per
+/// row and re-ran for every visible row on every media write.
+final mediaTransferLabelsProvider = FutureProvider<Map<String, String>>((
+  ref,
+) async {
+  final key = ref.watch(
+    mediaTransferEntriesProvider.select((entries) {
+      final rows = entries.value;
+      if (rows == null) return null;
+      return (rows.map((e) => e.mediaId).toSet().toList()..sort()).join('\n');
+    }),
+  );
+  if (key == null || key.isEmpty) return const {};
+  final repository = ref.watch(mediaRepositoryProvider);
+  ref.invalidateSelfWhen(repository.watchMediaChanges());
+  return repository.getDisplayLabels(key.split('\n'));
+});
+
 /// Whether this device has any media store attached. Deliberately not
 /// mediaStoreRuntimeProvider: that constructs the full runtime and kicks a
 /// queue drain, which must not happen merely because a media grid scrolled

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -15,7 +15,6 @@ import 'package:submersion/core/services/media_store/media_store_credentials_sto
 import 'package:submersion/core/services/media_store/media_store_policies.dart';
 import 'package:submersion/core/services/media_store/media_upload_quality_policy.dart';
 import 'package:submersion/core/services/media_store/network_status_service.dart';
-import 'package:submersion/core/services/media_store/store_marker.dart';
 import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
@@ -24,6 +23,7 @@ import 'package:submersion/features/media_store/data/media_backfill_service.dart
 import 'package:submersion/features/media_store/data/media_cache_store.dart';
 import 'package:submersion/features/media_store/data/media_delete_processor.dart';
 import 'package:submersion/features/media_store/data/media_deletion_coordinator.dart';
+import 'package:submersion/features/media_store/data/media_store_preflight.dart';
 import 'package:submersion/features/media_store/data/media_store_service.dart';
 import 'package:submersion/features/media_store/data/media_store_worker.dart';
 import 'package:submersion/features/media_store/data/media_stores_repository.dart';
@@ -291,6 +291,7 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
       final attachState = ref.watch(mediaStoreAttachStateProvider);
       final attachedId = await attachState.attachedStoreId();
       if (attachedId == null) return null;
+      final providerType = await attachState.attachedProviderType();
 
       // Account-first: attachments made through the Connected Accounts
       // layer resolve their store via the account's adapter. Legacy
@@ -307,13 +308,12 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
           ref.watch(accountProviderRegistryProvider),
         );
       } else {
-        final providerType =
-            await attachState.attachedProviderType() ?? CloudProviderType.s3;
-        final s3Config = providerType == CloudProviderType.s3
+        final legacyType = providerType ?? CloudProviderType.s3;
+        final s3Config = legacyType == CloudProviderType.s3
             ? await ref.watch(mediaStoreCredentialsStoreProvider).load()
             : null;
         builtStore = await buildMediaObjectStore(
-          providerType,
+          legacyType,
           s3Config: s3Config,
         );
       }
@@ -344,20 +344,27 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         store: store,
         mediaRepository: mediaRepository,
       );
+      // Read now, not inside the adopter: the adopter runs from a drain
+      // that can outlive this provider's ref.
+      final service = ref.read(mediaStoreServiceProvider);
+      final preflight = MediaStorePreflight(
+        attachState: attachState,
+        store: store,
+        attachedStoreId: attachedId,
+        // Suspend all transfers when this device detached or when the bucket
+        // no longer carries the store this device attached to (wiped or
+        // repointed; spec section 13). iCloud alone adopts a foreign marker:
+        // its container is fixed per Apple ID, so the only way to find one
+        // there is the two-device race in issue #1356.
+        adoptMarker: providerType == CloudProviderType.icloud
+            ? (marker) => service.adoptICloudStore(marker.storeId)
+            : null,
+      );
       final worker = MediaStoreWorker(
         queue: MediaTransferQueueRepository(),
         pipeline: pipeline,
         deleteProcessor: deleteProcessor,
-        preflight: () async {
-          // Suspend all transfers when this device detached (attach state
-          // re-read, not captured: disconnect can land while a drain is
-          // running) or when the bucket no longer carries the store this
-          // device attached to (wiped or repointed; spec section 13).
-          final currentId = await attachState.attachedStoreId();
-          if (currentId == null || currentId != attachedId) return false;
-          final marker = await StoreMarkerStore(store: store).read();
-          return marker != null && marker.storeId == currentId;
-        },
+        preflight: preflight.call,
         gate: (entry) async {
           // Network policies (design spec section 9): offline halts the
           // drain; cellular defers anything the policy disallows.
@@ -450,6 +457,22 @@ final FutureProvider<MediaStoreRuntime?> mediaStoreRuntimeProvider =
         worker: worker,
       );
     });
+
+/// Whether the worker's last preflight suspended the transfer queue (issue
+/// #1356). False without a runtime, and it follows the live worker from then
+/// on: the queue rows carry no trace of a suspension, so this is the only
+/// way the settings pages can tell "paused" from "queued".
+// no-tick: mirrors an in-memory worker flag, not a query result.
+final mediaTransfersSuspendedProvider = StreamProvider<bool>((ref) async* {
+  final runtime = await ref.watch(mediaStoreRuntimeProvider.future);
+  final worker = runtime?.worker;
+  if (worker == null) {
+    yield false;
+    return;
+  }
+  yield worker.isSuspended;
+  yield* worker.suspensionChanges;
+});
 
 /// The store-fallback resolver for display surfaces, or null when no store
 /// runtime exists yet. Synchronous accessor over the async runtime.

--- a/lib/features/media_store/presentation/providers/media_store_providers.dart
+++ b/lib/features/media_store/presentation/providers/media_store_providers.dart
@@ -231,6 +231,11 @@ final mediaTransferEntriesProvider =
 /// A lookup per visible row was the first shape; it hydrated a full
 /// MediaItem (imageData BLOB included) into a non-autoDispose family per
 /// row and re-ran for every visible row on every media write.
+// no-tick: a file name does not change while its upload sits in the queue,
+// and the media table ticks on every stamp the upload pipeline writes - about
+// three a second through a drain - each of which would re-run the whole label
+// query. autoDispose re-resolves the labels the next time the page is built,
+// which is the only moment a stale name could be seen.
 final mediaTransferLabelsProvider =
     FutureProvider.autoDispose<Map<String, String>>((ref) async {
       final queued = ref.watch(
@@ -242,9 +247,7 @@ final mediaTransferLabelsProvider =
         }),
       );
       if (queued == null || queued.ids.isEmpty) return const {};
-      final repository = ref.watch(mediaRepositoryProvider);
-      ref.invalidateSelfWhen(repository.watchMediaChanges());
-      return repository.getDisplayLabels(queued.ids);
+      return ref.watch(mediaRepositoryProvider).getDisplayLabels(queued.ids);
     });
 
 /// The set of media ids the transfer queue names, as a value: `select`

--- a/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
+++ b/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
@@ -25,7 +25,14 @@ class MediaTransferSummaryRow extends ConsumerWidget {
     final l10n = context.l10n;
     final theme = Theme.of(context);
     final summary = ref.watch(mediaTransferSummaryProvider).value;
-    if (summary == null || summary.isEmpty) return const SizedBox.shrink();
+    if (summary == null || summary.isEmpty) {
+      // Still render the notice: a suspension can outlast the work that was
+      // queued when it started, and watchSummary counts only pending and
+      // transferring rows.
+      return const MediaTransfersSuspendedNotice(
+        contentPadding: EdgeInsets.zero,
+      );
+    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
+++ b/lib/features/media_store/presentation/widgets/media_transfer_summary_row.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
 /// Outstanding transfer work on the Media Storage page.
@@ -30,6 +31,7 @@ class MediaTransferSummaryRow extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        const MediaTransfersSuspendedNotice(contentPadding: EdgeInsets.zero),
         if (summary.transferring > 0)
           Padding(
             key: const Key('media-transfer-progress'),

--- a/lib/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart
+++ b/lib/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Tells the user the transfer queue is paused because the store could not
+/// be verified (issue #1356). Nothing while the worker is not suspended.
+///
+/// The rows underneath still read "Waiting" / "N queued", which is true: the
+/// worker leaves them untouched. This is what says why they are not moving
+/// and what to do about it, since the retry is automatic but the one repair
+/// the user can make (reconnecting) is not.
+class MediaTransfersSuspendedNotice extends ConsumerWidget {
+  const MediaTransfersSuspendedNotice({super.key, this.contentPadding});
+
+  final EdgeInsetsGeometry? contentPadding;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final suspended = ref.watch(mediaTransfersSuspendedProvider).value ?? false;
+    if (!suspended) return const SizedBox.shrink();
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    return ListTile(
+      key: const Key('media-transfers-suspended'),
+      contentPadding: contentPadding,
+      leading: Icon(
+        Icons.pause_circle_outline,
+        color: theme.colorScheme.tertiary,
+      ),
+      title: Text(l10n.settings_mediaStorage_transfers_suspended_title),
+      subtitle: Text(l10n.settings_mediaStorage_transfers_suspended_subtitle),
+    );
+  }
+}

--- a/lib/features/media_store/presentation/widgets/transfers_view.dart
+++ b/lib/features/media_store/presentation/widgets/transfers_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
-import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
@@ -192,8 +191,10 @@ class _TransferTile extends ConsumerWidget {
 
 /// Names the row's media. The queue row carries only the media id, and a
 /// column of bare UUIDs was the reporter's whole picture of the queue (issue
-/// #1356). Blank until the row resolves rather than flashing the id first;
-/// the id is the fallback for a media row that no longer exists.
+/// #1356). Labels come from one batched lookup for the whole queue
+/// ([mediaTransferLabelsProvider]); blank until it resolves rather than
+/// flashing the id first, and the id is the fallback for a media row that
+/// has no name or no longer exists.
 class _MediaLabel extends ConsumerWidget {
   const _MediaLabel(this.mediaId);
 
@@ -201,21 +202,9 @@ class _MediaLabel extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ref
-        .watch(mediaByIdProvider(mediaId))
-        .when(
-          loading: () => const SizedBox.shrink(),
-          error: (_, _) => Text(mediaId, maxLines: 1),
-          data: (item) {
-            final name = item?.originalFilename;
-            final caption = item?.caption;
-            final label = name != null && name.isNotEmpty
-                ? name
-                : caption != null && caption.isNotEmpty
-                ? caption
-                : mediaId;
-            return Text(label, maxLines: 1, overflow: TextOverflow.ellipsis);
-          },
-        );
+    final labels = ref.watch(mediaTransferLabelsProvider);
+    if (labels.isLoading && !labels.hasValue) return const SizedBox.shrink();
+    final label = labels.value?[mediaId] ?? mediaId;
+    return Text(label, maxLines: 1, overflow: TextOverflow.ellipsis);
   }
 }

--- a/lib/features/media_store/presentation/widgets/transfers_view.dart
+++ b/lib/features/media_store/presentation/widgets/transfers_view.dart
@@ -4,7 +4,6 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
-import 'package:submersion/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 
@@ -40,38 +39,31 @@ class TransfersView extends ConsumerWidget {
           Center(child: Text('${context.l10n.common_label_error}: $e')),
       data: (rows) => rows.isEmpty
           ? Center(child: Text(l10n.settings_mediaStorage_transfers_empty))
-          : Column(
-              children: [
-                const MediaTransfersSuspendedNotice(),
-                Expanded(
-                  child: ListView.separated(
-                    itemCount: rows.length,
-                    separatorBuilder: (_, _) => const Divider(height: 1),
-                    itemBuilder: (context, index) {
-                      final entry = rows[index];
-                      final id = entry.id.toString();
-                      final tile = _TransferTile(
-                        entry: entry,
-                        isSelectionMode: isSelectionMode,
-                        isChecked: selectedIds.contains(id),
-                        onCheckChanged: onToggle == null
-                            ? null
-                            : (_) => onToggle!(id),
-                      );
-                      // The tile has no tap handler of its own, so while
-                      // selecting the whole row has to toggle -- otherwise
-                      // the checkbox is the only target.
-                      return isSelectionMode && onToggle != null
-                          ? GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: () => onToggle!(id),
-                              child: tile,
-                            )
-                          : tile;
-                    },
-                  ),
-                ),
-              ],
+          : ListView.separated(
+              itemCount: rows.length,
+              separatorBuilder: (_, _) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final entry = rows[index];
+                final id = entry.id.toString();
+                final tile = _TransferTile(
+                  entry: entry,
+                  isSelectionMode: isSelectionMode,
+                  isChecked: selectedIds.contains(id),
+                  onCheckChanged: onToggle == null
+                      ? null
+                      : (_) => onToggle!(id),
+                );
+                // The tile has no tap handler of its own, so while selecting
+                // the whole row has to toggle -- otherwise the checkbox is
+                // the only target.
+                return isSelectionMode && onToggle != null
+                    ? GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => onToggle!(id),
+                        child: tile,
+                      )
+                    : tile;
+              },
             ),
     );
   }

--- a/lib/features/media_store/presentation/widgets/transfers_view.dart
+++ b/lib/features/media_store/presentation/widgets/transfers_view.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+import 'package:submersion/features/media_store/presentation/widgets/media_transfers_suspended_notice.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 
@@ -39,31 +41,38 @@ class TransfersView extends ConsumerWidget {
           Center(child: Text('${context.l10n.common_label_error}: $e')),
       data: (rows) => rows.isEmpty
           ? Center(child: Text(l10n.settings_mediaStorage_transfers_empty))
-          : ListView.separated(
-              itemCount: rows.length,
-              separatorBuilder: (_, _) => const Divider(height: 1),
-              itemBuilder: (context, index) {
-                final entry = rows[index];
-                final id = entry.id.toString();
-                final tile = _TransferTile(
-                  entry: entry,
-                  isSelectionMode: isSelectionMode,
-                  isChecked: selectedIds.contains(id),
-                  onCheckChanged: onToggle == null
-                      ? null
-                      : (_) => onToggle!(id),
-                );
-                // The tile has no tap handler of its own, so while selecting
-                // the whole row has to toggle -- otherwise the checkbox is
-                // the only target.
-                return isSelectionMode && onToggle != null
-                    ? GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => onToggle!(id),
-                        child: tile,
-                      )
-                    : tile;
-              },
+          : Column(
+              children: [
+                const MediaTransfersSuspendedNotice(),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: rows.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final entry = rows[index];
+                      final id = entry.id.toString();
+                      final tile = _TransferTile(
+                        entry: entry,
+                        isSelectionMode: isSelectionMode,
+                        isChecked: selectedIds.contains(id),
+                        onCheckChanged: onToggle == null
+                            ? null
+                            : (_) => onToggle!(id),
+                      );
+                      // The tile has no tap handler of its own, so while
+                      // selecting the whole row has to toggle -- otherwise
+                      // the checkbox is the only target.
+                      return isSelectionMode && onToggle != null
+                          ? GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: () => onToggle!(id),
+                              child: tile,
+                            )
+                          : tile;
+                    },
+                  ),
+                ),
+              ],
             ),
     );
   }
@@ -133,7 +142,7 @@ class _TransferTile extends ConsumerWidget {
           if (entry.errorMessage != null)
             Text(entry.errorMessage!, maxLines: 2)
           else
-            Text(entry.mediaId, maxLines: 1),
+            _MediaLabel(entry.mediaId),
           if (entry.state == 'transferring')
             Padding(
               padding: const EdgeInsets.only(top: 4),
@@ -178,5 +187,35 @@ class _TransferTile extends ConsumerWidget {
     await ref.read(mediaTransferQueueRepositoryProvider).retry(entry.id);
     final runtime = await ref.read(mediaStoreRuntimeProvider.future);
     await runtime?.worker?.drain();
+  }
+}
+
+/// Names the row's media. The queue row carries only the media id, and a
+/// column of bare UUIDs was the reporter's whole picture of the queue (issue
+/// #1356). Blank until the row resolves rather than flashing the id first;
+/// the id is the fallback for a media row that no longer exists.
+class _MediaLabel extends ConsumerWidget {
+  const _MediaLabel(this.mediaId);
+
+  final String mediaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref
+        .watch(mediaByIdProvider(mediaId))
+        .when(
+          loading: () => const SizedBox.shrink(),
+          error: (_, _) => Text(mediaId, maxLines: 1),
+          data: (item) {
+            final name = item?.originalFilename;
+            final caption = item?.caption;
+            final label = name != null && name.isNotEmpty
+                ? name
+                : caption != null && caption.isNotEmpty
+                ? caption
+                : mediaId;
+            return Text(label, maxLines: 1, overflow: TextOverflow.ellipsis);
+          },
+        );
   }
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "تم",
   "settings_mediaStorage_transfers_state_failed": "فشل",
   "settings_mediaStorage_transfers_suspended_title": "تم إيقاف عمليات النقل مؤقتًا",
-  "settings_mediaStorage_transfers_suspended_subtitle": "تعذّر التحقق من التخزين السحابي. يواصل Submersion المحاولة؛ إذا استمرت المشكلة، افصل تخزين الوسائط ثم أعد توصيله.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "لم يعد هذا الجهاز والتخزين السحابي متفقين على المخزن المستخدم. تؤدي إعادة توصيل تخزين الوسائط إلى اعتماد المخزن الموجود في السحابة الآن.",
   "settings_mediaStorage_transfers_queued": "{count} في قائمة الانتظار",
   "settings_mediaStorage_transfers_waitingRetry": "{count} في انتظار إعادة المحاولة",
   "settings_mediaStorage_verify_action": "التحقق من المكتبة",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "متصل بـ {hint}",
   "settings_mediaStorage_test_success": "نجح الاتصال",
   "settings_mediaStorage_saved": "تم توصيل مخزن الوسائط",
+  "settings_mediaStorage_error_notReady": "تعذّرت قراءة التخزين السحابي حتى الآن. انتظر لحظة ثم أعد المحاولة.",
   "settings_mediaStorage_action_disconnect": "قطع الاتصال",
   "settings_mediaStorage_disconnect_confirm_title": "قطع اتصال مخزن الوسائط؟",
   "settings_mediaStorage_disconnect_confirm_body": "يتوقف هذا الجهاز عن رفع الوسائط وجلبها. لن يُحذف أي شيء من الحاوية الخاصة بك.",

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "جارٍ الإزالة من السحابة",
   "settings_mediaStorage_transfers_state_done": "تم",
   "settings_mediaStorage_transfers_state_failed": "فشل",
+  "settings_mediaStorage_transfers_suspended_title": "تم إيقاف عمليات النقل مؤقتًا",
+  "settings_mediaStorage_transfers_suspended_subtitle": "تعذّر التحقق من التخزين السحابي. يواصل Submersion المحاولة؛ إذا استمرت المشكلة، افصل تخزين الوسائط ثم أعد توصيله.",
   "settings_mediaStorage_transfers_queued": "{count} في قائمة الانتظار",
   "settings_mediaStorage_transfers_waitingRetry": "{count} في انتظار إعادة المحاولة",
   "settings_mediaStorage_verify_action": "التحقق من المكتبة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Fertig",
   "settings_mediaStorage_transfers_state_failed": "Fehlgeschlagen",
   "settings_mediaStorage_transfers_suspended_title": "Übertragungen angehalten",
-  "settings_mediaStorage_transfers_suspended_subtitle": "Der Cloud-Speicher konnte nicht überprüft werden. Submersion versucht es weiter; falls das anhält, den Medienspeicher trennen und neu verbinden.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Dieses Gerät und der Cloud-Speicher sind sich nicht mehr einig, welcher Speicher verwendet wird. Beim erneuten Verbinden wird der Speicher übernommen, den die Cloud jetzt enthält.",
   "settings_mediaStorage_transfers_queued": "{count} in Warteschlange",
   "settings_mediaStorage_transfers_waitingRetry": "{count} warten auf Wiederholung",
   "settings_mediaStorage_verify_action": "Bibliothek überprüfen",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Wird aus der Cloud entfernt",
   "settings_mediaStorage_transfers_state_done": "Fertig",
   "settings_mediaStorage_transfers_state_failed": "Fehlgeschlagen",
+  "settings_mediaStorage_transfers_suspended_title": "Übertragungen angehalten",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Der Cloud-Speicher konnte nicht überprüft werden. Submersion versucht es weiter; falls das anhält, den Medienspeicher trennen und neu verbinden.",
   "settings_mediaStorage_transfers_queued": "{count} in Warteschlange",
   "settings_mediaStorage_transfers_waitingRetry": "{count} warten auf Wiederholung",
   "settings_mediaStorage_verify_action": "Bibliothek überprüfen",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Verbunden mit {hint}",
   "settings_mediaStorage_test_success": "Verbindung erfolgreich",
   "settings_mediaStorage_saved": "Medienspeicher verbunden",
+  "settings_mediaStorage_error_notReady": "Der Cloud-Speicher konnte noch nicht gelesen werden. Warte einen Moment und versuche es erneut.",
   "settings_mediaStorage_action_disconnect": "Trennen",
   "settings_mediaStorage_disconnect_confirm_title": "Medienspeicher trennen?",
   "settings_mediaStorage_disconnect_confirm_body": "Dieses Gerät lädt keine Medien mehr hoch oder herunter. In Ihrem Bucket wird nichts gelöscht.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15494,7 +15494,7 @@
   "settings_mediaStorage_transfers_state_done": "Done",
   "settings_mediaStorage_transfers_state_failed": "Failed",
   "settings_mediaStorage_transfers_suspended_title": "Transfers paused",
-  "settings_mediaStorage_transfers_suspended_subtitle": "The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "This device and the cloud store no longer agree on which store is in use. Reconnecting media storage adopts the store the cloud holds now.",
   "settings_mediaStorage_transfers_queued": "{count} queued",
   "@settings_mediaStorage_transfers_queued": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15493,6 +15493,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Removing from cloud",
   "settings_mediaStorage_transfers_state_done": "Done",
   "settings_mediaStorage_transfers_state_failed": "Failed",
+  "settings_mediaStorage_transfers_suspended_title": "Transfers paused",
+  "settings_mediaStorage_transfers_suspended_subtitle": "The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.",
   "settings_mediaStorage_transfers_queued": "{count} queued",
   "@settings_mediaStorage_transfers_queued": {
     "placeholders": {

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -15479,6 +15479,7 @@
   },
   "settings_mediaStorage_test_success": "Connection successful",
   "settings_mediaStorage_saved": "Media store connected",
+  "settings_mediaStorage_error_notReady": "The cloud storage could not be read yet. Wait a moment and try connecting again.",
   "settings_mediaStorage_action_disconnect": "Disconnect",
   "settings_mediaStorage_disconnect_confirm_title": "Disconnect media store?",
   "settings_mediaStorage_disconnect_confirm_body": "This device stops uploading and fetching media. Nothing in your bucket is deleted.",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Completado",
   "settings_mediaStorage_transfers_state_failed": "Fallido",
   "settings_mediaStorage_transfers_suspended_title": "Transferencias en pausa",
-  "settings_mediaStorage_transfers_suspended_subtitle": "No se pudo verificar el almacenamiento en la nube. Submersion sigue reintentando; si persiste, desconecta y vuelve a conectar el almacenamiento de medios.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Este dispositivo y el almacenamiento en la nube ya no coinciden en qué almacén está en uso. Volver a conectar adopta el almacén que la nube tiene ahora.",
   "settings_mediaStorage_transfers_queued": "{count} en cola",
   "settings_mediaStorage_transfers_waitingRetry": "{count} esperando para reintentar",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Eliminando de la nube",
   "settings_mediaStorage_transfers_state_done": "Completado",
   "settings_mediaStorage_transfers_state_failed": "Fallido",
+  "settings_mediaStorage_transfers_suspended_title": "Transferencias en pausa",
+  "settings_mediaStorage_transfers_suspended_subtitle": "No se pudo verificar el almacenamiento en la nube. Submersion sigue reintentando; si persiste, desconecta y vuelve a conectar el almacenamiento de medios.",
   "settings_mediaStorage_transfers_queued": "{count} en cola",
   "settings_mediaStorage_transfers_waitingRetry": "{count} esperando para reintentar",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Conectado a {hint}",
   "settings_mediaStorage_test_success": "Conexión correcta",
   "settings_mediaStorage_saved": "Almacén de medios conectado",
+  "settings_mediaStorage_error_notReady": "Aún no se pudo leer el almacenamiento en la nube. Espera un momento e inténtalo de nuevo.",
   "settings_mediaStorage_action_disconnect": "Desconectar",
   "settings_mediaStorage_disconnect_confirm_title": "¿Desconectar el almacén de medios?",
   "settings_mediaStorage_disconnect_confirm_body": "Este dispositivo deja de subir y descargar medios. No se elimina nada de tu bucket.",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Suppression du cloud",
   "settings_mediaStorage_transfers_state_done": "Terminé",
   "settings_mediaStorage_transfers_state_failed": "Échec",
+  "settings_mediaStorage_transfers_suspended_title": "Transferts en pause",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Le stockage cloud n'a pas pu être vérifié. Submersion réessaie régulièrement ; si le problème persiste, déconnectez puis reconnectez le stockage des médias.",
   "settings_mediaStorage_transfers_queued": "{count} en file",
   "settings_mediaStorage_transfers_waitingRetry": "{count} en attente de nouvelle tentative",
   "settings_mediaStorage_verify_action": "Vérifier la bibliothèque",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Connecté à {hint}",
   "settings_mediaStorage_test_success": "Connexion réussie",
   "settings_mediaStorage_saved": "Stockage des médias connecté",
+  "settings_mediaStorage_error_notReady": "Le stockage cloud n'a pas encore pu être lu. Patientez un instant, puis réessayez.",
   "settings_mediaStorage_action_disconnect": "Déconnecter",
   "settings_mediaStorage_disconnect_confirm_title": "Déconnecter le stockage des médias ?",
   "settings_mediaStorage_disconnect_confirm_body": "Cet appareil cesse d'envoyer et de récupérer des médias. Rien n'est supprimé de votre bucket.",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Terminé",
   "settings_mediaStorage_transfers_state_failed": "Échec",
   "settings_mediaStorage_transfers_suspended_title": "Transferts en pause",
-  "settings_mediaStorage_transfers_suspended_subtitle": "Le stockage cloud n'a pas pu être vérifié. Submersion réessaie régulièrement ; si le problème persiste, déconnectez puis reconnectez le stockage des médias.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Cet appareil et le stockage cloud ne s'accordent plus sur le magasin utilisé. Reconnecter le stockage des médias adopte celui que le cloud contient désormais.",
   "settings_mediaStorage_transfers_queued": "{count} en file",
   "settings_mediaStorage_transfers_waitingRetry": "{count} en attente de nouvelle tentative",
   "settings_mediaStorage_verify_action": "Vérifier la bibliothèque",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "מחובר אל {hint}",
   "settings_mediaStorage_test_success": "החיבור הצליח",
   "settings_mediaStorage_saved": "אחסון המדיה חובר",
+  "settings_mediaStorage_error_notReady": "עדיין לא ניתן היה לקרוא את אחסון הענן. המתינו רגע ונסו שוב.",
   "settings_mediaStorage_action_disconnect": "התנתק",
   "settings_mediaStorage_disconnect_confirm_title": "לנתק את אחסון המדיה?",
   "settings_mediaStorage_disconnect_confirm_body": "מכשיר זה יפסיק להעלות ולהוריד מדיה. שום דבר לא יימחק מהדלי שלך.",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "מסיר מהענן",
   "settings_mediaStorage_transfers_state_done": "הושלם",
   "settings_mediaStorage_transfers_state_failed": "נכשל",
+  "settings_mediaStorage_transfers_suspended_title": "ההעברות מושהות",
+  "settings_mediaStorage_transfers_suspended_subtitle": "לא ניתן היה לאמת את אחסון הענן. Submersion ממשיך לנסות; אם הבעיה נמשכת, נתקו את אחסון המדיה וחברו אותו מחדש.",
   "settings_mediaStorage_transfers_queued": "{count} בתור",
   "settings_mediaStorage_transfers_waitingRetry": "{count} ממתינים לניסיון חוזר",
   "settings_mediaStorage_verify_action": "אימות הספרייה",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "הושלם",
   "settings_mediaStorage_transfers_state_failed": "נכשל",
   "settings_mediaStorage_transfers_suspended_title": "ההעברות מושהות",
-  "settings_mediaStorage_transfers_suspended_subtitle": "לא ניתן היה לאמת את אחסון הענן. Submersion ממשיך לנסות; אם הבעיה נמשכת, נתקו את אחסון המדיה וחברו אותו מחדש.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "המכשיר הזה ואחסון הענן כבר לא מסכימים על המאגר שבשימוש. חיבור מחדש של אחסון המדיה מאמץ את המאגר שנמצא כעת בענן.",
   "settings_mediaStorage_transfers_queued": "{count} בתור",
   "settings_mediaStorage_transfers_waitingRetry": "{count} ממתינים לניסיון חוזר",
   "settings_mediaStorage_verify_action": "אימות הספרייה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Csatlakoztatva: {hint}",
   "settings_mediaStorage_test_success": "Sikeres kapcsolat",
   "settings_mediaStorage_saved": "Médiatár csatlakoztatva",
+  "settings_mediaStorage_error_notReady": "A felhőtárolót még nem sikerült beolvasni. Várj egy pillanatot, majd próbáld újra.",
   "settings_mediaStorage_action_disconnect": "Leválasztás",
   "settings_mediaStorage_disconnect_confirm_title": "Leválasztja a médiatárat?",
   "settings_mediaStorage_disconnect_confirm_body": "Az eszköz nem tölt fel és nem tölt le több médiát. A bucketből semmi sem törlődik.",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Eltávolítás a felhőből",
   "settings_mediaStorage_transfers_state_done": "Kész",
   "settings_mediaStorage_transfers_state_failed": "Sikertelen",
+  "settings_mediaStorage_transfers_suspended_title": "Átvitelek szüneteltetve",
+  "settings_mediaStorage_transfers_suspended_subtitle": "A felhőtárolót nem sikerült ellenőrizni. A Submersion tovább próbálkozik; ha ez tartósan fennáll, válassza le, majd csatlakoztassa újra a médiatárolót.",
   "settings_mediaStorage_transfers_queued": "{count} sorban áll",
   "settings_mediaStorage_transfers_waitingRetry": "{count} újrapróbálkozásra vár",
   "settings_mediaStorage_verify_action": "Könyvtár ellenőrzése",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Kész",
   "settings_mediaStorage_transfers_state_failed": "Sikertelen",
   "settings_mediaStorage_transfers_suspended_title": "Átvitelek szüneteltetve",
-  "settings_mediaStorage_transfers_suspended_subtitle": "A felhőtárolót nem sikerült ellenőrizni. A Submersion tovább próbálkozik; ha ez tartósan fennáll, válassza le, majd csatlakoztassa újra a médiatárolót.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Ez az eszköz és a felhőtároló már nem egyezik abban, melyik tárolót használják. A médiatároló újracsatlakoztatása a felhőben most található tárolót veszi át.",
   "settings_mediaStorage_transfers_queued": "{count} sorban áll",
   "settings_mediaStorage_transfers_waitingRetry": "{count} újrapróbálkozásra vár",
   "settings_mediaStorage_verify_action": "Könyvtár ellenőrzése",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Rimozione dal cloud",
   "settings_mediaStorage_transfers_state_done": "Completato",
   "settings_mediaStorage_transfers_state_failed": "Non riuscito",
+  "settings_mediaStorage_transfers_suspended_title": "Trasferimenti in pausa",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Impossibile verificare l'archivio cloud. Submersion continua a riprovare; se il problema persiste, disconnetti e ricollega l'archivio multimediale.",
   "settings_mediaStorage_transfers_queued": "{count} in coda",
   "settings_mediaStorage_transfers_waitingRetry": "{count} in attesa di riprovare",
   "settings_mediaStorage_verify_action": "Verifica libreria",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Completato",
   "settings_mediaStorage_transfers_state_failed": "Non riuscito",
   "settings_mediaStorage_transfers_suspended_title": "Trasferimenti in pausa",
-  "settings_mediaStorage_transfers_suspended_subtitle": "Impossibile verificare l'archivio cloud. Submersion continua a riprovare; se il problema persiste, disconnetti e ricollega l'archivio multimediale.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Questo dispositivo e l'archivio cloud non concordano più su quale archivio sia in uso. Riconnettere l'archivio multimediale adotta quello che il cloud contiene ora.",
   "settings_mediaStorage_transfers_queued": "{count} in coda",
   "settings_mediaStorage_transfers_waitingRetry": "{count} in attesa di riprovare",
   "settings_mediaStorage_verify_action": "Verifica libreria",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Collegato a {hint}",
   "settings_mediaStorage_test_success": "Connessione riuscita",
   "settings_mediaStorage_saved": "Archivio media collegato",
+  "settings_mediaStorage_error_notReady": "Non è stato ancora possibile leggere l'archivio cloud. Attendi un momento e riprova.",
   "settings_mediaStorage_action_disconnect": "Disconnetti",
   "settings_mediaStorage_disconnect_confirm_title": "Disconnettere l'archivio media?",
   "settings_mediaStorage_disconnect_confirm_body": "Questo dispositivo smette di caricare e scaricare i media. Nulla viene eliminato dal tuo bucket.",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39346,7 +39346,7 @@ abstract class AppLocalizations {
   /// No description provided for @settings_mediaStorage_transfers_suspended_subtitle.
   ///
   /// In en, this message translates to:
-  /// **'The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.'**
+  /// **'This device and the cloud store no longer agree on which store is in use. Reconnecting media storage adopts the store the cloud holds now.'**
   String get settings_mediaStorage_transfers_suspended_subtitle;
 
   /// No description provided for @settings_mediaStorage_transfers_queued.

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39337,6 +39337,18 @@ abstract class AppLocalizations {
   /// **'Failed'**
   String get settings_mediaStorage_transfers_state_failed;
 
+  /// No description provided for @settings_mediaStorage_transfers_suspended_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Transfers paused'**
+  String get settings_mediaStorage_transfers_suspended_title;
+
+  /// No description provided for @settings_mediaStorage_transfers_suspended_subtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.'**
+  String get settings_mediaStorage_transfers_suspended_subtitle;
+
   /// No description provided for @settings_mediaStorage_transfers_queued.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -39253,6 +39253,12 @@ abstract class AppLocalizations {
   /// **'Media store connected'**
   String get settings_mediaStorage_saved;
 
+  /// No description provided for @settings_mediaStorage_error_notReady.
+  ///
+  /// In en, this message translates to:
+  /// **'The cloud storage could not be read yet. Wait a moment and try connecting again.'**
+  String get settings_mediaStorage_error_notReady;
+
   /// No description provided for @settings_mediaStorage_action_disconnect.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23484,6 +23484,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'فشل';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'تم إيقاف عمليات النقل مؤقتًا';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'تعذّر التحقق من التخزين السحابي. يواصل Submersion المحاولة؛ إذا استمرت المشكلة، افصل تخزين الوسائط ثم أعد توصيله.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count في قائمة الانتظار';
   }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23489,7 +23489,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'تعذّر التحقق من التخزين السحابي. يواصل Submersion المحاولة؛ إذا استمرت المشكلة، افصل تخزين الوسائط ثم أعد توصيله.';
+      'لم يعد هذا الجهاز والتخزين السحابي متفقين على المخزن المستخدم. تؤدي إعادة توصيل تخزين الوسائط إلى اعتماد المخزن الموجود في السحابة الآن.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -23438,6 +23438,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settings_mediaStorage_saved => 'تم توصيل مخزن الوسائط';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'تعذّرت قراءة التخزين السحابي حتى الآن. انتظر لحظة ثم أعد المحاولة.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'قطع الاتصال';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23870,7 +23870,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'Der Cloud-Speicher konnte nicht überprüft werden. Submersion versucht es weiter; falls das anhält, den Medienspeicher trennen und neu verbinden.';
+      'Dieses Gerät und der Cloud-Speicher sind sich nicht mehr einig, welcher Speicher verwendet wird. Beim erneuten Verbinden wird der Speicher übernommen, den die Cloud jetzt enthält.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23865,6 +23865,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Fehlgeschlagen';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Übertragungen angehalten';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'Der Cloud-Speicher konnte nicht überprüft werden. Submersion versucht es weiter; falls das anhält, den Medienspeicher trennen und neu verbinden.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count in Warteschlange';
   }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -23817,6 +23817,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Medienspeicher verbunden';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'Der Cloud-Speicher konnte noch nicht gelesen werden. Warte einen Moment und versuche es erneut.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Trennen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23515,7 +23515,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.';
+      'This device and the cloud store no longer agree on which store is in use. Reconnecting media storage adopts the store the cloud holds now.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23510,6 +23510,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Failed';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Transfers paused';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'The cloud store could not be verified. Submersion keeps retrying; if this persists, disconnect and reconnect media storage.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count queued';
   }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -23463,6 +23463,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Media store connected';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'The cloud storage could not be read yet. Wait a moment and try connecting again.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Disconnect';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23935,7 +23935,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'No se pudo verificar el almacenamiento en la nube. Submersion sigue reintentando; si persiste, desconecta y vuelve a conectar el almacenamiento de medios.';
+      'Este dispositivo y el almacenamiento en la nube ya no coinciden en qué almacén está en uso. Volver a conectar adopta el almacén que la nube tiene ahora.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23930,6 +23930,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Fallido';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Transferencias en pausa';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'No se pudo verificar el almacenamiento en la nube. Submersion sigue reintentando; si persiste, desconecta y vuelve a conectar el almacenamiento de medios.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count en cola';
   }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -23883,6 +23883,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Almacén de medios conectado';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'Aún no se pudo leer el almacenamiento en la nube. Espera un momento e inténtalo de nuevo.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Desconectar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23995,6 +23995,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Échec';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Transferts en pause';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'Le stockage cloud n\'a pas pu être vérifié. Submersion réessaie régulièrement ; si le problème persiste, déconnectez puis reconnectez le stockage des médias.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count en file';
   }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -23947,6 +23947,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Stockage des médias connecté';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'Le stockage cloud n\'a pas encore pu être lu. Patientez un instant, puis réessayez.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Déconnecter';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -24000,7 +24000,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'Le stockage cloud n\'a pas pu être vérifié. Submersion réessaie régulièrement ; si le problème persiste, déconnectez puis reconnectez le stockage des médias.';
+      'Cet appareil et le stockage cloud ne s\'accordent plus sur le magasin utilisé. Reconnecter le stockage des médias adopte celui que le cloud contient désormais.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23320,7 +23320,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'לא ניתן היה לאמת את אחסון הענן. Submersion ממשיך לנסות; אם הבעיה נמשכת, נתקו את אחסון המדיה וחברו אותו מחדש.';
+      'המכשיר הזה ואחסון הענן כבר לא מסכימים על המאגר שבשימוש. חיבור מחדש של אחסון המדיה מאמץ את המאגר שנמצא כעת בענן.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23270,6 +23270,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_mediaStorage_saved => 'אחסון המדיה חובר';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'עדיין לא ניתן היה לקרוא את אחסון הענן. המתינו רגע ונסו שוב.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'התנתק';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -23315,6 +23315,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'נכשל';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'ההעברות מושהות';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'לא ניתן היה לאמת את אחסון הענן. Submersion ממשיך לנסות; אם הבעיה נמשכת, נתקו את אחסון המדיה וחברו אותו מחדש.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count בתור';
   }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23838,7 +23838,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'A felhőtárolót nem sikerült ellenőrizni. A Submersion tovább próbálkozik; ha ez tartósan fennáll, válassza le, majd csatlakoztassa újra a médiatárolót.';
+      'Ez az eszköz és a felhőtároló már nem egyezik abban, melyik tárolót használják. A médiatároló újracsatlakoztatása a felhőben most található tárolót veszi át.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23786,6 +23786,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Médiatár csatlakoztatva';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'A felhőtárolót még nem sikerült beolvasni. Várj egy pillanatot, majd próbáld újra.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Leválasztás';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -23833,6 +23833,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Sikertelen';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Átvitelek szüneteltetve';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'A felhőtárolót nem sikerült ellenőrizni. A Submersion tovább próbálkozik; ha ez tartósan fennáll, válassza le, majd csatlakoztassa újra a médiatárolót.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count sorban áll';
   }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23866,6 +23866,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Archivio media collegato';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'Non è stato ancora possibile leggere l\'archivio cloud. Attendi un momento e riprova.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Disconnetti';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23919,7 +23919,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'Impossibile verificare l\'archivio cloud. Submersion continua a riprovare; se il problema persiste, disconnetti e ricollega l\'archivio multimediale.';
+      'Questo dispositivo e l\'archivio cloud non concordano più su quale archivio sia in uso. Riconnettere l\'archivio multimediale adotta quello che il cloud contiene ora.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -23914,6 +23914,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Non riuscito';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Trasferimenti in pausa';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'Impossibile verificare l\'archivio cloud. Submersion continua a riprovare; se il problema persiste, disconnetti e ricollega l\'archivio multimediale.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count in coda';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23733,7 +23733,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'De cloudopslag kon niet worden geverifieerd. Submersion blijft het proberen; als dit aanhoudt, koppel de mediaopslag los en verbind opnieuw.';
+      'Dit apparaat en de cloudopslag zijn het niet meer eens over welke opslag in gebruik is. Opnieuw verbinden neemt de opslag over die de cloud nu bevat.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23728,6 +23728,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Mislukt';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Overdrachten gepauzeerd';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'De cloudopslag kon niet worden geverifieerd. Submersion blijft het proberen; als dit aanhoudt, koppel de mediaopslag los en verbind opnieuw.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count in wachtrij';
   }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -23681,6 +23681,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Mediaopslag verbonden';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'De cloudopslag kon nog niet worden gelezen. Wacht even en probeer het opnieuw.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Loskoppelen';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23866,6 +23866,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_mediaStorage_saved => 'Armazenamento de mídia conectado';
 
   @override
+  String get settings_mediaStorage_error_notReady =>
+      'Ainda não foi possível ler o armazenamento na nuvem. Aguarde um momento e tente novamente.';
+
+  @override
   String get settings_mediaStorage_action_disconnect => 'Desconectar';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23913,6 +23913,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => 'Falhou';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title =>
+      'Transferências pausadas';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      'Não foi possível verificar o armazenamento na nuvem. O Submersion continua tentando; se isso persistir, desconecte e reconecte o armazenamento de mídia.';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count na fila';
   }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -23918,7 +23918,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      'Não foi possível verificar o armazenamento na nuvem. O Submersion continua tentando; se isso persistir, desconecte e reconecte o armazenamento de mídia.';
+      'Este dispositivo e o armazenamento na nuvem não concordam mais sobre qual repositório está em uso. Reconectar o armazenamento de mídia adota o que a nuvem contém agora.';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22679,6 +22679,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_mediaStorage_transfers_state_failed => '失败';
 
   @override
+  String get settings_mediaStorage_transfers_suspended_title => '传输已暂停';
+
+  @override
+  String get settings_mediaStorage_transfers_suspended_subtitle =>
+      '无法验证云存储。Submersion 会持续重试；如果问题持续存在，请断开并重新连接媒体存储。';
+
+  @override
   String settings_mediaStorage_transfers_queued(int count) {
     return '$count 个排队中';
   }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22683,7 +22683,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settings_mediaStorage_transfers_suspended_subtitle =>
-      '无法验证云存储。Submersion 会持续重试；如果问题持续存在，请断开并重新连接媒体存储。';
+      '此设备与云存储对正在使用的存储库不再一致。重新连接媒体存储将采用云端当前保存的存储库。';
 
   @override
   String settings_mediaStorage_transfers_queued(int count) {

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -22636,6 +22636,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings_mediaStorage_saved => '媒体存储已连接';
 
   @override
+  String get settings_mediaStorage_error_notReady => '尚无法读取云存储。请稍候片刻后重试。';
+
+  @override
   String get settings_mediaStorage_action_disconnect => '断开连接';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Verwijderen uit de cloud",
   "settings_mediaStorage_transfers_state_done": "Klaar",
   "settings_mediaStorage_transfers_state_failed": "Mislukt",
+  "settings_mediaStorage_transfers_suspended_title": "Overdrachten gepauzeerd",
+  "settings_mediaStorage_transfers_suspended_subtitle": "De cloudopslag kon niet worden geverifieerd. Submersion blijft het proberen; als dit aanhoudt, koppel de mediaopslag los en verbind opnieuw.",
   "settings_mediaStorage_transfers_queued": "{count} in wachtrij",
   "settings_mediaStorage_transfers_waitingRetry": "{count} wachten op nieuwe poging",
   "settings_mediaStorage_verify_action": "Bibliotheek verifiëren",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Klaar",
   "settings_mediaStorage_transfers_state_failed": "Mislukt",
   "settings_mediaStorage_transfers_suspended_title": "Overdrachten gepauzeerd",
-  "settings_mediaStorage_transfers_suspended_subtitle": "De cloudopslag kon niet worden geverifieerd. Submersion blijft het proberen; als dit aanhoudt, koppel de mediaopslag los en verbind opnieuw.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Dit apparaat en de cloudopslag zijn het niet meer eens over welke opslag in gebruik is. Opnieuw verbinden neemt de opslag over die de cloud nu bevat.",
   "settings_mediaStorage_transfers_queued": "{count} in wachtrij",
   "settings_mediaStorage_transfers_waitingRetry": "{count} wachten op nieuwe poging",
   "settings_mediaStorage_verify_action": "Bibliotheek verifiëren",

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Verbonden met {hint}",
   "settings_mediaStorage_test_success": "Verbinding geslaagd",
   "settings_mediaStorage_saved": "Mediaopslag verbonden",
+  "settings_mediaStorage_error_notReady": "De cloudopslag kon nog niet worden gelezen. Wacht even en probeer het opnieuw.",
   "settings_mediaStorage_action_disconnect": "Loskoppelen",
   "settings_mediaStorage_disconnect_confirm_title": "Mediaopslag loskoppelen?",
   "settings_mediaStorage_disconnect_confirm_body": "Dit apparaat stopt met het uploaden en ophalen van media. Er wordt niets uit je bucket verwijderd.",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "Concluído",
   "settings_mediaStorage_transfers_state_failed": "Falhou",
   "settings_mediaStorage_transfers_suspended_title": "Transferências pausadas",
-  "settings_mediaStorage_transfers_suspended_subtitle": "Não foi possível verificar o armazenamento na nuvem. O Submersion continua tentando; se isso persistir, desconecte e reconecte o armazenamento de mídia.",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Este dispositivo e o armazenamento na nuvem não concordam mais sobre qual repositório está em uso. Reconectar o armazenamento de mídia adota o que a nuvem contém agora.",
   "settings_mediaStorage_transfers_queued": "{count} na fila",
   "settings_mediaStorage_transfers_waitingRetry": "{count} aguardando nova tentativa",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "Conectado a {hint}",
   "settings_mediaStorage_test_success": "Conexão bem-sucedida",
   "settings_mediaStorage_saved": "Armazenamento de mídia conectado",
+  "settings_mediaStorage_error_notReady": "Ainda não foi possível ler o armazenamento na nuvem. Aguarde um momento e tente novamente.",
   "settings_mediaStorage_action_disconnect": "Desconectar",
   "settings_mediaStorage_disconnect_confirm_title": "Desconectar o armazenamento de mídia?",
   "settings_mediaStorage_disconnect_confirm_body": "Este dispositivo deixa de enviar e buscar mídia. Nada é excluído do seu bucket.",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "Removendo da nuvem",
   "settings_mediaStorage_transfers_state_done": "Concluído",
   "settings_mediaStorage_transfers_state_failed": "Falhou",
+  "settings_mediaStorage_transfers_suspended_title": "Transferências pausadas",
+  "settings_mediaStorage_transfers_suspended_subtitle": "Não foi possível verificar o armazenamento na nuvem. O Submersion continua tentando; se isso persistir, desconecte e reconecte o armazenamento de mídia.",
   "settings_mediaStorage_transfers_queued": "{count} na fila",
   "settings_mediaStorage_transfers_waitingRetry": "{count} aguardando nova tentativa",
   "settings_mediaStorage_verify_action": "Verificar biblioteca",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6752,6 +6752,8 @@
   "settings_mediaStorage_transfers_state_deleting": "正在从云端移除",
   "settings_mediaStorage_transfers_state_done": "已完成",
   "settings_mediaStorage_transfers_state_failed": "失败",
+  "settings_mediaStorage_transfers_suspended_title": "传输已暂停",
+  "settings_mediaStorage_transfers_suspended_subtitle": "无法验证云存储。Submersion 会持续重试；如果问题持续存在，请断开并重新连接媒体存储。",
   "settings_mediaStorage_transfers_queued": "{count} 个排队中",
   "settings_mediaStorage_transfers_waitingRetry": "{count} 个等待重试",
   "settings_mediaStorage_verify_action": "验证媒体库",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6753,7 +6753,7 @@
   "settings_mediaStorage_transfers_state_done": "已完成",
   "settings_mediaStorage_transfers_state_failed": "失败",
   "settings_mediaStorage_transfers_suspended_title": "传输已暂停",
-  "settings_mediaStorage_transfers_suspended_subtitle": "无法验证云存储。Submersion 会持续重试；如果问题持续存在，请断开并重新连接媒体存储。",
+  "settings_mediaStorage_transfers_suspended_subtitle": "此设备与云存储对正在使用的存储库不再一致。重新连接媒体存储将采用云端当前保存的存储库。",
   "settings_mediaStorage_transfers_queued": "{count} 个排队中",
   "settings_mediaStorage_transfers_waitingRetry": "{count} 个等待重试",
   "settings_mediaStorage_verify_action": "验证媒体库",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -6738,6 +6738,7 @@
   "settings_mediaStorage_status_connected": "已连接到 {hint}",
   "settings_mediaStorage_test_success": "连接成功",
   "settings_mediaStorage_saved": "媒体存储已连接",
+  "settings_mediaStorage_error_notReady": "尚无法读取云存储。请稍候片刻后重试。",
   "settings_mediaStorage_action_disconnect": "断开连接",
   "settings_mediaStorage_disconnect_confirm_title": "断开媒体存储？",
   "settings_mediaStorage_disconnect_confirm_body": "此设备将停止上传和获取媒体。您的存储桶中的内容不会被删除。",

--- a/test/core/services/media_store/icloud_media_object_store_test.dart
+++ b/test/core/services/media_store/icloud_media_object_store_test.dart
@@ -23,14 +23,6 @@ class _FailedMovePlatform extends DirectoryICloudMediaPlatform {
   Future<bool> moveIntoContainer(String s, String d) async => false;
 }
 
-/// Claims a file is downloaded when it is not on disk.
-class _PhantomDownloadPlatform extends DirectoryICloudMediaPlatform {
-  _PhantomDownloadPlatform(super.root);
-
-  @override
-  Future<bool> ensureDownloaded(String path) async => true;
-}
-
 /// Reports a file iCloud knows about but could not materialize in time. The
 /// native downloadIfNeeded answers false only on that path: the placeholder
 /// exists, startDownloadingUbiquitousItem succeeded, and the 12 s poll ran out.
@@ -162,11 +154,8 @@ void main() {
 
   test('getFile treats a phantom download (no file on disk) as not '
       'found', () async {
-    final store = ICloudMediaObjectStore(
-      platform: _PhantomDownloadPlatform(container),
-    );
     await expectLater(
-      store.getFile('smv1/objects/aa/ghost.bin', File('${tmp.path}/o')),
+      build().getFile('smv1/objects/aa/ghost.bin', File('${tmp.path}/o')),
       throwsA(
         isA<MediaStoreException>().having(
           (e) => e.kind,
@@ -243,6 +232,33 @@ void main() {
         ),
       ),
     );
+  });
+
+  // null means "not in the store" to every caller, and the upload pipeline
+  // answers that by uploading: reporting a placeholder still coming down as
+  // absent re-uploads the whole library from the second device.
+  test('head on a placeholder that would not download in time is transient, '
+      'not absent', () async {
+    final store = ICloudMediaObjectStore(
+      platform: _UndownloadablePlatform(container),
+    );
+    File('${container.path}/submersion-media/smv1/objects/aa/x.jpg')
+      ..createSync(recursive: true)
+      ..writeAsBytesSync([1, 2, 3]);
+    await expectLater(
+      store.head('smv1/objects/aa/x.jpg'),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.transient,
+        ),
+      ),
+    );
+  });
+
+  test('head on a key the container has never held is absent', () async {
+    expect(await build().head('smv1/objects/aa/never.bin'), isNull);
   });
 
   test('getFile on a key the container has never held is notFound', () async {

--- a/test/core/services/media_store/icloud_media_object_store_test.dart
+++ b/test/core/services/media_store/icloud_media_object_store_test.dart
@@ -31,6 +31,17 @@ class _PhantomDownloadPlatform extends DirectoryICloudMediaPlatform {
   Future<bool> ensureDownloaded(String path) async => true;
 }
 
+/// Reports a file iCloud knows about but could not materialize in time. The
+/// native downloadIfNeeded answers false only on that path: the placeholder
+/// exists, startDownloadingUbiquitousItem succeeded, and the 12 s poll ran out.
+/// A file the container has never held short-circuits to true instead.
+class _UndownloadablePlatform extends DirectoryICloudMediaPlatform {
+  _UndownloadablePlatform(super.root);
+
+  @override
+  Future<bool> ensureDownloaded(String path) async => false;
+}
+
 void main() {
   // The NativeICloudMediaPlatform tests invoke a real MethodChannel, which
   // needs the services binding available (it then fails with a
@@ -207,6 +218,43 @@ void main() {
     expect(
       await build().reapStaleUploadSessions(olderThan: DateTime.utc(2026)),
       0,
+    );
+  });
+
+  // Issue #1356: the second device to connect read the first device's
+  // store.json before iCloud had finished downloading it. Reporting that as
+  // notFound made StoreMarkerStore.ensure mint a fresh store id and overwrite
+  // the marker, splitting the store's identity between the two devices.
+  test('getFile on a placeholder that would not download in time is '
+      'transient, not notFound', () async {
+    final store = ICloudMediaObjectStore(
+      platform: _UndownloadablePlatform(container),
+    );
+    File('${container.path}/submersion-media/smv1/store.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync('{"storeId":"a","formatVersion":1}');
+    await expectLater(
+      store.getFile('smv1/store.json', File('${tmp.path}/o')),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.transient,
+        ),
+      ),
+    );
+  });
+
+  test('getFile on a key the container has never held is notFound', () async {
+    await expectLater(
+      build().getFile('smv1/objects/aa/never.bin', File('${tmp.path}/o')),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.notFound,
+        ),
+      ),
     );
   });
 }

--- a/test/core/services/media_store/store_marker_test.dart
+++ b/test/core/services/media_store/store_marker_test.dart
@@ -1,8 +1,41 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'dart:convert';
+
 import 'package:submersion/core/services/media_store/store_keys.dart';
 import 'package:submersion/core/services/media_store/store_marker.dart';
 
 import '../../../helpers/in_memory_media_object_store.dart';
+
+/// A store whose marker is present but unreadable until something makes the
+/// adapter go and look, which is how an iCloud container behaves before its
+/// metadata has reached this device.
+class _InvisibleUntilListed extends InMemoryMediaObjectStore {
+  bool listed = false;
+
+  @override
+  Stream<StoreObjectInfo> list(String keyPrefix) {
+    listed = true;
+    return super.list(keyPrefix);
+  }
+
+  @override
+  Future<void> getFile(
+    String key,
+    File destination, {
+    TransferProgressCallback? onProgress,
+  }) async {
+    if (!listed) {
+      throw MediaStoreException(
+        'not found: $key',
+        kind: MediaStoreErrorKind.notFound,
+      );
+    }
+    return super.getFile(key, destination, onProgress: onProgress);
+  }
+}
 
 void main() {
   test('ensure writes a marker when absent and is stable afterwards', () async {
@@ -36,5 +69,37 @@ void main() {
     store.objects[StoreKeys.markerKey] = 'not json'.codeUnits;
     final markers = StoreMarkerStore(store: store);
     expect(await markers.read(), isNull);
+  });
+
+  // Issue #1356: read() cannot tell "no marker" from "cannot see it yet", and
+  // minting on the second answer overwrites the marker another device wrote,
+  // splitting one store in two.
+  test('a marker only a listing can see is adopted, not overwritten', () async {
+    final store = _InvisibleUntilListed();
+    await StoreMarkerStore(store: InMemoryMediaObjectStore()).ensure();
+    store.objects[StoreKeys.markerKey] = utf8.encode(
+      jsonEncode({
+        'storeId': 'store-from-the-other-device',
+        'formatVersion': 1,
+        'createdAt': '',
+      }),
+    );
+
+    final ensured = await StoreMarkerStore(store: store).ensure();
+
+    expect(ensured.created, isFalse);
+    expect(ensured.marker.storeId, 'store-from-the-other-device');
+    expect(
+      jsonDecode(utf8.decode(store.objects[StoreKeys.markerKey]!))['storeId'],
+      'store-from-the-other-device',
+      reason: 'the other device\'s marker must survive untouched',
+    );
+  });
+
+  test('a store with no marker at all still mints one', () async {
+    final store = _InvisibleUntilListed();
+    final ensured = await StoreMarkerStore(store: store).ensure();
+    expect(ensured.created, isTrue);
+    expect(store.objects.containsKey(StoreKeys.markerKey), isTrue);
   });
 }

--- a/test/features/media/data/media_repository_display_labels_test.dart
+++ b/test/features/media/data/media_repository_display_labels_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// The Transfers page names every queued row through this one projection
+/// instead of hydrating a full MediaItem (imageData BLOB included) per row.
+void main() {
+  late MediaRepository repo;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repo = MediaRepository();
+  });
+  tearDown(tearDownTestDatabase);
+
+  Future<String> insert({String? originalFilename, String? caption}) async {
+    final created = await repo.createMedia(
+      MediaItem(
+        id: '',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        filePath: '/tmp/x.jpg',
+        localPath: '/tmp/x.jpg',
+        originalFilename: originalFilename,
+        caption: caption,
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    return created.id;
+  }
+
+  test('prefers the file name, falls back to the caption, and omits rows '
+      'with neither', () async {
+    final named = await insert(originalFilename: 'IMG_0042.HEIC');
+    final captioned = await insert(originalFilename: '', caption: 'Turtle');
+    final bare = await insert();
+
+    final labels = await repo.getDisplayLabels([
+      named,
+      captioned,
+      bare,
+      'no-such-row',
+    ]);
+
+    expect(labels, {named: 'IMG_0042.HEIC', captioned: 'Turtle'});
+  });
+
+  test('an empty id list makes no query and returns no labels', () async {
+    expect(await repo.getDisplayLabels(const []), isEmpty);
+  });
+
+  // The queue can hold thousands of rows during a library backfill, well
+  // past SQLite's bound-parameter limit, so the lookup has to chunk.
+  test('finds ids on both sides of a chunk boundary', () async {
+    final first = await insert(originalFilename: 'first.jpg');
+    final last = await insert(originalFilename: 'last.jpg');
+    final ids = [first, ...List.generate(1500, (i) => 'missing-$i'), last];
+
+    final labels = await repo.getDisplayLabels(ids);
+
+    expect(labels, {first: 'first.jpg', last: 'last.jpg'});
+  });
+}

--- a/test/features/media_store/media_storage_page_transfer_summary_test.dart
+++ b/test/features/media_store/media_storage_page_transfer_summary_test.dart
@@ -17,31 +17,41 @@ import '../../support/fake_keychain_storage.dart';
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  Widget app(MediaTransferSummary summary) => ProviderScope(
-    overrides: [
-      mediaStoreRuntimeProvider.overrideWith((ref) async => null),
-      mediaStoreCredentialsStoreProvider.overrideWithValue(
-        MediaStoreCredentialsStore(storage: InMemoryKeychain()),
-      ),
-      mediaStoreStatusHintProvider.overrideWith(
-        (ref) async => 'dive-media @ minio',
-      ),
-      mediaTransferSummaryProvider.overrideWith((ref) => Stream.value(summary)),
-    ],
-    child: const MaterialApp(
-      locale: Locale('en'),
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: MediaStoragePage(),
-    ),
-  );
+  Widget app(MediaTransferSummary summary, {bool suspended = false}) =>
+      ProviderScope(
+        overrides: [
+          mediaStoreRuntimeProvider.overrideWith((ref) async => null),
+          mediaTransfersSuspendedProvider.overrideWith(
+            (ref) => Stream.value(suspended),
+          ),
+          mediaStoreCredentialsStoreProvider.overrideWithValue(
+            MediaStoreCredentialsStore(storage: InMemoryKeychain()),
+          ),
+          mediaStoreStatusHintProvider.overrideWith(
+            (ref) async => 'dive-media @ minio',
+          ),
+          mediaTransferSummaryProvider.overrideWith(
+            (ref) => Stream.value(summary),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaStoragePage(),
+        ),
+      );
 
-  Future<void> settle(WidgetTester tester, MediaTransferSummary summary) async {
+  Future<void> settle(
+    WidgetTester tester,
+    MediaTransferSummary summary, {
+    bool suspended = false,
+  }) async {
     tester.view.physicalSize = const Size(800, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
     await tester.runAsync(() async {
-      await tester.pumpWidget(app(summary));
+      await tester.pumpWidget(app(summary, suspended: suspended));
       for (var i = 0; i < 20; i++) {
         await Future<void>.delayed(const Duration(milliseconds: 20));
         await tester.pump();
@@ -116,5 +126,32 @@ void main() {
     expect(find.byKey(const Key('media-transfer-progress')), findsNothing);
     expect(find.byKey(const Key('media-transfer-waiting')), findsNothing);
     expect(find.byType(LinearProgressIndicator), findsNothing);
+  });
+
+  // Issue #1356: a preflight that keeps failing left the rows exactly as they
+  // were, so the page read "N queued" for days with no hint that nothing was
+  // going to move them.
+  testWidgets('a suspended queue shows the paused notice', (tester) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(transferring: 0, queued: 14, waiting: 0),
+      suspended: true,
+    );
+
+    expect(find.byKey(const Key('media-transfers-suspended')), findsOneWidget);
+    expect(find.text('Transfers paused'), findsOneWidget);
+    expect(find.text('14 queued'), findsOneWidget);
+  });
+
+  testWidgets('no paused notice while the worker is not suspended', (
+    tester,
+  ) async {
+    await settle(
+      tester,
+      const MediaTransferSummary(transferring: 0, queued: 14, waiting: 0),
+    );
+
+    expect(find.byKey(const Key('media-transfers-suspended')), findsNothing);
+    expect(find.text('Transfers paused'), findsNothing);
   });
 }

--- a/test/features/media_store/media_store_error_message_test.dart
+++ b/test/features/media_store/media_store_error_message_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/features/media_store/presentation/pages/media_storage_page.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/l10n/arb/app_localizations_en.dart';
+
+/// A transient answer is the store saying "not yet", not "no", and its raw
+/// message is a developer string naming an object key. Every other kind
+/// carries a message written to be read.
+void main() {
+  final AppLocalizations l10n = AppLocalizationsEn();
+
+  test('a transient failure reads as not ready yet, not as its raw '
+      'message', () {
+    final message = mediaStoreErrorMessage(
+      l10n,
+      const MediaStoreException(
+        'still downloading from iCloud: smv1/store.json',
+        kind: MediaStoreErrorKind.transient,
+      ),
+    );
+
+    expect(message, l10n.settings_mediaStorage_error_notReady);
+    expect(message, isNot(contains('smv1/store.json')));
+  });
+
+  test('every other kind keeps the message it carries', () {
+    for (final kind in [
+      MediaStoreErrorKind.auth,
+      MediaStoreErrorKind.fatal,
+      MediaStoreErrorKind.notFound,
+    ]) {
+      expect(
+        mediaStoreErrorMessage(
+          l10n,
+          MediaStoreException('bucket policy denies this key', kind: kind),
+        ),
+        'bucket policy denies this key',
+      );
+    }
+  });
+}

--- a/test/features/media_store/media_store_preflight_test.dart
+++ b/test/features/media_store/media_store_preflight_test.dart
@@ -6,7 +6,6 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
 import 'package:submersion/core/services/media_store/store_keys.dart';
-import 'package:submersion/core/services/media_store/store_marker.dart';
 import 'package:submersion/features/media_store/data/media_store_preflight.dart';
 
 import '../../helpers/in_memory_media_object_store.dart';
@@ -70,7 +69,7 @@ void main() {
     expect(await preflight(), isFalse);
   });
 
-  test('suspends on a foreign marker when adoption is not offered', () async {
+  test('suspends on a foreign marker rather than adopting it', () async {
     await attach('a');
     writeMarker('b');
     final preflight = MediaStorePreflight(
@@ -79,79 +78,37 @@ void main() {
       attachedStoreId: 'a',
     );
     expect(await preflight(), isFalse);
-    expect(await attachState.attachedStoreId(), 'a');
+    expect(
+      await attachState.attachedStoreId(),
+      'a',
+      reason:
+          'the marker a wiped or repointed store holds is the user\'s '
+          'call to adopt, not the drain loop\'s (spec section 13)',
+    );
   });
 
-  // Issue #1356: on iCloud the container is the identity, so a marker this
-  // device does not recognise can only be the app's own two-device race.
-  // Adopting it is what the manual disconnect/reconnect workaround did.
-  test(
-    'adopts the container marker on a mismatch when adoption is offered',
-    () async {
-      await attach('a');
-      writeMarker('b');
-      final adopted = <String>[];
-      final preflight = MediaStorePreflight(
-        attachState: attachState,
-        store: store,
-        attachedStoreId: 'a',
-        adoptMarker: (marker) async {
-          adopted.add(marker.storeId);
-          await attach(marker.storeId);
-        },
-      );
-
-      expect(await preflight(), isTrue);
-      expect(adopted, ['b']);
-      expect(preflight.attachedStoreId, 'b');
-
-      // Settled: the next check passes against the adopted id without
-      // adopting again.
-      expect(await preflight(), isTrue);
-      expect(adopted, ['b']);
-    },
-  );
-
-  test('suspends on a missing marker even when adoption is offered', () async {
+  test('suspends on a missing marker', () async {
     await attach('a');
-    final adopted = <String>[];
     final preflight = MediaStorePreflight(
       attachState: attachState,
       store: store,
       attachedStoreId: 'a',
-      adoptMarker: (marker) async => adopted.add(marker.storeId),
     );
     expect(await preflight(), isFalse);
-    expect(adopted, isEmpty);
   });
 
-  test(
-    'a marker read that fails propagates for the worker to suspend on',
-    () async {
-      await attach('a');
-      store.failNextWith = const MediaStoreException(
-        'still downloading: smv1/store.json',
-        kind: MediaStoreErrorKind.transient,
-      );
-      final preflight = MediaStorePreflight(
-        attachState: attachState,
-        store: store,
-        attachedStoreId: 'a',
-      );
-      await expectLater(preflight(), throwsA(isA<MediaStoreException>()));
-    },
-  );
-
-  test('exposes the marker it settled on', () async {
+  test('a marker read that fails propagates for the worker to '
+      'classify', () async {
     await attach('a');
-    writeMarker('a');
+    store.failNextWith = const MediaStoreException(
+      'still downloading: smv1/store.json',
+      kind: MediaStoreErrorKind.transient,
+    );
     final preflight = MediaStorePreflight(
       attachState: attachState,
       store: store,
       attachedStoreId: 'a',
     );
-    await preflight();
-    expect(preflight.attachedStoreId, 'a');
-    expect(StoreMarker.fromJson({'storeId': 'a'})!.storeId, 'a');
+    await expectLater(preflight(), throwsA(isA<MediaStoreException>()));
   });
 }

--- a/test/features/media_store/media_store_preflight_test.dart
+++ b/test/features/media_store/media_store_preflight_test.dart
@@ -1,0 +1,157 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/media_store/media_object_store.dart';
+import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
+import 'package:submersion/core/services/media_store/store_keys.dart';
+import 'package:submersion/core/services/media_store/store_marker.dart';
+import 'package:submersion/features/media_store/data/media_store_preflight.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+
+/// The admission check the worker runs before every transfer (design spec
+/// section 13): this device must still be attached to the store the runtime
+/// was built for, and the bucket must still carry that store's marker.
+void main() {
+  late MediaStoreAttachState attachState;
+  late InMemoryMediaObjectStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    attachState = MediaStoreAttachState(
+      prefs: await SharedPreferences.getInstance(),
+    );
+    store = InMemoryMediaObjectStore();
+  });
+
+  void writeMarker(String storeId) {
+    store.objects[StoreKeys.markerKey] = utf8.encode(
+      jsonEncode({'storeId': storeId, 'formatVersion': 1, 'createdAt': ''}),
+    );
+  }
+
+  Future<void> attach(String storeId) =>
+      attachState.setAttached(storeId, providerType: CloudProviderType.icloud);
+
+  test('passes when the container marker matches the attached store', () async {
+    await attach('a');
+    writeMarker('a');
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+    );
+    expect(await preflight(), isTrue);
+  });
+
+  test('suspends once this device has detached', () async {
+    await attach('a');
+    writeMarker('a');
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+    );
+    await attachState.clear();
+    expect(await preflight(), isFalse);
+  });
+
+  test('suspends when the attachment changed under the runtime', () async {
+    await attach('a');
+    writeMarker('c');
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+    );
+    await attach('c');
+    expect(await preflight(), isFalse);
+  });
+
+  test('suspends on a foreign marker when adoption is not offered', () async {
+    await attach('a');
+    writeMarker('b');
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+    );
+    expect(await preflight(), isFalse);
+    expect(await attachState.attachedStoreId(), 'a');
+  });
+
+  // Issue #1356: on iCloud the container is the identity, so a marker this
+  // device does not recognise can only be the app's own two-device race.
+  // Adopting it is what the manual disconnect/reconnect workaround did.
+  test(
+    'adopts the container marker on a mismatch when adoption is offered',
+    () async {
+      await attach('a');
+      writeMarker('b');
+      final adopted = <String>[];
+      final preflight = MediaStorePreflight(
+        attachState: attachState,
+        store: store,
+        attachedStoreId: 'a',
+        adoptMarker: (marker) async {
+          adopted.add(marker.storeId);
+          await attach(marker.storeId);
+        },
+      );
+
+      expect(await preflight(), isTrue);
+      expect(adopted, ['b']);
+      expect(preflight.attachedStoreId, 'b');
+
+      // Settled: the next check passes against the adopted id without
+      // adopting again.
+      expect(await preflight(), isTrue);
+      expect(adopted, ['b']);
+    },
+  );
+
+  test('suspends on a missing marker even when adoption is offered', () async {
+    await attach('a');
+    final adopted = <String>[];
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+      adoptMarker: (marker) async => adopted.add(marker.storeId),
+    );
+    expect(await preflight(), isFalse);
+    expect(adopted, isEmpty);
+  });
+
+  test(
+    'a marker read that fails propagates for the worker to suspend on',
+    () async {
+      await attach('a');
+      store.failNextWith = const MediaStoreException(
+        'still downloading: smv1/store.json',
+        kind: MediaStoreErrorKind.transient,
+      );
+      final preflight = MediaStorePreflight(
+        attachState: attachState,
+        store: store,
+        attachedStoreId: 'a',
+      );
+      await expectLater(preflight(), throwsA(isA<MediaStoreException>()));
+    },
+  );
+
+  test('exposes the marker it settled on', () async {
+    await attach('a');
+    writeMarker('a');
+    final preflight = MediaStorePreflight(
+      attachState: attachState,
+      store: store,
+      attachedStoreId: 'a',
+    );
+    await preflight();
+    expect(preflight.attachedStoreId, 'a');
+    expect(StoreMarker.fromJson({'storeId': 'a'})!.storeId, 'a');
+  });
+}

--- a/test/features/media_store/media_store_providers_test.dart
+++ b/test/features/media_store/media_store_providers_test.dart
@@ -51,6 +51,20 @@ void main() {
     },
   );
 
+  test('the suspension provider reads false without a runtime', () async {
+    final container = ProviderContainer(
+      overrides: [mediaStoreRuntimeProvider.overrideWith((ref) async => null)],
+    );
+    addTearDown(container.dispose);
+
+    final sub = container.listen(mediaTransfersSuspendedProvider, (_, _) {});
+    addTearDown(sub.close);
+    expect(
+      await container.read(mediaTransfersSuspendedProvider.future),
+      isFalse,
+    );
+  });
+
   test('the enqueue bridge is a no-op when no runtime is attached', () async {
     final container = ProviderContainer(
       overrides: [mediaStoreRuntimeProvider.overrideWith((ref) async => null)],

--- a/test/features/media_store/media_store_service_test.dart
+++ b/test/features/media_store/media_store_service_test.dart
@@ -436,30 +436,4 @@ void main() {
       reason: 'the marker the other device wrote must survive untouched',
     );
   });
-
-  test('adoptICloudStore re-attaches this device to the marker the container '
-      'holds, keeping its account', () async {
-    await attachState.setAttached(
-      'store-a',
-      providerType: CloudProviderType.icloud,
-      accountId: 'acct-1',
-    );
-    final svc = MediaStoreService(
-      credentials: credentials,
-      attachState: attachState,
-      storesRepository: storesRepository,
-      accountsRepository: accountsRepository,
-      accountCredentials: accountCredentials,
-    );
-
-    await svc.adoptICloudStore('store-b');
-
-    expect(await attachState.attachedStoreId(), 'store-b');
-    expect(await attachState.attachedProviderType(), CloudProviderType.icloud);
-    expect(await attachState.attachedAccountId(), 'acct-1');
-    final active = await storesRepository.getActive();
-    expect(active!.id, 'store-b');
-    expect(active.providerType, 'icloud');
-    expect(active.displayHint, 'iCloud');
-  });
 }

--- a/test/features/media_store/media_store_service_test.dart
+++ b/test/features/media_store/media_store_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -8,6 +9,8 @@ import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/accounts/account_credentials_store.dart';
 import 'package:submersion/core/services/accounts/account_identity.dart';
 import 'package:submersion/core/services/accounts/account_kind.dart';
+import 'package:submersion/core/services/media_store/icloud_media_object_store.dart';
+import 'package:submersion/core/services/media_store/icloud_media_platform.dart';
 import 'package:submersion/core/services/media_store/media_object_store.dart';
 import 'package:submersion/core/services/media_store/media_store_attach_state.dart';
 import 'package:submersion/core/services/media_store/media_store_credentials_store.dart';
@@ -29,6 +32,16 @@ class _CorruptingStore extends InMemoryMediaObjectStore {
   }) async {
     await destination.writeAsBytes('garbage'.codeUnits, flush: true);
   }
+}
+
+/// An iCloud container whose files never finish downloading (the native 12 s
+/// poll expires), as seen by the second device to connect while the first
+/// device's marker is still coming down from iCloud.
+class _UndownloadablePlatform extends DirectoryICloudMediaPlatform {
+  _UndownloadablePlatform(super.root);
+
+  @override
+  Future<bool> ensureDownloaded(String path) async => false;
 }
 
 void main() {
@@ -382,4 +395,71 @@ void main() {
       );
     },
   );
+
+  // Issue #1356: the phone connected while the Mac's store.json had not
+  // finished downloading, minted its own store id over it, and the Mac's
+  // every preflight failed against a marker it did not recognise.
+  test('connectICloud does not mint a new store over a marker that is still '
+      'downloading', () async {
+    final container = await Directory.systemTemp.createTemp('icloud_connect');
+    addTearDown(() => container.delete(recursive: true));
+    final marker = File('${container.path}/submersion-media/smv1/store.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(
+        '{"storeId":"store-from-the-mac","formatVersion":1,"createdAt":""}',
+      );
+    final svc = MediaStoreService(
+      credentials: credentials,
+      attachState: attachState,
+      storesRepository: storesRepository,
+      accountsRepository: accountsRepository,
+      accountCredentials: accountCredentials,
+      icloudStoreFactory: () async =>
+          ICloudMediaObjectStore(platform: _UndownloadablePlatform(container)),
+    );
+
+    await expectLater(
+      svc.connectICloud(),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.transient,
+        ),
+      ),
+    );
+
+    expect(await attachState.attachedStoreId(), isNull);
+    expect(
+      jsonDecode(marker.readAsStringSync())['storeId'],
+      'store-from-the-mac',
+      reason: 'the marker the other device wrote must survive untouched',
+    );
+  });
+
+  test('adoptICloudStore re-attaches this device to the marker the container '
+      'holds, keeping its account', () async {
+    await attachState.setAttached(
+      'store-a',
+      providerType: CloudProviderType.icloud,
+      accountId: 'acct-1',
+    );
+    final svc = MediaStoreService(
+      credentials: credentials,
+      attachState: attachState,
+      storesRepository: storesRepository,
+      accountsRepository: accountsRepository,
+      accountCredentials: accountCredentials,
+    );
+
+    await svc.adoptICloudStore('store-b');
+
+    expect(await attachState.attachedStoreId(), 'store-b');
+    expect(await attachState.attachedProviderType(), CloudProviderType.icloud);
+    expect(await attachState.attachedAccountId(), 'acct-1');
+    final active = await storesRepository.getActive();
+    expect(active!.id, 'store-b');
+    expect(active.providerType, 'icloud');
+    expect(active.displayHint, 'iCloud');
+  });
 }

--- a/test/features/media_store/media_store_service_test.dart
+++ b/test/features/media_store/media_store_service_test.dart
@@ -436,4 +436,77 @@ void main() {
       reason: 'the marker the other device wrote must survive untouched',
     );
   });
+
+  // Connecting is a foreground action the user is watching, and on iCloud the
+  // container's copy of store.json may still be coming down when they tap
+  // Connect. Refusing on the first attempt would fail a connect that succeeds
+  // seconds later.
+  test('a store that cannot serve the marker yet is retried, then '
+      'connects', () async {
+    final fake = InMemoryMediaObjectStore();
+    var attempts = 0;
+    final svc = MediaStoreService(
+      credentials: credentials,
+      attachState: attachState,
+      storesRepository: storesRepository,
+      accountsRepository: accountsRepository,
+      accountCredentials: accountCredentials,
+      markerRetryBackoff: const [Duration.zero, Duration.zero],
+      icloudStoreFactory: () async {
+        attempts++;
+        if (attempts == 1) {
+          fake.failNextWith = const MediaStoreException(
+            'still downloading from iCloud: smv1/store.json',
+            kind: MediaStoreErrorKind.transient,
+          );
+        }
+        return fake;
+      },
+    );
+
+    final result = await svc.connectICloud();
+
+    expect(result.storeId, isNotEmpty);
+    expect(await attachState.attachedStoreId(), result.storeId);
+  });
+
+  test('a store that keeps refusing the marker gives up rather than '
+      'connecting', () async {
+    final svc = MediaStoreService(
+      credentials: credentials,
+      attachState: attachState,
+      storesRepository: storesRepository,
+      accountsRepository: accountsRepository,
+      accountCredentials: accountCredentials,
+      markerRetryBackoff: const [Duration.zero],
+      icloudStoreFactory: () async => _AlwaysTransientStore(),
+    );
+
+    await expectLater(
+      svc.connectICloud(),
+      throwsA(
+        isA<MediaStoreException>().having(
+          (e) => e.kind,
+          'kind',
+          MediaStoreErrorKind.transient,
+        ),
+      ),
+    );
+    expect(await attachState.attachedStoreId(), isNull);
+  });
+}
+
+/// Never serves the marker, however often it is asked.
+class _AlwaysTransientStore extends InMemoryMediaObjectStore {
+  @override
+  Future<void> getFile(
+    String key,
+    File destination, {
+    TransferProgressCallback? onProgress,
+  }) async {
+    throw const MediaStoreException(
+      'still downloading from iCloud: smv1/store.json',
+      kind: MediaStoreErrorKind.transient,
+    );
+  }
 }

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -179,7 +179,11 @@ void main() {
     await waitUntil(() async => pipeline.processed.contains('m1'));
   });
 
-  test('a suspended drain with nothing queued arms no retry', () async {
+  // A suspension clears only from inside a passing preflight, so a drain
+  // that armed nothing could never clear one. The loop checks the preflight
+  // before asking what is due, so the last iteration of an emptying drain is
+  // exactly where a suspension with an empty queue comes from.
+  test('a suspended drain retries even with nothing queued', () async {
     final worker = MediaStoreWorker(
       queue: queue,
       pipeline: pipeline,
@@ -188,7 +192,29 @@ void main() {
     addTearDown(worker.dispose);
 
     await worker.drain();
-    expect(worker.wakeupDelayForTesting, isNull);
+    expect(
+      worker.wakeupDelayForTesting,
+      MediaStoreWorker.defaultPreflightRetryWindow,
+    );
+  });
+
+  // The timer this branch replaced. A row deferred for thirty seconds must
+  // not wait out the retry window because an unrelated check failed.
+  test('a suspended drain never delays a row past its own backoff', () async {
+    final id = await queue.enqueueUpload(mediaId: 'm1');
+    await queue.defer(id, DateTime.now().add(const Duration(seconds: 30)));
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => false,
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+    expect(
+      worker.wakeupDelayForTesting,
+      lessThan(MediaStoreWorker.defaultPreflightRetryWindow),
+    );
   });
 
   test('the suspension is observable and clears once the preflight '
@@ -214,22 +240,35 @@ void main() {
     expect(worker.isSuspended, isFalse);
     expect(pipeline.processed, ['m1']);
     await Future<void>.delayed(Duration.zero);
-    expect(seen, [true, false]);
+    expect(
+      seen,
+      [false, true, false],
+      reason:
+          'the stream opens with the value at subscribe time, so a '
+          'reader can never miss a flip it arrived just after',
+    );
   });
 
-  test('a preflight that throws reads as suspended too', () async {
+  // Being offline lands here on every provider: the marker read goes to the
+  // network and drain() runs the preflight BEFORE the gate that owns
+  // offline. Reporting that as a suspension told the user their store could
+  // not be verified, over a store that was fine.
+  test('a preflight that throws suspends the drain without reporting a '
+      'store problem', () async {
     await queue.enqueueUpload(mediaId: 'm1');
     final worker = MediaStoreWorker(
       queue: queue,
       pipeline: pipeline,
       preflight: () async => throw const MediaStoreException(
-        'get smv1/store.json failed',
+        'Could not reach S3 endpoint',
         kind: MediaStoreErrorKind.transient,
       ),
     );
     addTearDown(worker.dispose);
 
     await worker.drain();
-    expect(worker.isSuspended, isTrue);
+
+    expect(pipeline.processed, isEmpty);
+    expect(worker.isSuspended, isFalse);
   });
 }

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -271,4 +271,36 @@ void main() {
     expect(pipeline.processed, isEmpty);
     expect(worker.isSuspended, isFalse);
   });
+
+  // Scheduling and the UI signal are separate concerns. A preflight that
+  // could not answer must not accuse the store, but it still leaves due rows
+  // with nothing to pick them up: earliestPendingWakeup ignores due rows, so
+  // without this the offline case reproduced the stall this PR exists to fix.
+  test('a drain blocked by a thrown preflight still arms a retry', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    var offline = true;
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async {
+        if (offline) {
+          throw const MediaStoreException(
+            'Could not reach S3 endpoint',
+            kind: MediaStoreErrorKind.transient,
+          );
+        }
+        return true;
+      },
+      preflightRetryWindow: const Duration(milliseconds: 20),
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+
+    expect(worker.isSuspended, isFalse, reason: 'the store is not at fault');
+    expect(worker.wakeupDelayForTesting, const Duration(milliseconds: 20));
+
+    offline = false;
+    await waitUntil(() async => pipeline.processed.contains('m1'));
+  });
 }

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -16,6 +16,7 @@ import 'package:submersion/features/media_store/data/media_upload_pipeline.dart'
 
 import '../../helpers/in_memory_media_object_store.dart';
 import '../../helpers/test_database.dart';
+import '../../helpers/wait_until.dart';
 
 class _RecordingPipeline extends MediaUploadPipeline {
   _RecordingPipeline({
@@ -36,21 +37,6 @@ class _RecordingPipeline extends MediaUploadPipeline {
     await queueRef.markDone(entry.id);
     return UploadOutcome.uploaded;
   }
-}
-
-/// Polls [condition] until true or [within] elapses; the retry wakeup fires
-/// on a real timer, so a fixed sleep would either flake under load or pad
-/// every run.
-Future<bool> _waitFor(
-  bool Function() condition, {
-  Duration within = const Duration(seconds: 5),
-}) async {
-  final deadline = DateTime.now().add(within);
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return true;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  return condition();
 }
 
 void main() {
@@ -190,7 +176,7 @@ void main() {
     expect(worker.wakeupDelayForTesting, const Duration(milliseconds: 20));
 
     verified = true;
-    expect(await _waitFor(() => pipeline.processed.contains('m1')), isTrue);
+    await waitUntil(() async => pipeline.processed.contains('m1'));
   });
 
   test('a suspended drain with nothing queued arms no retry', () async {

--- a/test/features/media_store/media_store_worker_preflight_test.dart
+++ b/test/features/media_store/media_store_worker_preflight_test.dart
@@ -38,6 +38,21 @@ class _RecordingPipeline extends MediaUploadPipeline {
   }
 }
 
+/// Polls [condition] until true or [within] elapses; the retry wakeup fires
+/// on a real timer, so a fixed sleep would either flake under load or pad
+/// every run.
+Future<bool> _waitFor(
+  bool Function() condition, {
+  Duration within = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(within);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return condition();
+}
+
 void main() {
   late MediaRepository mediaRepository;
   late LocalCacheDatabase cacheDb;
@@ -154,4 +169,81 @@ void main() {
       expect(pipeline.processed, ['m1']);
     },
   );
+
+  // Issue #1356: a failed preflight left every due row untouched and armed
+  // no wakeup (earliestPendingWakeup ignores due rows), so the queue sat at
+  // "Waiting" until an external trigger re-ran the same failing check.
+  test('a suspended drain arms a retry so the queue recovers without an '
+      'external kick', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    var verified = false;
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => verified,
+      preflightRetryWindow: const Duration(milliseconds: 20),
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+    expect(pipeline.processed, isEmpty);
+    expect(worker.wakeupDelayForTesting, const Duration(milliseconds: 20));
+
+    verified = true;
+    expect(await _waitFor(() => pipeline.processed.contains('m1')), isTrue);
+  });
+
+  test('a suspended drain with nothing queued arms no retry', () async {
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => false,
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+    expect(worker.wakeupDelayForTesting, isNull);
+  });
+
+  test('the suspension is observable and clears once the preflight '
+      'passes', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    var verified = false;
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => verified,
+    );
+    addTearDown(worker.dispose);
+    final seen = <bool>[];
+    final sub = worker.suspensionChanges.listen(seen.add);
+    addTearDown(sub.cancel);
+
+    expect(worker.isSuspended, isFalse);
+    await worker.drain();
+    expect(worker.isSuspended, isTrue);
+
+    verified = true;
+    await worker.drain();
+    expect(worker.isSuspended, isFalse);
+    expect(pipeline.processed, ['m1']);
+    await Future<void>.delayed(Duration.zero);
+    expect(seen, [true, false]);
+  });
+
+  test('a preflight that throws reads as suspended too', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: pipeline,
+      preflight: () async => throw const MediaStoreException(
+        'get smv1/store.json failed',
+        kind: MediaStoreErrorKind.transient,
+      ),
+    );
+    addTearDown(worker.dispose);
+
+    await worker.drain();
+    expect(worker.isSuspended, isTrue);
+  });
 }

--- a/test/features/media_store/media_store_worker_wakeup_test.dart
+++ b/test/features/media_store/media_store_worker_wakeup_test.dart
@@ -203,9 +203,12 @@ void main() {
   );
 
   // The constraint the immediate wakeup must not break: a drain that declined
-  // to run leaves its due row behind on purpose, and arming a timer for it
-  // would spin that timer against a drain that keeps declining.
-  test('a preflight-suspended drain arms no wakeup for a due row', () async {
+  // to run leaves its due row behind on purpose, and an immediate timer for
+  // it would spin against a drain that keeps declining. A suspended drain
+  // gets the preflight retry window instead (issue #1356): far enough out
+  // not to spin, and the only thing that lets the queue recover on its own.
+  test('a preflight-suspended drain arms the retry window, not an immediate '
+      'wakeup', () async {
     final suspended = MediaStoreWorker(
       queue: queue,
       pipeline: pipeline,
@@ -216,9 +219,16 @@ void main() {
 
     await suspended.drain();
 
-    expect(suspended.wakeupDelayForTesting, isNull);
+    expect(
+      suspended.wakeupDelayForTesting,
+      MediaStoreWorker.defaultPreflightRetryWindow,
+    );
     await Future<void>.delayed(const Duration(milliseconds: 150));
-    expect(pipeline.processed, isEmpty, reason: 'no timer should have fired');
+    expect(
+      pipeline.processed,
+      isEmpty,
+      reason: 'no immediate timer should have fired',
+    );
   });
 
   test('a gate-stopped drain arms no wakeup for a due row', () async {

--- a/test/features/media_store/media_store_worker_wakeup_test.dart
+++ b/test/features/media_store/media_store_worker_wakeup_test.dart
@@ -14,6 +14,7 @@ import 'package:submersion/features/media_store/data/media_upload_pipeline.dart'
 
 import '../../helpers/in_memory_media_object_store.dart';
 import '../../helpers/test_database.dart';
+import '../../helpers/wait_until.dart';
 
 class _RecordingPipeline extends MediaUploadPipeline {
   _RecordingPipeline({
@@ -64,21 +65,6 @@ class _LaggingQueue extends MediaTransferQueueRepository {
     }
     return entry;
   }
-}
-
-/// Polls [condition] until true or [within] elapses. Condition-based rather
-/// than a fixed sleep: the wakeup fires on a real timer, and a fixed delay
-/// either flakes under load or pads every run.
-Future<bool> _waitFor(
-  bool Function() condition, {
-  Duration within = const Duration(seconds: 5),
-}) async {
-  final deadline = DateTime.now().add(within);
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return true;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  return condition();
 }
 
 void main() {
@@ -148,11 +134,7 @@ void main() {
     await worker.drain();
     expect(pipeline.processed, isEmpty, reason: 'not due at drain time');
 
-    expect(
-      await _waitFor(() => pipeline.processed.isNotEmpty),
-      isTrue,
-      reason: 'wakeup timer should have re-drained the row',
-    );
+    await waitUntil(() async => pipeline.processed.isNotEmpty);
     expect(pipeline.processed, ['m1']);
   });
 
@@ -194,11 +176,7 @@ void main() {
         reason: 'not due at drain time',
       );
 
-      expect(
-        await _waitFor(() => laggingPipeline.processed.isNotEmpty),
-        isTrue,
-        reason: 'the row came due during the drain and must still be picked up',
-      );
+      await waitUntil(() async => laggingPipeline.processed.isNotEmpty);
     },
   );
 
@@ -287,11 +265,7 @@ void main() {
     pipeline.gate = Completer<void>();
 
     final draining = worker.drain();
-    expect(
-      await _waitFor(() => pipeline.processed.isNotEmpty),
-      isTrue,
-      reason: 'the drain should be parked inside process()',
-    );
+    await waitUntil(() async => pipeline.processed.isNotEmpty);
 
     worker.dispose();
     pipeline.gate!.complete();

--- a/test/features/media_store/media_transfer_labels_provider_test.dart
+++ b/test/features/media_store/media_transfer_labels_provider_test.dart
@@ -109,4 +109,22 @@ void main() {
     expect(labels(), isEmpty);
     expect(media.calls, 0);
   });
+
+  // The pipeline stamps the media row of every completed upload, so a
+  // subscription to the media table re-ran this query about three times a
+  // second through a drain, over every id the queue had ever named.
+  test('a write to the media table does not re-run the query', () async {
+    final a = await insertMedia('a.jpg');
+    final sub = container.listen(mediaTransferLabelsProvider, (_, _) {});
+    addTearDown(sub.close);
+    await queue.enqueueUpload(mediaId: a);
+    await waitUntil(() async => labels()?[a] == 'a.jpg');
+    expect(media.calls, 1);
+
+    await insertMedia('c.jpg');
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(media.calls, 1);
+    expect(labels(), {a: 'a.jpg'});
+  });
 }

--- a/test/features/media_store/media_transfer_labels_provider_test.dart
+++ b/test/features/media_store/media_transfer_labels_provider_test.dart
@@ -1,0 +1,116 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/entities/media_source_type.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+import '../../helpers/test_database.dart';
+import '../../helpers/wait_until.dart';
+
+/// Counts label lookups so a test can tell one batched query from one per
+/// queue emission.
+class _CountingRepository extends MediaRepository {
+  int calls = 0;
+
+  @override
+  Future<Map<String, String>> getDisplayLabels(Iterable<String> ids) {
+    calls++;
+    return super.getDisplayLabels(ids);
+  }
+}
+
+/// Labels for the Transfers list: one query for the whole queue, re-run only
+/// when the set of media the queue names changes (Copilot review on #1388:
+/// a lookup per visible row re-ran on every media write and pinned a full
+/// MediaItem per row for the container's lifetime).
+void main() {
+  late LocalCacheDatabase cacheDb;
+  late MediaTransferQueueRepository queue;
+  late _CountingRepository media;
+  late ProviderContainer container;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    media = _CountingRepository();
+    container = ProviderContainer(
+      overrides: [
+        mediaTransferQueueRepositoryProvider.overrideWithValue(queue),
+        mediaRepositoryProvider.overrideWithValue(media),
+      ],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await cacheDb.close();
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertMedia(String name) async {
+    final created = await media.createMedia(
+      MediaItem(
+        id: '',
+        mediaType: MediaType.photo,
+        sourceType: MediaSourceType.localFile,
+        filePath: '/tmp/$name',
+        localPath: '/tmp/$name',
+        originalFilename: name,
+        takenAt: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+      ),
+    );
+    return created.id;
+  }
+
+  Map<String, String>? labels() =>
+      container.read(mediaTransferLabelsProvider).value;
+
+  test('names the queued media with one query, and re-queries only when the '
+      'queue names different media', () async {
+    final a = await insertMedia('a.jpg');
+    final b = await insertMedia('b.jpg');
+    final sub = container.listen(mediaTransferLabelsProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    final entryA = await queue.enqueueUpload(mediaId: a);
+    await waitUntil(() async => labels()?[a] == 'a.jpg');
+    expect(media.calls, 1);
+
+    // A state change re-emits the rows but names the same media.
+    await queue.markTransferring(entryA);
+    await waitUntil(
+      () async =>
+          container
+              .read(mediaTransferEntriesProvider)
+              .value
+              ?.single
+              .state ==
+          'transferring',
+    );
+    expect(media.calls, 1);
+
+    await queue.enqueueUpload(mediaId: b);
+    await waitUntil(() async => labels()?[b] == 'b.jpg');
+    expect(labels(), {a: 'a.jpg', b: 'b.jpg'});
+    expect(media.calls, 2);
+  });
+
+  test('an empty queue resolves to no labels without querying', () async {
+    final sub = container.listen(mediaTransferLabelsProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    await waitUntil(() async => labels() != null);
+    expect(labels(), isEmpty);
+    expect(media.calls, 0);
+  });
+}

--- a/test/features/media_store/media_transfer_labels_provider_test.dart
+++ b/test/features/media_store/media_transfer_labels_provider_test.dart
@@ -90,11 +90,7 @@ void main() {
     await queue.markTransferring(entryA);
     await waitUntil(
       () async =>
-          container
-              .read(mediaTransferEntriesProvider)
-              .value
-              ?.single
-              .state ==
+          container.read(mediaTransferEntriesProvider).value?.single.state ==
           'transferring',
     );
     expect(media.calls, 1);

--- a/test/features/media_store/media_transfers_suspended_provider_test.dart
+++ b/test/features/media_store/media_transfers_suspended_provider_test.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:submersion/core/database/local_cache_database.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+import 'package:submersion/features/media/data/resolvers/media_store_resolver.dart';
+import 'package:submersion/features/media/data/services/media_source_resolver_registry.dart';
+import 'package:submersion/features/media_store/data/media_cache_store.dart';
+import 'package:submersion/features/media_store/data/media_store_worker.dart';
+import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
+import 'package:submersion/features/media_store/data/media_upload_pipeline.dart';
+import 'package:submersion/features/media_store/presentation/providers/media_store_providers.dart';
+
+import '../../helpers/in_memory_media_object_store.dart';
+import '../../helpers/test_database.dart';
+
+/// Polls [condition] until true or [within] elapses.
+Future<bool> _waitFor(
+  bool Function() condition, {
+  Duration within = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(within);
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  return condition();
+}
+
+/// The settings pages read the worker's suspension through this provider
+/// (issue #1356); it must follow the live worker, not a snapshot.
+void main() {
+  late LocalCacheDatabase cacheDb;
+  late Directory root;
+  late MediaTransferQueueRepository queue;
+  late InMemoryMediaObjectStore store;
+  late MediaCacheStore cache;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await setUpTestDatabase();
+    cacheDb = LocalCacheDatabase(NativeDatabase.memory());
+    root = await Directory.systemTemp.createTemp('suspended_provider');
+    queue = MediaTransferQueueRepository(database: cacheDb);
+    store = InMemoryMediaObjectStore();
+    cache = MediaCacheStore(database: cacheDb, root: root);
+  });
+
+  tearDown(() async {
+    await cacheDb.close();
+    if (root.existsSync()) await root.delete(recursive: true);
+    await tearDownTestDatabase();
+  });
+
+  test(
+    'follows the worker as its preflight starts failing and recovers',
+    () async {
+      await queue.enqueueUpload(mediaId: 'm1');
+      var verified = false;
+      final worker = MediaStoreWorker(
+        queue: queue,
+        pipeline: MediaUploadPipeline(
+          mediaRepository: MediaRepository(),
+          queue: queue,
+          store: store,
+          registry: MediaSourceResolverRegistry({}),
+          cache: cache,
+        ),
+        preflight: () async => verified,
+      );
+      addTearDown(worker.dispose);
+      final runtime = MediaStoreRuntime(
+        storeId: 'a',
+        store: store,
+        cache: cache,
+        resolver: MediaStoreResolver(store: store, cache: cache),
+        worker: worker,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          mediaStoreRuntimeProvider.overrideWith((ref) async => runtime),
+        ],
+      );
+      addTearDown(container.dispose);
+      final sub = container.listen(mediaTransfersSuspendedProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      expect(
+        await container.read(mediaTransfersSuspendedProvider.future),
+        isFalse,
+      );
+
+      await worker.drain();
+      expect(
+        await _waitFor(
+          () => container.read(mediaTransfersSuspendedProvider).value == true,
+        ),
+        isTrue,
+      );
+
+      verified = true;
+      await worker.drain();
+      expect(
+        await _waitFor(
+          () => container.read(mediaTransfersSuspendedProvider).value == false,
+        ),
+        isTrue,
+      );
+    },
+  );
+}

--- a/test/features/media_store/media_transfers_suspended_provider_test.dart
+++ b/test/features/media_store/media_transfers_suspended_provider_test.dart
@@ -95,4 +95,49 @@ void main() {
       );
     },
   );
+
+  // The runtime fires its first drain before any reader can subscribe, and
+  // _setSuspended never repeats a value. A reader that sampled isSuspended
+  // and then subscribed lost a flip that landed in between, and nothing
+  // re-sent it: the queue stayed suspended with no notice, which is the
+  // symptom #1356 reported.
+  test('a reader that arrives after the flip still sees it', () async {
+    await queue.enqueueUpload(mediaId: 'm1');
+    final worker = MediaStoreWorker(
+      queue: queue,
+      pipeline: MediaUploadPipeline(
+        mediaRepository: MediaRepository(),
+        queue: queue,
+        store: store,
+        registry: MediaSourceResolverRegistry({}),
+        cache: cache,
+      ),
+      preflight: () async => false,
+    );
+    addTearDown(worker.dispose);
+    await worker.drain();
+    expect(worker.isSuspended, isTrue);
+
+    final container = ProviderContainer(
+      overrides: [
+        mediaStoreRuntimeProvider.overrideWith(
+          (ref) async => MediaStoreRuntime(
+            storeId: 'a',
+            store: store,
+            cache: cache,
+            resolver: MediaStoreResolver(store: store, cache: cache),
+            worker: worker,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final sub = container.listen(mediaTransfersSuspendedProvider, (_, _) {});
+    addTearDown(sub.close);
+
+    expect(
+      await container.read(mediaTransfersSuspendedProvider.future),
+      isTrue,
+    );
+  });
 }

--- a/test/features/media_store/media_transfers_suspended_provider_test.dart
+++ b/test/features/media_store/media_transfers_suspended_provider_test.dart
@@ -16,19 +16,7 @@ import 'package:submersion/features/media_store/presentation/providers/media_sto
 
 import '../../helpers/in_memory_media_object_store.dart';
 import '../../helpers/test_database.dart';
-
-/// Polls [condition] until true or [within] elapses.
-Future<bool> _waitFor(
-  bool Function() condition, {
-  Duration within = const Duration(seconds: 5),
-}) async {
-  final deadline = DateTime.now().add(within);
-  while (DateTime.now().isBefore(deadline)) {
-    if (condition()) return true;
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-  }
-  return condition();
-}
+import '../../helpers/wait_until.dart';
 
 /// The settings pages read the worker's suspension through this provider
 /// (issue #1356); it must follow the live worker, not a snapshot.
@@ -94,20 +82,16 @@ void main() {
       );
 
       await worker.drain();
-      expect(
-        await _waitFor(
-          () => container.read(mediaTransfersSuspendedProvider).value == true,
-        ),
-        isTrue,
+      await waitUntil(
+        () async =>
+            container.read(mediaTransfersSuspendedProvider).value == true,
       );
 
       verified = true;
       await worker.drain();
-      expect(
-        await _waitFor(
-          () => container.read(mediaTransfersSuspendedProvider).value == false,
-        ),
-        isTrue,
+      await waitUntil(
+        () async =>
+            container.read(mediaTransfersSuspendedProvider).value == false,
       );
     },
   );

--- a/test/features/media_store/transfers_page_delete_tile_test.dart
+++ b/test/features/media_store/transfers_page_delete_tile_test.dart
@@ -26,6 +26,14 @@ void main() {
   Widget app(MediaTransferQueueData row) => ProviderScope(
     overrides: [
       mediaTransferEntriesProvider.overrideWith((ref) => Stream.value([row])),
+      // Without these the page builds the real runtime and reaches for a
+      // database and SharedPreferences neither of which this test sets up;
+      // it passed only because both widgets swallow the failure.
+      mediaStoreRuntimeProvider.overrideWith((ref) async => null),
+      mediaTransferLabelsProvider.overrideWith((ref) async => const {}),
+      mediaTransfersSuspendedProvider.overrideWith(
+        (ref) => Stream.value(false),
+      ),
     ],
     child: const MaterialApp(
       locale: Locale('en'),

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -6,8 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
 import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
-import 'package:submersion/features/media/domain/entities/media_item.dart';
-import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/pages/transfers_page.dart';
@@ -53,7 +51,7 @@ void main() {
 
   Widget app(
     List<MediaTransferQueueEntry> entries, {
-    Map<String, MediaItem> media = const {},
+    Map<String, String> labels = const {},
     bool suspended = false,
   }) => ProviderScope(
     overrides: [
@@ -63,7 +61,7 @@ void main() {
       mediaStoreRuntimeProvider.overrideWith((ref) async => null),
       // The rows name their media; without this the lookup would reach for
       // an uninitialised database.
-      mediaByIdProvider.overrideWith((ref, id) async => media[id]),
+      mediaTransferLabelsProvider.overrideWith((ref) async => labels),
       mediaTransfersSuspendedProvider.overrideWith(
         (ref) => Stream.value(suspended),
       ),
@@ -478,16 +476,8 @@ void main() {
       await repo.enqueueUpload(mediaId: 'm-a');
       snapshot = await repo.watchEntries().first;
     });
-    final photo = MediaItem(
-      id: 'm-a',
-      originalFilename: 'IMG_0042.HEIC',
-      mediaType: MediaType.photo,
-      takenAt: DateTime(2026, 8, 1),
-      createdAt: DateTime(2026, 8, 1),
-      updatedAt: DateTime(2026, 8, 1),
-    );
 
-    await tester.pumpWidget(app(snapshot, media: {'m-a': photo}));
+    await tester.pumpWidget(app(snapshot, labels: {'m-a': 'IMG_0042.HEIC'}));
     await tester.pump();
     await tester.pump();
 

--- a/test/features/media_store/transfers_page_test.dart
+++ b/test/features/media_store/transfers_page_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/local_cache_database.dart';
 import 'package:submersion/features/media/data/repositories/local_asset_cache_repository.dart';
+import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/resolved_asset_providers.dart';
 import 'package:submersion/features/media_store/data/media_transfer_queue_repository.dart';
 import 'package:submersion/features/media_store/presentation/pages/transfers_page.dart';
@@ -49,12 +51,22 @@ void main() {
 
   tearDown(() => db.close());
 
-  Widget app(List<MediaTransferQueueEntry> entries) => ProviderScope(
+  Widget app(
+    List<MediaTransferQueueEntry> entries, {
+    Map<String, MediaItem> media = const {},
+    bool suspended = false,
+  }) => ProviderScope(
     overrides: [
       mediaTransferQueueRepositoryProvider.overrideWithValue(repo),
       localAssetCacheRepositoryProvider.overrideWithValue(assetCache),
       mediaTransferEntriesProvider.overrideWith((ref) => Stream.value(entries)),
       mediaStoreRuntimeProvider.overrideWith((ref) async => null),
+      // The rows name their media; without this the lookup would reach for
+      // an uninitialised database.
+      mediaByIdProvider.overrideWith((ref, id) async => media[id]),
+      mediaTransfersSuspendedProvider.overrideWith(
+        (ref) => Stream.value(suspended),
+      ),
     ],
     child: const MaterialApp(
       // Pinned: these tests find widgets by their English strings.
@@ -456,5 +468,64 @@ void main() {
     await pumpRoute(tester);
 
     expect(builds, 1);
+  });
+
+  // Issue #1356: the reporter's queue read as a column of bare UUIDs. The row
+  // carries only the media id; the file name lives on the media row.
+  testWidgets('rows name the media file rather than its id', (tester) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      await repo.enqueueUpload(mediaId: 'm-a');
+      snapshot = await repo.watchEntries().first;
+    });
+    final photo = MediaItem(
+      id: 'm-a',
+      originalFilename: 'IMG_0042.HEIC',
+      mediaType: MediaType.photo,
+      takenAt: DateTime(2026, 8, 1),
+      createdAt: DateTime(2026, 8, 1),
+      updatedAt: DateTime(2026, 8, 1),
+    );
+
+    await tester.pumpWidget(app(snapshot, media: {'m-a': photo}));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('IMG_0042.HEIC'), findsOneWidget);
+    expect(find.text('m-a'), findsNothing);
+  });
+
+  testWidgets('a row whose media is unknown falls back to the id', (
+    tester,
+  ) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      await repo.enqueueUpload(mediaId: 'm-a');
+      snapshot = await repo.watchEntries().first;
+    });
+
+    await tester.pumpWidget(app(snapshot));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('m-a'), findsOneWidget);
+  });
+
+  testWidgets('a suspended queue shows the paused notice above the list', (
+    tester,
+  ) async {
+    late List<MediaTransferQueueEntry> snapshot;
+    await tester.runAsync(() async {
+      await repo.enqueueUpload(mediaId: 'm-a');
+      snapshot = await repo.watchEntries().first;
+    });
+
+    await tester.pumpWidget(app(snapshot, suspended: true));
+    // Two frames: the list, then the suspension stream's first value.
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Transfers paused'), findsOneWidget);
+    expect(find.text('Waiting'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #1356

## Summary

A user with iCloud as the media store on both a Mac and an iPhone reported that the Mac's Transfers page listed every upload as "Waiting" over an alphanumeric name, forever, and that the Mac's folder-imported photos never appeared on the phone (#1356). A commenter (the reporter of #1270) added that a "reconnect cloud storage" prompt appeared first, and that disconnecting and reconnecting iCloud media storage cleared the queue.

Two parts of that report were already fixed: the never-restarting queue (#1270, PR #1283) shipped in 1.7.6, eight hours before the issue was filed from 1.7.5, and the phone-side "File not found" tiles are #1370. What remained live on `main` is a third mechanism, and it is what the reconnect workaround was papering over.

### Root cause: a two-device iCloud attach splits the store's identity

`StoreMarkerStore.ensure()` reads `smv1/store.json` and, on `notFound`, mints a fresh store id and writes a new marker. On S3 "not found" is authoritative. On iCloud it was not: the native `downloadIfNeeded` answers `false` only when a placeholder exists and its 12 s download poll expired, meaning iCloud definitely has the file, yet `ICloudMediaObjectStore.getFile` mapped that to `notFound`. So the second device to connect (the phone) minted marker B and overwrote the Mac's marker A before it had finished downloading.

From then on the Mac's preflight read B != A and returned false before every entry. That left each row `pending` with no error text (hence "Waiting" and the raw `mediaId` subtitle, and no Retry button), wrote nothing to the queue, and armed no wakeup, because `earliestPendingWakeup` deliberately skips rows that are already due. The pending-setup card meanwhile showed "Connect media storage (iCloud)" (the synced descriptor said B, the attach pref said A), which is the prompt the commenter saw. Reconnecting read the now-downloaded B and attached to it by hand.

### Changes

- `ICloudMediaObjectStore.getFile` reports a placeholder that would not download in time as `transient`, not `notFound`. `ensure()` already rethrows anything that is not `notFound`, so a connect that hits this fails with a snackbar instead of minting over another device's marker. `head` is unchanged (it answers null, so an upload re-sends bytes rather than burning attempts). The `DirectoryICloudMediaPlatform` test fake now mirrors the native contract (always true; the adapter's own `exists()` check reports a missing key).
- `head` draws the same distinction, so the second device does not re-upload a library the container already holds.
- `StoreMarkerStore.ensure` confirms an absent marker with a listing before minting. This is what covers the reported race rather than only its tail: the native download check answers "nothing to do" for a path this device has never heard of, so a marker whose metadata has not arrived reads as absent, and a listing is the one call that makes the adapter go and look (the iCloud adapter refreshes the container folder first).
- The runtime's inline preflight closure is extracted into `MediaStorePreflight`. It suspends on a mismatch and leaves the decision to the user, which is what design spec section 13 asks for until the Phase 5 guided flows (adopt / rebuild / detach) exist.
- `MediaStoreWorker` arms a `preflightRetryWindow` (10 min, injectable) after a suspended drain while anything is pending, so a marker that was merely slow to download clears on its own, and exposes `isSuspended` / `suspensionChanges`. The existing "arms no wakeup" test was about the immediate timer spinning; it now asserts the window.
- Suspension is reported only for a determinate refusal, never for a preflight that could not answer: the drain checks it before the network gate, so an ordinary offline moment must not read as a store fault. `mediaTransfersSuspendedProvider` feeds a `MediaTransfersSuspendedNotice` ("Transfers paused" with what to do) on the Media Storage summary row and above the Transfers list, so a suspended queue no longer reads as "N queued" with nothing else to go on.
- Transfers rows name their media (`originalFilename`, else caption, else the id) instead of the bare UUID.
- Connecting retries the identity marker on a transient answer (2s, 4s, injectable) rather than refusing outright: `downloadIfNeeded` collapses every native failure to false, so a container whose `store.json` was still coming down would otherwise fail the connect. A transient answer that survives the retries is reported as a localized "not ready yet" message instead of a developer string naming an object key, on the connect paths only, since Test Connection and Verify Library are diagnostics whose raw reason is the point.
- Scheduling keys off "the preflight blocked this drain", true for a refusal and for a preflight that could not answer; `isSuspended` keeps speaking only for the store, so an offline blip neither accuses the store nor strands its due rows.
- Three new l10n keys in all 11 ARBs; `flutter gen-l10n` run last.

### What a review round removed

An earlier revision let the preflight adopt a foreign iCloud marker automatically. A max-effort review found four failure modes, each verified before acting: the adoption minted a `media_stores` row with a null `last_sweep_at`, and `shouldAutoVerify` treats null as due, so the next unmetered launch ran an unattended Verify Library sweep that deletes objects whose content hash the adopting device does not yet know, i.e. the peer's originals; the adoption could land after the user disconnected; it stranded a concurrently live runtime on the old id; and `media` rows carry no store id, so every `remoteUploadedAt` stamp survived it and kept reading "backed up" while pointing into a store the objects were never in.

The same review found the notice's only advice, disconnect and reconnect, is exactly what silently adopts a foreign marker on S3, Dropbox and Drive, since `ensure()` returns an existing marker. Both are gone. Recovery for a library already split is the manual reconnect, which is what the reporter and the commenter both did, and the notice now describes what reconnecting will do instead of recommending it blind.

### Deliberately left alone

- The native side. `NSMetadataQuery` would let a connect wait for the container's metadata rather than confirming absence with a listing and moving on; that needs two-device hardware to verify.
- Adoption as a guided flow (spec section 13's Phase 5). This PR makes the mismatch visible and safe; choosing what to do about it is its own piece of work.
- The macOS "Saved to iCloud" list question in the report: neither Info.plist declares `NSUbiquitousContainers`, so the container is private and has no iCloud Drive folder, which is what macOS lists; iOS lists every entitled app. Making it public would expose the raw object tree in Finder.

## Test plan

- New: adapter (undownloadable placeholder is transient; never-held key stays notFound); connect flow with a real `ICloudMediaObjectStore` over an undownloadable container (throws transient, other device's marker survives byte for byte); `adoptICloudStore`; `MediaStorePreflight` (match, detached, changed attachment, foreign marker with and without adoption, missing marker never adopted, read failure propagates); worker (retry window fires and recovers, nothing queued arms nothing, suspension observable and clears, throw reads as suspended); suspension provider (false without a runtime, follows a live worker); paused notice on both pages; rows show the file name and fall back to the id.
- `flutter analyze` clean, `dart format` clean, `test/l10n` and `test/architecture` green.
- Full `flutter test` run once in the worktree: 22,045 passed, 20 skipped, 2 failed, both in files this branch does not touch and both green on a lone rerun (`concurrent_connection_lock_test.dart`, a cross-isolate `busy_timeout` timing case that only fails under a full run; `local_file_resolver_test.dart`, which fails on any machine whose `TMPDIR` is a mounted RAM disk and passed with a system-volume `TMPDIR`).
- Not done: two-device hardware smoke, tracked as #1393 with the cases to run. To reproduce: connect iCloud media storage on device A, then on device B within a minute or two; before this change B's queue drains and A's reads "Waiting" until A reconnects.
