### PR TITLE
fix(sync): bound the gzip inflate in SyncEnvelope.open

### DIFF
--- a/lib/core/services/sync/changeset_log/changeset_reader.dart
+++ b/lib/core/services/sync/changeset_log/changeset_reader.dart
@@ -1,5 +1,8 @@
+import 'dart:typed_data';
+
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.dart';
+import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
@@ -209,9 +212,19 @@ class ChangesetReader {
         for (var seq = appliedThrough + 1; seq <= manifest.headSeq; seq++) {
           final csFile = byName[ChangesetLogLayout.changesetName(peerId, seq)];
           if (csFile == null) break; // gap -> apply what we have, retry later
-          final cs = _codec.decodeChangeset(
-            await provider.downloadFile(csFile.id),
-          );
+          final Uint8List csBytes;
+          try {
+            csBytes = await provider.downloadFile(csFile.id);
+          } on EnvelopeCorruptException {
+            // Same standing as the checksum failure below, so the same
+            // handling: break rather than throw, which reaches the cursor
+            // upsert and records the seqs already applied. Throwing here
+            // would unwind to the per-peer catch, which skips that upsert,
+            // so every later sync would re-download and re-apply this
+            // peer's whole backlog and still never advance past this seq.
+            break;
+          }
+          final cs = _codec.decodeChangeset(csBytes);
           if (!_codec.serializer.validateChecksum(cs)) {
             break; // corrupt changeset -> stop; a fixed sync retries from here
           }

--- a/lib/core/services/sync/crypto/sync_envelope.dart
+++ b/lib/core/services/sync/crypto/sync_envelope.dart
@@ -142,9 +142,15 @@ abstract final class SyncEnvelope {
       // the AAD and so is not authenticated at all, which is what lets a
       // keyless attacker turn any file into "not a gzip stream".
       //
-      // The blob cap matches the body cap and can never refuse what the
-      // body cap would accept: seal only sets the flag when the gzip is
-      // strictly smaller than its plaintext.
+      // The blob cap matches the body cap. For anything this seal wrote
+      // that is free: the flag is only set when the gzip came out strictly
+      // smaller than its plaintext, so the blob is always the shorter of
+      // the two and the body cap is the one that binds. A foreign writer
+      // is not bound by that, so a blob over the cap is refused on its
+      // length even if it would have inflated to something under it. That
+      // is deliberate. Such an envelope is itself a quarter-gigabyte file,
+      // and the alternative is copying it whole into the native filter
+      // before the first chunk comes back.
       try {
         return inflateBounded(
           payload,

--- a/lib/core/services/sync/crypto/sync_envelope.dart
+++ b/lib/core/services/sync/crypto/sync_envelope.dart
@@ -6,6 +6,7 @@ import 'package:cryptography/cryptography.dart';
 import 'package:uuid/uuid_value.dart';
 
 import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
+import 'package:submersion/core/utils/bounded_inflate.dart';
 
 /// Single-shot SBE1 envelope: the byte form of every encrypted sync file.
 ///
@@ -16,6 +17,21 @@ abstract final class SyncEnvelope {
   static const List<int> magic = [0x53, 0x42, 0x45, 0x31]; // "SBE1"
   static const int _headerLength = 4 + 16 + 1 + 12;
   static const int _flagGzip = 0x01;
+
+  /// The largest plaintext an envelope will gzip on seal or inflate to on
+  /// open.
+  ///
+  /// Derived from what a sync payload can legitimately be, not from a
+  /// round number. The only structurally bounded kind is a base part, cut
+  /// to exactly `BaseChunker.defaultPartSize` (8 MiB), so even a 648 MB
+  /// library publishes as 78 small envelopes; this leaves that path 32x of
+  /// headroom. The unbounded kind is a changeset, which is built,
+  /// JSON-encoded, gzipped and encrypted whole in memory on the writer and
+  /// decoded whole in memory on the reader. A plaintext past a few hundred
+  /// megabytes therefore cannot be applied even if it inflates, so the cap
+  /// refuses only payloads that were already fatal, and turns an OOM kill
+  /// into a transient-stop error.
+  static const int defaultMaxPlaintextBytes = 256 * 1024 * 1024;
 
   static final AesGcm _aesGcm = AesGcm.with256bits();
 
@@ -40,11 +56,18 @@ abstract final class SyncEnvelope {
     required String libraryKeyId,
     required String filename,
     bool compress = true,
+    int maxPlaintextBytes = defaultMaxPlaintextBytes,
     List<int>? nonceForTest,
   }) async {
     var payload = plaintext;
     var flags = 0;
-    if (compress) {
+    // A payload past the cap is stored uncompressed rather than refused: a
+    // device must never write an envelope [open] would reject, and only the
+    // gzip flag makes that possible. The upload is larger, but the write
+    // path stays total and nothing is stranded. Reaching this needs a
+    // single changeset of a quarter gigabyte, which the in-memory encode
+    // above it would already be struggling with.
+    if (compress && plaintext.length <= maxPlaintextBytes) {
       final gz = Uint8List.fromList(gzip.encode(plaintext));
       if (gz.length < plaintext.length) {
         payload = gz;
@@ -74,6 +97,7 @@ abstract final class SyncEnvelope {
     required SecretKey dataKey,
     required String expectedLibraryKeyId,
     required String filename,
+    int maxPlaintextBytes = defaultMaxPlaintextBytes,
   }) async {
     if (!hasMagic(envelope) || envelope.length < _headerLength + 16) {
       throw const EnvelopeCorruptException('Not an SBE1 envelope');
@@ -106,7 +130,33 @@ abstract final class SyncEnvelope {
       );
     }
     if ((flags & _flagGzip) != 0) {
-      return Uint8List.fromList(gzip.decode(payload));
+      // Bounded and chunked. gzip.decode is a single native call that has
+      // already allocated the whole body by the time it returns, so a
+      // length check after the fact buys nothing; the guard has to abort
+      // from inside the inflate.
+      //
+      // AES-GCM ran first, so reaching here means the payload authenticated
+      // under the library data key: the residual threat is a peer inside
+      // the trust boundary, not a network attacker. The gzip flag itself is
+      // read from header byte 20, which is outside both the ciphertext and
+      // the AAD and so is not authenticated at all, which is what lets a
+      // keyless attacker turn any file into "not a gzip stream".
+      //
+      // The blob cap matches the body cap and can never refuse what the
+      // body cap would accept: seal only sets the flag when the gzip is
+      // strictly smaller than its plaintext.
+      try {
+        return inflateBounded(
+          payload,
+          decoder: gzip.decoder,
+          maxBytes: maxPlaintextBytes,
+          maxBlobBytes: maxPlaintextBytes,
+        );
+      } on BoundedInflateException catch (e) {
+        throw EnvelopeCorruptException(
+          'Envelope payload rejected: ${e.message}',
+        );
+      }
     }
     return Uint8List.fromList(payload);
   }

--- a/lib/core/utils/bounded_inflate.dart
+++ b/lib/core/utils/bounded_inflate.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// A compressed blob was refused: too long, not a stream, or it expanded
+/// past the cap its caller allowed.
+///
+/// Callers translate this into whatever their own layer calls malformed
+/// input, so a bad blob never escapes as a private runtime type.
+class BoundedInflateException implements Exception {
+  final String message;
+
+  const BoundedInflateException(this.message);
+
+  @override
+  String toString() => 'BoundedInflateException: $message';
+}
+
+/// Inflates a compressed stream, refusing anything that expands past
+/// [maxBytes].
+///
+/// [decoder] chooses the framing, so the same guard covers zlib
+/// (`zlib.decoder`) and gzip (`gzip.decoder`). The decoder runs chunked, so
+/// a compression bomb is abandoned at the first chunk over the cap rather
+/// than after the whole body is in memory.
+///
+/// Throws [BoundedInflateException] if [bytes] is longer than
+/// [maxBlobBytes], is not a stream [decoder] accepts, or inflates past
+/// [maxBytes]. Errors that are not malformed input, an [ArgumentError] from
+/// a bad cap among them, are left to surface.
+///
+/// Not a completeness check. Both framings accept a truncated stream,
+/// returning the bytes they managed to inflate with no error, and a stream
+/// missing only its trailer returns its body in full, so the checksum is
+/// never verified. Both were measured. Callers must frame their own
+/// payload.
+Uint8List inflateBounded(
+  List<int> bytes, {
+  required Converter<List<int>, List<int>> decoder,
+  required int maxBytes,
+  required int maxBlobBytes,
+}) {
+  if (maxBytes < 0) {
+    throw ArgumentError.value(maxBytes, 'maxBytes', 'must not be negative');
+  }
+  if (maxBlobBytes < 0) {
+    throw ArgumentError.value(
+      maxBlobBytes,
+      'maxBlobBytes',
+      'must not be negative',
+    );
+  }
+  // Before the conversion, not inside the sink: the filter copies the whole
+  // input natively before it emits a first chunk, so a sink-side check
+  // never sees an oversized blob.
+  if (bytes.length > maxBlobBytes) {
+    throw BoundedInflateException(
+      'blob of ${bytes.length} byte(s) exceeds the $maxBlobBytes allowed',
+    );
+  }
+  final sink = _BoundedByteSink(maxBytes);
+  try {
+    final input = decoder.startChunkedConversion(sink);
+    input
+      ..add(bytes)
+      ..close();
+  } on FormatException catch (e) {
+    throw BoundedInflateException(
+      'not a valid compressed stream: ${e.message}',
+    );
+  }
+  return sink.takeBytes();
+}
+
+/// Collects inflated chunks and throws as soon as they pass [_maxBytes].
+class _BoundedByteSink implements Sink<List<int>> {
+  _BoundedByteSink(this._maxBytes);
+
+  final int _maxBytes;
+  final BytesBuilder _builder = BytesBuilder(copy: false);
+
+  @override
+  void add(List<int> chunk) {
+    if (_builder.length + chunk.length > _maxBytes) {
+      // Thrown from inside the inflate filter's own add, which unwinds it.
+      throw BoundedInflateException(
+        'inflated body exceeds the $_maxBytes byte(s) allowed',
+      );
+    }
+    _builder.add(chunk);
+  }
+
+  @override
+  void close() {}
+
+  Uint8List takeBytes() => _builder.takeBytes();
+}

--- a/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_verify_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
 import 'package:submersion/core/services/sync/sync_data_serializer.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
@@ -216,4 +217,85 @@ void main() {
       reason: 'the cursor must not advance past a base that was never applied',
     );
   });
+
+  test('a refused envelope keeps the progress made below it', () async {
+    // An envelope the decorator rejects (an over-cap gzip payload from a
+    // peer, or a tampered one) used to throw clear out of the changeset
+    // loop to the per-peer catch, which skips the cursor upsert. Every
+    // seq already applied was then re-downloaded and re-applied on every
+    // later sync, and the cursor could never advance past the bad seq: a
+    // livelock, not the transient stop the error type promises.
+    await setUpTestDatabase();
+    addTearDown(() => tearDownTestDatabase());
+    final db = DatabaseService.instance.database;
+    final serializer = SyncDataSerializer();
+    final codec = ChangesetCodec(serializer);
+    final writer = ChangesetWriter(
+      serializer,
+      codec,
+      PublishStateStore(db),
+      compactionByteRatio: 1000.0,
+      compactionMaxChangesets: 1 << 30,
+    );
+    final reader = ChangesetReader(codec, PeerCursorStore(db));
+    final provider = _RefusingCloudStorageProvider();
+    final folder = await provider.getOrCreateSyncFolder();
+
+    final peerId = await SyncRepository().getDeviceId();
+    // Base @1, then changesets @2 and @3.
+    for (var i = 1; i <= 3; i++) {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd$i', diveNumber: i),
+      );
+      await writer.publish(
+        provider: provider,
+        deviceId: peerId,
+        folderId: folder,
+        deletions: const [],
+      );
+    }
+    provider.refuseName = ChangesetLogLayout.changesetName(peerId, 3);
+
+    final applied = <SyncPayload>[];
+    await reader.pull(
+      provider: provider,
+      selfDeviceId: 'reader-x',
+      folderId: folder,
+      apply: (p) async => applied.add(p),
+      applyBaseFile: spyApplyBaseFile(applied),
+    );
+
+    final ids = applied.expand((p) => p.data.dives.map((d) => d['id'])).toSet();
+    expect(ids, contains('d2'), reason: 'seq 2 was readable and applied');
+    expect(
+      ids,
+      isNot(contains('d3')),
+      reason: 'a refused seq must not be applied',
+    );
+
+    final cursor = await PeerCursorStore(db).get(peerId, provider.providerId);
+    expect(
+      cursor?.lastSeqApplied,
+      2,
+      reason:
+          'the cursor must record the seqs already applied, so the next '
+          'sync retries only the refused one',
+    );
+  });
+}
+
+/// Refuses one file the way the encrypting decorator refuses an envelope it
+/// cannot open, so the reader sees a real [EnvelopeCorruptException] rather
+/// than a hand-thrown stand-in.
+class _RefusingCloudStorageProvider extends FakeCloudStorageProvider {
+  String? refuseName;
+
+  @override
+  Future<Uint8List> downloadFile(String fileId) async {
+    final name = fileId.substring(fileId.lastIndexOf('/') + 1);
+    if (name == refuseName) {
+      throw const EnvelopeCorruptException('Envelope payload rejected');
+    }
+    return super.downloadFile(fileId);
+  }
 }

--- a/test/core/services/sync/crypto/sync_envelope_test.dart
+++ b/test/core/services/sync/crypto/sync_envelope_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
 import 'package:submersion/core/services/sync/crypto/sync_envelope.dart';
 
@@ -143,4 +144,178 @@ void main() {
       );
     });
   });
+
+  group('SyncEnvelope payload size cap', () {
+    final key = SecretKey(List<int>.generate(32, (i) => i));
+    const keyId = '8f14e45f-ceea-467f-ab37-a10a8d5f4c11';
+
+    test('the cap clears the only structurally bounded payload', () {
+      // Base parts are sliced to exactly BaseChunker.defaultPartSize, so a
+      // 648 MB library publishes as 78 identical 8 MiB envelopes rather
+      // than one large one. Anchoring the cap to that constant keeps the
+      // relationship visible if either moves.
+      expect(
+        SyncEnvelope.defaultMaxPlaintextBytes,
+        greaterThanOrEqualTo(BaseChunker.defaultPartSize * 32),
+      );
+    });
+
+    test('open refuses a gzip bomb inside an authentic envelope', () async {
+      // Sealed with the real key, so this is the in-trust-boundary case the
+      // cap exists for: a malicious or buggy peer, or a compromised device.
+      // The gzip flag lives at header offset 20, outside both the ciphertext
+      // and the AAD, so setting it after sealing leaves authentication
+      // intact, which is exactly how an attacker reaches gzip.decode.
+      final bomb = _gzipZeros(mebibytes: 512);
+      expect(bomb.length, lessThan(1 << 20));
+      final envelope = await SyncEnvelope.seal(
+        plaintext: bomb,
+        dataKey: key,
+        libraryKeyId: keyId,
+        filename: 'ssv1.devA.cs.000000000001.json',
+        compress: false,
+      );
+      envelope[20] |= 0x01;
+
+      final before = ProcessInfo.currentRss;
+      await expectLater(
+        SyncEnvelope.open(
+          envelope: envelope,
+          dataKey: key,
+          expectedLibraryKeyId: keyId,
+          filename: 'ssv1.devA.cs.000000000001.json',
+          maxPlaintextBytes: 64 * 1024,
+        ),
+        throwsA(
+          isA<EnvelopeCorruptException>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds'),
+          ),
+        ),
+      );
+      // Buffering the whole body would need 512 MiB. Loose enough for GC
+      // noise and still far under that.
+      expect(ProcessInfo.currentRss - before, lessThan(64 * 1024 * 1024));
+    });
+
+    test('open refuses a flipped gzip flag rather than leaking a raw '
+        'FormatException', () async {
+      // An attacker with no key can still flip the unauthenticated flag
+      // byte. That turns plaintext into "not a gzip stream", which used to
+      // surface as dart:io's FormatException past every `on
+      // EnvelopeCorruptException` handler in sync.
+      final envelope = await SyncEnvelope.seal(
+        plaintext: Uint8List.fromList(utf8.encode('{"not":"gzip"}')),
+        dataKey: key,
+        libraryKeyId: keyId,
+        filename: 'ssv1.devA.manifest.json',
+        compress: false,
+      );
+      envelope[20] |= 0x01;
+
+      await expectLater(
+        SyncEnvelope.open(
+          envelope: envelope,
+          dataKey: key,
+          expectedLibraryKeyId: keyId,
+          filename: 'ssv1.devA.manifest.json',
+        ),
+        throwsA(isA<EnvelopeCorruptException>()),
+      );
+    });
+
+    test('an uncompressed payload over the cap still opens', () async {
+      // The cap bounds inflation, not the file: a payload with no gzip flag
+      // was never amplified, so refusing it would only strand data.
+      final plain = Uint8List.fromList(
+        List<int>.generate(8192, (i) => i % 251),
+      );
+      final envelope = await SyncEnvelope.seal(
+        plaintext: plain,
+        dataKey: key,
+        libraryKeyId: keyId,
+        filename: 'ssv1.devA.base.000000000001.p0000',
+        compress: false,
+      );
+      expect(
+        await SyncEnvelope.open(
+          envelope: envelope,
+          dataKey: key,
+          expectedLibraryKeyId: keyId,
+          filename: 'ssv1.devA.base.000000000001.p0000',
+          maxPlaintextBytes: 1024,
+        ),
+        plain,
+      );
+    });
+
+    test('seal stores a payload over the cap uncompressed so it can be '
+        'read back', () async {
+      // A device must never write an envelope it would itself refuse.
+      // Degrading to uncompressed keeps the write path total: the upload is
+      // larger, but nothing is stranded, which is the safer half of the
+      // trade for a payload this size.
+      final plain = Uint8List.fromList(
+        utf8.encode('{"repeat":"${'ab' * 4000}"}'),
+      );
+      final envelope = await SyncEnvelope.seal(
+        plaintext: plain,
+        dataKey: key,
+        libraryKeyId: keyId,
+        filename: 'ssv1.devA.cs.000000000002.json',
+        maxPlaintextBytes: 1024,
+      );
+      expect(envelope[20] & 0x01, 0, reason: 'gzip flag must not be set');
+      expect(
+        await SyncEnvelope.open(
+          envelope: envelope,
+          dataKey: key,
+          expectedLibraryKeyId: keyId,
+          filename: 'ssv1.devA.cs.000000000002.json',
+          maxPlaintextBytes: 1024,
+        ),
+        plain,
+      );
+    });
+
+    test('seal still compresses a payload under the cap', () async {
+      final plain = Uint8List.fromList(
+        utf8.encode('{"repeat":"${'ab' * 4000}"}'),
+      );
+      final envelope = await SyncEnvelope.seal(
+        plaintext: plain,
+        dataKey: key,
+        libraryKeyId: keyId,
+        filename: 'ssv1.devA.cs.000000000003.json',
+        maxPlaintextBytes: 1 << 20,
+      );
+      expect(envelope[20] & 0x01, 0x01, reason: 'gzip flag must be set');
+      expect(envelope.length, lessThan(plain.length));
+    });
+  });
+}
+
+/// Gzips [mebibytes] MiB of zeros without ever holding them.
+Uint8List _gzipZeros({required int mebibytes}) {
+  final chunks = <List<int>>[];
+  final sink = gzip.encoder.startChunkedConversion(_Collect(chunks));
+  final block = Uint8List(1024 * 1024);
+  for (var i = 0; i < mebibytes; i++) {
+    sink.add(block);
+  }
+  sink.close();
+  return Uint8List.fromList([for (final c in chunks) ...c]);
+}
+
+class _Collect implements Sink<List<int>> {
+  _Collect(this.chunks);
+
+  final List<List<int>> chunks;
+
+  @override
+  void add(List<int> data) => chunks.add(data);
+
+  @override
+  void close() {}
 }

--- a/test/core/services/sync/crypto/sync_envelope_test.dart
+++ b/test/core/services/sync/crypto/sync_envelope_test.dart
@@ -9,6 +9,8 @@ import 'package:submersion/core/services/sync/changeset_log/base_chunker.dart';
 import 'package:submersion/core/services/sync/crypto/crypto_errors.dart';
 import 'package:submersion/core/services/sync/crypto/sync_envelope.dart';
 
+import '../../../../support/compression_bombs.dart';
+
 Map<String, dynamic> _vectors() =>
     jsonDecode(
           File('test/fixtures/crypto/crypto_vectors.json').readAsStringSync(),
@@ -166,7 +168,11 @@ void main() {
       // The gzip flag lives at header offset 20, outside both the ciphertext
       // and the AAD, so setting it after sealing leaves authentication
       // intact, which is exactly how an attacker reaches gzip.decode.
-      final bomb = _gzipZeros(mebibytes: 512);
+      final bomb = compressZeros(gzip.encoder, mebibytes: 512);
+      // The cap below has to clear the compressed blob, because open fuses
+      // maxBlobBytes to it. Sized under it, the pre-conversion blob guard
+      // fires and nothing is ever inflated, which would leave the chunked
+      // abort (the whole point of the fix) untested at this layer.
       expect(bomb.length, lessThan(1 << 20));
       final envelope = await SyncEnvelope.seal(
         plaintext: bomb,
@@ -184,13 +190,13 @@ void main() {
           dataKey: key,
           expectedLibraryKeyId: keyId,
           filename: 'ssv1.devA.cs.000000000001.json',
-          maxPlaintextBytes: 64 * 1024,
+          maxPlaintextBytes: 1 << 20,
         ),
         throwsA(
           isA<EnvelopeCorruptException>().having(
             (e) => e.message,
             'message',
-            contains('exceeds'),
+            contains('inflated body exceeds'),
           ),
         ),
       );
@@ -203,8 +209,9 @@ void main() {
         'FormatException', () async {
       // An attacker with no key can still flip the unauthenticated flag
       // byte. That turns plaintext into "not a gzip stream", which used to
-      // surface as dart:io's FormatException past every `on
-      // EnvelopeCorruptException` handler in sync.
+      // escape as dart:io's FormatException: a type no caller can classify,
+      // so ChangesetReader's `on EnvelopeCorruptException` break could not
+      // see it and the failure fell through to the per-peer catch instead.
       final envelope = await SyncEnvelope.seal(
         plaintext: Uint8List.fromList(utf8.encode('{"not":"gzip"}')),
         dataKey: key,
@@ -294,28 +301,4 @@ void main() {
       expect(envelope.length, lessThan(plain.length));
     });
   });
-}
-
-/// Gzips [mebibytes] MiB of zeros without ever holding them.
-Uint8List _gzipZeros({required int mebibytes}) {
-  final chunks = <List<int>>[];
-  final sink = gzip.encoder.startChunkedConversion(_Collect(chunks));
-  final block = Uint8List(1024 * 1024);
-  for (var i = 0; i < mebibytes; i++) {
-    sink.add(block);
-  }
-  sink.close();
-  return Uint8List.fromList([for (final c in chunks) ...c]);
-}
-
-class _Collect implements Sink<List<int>> {
-  _Collect(this.chunks);
-
-  final List<List<int>> chunks;
-
-  @override
-  void add(List<int> data) => chunks.add(data);
-
-  @override
-  void close() {}
 }

--- a/test/core/services/sync/crypto/sync_envelope_test.dart
+++ b/test/core/services/sync/crypto/sync_envelope_test.dart
@@ -196,7 +196,13 @@ void main() {
           isA<EnvelopeCorruptException>().having(
             (e) => e.message,
             'message',
-            contains('inflated body exceeds'),
+            allOf(
+              contains('inflated body exceeds'),
+              // The reason is passed through, not the exception: a nested
+              // 'BoundedInflateException:' prefix here would mean open
+              // interpolated the error object instead of its message.
+              isNot(contains('BoundedInflateException')),
+            ),
           ),
         ),
       );

--- a/test/core/utils/bounded_inflate_test.dart
+++ b/test/core/utils/bounded_inflate_test.dart
@@ -169,6 +169,19 @@ void main() {
       expect(inflate(full.sublist(0, full.length - 4)), hasLength(300));
     });
 
+    test('names itself and its cause when it lands in a log', () {
+      // toString is what a bare log line shows, so it has to carry both the
+      // type and the reason. Callers that wrap this (SyncEnvelope.open) pass
+      // `message` on rather than the exception, so the reason survives
+      // without a second type prefix in front of it.
+      expect(
+        const BoundedInflateException(
+          'inflated body exceeds 4096 byte(s)',
+        ).toString(),
+        'BoundedInflateException: inflated body exceeds 4096 byte(s)',
+      );
+    });
+
     test('lets a programming error surface instead of wrapping it', () {
       expect(
         () => inflateBounded(

--- a/test/core/utils/bounded_inflate_test.dart
+++ b/test/core/utils/bounded_inflate_test.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/utils/bounded_inflate.dart';
 
+import '../../support/compression_bombs.dart';
+
 void main() {
   Uint8List gz(List<int> body) => Uint8List.fromList(gzip.encode(body));
   Uint8List zl(List<int> body) => Uint8List.fromList(zlib.encode(body));
@@ -75,7 +77,7 @@ void main() {
       // rather than the clock is deliberate: zlib inflates this in well
       // under a second, so a time bound cannot tell a chunked abort from a
       // decoder that buffered the lot and checked its length afterwards.
-      final bomb = _deflateZeros(mebibytes: 512);
+      final bomb = compressZeros(gzip.encoder, mebibytes: 512);
       expect(bomb.length, lessThan(1 << 20));
 
       final before = ProcessInfo.currentRss;
@@ -186,28 +188,4 @@ void main() {
       );
     });
   });
-}
-
-/// Deflates [mebibytes] MiB of zeros without ever holding them.
-Uint8List _deflateZeros({required int mebibytes}) {
-  final chunks = <List<int>>[];
-  final sink = gzip.encoder.startChunkedConversion(_Collect(chunks));
-  final block = Uint8List(1024 * 1024);
-  for (var i = 0; i < mebibytes; i++) {
-    sink.add(block);
-  }
-  sink.close();
-  return Uint8List.fromList([for (final c in chunks) ...c]);
-}
-
-class _Collect implements Sink<List<int>> {
-  _Collect(this.chunks);
-
-  final List<List<int>> chunks;
-
-  @override
-  void add(List<int> data) => chunks.add(data);
-
-  @override
-  void close() {}
 }

--- a/test/core/utils/bounded_inflate_test.dart
+++ b/test/core/utils/bounded_inflate_test.dart
@@ -72,11 +72,12 @@ void main() {
     });
 
     test('refuses a gzip bomb without inflating it whole', () {
-      // Half a gigabyte of zeros, deflated a mebibyte at a time so the
+      // Half a gigabyte of zeros, gzipped a mebibyte at a time so the
       // fixture itself never costs half a gigabyte. Asserting on memory
-      // rather than the clock is deliberate: zlib inflates this in well
-      // under a second, so a time bound cannot tell a chunked abort from a
-      // decoder that buffered the lot and checked its length afterwards.
+      // rather than the clock is deliberate: the inflater gets through this
+      // in well under a second, so a time bound cannot tell a chunked abort
+      // from a decoder that buffered the lot and checked its length
+      // afterwards.
       final bomb = compressZeros(gzip.encoder, mebibytes: 512);
       expect(bomb.length, lessThan(1 << 20));
 
@@ -137,8 +138,9 @@ void main() {
     });
 
     test('returns an empty body for empty input', () {
-      // zlib accepts zero bytes as zero output rather than as corruption.
-      // Ruling on an empty body is the caller's job, not the inflater's.
+      // Both framings accept zero bytes as zero output rather than as
+      // corruption. Ruling on an empty body is the caller's job, not the
+      // inflater's.
       expect(
         inflateBounded(
           Uint8List(0),

--- a/test/core/utils/bounded_inflate_test.dart
+++ b/test/core/utils/bounded_inflate_test.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/utils/bounded_inflate.dart';
+
+void main() {
+  Uint8List gz(List<int> body) => Uint8List.fromList(gzip.encode(body));
+  Uint8List zl(List<int> body) => Uint8List.fromList(zlib.encode(body));
+
+  group('inflateBounded', () {
+    test('returns the body of a gzip stream under the cap', () {
+      final body = List<int>.generate(5000, (i) => i % 251);
+      expect(
+        inflateBounded(
+          gz(body),
+          decoder: gzip.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: 1 << 20,
+        ),
+        body,
+      );
+    });
+
+    test('returns the body of a zlib stream under the cap', () {
+      // The decoder is a parameter so the same guard covers both framings:
+      // sync envelopes are gzip, the profile series codecs are zlib.
+      final body = List<int>.generate(5000, (i) => i % 251);
+      expect(
+        inflateBounded(
+          zl(body),
+          decoder: zlib.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: 1 << 20,
+        ),
+        body,
+      );
+    });
+
+    test('accepts a body of exactly maxBytes', () {
+      final body = List<int>.filled(4096, 9);
+      expect(
+        inflateBounded(
+          gz(body),
+          decoder: gzip.decoder,
+          maxBytes: 4096,
+          maxBlobBytes: 1 << 20,
+        ),
+        hasLength(4096),
+      );
+    });
+
+    test('refuses a body one byte over maxBytes', () {
+      final body = List<int>.filled(4097, 9);
+      expect(
+        () => inflateBounded(
+          gz(body),
+          decoder: gzip.decoder,
+          maxBytes: 4096,
+          maxBlobBytes: 1 << 20,
+        ),
+        throwsA(
+          isA<BoundedInflateException>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds the 4096 byte'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses a gzip bomb without inflating it whole', () {
+      // Half a gigabyte of zeros, deflated a mebibyte at a time so the
+      // fixture itself never costs half a gigabyte. Asserting on memory
+      // rather than the clock is deliberate: zlib inflates this in well
+      // under a second, so a time bound cannot tell a chunked abort from a
+      // decoder that buffered the lot and checked its length afterwards.
+      final bomb = _deflateZeros(mebibytes: 512);
+      expect(bomb.length, lessThan(1 << 20));
+
+      final before = ProcessInfo.currentRss;
+      expect(
+        () => inflateBounded(
+          bomb,
+          decoder: gzip.decoder,
+          maxBytes: 64 * 1024,
+          maxBlobBytes: 1 << 20,
+        ),
+        throwsA(isA<BoundedInflateException>()),
+      );
+      final grew = ProcessInfo.currentRss - before;
+      // Buffering the whole body would need 512 MiB. The threshold is loose
+      // enough for GC noise and still far under that.
+      expect(grew, lessThan(64 * 1024 * 1024));
+    });
+
+    test('refuses a blob longer than maxBlobBytes', () {
+      // Checked before the conversion: the filter copies the whole input
+      // natively before it emits a first chunk, so a sink-side check never
+      // sees an oversized blob.
+      final padded = Uint8List(4096)..setRange(0, 8, gz([1, 2, 3]));
+      expect(
+        () => inflateBounded(
+          padded,
+          decoder: gzip.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: 512,
+        ),
+        throwsA(
+          isA<BoundedInflateException>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds the 512 allowed'),
+          ),
+        ),
+      );
+    });
+
+    test('refuses bytes that are not a compressed stream', () {
+      expect(
+        () => inflateBounded(
+          Uint8List.fromList([1, 2, 3, 4, 5]),
+          decoder: gzip.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: 1 << 20,
+        ),
+        throwsA(
+          isA<BoundedInflateException>().having(
+            (e) => e.message,
+            'message',
+            contains('not a valid compressed stream'),
+          ),
+        ),
+      );
+    });
+
+    test('returns an empty body for empty input', () {
+      // zlib accepts zero bytes as zero output rather than as corruption.
+      // Ruling on an empty body is the caller's job, not the inflater's.
+      expect(
+        inflateBounded(
+          Uint8List(0),
+          decoder: gzip.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: 1 << 20,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('a truncated stream returns a short body rather than throwing', () {
+      // Pinned, not endorsed: the inflater reports no error for a lost tail,
+      // and dropping only the CRC/length trailer returns the body in full,
+      // so the checksum is never verified. Callers must frame their own
+      // payload; a sync envelope does, because AES-GCM authenticates the
+      // compressed bytes before they ever reach here.
+      final full = gz(List<int>.generate(300, (i) => i % 251));
+      Uint8List inflate(Uint8List b) => inflateBounded(
+        b,
+        decoder: gzip.decoder,
+        maxBytes: 1 << 20,
+        maxBlobBytes: 1 << 20,
+      );
+      expect(inflate(full.sublist(0, full.length ~/ 2)), hasLength(133));
+      expect(inflate(full.sublist(0, full.length - 4)), hasLength(300));
+    });
+
+    test('lets a programming error surface instead of wrapping it', () {
+      expect(
+        () => inflateBounded(
+          gz([1, 2, 3]),
+          decoder: gzip.decoder,
+          maxBytes: -1,
+          maxBlobBytes: 1 << 20,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => inflateBounded(
+          gz([1, 2, 3]),
+          decoder: gzip.decoder,
+          maxBytes: 1 << 20,
+          maxBlobBytes: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}
+
+/// Deflates [mebibytes] MiB of zeros without ever holding them.
+Uint8List _deflateZeros({required int mebibytes}) {
+  final chunks = <List<int>>[];
+  final sink = gzip.encoder.startChunkedConversion(_Collect(chunks));
+  final block = Uint8List(1024 * 1024);
+  for (var i = 0; i < mebibytes; i++) {
+    sink.add(block);
+  }
+  sink.close();
+  return Uint8List.fromList([for (final c in chunks) ...c]);
+}
+
+class _Collect implements Sink<List<int>> {
+  _Collect(this.chunks);
+
+  final List<List<int>> chunks;
+
+  @override
+  void add(List<int> data) => chunks.add(data);
+
+  @override
+  void close() {}
+}

--- a/test/support/compression_bombs.dart
+++ b/test/support/compression_bombs.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Compresses [mebibytes] MiB of zeros through [encoder], streaming so the
+/// fixture itself never costs [mebibytes] MiB.
+///
+/// The point of a bomb fixture is that the compressed form is tiny and the
+/// body is not, so building it the obvious way (allocate the body, encode
+/// it) would need exactly the memory the guard under test exists to avoid.
+Uint8List compressZeros(
+  Converter<List<int>, List<int>> encoder, {
+  required int mebibytes,
+}) {
+  final chunks = <List<int>>[];
+  final sink = encoder.startChunkedConversion(_Collect(chunks));
+  final block = Uint8List(1024 * 1024);
+  for (var i = 0; i < mebibytes; i++) {
+    sink.add(block);
+  }
+  sink.close();
+  final out = BytesBuilder(copy: false);
+  for (final c in chunks) {
+    out.add(c);
+  }
+  return out.takeBytes();
+}
+
+class _Collect implements Sink<List<int>> {
+  _Collect(this.chunks);
+
+  final List<List<int>> chunks;
+
+  @override
+  void add(List<int> data) => chunks.add(data);
+
+  @override
+  void close() {}
+}


### PR DESCRIPTION
Closes #1412.

## The defect

`SyncEnvelope.open` gunzipped the decrypted payload with no size bound:

```dart
if ((flags & _flagGzip) != 0) {
  return Uint8List.fromList(gzip.decode(payload));
}
```

Every encrypted sync file flows through here, so a payload that expands
arbitrarily was materialised whole in memory.

As the issue says, this sits behind AES-256-GCM: `_aesGcm.decrypt` runs
first and throws on any tampering, so an attacker has to already hold the
library data key. The severity is "peer inside the trust boundary can spike
memory on every other device in the library", not "remote attacker". The
guard is one comparison and the residual cases are real: a shared family
library, a stolen device, a buggy writer.

## The guard has to run chunked

`gzip.decode` is a single native call that has already allocated the whole
body by the time it returns, so `if (out.length > cap) throw` is theatre.
The new `inflateBounded` drives the decoder through
`startChunkedConversion` and throws from inside the sink, which unwinds the
native filter mid-stream. dart:io emits 64 KiB chunks (measured), so a bomb
is abandoned within one chunk of the cap.

The test asserts on RSS rather than the clock, because zlib inflates half a
gigabyte in well under a second: a time bound cannot tell a chunked abort
from a decoder that buffered the lot and checked its length afterwards.

## Where the helper lives

`lib/core/utils/bounded_inflate.dart` is the shared, codec-parameterised
home the issue asks for. `#1387` currently carries a zlib-only copy at
`lib/features/dive_log/domain/codecs/bounded_inflate.dart`; that PR is
still open, so this could not build on it. The shared version takes the
decoder as a parameter (`gzip.decoder` here, `zlib.decoder` there) and
throws its own `BoundedInflateException` rather than a dive-specific type,
so both #1387 and #1411 can re-point at it without inheriting each other's
error taxonomy.

## Where the cap comes from

256 MiB, derived from what a sync payload can legitimately be rather than
from the series constants, which are sized for one dive profile.

- **Base parts are the only structurally bounded kind**, cut to exactly
  `BaseChunker.defaultPartSize` (8 MiB). Even the 648 MB library from #358
  publishes as 78 small envelopes, so that path keeps 32x of headroom. A
  test pins the cap to that constant so the relationship stays visible if
  either moves.
- **Changesets are the unbounded kind**, but they are built, JSON-encoded,
  gzipped and encrypted whole in memory on the writer
  (`changeset_writer.dart:246,291`) and decoded whole in memory on the
  reader (`changeset_reader.dart:213`). A plaintext past a few hundred
  megabytes therefore cannot be applied even if it inflates. The cap
  refuses only payloads that were already fatal, and turns an OOM kill into
  a transient-stop error.
- Manifests, retirement markers and the two `submersion_library_*.json`
  markers are all under ~100 KB.

## Seal enforces the same bound

A device must never write an envelope it would itself refuse, and only the
gzip flag makes that possible. `seal` therefore declines to compress past
the cap, which keeps the write path total: such an upload is larger, but
nothing is stranded. Refusing the write instead would strand a user's data
with no recourse.

The wire format is unchanged. The cap is reader and writer policy, so the
spec's section 3.3 layout still describes the bytes exactly.

## Bonus: the gzip flag is not authenticated

Header byte 20 sits outside both the ciphertext and the AAD (which is only
the filename), so a keyless attacker can flip it. That used to turn any
envelope into "not a gzip stream" and surface `dart:io`'s
`FormatException`, a type no `on EnvelopeCorruptException` handler in sync
could name. It is now `EnvelopeCorruptException` like every other envelope
rejection, which is also what the test exploits to build an authentic bomb
envelope.

## Tests

TDD throughout; every test was watched fail first.

- `test/core/utils/bounded_inflate_test.dart` (10 new): gzip and zlib
  bodies, exact-cap and one-over, a 512 MiB bomb refused with RSS growth
  under 64 MiB, an over-length blob, non-stream input, empty input, the
  pinned truncation behaviour, and negative caps surfacing as
  `ArgumentError` rather than being wrapped.
- `test/core/services/sync/crypto/sync_envelope_test.dart` (6 new): the cap
  versus `BaseChunker.defaultPartSize`, a bomb inside an authentic
  envelope, the flipped-flag case, an uncompressed over-cap payload still
  opening, seal degrading to uncompressed past the cap, and seal still
  compressing under it.

`flutter analyze`: clean. `flutter test test/core/services/sync
test/core/services/cloud_storage test/features/backup`: 1507 passed, 1
skipped (pre-existing).

---

## Follow-up from review

Three findings on the first commit, all confirmed by measurement.

**The envelope-level bomb test never inflated anything.** `open` fuses
`maxBlobBytes` to `maxPlaintextBytes`, the fixture is 521,844 compressed
bytes, and the test passed a 64 KiB cap, so the pre-conversion blob guard
fired and `startChunkedConversion` was never reached. `contains('exceeds')`
matched either guard's message, so the assertion could not tell, and the
RSS bound was vacuously true because nothing had been buffered. The cap is
now 1 MiB, so the blob clears the first guard and the 512 MiB body trips
the sink; the assertion pins `inflated body exceeds`, which only the sink
emits.

**A refused envelope was worse than the transient stop this PR claimed.**
`ChangesetReader`'s changeset loop `break`s on a checksum failure so it
falls through to the cursor upsert and keeps the seqs already applied. An
`EnvelopeCorruptException` from the download threw straight past that to
the per-peer `catch (_)`, which skips the upsert. The new test in
`changeset_reader_verify_test.dart` showed the cursor coming back `null`:
the base and every changeset below the bad seq were committed to the
database but never recorded, so each later sync re-downloaded and
re-applied the whole backlog and still could not advance past that seq. A
livelock, not a retry. The download now breaks like the checksum case does,
which is what makes the cap's doc comment true.

That handler is silent and swallows far more than this path, so the wider
problem is filed as #1417 rather than widened here.

**A test comment claimed a fix that did not exist.** It said the typed
exception rescued `on EnvelopeCorruptException` handlers in sync; there
were none, every sync catch site was blanket. There is one now, in the
reader, so the comment says what is actually true.

Copilot's two review comments are also in: the blob-cap comment
over-promised for foreign writers (it holds only for envelopes this `seal`
wrote), and the bomb fixture's comments still called it deflated and named
zlib as the inflater after the helper moved to `test/support`.
