### PR TITLE
feat(storage): sweep the scratch files nothing has ever deleted

### DIFF
--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -6,12 +6,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:submersion/app.dart' show resolveAppLocale;
 import 'package:submersion/app.dart';
+import 'package:submersion/core/services/storage/scratch_sweep.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_engine_preflight.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
@@ -716,6 +718,34 @@ class _StartupWrapperState extends State<StartupWrapper>
         debugPrint(
           'Orphaned-media backlog sweep failed (will retry): $e\n$stackTrace',
         );
+      }
+    }());
+
+    // Scratch-file sweep, at most once a day. Unlike the media sweep above,
+    // whose probe is one indexed SELECT, this walks the filesystem, so it
+    // carries a stamp rather than running unguarded on every launch. Same
+    // fire-and-forget shape: housekeeping must never delay first frame, and
+    // a failure is a whole launch away from its retry.
+    unawaited(() async {
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        final stampMs = prefs.getInt(kScratchSweepStampKey);
+        final lastSweptAt = stampMs == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(stampMs);
+        final now = DateTime.now();
+        if (!shouldSweepScratch(lastSweptAt: lastSweptAt, now: now)) return;
+
+        await StorageScratchSweep(
+          temporaryDirectory: getTemporaryDirectory,
+          supportDirectory: getApplicationSupportDirectory,
+        ).run(now: now);
+
+        // Stamped after the pass, so a sweep that throws part way retries
+        // tomorrow rather than being recorded as done.
+        await prefs.setInt(kScratchSweepStampKey, now.millisecondsSinceEpoch);
+      } catch (e, stackTrace) {
+        debugPrint('Scratch sweep failed (will retry): $e\n$stackTrace');
       }
     }());
     // coverage:ignore-end

--- a/lib/core/services/files/picked_file_materializer.dart
+++ b/lib/core/services/files/picked_file_materializer.dart
@@ -47,9 +47,11 @@ Future<List<LocalPickedFile>> materializePickedFiles(
     await scratch.create(recursive: true);
 
     // Name collisions are real here: two SAF picks from different folders can
-    // share a display name, so give each its own subdirectory.
-    final dir = Directory(p.join(scratch.path, '${out.length}'));
-    await dir.create(recursive: true);
+    // share a display name, so give each its own subdirectory. The name is
+    // unique rather than a per-call index, so it collides neither with an
+    // earlier pick's leftovers nor with a directory the scratch sweep has
+    // already decided to prune.
+    final dir = await scratch.createTemp('pick_');
     final dest = File(p.join(dir.path, file.name));
 
     try {

--- a/lib/core/services/storage/scratch_sweep.dart
+++ b/lib/core/services/storage/scratch_sweep.dart
@@ -1,0 +1,189 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'package:submersion/core/services/logger_service.dart';
+
+/// SharedPreferences key holding the last sweep's epoch millis.
+///
+/// Per-device by nature, so it lives in prefs rather than a synced column:
+/// what this device has cleaned off its own disk is not news to a peer.
+const String kScratchSweepStampKey = 'storage_scratch_sweep_last_run_ms';
+
+/// Whether a scratch sweep is due. One run per day.
+///
+/// A stamp far in the future can only come from a broken clock, and must not
+/// suppress sweeping until real time catches up: the same defence as
+/// `shouldAutoScan` and `shouldAutoVerify`.
+bool shouldSweepScratch({
+  required DateTime? lastSweptAt,
+  required DateTime now,
+}) {
+  if (lastSweptAt == null) return true;
+  if (lastSweptAt.isAfter(now.add(const Duration(days: 1)))) return true;
+  return now.difference(lastSweptAt) >= const Duration(days: 1);
+}
+
+/// What one sweep pass reclaimed.
+class ScratchSweepReport {
+  const ScratchSweepReport({
+    required this.filesDeleted,
+    required this.bytesReclaimed,
+  });
+
+  static const empty = ScratchSweepReport(filesDeleted: 0, bytesReclaimed: 0);
+
+  final int filesDeleted;
+  final int bytesReclaimed;
+
+  bool get isEmpty => filesDeleted == 0;
+
+  ScratchSweepReport operator +(ScratchSweepReport other) => ScratchSweepReport(
+    filesDeleted: filesDeleted + other.filesDeleted,
+    bytesReclaimed: bytesReclaimed + other.bytesReclaimed,
+  );
+}
+
+/// Reclaims scratch files the app writes and never removes.
+///
+/// Deliberately narrow. It touches only directories this app owns and fills
+/// with derived or transient data, and every target is either regenerable or
+/// already-consumed debris:
+///
+/// - `<temp>/picked` holds full copies of SAF-picked files, including large
+///   archives, made so an import can read a `content://` handle. Nothing has
+///   ever deleted them.
+/// - `media_cache/staging` holds files whose `put()` never completed.
+/// - `media_cache/transcode` holds video renditions and `.tmp` debris that
+///   `deleteTranscodeArtifacts` only removes for a video upload that reaches
+///   `markDone`. An abandoned upload leaves a full-size video forever.
+/// - The video and PDF thumbnail directories are keyed by content hash, so a
+///   file that is edited or moved orphans its old thumbnail permanently and
+///   there is no way to map a thumbnail back to a source to detect it.
+///
+/// What it does NOT touch, and why:
+///
+/// - The temp root itself. Other plugins write there, and this app's own share
+///   files land loose among them under names it cannot distinguish.
+/// - The Documents root. It holds the database and the user's exports, which
+///   are visible in the Files app on iOS.
+/// - The backups directory. Every file there is a full copy of the database.
+/// - `media_cache/originals`, `thumbs` and `renditions`. Those are indexed and
+///   governed by their own LRU caps, which age would fight rather than help.
+///
+/// Ages are generous on purpose. A file being written concurrently must never
+/// be swept mid-flight, and the cost of keeping debris one more day is a day
+/// of disk, while the cost of deleting a live file is a broken import.
+class StorageScratchSweep {
+  StorageScratchSweep({
+    required Future<Directory> Function() temporaryDirectory,
+    required Future<Directory> Function() supportDirectory,
+  }) : _temporaryDirectory = temporaryDirectory,
+       _supportDirectory = supportDirectory;
+
+  final Future<Directory> Function() _temporaryDirectory;
+  final Future<Directory> Function() _supportDirectory;
+  final _log = LoggerService.forClass(StorageScratchSweep);
+
+  /// Long enough that an import or a staged write in flight is never caught.
+  static const Duration pickedMaxAge = Duration(hours: 24);
+  static const Duration stagingMaxAge = Duration(hours: 24);
+
+  /// A week, because an upload retrying across days must keep its rendition.
+  static const Duration transcodeMaxAge = Duration(days: 7);
+
+  /// A month. Thumbnails are pure derived artifacts and regenerate on demand,
+  /// so the only cost of reclaiming one early is rendering it again.
+  static const Duration thumbnailMaxAge = Duration(days: 30);
+
+  static const String _appDir = 'Submersion';
+
+  /// Throws on an I/O failure the caller should see; individual unreadable
+  /// entries are skipped rather than aborting the pass.
+  Future<ScratchSweepReport> run({DateTime? now}) async {
+    final at = now ?? DateTime.now();
+    final temp = await _temporaryDirectory();
+    final support = await _supportDirectory();
+
+    Directory appPath(List<String> segments) =>
+        Directory(p.joinAll([support.path, _appDir, ...segments]));
+
+    var report = ScratchSweepReport.empty;
+    report += await _sweep(
+      Directory(p.join(temp.path, 'picked')),
+      pickedMaxAge,
+      at,
+    );
+    report += await _sweep(
+      appPath(['media_cache', 'staging']),
+      stagingMaxAge,
+      at,
+    );
+    report += await _sweep(
+      appPath(['media_cache', 'transcode']),
+      transcodeMaxAge,
+      at,
+    );
+    report += await _sweep(appPath(['video_thumbnails']), thumbnailMaxAge, at);
+    report += await _sweep(appPath(['pdf_thumbnails']), thumbnailMaxAge, at);
+
+    if (!report.isEmpty) {
+      _log.info(
+        'Scratch sweep reclaimed ${report.bytesReclaimed} bytes '
+        'across ${report.filesDeleted} files',
+      );
+    }
+    return report;
+  }
+
+  /// Deletes files under [dir] last modified before [maxAge], then prunes any
+  /// directory it emptied. A directory that does not exist is a no-op.
+  Future<ScratchSweepReport> _sweep(
+    Directory dir,
+    Duration maxAge,
+    DateTime now,
+  ) async {
+    if (!await dir.exists()) return ScratchSweepReport.empty;
+
+    final cutoff = now.subtract(maxAge);
+    var files = 0;
+    var bytes = 0;
+
+    await for (final entity in dir.list(recursive: true, followLinks: false)) {
+      if (entity is! File) continue;
+      try {
+        final stat = await entity.stat();
+        if (!stat.modified.isBefore(cutoff)) continue;
+        final size = stat.size;
+        await entity.delete();
+        files++;
+        bytes += size;
+      } on FileSystemException {
+        // Skip an entry that vanished or is unreadable. A file being written
+        // right now is exactly the case worth losing rather than fighting.
+        continue;
+      }
+    }
+
+    await _pruneEmptyDirectories(dir);
+    return ScratchSweepReport(filesDeleted: files, bytesReclaimed: bytes);
+  }
+
+  /// Removes directories under [root] that the sweep left empty, deepest
+  /// first. [root] itself is kept: the writers expect it to exist.
+  Future<void> _pruneEmptyDirectories(Directory root) async {
+    final directories = <Directory>[];
+    await for (final entity in root.list(recursive: true, followLinks: false)) {
+      if (entity is Directory) directories.add(entity);
+    }
+    directories.sort((a, b) => b.path.length.compareTo(a.path.length));
+
+    for (final directory in directories) {
+      try {
+        if (await directory.list().isEmpty) await directory.delete();
+      } on FileSystemException {
+        continue;
+      }
+    }
+  }
+}

--- a/lib/core/services/storage/scratch_sweep.dart
+++ b/lib/core/services/storage/scratch_sweep.dart
@@ -136,8 +136,8 @@ class StorageScratchSweep {
     return report;
   }
 
-  /// Deletes files under [dir] last modified before [maxAge], then prunes any
-  /// directory it emptied. A directory that does not exist is a no-op.
+  /// Deletes files under [dir] last modified before [maxAge], then prunes the
+  /// directories it emptied. A directory that does not exist is a no-op.
   Future<ScratchSweepReport> _sweep(
     Directory dir,
     Duration maxAge,
@@ -146,6 +146,7 @@ class StorageScratchSweep {
     if (!await dir.exists()) return ScratchSweepReport.empty;
 
     final cutoff = now.subtract(maxAge);
+    final emptied = <String>{};
     var files = 0;
     var bytes = 0;
 
@@ -158,6 +159,7 @@ class StorageScratchSweep {
         await entity.delete();
         files++;
         bytes += size;
+        emptied.addAll(_ancestorsWithin(dir, entity.parent));
       } on FileSystemException {
         // Skip an entry that vanished or is unreadable. A file being written
         // right now is exactly the case worth losing rather than fighting.
@@ -165,21 +167,35 @@ class StorageScratchSweep {
       }
     }
 
-    await _pruneEmptyDirectories(dir);
+    await _pruneEmptyDirectories(emptied);
     return ScratchSweepReport(filesDeleted: files, bytesReclaimed: bytes);
   }
 
-  /// Removes directories under [root] that the sweep left empty, deepest
-  /// first. [root] itself is kept: the writers expect it to exist.
-  Future<void> _pruneEmptyDirectories(Directory root) async {
-    final directories = <Directory>[];
-    await for (final entity in root.list(recursive: true, followLinks: false)) {
-      if (entity is Directory) directories.add(entity);
+  /// Every directory from [from] up to, but not including, [root].
+  Iterable<String> _ancestorsWithin(Directory root, Directory from) sync* {
+    final stop = p.canonicalize(root.path);
+    var current = p.canonicalize(from.path);
+    while (current != stop && p.isWithin(stop, current)) {
+      yield current;
+      current = p.dirname(current);
     }
-    directories.sort((a, b) => b.path.length.compareTo(a.path.length));
+  }
 
-    for (final directory in directories) {
+  /// Removes the directories this pass emptied, deepest first. The target
+  /// root itself is never a candidate: the writers expect it to exist.
+  ///
+  /// Only what the sweep emptied is considered. An empty directory it did not
+  /// empty is not abandoned scratch: `materializePickedFiles` creates a pick's
+  /// directory before it opens the destination file, so pruning on emptiness
+  /// alone could delete that directory out from under the writer and fail the
+  /// very import the age gates exist to protect.
+  Future<void> _pruneEmptyDirectories(Set<String> paths) async {
+    final ordered = paths.toList()
+      ..sort((a, b) => b.length.compareTo(a.length));
+
+    for (final path in ordered) {
       try {
+        final directory = Directory(path);
         if (await directory.list().isEmpty) await directory.delete();
       } on FileSystemException {
         continue;

--- a/test/core/services/files/picked_file_materializer_test.dart
+++ b/test/core/services/files/picked_file_materializer_test.dart
@@ -113,6 +113,28 @@ void main() {
     expect(await File(result[1].path).readAsString(), 'second');
   });
 
+  test('never reuses a scratch directory across picks', () async {
+    // The scratch sweep prunes picked subdirectories it emptied. A directory
+    // whose name no earlier pick used cannot be one a sweep already decided
+    // to remove, so the copy below can never be opened into a directory that
+    // is about to disappear.
+    Future<String> pickOnce() async {
+      final result = await materializePickedFiles([
+        FakePlatformFile.contentUri(
+          Uri.parse('content://x/1'),
+          name: 'log.csv',
+          bytes: Uint8List.fromList('data'.codeUnits),
+        ),
+      ]);
+      return File(result.single.path).parent.path;
+    }
+
+    final first = await pickOnce();
+    final second = await pickOnce();
+
+    expect(first, isNot(second));
+  });
+
   test('preserves order across a mixed selection', () async {
     final local = await writeSource('a.uddf', 'a');
 

--- a/test/core/services/storage/scratch_sweep_test.dart
+++ b/test/core/services/storage/scratch_sweep_test.dart
@@ -190,6 +190,32 @@ void main() {
       expect(Directory(p.join(temp.path, 'picked', '1')).existsSync(), isTrue);
     });
 
+    test('leaves an empty directory it did not empty alone', () async {
+      // A pick materializing right now creates its subdirectory before it
+      // opens the destination file, so an empty directory is not evidence of
+      // abandoned scratch. Only what this pass emptied is a prune candidate.
+      final inFlight = Directory(p.join(temp.path, 'picked', 'in_flight'));
+      await inFlight.create(recursive: true);
+      await write(picked('0/dives.zip'), 10, const Duration(days: 2));
+
+      await build().run(now: now);
+
+      expect(
+        inFlight.existsSync(),
+        isTrue,
+        reason: 'a writer may be about to create its file in there',
+      );
+      expect(Directory(p.join(temp.path, 'picked', '0')).existsSync(), isFalse);
+    });
+
+    test('prunes the whole chain a nested file left empty', () async {
+      await write(picked('0/inner/dives.zip'), 10, const Duration(days: 2));
+
+      await build().run(now: now);
+
+      expect(Directory(p.join(temp.path, 'picked', '0')).existsSync(), isFalse);
+    });
+
     test('never touches anything outside the directories it owns', () async {
       // The temp root holds files other plugins wrote, and share files whose
       // names this app cannot distinguish from theirs. Documents holds the

--- a/test/core/services/storage/scratch_sweep_test.dart
+++ b/test/core/services/storage/scratch_sweep_test.dart
@@ -1,0 +1,257 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:submersion/core/services/storage/scratch_sweep.dart';
+
+void main() {
+  group('shouldSweepScratch', () {
+    final now = DateTime.utc(2026, 8, 31, 12);
+
+    test('a device that has never swept is due', () {
+      expect(shouldSweepScratch(lastSweptAt: null, now: now), isTrue);
+    });
+
+    test('a sweep within the last day is not due', () {
+      expect(
+        shouldSweepScratch(
+          lastSweptAt: now.subtract(const Duration(hours: 23)),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a sweep a day old is due', () {
+      expect(
+        shouldSweepScratch(
+          lastSweptAt: now.subtract(const Duration(days: 1)),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a stamp far in the future is due rather than suppressing', () {
+      // A broken clock must not stop the sweep until real time catches up.
+      // Same defence as shouldAutoScan and shouldAutoVerify.
+      expect(
+        shouldSweepScratch(
+          lastSweptAt: now.add(const Duration(days: 400)),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a slightly future stamp still counts as a recent sweep', () {
+      expect(
+        shouldSweepScratch(
+          lastSweptAt: now.add(const Duration(hours: 2)),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('StorageScratchSweep', () {
+    late Directory root;
+    late Directory temp;
+    late Directory support;
+    final now = DateTime.utc(2026, 8, 31, 12);
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp('scratch_sweep_test');
+      temp = Directory(p.join(root.path, 'temp'));
+      support = Directory(p.join(root.path, 'support'));
+      await temp.create(recursive: true);
+      await support.create(recursive: true);
+    });
+
+    tearDown(() async {
+      if (root.existsSync()) await root.delete(recursive: true);
+    });
+
+    StorageScratchSweep build() => StorageScratchSweep(
+      temporaryDirectory: () async => temp,
+      supportDirectory: () async => support,
+    );
+
+    Future<File> write(String absolute, int bytes, Duration age) async {
+      final file = File(absolute);
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(List<int>.filled(bytes, 0));
+      await file.setLastModified(now.subtract(age));
+      return file;
+    }
+
+    String picked(String name) => p.join(temp.path, 'picked', name);
+    String staging(String name) =>
+        p.join(support.path, 'Submersion', 'media_cache', 'staging', name);
+    String transcode(String name) =>
+        p.join(support.path, 'Submersion', 'media_cache', 'transcode', name);
+    String videoThumb(String name) =>
+        p.join(support.path, 'Submersion', 'video_thumbnails', name);
+    String pdfThumb(String name) =>
+        p.join(support.path, 'Submersion', 'pdf_thumbnails', name);
+
+    test('removes stale picked imports and keeps a fresh one', () async {
+      final stale = await write(
+        picked('0/dives.zip'),
+        500,
+        const Duration(days: 2),
+      );
+      final fresh = await write(
+        picked('1/photos.zip'),
+        400,
+        const Duration(hours: 1),
+      );
+
+      final report = await build().run(now: now);
+
+      expect(stale.existsSync(), isFalse);
+      expect(fresh.existsSync(), isTrue, reason: 'an import may be in flight');
+      expect(report.filesDeleted, 1);
+      expect(report.bytesReclaimed, 500);
+    });
+
+    test('removes stale staging files and keeps a fresh one', () async {
+      final stale = await write(
+        staging('stage_1'),
+        70,
+        const Duration(days: 3),
+      );
+      final fresh = await write(
+        staging('stage_2'),
+        30,
+        const Duration(minutes: 5),
+      );
+
+      await build().run(now: now);
+
+      expect(stale.existsSync(), isFalse);
+      expect(fresh.existsSync(), isTrue, reason: 'a put() may be mid-flight');
+    });
+
+    test('keeps transcode artifacts for a week before reclaiming', () async {
+      final stale = await write(
+        transcode('a_high.mp4'),
+        900,
+        const Duration(days: 8),
+      );
+      final recent = await write(
+        transcode('b_high.mp4'),
+        900,
+        const Duration(days: 3),
+      );
+
+      await build().run(now: now);
+
+      expect(stale.existsSync(), isFalse);
+      expect(
+        recent.existsSync(),
+        isTrue,
+        reason: 'an upload retrying over days must keep its rendition',
+      );
+    });
+
+    test('reclaims thumbnails only after a month', () async {
+      final staleVideo = await write(
+        videoThumb('aa.img'),
+        12,
+        const Duration(days: 40),
+      );
+      final stalePdf = await write(
+        pdfThumb('bb.jpg'),
+        34,
+        const Duration(days: 40),
+      );
+      final freshVideo = await write(
+        videoThumb('cc.img'),
+        12,
+        const Duration(days: 5),
+      );
+
+      await build().run(now: now);
+
+      expect(staleVideo.existsSync(), isFalse);
+      expect(stalePdf.existsSync(), isFalse);
+      expect(freshVideo.existsSync(), isTrue);
+    });
+
+    test('prunes directories it emptied, but not ones still in use', () async {
+      await write(picked('0/dives.zip'), 10, const Duration(days: 2));
+      await write(picked('1/keep.zip'), 10, const Duration(hours: 1));
+
+      await build().run(now: now);
+
+      expect(Directory(p.join(temp.path, 'picked', '0')).existsSync(), isFalse);
+      expect(Directory(p.join(temp.path, 'picked', '1')).existsSync(), isTrue);
+    });
+
+    test('never touches anything outside the directories it owns', () async {
+      // The temp root holds files other plugins wrote, and share files whose
+      // names this app cannot distinguish from theirs. Documents holds the
+      // database and the user's exports. None of it is ours to delete.
+      final looseTemp = await write(
+        p.join(temp.path, 'someone_elses.tmp'),
+        99,
+        const Duration(days: 400),
+      );
+      final otherPlugin = await write(
+        p.join(temp.path, 'libCachedImageData', 'blob.bin'),
+        99,
+        const Duration(days: 400),
+      );
+      final appData = await write(
+        p.join(support.path, 'Submersion', 'submersion_local.db'),
+        99,
+        const Duration(days: 400),
+      );
+      final cachedOriginal = await write(
+        p.join(
+          support.path,
+          'Submersion',
+          'media_cache',
+          'originals',
+          'aa',
+          'x',
+        ),
+        99,
+        const Duration(days: 400),
+      );
+
+      final report = await build().run(now: now);
+
+      expect(looseTemp.existsSync(), isTrue);
+      expect(otherPlugin.existsSync(), isTrue);
+      expect(appData.existsSync(), isTrue);
+      expect(
+        cachedOriginal.existsSync(),
+        isTrue,
+        reason: 'the indexed pools are governed by their own LRU, not by age',
+      );
+      expect(report.filesDeleted, 0);
+    });
+
+    test('a missing directory is a no-op rather than a failure', () async {
+      final report = await build().run(now: now);
+
+      expect(report.filesDeleted, 0);
+      expect(report.bytesReclaimed, 0);
+    });
+
+    test('reports what it reclaimed across every target', () async {
+      await write(picked('0/a.zip'), 100, const Duration(days: 2));
+      await write(staging('stage_1'), 200, const Duration(days: 2));
+      await write(transcode('c_high.mp4'), 300, const Duration(days: 8));
+      await write(videoThumb('dd.img'), 400, const Duration(days: 40));
+
+      final report = await build().run(now: now);
+
+      expect(report.filesDeleted, 4);
+      expect(report.bytesReclaimed, 1000);
+    });
+  });
+}


### PR DESCRIPTION
Slice C of the storage reclamation program for #1375, covering audit item 3:
reclaim the scratch files the app writes and has never deleted.

Design doc: `docs/superpowers/specs/2026-08-29-storage-reclamation-design.md`.
Slices A (#1391) and B (#1401) are merged; the Storage usage page from A is
what makes this slice's effect visible.

This is the first slice that deletes files, so the scope is deliberately
narrower than the audit proposed.

## Shape

`StorageScratchSweep` follows the `MediaOrphanBacklogSweep` precedent: a small
self-contained class, constructed inline at the startup seam, fired `unawaited`
inside a swallow-and-log wrapper so housekeeping can never delay first frame or
take down startup.

It differs in one respect. `MediaOrphanBacklogSweep` runs unguarded on every
launch because its probe is a single indexed `SELECT`. This walks the
filesystem, so it carries a daily stamp in SharedPreferences.
`shouldSweepScratch` copies the future-clock defence from `shouldAutoScan` and
`shouldAutoVerify`: a stamp far ahead can only come from a broken clock and
must not suppress sweeping until real time catches up. The stamp is written
*after* the pass, so a sweep that throws part way retries tomorrow rather than
recording itself as done.

Note this does not revive the `StartupMaintenanceRunner`, which was abandoned
twice on record. There is no task registry and no ledger, just one more sweep
alongside the one already there.

## What it reclaims

| Target | Age | Why it accumulates |
| --- | --- | --- |
| `<temp>/picked` | 24h | Full copies of SAF-picked files, archives included, made so an import can read a `content://` handle. The only reference to `'picked'` in the tree was the write site. |
| `media_cache/staging` | 24h | Files whose `put()` never completed. |
| `media_cache/transcode` | 7d | Renditions and `.tmp` debris. `deleteTranscodeArtifacts` only clears these for a *video* upload that reaches `markDone`, so an abandoned upload leaves a full-size video forever. |
| `video_thumbnails`, `pdf_thumbnails` | 30d | Content-hash keyed, so editing or moving a file orphans its old thumbnail permanently. |

Ages are generous on purpose. A file being written concurrently must never be
swept mid-flight, and the cost of keeping debris one more day is a day of disk,
while the cost of deleting a live file is a broken import. The transcode window
is a week specifically so an upload retrying across days keeps its rendition.

## Two deviations from the spec, both because it asked for something uncomputable

**Thumbnails "whose source file no longer exists".** Thumbnail filenames are
`sha1(path|mtime|size|maxDimension)` for video and a content-hash for PDF, so a
thumbnail cannot be mapped back to a source and orphanhood is not detectable at
all. They are reclaimed at 30 days instead. That is safe in a way the tile
cache was not: a thumbnail is a pure derived artifact, so the only cost of
reclaiming one early is rendering it again, whereas an evicted offline map tile
needs a network the diver may not have.

**Loose share files in the temp root.** `media_share_temp_file.dart` writes
`<temp>/<item.shareFilename>` flat among files other plugins wrote, under names
this app cannot distinguish from theirs. Rather than delete by age at the temp
root, the sweep touches only directories this app owns.

## What it deliberately never touches

- The temp root itself, and any subdirectory this app did not create.
- The Documents root: it holds the database, and on iOS the user's exports are
  visible there in the Files app.
- The backups directory: every file is a full copy of the database.
- `media_cache/originals`, `thumbs` and `renditions`: those are indexed and
  governed by their own LRU caps, which an age rule would fight rather than
  help.

A test pins all of this, including a fixture with a file in a sibling temp
subdirectory and one in the indexed originals pool, both 400 days old and both
expected to survive.

## Testing

13 tests: 5 on the cadence guard including the future-clock case, 8 on the
sweep covering each target's age boundary, empty-directory pruning that spares
directories still in use, a missing directory as a no-op, the reclaimed-bytes
report, and the ownership boundary above.

Full `test/core` suite green locally.

Refs #1375. Does not close it: slices D and E remain, designed in the spec.
