### PR TITLE
fix(ble): stop the connect reporting success on a dead link, and the diagnostics naming the wrong cause

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -268,12 +268,12 @@ class BleIoStream(
                 // Silent before #957: the only trace a Petrel 2 owner could
                 // send was "writeChar=null", which is a symptom of both this
                 // branch and the no-usable-service one below.
-                // Release first. describeDiscoveryFailure's second argument
-                // is deviceType(), a binder round trip that raises
-                // SecurityException if BLUETOOTH_CONNECT is revoked
-                // mid-download; AOSP swallows a throw from this callback, so
-                // the release would simply never run and an immediate failure
-                // would become a 15-second hang.
+                // Release first, and deviceType() swallows its own
+                // SecurityException: the argument is a binder round trip that
+                // can fail if BLUETOOTH_CONNECT is revoked mid-download, and
+                // AOSP swallows a throw from this callback. Ordering alone
+                // saves the release but still loses the log line, so both are
+                // needed.
                 connectSemaphore.release()
                 NativeLogger.e(TAG, "BLE",
                     GattDiagnostics.describeDiscoveryFailure(status, deviceType()))
@@ -680,7 +680,18 @@ class BleIoStream(
     // every connect and every discovery failure because a dual-mode radio
     // changes what a failure means (issue #957); the stack answers UNKNOWN
     // for a device it has not seen advertise, which is itself worth seeing.
-    private fun deviceType(): Int = device.type
+    // device.type is a binder round trip annotated
+    // @RequiresPermission(BLUETOOTH_CONNECT), and the permission can be
+    // revoked mid-download. Both callers are inside a log argument, and AOSP
+    // swallows a throw from a GATT callback, so an escaping SecurityException
+    // would silently delete the very error line it is decorating. An unknown
+    // radio type costs one clause of a diagnostic; a lost diagnostic costs
+    // the whole bug report.
+    private fun deviceType(): Int = try {
+        device.type
+    } catch (e: SecurityException) {
+        GattDiagnostics.DEVICE_TYPE_UNKNOWN
+    }
 
     // Connect to the BLE device and discover services.
     // Blocks until ready or timeout. Returns true on success.

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -401,8 +401,7 @@ class BleIoStream(
                     // Only the two DEBUG lines inside subscribeToNotifications
                     // said anything, and neither is an error.
                     NativeLogger.e(TAG, "BLE",
-                        "Notification subscription could not be started; the " +
-                            "connection cannot carry a serial session")
+                        GattDiagnostics.SUBSCRIPTION_NOT_STARTED)
                 }
             } else {
                 // Discovery worked but nothing here can carry a serial
@@ -443,6 +442,20 @@ class BleIoStream(
                 ) {
                     return
                 }
+                // On a credit-flow device Data TX is subscribed from here
+                // rather than from onServicesDiscovered, so the error that
+                // path logs for a subscribe that never started belongs on
+                // this one too. Without it the credits handshake succeeding
+                // and the data subscribe then failing to start reads as a
+                // clean connect that answers nothing.
+                NativeLogger.e(TAG, "BLE", GattDiagnostics.SUBSCRIPTION_NOT_STARTED)
+            } else if (completed == SetupStep.CREDITS_NOTIFY) {
+                // Credits are required and the module refused the
+                // subscription: the branch above already took every case
+                // where the failure is survivable. Nothing more is
+                // attempted, so this is the last word on the connect.
+                NativeLogger.e(TAG, "BLE",
+                    GattDiagnostics.describeCreditsSubscriptionFailure(status))
             } else if (completed == SetupStep.DATA_NOTIFY && ok) {
                 // The one point where the peripheral has confirmed it will
                 // push data. connectAndDiscover reports on this rather than
@@ -456,6 +469,15 @@ class BleIoStream(
                 } else if (!creditsRequired) {
                     abandonCreditFlowControl("initial credit write rejected")
                 }
+            } else if (completed == SetupStep.DATA_NOTIFY) {
+                // The computer accepted the CCCD write and then completed it
+                // with a failure status, which leaves dataNotifyReady false
+                // and fails the connect. writeDescriptor() returning true is
+                // only the local stack queueing the write; the peripheral's
+                // answer arrives here, and until this the whole account of a
+                // refusal was the DEBUG status line above.
+                NativeLogger.e(TAG, "BLE",
+                    GattDiagnostics.describeDataSubscriptionFailure(status))
             }
 
             // Nothing further in flight; GATT is free for I/O.

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleIoStream.kt
@@ -158,6 +158,11 @@ class BleIoStream(
     private val gattOperation = Semaphore(1)
     private val connectSemaphore = Semaphore(0)
     private var connected = false
+
+    // Whether the Data TX CCCD write completed successfully. Assigning
+    // notifyCharacteristic only means a candidate was found; until the
+    // descriptor write lands the peripheral sends nothing.
+    private var dataNotifyReady = false
     private var readBuffer = ByteArray(0)
 
     private val pinSemaphore = Semaphore(0)
@@ -199,7 +204,17 @@ class BleIoStream(
                 // Request a larger MTU before discovering services.
                 // Android defaults to 23 bytes (20 payload); CoreBluetooth
                 // negotiates automatically but Android requires an explicit call.
-                gatt.requestMtu(512)
+                // A refused request never produces onMtuChanged, and
+                // onMtuChanged is the only path in this class that reaches
+                // discoverServices(), so a discarded false here costs the
+                // caller the whole 15-second connect timeout for a failure
+                // the stack already reported. Same reasoning as the
+                // discoverServices() check in onMtuChanged below.
+                if (!gatt.requestMtu(512)) {
+                    NativeLogger.e(TAG, "BLE",
+                        "requestMtu(512) was refused by the Bluetooth stack")
+                    connectSemaphore.release()
+                }
             } else {
                 connected = false
                 lastDisconnectStatus = status
@@ -228,7 +243,9 @@ class BleIoStream(
                 // drains the semaphore before issuing.
                 lastWriteStatus = BluetoothGatt.GATT_FAILURE
                 writeSemaphore.release()
-                NativeLogger.d(TAG, "BLE", "onConnectionStateChange: disconnected status=$status")
+                NativeLogger.d(TAG, "BLE",
+                    "onConnectionStateChange: disconnected status=$status " +
+                        "(${GattDiagnostics.describeConnectionStatus(status)})")
                 connectSemaphore.release()
             }
         }
@@ -251,9 +268,15 @@ class BleIoStream(
                 // Silent before #957: the only trace a Petrel 2 owner could
                 // send was "writeChar=null", which is a symptom of both this
                 // branch and the no-usable-service one below.
+                // Release first. describeDiscoveryFailure's second argument
+                // is deviceType(), a binder round trip that raises
+                // SecurityException if BLUETOOTH_CONNECT is revoked
+                // mid-download; AOSP swallows a throw from this callback, so
+                // the release would simply never run and an immediate failure
+                // would become a 15-second hang.
+                connectSemaphore.release()
                 NativeLogger.e(TAG, "BLE",
                     GattDiagnostics.describeDiscoveryFailure(status, deviceType()))
-                connectSemaphore.release()
                 return
             }
 
@@ -370,6 +393,17 @@ class BleIoStream(
                 } else {
                     subscribeToNotifications(gatt, bestNotify, SetupStep.DATA_NOTIFY)
                 }
+                if (!startedSetup) {
+                    // The characteristics are assigned by now, so without
+                    // this the connect reports success on a link that can
+                    // never deliver a byte: every libdivecomputer read would
+                    // block to timeout with no notification subscription.
+                    // Only the two DEBUG lines inside subscribeToNotifications
+                    // said anything, and neither is an error.
+                    NativeLogger.e(TAG, "BLE",
+                        "Notification subscription could not be started; the " +
+                            "connection cannot carry a serial session")
+                }
             } else {
                 // Discovery worked but nothing here can carry a serial
                 // session. Name what the computer did expose: those UUIDs
@@ -410,6 +444,10 @@ class BleIoStream(
                     return
                 }
             } else if (completed == SetupStep.DATA_NOTIFY && ok) {
+                // The one point where the peripheral has confirmed it will
+                // push data. connectAndDiscover reports on this rather than
+                // on the characteristic being non-null.
+                dataNotifyReady = true
                 if (creditsWriteCharacteristic == null) {
                     // No credit flow control on this device, or already
                     // abandoned: GATT is free for I/O.
@@ -682,6 +720,17 @@ class BleIoStream(
         } else {
             device.connectGatt(context, false, gattCallback)
         }
+        // connectGatt returns null when the adapter service is unbound or
+        // BLE is unsupported, which is what turning Bluetooth off between
+        // the scan and the download looks like. No callback can ever fire,
+        // so waiting would burn the full 15 seconds and then report the
+        // generic failure that issue #957 was filed about.
+        if (gatt == null) {
+            NativeLogger.e(TAG, "BLE",
+                "connectGatt returned null; Bluetooth is off or the adapter " +
+                    "is unavailable")
+            return false
+        }
         if (!connectSemaphore.tryAcquire(15, TimeUnit.SECONDS)) {
             NativeLogger.e(TAG, "BLE", "connectAndDiscover: semaphore timeout")
             return false
@@ -690,8 +739,11 @@ class BleIoStream(
         // granted, so a failed handshake means the first command write would
         // fail rather than the download merely being slow (issue #923).
         val terminalIoReady = creditsWriteCharacteristic == null || credits > 0
-        val ok = connected && writeCharacteristic != null && terminalIoReady
-        NativeLogger.d(TAG, "BLE", "connectAndDiscover: connected=$connected writeChar=${writeCharacteristic?.uuid} credits=$credits result=$ok")
+        val ok = connected &&
+            writeCharacteristic != null &&
+            dataNotifyReady &&
+            terminalIoReady
+        NativeLogger.d(TAG, "BLE", "connectAndDiscover: connected=$connected writeChar=${writeCharacteristic?.uuid} notifyReady=$dataNotifyReady credits=$credits result=$ok")
         return ok
     }
 

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
@@ -24,17 +24,42 @@ object GattDiagnostics {
     const val DEVICE_TYPE_LE = 2
     const val DEVICE_TYPE_DUAL = 3
 
-    // Mirrors android.bluetooth.BluetoothGatt.GATT_SUCCESS plus the
-    // connection-layer statuses the stack passes through unchanged. Only
-    // GATT_SUCCESS and a handful of ATT codes are public API; the rest come
-    // from the HCI error codes in stack/include/gatt_api.h and are stable.
+    // A BluetoothGattCallback status is read in one of two disjoint number
+    // spaces, and they collide. An operation callback (onServicesDiscovered,
+    // onDescriptorWrite, onCharacteristicRead/Write) carries an ATT protocol
+    // error; onConnectionStateChange carries an HCI connection error passed
+    // through unchanged. Both define 8: ATT 0x08 is insufficient
+    // authorization, HCI 0x08 is connection timeout. Describing one with the
+    // other's table does not degrade to a vague answer, it produces a
+    // confident wrong one, so the two tables are kept apart and each
+    // describer names the space it reads.
+
+    // ATT protocol errors (Bluetooth core spec vol 3 part F 3.4.1.1, mirrored
+    // in stack/include/gatt_api.h). GATT_SUCCESS and a handful of these are
+    // public API on android.bluetooth.BluetoothGatt; the rest are stable.
     const val GATT_SUCCESS = 0
-    const val GATT_INSUFFICIENT_AUTHENTICATION = 5
-    const val GATT_CONN_TIMEOUT = 8
-    const val GATT_CONN_TERMINATE_PEER_USER = 19
-    const val GATT_CONN_TERMINATE_LOCAL_HOST = 22
-    const val GATT_CONN_LMP_TIMEOUT = 34
-    const val GATT_CONN_FAIL_ESTABLISH = 62
+    const val ATT_INVALID_HANDLE = 1
+    const val ATT_READ_NOT_PERMITTED = 2
+    const val ATT_WRITE_NOT_PERMITTED = 3
+    const val ATT_INSUFFICIENT_AUTHENTICATION = 5
+    const val ATT_REQUEST_NOT_SUPPORTED = 6
+    const val ATT_INVALID_OFFSET = 7
+    const val ATT_INSUFFICIENT_AUTHORIZATION = 8
+    const val ATT_ATTRIBUTE_NOT_FOUND = 10
+    const val ATT_INSUFFICIENT_KEY_SIZE = 12
+    const val ATT_INVALID_ATTRIBUTE_LENGTH = 13
+    const val ATT_INSUFFICIENT_ENCRYPTION = 15
+
+    // HCI connection errors, as delivered to onConnectionStateChange.
+    const val CONN_TIMEOUT = 8
+    const val CONN_TERMINATE_PEER_USER = 19
+    const val CONN_TERMINATE_LOCAL_HOST = 22
+    const val CONN_LMP_TIMEOUT = 34
+    const val CONN_FAIL_ESTABLISH = 62
+    const val CONN_AUTH_FAILURE = 137
+    const val CONN_TIMEOUT_HCI = 147
+
+    // Reported in both spaces.
     const val GATT_INTERNAL_ERROR = 129
     const val GATT_ERROR = 133
     const val GATT_CONN_CANCEL = 256
@@ -66,24 +91,41 @@ object GattDiagnostics {
     fun describeTransport(leRequested: Boolean): String =
         if (leRequested) "LE" else "AUTO (LE cannot be demanded below API 23)"
 
-    /** Human-readable reason for a BluetoothGattCallback status code. */
-    fun describeGattStatus(status: Int): String = when (status) {
+    /**
+     * Reason for a status delivered by an ATT operation callback, such as
+     * [android.bluetooth.BluetoothGattCallback.onServicesDiscovered].
+     *
+     * Do not use for onConnectionStateChange: see [describeConnectionStatus]
+     * and the note on the constants above for the codes that collide.
+     */
+    fun describeAttStatus(status: Int): String = when (status) {
         GATT_SUCCESS ->
             "success"
-        GATT_INSUFFICIENT_AUTHENTICATION ->
+        ATT_INVALID_HANDLE ->
+            "the computer rejected the handle as invalid"
+        ATT_READ_NOT_PERMITTED ->
+            "the computer does not permit reading that attribute"
+        ATT_WRITE_NOT_PERMITTED ->
+            "the computer does not permit writing that attribute"
+        ATT_INSUFFICIENT_AUTHENTICATION ->
             "insufficient authentication; the stored pairing keys are stale " +
                 "or the computer demanded encryption"
-        GATT_CONN_TIMEOUT ->
-            "the connection timed out; the computer moved out of range or " +
-                "switched its radio off"
-        GATT_CONN_TERMINATE_PEER_USER ->
-            "the computer closed the connection"
-        GATT_CONN_TERMINATE_LOCAL_HOST ->
-            "this phone closed the connection"
-        GATT_CONN_LMP_TIMEOUT ->
-            "the computer stopped answering the radio link"
-        GATT_CONN_FAIL_ESTABLISH ->
-            "the connection could not be established"
+        ATT_REQUEST_NOT_SUPPORTED ->
+            "the computer does not support that request"
+        ATT_INVALID_OFFSET ->
+            "the computer rejected the offset as invalid"
+        ATT_INSUFFICIENT_AUTHORIZATION ->
+            "insufficient authorization; usually a bond problem, so removing " +
+                "the pairing on both sides and pairing again is the first " +
+                "thing to try"
+        ATT_ATTRIBUTE_NOT_FOUND ->
+            "the computer reported no such attribute"
+        ATT_INSUFFICIENT_KEY_SIZE ->
+            "the negotiated encryption key is too short for that attribute"
+        ATT_INVALID_ATTRIBUTE_LENGTH ->
+            "the computer rejected the attribute length"
+        ATT_INSUFFICIENT_ENCRYPTION ->
+            "the attribute needs an encrypted link and this one is not"
         GATT_INTERNAL_ERROR ->
             "internal Bluetooth stack error"
         GATT_ERROR ->
@@ -94,7 +136,43 @@ object GattDiagnostics {
         GATT_FAILURE ->
             "the operation failed"
         else ->
-            "unknown GATT status ($status)"
+            "unknown ATT status ($status)"
+    }
+
+    /**
+     * Reason for a status delivered by
+     * [android.bluetooth.BluetoothGattCallback.onConnectionStateChange],
+     * which reads in the HCI connection space rather than the ATT one.
+     */
+    fun describeConnectionStatus(status: Int): String = when (status) {
+        GATT_SUCCESS ->
+            "success"
+        CONN_TIMEOUT ->
+            "the connection timed out; the computer moved out of range or " +
+                "switched its radio off"
+        CONN_TERMINATE_PEER_USER ->
+            "the computer closed the connection"
+        CONN_TERMINATE_LOCAL_HOST ->
+            "this phone closed the connection"
+        CONN_LMP_TIMEOUT ->
+            "the computer stopped answering the radio link"
+        CONN_FAIL_ESTABLISH ->
+            "the connection could not be established"
+        CONN_AUTH_FAILURE ->
+            "authentication failed; the pairing keys are stale on one side"
+        CONN_TIMEOUT_HCI ->
+            "the connection could not be established before the radio gave up"
+        GATT_INTERNAL_ERROR ->
+            "internal Bluetooth stack error"
+        GATT_ERROR ->
+            "generic GATT error; on a connect this is usually a stale bond " +
+                "or a computer that is not advertising"
+        GATT_CONN_CANCEL ->
+            "the connection attempt was cancelled"
+        GATT_FAILURE ->
+            "the operation failed"
+        else ->
+            "unknown connection status ($status)"
     }
 
     /**
@@ -116,7 +194,7 @@ object GattDiagnostics {
      */
     fun describeDiscoveryFailure(status: Int, deviceType: Int): String {
         val base = "Service discovery failed: status=$status " +
-            "(${describeGattStatus(status)}); the computer's radio is " +
+            "(${describeAttStatus(status)}); the computer's radio is " +
             describeDeviceType(deviceType)
         if (deviceType != DEVICE_TYPE_DUAL) return base
         return "$base. Dual-mode is a known trap: under TRANSPORT_AUTO " +

--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/GattDiagnostics.kt
@@ -205,6 +205,50 @@ object GattDiagnostics {
     }
 
     /**
+     * Message for a subscription whose CCCD write was never issued: the
+     * characteristic carries no CCCD, or the local stack refused to queue
+     * the write. Nothing reached the computer, so there is no ATT status to
+     * report and none is claimed.
+     *
+     * Shared by both sites that start a subscription, the first one in
+     * onServicesDiscovered and the Data TX one that a credit-flow device
+     * starts from onDescriptorWrite instead.
+     */
+    const val SUBSCRIPTION_NOT_STARTED =
+        "Notification subscription could not be started; the connection " +
+            "cannot carry a serial session"
+
+    /**
+     * Message for a Data TX CCCD write the computer accepted and then
+     * completed with a failure status.
+     *
+     * This is the other half of [SUBSCRIPTION_NOT_STARTED] and has to read
+     * differently: there the write never left this phone, while here the
+     * computer answered and refused, so the ATT status is its own account
+     * of why. Either way the peripheral sends nothing and every
+     * libdivecomputer read blocks to timeout.
+     */
+    fun describeDataSubscriptionFailure(status: Int): String =
+        "Data TX notification subscription failed: status=$status " +
+            "(${describeAttStatus(status)}); the computer will send nothing, " +
+            "so the connection cannot carry a serial session"
+
+    /**
+     * The Terminal I/O twin of [describeDataSubscriptionFailure], for the
+     * Credits TX subscription that is written first.
+     *
+     * Only reached on a module that requires credit flow control, which
+     * keeps its UART bridge closed until the subscription exists (#923):
+     * that failure is terminal rather than something to run without. A
+     * u-blox module, where flow control is optional, never comes here; it
+     * abandons credits and carries on, which is a warning, not an error.
+     */
+    fun describeCreditsSubscriptionFailure(status: Int): String =
+        "Terminal I/O: Credits TX subscription failed: status=$status " +
+            "(${describeAttStatus(status)}); the module keeps its UART " +
+            "bridge closed without it, so no command can reach the computer"
+
+    /**
      * Message for a discovery that completed but exposed no service
      * carrying both a write and a notify/indicate characteristic, which is
      * the pair the serial bridge needs.

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
@@ -275,4 +275,65 @@ class GattDiagnosticsTest {
         assertTrue(message.contains("00001800-0000-1000-8000-00805f9b34fb"))
         assertTrue(message.contains("0000fefb-0000-1000-8000-00805f9b34fb"))
     }
+
+    @Test
+    fun aRefusedDataSubscriptionNamesTheAttReasonForIt() {
+        // onDescriptorWrite is an ATT callback, so status 8 here is an
+        // authorization failure, not the connection timeout the same number
+        // means on onConnectionStateChange. Sending a reporter after range
+        // and battery for a bond problem is the misdiagnosis this suite
+        // exists to prevent.
+        val message = GattDiagnostics.describeDataSubscriptionFailure(
+            GattDiagnostics.ATT_INSUFFICIENT_AUTHORIZATION
+        )
+
+        assertTrue(message.contains("status=8"))
+        assertTrue(message.contains("authorization"))
+        assertFalse(message.contains("out of range"))
+    }
+
+    @Test
+    fun aRefusedCreditsSubscriptionNamesTheBridgeItLeavesShut() {
+        // A Telit module answers nothing at all without this subscription,
+        // so the message has to say why the link is dead rather than just
+        // that a descriptor write failed (#923).
+        val message = GattDiagnostics.describeCreditsSubscriptionFailure(
+            GattDiagnostics.ATT_INSUFFICIENT_AUTHENTICATION
+        )
+
+        assertTrue(message.contains("Credits TX"))
+        assertTrue(message.contains("bridge"))
+        assertTrue(message.contains("status=5"))
+        assertTrue(message.contains("pairing"))
+    }
+
+    @Test
+    fun theTwoSubscriptionFailuresAreNotInterchangeable() {
+        // They are logged from adjacent branches of one callback. An
+        // implementation that routed both through a single message would
+        // leave a log that cannot say which subscription died, which is the
+        // difference between a Terminal I/O handshake problem and a data
+        // characteristic the computer refuses to push.
+        val status = GattDiagnostics.GATT_ERROR
+        val data = GattDiagnostics.describeDataSubscriptionFailure(status)
+        val credits = GattDiagnostics.describeCreditsSubscriptionFailure(status)
+
+        assertFalse(data == credits)
+        assertTrue(data.contains("Data TX"))
+        assertFalse(data.contains("Credits TX"))
+    }
+
+    @Test
+    fun aSubscribeThatNeverStartedClaimsNoStatusItCouldNotHave() {
+        // Nothing reached the computer on this path, so there is no ATT
+        // status to name. A message that rendered one anyway would invent a
+        // verdict the peripheral never gave.
+        assertFalse(GattDiagnostics.SUBSCRIPTION_NOT_STARTED.contains("status="))
+        assertFalse(
+            GattDiagnostics.SUBSCRIPTION_NOT_STARTED ==
+                GattDiagnostics.describeDataSubscriptionFailure(
+                    GattDiagnostics.GATT_SUCCESS
+                )
+        )
+    }
 }

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/GattDiagnosticsTest.kt
@@ -47,28 +47,126 @@ class GattDiagnosticsTest {
     }
 
     @Test
-    fun commonGattStatusesAreExplained() {
-        assertTrue(GattDiagnostics.describeGattStatus(0).contains("success"))
+    fun commonAttStatusesAreExplained() {
+        assertTrue(GattDiagnostics.describeAttStatus(0).contains("success"))
         assertTrue(
-            GattDiagnostics.describeGattStatus(
-                GattDiagnostics.GATT_INSUFFICIENT_AUTHENTICATION
+            GattDiagnostics.describeAttStatus(
+                GattDiagnostics.ATT_INSUFFICIENT_AUTHENTICATION
             ).contains("pairing")
         )
-        assertTrue(
-            GattDiagnostics.describeGattStatus(
-                GattDiagnostics.GATT_CONN_TIMEOUT
-            ).contains("timed out")
-        )
-        assertTrue(
-            GattDiagnostics.describeGattStatus(
-                GattDiagnostics.GATT_ERROR
-            ).isNotEmpty()
+        assertEquals(
+            "generic GATT error; usually the computer refused the operation " +
+                "or the link was not usable for it",
+            GattDiagnostics.describeAttStatus(GattDiagnostics.GATT_ERROR)
         )
     }
 
     @Test
-    fun unknownGattStatusReportsItsValue() {
-        assertTrue(GattDiagnostics.describeGattStatus(200).contains("200"))
+    fun statusEightReadsAsAuthorizationOnAnAttCallback() {
+        // ATT 0x08 is insufficient authorization, a bond problem. The HCI
+        // connection space also defines 8, as a connection timeout, and
+        // describing an onServicesDiscovered status with that table sent the
+        // reporter after range and battery for what pairing again fixes.
+        val message = GattDiagnostics.describeAttStatus(
+            GattDiagnostics.ATT_INSUFFICIENT_AUTHORIZATION
+        )
+
+        assertTrue(message.contains("authorization"))
+        assertFalse(message.contains("out of range"))
+        assertFalse(message.contains("timed out"))
+    }
+
+    @Test
+    fun statusEightStillReadsAsATimeoutOnAConnectionCallback() {
+        val message = GattDiagnostics.describeConnectionStatus(
+            GattDiagnostics.CONN_TIMEOUT
+        )
+
+        assertTrue(message.contains("timed out"))
+        assertFalse(message.contains("authorization"))
+    }
+
+    @Test
+    fun theTwoStatusSpacesDisagreeAboutEightOnPurpose() {
+        // Pins the collision itself: if either table is ever folded back
+        // into the other, one of these call sites starts lying.
+        assertFalse(
+            GattDiagnostics.describeAttStatus(8) ==
+                GattDiagnostics.describeConnectionStatus(8)
+        )
+    }
+
+    @Test
+    fun everyKnownAttStatusHasItsOwnDescription() {
+        // The sibling suites (BondDiagnosticsTest, BleScanDiagnosticsTest)
+        // both carry this assertion; without it a copy-paste that gives two
+        // codes the same text reads as a working table.
+        val known = listOf(
+            GattDiagnostics.GATT_SUCCESS,
+            GattDiagnostics.ATT_INVALID_HANDLE,
+            GattDiagnostics.ATT_READ_NOT_PERMITTED,
+            GattDiagnostics.ATT_WRITE_NOT_PERMITTED,
+            GattDiagnostics.ATT_INSUFFICIENT_AUTHENTICATION,
+            GattDiagnostics.ATT_REQUEST_NOT_SUPPORTED,
+            GattDiagnostics.ATT_INVALID_OFFSET,
+            GattDiagnostics.ATT_INSUFFICIENT_AUTHORIZATION,
+            GattDiagnostics.ATT_ATTRIBUTE_NOT_FOUND,
+            GattDiagnostics.ATT_INSUFFICIENT_KEY_SIZE,
+            GattDiagnostics.ATT_INVALID_ATTRIBUTE_LENGTH,
+            GattDiagnostics.ATT_INSUFFICIENT_ENCRYPTION,
+            GattDiagnostics.GATT_INTERNAL_ERROR,
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.GATT_CONN_CANCEL,
+            GattDiagnostics.GATT_FAILURE
+        )
+        val descriptions = known.map { GattDiagnostics.describeAttStatus(it) }
+
+        assertEquals(known.size, descriptions.toSet().size)
+        assertTrue(descriptions.none { it.contains("unknown") })
+    }
+
+    @Test
+    fun everyKnownConnectionStatusHasItsOwnDescription() {
+        val known = listOf(
+            GattDiagnostics.GATT_SUCCESS,
+            GattDiagnostics.CONN_TIMEOUT,
+            GattDiagnostics.CONN_TERMINATE_PEER_USER,
+            GattDiagnostics.CONN_TERMINATE_LOCAL_HOST,
+            GattDiagnostics.CONN_LMP_TIMEOUT,
+            GattDiagnostics.CONN_FAIL_ESTABLISH,
+            GattDiagnostics.CONN_AUTH_FAILURE,
+            GattDiagnostics.CONN_TIMEOUT_HCI,
+            GattDiagnostics.GATT_INTERNAL_ERROR,
+            GattDiagnostics.GATT_ERROR,
+            GattDiagnostics.GATT_CONN_CANCEL,
+            GattDiagnostics.GATT_FAILURE
+        )
+        val descriptions =
+            known.map { GattDiagnostics.describeConnectionStatus(it) }
+
+        assertEquals(known.size, descriptions.toSet().size)
+        assertTrue(descriptions.none { it.contains("unknown") })
+    }
+
+    @Test
+    fun theStatusThisRepoKeepsCitingIsNotUnknown() {
+        // 147 appears three times in DiveComputerHostApiImpl's own comments
+        // as the stale-bond failure, and used to render as "unknown".
+        assertFalse(
+            GattDiagnostics.describeConnectionStatus(147).contains("unknown")
+        )
+    }
+
+    @Test
+    fun unknownStatusReportsItsValueAndItsSpace() {
+        assertTrue(GattDiagnostics.describeAttStatus(200).contains("200"))
+        assertTrue(GattDiagnostics.describeAttStatus(200).contains("ATT"))
+        assertTrue(
+            GattDiagnostics.describeConnectionStatus(200).contains("200")
+        )
+        assertTrue(
+            GattDiagnostics.describeConnectionStatus(200).contains("connection")
+        )
     }
 
     @Test
@@ -113,13 +211,34 @@ class GattDiagnosticsTest {
     }
 
     @Test
-    fun singleModeDiscoveryFailureDoesNotBlameTheTransport() {
-        val message = GattDiagnostics.describeDiscoveryFailure(
-            GattDiagnostics.GATT_ERROR,
-            GattDiagnostics.DEVICE_TYPE_LE
+    fun onlyADualModeRadioEarnsTheTransportAddendum() {
+        // Testing DEVICE_TYPE_LE alone under-constrains the guard: an
+        // implementation written `if (type == DEVICE_TYPE_LE) return base`
+        // would pass. Every non-dual type has to be checked, and the
+        // addendum is identified by its own words rather than by "Classic",
+        // which the CLASSIC base string legitimately contains.
+        val nonDual = listOf(
+            GattDiagnostics.DEVICE_TYPE_UNKNOWN,
+            GattDiagnostics.DEVICE_TYPE_CLASSIC,
+            GattDiagnostics.DEVICE_TYPE_LE,
+            42
         )
-
-        assertFalse(message.contains("Classic"))
+        for (type in nonDual) {
+            val message = GattDiagnostics.describeDiscoveryFailure(
+                GattDiagnostics.GATT_ERROR,
+                type
+            )
+            assertFalse(
+                "type $type must not earn the addendum",
+                message.contains("TRANSPORT_AUTO")
+            )
+        }
+        assertTrue(
+            GattDiagnostics.describeDiscoveryFailure(
+                GattDiagnostics.GATT_ERROR,
+                GattDiagnostics.DEVICE_TYPE_DUAL
+            ).contains("TRANSPORT_AUTO")
+        )
     }
 
     @Test
@@ -150,7 +269,9 @@ class GattDiagnosticsTest {
             )
         )
 
-        assertTrue(message.contains("2"))
+        // "2" alone passed only because neither fixture UUID contains that
+        // digit; assert the count as it is actually rendered.
+        assertTrue(message.contains("2 service(s)"))
         assertTrue(message.contains("00001800-0000-1000-8000-00805f9b34fb"))
         assertTrue(message.contains("0000fefb-0000-1000-8000-00805f9b34fb"))
     }

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -20,15 +20,18 @@ namespace {
 // bug report reads the same way as the ones this code was modelled on.
 constexpr char kBleCategory[] = "BLE";
 
+// Colon-free upper-case hex, the one form a Windows address takes anywhere
+// else in this plugin: ble_scanner.cc formats the same uint64 as "%012llX",
+// that string is DiscoveredDevice::address(), it is the access-code storage
+// key, it is what dive_computer_host_api_impl.cc parses back with strtoull,
+// and it is what the Dart log prints. A colon-separated form here would mean
+// the connect and error lines could not be matched to the device that
+// produced them, and bluetoothAddressesMatch (discovery_providers.dart) only
+// upper-cases before comparing, so it would not bridge the two spellings.
 std::string FormatAddress(uint64_t address) {
-    char buffer[18];
-    std::snprintf(buffer, sizeof(buffer), "%02X:%02X:%02X:%02X:%02X:%02X",
-                  static_cast<unsigned>((address >> 40) & 0xFF),
-                  static_cast<unsigned>((address >> 32) & 0xFF),
-                  static_cast<unsigned>((address >> 24) & 0xFF),
-                  static_cast<unsigned>((address >> 16) & 0xFF),
-                  static_cast<unsigned>((address >> 8) & 0xFF),
-                  static_cast<unsigned>(address & 0xFF));
+    char buffer[13];
+    std::snprintf(buffer, sizeof(buffer), "%012llX",
+                  static_cast<unsigned long long>(address));
     return std::string(buffer);
 }
 
@@ -164,14 +167,26 @@ bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
                       bluetooth_address)
                       .get();
         if (!device_) {
-            // Windows resolves the address against its own device database,
-            // so this is not "the computer is off": it is Windows holding no
-            // LE record for the address at all, which is what a dual-mode
-            // computer known only as a Bluetooth Classic device looks like.
+            // Phrased as a lead rather than a verdict, for the same reason
+            // the Android twin was (GattDiagnostics.describeDiscoveryFailure):
+            // naming one cause as fact sends the reporter down it. Windows
+            // resolves the address against its own device database, so a
+            // dual-mode computer known only as a Classic device is one
+            // explanation, but the single-argument FromBluetoothAddressAsync
+            // resolves against a public address type and so also misses a
+            // random-static advertiser (#1232), and a stored address the
+            // stack has not seen advertise recently fails here too
+            // (discovery_providers.dart).
             NativeLogger::Error(kBleCategory,
                                 "No Bluetooth LE device for " + address +
-                                    "; Windows has no LE record for this "
-                                    "address");
+                                    "; Windows resolved no LE record for this "
+                                    "address. Known causes: a dual-mode "
+                                    "computer Windows knows only as a "
+                                    "Bluetooth Classic device, an address "
+                                    "the stack has not seen advertise "
+                                    "recently, or a random-static advertising "
+                                    "address. Re-running a scan before the "
+                                    "connect distinguishes the second");
             return false;
         }
 
@@ -192,15 +207,20 @@ bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
         }
 
         return DiscoverCharacteristics();
+    // DiscoverCharacteristics runs inside this try and does not catch its
+    // own .get() throws, so these handlers see discovery failures too.
+    // Saying "connect" would tell the reader the link never came up when it
+    // may have come up and died during discovery, which is exactly the
+    // distinction #957 was about.
     } catch (const winrt::hresult_error& e) {
         NativeLogger::Error(kBleCategory,
-                            "Connect to " + address + " threw: " +
-                                winrt::to_string(e.message()));
+                            "Connect or service discovery for " + address +
+                                " threw: " + winrt::to_string(e.message()));
         return false;
     } catch (...) {
         NativeLogger::Error(kBleCategory,
-                            "Connect to " + address + " threw an unknown "
-                            "error");
+                            "Connect or service discovery for " + address +
+                                " threw an unknown error");
         return false;
     }
 }
@@ -231,7 +251,6 @@ bool BleIoStream::DiscoverCharacteristics() {
     Candidate best;
 
     for (auto const& service : services_result.Services()) {
-        discovered_service_uuids.push_back(DescribeUuid(service.Uuid()));
         auto chars_result =
             service.GetCharacteristicsAsync(BluetoothCacheMode::Uncached)
                 .get();
@@ -242,6 +261,13 @@ bool BleIoStream::DiscoverCharacteristics() {
                                    DescribeGattStatus(chars_result.Status()));
             continue;
         }
+        // Counted only now. Pushing before the gate made the terminal "no
+        // usable service; N service(s) seen" line assert a fact about
+        // characteristics that were never enumerated: on an unpaired machine
+        // every service returns AccessDenied, and the summary would send a
+        // maintainer into UUID archaeology when the adjacent WARN lines
+        // already say the machine simply needs pairing.
+        discovered_service_uuids.push_back(DescribeUuid(service.Uuid()));
 
         GattCharacteristic best_write{nullptr};
         int best_write_score = -1;
@@ -403,19 +429,34 @@ bool BleIoStream::DiscoverCharacteristics() {
         // precisely so an optional handshake cannot break a working device.
         // Treat a throw exactly like a non-Success status instead.
         auto credits_cccd_result = GattCommunicationStatus::Unreachable;
+        // Kept separate from the status. Unreachable is only a convenient
+        // non-Success value to take the failure branch with, and running it
+        // through DescribeGattStatus would report "out of range, switched
+        // its radio off, or dropped the link" for what may be an
+        // authentication or access error whose HRESULT names the real cause.
+        // On a Telit module this is terminal, so it is the last line in the
+        // log and has to be true.
+        std::string credits_cccd_threw;
         try {
             credits_cccd_result =
                 credits_notify_characteristic_
                     .WriteClientCharacteristicConfigurationDescriptorAsync(
                         credits_cccd_value)
                     .get();
+        } catch (const winrt::hresult_error& e) {
+            credits_cccd_result = GattCommunicationStatus::Unreachable;
+            credits_cccd_threw = winrt::to_string(e.message());
         } catch (...) {
             credits_cccd_result = GattCommunicationStatus::Unreachable;
+            credits_cccd_threw = "unknown error";
         }
         if (credits_cccd_result != GattCommunicationStatus::Success) {
             NativeLogger::Warn(kBleCategory,
                                "Terminal I/O credit subscription failed: " +
-                                   DescribeGattStatus(credits_cccd_result));
+                                   (credits_cccd_threw.empty()
+                                        ? DescribeGattStatus(
+                                              credits_cccd_result)
+                                        : "threw: " + credits_cccd_threw));
             if (credits_required_) return false;
             // u-blox flow control is optional; fall back to running without it
             // rather than failing a device that works today.

--- a/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
+++ b/packages/libdivecomputer_plugin/windows/ble_io_stream.cc
@@ -1,6 +1,7 @@
 #include "ble_io_stream.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <sstream>
@@ -28,6 +29,17 @@ constexpr char kBleCategory[] = "BLE";
 // the connect and error lines could not be matched to the device that
 // produced them, and bluetoothAddressesMatch (discovery_providers.dart) only
 // upper-cases before comparing, so it would not bridge the two spellings.
+// HRESULT code plus message. The message alone is localized and often
+// generic ("The object has been closed"), while the code is what a bug
+// report can be searched on and what names an access or authentication
+// failure precisely.
+std::string DescribeHresult(const winrt::hresult_error& e) {
+    char code[16];
+    std::snprintf(code, sizeof(code), "0x%08X",
+                  static_cast<unsigned int>(static_cast<int32_t>(e.code())));
+    return std::string(code) + " " + winrt::to_string(e.message());
+}
+
 std::string FormatAddress(uint64_t address) {
     char buffer[13];
     std::snprintf(buffer, sizeof(buffer), "%012llX",
@@ -215,7 +227,7 @@ bool BleIoStream::ConnectAndDiscover(uint64_t bluetooth_address) {
     } catch (const winrt::hresult_error& e) {
         NativeLogger::Error(kBleCategory,
                             "Connect or service discovery for " + address +
-                                " threw: " + winrt::to_string(e.message()));
+                                " threw: " + DescribeHresult(e));
         return false;
     } catch (...) {
         NativeLogger::Error(kBleCategory,
@@ -445,7 +457,7 @@ bool BleIoStream::DiscoverCharacteristics() {
                     .get();
         } catch (const winrt::hresult_error& e) {
             credits_cccd_result = GattCommunicationStatus::Unreachable;
-            credits_cccd_threw = winrt::to_string(e.message());
+            credits_cccd_threw = DescribeHresult(e);
         } catch (...) {
             credits_cccd_result = GattCommunicationStatus::Unreachable;
             credits_cccd_threw = "unknown error";

--- a/packages/libdivecomputer_plugin/windows/native_logger.cc
+++ b/packages/libdivecomputer_plugin/windows/native_logger.cc
@@ -37,9 +37,17 @@ void NativeLogger::Log(const std::string& category, const std::string& level,
     // outlives no shutdown of its own.
     std::lock_guard<std::mutex> lock(mutex_);
     if (api_ == nullptr) return;
-    // A logging failure must never take the download with it.
-    api_->OnLogEvent(
-        category, level, message, [] {}, [](const FlutterError&) {});
+    // A logging failure must never take the download with it. The no-op
+    // reply callbacks only cover a Dart-side error reply; a throw from the
+    // send itself (a bad_alloc from the string or EncodableValue copies)
+    // would escape, and the BLE transport logs from a std::thread whose
+    // entry function has no handler, where an escaping exception is
+    // std::terminate. Android's NativeLogger.kt wraps the same call.
+    try {
+        api_->OnLogEvent(
+            category, level, message, [] {}, [](const FlutterError&) {});
+    } catch (...) {
+    }
 }
 
 }  // namespace libdivecomputer_plugin


### PR DESCRIPTION
## Summary

Follow-up to #1398, from a review of its result. That PR replaced silence
with an explanation on two discovery paths. This fixes the branches where
the explanation is confidently **wrong**, plus three more ways a connect
ends in the generic "Failed to connect to device" that #957 was about.

Nothing here changes the #957 fix itself.

## The one that matters most

**A failed notification subscription reported the connect as successful.**
`writeCharacteristic` is assigned before the subscribe runs, so

```kotlin
ok = connected && writeCharacteristic != null && terminalIoReady
```

was `true` on a link that can never deliver a byte. The download then
proceeded and every libdivecomputer read blocked to timeout. The whole trace
was two DEBUG lines (`CCCD descriptor: NULL`, `writeDescriptor returned:
false`) and no error at all. `connectAndDiscover` now reports on the Data TX
CCCD write actually completing, and the failure logs an error. The Windows
counterpart already treated the same condition as fatal.

## The diagnostics could name the wrong cause

`GattDiagnostics` had one status table serving two disjoint number spaces
that collide at 8:

| Code | ATT operation callback | HCI connection callback |
| --- | --- | --- |
| 8 | insufficient authorization (a bond problem) | connection timeout |

The single table asserted the *connection* meaning, and its only call site is
`onServicesDiscovered`, which is an ATT callback. A computer failing
discovery with status 8 was told "the computer moved out of range or switched
its radio off", sending the reporter after range and battery for something
this codebase repairs one code away. Split into `describeAttStatus` and
`describeConnectionStatus`, each naming its space, with the missing ATT
protocol errors and the connection codes this repo's own comments already
cite (137, 147, previously rendered as "unknown") filled in.

## Three more silent 15-second hangs (Android)

- `requestMtu(512)` discarded its Boolean return, and `onMtuChanged` is the
  only path in the class that reaches `discoverServices()`. A refused request
  burned the full connect timeout. Now checked, exactly as the
  `discoverServices()` call one callback later already was.
- `connectGatt` can return null (adapter unbound, BLE unsupported, Bluetooth
  switched off between the scan and the download). No callback can fire, so
  the connect waited out 15 seconds and teardown no-oped, since `close()` is
  null-safe throughout.
- The discovery-failure diagnostic ran *before* `connectSemaphore.release()`,
  and its `deviceType()` argument is a binder round trip that raises
  `SecurityException` if `BLUETOOTH_CONNECT` is revoked mid-download. AOSP
  swallows a throw from that callback, so the release never ran and an
  immediate failure became a full hang. Released first.

## Windows

- `NativeLogger::Log` had no try/catch, so its own comment ("a logging
  failure must never take the download with it") was not enforced. The no-op
  reply callbacks only cover a Dart-side error reply, and the BLE transport
  logs from a `std::thread` whose entry function has no handler, where an
  escaping exception is `std::terminate`. Android's equivalent wraps the call.
- Service UUIDs were counted *before* the characteristics gate, so the
  terminal "no usable service; N service(s) seen" line asserted a fact about
  characteristics that were never enumerated. On an unpaired machine every
  service returns `AccessDenied`, and that summary reads as an unknown
  profile rather than as "pair the computer first".
- The Terminal I/O credit warning ran a synthetic sentinel through
  `DescribeGattStatus`, fabricating "out of range, switched its radio off, or
  dropped the link" for what may be an authentication error. The HRESULT
  naming the real cause is logged instead. On a Telit module this is terminal,
  so it is the last line in the log.
- The connect catch handlers also see `DiscoverCharacteristics` throws, which
  has no local handler, so a link that died during discovery was reported as a
  connect that never came up. They now name both phases.
- `FormatAddress` rendered the address with colons, a form used nowhere else
  on Windows: `ble_scanner.cc`, the access-code storage key, the `strtoull`
  parse and the Dart log all use colon-free upper-case hex, and
  `bluetoothAddressesMatch` only upper-cases before comparing, so the two
  spellings would not match.
- The "Windows has no LE record" message stated one cause as fact. It is now
  a lead listing the known causes, matching the softening the Android twin got
  in #1398 itself.

## Tests

`GattDiagnosticsTest` would have passed a wrong implementation: it lacked the
distinctness assertion both sibling diagnostics suites carry, its only
negative dual-mode case would pass an `== DEVICE_TYPE_LE` guard, and two
assertions could not fail (`isNotEmpty()` against a table with an `else` arm,
and `contains("2")` that passed only because neither fixture UUID contains
that digit). 12 tests to 18, including the status-8 collision pinned from
both sides.

## Test plan

- `:libdivecomputer_plugin:testDebugUnitTest`: **79 pass, 0 failures**
  (GattDiagnosticsTest 18, was 12). Verified the run was real with a bogus
  `--tests` filter as a control, which fails with "No tests found".
- Mutation check: folding the ATT table back onto the connection meaning for
  status 8 fails `statusEightReadsAsAuthorizationOnAnAttCallback` and
  `theTwoStatusSpacesDisagreeAboutEightOnPurpose`; restoring is green.
- `flutter analyze` clean on the whole project; `dart format` clean.
- The new C++ expressions were type-checked against stubs with
  `clang++ -std=c++17 -Wall -Wextra` (the ternary in the credit warning, and
  `FormatAddress` producing 12-char zero-padded hex). **The Windows plugin
  itself cannot be compiled on this machine**, so the Build Windows CI job is
  the real check on that half.
- The Android changes are in `BleIoStream`, which has no test coverage at all
  (it needs a live GATT stack), so those four fixes are verified by reading
  against the AOSP contracts, not by test. Field verification on a Petrel 2
  would be worth doing before relying on them.

## Deliberately not changed

- **`TRANSPORT_LE` still forced, with no Classic fallback.** That is the #957
  fix. A reviewer suggested a fallback retry, but adding one on the strength
  of a code reading rather than field evidence risks reintroducing the exact
  bug #1398 closed.
- **The Windows platform-thread hand-off for pigeon sends.** Real, but it
  predates #1398 and applies to every Windows callback (`OnDownloadProgress`,
  `OnDiveDownloaded`, `OnDeviceDiscovered`), so it wants its own change rather
  than being smuggled in here.
