### PR TITLE
fix(import): decode Suunto ZRAWDATA profiles from MacDive databases

### DIFF
--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -2,10 +2,12 @@
 
 **Status:** `ZRAWDATA` is **SOLVED** — see "Update 2026-08-09" at the end of this document. It is the raw Shearwater download stream stored *still compressed*; decompressing it with libdivecomputer's own two passes yields Petrel Native Format, and 266/267 dives in the reference corpus decode against ground truth. MacDive SQLite profile import works for Shearwater dives as of that date.
 
-`ZSAMPLES` remains NO-GO (AES-encrypted with a per-dive key, documented below) but is now moot: every Shearwater dive that has `ZSAMPLES` also has `ZRAWDATA`. Non-Shearwater dives have neither and still need MacDive's XML export.
+`ZSAMPLES` remains NO-GO (AES-encrypted with a per-dive key, documented below) but is now moot: every Shearwater dive that has `ZSAMPLES` also has `ZRAWDATA`.
+
+**Correction (see "Update 2026-08-29" below):** the claim in the previous paragraph that "non-Shearwater dives have neither [`ZSAMPLES` nor `ZRAWDATA`] and still need MacDive's XML export" was never actually tested against Suunto computers — the investigation corpus contained none. It turns out at least three Suunto models (EON Steel, EON Steel Black, Cobra) do populate `ZRAWDATA`, and unlike Shearwater's, theirs needs no decompression at all.
 
 The 2026-04-24 "ZRAWDATA pivot invalidated" section below is **historically inaccurate** and is retained only to show how the wrong conclusion was reached.
-**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved)
+**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved), 2026-08-29 (Suunto ZRAWDATA confirmed)
 **Author:** Eric Griffin
 **Spec:** `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
 **Plan:** `docs/superpowers/plans/2026-04-23-macdive-zsamples-phase-1-spike.md`
@@ -474,3 +476,21 @@ Model number does not matter within the Petrel family: "Petrel 2" (3) and "Tern"
 ### Caller-facing trap
 
 `libdc_parse_raw_dive` returned **rc = 0 with an empty error buffer** on the failed compressed parse, having produced a zeroed dive — `extract_dive_fields` swallows per-field failures. Any caller must validate sample count or max depth rather than trusting the return code, or a regression in the decompression step lands silently as a wave of empty dives. `MacDiveDiveMapper._attachProfile` treats an empty sample list as failure for exactly this reason.
+
+## Update 2026-08-29: Suunto `ZRAWDATA` also confirmed
+
+The 2026-08-09 update solved `ZRAWDATA` for Shearwater but restated, unchallenged, the original spike's conclusion that non-Shearwater computers carry no `ZRAWDATA` at all. That conclusion was never actually tested against Suunto — the 540-dive investigation corpus (see "Per-computer presence" above) contained Shearwater, Oceanic Matrix Master, and no-computer dives only, never a Suunto one.
+
+A Submersion user's real MacDive database contains Suunto dives, and their `ZRAWDATA` **is** populated. Unlike Shearwater's stream, Suunto's is stored **uncompressed**, already in the exact byte layout libdivecomputer's own parsers expect for that computer family — no RLE/XOR decompression pass needed, confirmed by feeding the raw blob straight into `parseRawDiveData` and getting correct profile samples back.
+
+Confirmed by model (against real MacDive `ZRAWDATA`, not just the vendor name):
+
+| MacDive `ZCOMPUTER` string | libdivecomputer product | Native format |
+|---|---|---|
+| `Suunto EON Steel` | EON Steel | SBEM |
+| `Suunto EON Steel Black` | EON Steel Black | SBEM |
+| `Suunto Cobra` | Cobra | Vyper dive-header |
+
+Implemented in `MacDiveDiveMapper._suuntoVendorProduct` / `_attachProfile` (`lib/features/universal_import/data/services/macdive_dive_mapper.dart`): the mapper now branches on vendor, running `ShearwaterRawDecompressor` only for Shearwater and passing every other recognized vendor's bytes straight to `parse`. See [submersion-app/submersion#1399](https://github.com/submersion-app/submersion/issues/1399) and the fix PR.
+
+**Not yet validated:** other Suunto models likely follow the same uncompressed-native-format pattern (Suunto's own product line shares firmware lineage), but no real `ZRAWDATA` from any other Suunto model has been confirmed. Computers outside the three above still fall through to the "no `ZRAWDATA`" warning path — a future contributor with real data from another Suunto model should add it to `_suuntoVendorProduct` only after confirming its `ZRAWDATA` parses cleanly, per the caller-facing trap noted above (a failed native parse can silently return a zeroed dive rather than an error).

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -33,17 +33,25 @@ typedef MacDiveRawParseFn =
 /// `MacDiveXmlParser` so the downstream `UddfEntityImporter` processes
 /// both sources through the same code path.
 ///
-/// Profile samples come from `ZRAWDATA`, which holds the raw Shearwater
-/// download stream still in its compressed form. [ShearwaterRawDecompressor]
+/// Profile samples come from `ZRAWDATA`. For Shearwater computers this holds
+/// the raw download stream still in its compressed form: [ShearwaterRawDecompressor]
 /// reverses the two compression passes to recover Petrel Native Format, which
 /// libdivecomputer parses directly. See
 /// `docs/import-formats/macdive-zsamples.md`.
 ///
+/// A handful of Suunto computers ([_suuntoVendorProduct]) store `ZRAWDATA`
+/// uncompressed, already in the exact byte layout libdivecomputer's own
+/// parsers expect (SBEM for the EON Steel family, the Vyper dive-header
+/// format for Cobra) - confirmed by feeding real MacDive exports through
+/// `parseRawDiveData` with no transformation. Those bytes go straight to the
+/// parser; only Shearwater's stream needs decompressing first.
+///
 /// `ZSAMPLES` is AES-encrypted with a per-dive key and remains undecodable,
-/// but it is also redundant: every dive that has `ZSAMPLES` from a Shearwater
-/// computer also has `ZRAWDATA`. Dives whose computer is not a Shearwater
-/// carry no `ZRAWDATA` at all; those raise one aggregated [ImportWarning]
-/// pointing at MacDive's XML export as the working profile path.
+/// but it is also redundant: every dive that has `ZSAMPLES` from a computer
+/// [_vendorProduct] recognises also has a usable `ZRAWDATA`. Dives on an
+/// unrecognised computer carry no decodable `ZRAWDATA`; those raise one
+/// aggregated [ImportWarning] pointing at MacDive's XML export as the
+/// working profile path.
 class MacDiveDiveMapper {
   const MacDiveDiveMapper._();
 
@@ -249,13 +257,33 @@ class MacDiveDiveMapper {
   static bool _hasRawProfile(MacDiveRawDive d) =>
       d.rawDataBlob != null && d.rawDataBlob!.isNotEmpty;
 
+  /// MacDive's `ZCOMPUTER` strings for the handful of Suunto models confirmed
+  /// (against real MacDive `ZRAWDATA`, not just the vendor name) to store
+  /// their raw download already in libdivecomputer's native format. Every
+  /// entry here is a full string match against `ZCOMPUTER` as MacDive writes
+  /// it, unlike Shearwater's "strip the prefix, look up the model" scheme,
+  /// because these were verified one model at a time rather than derived from
+  /// a general naming convention. Add a computer here only after confirming
+  /// its `ZRAWDATA` parses cleanly - unlike Shearwater's transport-compressed
+  /// stream, an unverified Suunto model could be stored in a different raw
+  /// format entirely.
+  static const _suuntoVendorProduct = {
+    'Suunto EON Steel': ('Suunto', 'EON Steel'),
+    'Suunto EON Steel Black': ('Suunto', 'EON Steel Black'),
+    'Suunto Cobra': ('Suunto', 'Cobra'),
+  };
+
   /// MacDive records the computer as a display string such as
   /// "Shearwater Teric". Strip the vendor prefix and reuse the model table
-  /// the Shearwater Cloud importer already maintains.
+  /// the Shearwater Cloud importer already maintains. Suunto has no such
+  /// prefix convention to strip, so [_suuntoVendorProduct] matches the whole
+  /// string instead.
   static (String, String)? _vendorProduct(String? computer) {
     if (computer == null) return null;
     final trimmed = computer.trim();
     if (trimmed.isEmpty) return null;
+    final suunto = _suuntoVendorProduct[trimmed];
+    if (suunto != null) return suunto;
     const prefix = 'Shearwater ';
     final model = trimmed.startsWith(prefix)
         ? trimmed.substring(prefix.length)
@@ -274,15 +302,15 @@ class MacDiveDiveMapper {
     final vendorProduct = _vendorProduct(d.computer);
     if (vendorProduct == null) return false;
 
-    final decompressed = ShearwaterRawDecompressor.decompress(d.rawDataBlob!);
-    if (decompressed == null || decompressed.isEmpty) return false;
+    // Only Shearwater stores ZRAWDATA in its own transport-compressed form;
+    // every other recognised vendor's bytes are already the native format
+    // libdivecomputer expects (see _suuntoVendorProduct).
+    final payload = vendorProduct.$1 == 'Shearwater'
+        ? ShearwaterRawDecompressor.decompress(d.rawDataBlob!)
+        : d.rawDataBlob!;
+    if (payload == null || payload.isEmpty) return false;
 
-    final parsed = await parse(
-      vendorProduct.$1,
-      vendorProduct.$2,
-      0,
-      decompressed,
-    );
+    final parsed = await parse(vendorProduct.$1, vendorProduct.$2, 0, payload);
     // A failed native parse does not always surface as an error: the macOS
     // wrapper has been observed returning success with a zeroed dive (no
     // samples, 0 m, epoch date). Treat "no samples" as the real signal, so a

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -394,6 +394,82 @@ void main() {
     });
 
     test(
+      'Suunto EON Steel Black ZRAWDATA is passed through unmodified',
+      () async {
+        final calls = <(String, String, int)>[];
+        final payload = await MacDiveDiveMapper.toPayload(
+          _suuntoRawDataLogbook(
+            computer: 'Suunto EON Steel Black',
+            raw: _suuntoFixture,
+          ),
+          parseRaw: (vendor, product, model, data) async {
+            calls.add((vendor, product, data.length));
+            return _parsedDive(
+              samples: [
+                pigeon.ProfileSample(
+                  timeSeconds: 0,
+                  depthMeters: 1.2,
+                  temperatureCelsius: 22.0,
+                  pressureBar: 190.0,
+                ),
+              ],
+            );
+          },
+        );
+
+        expect(calls, hasLength(1));
+        expect(calls.single.$1, 'Suunto');
+        expect(calls.single.$2, 'EON Steel Black');
+        // Unlike Shearwater, the bytes reach the parser exactly as MacDive
+        // stored them - no decompression pass.
+        expect(calls.single.$3, _suuntoFixture.length);
+
+        final dives = payload.entitiesOf(ImportEntityType.dives);
+        expect(dives.where((d) => d.containsKey('profile')), hasLength(1));
+        expect(payload.warnings, isEmpty);
+      },
+    );
+
+    test(
+      'Suunto EON Steel and Cobra also resolve to (Suunto, model)',
+      () async {
+        final calls = <(String, String)>[];
+        Future<pigeon.ParsedDive> parse(
+          String vendor,
+          String product,
+          int model,
+          Uint8List data,
+        ) async {
+          calls.add((vendor, product));
+          return _parsedDive(
+            samples: [
+              pigeon.ProfileSample(
+                timeSeconds: 0,
+                depthMeters: 3.0,
+                temperatureCelsius: 20.0,
+                pressureBar: 180.0,
+              ),
+            ],
+          );
+        }
+
+        await MacDiveDiveMapper.toPayload(
+          _suuntoRawDataLogbook(
+            computer: 'Suunto EON Steel',
+            raw: _suuntoFixture,
+          ),
+          parseRaw: parse,
+        );
+        await MacDiveDiveMapper.toPayload(
+          _suuntoRawDataLogbook(computer: 'Suunto Cobra', raw: _suuntoFixture),
+          parseRaw: parse,
+        );
+
+        expect(calls, [('Suunto', 'EON Steel'), ('Suunto', 'Cobra')]);
+      },
+    );
+
+    test(
       'unrecognised computer counts toward one aggregated warning',
       () async {
         final payload = await MacDiveDiveMapper.toPayload(
@@ -527,6 +603,45 @@ Uint8List _hex(String s) {
     out[i] = int.parse(s.substring(i * 2, i * 2 + 2), radix: 16);
   }
   return out;
+}
+
+/// Stand-in for a Suunto `ZRAWDATA` blob. The real format (SBEM for EON
+/// Steel, the Vyper dive-header layout for Cobra) is confirmed elsewhere
+/// against real MacDive data; these tests stub `parseRaw`, so the bytes only
+/// need to be non-empty and pass through _attachProfile unmodified.
+final _suuntoFixture = Uint8List.fromList(List.filled(24, 0x11));
+
+/// One dive on [computer] carrying [raw] as its `ZRAWDATA`.
+MacDiveRawLogbook _suuntoRawDataLogbook({
+  required String computer,
+  required Uint8List raw,
+}) {
+  return MacDiveRawLogbook(
+    dives: [
+      MacDiveRawDive(
+        pk: 1,
+        uuid: 'dive-1',
+        computer: computer,
+        rawDataBlob: raw,
+      ),
+    ],
+    sitesByPk: const {},
+    buddiesByPk: const {},
+    tagsByPk: const {},
+    gearByPk: const {},
+    tanksByPk: const {},
+    gasesByPk: const {},
+    tankAndGases: const [],
+    crittersByPk: const {},
+    certifications: const [],
+    serviceRecords: const [],
+    events: const [],
+    diveToBuddyPks: const {},
+    diveToTagPks: const {},
+    diveToGearPks: const {},
+    diveToCritterPks: const {},
+    unitsPreference: 'Metric',
+  );
 }
 
 /// Two dives carrying a real compressed blob plus one manual dive with none.

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -396,14 +396,14 @@ void main() {
     test(
       'Suunto EON Steel Black ZRAWDATA is passed through unmodified',
       () async {
-        final calls = <(String, String, int)>[];
+        final calls = <(String, String, Uint8List)>[];
         final payload = await MacDiveDiveMapper.toPayload(
           _suuntoRawDataLogbook(
             computer: 'Suunto EON Steel Black',
             raw: _suuntoFixture,
           ),
           parseRaw: (vendor, product, model, data) async {
-            calls.add((vendor, product, data.length));
+            calls.add((vendor, product, data));
             return _parsedDive(
               samples: [
                 pigeon.ProfileSample(
@@ -421,8 +421,10 @@ void main() {
         expect(calls.single.$1, 'Suunto');
         expect(calls.single.$2, 'EON Steel Black');
         // Unlike Shearwater, the bytes reach the parser exactly as MacDive
-        // stored them - no decompression pass.
-        expect(calls.single.$3, _suuntoFixture.length);
+        // stored them - no decompression pass. Compared byte for byte, not by
+        // length, because the XOR-delta half of the Shearwater decompressor
+        // rewrites a buffer in place without changing its size.
+        expect(calls.single.$3, orderedEquals(_suuntoFixture));
 
         final dives = payload.entitiesOf(ImportEntityType.dives);
         expect(dives.where((d) => d.containsKey('profile')), hasLength(1));
@@ -607,9 +609,21 @@ Uint8List _hex(String s) {
 
 /// Stand-in for a Suunto `ZRAWDATA` blob. The real format (SBEM for EON
 /// Steel, the Vyper dive-header layout for Cobra) is confirmed elsewhere
-/// against real MacDive data; these tests stub `parseRaw`, so the bytes only
-/// need to be non-empty and pass through _attachProfile unmodified.
-final _suuntoFixture = Uint8List.fromList(List.filled(24, 0x11));
+/// against real MacDive data; these tests stub `parseRaw`, so the bytes never
+/// have to be a valid dive - but their shape is chosen so that any accidental
+/// Shearwater-style transformation would visibly alter them:
+///
+/// * longer than 32 bytes, so [ShearwaterRawDecompressor.applyXorDelta] (which
+///   preserves length and would therefore slip past a length-only check) has
+///   blocks to fold together;
+/// * non-uniform, so that XOR fold produces different bytes rather than a
+///   coincidentally identical buffer;
+/// * 45 bytes, i.e. a bit count divisible by 9, so
+///   [ShearwaterRawDecompressor.decompressLre] would accept the stream instead
+///   of rejecting it as malformed and short-circuiting the test.
+final _suuntoFixture = Uint8List.fromList(
+  List.generate(45, (i) => (i * 7 + 3) & 0xFF),
+);
 
 /// One dive on [computer] carrying [raw] as its `ZRAWDATA`.
 MacDiveRawLogbook _suuntoRawDataLogbook({


### PR DESCRIPTION
## Summary

The core problem: dive profiles could not be recovered from a MacDive database import that includes Suunto computers. This was an *expected* condition under the project's existing MacDive import analysis - [`docs/import-formats/macdive-zsamples.md:5`](docs/import-formats/macdive-zsamples.md#L5) states "every Shearwater dive that has `ZSAMPLES` also has `ZRAWDATA`. Non-Shearwater dives have neither and still need MacDive's XML export," an assumption drawn from the per-computer presence table at [lines 22-31](docs/import-formats/macdive-zsamples.md#L22-L31), which covered only Shearwater, Oceanic, and no-computer dives - no Suunto computer was ever present in the investigation corpus, so the "non-Shearwater = no `ZRAWDATA`" conclusion was never actually tested against Suunto data.

It turns out Suunto computers **do** have saved `ZRAWDATA` - already uncompressed, in libdivecomputer's native format, needing no decompression pass at all. This PR adds the logic to trap the specific Suunto computers we have real data confirming (EON Steel, EON Steel Black, Cobra). Other Suunto models likely behave the same way, but we don't yet have data to validate that, so they're left going through the existing "no `ZRAWDATA`" warning path until confirmed.

Fixes #1399

## Changes

- Add `_suuntoVendorProduct`, a lookup table matching MacDive's full `ZCOMPUTER` string for the three confirmed Suunto models to their `(vendor, product)` pair.
- `_vendorProduct` checks the Suunto table first, then falls back to Shearwater's existing prefix-strip lookup.
- `_attachProfile` only runs `ShearwaterRawDecompressor` for Shearwater; other recognized vendors' bytes go straight to the native parser.
- Add tests covering pass-through byte count and correct vendor/product resolution for all three Suunto models.
- Correct `docs/import-formats/macdive-zsamples.md`, which previously (and incorrectly) stated non-Shearwater computers never populate `ZRAWDATA` - that claim was never tested against Suunto data.

## Test Plan

- [x] `flutter test` passes
- [x] `flutter analyze` passes
- [x] Manual testing on: macOS - beyond unit tests, this fix was validated in a full local build: imported a real MacDive database containing Suunto dives and confirmed dive profiles are now recovered and displayed correctly, where previously they were empty