### PR TITLE
fix(ble): connect Android BLE over the LE transport, and stop losing the reason a connect failed

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -235,12 +235,24 @@ class BleIoStream(
 
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
             NativeLogger.d(TAG, "BLE", "onMtuChanged: mtu=$mtu status=$status")
-            // MTU negotiation complete; now discover services.
-            gatt.discoverServices()
+            // MTU negotiation complete; now discover services. A refused
+            // request never produces onServicesDiscovered, so waking the
+            // caller here is what stops it from sitting out the whole
+            // 15-second connect timeout for a failure already known.
+            if (!gatt.discoverServices()) {
+                NativeLogger.e(TAG, "BLE",
+                    "discoverServices() was refused by the Bluetooth stack")
+                connectSemaphore.release()
+            }
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
+                // Silent before #957: the only trace a Petrel 2 owner could
+                // send was "writeChar=null", which is a symptom of both this
+                // branch and the no-usable-service one below.
+                NativeLogger.e(TAG, "BLE",
+                    GattDiagnostics.describeDiscoveryFailure(status, deviceType()))
                 connectSemaphore.release()
                 return
             }
@@ -358,6 +370,14 @@ class BleIoStream(
                 } else {
                     subscribeToNotifications(gatt, bestNotify, SetupStep.DATA_NOTIFY)
                 }
+            } else {
+                // Discovery worked but nothing here can carry a serial
+                // session. Name what the computer did expose: those UUIDs
+                // are what a new descriptor would have to be written from,
+                // and an empty list means the connection was never usable.
+                NativeLogger.e(TAG, "BLE", GattDiagnostics.describeNoUsableService(
+                    gatt.services.map { it.uuid.toString() }
+                ))
             }
 
             // If a setup operation was started, wait for its completion
@@ -618,6 +638,12 @@ class BleIoStream(
         }
     }
 
+    // Which radios the stack believes this computer has. Reported alongside
+    // every connect and every discovery failure because a dual-mode radio
+    // changes what a failure means (issue #957); the stack answers UNKNOWN
+    // for a device it has not seen advertise, which is itself worth seeing.
+    private fun deviceType(): Int = device.type
+
     // Connect to the BLE device and discover services.
     // Blocks until ready or timeout. Returns true on success.
     //
@@ -628,7 +654,31 @@ class BleIoStream(
     // because they won't respond to pairing requests without an active
     // GATT connection.
     fun connectAndDiscover(): Boolean {
-        gatt = device.connectGatt(context, false, gattCallback)
+        NativeLogger.d(TAG, "BLE",
+            "connectGatt: ${device.address} radio=" +
+                GattDiagnostics.describeDeviceType(deviceType()) +
+                " transport=LE")
+        // Demand the LE transport rather than letting the stack choose.
+        //
+        // TRANSPORT_AUTO resolves to Bluetooth Classic for a dual-mode
+        // device, and a computer whose GATT server lives only on the LE
+        // radio then connects, negotiates an MTU, and answers service
+        // discovery with nothing -- the exact shape of the Shearwater
+        // Petrel 2 failure in issue #957, whose Panasonic module is
+        // dual-mode (libdivecomputer lists that model as both
+        // DC_TRANSPORT_BLUETOOTH and DC_TRANSPORT_BLE, unlike the LE-only
+        // Petrel 3 / Perdix 2 / Teric that download fine).
+        //
+        // Safe for every other computer: this stream is only ever reached
+        // from a BLE scan, so the peripheral is LE-capable by construction,
+        // and TRANSPORT_AUTO already resolves to LE for an LE-only radio.
+        gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            device.connectGatt(
+                context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
+            )
+        } else {
+            device.connectGatt(context, false, gattCallback)
+        }
         if (!connectSemaphore.tryAcquire(15, TimeUnit.SECONDS)) {
             NativeLogger.e(TAG, "BLE", "connectAndDiscover: semaphore timeout")
             return false

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -654,10 +654,13 @@ class BleIoStream(
     // because they won't respond to pairing requests without an active
     // GATT connection.
     fun connectAndDiscover(): Boolean {
+        // One flag drives both the overload and the line that reports it, so
+        // the log can never claim a transport the connect did not use.
+        val leTransport = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
         NativeLogger.d(TAG, "BLE",
             "connectGatt: ${device.address} radio=" +
                 GattDiagnostics.describeDeviceType(deviceType()) +
-                " transport=LE")
+                " transport=" + GattDiagnostics.describeTransport(leTransport))
         // Demand the LE transport rather than letting the stack choose.
         //
         // TRANSPORT_AUTO resolves to Bluetooth Classic for a dual-mode
@@ -672,7 +675,7 @@ class BleIoStream(
         // Safe for every other computer: this stream is only ever reached
         // from a BLE scan, so the peripheral is LE-capable by construction,
         // and TRANSPORT_AUTO already resolves to LE for an LE-only radio.
-        gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        gatt = if (leTransport) {
             device.connectGatt(
                 context, false, gattCallback, BluetoothDevice.TRANSPORT_LE
             )

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
@@ -55,6 +55,17 @@ object GattDiagnostics {
         else -> "unrecognized device type ($type)"
     }
 
+    /**
+     * Names the transport a connect actually ran on.
+     *
+     * Written from the same flag that picks the connectGatt overload so the
+     * two cannot drift: a line that claimed LE while the call fell back to
+     * TRANSPORT_AUTO would misreport the one fact this instrumentation
+     * exists to establish.
+     */
+    fun describeTransport(leRequested: Boolean): String =
+        if (leRequested) "LE" else "AUTO (LE cannot be demanded below API 23)"
+
     /** Human-readable reason for a BluetoothGattCallback status code. */
     fun describeGattStatus(status: Int): String = when (status) {
         GATT_SUCCESS ->

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
@@ -101,19 +101,29 @@ object GattDiagnostics {
      * Message for a service discovery the stack refused, naming the radio
      * the computer was reached on.
      *
-     * A dual-mode computer earns an extra clause: Android connects such a
-     * device over Bluetooth Classic unless the caller demands
-     * TRANSPORT_LE, and a GATT server that only exists on the LE radio is
-     * then invisible. That is the failure behind #957, and naming it in the
-     * log is what makes a future report of it self-diagnosing.
+     * A dual-mode computer earns an extra clause naming the trap behind
+     * #957: under TRANSPORT_AUTO Android connects such a radio over
+     * Bluetooth Classic, where a GATT server that exists only on the LE
+     * radio is invisible.
+     *
+     * Phrased as a lead to check rather than a verdict. This build already
+     * demands TRANSPORT_LE, so on a current log the transport is not the
+     * explanation, and a dual-mode radio fails discovery for the same
+     * ordinary reasons any other radio does: an unstable link, an ATT
+     * error, a computer that dropped out of upload mode. Pointing the
+     * reader at the connect line keeps the addendum useful without
+     * pre-deciding the diagnosis for them.
      */
     fun describeDiscoveryFailure(status: Int, deviceType: Int): String {
         val base = "Service discovery failed: status=$status " +
             "(${describeGattStatus(status)}); the computer's radio is " +
             describeDeviceType(deviceType)
         if (deviceType != DEVICE_TYPE_DUAL) return base
-        return "$base. A dual-mode computer answers GATT only on its LE " +
-            "radio, so this discovery must run over the LE transport"
+        return "$base. Dual-mode is a known trap: under TRANSPORT_AUTO " +
+            "Android connects such a radio over Bluetooth Classic, where " +
+            "an LE-only GATT server is invisible. Check the transport on " +
+            "the connect line above before assuming that is the cause " +
+            "here; an unstable link or an ATT error fails discovery too"
     }
 
     /**

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
@@ -1,0 +1,128 @@
+package com.submersion.libdivecomputer
+
+// Explains why a GATT connection produced no usable serial characteristics.
+//
+// A Shearwater Petrel 2 owner reported "Failed to connect to device" and
+// sent a debug log whose whole account of the failure was
+// "connectAndDiscover: connected=true writeChar=null credits=0
+// result=false" (issue #957). The link was up and the MTU had been
+// negotiated, so the failure was somewhere in service discovery -- but
+// every branch that leaves writeCharacteristic null returned silently:
+// a discovery the stack refused returned early on its status, and a
+// discovery that produced no service with both a write and a notify
+// characteristic simply fell through. The two are different bugs with
+// different fixes and the log could not tell them apart.
+//
+// Framework-free so it can run as a JVM unit test; the Android GATT
+// constants are duplicated here rather than referenced, as BondDiagnostics
+// does for the bond states and BleScanDiagnostics for the scan failures.
+object GattDiagnostics {
+
+    // Mirrors android.bluetooth.BluetoothDevice device types.
+    const val DEVICE_TYPE_UNKNOWN = 0
+    const val DEVICE_TYPE_CLASSIC = 1
+    const val DEVICE_TYPE_LE = 2
+    const val DEVICE_TYPE_DUAL = 3
+
+    // Mirrors android.bluetooth.BluetoothGatt.GATT_SUCCESS plus the
+    // connection-layer statuses the stack passes through unchanged. Only
+    // GATT_SUCCESS and a handful of ATT codes are public API; the rest come
+    // from the HCI error codes in stack/include/gatt_api.h and are stable.
+    const val GATT_SUCCESS = 0
+    const val GATT_INSUFFICIENT_AUTHENTICATION = 5
+    const val GATT_CONN_TIMEOUT = 8
+    const val GATT_CONN_TERMINATE_PEER_USER = 19
+    const val GATT_CONN_TERMINATE_LOCAL_HOST = 22
+    const val GATT_CONN_LMP_TIMEOUT = 34
+    const val GATT_CONN_FAIL_ESTABLISH = 62
+    const val GATT_INTERNAL_ERROR = 129
+    const val GATT_ERROR = 133
+    const val GATT_CONN_CANCEL = 256
+    const val GATT_FAILURE = 257
+
+    /**
+     * Human-readable name for a BluetoothDevice.getType() value.
+     *
+     * The distinction matters: a dual-mode radio is reached over Bluetooth
+     * Classic by default, and a computer that serves its serial bridge only
+     * over LE then answers service discovery with nothing.
+     */
+    fun describeDeviceType(type: Int): String = when (type) {
+        DEVICE_TYPE_CLASSIC -> "Bluetooth Classic only"
+        DEVICE_TYPE_LE -> "LE only"
+        DEVICE_TYPE_DUAL -> "dual-mode (Bluetooth Classic + LE)"
+        DEVICE_TYPE_UNKNOWN -> "unknown to the Bluetooth stack"
+        else -> "unrecognized device type ($type)"
+    }
+
+    /** Human-readable reason for a BluetoothGattCallback status code. */
+    fun describeGattStatus(status: Int): String = when (status) {
+        GATT_SUCCESS ->
+            "success"
+        GATT_INSUFFICIENT_AUTHENTICATION ->
+            "insufficient authentication; the stored pairing keys are stale " +
+                "or the computer demanded encryption"
+        GATT_CONN_TIMEOUT ->
+            "the connection timed out; the computer moved out of range or " +
+                "switched its radio off"
+        GATT_CONN_TERMINATE_PEER_USER ->
+            "the computer closed the connection"
+        GATT_CONN_TERMINATE_LOCAL_HOST ->
+            "this phone closed the connection"
+        GATT_CONN_LMP_TIMEOUT ->
+            "the computer stopped answering the radio link"
+        GATT_CONN_FAIL_ESTABLISH ->
+            "the connection could not be established"
+        GATT_INTERNAL_ERROR ->
+            "internal Bluetooth stack error"
+        GATT_ERROR ->
+            "generic GATT error; usually the computer refused the operation " +
+                "or the link was not usable for it"
+        GATT_CONN_CANCEL ->
+            "the connection attempt was cancelled"
+        GATT_FAILURE ->
+            "the operation failed"
+        else ->
+            "unknown GATT status ($status)"
+    }
+
+    /**
+     * Message for a service discovery the stack refused, naming the radio
+     * the computer was reached on.
+     *
+     * A dual-mode computer earns an extra clause: Android connects such a
+     * device over Bluetooth Classic unless the caller demands
+     * TRANSPORT_LE, and a GATT server that only exists on the LE radio is
+     * then invisible. That is the failure behind #957, and naming it in the
+     * log is what makes a future report of it self-diagnosing.
+     */
+    fun describeDiscoveryFailure(status: Int, deviceType: Int): String {
+        val base = "Service discovery failed: status=$status " +
+            "(${describeGattStatus(status)}); the computer's radio is " +
+            describeDeviceType(deviceType)
+        if (deviceType != DEVICE_TYPE_DUAL) return base
+        return "$base. A dual-mode computer answers GATT only on its LE " +
+            "radio, so this discovery must run over the LE transport"
+    }
+
+    /**
+     * Message for a discovery that completed but exposed no service
+     * carrying both a write and a notify/indicate characteristic, which is
+     * the pair the serial bridge needs.
+     *
+     * An empty list is reported in its own words: no services at all means
+     * the connection was not really usable, while a populated list that
+     * still yields no pair means the computer is exposing something this
+     * build does not know how to drive, and the UUIDs are what a new
+     * descriptor would be written from.
+     */
+    fun describeNoUsableService(serviceUuids: List<String>): String {
+        if (serviceUuids.isEmpty()) {
+            return "Service discovery succeeded but the computer reported " +
+                "no services at all"
+        }
+        return "No discovered service carries both a write and a notify " +
+            "characteristic; ${serviceUuids.size} service(s) seen: " +
+            serviceUuids.joinToString(", ")
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
@@ -1,0 +1,128 @@
+package com.submersion.libdivecomputer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// JVM tests for the GATT connect/discovery diagnostics (issue #957).
+//
+// A Shearwater Petrel 2 owner reported "Failed to connect to device" and
+// sent a debug log whose entire account of the failure was
+// "connectAndDiscover: connected=true writeChar=null credits=0
+// result=false". Every path that can leave writeChar null returned without
+// logging anything: a refused service discovery returned early, and a
+// discovery that found no usable service simply fell through. These tests
+// pin the messages that tell those cases apart in a bug report.
+class GattDiagnosticsTest {
+
+    @Test
+    fun dualModeDeviceTypeIsNamed() {
+        val described = GattDiagnostics.describeDeviceType(
+            GattDiagnostics.DEVICE_TYPE_DUAL
+        )
+
+        assertTrue(described.contains("dual"))
+        assertTrue(described.contains("LE"))
+    }
+
+    @Test
+    fun everyDeviceTypeIsDescribed() {
+        assertEquals("Bluetooth Classic only", GattDiagnostics.describeDeviceType(
+            GattDiagnostics.DEVICE_TYPE_CLASSIC
+        ))
+        assertEquals("LE only", GattDiagnostics.describeDeviceType(
+            GattDiagnostics.DEVICE_TYPE_LE
+        ))
+        assertTrue(
+            GattDiagnostics.describeDeviceType(
+                GattDiagnostics.DEVICE_TYPE_UNKNOWN
+            ).contains("unknown")
+        )
+    }
+
+    @Test
+    fun unrecognizedDeviceTypeStillReportsItsValue() {
+        assertTrue(GattDiagnostics.describeDeviceType(42).contains("42"))
+    }
+
+    @Test
+    fun commonGattStatusesAreExplained() {
+        assertTrue(GattDiagnostics.describeGattStatus(0).contains("success"))
+        assertTrue(
+            GattDiagnostics.describeGattStatus(
+                GattDiagnostics.GATT_INSUFFICIENT_AUTHENTICATION
+            ).contains("pairing")
+        )
+        assertTrue(
+            GattDiagnostics.describeGattStatus(
+                GattDiagnostics.GATT_CONN_TIMEOUT
+            ).contains("timed out")
+        )
+        assertTrue(
+            GattDiagnostics.describeGattStatus(
+                GattDiagnostics.GATT_ERROR
+            ).isNotEmpty()
+        )
+    }
+
+    @Test
+    fun unknownGattStatusReportsItsValue() {
+        assertTrue(GattDiagnostics.describeGattStatus(200).contains("200"))
+    }
+
+    @Test
+    fun discoveryFailureNamesTheStatusAndTheDeviceType() {
+        val message = GattDiagnostics.describeDiscoveryFailure(
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.DEVICE_TYPE_LE
+        )
+
+        assertTrue(message.contains("133"))
+        assertTrue(message.contains("LE only"))
+    }
+
+    @Test
+    fun discoveryFailureOnADualModeDeviceNamesTheTransportTrap() {
+        val message = GattDiagnostics.describeDiscoveryFailure(
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.DEVICE_TYPE_DUAL
+        )
+
+        // The dual-mode radio is the whole diagnosis of #957: Android
+        // connects such a device over Bluetooth Classic unless the LE
+        // transport is demanded, and GATT discovery then finds nothing.
+        assertTrue(message.contains("Classic"))
+    }
+
+    @Test
+    fun singleModeDiscoveryFailureDoesNotBlameTheTransport() {
+        val message = GattDiagnostics.describeDiscoveryFailure(
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.DEVICE_TYPE_LE
+        )
+
+        assertFalse(message.contains("Classic"))
+    }
+
+    @Test
+    fun emptyDiscoveryIsDistinguishedFromAnUnusableOne() {
+        val empty = GattDiagnostics.describeNoUsableService(emptyList())
+
+        assertTrue(empty.contains("no services"))
+    }
+
+    @Test
+    fun unusableDiscoveryListsWhatTheComputerExposed() {
+        val message = GattDiagnostics.describeNoUsableService(
+            listOf(
+                "00001800-0000-1000-8000-00805f9b34fb",
+                "0000fefb-0000-1000-8000-00805f9b34fb"
+            )
+        )
+
+        assertTrue(message.contains("2"))
+        assertTrue(message.contains("00001800-0000-1000-8000-00805f9b34fb"))
+        assertTrue(message.contains("0000fefb-0000-1000-8000-00805f9b34fb"))
+    }
+}

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
@@ -106,6 +106,18 @@ class GattDiagnosticsTest {
     }
 
     @Test
+    fun theTransportLabelFollowsWhatTheConnectActuallyRequested() {
+        assertEquals("LE", GattDiagnostics.describeTransport(true))
+
+        // A log that claims LE on a connect that ran under TRANSPORT_AUTO
+        // would misreport the one fact this instrumentation exists to
+        // establish, so the fallback must never read as LE.
+        val fallback = GattDiagnostics.describeTransport(false)
+        assertFalse(fallback == "LE")
+        assertTrue(fallback.contains("AUTO"))
+    }
+
+    @Test
     fun emptyDiscoveryIsDistinguishedFromAnUnusableOne() {
         val empty = GattDiagnostics.describeNoUsableService(emptyList())
 

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
@@ -89,10 +89,27 @@ class GattDiagnosticsTest {
             GattDiagnostics.DEVICE_TYPE_DUAL
         )
 
-        // The dual-mode radio is the whole diagnosis of #957: Android
-        // connects such a device over Bluetooth Classic unless the LE
-        // transport is demanded, and GATT discovery then finds nothing.
+        // The dual-mode radio is the whole diagnosis of #957: under
+        // TRANSPORT_AUTO Android connects such a device over Bluetooth
+        // Classic, and GATT discovery then finds nothing.
         assertTrue(message.contains("Classic"))
+        assertTrue(message.contains("TRANSPORT_AUTO"))
+    }
+
+    @Test
+    fun theDualModeAddendumIsALeadRatherThanAVerdict() {
+        val message = GattDiagnostics.describeDiscoveryFailure(
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.DEVICE_TYPE_DUAL
+        )
+
+        // Since this build demands TRANSPORT_LE, the transport is not the
+        // explanation on a current log, and a dual-mode radio fails
+        // discovery for the same ordinary reasons any other radio does.
+        // The line must send the reader to the connect line rather than
+        // deciding the diagnosis for them.
+        assertTrue(message.contains("connect line"))
+        assertTrue(message.contains("before assuming"))
     }
 
     @Test

--- a/packages/libdivecomputer_plugin/windows/CMakeLists.txt
+++ b/packages/libdivecomputer_plugin/windows/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library(${PLUGIN_NAME} SHARED
     dive_converter.cc
     ble_scanner.cc
     ble_io_stream.cc
+    native_logger.cc
     serial_scanner.cc
     serial_io_stream.cc
     dive_computer_api.g.cc

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -1,7 +1,11 @@
 #include "ble_io_stream.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
+#include <sstream>
+
+#include "native_logger.h"
 
 namespace libdivecomputer_plugin {
 
@@ -9,6 +13,68 @@ using namespace winrt::Windows::Devices::Bluetooth;
 using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
 using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Storage::Streams;
+
+namespace {
+
+// Log category shared with the Android and darwin transports, so a Windows
+// bug report reads the same way as the ones this code was modelled on.
+constexpr char kBleCategory[] = "BLE";
+
+std::string FormatAddress(uint64_t address) {
+    char buffer[18];
+    std::snprintf(buffer, sizeof(buffer), "%02X:%02X:%02X:%02X:%02X:%02X",
+                  static_cast<unsigned>((address >> 40) & 0xFF),
+                  static_cast<unsigned>((address >> 32) & 0xFF),
+                  static_cast<unsigned>((address >> 24) & 0xFF),
+                  static_cast<unsigned>((address >> 16) & 0xFF),
+                  static_cast<unsigned>((address >> 8) & 0xFF),
+                  static_cast<unsigned>(address & 0xFF));
+    return std::string(buffer);
+}
+
+// Formatted by hand rather than through winrt::to_hstring so the output
+// matches the lowercase 8-4-4-4-12 form Android's UUID.toString() logs, and
+// so no cppwinrt overload has to exist for it.
+std::string DescribeUuid(const winrt::guid& uuid) {
+    char buffer[37];
+    std::snprintf(buffer, sizeof(buffer),
+                  "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+                  static_cast<unsigned>(uuid.Data1),
+                  static_cast<unsigned>(uuid.Data2),
+                  static_cast<unsigned>(uuid.Data3),
+                  static_cast<unsigned>(uuid.Data4[0]),
+                  static_cast<unsigned>(uuid.Data4[1]),
+                  static_cast<unsigned>(uuid.Data4[2]),
+                  static_cast<unsigned>(uuid.Data4[3]),
+                  static_cast<unsigned>(uuid.Data4[4]),
+                  static_cast<unsigned>(uuid.Data4[5]),
+                  static_cast<unsigned>(uuid.Data4[6]),
+                  static_cast<unsigned>(uuid.Data4[7]));
+    return std::string(buffer);
+}
+
+// GattCommunicationStatus says which half of a failed GATT call to look at:
+// Unreachable is the link, AccessDenied is Windows' own pairing state, and
+// ProtocolError is the computer answering with an ATT error.
+std::string DescribeGattStatus(GattCommunicationStatus status) {
+    switch (status) {
+        case GattCommunicationStatus::Success:
+            return "success";
+        case GattCommunicationStatus::Unreachable:
+            return "unreachable; the computer is out of range, switched its "
+                   "radio off, or dropped the link";
+        case GattCommunicationStatus::ProtocolError:
+            return "protocol error; the computer refused the request";
+        case GattCommunicationStatus::AccessDenied:
+            return "access denied; Windows will not talk to this computer "
+                   "without pairing it first";
+        default:
+            return "unknown status (" +
+                   std::to_string(static_cast<int>(status)) + ")";
+    }
+}
+
+}  // namespace
 
 // Same UUIDs as the macOS/iOS BleIoStream.
 const winrt::guid BleIoStream::kPreferredServiceUuid{
@@ -91,11 +157,23 @@ BleIoStream::BleIoStream() = default;
 BleIoStream::~BleIoStream() { Close(); }
 
 bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
+    const std::string address = FormatAddress(bluetooth_address);
+    NativeLogger::Debug(kBleCategory, "Connecting to " + address);
     try {
         device_ = BluetoothLEDevice::FromBluetoothAddressAsync(
                       bluetooth_address)
                       .get();
-        if (!device_) return false;
+        if (!device_) {
+            // Windows resolves the address against its own device database,
+            // so this is not "the computer is off": it is Windows holding no
+            // LE record for the address at all, which is what a dual-mode
+            // computer known only as a Bluetooth Classic device looks like.
+            NativeLogger::Error(kBleCategory,
+                                "No Bluetooth LE device for " + address +
+                                    "; Windows has no LE record for this "
+                                    "address");
+            return false;
+        }
 
         device_name_ = winrt::to_string(device_.Name());
 
@@ -114,7 +192,15 @@ bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
         }
 
         return DiscoverCharacteristics();
+    } catch (const winrt::hresult_error& e) {
+        NativeLogger::Error(kBleCategory,
+                            "Connect to " + address + " threw: " +
+                                winrt::to_string(e.message()));
+        return false;
     } catch (...) {
+        NativeLogger::Error(kBleCategory,
+                            "Connect to " + address + " threw an unknown "
+                            "error");
         return false;
     }
 }
@@ -123,8 +209,16 @@ bool BleIoStream::DiscoverCharacteristics() {
     auto services_result =
         device_.GetGattServicesAsync(BluetoothCacheMode::Uncached).get();
     if (services_result.Status() != GattCommunicationStatus::Success) {
+        NativeLogger::Error(kBleCategory,
+                            "Service discovery failed: " +
+                                DescribeGattStatus(services_result.Status()));
         return false;
     }
+
+    // The UUIDs a computer actually exposed are what a new descriptor gets
+    // written from, and their absence is the whole diagnosis when none of
+    // them can carry a serial session (issue #957).
+    std::vector<std::string> discovered_service_uuids;
 
     struct Candidate {
         int score = -1;
@@ -137,10 +231,15 @@ bool BleIoStream::DiscoverCharacteristics() {
     Candidate best;
 
     for (auto const& service : services_result.Services()) {
+        discovered_service_uuids.push_back(DescribeUuid(service.Uuid()));
         auto chars_result =
             service.GetCharacteristicsAsync(BluetoothCacheMode::Uncached)
                 .get();
         if (chars_result.Status() != GattCommunicationStatus::Success) {
+            NativeLogger::Warn(kBleCategory,
+                               "Service " + DescribeUuid(service.Uuid()) +
+                                   " listed no characteristics: " +
+                                   DescribeGattStatus(chars_result.Status()));
             continue;
         }
 
@@ -251,7 +350,31 @@ bool BleIoStream::DiscoverCharacteristics() {
         }
     }
 
-    if (best.score < 0) return false;
+    if (best.score < 0) {
+        if (discovered_service_uuids.empty()) {
+            NativeLogger::Error(kBleCategory,
+                                "Service discovery succeeded but the computer "
+                                "reported no services at all");
+        } else {
+            std::ostringstream seen;
+            for (size_t i = 0; i < discovered_service_uuids.size(); i++) {
+                if (i > 0) seen << ", ";
+                seen << discovered_service_uuids[i];
+            }
+            NativeLogger::Error(
+                kBleCategory,
+                "No discovered service carries both a write and a notify "
+                "characteristic; " +
+                    std::to_string(discovered_service_uuids.size()) +
+                    " service(s) seen: " + seen.str());
+        }
+        return false;
+    }
+
+    NativeLogger::Debug(kBleCategory,
+                        "Data service selected: write=" +
+                            DescribeUuid(best.write.Uuid()) +
+                            " notify=" + DescribeUuid(best.notify.Uuid()));
 
     write_characteristic_ = best.write;
     notify_characteristic_ = best.notify;
@@ -290,6 +413,9 @@ bool BleIoStream::DiscoverCharacteristics() {
             credits_cccd_result = GattCommunicationStatus::Unreachable;
         }
         if (credits_cccd_result != GattCommunicationStatus::Success) {
+            NativeLogger::Warn(kBleCategory,
+                               "Terminal I/O credit subscription failed: " +
+                                   DescribeGattStatus(credits_cccd_result));
             if (credits_required_) return false;
             // u-blox flow control is optional; fall back to running without it
             // rather than failing a device that works today.
@@ -316,6 +442,10 @@ bool BleIoStream::DiscoverCharacteristics() {
                 cccd_value)
             .get();
     if (cccd_result != GattCommunicationStatus::Success) {
+        NativeLogger::Error(kBleCategory,
+                            "Could not subscribe to notifications on " +
+                                DescribeUuid(notify_characteristic_.Uuid()) +
+                                ": " + DescribeGattStatus(cccd_result));
         return false;
     }
 
@@ -347,6 +477,8 @@ bool BleIoStream::GrantInitialCredits() {
     }
 
     if (!granted) {
+        NativeLogger::Warn(kBleCategory,
+                           "Terminal I/O initial credit grant was refused");
         // A Telit bridge carries nothing without credits, so the connection is
         // dead. u-blox flow control is optional and the service already works
         // with no handshake at all, so fall back to that instead.

--- a/packages/libdivecomputer_plugin/windows/dive_computer_host_api_impl.cc
+++ b/packages/libdivecomputer_plugin/windows/dive_computer_host_api_impl.cc
@@ -1,6 +1,7 @@
 #include "dive_computer_host_api_impl.h"
 
 #include "dive_converter.h"
+#include "native_logger.h"
 #include "serial_scanner.h"
 
 #include <climits>
@@ -16,12 +17,17 @@ namespace libdivecomputer_plugin {
 DiveComputerHostApiImpl::DiveComputerHostApiImpl(
     flutter::BinaryMessenger* messenger)
     : flutter_api_(
-          std::make_unique<DiveComputerFlutterApi>(messenger)) {}
+          std::make_unique<DiveComputerFlutterApi>(messenger)) {
+    NativeLogger::SetFlutterApi(flutter_api_.get());
+}
 
 DiveComputerHostApiImpl::~DiveComputerHostApiImpl() {
     if (download_thread_.joinable()) {
         download_thread_.join();
     }
+    // After the download thread is joined, so nothing can be mid-log, and
+    // before flutter_api_ is destroyed with this object.
+    NativeLogger::SetFlutterApi(nullptr);
 }
 
 void DiveComputerHostApiImpl::GetDeviceDescriptors(

--- a/packages/libdivecomputer_plugin/windows/native_logger.cc
+++ b/packages/libdivecomputer_plugin/windows/native_logger.cc
@@ -1,0 +1,45 @@
+#include "native_logger.h"
+
+namespace libdivecomputer_plugin {
+
+std::mutex NativeLogger::mutex_;
+DiveComputerFlutterApi* NativeLogger::api_ = nullptr;
+
+void NativeLogger::SetFlutterApi(DiveComputerFlutterApi* api) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    api_ = api;
+}
+
+void NativeLogger::Debug(const std::string& category,
+                         const std::string& message) {
+    Log(category, "DEBUG", message);
+}
+
+void NativeLogger::Info(const std::string& category,
+                        const std::string& message) {
+    Log(category, "INFO", message);
+}
+
+void NativeLogger::Warn(const std::string& category,
+                        const std::string& message) {
+    Log(category, "WARN", message);
+}
+
+void NativeLogger::Error(const std::string& category,
+                         const std::string& message) {
+    Log(category, "ERROR", message);
+}
+
+void NativeLogger::Log(const std::string& category, const std::string& level,
+                       const std::string& message) {
+    // Held across the send so the plugin cannot destroy the API underneath
+    // an in-flight call: the BLE transport logs from a download thread that
+    // outlives no shutdown of its own.
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (api_ == nullptr) return;
+    // A logging failure must never take the download with it.
+    api_->OnLogEvent(
+        category, level, message, [] {}, [](const FlutterError&) {});
+}
+
+}  // namespace libdivecomputer_plugin

--- a/packages/libdivecomputer_plugin/windows/native_logger.h
+++ b/packages/libdivecomputer_plugin/windows/native_logger.h
@@ -1,0 +1,46 @@
+#ifndef NATIVE_LOGGER_H_
+#define NATIVE_LOGGER_H_
+
+#include <mutex>
+#include <string>
+
+#include "dive_computer_api.g.h"
+
+namespace libdivecomputer_plugin {
+
+// Forwards native log lines into the Dart layer's debug log, the way
+// Android's NativeLogger.kt and darwin's NativeLogger.swift already do.
+//
+// Windows had no such bridge: every failure inside the BLE transport was
+// invisible, and a Windows bug report could carry nothing between "device
+// discovered" and "Failed to connect to device" (issue #957, a Shearwater
+// Petrel 2 that failed on both Windows 11 and Android; only the Android
+// half of the report could be diagnosed from a log).
+//
+// Deliberately used on the connect and discovery paths only, not from the
+// GATT notification handler: pigeon calls reach the Flutter engine from
+// whichever thread the caller runs on, and a per-packet log line during a
+// logbook dump would put that on the transport's hot path.
+class NativeLogger {
+ public:
+  // Called by the plugin as it takes and releases ownership of the API.
+  // Passing nullptr stops forwarding, which must happen before the API is
+  // destroyed.
+  static void SetFlutterApi(DiveComputerFlutterApi* api);
+
+  static void Debug(const std::string& category, const std::string& message);
+  static void Info(const std::string& category, const std::string& message);
+  static void Warn(const std::string& category, const std::string& message);
+  static void Error(const std::string& category, const std::string& message);
+
+ private:
+  static void Log(const std::string& category, const std::string& level,
+                  const std::string& message);
+
+  static std::mutex mutex_;
+  static DiveComputerFlutterApi* api_;
+};
+
+}  // namespace libdivecomputer_plugin
+
+#endif  // NATIVE_LOGGER_H_


### PR DESCRIPTION
Fixes #957.

## The evidence

The reporter's debug log is the whole diagnosis:

```
08:52:21.444  onMtuChanged: mtu=64 status=0
08:52:21.450  connectAndDiscover: connected=true writeChar=null credits=0 result=false
08:52:21.454  Download failed (connect_failed): Failed to connect to device
```

Six milliseconds between MTU negotiation and giving up, with no `Service:`
lines and no `disconnected status=` line. Real GATT discovery takes hundreds
of milliseconds and `onServicesDiscovered` logs one line per service, so the
connect semaphore was released without the discovery loop iterating once.
Exactly two code paths do that, and both were completely silent.

## Root cause

`BleIoStream` called `device.connectGatt(context, false, callback)`, the
three-argument form, which is `TRANSPORT_AUTO`. Android resolves
`TRANSPORT_AUTO` to Bluetooth Classic for a dual-mode radio, and a computer
whose GATT server exists only on its LE radio then connects, negotiates an
MTU, and answers service discovery with nothing.

Three independent lines of evidence say the Petrel 2 is dual-mode:

* The device address in the log, `00:13:43:72:14:EE`, carries an OUI
  registered to Matsushita/Panasonic, whose Bluetooth modules in that block
  are the PAN1026 dual-mode (BR/EDR + BLE) family.
* libdivecomputer's `descriptor.c` lists Petrel 2 as
  `DC_TRANSPORT_BLUETOOTH | DC_TRANSPORT_BLE`, while the Petrel 3, Perdix 2
  and Teric that download fine are `DC_TRANSPORT_BLE` only. The one failing
  Shearwater is the one dual-mode Shearwater, which is what explains why this
  model alone fails.
* The behaviour is documented upstream: NordicSemiconductor/Android-nRF-Connect#29
  and Polidea/RxAndroidBle#277 both describe dual-mode devices failing service
  discovery under `TRANSPORT_AUTO` and being fixed by `TRANSPORT_LE`.

## The change

**Android, the fix.** Request `BluetoothDevice.TRANSPORT_LE` explicitly. Safe
for every other computer: `BleIoStream` is only reachable from a BLE scan, so
the peripheral is LE-capable by construction, and `TRANSPORT_AUTO` already
resolves to LE for an LE-only radio. The `SDK_INT >= M` guard exists only
because the plugin module declares `minSdk 21` while the app declares 26.

**Android, the diagnostics.** New `GattDiagnostics`, framework-free in the
style of `BondDiagnostics` and `BleScanDiagnostics` so it runs as a JVM unit
test, decoding GATT statuses and device types and naming the dual-mode
transport trap. `BleIoStream` now logs the discovery status, the service UUIDs
a computer did expose when none of them can carry a serial session, and a
refused `discoverServices()`, which previously burned the whole 15-second
connect timeout without a word. This is the same lesson as #123 and #1029:
three rounds of user logs said nothing because every branch ahead of the
symptom returned silently.

**Windows.** The BLE transport logged nothing at all: `ConnectAndDiscover` was
`catch (...) { return false; }` and nothing under `windows/` ever called the
generated `OnLogEvent`. Added `windows/native_logger.{h,cc}` mirroring
Android's `NativeLogger.kt` and darwin's `NativeLogger.swift`, wired into the
host API constructor and destructor, and instrumented the connect and
discovery paths only, deliberately not the notification hot path.

## What is deliberately not claimed

No Windows fix. WinRT is LE-only, so it cannot have the transport bug, and the
Windows half of #957 stays undiagnosed until a reporter sends a log from a
build carrying this bridge. The first suspects there, noted in the code, are
`FromBluetoothAddressAsync` returning null when Windows holds only a Classic
record for the address, and `AccessDenied` meaning Windows wants the computer
paired. darwin and Linux are untouched: CoreBluetooth is LE-only by
construction.

## Testing

* `:libdivecomputer_plugin:testDebugUnitTest` passes, including 10 new
  `GattDiagnosticsTest` cases written before the implementation. A deliberately
  bogus `--tests` filter fails as a control, confirming the new tests really ran.
* The Windows C++ cannot be compiled on macOS; CI's `Build Windows` job is the
  check.
* **Hardware verification by the reporters is still pending.** If the next
  Android log shows `radio=LE only`, the transport diagnosis is refuted and the
  new lines will say what actually failed instead.
