### PR TITLE
fix(dive-log): let a diver clear a star rating back to no rating

### DIFF
--- a/lib/features/dive_log/presentation/pages/dive_edit_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_edit_page.dart
@@ -1058,6 +1058,7 @@ class _DiveEditPageState extends ConsumerState<DiveEditPage> {
                   label: l10n.diveLog_edit_section_rating,
                   value: _rating,
                   onChanged: (v) => setState(() => _rating = v),
+                  clearTooltip: l10n.common_action_clearRating,
                 ),
               ),
               _gatedRow(

--- a/lib/features/dive_log/presentation/widgets/edit_sections/experience_section.dart
+++ b/lib/features/dive_log/presentation/widgets/edit_sections/experience_section.dart
@@ -48,6 +48,7 @@ class ExperienceSection extends StatelessWidget {
           label: l10n.diveLog_edit_section_rating,
           value: rating,
           onChanged: onRatingChanged,
+          clearTooltip: l10n.common_action_clearRating,
         ),
         sightingsChild,
         FormRow.text(

--- a/lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart
+++ b/lib/features/dive_sites/presentation/widgets/edit_sections/dive_info_section.dart
@@ -162,6 +162,7 @@ class DiveInfoSection extends StatelessWidget {
               value: rating,
               onChanged: onRatingChanged,
               onClear: onRatingCleared,
+              clearTooltip: l10n.common_action_clearRating,
             ),
           ],
         ),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "فحوصات رفيق الغوص، قوائم تجهيز CCR، توضيب المعدات",
   "common_action_back": "رجوع",
   "common_action_cancel": "إلغاء",
+  "common_action_clearRating": "مسح التقييم",
   "common_action_close": "إغلاق",
   "common_action_delete": "حذف",
   "common_action_edit": "تعديل",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Buddy-Checks, CCR-Aufbaulisten, Ausrüstungspacken",
   "common_action_back": "Zurück",
   "common_action_cancel": "Abbrechen",
+  "common_action_clearRating": "Bewertung löschen",
   "common_action_close": "Schließen",
   "common_action_delete": "Löschen",
   "common_action_edit": "Bearbeiten",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1615,6 +1615,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Buddy checks, CCR build lists, gear packing",
   "common_action_back": "Back",
   "common_action_cancel": "Cancel",
+  "common_action_clearRating": "Clear rating",
   "common_action_close": "Close",
   "common_action_continue": "Continue",
   "common_action_delete": "Delete",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1633,6 +1633,9 @@
   "@common_action_cancel": {
     "description": "Generic cancel action"
   },
+  "@common_action_clearRating": {
+    "description": "Tooltip on the icon that removes a star rating from a form row, returning it to no rating"
+  },
   "@common_action_close": {
     "description": "Generic close action used for dialogs, menus, etc."
   },

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Comprobaciones en pareja, listas de montaje CCR, preparación del equipo",
   "common_action_back": "Atrás",
   "common_action_cancel": "Cancelar",
+  "common_action_clearRating": "Borrar valoración",
   "common_action_close": "Cerrar",
   "common_action_delete": "Eliminar",
   "common_action_edit": "Editar",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Vérifications entre binômes, listes de montage CCR, préparation du matériel",
   "common_action_back": "Retour",
   "common_action_cancel": "Annuler",
+  "common_action_clearRating": "Effacer la note",
   "common_action_close": "Fermer",
   "common_action_delete": "Supprimer",
   "common_action_edit": "Modifier",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "בדיקות באדי, רשימות הרכבת CCR, אריזת ציוד",
   "common_action_back": "חזרה",
   "common_action_cancel": "ביטול",
+  "common_action_clearRating": "נקה דירוג",
   "common_action_close": "סגירה",
   "common_action_delete": "מחיקה",
   "common_action_edit": "עריכה",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Társellenőrzések, CCR összeszerelési listák, felszereléscsomagolás",
   "common_action_back": "Vissza",
   "common_action_cancel": "Megse",
+  "common_action_clearRating": "Értékelés törlése",
   "common_action_close": "Bezaras",
   "common_action_delete": "Torles",
   "common_action_edit": "Szerkesztes",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Buddy check, liste di montaggio CCR, preparazione attrezzatura",
   "common_action_back": "Indietro",
   "common_action_cancel": "Annulla",
+  "common_action_clearRating": "Cancella valutazione",
   "common_action_close": "Chiudi",
   "common_action_delete": "Elimina",
   "common_action_edit": "Modifica",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -4421,6 +4421,12 @@ abstract class AppLocalizations {
   /// **'Cancel'**
   String get common_action_cancel;
 
+  /// No description provided for @common_action_clearRating.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear rating'**
+  String get common_action_clearRating;
+
   /// Generic close action used for dialogs, menus, etc.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -4421,7 +4421,7 @@ abstract class AppLocalizations {
   /// **'Cancel'**
   String get common_action_cancel;
 
-  /// No description provided for @common_action_clearRating.
+  /// Tooltip on the icon that removes a star rating from a form row, returning it to no rating
   ///
   /// In en, this message translates to:
   /// **'Clear rating'**

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -2559,6 +2559,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get common_action_cancel => 'إلغاء';
 
   @override
+  String get common_action_clearRating => 'مسح التقييم';
+
+  @override
   String get common_action_close => 'إغلاق';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -2617,6 +2617,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get common_action_cancel => 'Abbrechen';
 
   @override
+  String get common_action_clearRating => 'Bewertung löschen';
+
+  @override
   String get common_action_close => 'Schließen';
 
   @override

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -2560,6 +2560,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get common_action_cancel => 'Cancel';
 
   @override
+  String get common_action_clearRating => 'Clear rating';
+
+  @override
   String get common_action_close => 'Close';
 
   @override

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -2615,6 +2615,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get common_action_cancel => 'Cancelar';
 
   @override
+  String get common_action_clearRating => 'Borrar valoración';
+
+  @override
   String get common_action_close => 'Cerrar';
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -2617,6 +2617,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get common_action_cancel => 'Annuler';
 
   @override
+  String get common_action_clearRating => 'Effacer la note';
+
+  @override
   String get common_action_close => 'Fermer';
 
   @override

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -2538,6 +2538,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get common_action_cancel => 'ביטול';
 
   @override
+  String get common_action_clearRating => 'נקה דירוג';
+
+  @override
   String get common_action_close => 'סגירה';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -2599,6 +2599,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get common_action_cancel => 'Megse';
 
   @override
+  String get common_action_clearRating => 'Értékelés törlése';
+
+  @override
   String get common_action_close => 'Bezaras';
 
   @override

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -2610,6 +2610,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get common_action_cancel => 'Annulla';
 
   @override
+  String get common_action_clearRating => 'Cancella valutazione';
+
+  @override
   String get common_action_close => 'Chiudi';
 
   @override

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -2592,6 +2592,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get common_action_cancel => 'Annuleren';
 
   @override
+  String get common_action_clearRating => 'Beoordeling wissen';
+
+  @override
   String get common_action_close => 'Sluiten';
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -2612,6 +2612,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get common_action_cancel => 'Cancelar';
 
   @override
+  String get common_action_clearRating => 'Limpar avaliação';
+
+  @override
   String get common_action_close => 'Fechar';
 
   @override

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -2463,6 +2463,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get common_action_cancel => '取消';
 
   @override
+  String get common_action_clearRating => '清除评分';
+
+  @override
   String get common_action_close => '关闭';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Buddychecks, CCR-opbouwlijsten, uitrusting inpakken",
   "common_action_back": "Terug",
   "common_action_cancel": "Annuleren",
+  "common_action_clearRating": "Beoordeling wissen",
   "common_action_close": "Sluiten",
   "common_action_delete": "Verwijderen",
   "common_action_edit": "Bewerken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1008,6 +1008,7 @@
   "settings_manage_preDiveChecklists_subtitle": "Verificações de dupla, listas de montagem de CCR, preparação de equipamento",
   "common_action_back": "Voltar",
   "common_action_cancel": "Cancelar",
+  "common_action_clearRating": "Limpar avaliação",
   "common_action_close": "Fechar",
   "common_action_delete": "Excluir",
   "common_action_edit": "Editar",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1102,6 +1102,7 @@
   "settings_manage_preDiveChecklists_subtitle": "潜伴检查、CCR 组装清单、装备打包",
   "common_action_back": "返回",
   "common_action_cancel": "取消",
+  "common_action_clearRating": "清除评分",
   "common_action_close": "关闭",
   "common_action_delete": "删除",
   "common_action_edit": "编辑",

--- a/lib/shared/widgets/forms/form_row.dart
+++ b/lib/shared/widgets/forms/form_row.dart
@@ -517,9 +517,10 @@ class _FormRowState extends State<FormRow> {
   Widget _clearAffordance(BuildContext context, VoidCallback onTap) {
     final button = InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(10),
-      child: Padding(
-        padding: const EdgeInsets.all(2),
+      borderRadius: BorderRadius.circular(FormStyle.clearTapTarget / 2),
+      child: SizedBox(
+        width: FormStyle.clearTapTarget,
+        height: FormStyle.clearTapTarget,
         child: Icon(
           Icons.clear,
           size: 16,

--- a/lib/shared/widgets/forms/form_row.dart
+++ b/lib/shared/widgets/forms/form_row.dart
@@ -50,6 +50,7 @@ class FormRow extends StatefulWidget {
        value = null,
        onTap = null,
        onClear = null,
+       clearTooltip = null,
        boolValue = null,
        onBoolChanged = null,
        intValue = null,
@@ -63,6 +64,7 @@ class FormRow extends StatefulWidget {
     required this.onTap,
     this.placeholder,
     this.onClear,
+    this.clearTooltip,
   }) : _kind = _RowKind.picker,
        enabled = true,
        helpText = null,
@@ -91,6 +93,7 @@ class FormRow extends StatefulWidget {
       controller = null,
       inputFormatters = null,
       onClear = null,
+      clearTooltip = null,
       placeholder = null,
       suffixText = null,
       keyboardType = null,
@@ -120,6 +123,7 @@ class FormRow extends StatefulWidget {
        decoration = null,
        inputFormatters = null,
        onClear = null,
+       clearTooltip = null,
        boolValue = value,
        onBoolChanged = onChanged,
        controller = null,
@@ -142,6 +146,7 @@ class FormRow extends StatefulWidget {
     required int value,
     required ValueChanged<int> onChanged,
     this.onClear,
+    this.clearTooltip,
   }) : _kind = _RowKind.rating,
        enabled = true,
        helpText = null,
@@ -173,6 +178,7 @@ class FormRow extends StatefulWidget {
       controller = null,
       inputFormatters = null,
       onClear = null,
+      clearTooltip = null,
       value = null,
       placeholder = null,
       suffixText = null,
@@ -209,6 +215,12 @@ class FormRow extends StatefulWidget {
   final InputDecoration? decoration;
   final VoidCallback? onTap;
   final VoidCallback? onClear;
+
+  /// Names the clear affordance for pointer and screen-reader users. Passed
+  /// in already localized: this widget sits below the l10n layer, and
+  /// reaching for it here would throw in every consumer test that pumps a
+  /// bare MaterialApp.
+  final String? clearTooltip;
   final bool? boolValue;
   final ValueChanged<bool>? onBoolChanged;
   final int? intValue;
@@ -422,18 +434,7 @@ class _FormRowState extends State<FormRow> {
               ),
               if (widget.onClear != null && !empty) ...[
                 const SizedBox(width: 4),
-                InkWell(
-                  onTap: widget.onClear,
-                  borderRadius: BorderRadius.circular(10),
-                  child: Padding(
-                    padding: const EdgeInsets.all(2),
-                    child: Icon(
-                      Icons.clear,
-                      size: 16,
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
+                _clearAffordance(context, widget.onClear!),
               ],
               Icon(
                 Icons.chevron_right,
@@ -465,15 +466,25 @@ class _FormRowState extends State<FormRow> {
         );
 
       case _RowKind.rating:
+        final rating = widget.intValue!;
+        // Zero stars is a real answer, not the absence of one, so the row keeps
+        // two ways back to it: re-tapping the star that already holds the
+        // rating (what divers reach for first), and the explicit clear icon.
+        // Both go through the same callback, so a caller whose onClear does
+        // extra bookkeeping cannot have it skipped by the gesture it did not
+        // anticipate.
+        final clear = widget.onClear ?? () => widget.onIntChanged!(0);
         return _shell(
           context,
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               ...List.generate(5, (i) {
-                final filled = i < widget.intValue!;
+                final stars = i + 1;
+                final filled = i < rating;
                 return InkWell(
-                  onTap: () => widget.onIntChanged!(i + 1),
+                  onTap: () =>
+                      stars == rating ? clear() : widget.onIntChanged!(stars),
                   borderRadius: BorderRadius.circular(12),
                   child: Padding(
                     padding: const EdgeInsets.all(2),
@@ -487,20 +498,9 @@ class _FormRowState extends State<FormRow> {
                   ),
                 );
               }),
-              if (widget.onClear != null && widget.intValue! > 0) ...[
+              if (rating > 0) ...[
                 const SizedBox(width: 4),
-                InkWell(
-                  onTap: widget.onClear,
-                  borderRadius: BorderRadius.circular(10),
-                  child: Padding(
-                    padding: const EdgeInsets.all(2),
-                    child: Icon(
-                      Icons.clear,
-                      size: 16,
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
+                _clearAffordance(context, clear),
               ],
             ],
           ),
@@ -509,5 +509,25 @@ class _FormRowState extends State<FormRow> {
       case _RowKind.custom:
         return _shell(context, trailing: widget.child!);
     }
+  }
+
+  /// The bare X shared by the picker and rating rows. Wrapped in a [Tooltip]
+  /// only when the caller named it, so rows that never supplied a label keep
+  /// rendering exactly as before.
+  Widget _clearAffordance(BuildContext context, VoidCallback onTap) {
+    final button = InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: const EdgeInsets.all(2),
+        child: Icon(
+          Icons.clear,
+          size: 16,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+    final tooltip = widget.clearTooltip;
+    return tooltip == null ? button : Tooltip(message: tooltip, child: button);
   }
 }

--- a/lib/shared/widgets/forms/form_style.dart
+++ b/lib/shared/widgets/forms/form_style.dart
@@ -13,6 +13,15 @@ abstract final class FormStyle {
     vertical: 11,
   );
 
+  /// Side of the square tap target behind a row's clear (X) affordance.
+  ///
+  /// 26 is what the row can give away for free: a rating row's star buttons
+  /// are already 26 tall, so the clear target fills that band without moving
+  /// the row's 48px height. Going to Material's full 48 would push every row
+  /// carrying a clear icon to 66, and growing the target sideways instead
+  /// would overlap the fifth star's own target.
+  static const double clearTapTarget = 26;
+
   /// Padding around a hero stat strip.
   static const EdgeInsets heroPadding = EdgeInsets.symmetric(
     horizontal: 12,

--- a/test/features/dive_log/data/repositories/dive_repository_rating_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_rating_test.dart
@@ -1,0 +1,63 @@
+import 'package:drift/drift.dart' show Variable;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart'
+    as domain;
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late DiveRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  domain.Dive makeDive({int? rating, String id = ''}) => domain.Dive(
+    id: id,
+    dateTime: DateTime.utc(2026, 7, 1, 10, 0),
+    rating: rating,
+  );
+
+  Future<int?> rawRating(String id) async {
+    final row = await db
+        .customSelect(
+          'SELECT rating FROM dives WHERE id = ?',
+          variables: [Variable.withString(id)],
+        )
+        .getSingle();
+    return row.read<int?>('rating');
+  }
+
+  group('rating persistence', () {
+    test('round-trips a rating', () async {
+      final created = await repository.createDive(makeDive(rating: 4));
+      final loaded = await repository.getDiveById(created.id);
+      expect(loaded!.rating, 4);
+    });
+
+    test('updateDive clears a rating the diver removed', () async {
+      // The edit form maps zero stars to a null rating, so clearing has to
+      // survive the companion write. Value.absent() would preserve the old
+      // number and leave the diver unable to un-rate a dive at all.
+      // Built by construction rather than copyWith: Dive.copyWith uses the
+      // `?? this.field` idiom project-wide, so it cannot clear a nullable
+      // field, and neither can it stand in for what the form saves.
+      final created = await repository.createDive(makeDive(rating: 4));
+      expect(await rawRating(created.id), 4);
+
+      await repository.updateDive(makeDive(id: created.id));
+
+      expect(await rawRating(created.id), isNull);
+      final loaded = await repository.getDiveById(created.id);
+      expect(loaded!.rating, isNull);
+    });
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_edit_rating_clear_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_edit_rating_clear_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_edit_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/tank_presets/presentation/providers/tank_preset_providers.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/test_app.dart';
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1333: a diver who set a star rating by accident had no way back to
+/// no rating at all. The row-level gestures are covered in
+/// test/shared/widgets/forms/form_row_test.dart; what these tests pin is the
+/// hop between them and storage, where the page turns zero stars into the null
+/// the dives table needs. Zero and null are both falsy-looking and the entity
+/// accepts either, so nothing but an end-to-end save catches a regression here.
+void main() {
+  late DiveRepository repository;
+
+  setUp(() async {
+    await setUpTestDatabase();
+    repository = DiveRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Dive buildDive({int? rating}) => Dive(
+    id: 'dive-rating',
+    diveNumber: 1,
+    dateTime: DateTime(2026, 3, 28, 10, 0),
+    entryTime: DateTime(2026, 3, 28, 10, 5),
+    bottomTime: const Duration(minutes: 40),
+    maxDepth: 20.0,
+    rating: rating,
+    tanks: const [],
+    profile: const [],
+    equipment: const [],
+    notes: '',
+    photoIds: const [],
+    sightings: const [],
+    weights: const [],
+    tags: const [],
+  );
+
+  Future<void> pumpEditPage(WidgetTester tester, String diveId) async {
+    tester.view.physicalSize = const Size(1200, 4000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final base = await getBaseOverrides();
+    await tester.pumpWidget(
+      testApp(
+        overrides: [
+          ...base,
+          diveRepositoryProvider.overrideWithValue(repository),
+          diveListNotifierProvider.overrideWith(
+            (ref) => DiveListNotifier(repository, ref),
+          ),
+          customTankPresetsProvider.overrideWith((ref) async => []),
+        ],
+        locale: const Locale('en'),
+        child: DiveEditPage(diveId: diveId, embedded: true),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The group is collapsed by default and does not mount its rows until it
+  /// opens; the header row is the toggle.
+  Future<void> expandExperience(WidgetTester tester) async {
+    final header = find.text('Experience');
+    await tester.scrollUntilVisible(
+      header,
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(header);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> save(WidgetTester tester) async {
+    await tester.ensureVisible(find.text('Save'));
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the clear affordance saves the dive with no rating', (
+    tester,
+  ) async {
+    final created = await repository.createDive(buildDive(rating: 4));
+    await pumpEditPage(tester, created.id);
+    await expandExperience(tester);
+
+    expect(find.byIcon(Icons.star), findsNWidgets(4));
+    await tester.tap(find.byTooltip('Clear rating'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.star), findsNothing);
+
+    await save(tester);
+
+    final saved = await repository.getDiveById(created.id);
+    expect(saved!.rating, isNull);
+  });
+
+  testWidgets('re-tapping the current rating saves the dive with no rating', (
+    tester,
+  ) async {
+    final created = await repository.createDive(buildDive(rating: 4));
+    await pumpEditPage(tester, created.id);
+    await expandExperience(tester);
+
+    await tester.tap(find.byIcon(Icons.star).at(3));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.star), findsNothing);
+
+    await save(tester);
+
+    final saved = await repository.getDiveById(created.id);
+    expect(saved!.rating, isNull);
+  });
+
+  testWidgets('an untouched rating survives an open and save', (tester) async {
+    final created = await repository.createDive(buildDive(rating: 4));
+    await pumpEditPage(tester, created.id);
+    await expandExperience(tester);
+
+    await save(tester);
+
+    final saved = await repository.getDiveById(created.id);
+    expect(saved!.rating, 4);
+  });
+}

--- a/test/features/dive_log/presentation/widgets/edit_sections/experience_section_test.dart
+++ b/test/features/dive_log/presentation/widgets/edit_sections/experience_section_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/edit_sections/experience_section.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+void main() {
+  late TextEditingController notesController;
+  final ratings = <int>[];
+
+  setUp(() {
+    notesController = TextEditingController();
+    ratings.clear();
+  });
+
+  tearDown(() => notesController.dispose());
+
+  Widget host({required int rating}) {
+    return MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: ExperienceSection(
+            expanded: true,
+            onToggle: () {},
+            summary: '',
+            isEmpty: false,
+            rating: rating,
+            onRatingChanged: ratings.add,
+            notesController: notesController,
+            notesPlaceholder: 'Notes',
+            sightingsChild: const SizedBox.shrink(),
+            tagsChild: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('a rated dive offers a clear affordance that reports zero', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(rating: 3));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.star), findsNWidgets(3));
+    expect(find.byTooltip('Clear rating'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Clear rating'));
+    await tester.pump();
+
+    expect(ratings, [0]);
+  });
+
+  testWidgets('re-tapping the current rating reports zero', (tester) async {
+    await tester.pumpWidget(host(rating: 3));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.star).at(2));
+    await tester.pump();
+
+    expect(ratings, [0]);
+  });
+
+  testWidgets('an unrated dive shows no clear affordance', (tester) async {
+    await tester.pumpWidget(host(rating: 0));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.star), findsNothing);
+    expect(find.byTooltip('Clear rating'), findsNothing);
+  });
+}

--- a/test/shared/widgets/forms/form_row_test.dart
+++ b/test/shared/widgets/forms/form_row_test.dart
@@ -1,9 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/shared/widgets/forms/form_row.dart';
+import 'package:submersion/shared/widgets/forms/form_style.dart';
 
 Widget _wrap(Widget child) => MaterialApp(
   home: Scaffold(body: Material(child: child)),
+);
+
+/// Same host, but shrink-wrapped so the row reports its own height rather
+/// than filling the body.
+Widget _wrapIntrinsic(Widget child) => MaterialApp(
+  home: Scaffold(
+    body: Material(
+      child: Column(mainAxisSize: MainAxisSize.min, children: [child]),
+    ),
+  ),
 );
 
 void main() {
@@ -421,6 +432,35 @@ void main() {
       await tester.tap(find.byIcon(Icons.star).at(2));
       expect(cleared, 1);
       expect(reported, isEmpty);
+    });
+
+    testWidgets('clear affordance is as tappable as the row band allows', (
+      tester,
+    ) async {
+      // The X is a 16px glyph, so its tap target has to be stated rather than
+      // inherited from the icon. 26 is the star buttons' own height: filling
+      // that band costs the row nothing, while Material's 48 would push every
+      // row carrying a clear icon from 48 to 66.
+      await tester.pumpWidget(
+        _wrapIntrinsic(
+          FormRow.rating(label: 'Rating', value: 3, onChanged: (_) {}),
+        ),
+      );
+      final target = tester.getSize(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.clear),
+              matching: find.byType(InkWell),
+            )
+            .first,
+      );
+      expect(target.width, FormStyle.clearTapTarget);
+      expect(target.height, FormStyle.clearTapTarget);
+      expect(
+        tester.getSize(find.byType(FormRow)).height,
+        48,
+        reason: 'a bigger target must not make the row taller',
+      );
     });
 
     testWidgets('clear affordance carries the caller tooltip', (tester) async {

--- a/test/shared/widgets/forms/form_row_test.dart
+++ b/test/shared/widgets/forms/form_row_test.dart
@@ -333,5 +333,114 @@ void main() {
       expect(value, 0);
       expect(find.byIcon(Icons.clear), findsNothing);
     });
+
+    testWidgets('rating row clears through onChanged without an onClear', (
+      tester,
+    ) async {
+      var value = 3;
+      await tester.pumpWidget(
+        _wrap(
+          StatefulBuilder(
+            builder: (context, setState) => FormRow.rating(
+              label: 'Rating',
+              value: value,
+              onChanged: (v) => setState(() => value = v),
+            ),
+          ),
+        ),
+      );
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pumpAndSettle();
+      expect(value, 0);
+      expect(find.byIcon(Icons.clear), findsNothing);
+      expect(find.byIcon(Icons.star), findsNothing);
+      expect(find.byIcon(Icons.star_border), findsNWidgets(5));
+    });
+
+    testWidgets('rating row hides the clear affordance at zero', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(FormRow.rating(label: 'Rating', value: 0, onChanged: (_) {})),
+      );
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('tapping the star that holds the current rating clears it', (
+      tester,
+    ) async {
+      int? rated;
+      await tester.pumpWidget(
+        _wrap(
+          FormRow.rating(
+            label: 'Rating',
+            value: 3,
+            onChanged: (v) => rated = v,
+          ),
+        ),
+      );
+      // The third star is the last filled one, so it carries the current value.
+      await tester.tap(find.byIcon(Icons.star).at(2));
+      expect(rated, 0);
+    });
+
+    testWidgets('tapping below the current rating lowers it instead of '
+        'clearing', (tester) async {
+      int? rated;
+      await tester.pumpWidget(
+        _wrap(
+          FormRow.rating(
+            label: 'Rating',
+            value: 3,
+            onChanged: (v) => rated = v,
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.star).first);
+      expect(rated, 1);
+    });
+
+    testWidgets('re-tapping the current rating routes through onClear', (
+      tester,
+    ) async {
+      // A caller that passes onClear has bookkeeping of its own to do, so the
+      // gesture it did not anticipate must not bypass it.
+      var cleared = 0;
+      final reported = <int>[];
+      await tester.pumpWidget(
+        _wrap(
+          FormRow.rating(
+            label: 'Rating',
+            value: 3,
+            onChanged: reported.add,
+            onClear: () => cleared++,
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.star).at(2));
+      expect(cleared, 1);
+      expect(reported, isEmpty);
+    });
+
+    testWidgets('clear affordance carries the caller tooltip', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          FormRow.rating(
+            label: 'Rating',
+            value: 2,
+            onChanged: (_) {},
+            clearTooltip: 'Clear rating',
+          ),
+        ),
+      );
+      expect(
+        find.byTooltip('Clear rating'),
+        findsOneWidget,
+        reason:
+            'the X is a bare icon, so it needs a name for pointer and '
+            'screen-reader users alike',
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #1333.

## The problem

A dive's Experience section could reach one through five stars but never zero. Every star tap emitted `i + 1`, so a rating set by accident was permanent: the reporter had "accidentally added a star sometime but unable to remove it."

`FormRow.rating` did already carry an X clear affordance, but it was gated on the caller passing `onClear`, and the dive site editor was the only one of the three rating call sites that did. The dive's own rating row and the bulk-edit rating row passed none.

## The fix

`FormRow.rating` now offers two ways back to no rating:

- Re-tapping the star that already holds the current value clears it. This is the same gesture the dive center rating selector has always used, so the app is now consistent about it.
- The clear icon appears for any non-zero rating, defaulting to `onChanged(0)` when the caller passed no `onClear` of its own.

Both gestures route through a single callback, so a caller whose `onClear` does extra bookkeeping cannot have it skipped by the gesture it did not anticipate. The X and the picker row's X are now one extracted `_clearAffordance`, so their hit target and styling cannot drift apart.

A new `common_action_clearRating` string names the icon via a `Tooltip`. It is passed in as a parameter rather than read with `context.l10n` inside the widget: `form_row.dart` sits under `shared/`, and reaching for localizations there throws in every consumer test that pumps a bare `MaterialApp`.

Bulk edit picks up the same capability through the shared row, so clearing the rating across a selection now works rather than silently applying nothing (`BulkField.rating` already mapped to `Value(i.rating)`).

## Storage needed no change, but is now pinned

The edit page already maps zero stars to a null rating, and `updateDive` writes `rating: Value(dive.rating)` rather than `Value.absent()`, so the column is set to SQL NULL instead of being left untouched. Cross-device clearing is likewise already correct: dives carry an HLC, so the sync serializer applies rows with `.toCompanion(false)` and a present null propagates.

Both halves were previously covered by tests that never met in the middle, so the expression that turns the row's `0` into the repository's `null` had nothing crossing it. `dive_edit_rating_clear_test.dart` now covers that hop end to end.

## Tests

- `form_row_test.dart`: clearing without an `onClear`, no affordance at zero, re-tap clears, tapping below the current rating still lowers it, the re-tap routes through an explicit `onClear`, and the tooltip is present.
- `experience_section_test.dart` (new): the dive's own section shows and honors the affordance.
- `dive_edit_rating_clear_test.dart` (new): both gestures, then Save, then reload; the dive comes back with a null rating. Plus an open-and-save guard that an untouched rating survives.
- `dive_repository_rating_test.dart` (new): a cleared rating reaches the column as SQL NULL, checked with raw SQL.

`flutter analyze` clean project-wide, `dart format` clean, and the full local suite is green at 22,285 tests. The one local failure was `local_file_resolver_test.dart`'s system-volume assertion under a RAM-disk `$TMPDIR`; that file passes 44/44 with a system-volume `$TMPDIR` and is untouched by this change.

## One deliberate behavior delta

Dive site ratings are stored as doubles and rendered through `.round()`, so an imported 4.5 draws as five filled stars. Re-tapping that fifth star now clears the rating rather than normalizing it to 5.0. One more tap restores it, and the int-valued row genuinely cannot tell the two cases apart, so no special case was added.