### PR TITLE
fix(dive-edit): keep fields the form does not display on save

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -4967,6 +4967,22 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         // Preserve legacy buddy/divemaster text fields
         buddy: _existingDive?.buddy,
         diveMaster: _existingDive?.diveMaster,
+        // Fields this form has no widget for. updateDive writes every column
+        // from the entity it is handed, so anything not carried through here
+        // is reset to the entity default on every save (issue #1392). The
+        // census test in dive_edit_save_field_census_test.dart fails when a
+        // new field is added to the writer without being carried here.
+        isPlanned: _existingDive?.isPlanned ?? false,
+        diveComputerModel: _existingDive?.diveComputerModel,
+        diveComputerSerial: _existingDive?.diveComputerSerial,
+        diveComputerFirmware: _existingDive?.diveComputerFirmware,
+        decoAlgorithm: _existingDive?.decoAlgorithm,
+        decoConservatism: _existingDive?.decoConservatism,
+        gradientFactorLow: _existingDive?.gradientFactorLow,
+        gradientFactorHigh: _existingDive?.gradientFactorHigh,
+        weatherCode: _existingDive?.weatherCode,
+        importId: _existingDive?.importId,
+        surfaceInterval: _existingDive?.surfaceInterval,
         diverRoleId: _diverRoleId,
         // CCR/SCR rebreather settings
         diveMode: _diveMode,

--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -4967,11 +4967,13 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
         // Preserve legacy buddy/divemaster text fields
         buddy: _existingDive?.buddy,
         diveMaster: _existingDive?.diveMaster,
-        // Fields this form has no widget for. updateDive writes every column
-        // from the entity it is handed, so anything not carried through here
-        // is reset to the entity default on every save (issue #1392). The
-        // census test in dive_edit_save_field_census_test.dart fails when a
-        // new field is added to the writer without being carried here.
+        // Fields this form has no widget for. Every column updateDive does
+        // write, it writes unconditionally, with no merge against the stored
+        // row, so anything not carried through here is reset to the entity
+        // default on every save (issue #1392). Columns it deliberately omits
+        // (computerId, the entry/exit location pair) are not at risk and are
+        // not listed. The census test in dive_edit_save_field_census_test.dart
+        // fails when a new field is added to the writer without a carry here.
         isPlanned: _existingDive?.isPlanned ?? false,
         diveComputerModel: _existingDive?.diveComputerModel,
         diveComputerSerial: _existingDive?.diveComputerSerial,

--- a/test/features/dive_log/presentation/pages/dive_edit_preserves_hidden_fields_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_preserves_hidden_fields_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/shared/widgets/forms/form_row.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Widget-level regression for issue #1392:
+/// "Saving a dive in the editor silently resets dive computer, deco and
+/// planned-dive fields".
+///
+/// The edit form owns a subset of the dive's columns. Everything else on the
+/// row (where the dive was downloaded from, the deco settings it ran on, the
+/// planner flag that keeps it out of statistics) must survive a save untouched,
+/// because `DiveRepository.updateDive` writes every column from the entity it
+/// is handed. This drives the real edit flow against a real database so the
+/// assertion is on the stored row, not on what the form thinks it sent.
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<void> pumpEditor(
+    WidgetTester tester,
+    String diveId, {
+    void Function(String)? onSaved,
+  }) async {
+    tester.view.physicalSize = const Size(950, 8000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final overrides = await getBaseOverrides();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...overrides.cast<Override>(),
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DiveEditPage(
+              diveId: diveId,
+              embedded: true,
+              onSaved: onSaved,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'saving an edited dive keeps the fields the form does not display',
+    (tester) async {
+      // Every value here is one the edit form has no widget for. Each is set
+      // to something other than the entity default so a reset is visible.
+      final dive = await repository.createDive(
+        Dive(
+          id: 'dive-1392',
+          name: 'Original name',
+          dateTime: DateTime.utc(2026, 5, 1, 10),
+          maxDepth: 30.0,
+          isPlanned: true,
+          diveComputerModel: 'Shearwater Perdix 2',
+          diveComputerSerial: 'SN-1392',
+          diveComputerFirmware: '93',
+          decoAlgorithm: 'buhlmann',
+          decoConservatism: 2,
+          gradientFactorLow: 40,
+          gradientFactorHigh: 85,
+          weatherCode: 61,
+          importId: 'import-1392',
+          surfaceInterval: const Duration(hours: 1, minutes: 30),
+        ),
+      );
+
+      // Sanity: the repository round-trips all of these, so a later reset can
+      // only come from the save path.
+      final stored = (await repository.getDiveById(dive.id))!;
+      expect(stored.isPlanned, isTrue);
+      expect(stored.diveComputerModel, 'Shearwater Perdix 2');
+      expect(stored.surfaceInterval, const Duration(hours: 1, minutes: 30));
+
+      String? savedId;
+      await pumpEditor(tester, dive.id, onSaved: (id) => savedId = id);
+
+      // Change one field the form does own, which is the reproduction in the
+      // issue and also guarantees the Save button is enabled. A FormRow.text
+      // stays collapsed until tapped, so open it before typing.
+      final nameRow = find
+          .ancestor(of: find.text('Name'), matching: find.byType(FormRow))
+          .first;
+      await tester.ensureVisible(nameRow);
+      await tester.pumpAndSettle();
+      await tester.tap(nameRow);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.descendant(of: nameRow, matching: find.byType(TextField)),
+        'Renamed',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(savedId, isNotNull, reason: 'save should complete');
+
+      final reloaded = (await repository.getDiveById(dive.id))!;
+      expect(reloaded.name, 'Renamed', reason: 'the edited field is applied');
+
+      expect(reloaded.isPlanned, isTrue, reason: 'isPlanned reset');
+      expect(
+        reloaded.diveComputerModel,
+        'Shearwater Perdix 2',
+        reason: 'diveComputerModel reset',
+      );
+      expect(
+        reloaded.diveComputerSerial,
+        'SN-1392',
+        reason: 'diveComputerSerial reset',
+      );
+      expect(
+        reloaded.diveComputerFirmware,
+        '93',
+        reason: 'diveComputerFirmware reset',
+      );
+      expect(reloaded.decoAlgorithm, 'buhlmann', reason: 'decoAlgorithm reset');
+      expect(reloaded.decoConservatism, 2, reason: 'decoConservatism reset');
+      expect(reloaded.gradientFactorLow, 40, reason: 'gradientFactorLow reset');
+      expect(
+        reloaded.gradientFactorHigh,
+        85,
+        reason: 'gradientFactorHigh reset',
+      );
+      expect(reloaded.weatherCode, 61, reason: 'weatherCode reset');
+      expect(reloaded.importId, 'import-1392', reason: 'importId reset');
+      expect(
+        reloaded.surfaceInterval,
+        const Duration(hours: 1, minutes: 30),
+        reason: 'surfaceInterval reset',
+      );
+    },
+  );
+}

--- a/test/features/dive_log/presentation/pages/dive_edit_preserves_hidden_fields_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_preserves_hidden_fields_test.dart
@@ -39,6 +39,18 @@ void main() {
     String diveId, {
     void Function(String)? onSaved,
   }) async {
+    // The finders below match English literals. flutter_test forwards the
+    // host machine's locale list rather than a fixed en_US, so an unpinned
+    // MaterialApp renders a translated UI for a developer whose primary
+    // locale is one of the eleven this app supports, and every finder misses.
+    // Forcing a non-English host locale here means the pin on MaterialApp
+    // below is load-bearing everywhere, instead of only on those machines:
+    // remove it and this test fails on any runner, CI included.
+    tester.platformDispatcher.localesTestValue = const [
+      Locale('fr'),
+      Locale('en'),
+    ];
+    addTearDown(tester.platformDispatcher.clearLocalesTestValue);
     tester.view.physicalSize = const Size(950, 8000);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -54,6 +66,10 @@ void main() {
           customTankPresetsProvider.overrideWith((ref) async => []),
         ],
         child: MaterialApp(
+          // Pinned: flutter_test forwards the host machine's locale list, so
+          // an unpinned MaterialApp resolves to a translated UI on a
+          // non-English dev machine and every English finder below misses.
+          locale: const Locale('en'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(

--- a/test/features/dive_log/presentation/pages/dive_edit_save_field_census_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_save_field_census_test.dart
@@ -30,6 +30,29 @@ void main() {
         'legacy single weight type; retired together with weightAmount',
   };
 
+  /// The named arguments of the constructor call [literal] belongs to, and
+  /// only those.
+  ///
+  /// A bare `^\s+(\w+):` also matches the arguments of nested constructors
+  /// (`scrubber: ScrubberInfo(type: ..., ratedMinutes: ...)`), which would let
+  /// a future `Dive` field whose name collides with a nested argument pass as
+  /// "named" and slip past this guard. `dart format` puts every top-level
+  /// argument at one indent and indents nested ones strictly further, so the
+  /// shallowest indent is the literal's own argument level. A nested argument
+  /// written on one line is excluded too, because `^` only matches the first
+  /// `name:` on each line.
+  Set<String> topLevelNamedArgs(String literal) {
+    final rows = RegExp(r'^( +)(\w+):', multiLine: true).allMatches(literal);
+    if (rows.isEmpty) return {};
+    final topLevel = rows
+        .map((m) => m.group(1)!.length)
+        .reduce((a, b) => a < b ? a : b);
+    return rows
+        .where((m) => m.group(1)!.length == topLevel)
+        .map((m) => m.group(2)!)
+        .toSet();
+  }
+
   String between(String source, String start, String end, String what) {
     final from = source.indexOf(start);
     expect(from, greaterThanOrEqualTo(0), reason: 'could not find $what');
@@ -75,10 +98,7 @@ void main() {
       '\n      );',
       'the Dive literal in _saveDive',
     );
-    final named = RegExp(
-      r'^\s+(\w+):',
-      multiLine: true,
-    ).allMatches(literal).map((m) => m.group(1)!).toSet();
+    final named = topLevelNamedArgs(literal);
 
     // Guard the parsers themselves: a moved marker must not pass vacuously.
     expect(ctorParams.length, greaterThan(60));
@@ -113,5 +133,35 @@ void main() {
             'updateDive writes; remove it',
       );
     }
+  });
+
+  test('the named-argument parser ignores nested constructor arguments', () {
+    // A field name deliberately shared between the outer literal and a nested
+    // constructor: the collision the census would otherwise be blind to.
+    const literal = '''
+final dive = Dive(
+        id: widget.diveId ?? '',
+        notes: _notesController.text,
+        scrubber: _scrubberType != null
+            ? ScrubberInfo(
+                type: _scrubberType!,
+                ratedMinutes: _scrubberDurationMinutes,
+                notes: 'nested, not a Dive argument',
+              )
+            : null,
+        weights: const [DiveWeight(amountKg: 4, weightType: WeightType.belt)],
+''';
+
+    final named = topLevelNamedArgs(literal);
+
+    expect(named, containsAll(<String>['id', 'notes', 'scrubber', 'weights']));
+    expect(
+      named,
+      isNot(anyElement(isIn(<String>['type', 'ratedMinutes', 'amountKg']))),
+      reason:
+          'arguments of a nested constructor must not count as named by the '
+          'Dive literal, or a Dive field sharing one of their names would '
+          'slip past the census',
+    );
   });
 }

--- a/test/features/dive_log/presentation/pages/dive_edit_save_field_census_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_save_field_census_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Source-level drift guard for issue #1392.
+///
+/// `DiveEditPage._saveDive` builds a fresh `Dive(...)` and
+/// `DiveRepository.updateDive` writes every column it reads off that entity.
+/// Any `Dive` field the writer reads but the form literal never names is
+/// therefore reset to the entity default on every save. The widget test in
+/// `dive_edit_preserves_hidden_fields_test.dart` proves the fields known today
+/// survive; this test makes the next field added to the entity and the writer,
+/// but not to the form, fail here instead of silently wiping data.
+void main() {
+  const entityPath = 'lib/features/dive_log/domain/entities/dive.dart';
+  const repositoryPath =
+      'lib/features/dive_log/data/repositories/dive_repository_impl.dart';
+  const editPagePath =
+      'lib/features/dive_log/presentation/pages/dive_edit_page.dart';
+
+  /// Fields `updateDive` reads that the form is allowed to leave unnamed.
+  /// Every entry needs a reason: either the value reaches the row another way
+  /// or dropping it is the intended migration.
+  const allowed = <String, String>{
+    'tripId': 'updateDive falls back to dive.trip?.id, which the form names',
+    'weightAmount':
+        'legacy single weight; the form migrates it into weights on load '
+        'and saves that list, so the legacy column is retired on purpose',
+    'weightType':
+        'legacy single weight type; retired together with weightAmount',
+  };
+
+  String between(String source, String start, String end, String what) {
+    final from = source.indexOf(start);
+    expect(from, greaterThanOrEqualTo(0), reason: 'could not find $what');
+    final to = source.indexOf(end, from + start.length);
+    expect(to, greaterThan(from), reason: 'could not find the end of $what');
+    return source.substring(from, to);
+  }
+
+  test('every Dive field updateDive writes is named by _saveDive', () {
+    final entity = File(entityPath).readAsStringSync();
+    final repository = File(repositoryPath).readAsStringSync();
+    final editPage = File(editPagePath).readAsStringSync();
+
+    final constructor = between(
+      entity,
+      '  const Dive({',
+      '\n  });',
+      'the Dive constructor',
+    );
+    final ctorParams = RegExp(
+      r'this\.(\w+)',
+    ).allMatches(constructor).map((m) => m.group(1)!).toSet();
+
+    final writer = between(
+      repository,
+      'Future<void> updateDive(domain.Dive dive) async {',
+      '_syncRepository.markRecordPending(',
+      'the updateDive companion write',
+    );
+    final written = RegExp(
+      r'\bdive\.(\w+)',
+    ).allMatches(writer).map((m) => m.group(1)!).toSet();
+
+    final saveMethod = between(
+      editPage,
+      'Future<void> _saveDive(',
+      'ref.read(paginatedDiveListProvider.notifier)',
+      '_saveDive',
+    );
+    final literal = between(
+      saveMethod,
+      'final dive = Dive(',
+      '\n      );',
+      'the Dive literal in _saveDive',
+    );
+    final named = RegExp(
+      r'^\s+(\w+):',
+      multiLine: true,
+    ).allMatches(literal).map((m) => m.group(1)!).toSet();
+
+    // Guard the parsers themselves: a moved marker must not pass vacuously.
+    expect(ctorParams.length, greaterThan(60));
+    expect(written.intersection(ctorParams).length, greaterThan(50));
+    expect(named.length, greaterThan(50));
+
+    final unnamed =
+        written
+            .intersection(ctorParams)
+            .difference(named)
+            .difference(allowed.keys.toSet())
+            .toList()
+          ..sort();
+
+    expect(
+      unnamed,
+      isEmpty,
+      reason:
+          'updateDive writes these Dive fields but _saveDive never names '
+          'them, so every save resets them to the entity default. Carry '
+          'each one through from _existingDive, or add it to the allow '
+          'list in this test with a reason: $unnamed',
+    );
+
+    // The allow list must not outlive its entries.
+    for (final field in allowed.keys) {
+      expect(
+        written.contains(field) && !named.contains(field),
+        isTrue,
+        reason:
+            '$field is on the allow list but is no longer an unnamed field '
+            'updateDive writes; remove it',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Opening a dive in the editor and saving it, without changing anything, silently reset eleven columns to their defaults: the dive computer the dive was downloaded from, its deco settings, the weather code, the import id, the stored surface interval, and the `isPlanned` flag that keeps planner-created dives out of statistics.

`_saveDive` builds a fresh `Dive(...)` and hand-carries a chosen subset of the loaded row, while `DiveRepository.updateDive` writes every column unconditionally from the entity it is handed. Anything the form does not carry takes the entity default and overwrites real data. Same class as #1187 (a partial entity handed to a whole-row writer), one layer up.

The fix stays at the producer. `updateDive` keeps its whole-row contract, which every other caller (altitude enricher, weather repository, planner conversion) relies on; merge-on-null there would make fields unclearable. `Dive.copyWith` was not an option either: it is `??`-based, so it cannot clear a depth or temperature the user blanked out.

The issue listed ten fields. `updateDive` also writes `surfaceIntervalSeconds`, so `surfaceInterval` is the eleventh.

Closes #1392

## Changes

- `dive_edit_page.dart` (`_saveDive`): carry `isPlanned`, `diveComputerModel`, `diveComputerSerial`, `diveComputerFirmware`, `decoAlgorithm`, `decoConservatism`, `gradientFactorLow`, `gradientFactorHigh`, `weatherCode`, `importId` and `surfaceInterval` through from `_existingDive`, next to the existing `isFavorite` / `profile` / `photoIds` carry-throughs.
- `dive_edit_preserves_hidden_fields_test.dart`: real in-memory database round trip. Creates a dive with all eleven fields set to non-default values, opens the editor, renames the dive, taps Save, reloads, and asserts each field survived. Failed on `isPlanned` before the fix.
- `dive_edit_save_field_census_test.dart`: source-level drift guard. Parses the `dive.<field>` reads inside `updateDive` and the named args of the `Dive(...)` literal in `_saveDive`, and fails naming any field in the first set but not the second. Failed with exactly the eleven fields before the fix. Three fields are on a reasoned allow list: `tripId` (the writer falls back to `dive.trip?.id`, which the form names) and the legacy `weightAmount` / `weightType` (the form migrates them into `weights` on load, so retiring the legacy column is intentional). The allow list also asserts its own entries are still live so it cannot outlive them.

Deliberately untouched: `computerId`, `entryLocation`, `exitLocation` are not written by `updateDive` at all, so they were never at risk.

## Test Plan

- [x] `flutter test test/features/dive_log/presentation/pages/` passes (340 tests, 1 pre-existing skip)
- [x] `flutter analyze` passes
- [x] `dart format --set-exit-if-changed lib/ test/` clean
- [ ] Manual testing on: not yet; the round-trip test drives the real edit page against a real database
