### PR TITLE
fix(dive-profile-chart): guard stale touch indices before fl_chart indicator lookup

### DIFF
--- a/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
+++ b/lib/features/dive_log/presentation/widgets/dive_profile_chart.dart
@@ -2903,15 +2903,20 @@ class _DiveProfileChartState extends ConsumerState<DiveProfileChart> {
               handleBuiltInTouches: true,
               getTouchedSpotIndicator: (barData, spotIndexes) {
                 final suppressed = _suppressedDepthIndicatorSpots;
-                if (suppressed.isEmpty) {
-                  return defaultTouchedIndicators(barData, spotIndexes);
-                }
+                // spotIndexes can reference a touch captured against a
+                // previous frame's bar data (e.g. a consolidate-dive merge
+                // shortens the profile mid-touch); indexing barData.spots
+                // with a stale, now out-of-range index throws in fl_chart's
+                // own defaultTouchedIndicators, so drop those here first.
                 // Hide the built-in focus dot on the extra velocity bands so a
                 // single depth dot remains; every other line keeps its default
                 // indicator. See [velocityIndicatorSuppression].
                 return [
                   for (final index in spotIndexes)
-                    if (_isSuppressedIndicatorSpot(barData, index, suppressed))
+                    if (index < 0 || index >= barData.spots.length)
+                      null
+                    else if (suppressed.isNotEmpty &&
+                        _isSuppressedIndicatorSpot(barData, index, suppressed))
                       null
                     else
                       defaultTouchedIndicators(barData, [index]).first,

--- a/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
+++ b/test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart
@@ -4130,6 +4130,29 @@ void main() {
       },
     );
 
+    testWidgets('touched spot indicator ignores a stale out-of-range index', (
+      tester,
+    ) async {
+      // Regression: consolidating two dives can shorten the profile mid
+      // touch, leaving spotIndexes from a previous frame's (longer) bar
+      // data. fl_chart's own defaultTouchedIndicators indexes
+      // barData.spots directly and throws a RangeError on a stale index;
+      // getTouchedSpotIndicator must drop it instead of forwarding it.
+      final profile = _makeProfile(points: 12);
+      await tester.pumpWidget(
+        buildWithLegend(profile: profile, ascentRates: const []),
+      );
+      await tester.pumpAndSettle();
+
+      final data = primaryChartData(tester);
+      final bar = data.lineBarsData.first;
+      final indicator = data.lineTouchData.getTouchedSpotIndicator;
+
+      expect(() => indicator(bar, [bar.spots.length + 685]), returnsNormally);
+      expect(indicator(bar, [bar.spots.length + 685]).single, isNull);
+      expect(indicator(bar, const [-1]).single, isNull);
+    });
+
     testWidgets('tooltip builds when hovering a non-first velocity segment', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- Fixes #1440: consolidating two dives (same dive imported from two computers) could crash the profile chart with a `RangeError` thrown from fl_chart's `defaultTouchedIndicators`.
- `getTouchedSpotIndicator` in `dive_profile_chart.dart` now bounds-checks each touched spot index against the current `barData.spots.length` before delegating to fl_chart or the existing indicator-suppression logic, dropping any stale, out-of-range index instead of forwarding it.
- Stale indices happen when a consolidate-dive merge shortens the profile mid-touch, so a touch captured against a previous (longer) frame's bar data ends up out of range for the new bar data.

## Test plan
- [x] Added a regression test (`touched spot indicator ignores a stale out-of-range index`) that reproduces the exact crash without the fix and passes with it.
- [x] `flutter test test/features/dive_log/presentation/widgets/dive_profile_chart_test.dart` — all 167 tests pass.
- [x] `flutter analyze lib/features/dive_log/presentation/widgets/dive_profile_chart.dart` — no issues.
- [x] `dart format` run on changed files.