### PR TITLE
fix: review follow-ups for the profile sample storage migration

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -4338,8 +4338,10 @@ class AppDatabase extends _$AppDatabase {
   /// different parents, so one can be packable on a database where the other
   /// is not.
   Future<void> _dropLegacyProfileTable() async {
+    final present = await _tableExists('dive_profiles');
     await customStatement('DROP INDEX IF EXISTS idx_dive_profiles_dive_id');
     await customStatement('DROP TABLE IF EXISTS dive_profiles');
+    if (present) _droppedLegacySampleTables = true;
   }
 
   /// v183: drops the row-per-sample tank pressure table. The mirror of
@@ -4347,9 +4349,26 @@ class AppDatabase extends _$AppDatabase {
   /// (that table waits for `dive_tanks`, which `dive_profile_series` does
   /// not need).
   Future<void> _dropLegacyTankTable() async {
+    final present = await _tableExists('tank_pressure_profiles');
     await customStatement('DROP INDEX IF EXISTS idx_tank_pressure_dive_tank');
     await customStatement('DROP TABLE IF EXISTS tank_pressure_profiles');
+    if (present) _droppedLegacySampleTables = true;
   }
+
+  bool _droppedLegacySampleTables = false;
+
+  /// True once this connection has actually dropped a row-per-sample legacy
+  /// table, whether from the v183 rung or from the beforeOpen backstop.
+  ///
+  /// The pages those tables held are most of an older file, and only a
+  /// VACUUM returns them to the filesystem. Which open performs the drop is
+  /// not something the stored schema version can answer: the rung is allowed
+  /// to skip it (its pack threw, the series table's foreign-key parents were
+  /// absent, or the residue count found rows no series covered), and the
+  /// backstop then drops on the first later open whose pack succeeds, by
+  /// which time the file is long since stamped 183. So the reclamation keys
+  /// off this, the event itself. See [DatabaseService].
+  bool get droppedLegacySampleTables => _droppedLegacySampleTables;
 
   /// True when [table] exists in this database right now.
   Future<bool> _tableExists(String table) async {

--- a/lib/core/database/legacy_sample_staging.dart
+++ b/lib/core/database/legacy_sample_staging.dart
@@ -275,11 +275,19 @@ Future<ProfilePackReport> packStagedLegacyRows(
     byTank: false,
     byGroupIdentity: true,
   );
+  // byGroupIdentity here too, for the reason the pack above carries. The
+  // pressure side has no source or primary flag, so all it buys is the
+  // null-computer wildcard, and that is exactly the case that matters: this
+  // device stamps a computer onto its own series after packing while a peer
+  // below the floor still holds the same readings unattributed. Without it
+  // the clear demands an exact match the pack never made, so the staged
+  // rows are never deleted and every later apply re-runs the whole pack.
   await _clearStagedRowsAlreadyPacked(
     db,
     staging: kLegacyTankStagingTable,
     series: 'tank_pressure_series',
     byTank: true,
+    byGroupIdentity: true,
   );
   return report;
 }

--- a/lib/core/database/legacy_tank_orphan_adoption.dart
+++ b/lib/core/database/legacy_tank_orphan_adoption.dart
@@ -1,0 +1,106 @@
+/// The pressure-row orphan adoption the packer runs before it packs.
+///
+/// Split from `profile_series_pack.dart` to keep that file under the
+/// project's 800-line limit. It is a pre-pass over the legacy table rather
+/// than part of the pack: it rewrites `tank_id` in place so the rows the
+/// packer then reads already name a tank the dive still has.
+library;
+
+import 'package:drift/drift.dart';
+import 'package:submersion/core/database/profile_series_pack_coverage.dart';
+
+/// Re-points pressure rows whose tank id is no longer one of the dive's
+/// tanks at a tank that is, in place, before anything is packed.
+///
+/// `tank_pressure_series.tank_id` is a NOT NULL foreign key, so an orphan
+/// cannot be packed as it stands, and after v183 every reader reads series:
+/// leaving it behind drops that dive's pressure curve and per-cylinder SAC,
+/// and its rows keep the legacy table alive forever, since the residue
+/// count can never cover a tank that does not exist.
+///
+/// The rule is the v102 rung's ([AppDatabase] `_relinkStrandedTankPressures`)
+/// and `GasAnalysisService`'s read-time resolver, so a dive reads the same
+/// before and after packing: exact id matches are left alone, and the
+/// remaining orphans, in first-sample order, are paired with the dive's
+/// still-unmatched tanks in tank order. Both sides are totally ordered
+/// (ties broken by id) and every device runs it over the same rows, so two
+/// devices packing the same logbook reach the same tank ids and the derived
+/// series ids still converge.
+///
+/// Healing the rows rather than remapping in memory keeps everything
+/// downstream, the coverage predicate and residue count included, working
+/// on ids that exist. Idempotent: a second run finds no orphans.
+Future<void> adoptStrandedTankPressures(
+  DatabaseConnectionUser db,
+  String table,
+) async {
+  if (!await legacyTableExists(db, 'dive_tanks')) return;
+  final tankColumns = await legacyColumnNames(db, 'dive_tanks');
+  if (!tankColumns.containsAll(const {'id', 'dive_id'})) return;
+  final hasOrder = tankColumns.contains('tank_order');
+  final tankRows = await db
+      .customSelect(
+        'SELECT dive_id, id${hasOrder ? ', tank_order' : ''} FROM dive_tanks',
+      )
+      .get();
+  final tanksByDive = <String, List<({String id, int order})>>{};
+  for (final r in tankRows) {
+    (tanksByDive[r.read<String>('dive_id')] ??= []).add((
+      id: r.read<String>('id'),
+      order: hasOrder ? (r.readNullable<int>('tank_order') ?? 0) : 0,
+    ));
+  }
+  if (tanksByDive.isEmpty) return;
+
+  final keyRows = await db
+      .customSelect(
+        'SELECT dive_id, tank_id, MIN(timestamp) AS first_ts FROM $table '
+        'WHERE tank_id IS NOT NULL AND timestamp IS NOT NULL '
+        'GROUP BY dive_id, tank_id',
+      )
+      .get();
+  final keysByDive = <String, List<({String tankId, int firstTs})>>{};
+  for (final r in keyRows) {
+    (keysByDive[r.read<String>('dive_id')] ??= []).add((
+      tankId: r.read<String>('tank_id'),
+      firstTs: r.read<int>('first_ts'),
+    ));
+  }
+
+  for (final entry in keysByDive.entries) {
+    final diveId = entry.key;
+    final tanks = tanksByDive[diveId];
+    if (tanks == null || tanks.isEmpty) continue;
+    final currentIds = {for (final t in tanks) t.id};
+    final matchedIds = {
+      for (final k in entry.value)
+        if (currentIds.contains(k.tankId)) k.tankId,
+    };
+    final orphans =
+        [
+          for (final k in entry.value)
+            if (!currentIds.contains(k.tankId)) k,
+        ]..sort((a, b) {
+          final byTime = a.firstTs.compareTo(b.firstTs);
+          return byTime != 0 ? byTime : a.tankId.compareTo(b.tankId);
+        });
+    if (orphans.isEmpty) continue;
+    final free =
+        [
+          for (final t in tanks)
+            if (!matchedIds.contains(t.id)) t,
+        ]..sort((a, b) {
+          // id tie-break: tanks sharing the default order must still pair
+          // deterministically, and Dart's sort is not stable.
+          final byOrder = a.order.compareTo(b.order);
+          return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
+        });
+    final pairs = orphans.length < free.length ? orphans.length : free.length;
+    for (var i = 0; i < pairs; i++) {
+      await db.customStatement(
+        'UPDATE $table SET tank_id = ? WHERE dive_id = ? AND tank_id = ?',
+        [free[i].id, diveId, orphans[i].tankId],
+      );
+    }
+  }
+}

--- a/lib/core/database/legacy_tank_orphan_adoption.dart
+++ b/lib/core/database/legacy_tank_orphan_adoption.dart
@@ -52,10 +52,20 @@ Future<void> adoptStrandedTankPressures(
   }
   if (tanksByDive.isEmpty) return;
 
+  // Filtered on storage class, not just on NULL. This is a prologue: it
+  // runs before the first dive's transaction and OUTSIDE the per-dive
+  // try/catch the rest of the design rests on, so a throw here costs every
+  // dive rather than one, on this open and on every later one. And SQLite
+  // orders storage classes, so MIN over a group whose values are all text
+  // returns text; drift's `read<int>` converts by parsing, which throws a
+  // FormatException on anything but a numeric string. A row this filter
+  // excludes holds no readable sample anyway, and the packer's own loops
+  // step over it for exactly the same reason.
   final keyRows = await db
       .customSelect(
         'SELECT dive_id, tank_id, MIN(timestamp) AS first_ts FROM $table '
-        'WHERE tank_id IS NOT NULL AND timestamp IS NOT NULL '
+        'WHERE ${readableTextSql('tank_id')} '
+        'AND ${readableNumberSql('timestamp')} '
         'GROUP BY dive_id, tank_id',
       )
       .get();

--- a/lib/core/database/profile_series_pack.dart
+++ b/lib/core/database/profile_series_pack.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:submersion/core/database/legacy_tank_orphan_adoption.dart';
 import 'package:submersion/core/database/profile_series_pack_coverage.dart';
 import 'package:submersion/core/database/profile_series_pack_rows.dart';
 import 'package:submersion/core/services/sync/hlc.dart';
@@ -127,7 +128,7 @@ Future<ProfilePackReport> packLegacyProfileRows(
   // kept, not deleted, and the migration's own adoption still heals this
   // device's rows.
   if (canPackTanks && !byGroupIdentity) {
-    await _adoptStrandedTankPressures(db, tankTable);
+    await adoptStrandedTankPressures(db, tankTable);
   }
   final tankScan = canPackTanks
       ? await _scanLegacyDives(
@@ -135,6 +136,7 @@ Future<ProfilePackReport> packLegacyProfileRows(
           legacyTable: tankTable,
           seriesTable: 'tank_pressure_series',
           byTank: true,
+          byGroupIdentity: byGroupIdentity,
         )
       : _emptyScan;
   final unpackedProfileDives = profileScan.unpacked;
@@ -209,19 +211,35 @@ Future<ProfilePackReport> packLegacyProfileRows(
                 variables: [Variable<String>(diveId)],
               )
               .get();
-          final groups = <_ProfileKey, List<ProfileSample>>{};
+          final groups = <_ProfileKey, _ProfileGroup>{};
           for (final row in rows) {
             final sample = profileSampleOf(row.data);
             if (sample == null) {
               skippedRows++;
               continue;
             }
+            // The RAW parent ids are kept alongside the resolved key. The
+            // key resolves a dangling id to null so the insert can satisfy
+            // the foreign key, which merges those rows into the
+            // null-parent group; coverage is a different question, and it
+            // is asked of the raw value, because "names no computer" and
+            // "names a computer this device has not merged yet" are the
+            // wildcard and a distinct source respectively. A merged group
+            // therefore carries more than one raw identity, and is covered
+            // only when every one of them is.
+            final rawComputerId = _textOf(row.data['computer_id']);
+            final rawSourceId = _textOf(row.data['source_id']);
             final key = _ProfileKey(
-              computerId: _resolvedParent(row.data['computer_id'], computerIds),
-              sourceId: _resolvedParent(row.data['source_id'], sourceIds),
+              computerId: _resolvedParent(rawComputerId, computerIds),
+              sourceId: _resolvedParent(rawSourceId, sourceIds),
               isPrimary: hasPrimary ? _boolOf(row.data['is_primary']) : true,
             );
-            groups.putIfAbsent(key, () => []).add(sample);
+            (groups[key] ??= (samples: [], rawParents: {}))
+              ..samples.add(sample)
+              ..rawParents.add((
+                computerId: rawComputerId,
+                sourceId: rawSourceId,
+              ));
           }
           for (final entry in groups.entries) {
             if (!diveIds.contains(diveId)) {
@@ -234,21 +252,23 @@ Future<ProfilePackReport> packLegacyProfileRows(
             // and the original it demoted), and (dive, computer) alone
             // calls the second one done.
             final covered = byGroupIdentity
-                ? coveredProfileGroups.any(
-                    (g) =>
-                        g.diveId == diveId &&
-                        g.isPrimary == key.isPrimary &&
-                        (key.computerId == null ||
-                            g.computerId == key.computerId) &&
-                        (key.sourceId == null || g.sourceId == key.sourceId),
+                ? entry.value.rawParents.every(
+                    (raw) => coveredProfileGroups.any(
+                      (g) =>
+                          g.diveId == diveId &&
+                          g.isPrimary == key.isPrimary &&
+                          (raw.computerId == null ||
+                              g.computerId == key.computerId) &&
+                          (raw.sourceId == null || g.sourceId == key.sourceId),
+                    ),
                   )
                 : coveredProfiles.contains((diveId, key.computerId));
             if (covered) {
               // Already packed under this identity; the stored series wins.
               continue;
             }
-            final samples = dedupeExactSamples(entry.value);
-            dropped += entry.value.length - samples.length;
+            final samples = dedupeExactSamples(entry.value.samples);
+            dropped += entry.value.samples.length - samples.length;
             final encoded = codec.encode(samples);
             final summary = encoded.summary;
             final inserted = await db.customUpdate(
@@ -343,27 +363,30 @@ Future<ProfilePackReport> packLegacyProfileRows(
                 variables: [Variable<String>(diveId)],
               )
               .get();
-          final groups = <_TankKey, List<TankPressureSample>>{};
+          final groups = <_TankKey, _TankGroup>{};
           for (final row in rows) {
-            final tankId = row.data['tank_id'] as String?;
+            final tankId = _textOf(row.data['tank_id']);
             final timestamp = row.data['timestamp'] as num?;
             final pressure = row.data['pressure'] as num?;
             if (tankId == null || timestamp == null || pressure == null) {
               skippedRows++;
               continue;
             }
+            // Raw alongside resolved, for the reason the profile loop above
+            // documents.
+            final rawComputerId = _textOf(row.data['computer_id']);
             final key = _TankKey(
               tankId: tankId,
-              computerId: _resolvedParent(row.data['computer_id'], computerIds),
+              computerId: _resolvedParent(rawComputerId, computerIds),
             );
-            groups
-                .putIfAbsent(key, () => [])
-                .add(
-                  TankPressureSample(
-                    timestamp: timestamp.toInt(),
-                    pressure: pressure.toDouble(),
-                  ),
-                );
+            (groups[key] ??= (samples: [], rawComputerIds: {}))
+              ..samples.add(
+                TankPressureSample(
+                  timestamp: timestamp.toInt(),
+                  pressure: pressure.toDouble(),
+                ),
+              )
+              ..rawComputerIds.add(rawComputerId);
           }
           for (final entry in groups.entries) {
             final key = entry.key;
@@ -372,14 +395,16 @@ Future<ProfilePackReport> packLegacyProfileRows(
               continue;
             }
             // Same null-is-a-wildcard rule as the profile check above, on
-            // the identity-grained path only.
+            // the identity-grained path only, and asked of the raw ids for
+            // the same reason.
             final coveredTank = byGroupIdentity
-                ? coveredTanks.any(
-                    (g) =>
-                        g.diveId == diveId &&
-                        g.tankId == key.tankId &&
-                        (key.computerId == null ||
-                            g.computerId == key.computerId),
+                ? entry.value.rawComputerIds.every(
+                    (raw) => coveredTanks.any(
+                      (g) =>
+                          g.diveId == diveId &&
+                          g.tankId == key.tankId &&
+                          (raw == null || g.computerId == key.computerId),
+                    ),
                   )
                 : coveredTanks.contains((
                     diveId: diveId,
@@ -389,8 +414,8 @@ Future<ProfilePackReport> packLegacyProfileRows(
             if (coveredTank) {
               continue;
             }
-            final samples = dedupeExactPressureSamples(entry.value);
-            dropped += entry.value.length - samples.length;
+            final samples = dedupeExactPressureSamples(entry.value.samples);
+            dropped += entry.value.samples.length - samples.length;
             final encoded = codec.encode(samples);
             final inserted = await db.customUpdate(
               'INSERT OR IGNORE INTO tank_pressure_series ('
@@ -456,102 +481,6 @@ Future<ProfilePackReport> packLegacyProfileRows(
   );
 }
 
-/// Re-points pressure rows whose tank id is no longer one of the dive's
-/// tanks at a tank that is, in place, before anything is packed.
-///
-/// `tank_pressure_series.tank_id` is a NOT NULL foreign key, so an orphan
-/// cannot be packed as it stands, and after v183 every reader reads series:
-/// leaving it behind drops that dive's pressure curve and per-cylinder SAC,
-/// and its rows keep the legacy table alive forever, since the residue
-/// count can never cover a tank that does not exist.
-///
-/// The rule is the v102 rung's ([AppDatabase] `_relinkStrandedTankPressures`)
-/// and `GasAnalysisService`'s read-time resolver, so a dive reads the same
-/// before and after packing: exact id matches are left alone, and the
-/// remaining orphans, in first-sample order, are paired with the dive's
-/// still-unmatched tanks in tank order. Both sides are totally ordered
-/// (ties broken by id) and every device runs it over the same rows, so two
-/// devices packing the same logbook reach the same tank ids and the derived
-/// series ids still converge.
-///
-/// Healing the rows rather than remapping in memory keeps everything
-/// downstream, the coverage predicate and residue count included, working
-/// on ids that exist. Idempotent: a second run finds no orphans.
-Future<void> _adoptStrandedTankPressures(
-  DatabaseConnectionUser db,
-  String table,
-) async {
-  if (!await legacyTableExists(db, 'dive_tanks')) return;
-  final tankColumns = await legacyColumnNames(db, 'dive_tanks');
-  if (!tankColumns.containsAll(const {'id', 'dive_id'})) return;
-  final hasOrder = tankColumns.contains('tank_order');
-  final tankRows = await db
-      .customSelect(
-        'SELECT dive_id, id${hasOrder ? ', tank_order' : ''} FROM dive_tanks',
-      )
-      .get();
-  final tanksByDive = <String, List<({String id, int order})>>{};
-  for (final r in tankRows) {
-    (tanksByDive[r.read<String>('dive_id')] ??= []).add((
-      id: r.read<String>('id'),
-      order: hasOrder ? (r.readNullable<int>('tank_order') ?? 0) : 0,
-    ));
-  }
-  if (tanksByDive.isEmpty) return;
-
-  final keyRows = await db
-      .customSelect(
-        'SELECT dive_id, tank_id, MIN(timestamp) AS first_ts FROM $table '
-        'WHERE tank_id IS NOT NULL AND timestamp IS NOT NULL '
-        'GROUP BY dive_id, tank_id',
-      )
-      .get();
-  final keysByDive = <String, List<({String tankId, int firstTs})>>{};
-  for (final r in keyRows) {
-    (keysByDive[r.read<String>('dive_id')] ??= []).add((
-      tankId: r.read<String>('tank_id'),
-      firstTs: r.read<int>('first_ts'),
-    ));
-  }
-
-  for (final entry in keysByDive.entries) {
-    final diveId = entry.key;
-    final tanks = tanksByDive[diveId];
-    if (tanks == null || tanks.isEmpty) continue;
-    final currentIds = {for (final t in tanks) t.id};
-    final matchedIds = {
-      for (final k in entry.value)
-        if (currentIds.contains(k.tankId)) k.tankId,
-    };
-    final orphans =
-        [
-          for (final k in entry.value)
-            if (!currentIds.contains(k.tankId)) k,
-        ]..sort((a, b) {
-          final byTime = a.firstTs.compareTo(b.firstTs);
-          return byTime != 0 ? byTime : a.tankId.compareTo(b.tankId);
-        });
-    if (orphans.isEmpty) continue;
-    final free =
-        [
-          for (final t in tanks)
-            if (!matchedIds.contains(t.id)) t,
-        ]..sort((a, b) {
-          // id tie-break: tanks sharing the default order must still pair
-          // deterministically, and Dart's sort is not stable.
-          final byOrder = a.order.compareTo(b.order);
-          return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
-        });
-    final pairs = orphans.length < free.length ? orphans.length : free.length;
-    for (var i = 0; i < pairs; i++) {
-      await db.customStatement(
-        'UPDATE $table SET tank_id = ? WHERE dive_id = ? AND tank_id = ?',
-        [free[i].id, diveId, orphans[i].tankId],
-      );
-    }
-  }
-}
-
 class _ProfileKey {
   const _ProfileKey({
     required this.computerId,
@@ -573,6 +502,22 @@ class _ProfileKey {
   @override
   int get hashCode => Object.hash(computerId, sourceId, isPrimary);
 }
+
+/// One packed profile group: the samples, plus every RAW `(computer_id,
+/// source_id)` pair that resolved into this group's key. Coverage is asked
+/// of the raw pairs, the way [legacyRowCoveredSql] asks it of the raw
+/// columns; the key's resolved ids are what the insert can actually store.
+typedef _ProfileGroup = ({
+  List<ProfileSample> samples,
+  Set<({String? computerId, String? sourceId})> rawParents,
+});
+
+/// [_ProfileGroup]'s pressure twin. A pressure row carries no source or
+/// primary flag, so its raw identity is the computer id alone.
+typedef _TankGroup = ({
+  List<TankPressureSample> samples,
+  Set<String?> rawComputerIds,
+});
 
 class _TankKey {
   const _TankKey({required this.tankId, required this.computerId});
@@ -706,13 +651,19 @@ Future<Set<String>> _parentIds(DatabaseConnectionUser db, String table) async {
   return {for (final row in rows) row.read<String>('id')};
 }
 
-/// [value] when it still names a row in [parents], null otherwise. A legacy
+/// [id] when it still names a row in [parents], null otherwise. A legacy
 /// row can point at a computer or source that has since been deleted, which
 /// under `PRAGMA foreign_keys = ON` no insert could carry.
-String? _resolvedParent(Object? value, Set<String> parents) {
-  final id = value as String?;
-  return id != null && parents.contains(id) ? id : null;
-}
+String? _resolvedParent(String? id, Set<String> parents) =>
+    id != null && parents.contains(id) ? id : null;
+
+/// A legacy id column read as text, or null when the value is not text.
+///
+/// Every id column is declared TEXT, so SQLite's affinity has already made
+/// this the identity function for anything a supported build wrote. It is
+/// here for a restored or hand-repaired file, where a value of another
+/// storage class would otherwise throw from a cast and cost the dive.
+String? _textOf(Object? value) => value is String ? value : null;
 
 /// The clock value migrated rows carry. Null when this device has never
 /// synced: there is no device id to stamp with, and nothing to publish to.
@@ -740,11 +691,20 @@ Future<String?> _migrationHlc(DatabaseConnectionUser db, int nowMs) async {
   return Hlc(nowMs, 0, deviceId).toString();
 }
 
+/// The legacy `is_primary` value as a bool.
+///
+/// The SQL half of this rule is `_primarySql` in
+/// `profile_series_pack_coverage.dart`, and the two decide the same thing
+/// for the same row: this one whether to WRITE the series, that one whether
+/// the staged rows may be cleared. They have to agree on every value, so
+/// change them together.
 bool _boolOf(Object? value) {
   if (value is bool) return value;
   if (value is num) return value != 0;
   // Every legacy schema declares is_primary NOT NULL DEFAULT 1, so a null
   // here means the column is not carrying a value at all; a legacy row with
-  // no flag is the dive's live profile, which is what true says.
+  // no flag is the dive's live profile, which is what true says. Text lands
+  // here too: the staging table takes a peer's JSON, and INTEGER affinity
+  // leaves a value it cannot convert as text.
   return true;
 }

--- a/lib/core/database/profile_series_pack.dart
+++ b/lib/core/database/profile_series_pack.dart
@@ -16,19 +16,23 @@ typedef ProfilePackReport = ({
   int droppedSamples,
   int skippedOrphans,
 
-  /// Legacy rows without a timestamp or depth (pressure, tank id for tanks),
-  /// stepped over.
+  /// Legacy rows without a READABLE timestamp or depth (pressure, tank id
+  /// for tanks), stepped over.
+  ///
+  /// Readable, not merely present: a hand-repaired or bit-rotted file can
+  /// hold text in a REAL column, and such a row holds no sample for the
+  /// same reason a null one does not.
   int skippedRows,
 
   /// Dives the packer could not read or encode, counted once per dive per
   /// legacy table and stepped over.
   ///
-  /// A legacy table can hold a value no reader expects: a text depth in a
-  /// REAL column from a hand-repaired or bit-rotted file, or a group the
-  /// codec refuses to encode. Isolating it per dive is what keeps one such
-  /// row from costing every dive the scan had not reached yet, which after
-  /// v183 (when nothing reads the legacy tables any more) would be a
-  /// silent, permanent loss rather than a deferred retry.
+  /// What lands here is a whole GROUP the codec refuses to encode, not one
+  /// bad value: an unreadable column is [skippedRows] and costs its own row.
+  /// Isolating the rest per dive is what keeps one such group from costing
+  /// every dive the scan had not reached yet, which after v183 (when
+  /// nothing reads the legacy tables any more) would be a silent, permanent
+  /// loss rather than a deferred retry.
   int failedDives,
 
   /// Dives whose legacy (or staged) rows were discarded because the dive
@@ -86,7 +90,8 @@ typedef ProfilePackReport = ({
 /// packs an older peer's inbound row-per-sample rows once the real
 /// `dive_profiles` / `tank_pressure_profiles` tables are gone (v183).
 ///
-/// A dive whose legacy rows are ALL malformed (null timestamp or depth) gets
+/// A dive whose legacy rows are ALL malformed (no readable timestamp or
+/// depth) gets
 /// no series row and is rescanned on every open; that is a bounded per-open
 /// cost on a damaged database, not a retry bug.
 Future<ProfilePackReport> packLegacyProfileRows(
@@ -365,10 +370,15 @@ Future<ProfilePackReport> packLegacyProfileRows(
               .get();
           final groups = <_TankKey, _TankGroup>{};
           for (final row in rows) {
+            // Type tests, not casts, for the reason [profileSampleOf]
+            // carries: an unreadable value means this ROW holds no sample,
+            // which is what a null in the same column means and has always
+            // been stepped over. A cast would throw instead, and the catch
+            // is per dive.
             final tankId = _textOf(row.data['tank_id']);
-            final timestamp = row.data['timestamp'] as num?;
-            final pressure = row.data['pressure'] as num?;
-            if (tankId == null || timestamp == null || pressure == null) {
+            final timestamp = row.data['timestamp'];
+            final pressure = row.data['pressure'];
+            if (tankId == null || timestamp is! num || pressure is! num) {
               skippedRows++;
               continue;
             }

--- a/lib/core/database/profile_series_pack_coverage.dart
+++ b/lib/core/database/profile_series_pack_coverage.dart
@@ -200,9 +200,7 @@ Future<String> legacyRowCoveredSql(
     // takes the same null-is-a-wildcard rule as computer_id, for the same
     // reason (adoptUnattributed moves it from NULL to a source).
     final sourceMatch = 's.source_id IS ${await resolvedSourceSql(db)}';
-    final primary = columns.contains('is_primary')
-        ? 'CASE WHEN p.is_primary THEN 1 ELSE 0 END'
-        : '1';
+    final primary = columns.contains('is_primary') ? _primarySql : '1';
     group =
         'AND (p.source_id IS NULL OR $sourceMatch) '
         'AND s.is_primary = $primary';
@@ -210,6 +208,23 @@ Future<String> legacyRowCoveredSql(
   return 'EXISTS (SELECT 1 FROM $seriesTable s '
       'WHERE s.dive_id = p.dive_id $tank $computer $group)';
 }
+
+/// The legacy `is_primary` value as the 0 or 1 a series row stores, spelled
+/// to agree with the packer's `_boolOf` on EVERY value.
+///
+/// A plain `CASE WHEN p.is_primary` disagrees with it twice, and each
+/// disagreement leaves the staged rows undrained forever while the packer
+/// re-runs over them on every sync apply: SQLite sends a NULL to the ELSE
+/// and reads it as demoted, where `_boolOf` reads an absent flag as the
+/// dive's live profile; and it applies its own text-to-numeric rule, so a
+/// peer's `"isPrimary": "yes"`, which INTEGER affinity leaves as text, reads
+/// as demoted where `_boolOf` reads any non-num as primary. Testing
+/// `typeof` first confines SQLite's truthiness to the numeric values both
+/// sides agree on. Change this and `_boolOf` together.
+const String _primarySql =
+    'CASE WHEN p.is_primary IS NULL THEN 1 '
+    "WHEN typeof(p.is_primary) IN ('integer', 'real') "
+    'THEN (CASE WHEN p.is_primary THEN 1 ELSE 0 END) ELSE 1 END';
 
 /// [resolvedComputerSql]'s twin for `source_id`.
 Future<String> resolvedSourceSql(DatabaseConnectionUser db) async =>

--- a/lib/core/database/profile_series_pack_coverage.dart
+++ b/lib/core/database/profile_series_pack_coverage.dart
@@ -36,10 +36,11 @@ typedef LegacyPackResidue = ({int profiles, int tanks});
 /// ever sees.
 ///
 /// A row that can NEVER be packed does not count, or the table would be
-/// kept forever and its pages never reclaimed: a row with no timestamp,
-/// depth, or pressure holds no sample, and a row whose dive is gone could
-/// never have been rendered. A row whose tank is gone DOES count: the dive
-/// is still the diver's, and those bytes are the only copy left.
+/// kept forever and its pages never reclaimed: a row with no READABLE
+/// timestamp, depth, or pressure holds no sample, and a row whose dive is
+/// gone could never have been rendered. A row whose tank is gone DOES
+/// count: the dive is still the diver's, and those bytes are the only copy
+/// left.
 Future<LegacyPackResidue> countLegacyRowsAwaitingPack(
   DatabaseConnectionUser db, {
   String profileTable = 'dive_profiles',
@@ -79,7 +80,7 @@ Future<int> _countUnpackedProfileRows(
       .customSelect(
         'SELECT COALESCE(SUM(p.n), 0) AS n FROM '
         '(SELECT $identity, COUNT(*) AS n FROM $table '
-        'WHERE timestamp IS NOT NULL AND depth IS NOT NULL '
+        'WHERE ${_readableNumber('timestamp')} AND ${_readableNumber('depth')} '
         'GROUP BY $identity) p '
         'WHERE EXISTS (SELECT 1 FROM dives d WHERE d.id = p.dive_id) '
         'AND NOT $covered',
@@ -119,8 +120,9 @@ Future<int> _countUnpackedTankRows(
       .customSelect(
         'SELECT COALESCE(SUM(p.n), 0) AS n FROM '
         '(SELECT $identity, COUNT(*) AS n FROM $table '
-        'WHERE timestamp IS NOT NULL AND pressure IS NOT NULL '
-        'AND tank_id IS NOT NULL GROUP BY $identity) p '
+        'WHERE ${_readableNumber('timestamp')} '
+        'AND ${_readableNumber('pressure')} '
+        "AND typeof(tank_id) = 'text' GROUP BY $identity) p "
         'WHERE EXISTS (SELECT 1 FROM dives d WHERE d.id = p.dive_id) '
         'AND NOT $covered',
       )
@@ -240,6 +242,17 @@ Future<String> resolvedComputerSql(DatabaseConnectionUser db) async =>
     await legacyTableExists(db, 'dive_computers')
     ? '(SELECT c.id FROM dive_computers c WHERE c.id = p.computer_id)'
     : 'NULL';
+
+/// SQL for "[column] holds a number the packer can read", the predicate
+/// half of `profileSampleOf`'s `is! num` test.
+///
+/// `IS NOT NULL` is not the same question. SQLite carries a storage class
+/// per value, so a REAL-affinity column can hold text it could not convert;
+/// that row is not null but holds no sample, the packer steps over it, and
+/// counting it as awaiting pack would keep the legacy table and its pages
+/// forever waiting for a pack that can never claim it.
+String _readableNumber(String column) =>
+    "typeof($column) IN ('integer', 'real')";
 
 Future<int> _countRows(DatabaseConnectionUser db, String table) async {
   final rows = await db

--- a/lib/core/database/profile_series_pack_coverage.dart
+++ b/lib/core/database/profile_series_pack_coverage.dart
@@ -80,7 +80,7 @@ Future<int> _countUnpackedProfileRows(
       .customSelect(
         'SELECT COALESCE(SUM(p.n), 0) AS n FROM '
         '(SELECT $identity, COUNT(*) AS n FROM $table '
-        'WHERE ${_readableNumber('timestamp')} AND ${_readableNumber('depth')} '
+        'WHERE ${readableNumberSql('timestamp')} AND ${readableNumberSql('depth')} '
         'GROUP BY $identity) p '
         'WHERE EXISTS (SELECT 1 FROM dives d WHERE d.id = p.dive_id) '
         'AND NOT $covered',
@@ -120,9 +120,9 @@ Future<int> _countUnpackedTankRows(
       .customSelect(
         'SELECT COALESCE(SUM(p.n), 0) AS n FROM '
         '(SELECT $identity, COUNT(*) AS n FROM $table '
-        'WHERE ${_readableNumber('timestamp')} '
-        'AND ${_readableNumber('pressure')} '
-        "AND typeof(tank_id) = 'text' GROUP BY $identity) p "
+        'WHERE ${readableNumberSql('timestamp')} '
+        'AND ${readableNumberSql('pressure')} '
+        "AND ${readableTextSql('tank_id')} GROUP BY $identity) p "
         'WHERE EXISTS (SELECT 1 FROM dives d WHERE d.id = p.dive_id) '
         'AND NOT $covered',
       )
@@ -251,8 +251,18 @@ Future<String> resolvedComputerSql(DatabaseConnectionUser db) async =>
 /// that row is not null but holds no sample, the packer steps over it, and
 /// counting it as awaiting pack would keep the legacy table and its pages
 /// forever waiting for a pack that can never claim it.
-String _readableNumber(String column) =>
+///
+/// Also the guard on READING such a column as a number. Drift's `read<int>`
+/// converts rather than casts, but converting is `int.parse`, so numeric
+/// text passes and anything else throws a [FormatException]. Any query that
+/// reads a legacy numeric column has to filter on this first.
+String readableNumberSql(String column) =>
     "typeof($column) IN ('integer', 'real')";
+
+/// SQL for "[column] holds text", the guard on reading a legacy id column
+/// with `read<String>`. See [readableNumberSql] for why a declared type is
+/// not enough on these tables.
+String readableTextSql(String column) => "typeof($column) = 'text'";
 
 Future<int> _countRows(DatabaseConnectionUser db, String table) async {
   final rows = await db

--- a/lib/core/database/profile_series_pack_rows.dart
+++ b/lib/core/database/profile_series_pack_rows.dart
@@ -9,12 +9,20 @@ import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 
 /// Reads a legacy `dive_profiles` row by column name. Absent columns (an
 /// older fixture or a partially migrated table) read as null. Returns null
-/// when the row has no timestamp or depth: a restored or hand-repaired
-/// legacy table can hold such rows and they cannot become a sample.
+/// when the row has no READABLE timestamp or depth: a restored or
+/// hand-repaired legacy table can hold such rows and they cannot become a
+/// sample.
+///
+/// `is! num` rather than a null check, because the two are the same thing
+/// here. SQLite carries a storage class per value, so a REAL-affinity
+/// column can hold text it could not convert, and a cast would throw. The
+/// packer catches that per DIVE, so one unreadable byte would cost the
+/// dive its whole profile and keep its legacy rows back for a retry that
+/// re-reads the same byte and fails identically, forever.
 ProfileSample? profileSampleOf(Map<String, Object?> data) {
-  final timestamp = data['timestamp'] as num?;
-  final depth = data['depth'] as num?;
-  if (timestamp == null || depth == null) return null;
+  final timestamp = data['timestamp'];
+  final depth = data['depth'];
+  if (timestamp is! num || depth is! num) return null;
   return ProfileSample(
     timestamp: timestamp.toInt(),
     depth: depth.toDouble(),

--- a/lib/core/database/profile_series_pack_rows.dart
+++ b/lib/core/database/profile_series_pack_rows.dart
@@ -4,6 +4,7 @@
 /// Flutter, only what a headless isolate can run.
 library;
 
+import 'package:submersion/core/utils/number_utils.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
 
 /// Reads a legacy `dive_profiles` row by column name. Absent columns (an
@@ -46,6 +47,16 @@ ProfileSample? profileSampleOf(Map<String, Object?> data) {
   );
 }
 
-double? realOf(Object? value) => (value as num?)?.toDouble();
+/// One OPTIONAL sample field, or null when the stored value is not a number.
+///
+/// SQLite carries a storage class per value, not per column, so a
+/// REAL-affinity column in a restored or hand-repaired file can hold text it
+/// could not convert. A cast would throw, and the packer's isolation is
+/// per DIVE: one unreadable pressure reading would cost that dive its entire
+/// profile, permanently, because nothing reads the legacy tables after v183.
+/// Degrading the one field is the proportionate answer. `timestamp` and
+/// `depth` above are deliberately NOT read this way: without them there is
+/// no sample, so the row is skipped as a whole.
+double? realOf(Object? value) => asDoubleOrNull(value);
 
-int? intOf(Object? value) => (value as num?)?.toInt();
+int? intOf(Object? value) => value is num ? value.toInt() : null;

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -362,8 +362,21 @@ class DatabaseService {
       await migrator.customSelect('SELECT 1').get();
       // [storedBefore] is the version the file had ON DISK before the
       // ladder ran, read by the caller: keying off the migrator's own
-      // version here would always read 183 and never VACUUM.
-      if (willVacuum) {
+      // version here would always read 183 and never VACUUM. The ladder's
+      // own beforeOpen backstop can also drop the legacy tables on a file
+      // already stamped 183, which no version comparison can see, so the
+      // drop itself is the second reason to reclaim.
+      //
+      // Unreachable while 183 is the current version, because this method
+      // only runs with a ladder pending and every such file is below 183.
+      // It is here for the rung after next: a file stamped 183 whose v184
+      // ladder is pending has willVacuum false, and its backstop can still
+      // be the open that finally drops the tables. The background executor
+      // reopens on a fresh connection that no longer sees them, so nothing
+      // downstream would catch it.
+      final unplannedReclaim =
+          !willVacuum && migrator.droppedLegacySampleTables;
+      if (vacuumPending() && (willVacuum || unplannedReclaim)) {
         // v183 dropped the row-per-sample tables, which on an older file are
         // most of its pages. VACUUM here: outside any migration transaction,
         // on the one exclusive main-isolate connection, and before the
@@ -371,15 +384,18 @@ class DatabaseService {
         // out-of-space temp store leaves a correct database that is merely
         // larger than it needs to be.
         //
-        // One shot, by design. It runs only on the open that crossed 183, so
-        // a database whose rung skipped the drop and lost the tables later
-        // through the beforeOpen backstop never reaches this, and neither
-        // does one whose VACUUM was killed part way. Both are correct, just
-        // still carrying the free pages; the next real VACUUM is whatever
-        // maintenance the user runs. The ticket is taken before the attempt,
-        // not after, so a VACUUM that throws is not retried either.
+        // One shot per open. A VACUUM killed part way leaves a correct
+        // database still carrying its free pages, and the drop that earned
+        // the reclamation has already happened, so nothing asks again. The
+        // ticket is taken before the attempt, not after, so a VACUUM that
+        // throws is not retried either.
+        //
+        // Announced as a step only when it was PLANNED. The totals were
+        // fixed before the ladder started so every report of this open
+        // agrees, and reporting an unplanned reclaim as a step would send
+        // the bar past its own total.
         takeVacuumTicket();
-        report(ladderSteps, ladderSteps);
+        if (!unplannedReclaim) report(ladderSteps, ladderSteps);
         try {
           await migrator.customStatement('VACUUM');
         } catch (e, stackTrace) {
@@ -390,7 +406,7 @@ class DatabaseService {
             stackTrace: stackTrace,
           );
         }
-        report(ladderSteps + 1, ladderSteps);
+        if (!unplannedReclaim) report(ladderSteps + 1, ladderSteps);
       }
     } catch (_) {
       // Best-effort close so we don't leak the connection (or its locks, which
@@ -441,6 +457,29 @@ class DatabaseService {
       // not race this connection's locks.
       await closeDatabaseForAppShutdown(database, background: background);
       rethrow;
+    }
+    // The forcing statement above ran beforeOpen, and that is where the
+    // v183 backstop drops a legacy sample table the rung had to skip. This
+    // open has no pending ladder, so nothing else will ever reclaim those
+    // pages: without this the diver's file stays at its pre-migration size
+    // permanently, because there is no other VACUUM of the live database
+    // anywhere in the app.
+    //
+    // On the worker isolate, so a large rewrite does not block the UI, and
+    // awaited, so nothing queries a file mid-VACUUM. Non-fatal for the same
+    // reason as the migration path's copy: a busy lock or a full temp store
+    // leaves a correct database that is merely larger than it needs to be.
+    if (database.droppedLegacySampleTables) {
+      try {
+        await database.customStatement('VACUUM');
+      } catch (e, stackTrace) {
+        _log.warning(
+          'VACUUM after the backstop dropped the legacy sample tables was '
+          'skipped; the database is correct but has not reclaimed their pages',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
     }
     _background = background;
     return database;

--- a/lib/core/services/sync/sync_data_serializer.dart
+++ b/lib/core/services/sync/sync_data_serializer.dart
@@ -3173,6 +3173,37 @@ class SyncDataSerializer {
     }
   }
 
+  /// Compares one header scalar against the value the blob decodes to, by
+  /// bit pattern rather than with `!=`.
+  ///
+  /// `!=` reports -0.0 as equal to 0.0, so a header that genuinely
+  /// disagrees with its blob at that value would pass the very check that
+  /// exists to catch a tampered one. It also reports NaN as different from
+  /// itself, which would be the wrong answer for a header that matches its
+  /// blob exactly; [_profileSeriesHeaderIsStorable] rejects a non-finite
+  /// header before this ever has to decide, for a different reason.
+  static bool _headerDoubleDiffers(double fromBlob, double fromHeader) =>
+      fromBlob.compareTo(fromHeader) != 0;
+
+  /// False when a scalar the row carries cannot be stored in its column.
+  ///
+  /// `max_depth`, `first_depth` and `last_depth` are NOT NULL REAL columns
+  /// and SQLite stores a non-finite double as NULL, so an infinite or NaN
+  /// header fails the insert. That insert is one batch for every series
+  /// record in the payload and runs inside the merge transaction, so one
+  /// such row would take down the whole batch rather than itself: this
+  /// filter drops it here, where a skip costs one record and one log line.
+  ///
+  /// Non-finite depths are a real input class ([ProfileSeriesSummary.of]
+  /// seeds `maxDepth` from the first sample with a `>` that never
+  /// overwrites a NaN seed, and the data-quality builder filters on
+  /// `depth.isFinite`), even though no peer can send one through JSON,
+  /// which encodes neither NaN nor infinity.
+  static bool _profileSeriesHeaderIsStorable(DiveProfileSeriesRow row) =>
+      row.maxDepth.isFinite &&
+      row.firstDepth.isFinite &&
+      row.lastDepth.isFinite;
+
   /// A peer's packed samples are decoded once before they are written so a
   /// corrupt or truncated blob never reaches the readers. Returns false (and
   /// logs) when the blob does not decode or when the summary computed from
@@ -3185,15 +3216,22 @@ class SyncDataSerializer {
   /// the blob, would otherwise write scalars that disagree with the samples
   /// they claim to summarize.
   bool _profileSeriesBlobIsSound(DiveProfileSeriesRow row) {
+    if (!_profileSeriesHeaderIsStorable(row)) {
+      _log.warning(
+        'Skipping diveProfileSeries ${row.id}: a non-finite depth scalar '
+        'cannot be stored in a NOT NULL REAL column',
+      );
+      return false;
+    }
     try {
       final decoded = const ProfileSeriesCodec().decode(row.samples);
       final summary = ProfileSeriesSummary.of(decoded);
       if (summary.sampleCount != row.sampleCount ||
           summary.startTimestamp != row.startTimestamp ||
           summary.endTimestamp != row.endTimestamp ||
-          summary.maxDepth != row.maxDepth ||
-          summary.firstDepth != row.firstDepth ||
-          summary.lastDepth != row.lastDepth ||
+          _headerDoubleDiffers(summary.maxDepth, row.maxDepth) ||
+          _headerDoubleDiffers(summary.firstDepth, row.firstDepth) ||
+          _headerDoubleDiffers(summary.lastDepth, row.lastDepth) ||
           summary.hasDecoType != row.hasDecoType ||
           summary.hasDecoStop != row.hasDecoStop ||
           summary.hasPositiveCeiling != row.hasPositiveCeiling) {
@@ -3231,6 +3269,10 @@ class SyncDataSerializer {
   }
 
   /// The tank twin of [_profileSeriesBlobIsSound].
+  ///
+  /// [TankPressureSeriesSummary] carries only counts and timestamps, so every
+  /// scalar compared here is an int; a double scalar added later belongs in
+  /// [_headerDoubleDiffers] rather than behind a plain `!=`.
   bool _tankSeriesBlobIsSound(TankPressureSeriesRow row) {
     try {
       final decoded = const TankPressureSeriesCodec().decode(row.samples);

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -3621,6 +3621,9 @@ class SyncService {
           if (inboundOnlyLegacyEntities.containsKey(table)) {
             sawLegacySamples = true;
           }
+          if (table == 'dives' || table == 'diveTanks') {
+            sawParents = true;
+          }
           batch.add(jsonDecode(utf8.decode(rowBytes)) as Map<String, dynamic>);
           if (batch.length >= batchSize) await flush();
         },

--- a/lib/features/data_quality/presentation/pages/data_quality_inbox_page.dart
+++ b/lib/features/data_quality/presentation/pages/data_quality_inbox_page.dart
@@ -165,10 +165,21 @@ class _DataQualityInboxPageState extends ConsumerState<DataQualityInboxPage> {
           ),
         );
       case SplitSourceRepair(:final diveId, :final sourceId):
-        final newId = await ref
-            .read(diveSplitServiceProvider)
-            .split(diveId: diveId, sourceId: sourceId);
-        scheduleQualityScan([diveId, newId]);
+        // Split does not return a RepairResult, so withUndo cannot wrap it.
+        // It still has to report a failure: it refuses a source that no
+        // longer belongs to the dive, and a dive whose stored series this
+        // build cannot decode. Left unwrapped, the tap did nothing visible
+        // and the finding stayed open forever.
+        try {
+          final newId = await ref
+              .read(diveSplitServiceProvider)
+              .split(diveId: diveId, sourceId: sourceId);
+          scheduleQualityScan([diveId, newId]);
+        } catch (e) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n.diveLog_sources_splitFailed)),
+          );
+        }
       case DespikeRepair(:final diveId):
         await withUndo(
           () => executor.applyProfileRepair(

--- a/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_repository_impl.dart
@@ -1052,11 +1052,31 @@ class DiveComputerRepository {
     ]);
     // Delete profile points for this computer+dive
     await _profileSeries.deleteByComputer(diveId, computerId);
-    // Delete the data source row for this computer+dive
-    await _db.customStatement(
-      'DELETE FROM dive_data_sources WHERE dive_id = ? AND computer_id = ?',
-      [diveId, computerId],
-    );
+    // Whatever series survive that (deleteByComputer never matches the
+    // null-computer series a manual edit writes) must give up their
+    // source_id explicitly before the row they point at goes: the FK is ON
+    // DELETE SET NULL, so the cascade would strip their attribution with no
+    // updated_at bump, no hlc restamp and nothing pending, leaving this
+    // device to resolve their owner differently from every peer forever (see
+    // ProfileSeriesRepository.clearSource). One transaction with the delete,
+    // so a failure between them cannot publish series that gave up an
+    // attribution the source row still claims.
+    await _db.transaction(() async {
+      final doomed =
+          await (_db.select(_db.diveDataSources)..where(
+                (t) =>
+                    t.diveId.equals(diveId) & t.computerId.equals(computerId),
+              ))
+              .get();
+      for (final source in doomed) {
+        await _profileSeries.clearSource(source.id);
+      }
+      // Delete the data source row for this computer+dive
+      await _db.customStatement(
+        'DELETE FROM dive_data_sources WHERE dive_id = ? AND computer_id = ?',
+        [diveId, computerId],
+      );
+    });
   }
 
   /// Import a profile and associate it with a dive (creating one if needed).

--- a/lib/features/dive_log/data/repositories/dive_repository_impl.dart
+++ b/lib/features/dive_log/data/repositories/dive_repository_impl.dart
@@ -1130,13 +1130,25 @@ class DiveRepository {
 
         final primaryComputerId = primaryReading?.computerId;
 
-        if (primaryComputerId != null) {
+        // Take the by-computer branch only when that computer actually owns a
+        // series. Deleting the edit and then promoting nothing leaves the
+        // dive with zero primary series: it keeps rendering, because
+        // getDiveById and getMergedProfile ignore the flag, while
+        // getDiveProfile, getAscentDescentRates, getTimeAtDepthRanges and the
+        // data-quality prefilters all silently skip it. That is reachable
+        // whenever the primary source names a computer that owns no samples
+        // (a metadata-only source, or one whose samples a consolidation
+        // re-stamped onto a different computer). setPrimaryDataSource and
+        // DiveComputerRepository.setPrimaryProfile guard their own
+        // demote-then-promote pairs the same way (issue #1149).
+        if (primaryComputerId != null &&
+            await _profileSeries.ownsComputer(diveId, primaryComputerId)) {
           // Multi-computer dive: only the previously-primary computer's
           // series come back.
           await _profileSeries.promoteByComputer(diveId, primaryComputerId);
         } else {
-          // Single-computer dive (or no computer reading): everything left is
-          // the live profile.
+          // Single-computer dive (or no computer reading, or a primary
+          // computer that owns nothing): everything left is the live profile.
           await _profileSeries.promoteAll(diveId);
         }
       });
@@ -6272,9 +6284,20 @@ class DiveRepository {
   /// Delete a computer reading snapshot by its ID.
   Future<void> deleteComputerReading(String id) async {
     try {
-      await (_db.delete(
-        _db.diveDataSources,
-      )..where((t) => t.id.equals(id))).go();
+      // Clear the series first: dive_profile_series.source_id is ON DELETE
+      // SET NULL, so the delete below would strip their attribution through
+      // the cascade without a fresh updated_at, an hlc restamp or a pending
+      // mark, and this device would resolve their owner differently from
+      // every peer forever (see ProfileSeriesRepository.clearSource). The
+      // computer_id twin of this is DiveComputerRepository.deleteComputer.
+      // One transaction, so a failure between them cannot publish series
+      // that gave up an attribution the source row still claims.
+      await _db.transaction(() async {
+        await _profileSeries.clearSource(id);
+        await (_db.delete(
+          _db.diveDataSources,
+        )..where((t) => t.id.equals(id))).go();
+      });
       SyncEventBus.notifyLocalChange();
     } catch (e, stackTrace) {
       _log.error(

--- a/lib/features/dive_log/data/repositories/profile_series_repository.dart
+++ b/lib/features/dive_log/data/repositories/profile_series_repository.dart
@@ -517,6 +517,35 @@ class ProfileSeriesRepository {
   Future<List<String>> deleteByIds(List<String> ids) =>
       ids.isEmpty ? Future.value(const []) : _delete((t) => t.id.isIn(ids));
 
+  /// Nulls `source_id` on every series of [sourceId] and restamps each, the
+  /// `clearComputer` rule applied to the other identity column.
+  ///
+  /// `source_id` is ON DELETE SET NULL, so deleting the `dive_data_sources`
+  /// row without this changes the series with no `updated_at` bump, no hlc
+  /// restamp and nothing pending. This device then resolves ownership
+  /// (`_ownedBy`, `getProfilesByDataSource`, `promoteWinnerOwnedBy`) as if
+  /// the series were unattributed while every peer still resolves it to the
+  /// deleted source, so the two group their source chips differently and a
+  /// later `setPrimaryDataSource` picks a different primary on each. Nothing
+  /// heals it either: a series row publishes only when its own hlc advances.
+  ///
+  /// Returns the number of series touched.
+  Future<int> clearSource(String sourceId, {int? now}) async {
+    final nowMs = now ?? DateTime.now().millisecondsSinceEpoch;
+    final ids = await _ids((t) => t.sourceId.equals(sourceId));
+    if (ids.isEmpty) return 0;
+    await _writeChunked(
+      ids,
+      DiveProfileSeriesCompanion(
+        sourceId: const Value(null),
+        updatedAt: Value(nowMs),
+      ),
+      nowMs,
+    );
+    SyncEventBus.notifyLocalChange();
+    return ids.length;
+  }
+
   /// Nulls `computer_id` on every series of [computerId] and restamps each
   /// (the FK's ON DELETE SET NULL would change the rows without an hlc bump,
   /// so peers would never learn). Returns the number of series touched.
@@ -547,12 +576,28 @@ class ProfileSeriesRepository {
   /// A recreated computer takes back the null-computer series of [diveIds]
   /// whose only computer source is the one being relinked (the legacy
   /// `dive_profiles` relink, series twin).
+  ///
+  /// A series that is primary while the same dive also carries a demoted one
+  /// is left alone. That is the shape `saveEditedProfile` writes, and the
+  /// primary half of it is the user's manual correction, which carries a null
+  /// computer on purpose rather than because a computer delete stripped one.
+  /// Stamping it would hand the edit to the next reparse of the dive, whose
+  /// first act is `deleteByComputer`, and a series is deleted whole: the
+  /// correction would be gone here and tombstoned on every peer. The same
+  /// predicate spares a file-imported profile that `setPrimaryDataSource`
+  /// promoted over the computer's samples.
+  ///
+  /// The demoted half is still relinked. It really is the computer's own
+  /// output, restoring its attribution is the point of the relink, and a
+  /// reparse that replaces a superseded generation replaces exactly what that
+  /// computer produced.
   Future<int> relinkComputer(
     String computerId,
     List<String> diveIds, {
     int? now,
   }) {
     if (diveIds.isEmpty) return Future.value(0);
+    final sibling = _db.alias(_db.diveProfileSeries, 'demoted_sibling');
     return _setComputer(
       computerId,
       (t) =>
@@ -565,7 +610,16 @@ class ProfileSeriesRepository {
               ..groupBy([
                 _db.diveDataSources.diveId,
               ], having: _db.diveDataSources.id.count().equals(1)),
-          ),
+          ) &
+          (t.isPrimary.equals(false) |
+              notExistsQuery(
+                _db.selectOnly(sibling)
+                  ..addColumns([sibling.id])
+                  ..where(
+                    sibling.diveId.equalsExp(t.diveId) &
+                        sibling.isPrimary.equals(false),
+                  ),
+              )),
       now: now,
     );
   }

--- a/lib/features/divers/data/repositories/diver_repository.dart
+++ b/lib/features/divers/data/repositories/diver_repository.dart
@@ -284,6 +284,24 @@ class DiverRepository {
     return [for (final r in rows) r.read<String>(column)];
   }
 
+  /// Whether the pre-v183 row-per-sample `dive_profiles` table is still in
+  /// this database. Every current build reads samples from the series
+  /// tables, so a hit here means the v183 pack could not finish and the
+  /// table was deliberately kept for a later retry.
+  ///
+  /// Mirrors `DiveComputerRepository._legacyProfilesTableExists`; the two
+  /// guard the same statement against the same failure and the check is one
+  /// query, not worth a dependency between the repositories.
+  Future<bool> _legacyProfilesTableExists() async {
+    final rows = await _db
+        .customSelect(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+          "AND name = 'dive_profiles'",
+        )
+        .get();
+    return rows.isNotEmpty;
+  }
+
   /// Delete a diver, reassigning shared trips/sites to a surviving diver first.
   ///
   /// - If surviving divers exist, shared trips and sites owned by [id] are
@@ -433,6 +451,25 @@ class DiverRepository {
             entityType: 'dives',
             recordId: diveId,
             localUpdatedAt: clearedAt,
+          );
+        }
+        // The v183 rung drops dive_profiles only once its rows have actually
+        // moved into the series table, so a device whose pack threw still
+        // carries it, and its computer_id FK has no ON DELETE action. A
+        // surviving row on another diver's dive fails step 4's
+        // `DELETE FROM dive_computers` with SqliteException(787) and rolls
+        // the whole delete back, so the diver could never be deleted on that
+        // device. Same #823 failure, same fix as
+        // DiveComputerRepository.deleteComputer. The table is no longer
+        // synced, so this only unblocks the FK: nothing to stamp or mark.
+        if (await _legacyProfilesTableExists()) {
+          await _db.customStatement(
+            'UPDATE dive_profiles SET computer_id = NULL '
+            'WHERE computer_id IN '
+            '(SELECT id FROM dive_computers WHERE diver_id = ?) '
+            // stats-scope-exempt: reassignment cascade, not a statistic.
+            'AND dive_id NOT IN (SELECT id FROM dives WHERE diver_id = ?)',
+            [id, id],
           );
         }
 

--- a/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/dive_computer_adapter.dart
@@ -20,6 +20,7 @@ import 'package:submersion/features/dive_log/data/repositories/dive_computer_rep
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_cancellation_token.dart';
@@ -60,11 +61,21 @@ enum _ConsolidateOutcome {
   /// reject with `ArgumentError('sameComputer...')`.
   skippedSameComputer,
 
+  /// The download was imported as a standalone dive and KEPT that way: the
+  /// fold refused because the PRE-EXISTING target holds a series this build
+  /// cannot decode. The download itself is sound, so deleting it would lose
+  /// it for good.
+  keptStandalone,
+
   /// The download was imported as a standalone dive, but folding it into
   /// the target failed unexpectedly. The orphaned standalone dive was
   /// deleted to avoid stranding it.
   failed,
 }
+
+/// What a `_consolidateDive` call did, plus the id of the standalone dive it
+/// left behind (only [_ConsolidateOutcome.keptStandalone] leaves one).
+typedef _ConsolidateResult = ({_ConsolidateOutcome outcome, String? diveId});
 
 /// Import source adapter for dive computer downloads.
 ///
@@ -546,14 +557,17 @@ class DiveComputerAdapter implements ImportSourceAdapter {
         final diveGroup = bundle.groups[ImportEntityType.dives];
         final matchResult = diveGroup?.matchResults?[index];
         if (matchResult != null) {
-          final outcome = await _consolidateDive(
-            dive,
-            matchResult.diveId,
-            comp,
-          );
-          switch (outcome) {
+          final result = await _consolidateDive(dive, matchResult.diveId, comp);
+          switch (result.outcome) {
             case _ConsolidateOutcome.consolidated:
               consolidated++;
+            case _ConsolidateOutcome.keptStandalone:
+              // The fold refused, but the download survived as its own dive,
+              // so it counts as imported. Reporting it as skipped would hide
+              // a dive the fingerprint is about to advance past.
+              imported++;
+              final keptId = result.diveId;
+              if (keptId != null) importedDiveIds.add(keptId);
             case _ConsolidateOutcome.skippedSameComputer:
             case _ConsolidateOutcome.failed:
               skipped++;
@@ -679,14 +693,20 @@ class DiveComputerAdapter implements ImportSourceAdapter {
   ///   ("sameComputer...") when the secondary shares [targetDiveId]'s
   ///   `computerId`. Checking that up front avoids importing a dive that is
   ///   guaranteed to fail the fold.
+  /// - **Refusal about the TARGET (kept):** [UnreadableSeriesException] says
+  ///   the pre-existing target dive holds a profile or pressure series this
+  ///   build cannot decode, so `apply` refused before writing anything. The
+  ///   download is not at fault and is the only copy of this dive: the
+  ///   fingerprint advances past it on the way out of `performImport`, so
+  ///   deleting it would lose it for good. It is kept standalone instead.
   /// - **Unexpected failure (compensated):** if the import succeeds but
   ///   `apply` throws for any other reason, the freshly-imported dive is
   ///   deleted via [DiveRepository.bulkDeleteDives] (tombstone-honoring)
   ///   instead of being left as a bare, unconsolidated duplicate.
   ///
-  /// Returns a [_ConsolidateOutcome] describing what happened so the caller
+  /// Returns a [_ConsolidateResult] describing what happened so the caller
   /// can adjust the import summary's counters instead of aborting the loop.
-  Future<_ConsolidateOutcome> _consolidateDive(
+  Future<_ConsolidateResult> _consolidateDive(
     DownloadedDive dive,
     String targetDiveId,
     DiveComputer comp,
@@ -695,7 +715,7 @@ class DiveComputerAdapter implements ImportSourceAdapter {
       targetDiveId,
     );
     if (targetComputerId != null && targetComputerId == comp.id) {
-      return _ConsolidateOutcome.skippedSameComputer;
+      return (outcome: _ConsolidateOutcome.skippedSameComputer, diveId: null);
     }
 
     String? newDiveId;
@@ -713,7 +733,20 @@ class DiveComputerAdapter implements ImportSourceAdapter {
         targetDiveId: targetDiveId,
         secondaryDiveIds: [newDiveId],
       );
-      return _ConsolidateOutcome.consolidated;
+      return (outcome: _ConsolidateOutcome.consolidated, diveId: newDiveId);
+    } on UnreadableSeriesException catch (e) {
+      final keptId = newDiveId;
+      if (keptId != null) {
+        _log.warning(
+          'Kept downloaded dive $keptId standalone instead of folding it '
+          'into $targetDiveId: that dive holds ${e.seriesIds.length} '
+          'series this build cannot decode',
+        );
+        return (outcome: _ConsolidateOutcome.keptStandalone, diveId: keptId);
+      }
+      // Nothing was imported, so there is nothing to keep or compensate.
+      _log.error('Consolidation fold refused for $targetDiveId', error: e);
+      return (outcome: _ConsolidateOutcome.failed, diveId: null);
     } catch (e, st) {
       _log.error(
         'Consolidation fold failed for dive into $targetDiveId',
@@ -735,7 +768,7 @@ class DiveComputerAdapter implements ImportSourceAdapter {
           );
         }
       }
-      return _ConsolidateOutcome.failed;
+      return (outcome: _ConsolidateOutcome.failed, diveId: null);
     }
   }
 

--- a/lib/features/import_wizard/data/adapters/suunto_cloud_adapter.dart
+++ b/lib/features/import_wizard/data/adapters/suunto_cloud_adapter.dart
@@ -4,6 +4,7 @@ import 'package:uuid/uuid.dart';
 
 import 'package:submersion/core/domain/models/incoming_dive_data.dart';
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/suunto_cloud/suunto_cloud_client.dart';
 import 'package:submersion/core/services/suunto_cloud/suunto_dive_parser.dart';
 import 'package:submersion/core/services/suunto_cloud/suunto_session_store.dart';
@@ -17,6 +18,7 @@ import 'package:submersion/features/dive_log/data/repositories/dive_computer_rep
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
 import 'package:submersion/features/import_wizard/domain/adapters/import_source_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
 import 'package:submersion/features/import_wizard/domain/models/import_cancellation_token.dart';
@@ -50,7 +52,16 @@ final suuntoCloudDivesFetchedProvider = StateProvider<bool>((ref) => false);
 
 /// Outcome of a single `SuuntoCloudAdapter._consolidateDive` call. Mirrors
 /// `DiveComputerAdapter`'s outcome type -- see that class for the rationale.
-enum _ConsolidateOutcome { consolidated, skippedSameComputer, failed }
+enum _ConsolidateOutcome {
+  consolidated,
+  skippedSameComputer,
+  keptStandalone,
+  failed,
+}
+
+/// What a `_consolidateDive` call did, plus the id of the standalone dive it
+/// left behind (only [_ConsolidateOutcome.keptStandalone] leaves one).
+typedef _ConsolidateResult = ({_ConsolidateOutcome outcome, String? diveId});
 
 /// Import source adapter for dives pulled from the Suunto cloud
 /// (app.suunto.com), via the undocumented Sports-Tracker API.
@@ -65,6 +76,8 @@ enum _ConsolidateOutcome { consolidated, skippedSameComputer, failed }
 /// is resolved per-dive (by device model + serial number) instead of once
 /// per session.
 class SuuntoCloudAdapter implements ImportSourceAdapter {
+  static final _log = LoggerService.forClass(SuuntoCloudAdapter);
+
   SuuntoCloudAdapter({
     required DiveImportService importService,
     required DiveComputerRepository computerRepository,
@@ -321,14 +334,22 @@ class SuuntoCloudAdapter implements ImportSourceAdapter {
         final diveGroup = bundle.groups[ImportEntityType.dives];
         final matchResult = diveGroup?.matchResults?[index];
         if (matchResult != null) {
-          final outcome = await _consolidateDive(
+          final result = await _consolidateDive(
             parsed,
             matchResult.diveId,
             comp,
           );
-          switch (outcome) {
+          switch (result.outcome) {
             case _ConsolidateOutcome.consolidated:
               consolidated++;
+              importedCountByComputerId[comp.id] =
+                  (importedCountByComputerId[comp.id] ?? 0) + 1;
+            case _ConsolidateOutcome.keptStandalone:
+              // The fold refused, but the download survived as its own dive,
+              // so it counts as imported rather than skipped.
+              imported++;
+              final keptId = result.diveId;
+              if (keptId != null) importedDiveIds.add(keptId);
               importedCountByComputerId[comp.id] =
                   (importedCountByComputerId[comp.id] ?? 0) + 1;
             case _ConsolidateOutcome.skippedSameComputer:
@@ -490,8 +511,8 @@ class SuuntoCloudAdapter implements ImportSourceAdapter {
 
   /// Consolidate a downloaded dive as a secondary computer reading on an
   /// existing dive. Mirrors `DiveComputerAdapter._consolidateDive` -- see
-  /// that method's doc comment for the two failure modes it guards against.
-  Future<_ConsolidateOutcome> _consolidateDive(
+  /// that method's doc comment for the failure modes it guards against.
+  Future<_ConsolidateResult> _consolidateDive(
     SuuntoParsedDive parsed,
     String targetDiveId,
     DiveComputer comp,
@@ -500,7 +521,7 @@ class SuuntoCloudAdapter implements ImportSourceAdapter {
       targetDiveId,
     );
     if (targetComputerId != null && targetComputerId == comp.id) {
-      return _ConsolidateOutcome.skippedSameComputer;
+      return (outcome: _ConsolidateOutcome.skippedSameComputer, diveId: null);
     }
 
     String? newDiveId;
@@ -516,18 +537,44 @@ class SuuntoCloudAdapter implements ImportSourceAdapter {
         targetDiveId: targetDiveId,
         secondaryDiveIds: [newDiveId],
       );
-      return _ConsolidateOutcome.consolidated;
-    } catch (_) {
+      return (outcome: _ConsolidateOutcome.consolidated, diveId: newDiveId);
+    } on UnreadableSeriesException catch (e) {
+      // The refusal is about the PRE-EXISTING target dive's stored series,
+      // not about this download, so the download is kept as its own dive
+      // instead of being compensated away.
+      final keptId = newDiveId;
+      if (keptId != null) {
+        _log.warning(
+          'Kept downloaded dive $keptId standalone instead of folding it '
+          'into $targetDiveId: that dive holds ${e.seriesIds.length} '
+          'series this build cannot decode',
+        );
+        return (outcome: _ConsolidateOutcome.keptStandalone, diveId: keptId);
+      }
+      // Nothing was imported, so there is nothing to keep or compensate.
+      _log.error('Consolidation fold refused for $targetDiveId', error: e);
+      return (outcome: _ConsolidateOutcome.failed, diveId: null);
+    } catch (e, st) {
+      _log.error(
+        'Consolidation fold failed for dive into $targetDiveId',
+        error: e,
+        stackTrace: st,
+      );
       if (newDiveId != null) {
         try {
           await _diveRepository.bulkDeleteDives([newDiveId]);
-        } catch (_) {
+        } catch (deleteError, deleteStack) {
           // The compensating delete failed too; fall through rather than
           // rethrow, so the import loop still processes the remaining dives
           // instead of aborting on a stranded standalone dive.
+          _log.error(
+            'Compensating delete failed for orphaned dive $newDiveId',
+            error: deleteError,
+            stackTrace: deleteStack,
+          );
         }
       }
-      return _ConsolidateOutcome.failed;
+      return (outcome: _ConsolidateOutcome.failed, diveId: null);
     }
   }
 }

--- a/lib/features/universal_import/presentation/providers/import_consolidation_service.dart
+++ b/lib/features/universal_import/presentation/providers/import_consolidation_service.dart
@@ -1,6 +1,7 @@
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
+import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
 import 'package:submersion/features/universal_import/data/services/import_duplicate_checker.dart';
 
 const _log = LoggerService('ImportConsolidationService');
@@ -11,6 +12,7 @@ class ConsolidationSummary {
   const ConsolidationSummary({
     required this.consolidated,
     required this.failed,
+    this.keptStandalone = 0,
     this.removedDiveIds = const {},
   });
 
@@ -21,6 +23,12 @@ class ConsolidationSummary {
   /// been imported as a standalone dive. Each one was deleted (see
   /// [performConsolidations]) rather than left stranded.
   final int failed;
+
+  /// Number of dives whose fold was refused because the PRE-EXISTING match
+  /// holds a series this build cannot decode. Each one was left in place as
+  /// its own standalone dive rather than deleted, so none of them appear in
+  /// [removedDiveIds].
+  final int keptStandalone;
 
   /// The freshly-imported standalone dive ids that are NO LONGER present after
   /// this call -- each was either folded into its match (and tombstoned by
@@ -51,6 +59,12 @@ class ConsolidationSummary {
 /// via [DiveRepository.bulkDeleteDives] (tombstone-honoring) so it doesn't
 /// strand as a bare, unconsolidated duplicate, and the loop continues with
 /// the remaining indices rather than aborting the whole import.
+///
+/// [UnreadableSeriesException] is the one exception to that: it says the
+/// PRE-EXISTING match holds a profile or pressure series this build cannot
+/// decode, so `apply` refused before writing anything. The freshly-imported
+/// dive is not at fault, so it is KEPT standalone (counted in
+/// [ConsolidationSummary.keptStandalone]) rather than deleted.
 Future<ConsolidationSummary> performConsolidations({
   required Set<int> indices,
   required Map<int, String> diveIdByIndex,
@@ -60,6 +74,7 @@ Future<ConsolidationSummary> performConsolidations({
 }) async {
   var consolidated = 0;
   var failed = 0;
+  var keptStandalone = 0;
   final removedDiveIds = <String>{};
 
   for (final index in indices) {
@@ -77,6 +92,17 @@ Future<ConsolidationSummary> performConsolidations({
       consolidated++;
       // The fold tombstoned the standalone dive.
       removedDiveIds.add(newDiveId);
+    } on UnreadableSeriesException catch (e) {
+      // The refusal is about the pre-existing match's stored series, not
+      // about the dive just imported. That dive is good data and this is
+      // its only copy, so it stays standalone: it is deliberately NOT added
+      // to [removedDiveIds], so the caller keeps counting it as imported.
+      _log.warning(
+        'Kept imported dive $newDiveId standalone instead of folding it '
+        'into ${matchResult.diveId}: that dive holds ${e.seriesIds.length} '
+        'series this build cannot decode',
+      );
+      keptStandalone++;
     } catch (e, st) {
       _log.error(
         'Consolidation fold failed for dive into ${matchResult.diveId}',
@@ -106,6 +132,7 @@ Future<ConsolidationSummary> performConsolidations({
   return ConsolidationSummary(
     consolidated: consolidated,
     failed: failed,
+    keptStandalone: keptStandalone,
     removedDiveIds: removedDiveIds,
   );
 }

--- a/test/core/database/migration_v183_drop_legacy_tables_test.dart
+++ b/test/core/database/migration_v183_drop_legacy_tables_test.dart
@@ -476,32 +476,34 @@ void main() {
     },
   );
 
-  test(
-    'a v182 pack that throws still reaches 183 and keeps the legacy table',
-    () async {
-      final raw = sqlite3.sqlite3.openInMemory();
-      addTearDown(raw.close);
-      // Below 182, so the v182 rung itself runs. Its pack throws on the
-      // text timestamp (profileSampleOf casts unchecked), and an unguarded
-      // rung would rethrow out of onUpgrade and leave a database that
-      // cannot be opened on any relaunch.
-      legacyDdlAt180(raw, userVersion: 181);
-      seedParents(raw);
-      raw.execute(
-        "INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, "
-        "depth) VALUES ('p1', 'd1', 1, 'not-a-number', 1.0)",
-      );
+  test('a v182 pack that cannot write its series still reaches 183 and keeps '
+      'the legacy table', () async {
+    final raw = sqlite3.sqlite3.openInMemory();
+    addTearDown(raw.close);
+    // Below 182, so the v182 rung itself runs. A pre-existing
+    // dive_profile_series without its samples column, the shape
+    // backstop_resilience_test uses: CREATE TABLE IF NOT EXISTS leaves it
+    // alone, so every packer INSERT fails. An unguarded rung would let
+    // that out of onUpgrade and leave a database that cannot be opened on
+    // any relaunch, and the row is perfectly READABLE, so dropping the
+    // legacy table would destroy the only copy of it.
+    legacyDdlAt180(raw, userVersion: 181);
+    seedParents(raw);
+    raw.execute(
+      'INSERT INTO dive_profiles (id, dive_id, is_primary, timestamp, '
+      "depth) VALUES ('p1', 'd1', 1, 0, 1.0)",
+    );
+    malformedSeriesTable(raw);
 
-      final db = AppDatabase(
-        NativeDatabase.opened(raw, closeUnderlyingOnClose: false),
-      );
-      addTearDown(db.close);
-      await expectLater(db.customSelect('SELECT 1').get(), completes);
+    final db = AppDatabase(
+      NativeDatabase.opened(raw, closeUnderlyingOnClose: false),
+    );
+    addTearDown(db.close);
+    await expectLater(db.customSelect('SELECT 1').get(), completes);
 
-      expect(scalar(raw, 'PRAGMA user_version'), 183);
-      expect(scalar(raw, 'SELECT COUNT(*) AS n FROM dive_profiles'), 1);
-    },
-  );
+    expect(scalar(raw, 'PRAGMA user_version'), 183);
+    expect(scalar(raw, 'SELECT COUNT(*) AS n FROM dive_profiles'), 1);
+  });
 
   test('an orphaned tank pressure row keeps its legacy table', () async {
     final raw = sqlite3.sqlite3.openInMemory();

--- a/test/core/database/profile_series_pack_coverage_parity_test.dart
+++ b/test/core/database/profile_series_pack_coverage_parity_test.dart
@@ -287,6 +287,35 @@ void main() {
       expect(report.tankSeries, 1);
     });
 
+    test('a text timestamp on an ORPHAN pressure row does not abort the '
+        'whole pack', () async {
+      // The orphan adoption is a prologue: it runs before the first dive's
+      // transaction and OUTSIDE the per-dive try/catch the rest of the
+      // design rests on, so a throw there costs every dive, on this open
+      // and on every later one. It reads MIN(timestamp) as an int, and
+      // SQLite's MIN over a group whose only values are TEXT returns TEXT,
+      // which drift parses and throws a FormatException on. Reported by
+      // Copilot on PR #1444.
+      final open = await openLegacy();
+      seedParents(open.raw);
+      // Orphan tank id, so the adoption pre-pass actually reaches this
+      // group, with a timestamp SQLite kept as text.
+      open.raw.execute(
+        'INSERT INTO tank_pressure_profiles (id, dive_id, tank_id, timestamp, '
+        "pressure, computer_id) VALUES ('q1', 'd1', 'gone', 'noon', 200.0, "
+        'NULL)',
+      );
+      open.raw.execute(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
+        "VALUES ('p1', 'd1', 0, 5.0, 1), ('p2', 'd1', 60, 6.0, 1)",
+      );
+
+      final report = await packLegacyProfileRows(open.db, nowMs: 1);
+
+      // The profile side has nothing wrong with it and must still land.
+      expect(report.profileSeries, 1);
+    });
+
     test('an unreadable row does not keep the legacy table alive', () async {
       // The residue count gates dropping the legacy table, and it already
       // excludes a row that can NEVER be packed so the table is not kept

--- a/test/core/database/profile_series_pack_coverage_parity_test.dart
+++ b/test/core/database/profile_series_pack_coverage_parity_test.dart
@@ -5,6 +5,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/legacy_sample_staging.dart';
 import 'package:submersion/core/database/profile_series_pack.dart';
+import 'package:submersion/core/database/profile_series_pack_coverage.dart';
 import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
 import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
@@ -236,21 +237,79 @@ void main() {
       expect(samples.read<int>('sample_count'), 2);
     });
 
-    test('a text depth costs one dive, not the pack', () async {
+    test('a text depth costs its own row, not the dive', () async {
+      // An unreadable timestamp or depth means the ROW holds no sample,
+      // which is the same thing a null in either column means, and nulls
+      // have always been stepped over as skippedRows. Failing the whole
+      // dive instead is worse than it looks: the dive is kept back for "a
+      // later open to retry", but the retry reads the same byte and fails
+      // the same way, so the profile is never visible and the legacy table
+      // that holds it can never be dropped.
       final open = await openLegacy();
       seedParents(open.raw);
       open.raw.execute(
         'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
-        "VALUES ('bad', 'd1', 0, 'deep', 1)",
-      );
-      open.raw.execute(
-        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
-        "VALUES ('ok1', 'd2', 0, 5.0, 1), ('ok2', 'd2', 60, 6.0, 1)",
+        "VALUES ('bad', 'd1', 0, 'deep', 1), ('ok1', 'd1', 60, 6.0, 1), "
+        "('ok2', 'd1', 120, 7.0, 1)",
       );
 
       final report = await packLegacyProfileRows(open.db, nowMs: 1);
 
-      expect(report.profileSeries, 1, reason: 'd2 must still pack');
+      expect(report.failedDives, 0);
+      expect(report.skippedRows, 1);
+      expect(report.profileSeries, 1);
+      final samples = await open.db
+          .customSelect(
+            'SELECT sample_count FROM dive_profile_series WHERE dive_id = ?',
+            variables: const [Variable<String>('d1')],
+          )
+          .getSingle();
+      expect(samples.read<int>('sample_count'), 2);
+    });
+
+    test('a text timestamp on a pressure row costs its own row, not the '
+        'dive', () async {
+      // The tank loop's twin of the case above. Reported by Copilot on
+      // PR #1444.
+      final open = await openLegacy();
+      seedParents(open.raw);
+      open.raw.execute(
+        'INSERT INTO tank_pressure_profiles (id, dive_id, tank_id, timestamp, '
+        "pressure, computer_id) VALUES ('q1', 'd1', 't1', 'noon', 200.0, NULL),"
+        " ('q2', 'd1', 't1', 60, 190.0, NULL), "
+        "('q3', 'd1', 't1', 120, 180.0, NULL)",
+      );
+
+      final report = await packLegacyProfileRows(open.db, nowMs: 1);
+
+      expect(report.failedDives, 0);
+      expect(report.skippedRows, 1);
+      expect(report.tankSeries, 1);
+    });
+
+    test('an unreadable row does not keep the legacy table alive', () async {
+      // The residue count gates dropping the legacy table, and it already
+      // excludes a row that can NEVER be packed so the table is not kept
+      // forever. A row whose timestamp or depth SQLite cannot read as a
+      // number is exactly that, the same as the null the count already
+      // steps over.
+      final open = await openLegacy();
+      seedParents(open.raw);
+      open.raw.execute(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
+        "VALUES ('bad', 'd1', 0, 'deep', 1), ('ok1', 'd1', 60, 6.0, 1)",
+      );
+      open.raw.execute(
+        'INSERT INTO tank_pressure_profiles (id, dive_id, tank_id, timestamp, '
+        "pressure, computer_id) VALUES ('q1', 'd1', 't1', 'noon', 200.0, NULL),"
+        " ('q2', 'd1', 't1', 60, 190.0, NULL)",
+      );
+
+      await packLegacyProfileRows(open.db, nowMs: 1);
+
+      final residue = await countLegacyRowsAwaitingPack(open.db);
+      expect(residue.profiles, 0);
+      expect(residue.tanks, 0);
     });
   });
 }

--- a/test/core/database/profile_series_pack_coverage_parity_test.dart
+++ b/test/core/database/profile_series_pack_coverage_parity_test.dart
@@ -1,0 +1,256 @@
+import 'package:drift/drift.dart' show Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/database/legacy_sample_staging.dart';
+import 'package:submersion/core/database/profile_series_pack.dart';
+import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/tank_pressure_series_codec.dart';
+
+import '../../helpers/legacy_profile_fixtures.dart';
+import '../../helpers/test_database.dart';
+
+/// Coverage ("is this legacy row already represented by a series row") is
+/// answered twice, in two languages: in Dart by the packer, to decide
+/// whether to WRITE a series, and in SQL by `legacyRowCoveredSql`, to decide
+/// whether to DELETE the staged rows and whether a legacy table may be
+/// dropped. The two have to give the same answer for every row.
+///
+/// Where they disagree the damage is always the same shape: the Dart side
+/// calls a group covered so nothing is written, the SQL side calls it
+/// uncovered so nothing is cleared, and the staging table never drains. The
+/// pack then re-runs over those rows on every sync apply for the life of the
+/// install while the peer's samples are never visible.
+void main() {
+  group('staging path', () {
+    late AppDatabase db;
+    late ProfileSeriesRepository series;
+    late TankPressureSeriesRepository tankSeries;
+    final now = DateTime(2026, 6, 1).millisecondsSinceEpoch;
+
+    Future<int> stagedProfiles() async =>
+        (await db
+                .customSelect(
+                  'SELECT COUNT(*) AS n FROM $kLegacyProfileStagingTable',
+                )
+                .getSingle())
+            .read<int>('n');
+
+    Future<int> stagedTanks() async =>
+        (await db
+                .customSelect(
+                  'SELECT COUNT(*) AS n FROM $kLegacyTankStagingTable',
+                )
+                .getSingle())
+            .read<int>('n');
+
+    setUp(() async {
+      db = await setUpTestDatabase();
+      series = ProfileSeriesRepository();
+      tankSeries = TankPressureSeriesRepository();
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion.insert(
+              id: 'dive-1',
+              diveDateTime: now,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion.insert(
+              id: 'comp-1',
+              name: 'comp-1',
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+      await db
+          .into(db.diveTanks)
+          .insert(DiveTanksCompanion.insert(id: 'tank-a', diveId: 'dive-1'));
+      await ensureLegacyStagingTables(db);
+    });
+
+    tearDown(tearDownTestDatabase);
+
+    test('unattributed staged pressures drain against a series that names a '
+        'computer', () async {
+      // The motivating case the docstring names: consolidation's
+      // stampComputerWhereNull put a computer on this device's series while a
+      // peer below the floor still holds the same readings unattributed.
+      await tankSeries.insertSeries(
+        diveId: 'dive-1',
+        tankId: 'tank-a',
+        computerId: 'comp-1',
+        samples: const [
+          TankPressureSample(timestamp: 0, pressure: 200.0),
+          TankPressureSample(timestamp: 60, pressure: 199.0),
+        ],
+        now: now,
+      );
+      await stageLegacyTankRows(db, [
+        for (var t = 0; t < 2; t++)
+          {
+            'id': 'q$t',
+            'diveId': 'dive-1',
+            'tankId': 'tank-a',
+            'timestamp': t * 60,
+            'pressure': 200.0 - t,
+          },
+      ]);
+
+      await packStagedLegacyRows(db);
+
+      // The pack's in-Dart check treats the null computer as a wildcard and
+      // writes nothing, so the clear has to agree and drain the rows. Today
+      // the clear demands an exact match and leaves them staged forever.
+      expect(await stagedTanks(), 0);
+      expect(await hasStagedLegacyRows(db), isFalse);
+    });
+
+    test('a staged row naming a computer this device does not hold is not '
+        'swallowed by the null wildcard', () async {
+      // This device already holds dive-1 from comp-1.
+      await series.insertSeries(
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        samples: const [
+          ProfileSample(timestamp: 0, depth: 1.0),
+          ProfileSample(timestamp: 60, depth: 2.0),
+        ],
+        now: now,
+      );
+      // The peer's rows name a SECOND computer whose dive_computers row has
+      // not merged here yet. `_resolvedParent` collapses that dangling id to
+      // null, but the row still names a genuinely different source: the
+      // wildcard is for a row that names NO computer, so these must be
+      // packed as their own unattributed series rather than declared covered
+      // by comp-1's.
+      await stageLegacyProfileRows(db, [
+        for (var t = 0; t < 2; t++)
+          {
+            'id': 'p$t',
+            'diveId': 'dive-1',
+            'computerId': 'comp-absent',
+            'isPrimary': true,
+            'timestamp': t * 60,
+            'depth': 10.0 + t,
+          },
+      ]);
+
+      await packStagedLegacyRows(db);
+
+      final all = await series.getSeriesForDive('dive-1');
+      expect(all, hasLength(2));
+      final unattributed = all.where((s) => s.computerId == null);
+      expect(unattributed, hasLength(1));
+      expect(await stagedProfiles(), 0);
+    });
+
+    test('a staged is_primary SQLite cannot read as a number packs and '
+        'drains', () async {
+      // The staging table takes a peer's JSON. `is_primary` is declared
+      // INTEGER NOT NULL, but SQLite's INTEGER affinity leaves text it
+      // cannot convert as TEXT, so a peer that sends anything other than a
+      // number or a bool lands a string in the column. Dart's `_boolOf`
+      // reads any non-num as primary while the clear's
+      // `CASE WHEN p.is_primary` applies SQLite's own truthiness and reads
+      // it as demoted, so the two disagree and the rows never clear.
+      await stageLegacyProfileRows(db, [
+        for (var t = 0; t < 2; t++)
+          {
+            'id': 'p$t',
+            'diveId': 'dive-1',
+            'isPrimary': 'yes',
+            'timestamp': t * 60,
+            'depth': 5.0 + t,
+          },
+      ]);
+      final stored = await db
+          .customSelect(
+            'SELECT typeof(is_primary) AS t FROM $kLegacyProfileStagingTable '
+            'LIMIT 1',
+          )
+          .getSingle();
+      expect(
+        stored.read<String>('t'),
+        'text',
+        reason: 'the scenario needs the value to survive as text',
+      );
+
+      await packStagedLegacyRows(db);
+
+      expect(await series.getSeriesForDive('dive-1'), hasLength(1));
+      expect(await stagedProfiles(), 0);
+      expect(await hasStagedLegacyRows(db), isFalse);
+    });
+  });
+
+  group('migration path', () {
+    Future<({AppDatabase db, sqlite3.Database raw})> openLegacy() async {
+      final raw = sqlite3.sqlite3.openInMemory();
+      addTearDown(raw.close);
+      legacyDdlAt180(raw, userVersion: 182);
+      final db = AppDatabase(
+        NativeDatabase.opened(raw, closeUnderlyingOnClose: false),
+      );
+      addTearDown(db.close);
+      await db.customSelect('SELECT 1').get();
+      createLegacyProfileTables(raw);
+      return (db: db, raw: raw);
+    }
+
+    test('an unreadable OPTIONAL field costs its own value, not the dive\'s '
+        'whole profile', () async {
+      // SQLite carries a storage class per VALUE, not per column, so a
+      // REAL-affinity column can hold text SQLite could not convert, from a
+      // hand-repaired or bit-rotted file. `timestamp` and `depth` are what
+      // makes a sample, so a bad one there correctly costs the dive. Every
+      // other column is one optional field of one sample, and dropping the
+      // dive's ENTIRE profile over it is a permanent loss: nothing reads the
+      // legacy tables after v183.
+      final open = await openLegacy();
+      seedParents(open.raw);
+      open.raw.execute(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, pressure, '
+        "is_primary) VALUES ('p1', 'd1', 0, 5.0, 'bar?', 1), "
+        "('p2', 'd1', 60, 6.0, 190.0, 1)",
+      );
+
+      final report = await packLegacyProfileRows(open.db, nowMs: 1);
+
+      expect(report.profileSeries, 1);
+      expect(report.failedDives, 0);
+      final samples = await open.db
+          .customSelect(
+            'SELECT sample_count FROM dive_profile_series WHERE dive_id = ?',
+            variables: const [Variable<String>('d1')],
+          )
+          .getSingle();
+      expect(samples.read<int>('sample_count'), 2);
+    });
+
+    test('a text depth costs one dive, not the pack', () async {
+      final open = await openLegacy();
+      seedParents(open.raw);
+      open.raw.execute(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
+        "VALUES ('bad', 'd1', 0, 'deep', 1)",
+      );
+      open.raw.execute(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, is_primary) '
+        "VALUES ('ok1', 'd2', 0, 5.0, 1), ('ok2', 'd2', 60, 6.0, 1)",
+      );
+
+      final report = await packLegacyProfileRows(open.db, nowMs: 1);
+
+      expect(report.profileSeries, 1, reason: 'd2 must still pack');
+    });
+  });
+}

--- a/test/core/database/profile_series_pack_isolation_test.dart
+++ b/test/core/database/profile_series_pack_isolation_test.dart
@@ -6,13 +6,23 @@ import 'package:submersion/core/database/profile_series_pack.dart';
 
 import '../../helpers/legacy_profile_fixtures.dart';
 
-/// One unreadable legacy row must cost its own dive and nothing more.
+/// One unreadable legacy VALUE must cost its own row and nothing more.
 ///
 /// The rungs and the beforeOpen backstop catch whatever the packer throws,
 /// which keeps the database openable but leaves every dive the packer had
 /// not reached yet unpacked, on this open and on every later one. Nothing
 /// reads `dive_profiles` after v183, so those profiles would be invisible
 /// while the dive still looked whole.
+///
+/// An unreadable timestamp, depth or pressure means the ROW holds no
+/// sample, which is what a null in the same column has always meant, so it
+/// is counted in `skippedRows` and the rest of the dive still packs. Costing
+/// the whole dive instead only looked like a deferred retry: the dive was
+/// held back for a later open that reads the same byte and fails the same
+/// way, so its good samples were never visible either. Failure at DIVE
+/// granularity is still real, for a group the codec or the database refuses
+/// to write, and is pinned by `migration_v183_rung_resilience_test.dart`
+/// and `backstop_resilience_test.dart`.
 void main() {
   Future<({AppDatabase db, sqlite3.Database raw})> openLegacy() async {
     final raw = sqlite3.sqlite3.openInMemory();
@@ -28,8 +38,8 @@ void main() {
   }
 
   /// A row whose `depth` holds text. SQLite's REAL affinity keeps a
-  /// non-numeric string as TEXT, so the packer's `as num?` throws on it the
-  /// way a bit-rotted or hand-repaired table would.
+  /// non-numeric string as TEXT, the way a bit-rotted or hand-repaired
+  /// table would, and the packer reads it as no sample at all.
   void unreadableProfileRow(sqlite3.Database raw, String id, String diveId) {
     raw.execute(
       'INSERT INTO dive_profiles (id, dive_id, computer_id, source_id, '
@@ -53,7 +63,7 @@ void main() {
     return [for (final r in rows) r.read<String>('dive_id')];
   }
 
-  test('an unreadable dive does not stop the dives after it', () async {
+  test('an unreadable row does not stop the dives after it', () async {
     final open = await openLegacy();
     seedParents(open.raw);
     // d1 sorts first, and the scan walks dives in dive_id order.
@@ -63,12 +73,13 @@ void main() {
     final report = await packLegacyProfileRows(open.db, nowMs: 1);
 
     expect(report.profileSeries, 1);
-    expect(report.failedDives, 1);
+    expect(report.failedDives, 0);
+    expect(report.skippedRows, 1);
     expect(await packedDiveIds(open.db, 'dive_profile_series'), ['d2']);
   });
 
   test(
-    'an unreadable profile dive does not stop the tank pressure pack',
+    'an unreadable profile row does not stop the tank pressure pack',
     () async {
       final open = await openLegacy();
       seedParents(open.raw);
@@ -80,14 +91,15 @@ void main() {
 
       final report = await packLegacyProfileRows(open.db, nowMs: 1);
 
-      expect(report.failedDives, 1);
+      expect(report.failedDives, 0);
+      expect(report.skippedRows, 1);
       expect(report.tankSeries, 1);
       expect(await packedDiveIds(open.db, 'tank_pressure_series'), ['d1']);
     },
   );
 
   test(
-    'an unreadable tank dive does not stop the tank dives after it',
+    'an unreadable tank row does not stop the tank dives after it',
     () async {
       final open = await openLegacy();
       seedParents(open.raw);
@@ -105,7 +117,8 @@ void main() {
 
       final report = await packLegacyProfileRows(open.db, nowMs: 1);
 
-      expect(report.failedDives, 1);
+      expect(report.failedDives, 0);
+      expect(report.skippedRows, 1);
       expect(report.tankSeries, 1);
       expect(await packedDiveIds(open.db, 'tank_pressure_series'), ['d2']);
     },

--- a/test/core/services/database_service_vacuum_test.dart
+++ b/test/core/services/database_service_vacuum_test.dart
@@ -167,6 +167,64 @@ void main() {
     },
   );
 
+  test('a file stamped 183 whose legacy table the BACKSTOP drops is '
+      'VACUUMed', () async {
+    // The v183 rung is explicitly allowed to skip its drop: its own pack
+    // threw, the series table's foreign-key parents were absent, or the
+    // residue count found rows no series covered. The file is stamped 183
+    // either way, and the beforeOpen backstop drops the tables on the first
+    // later open whose pack succeeds. That open has no pending ladder, so a
+    // reclamation keyed on the stored version never runs for it, and there
+    // is no other VACUUM of the live database anywhere in the app: the
+    // diver's file keeps every freed page forever.
+    await seedFile((raw) {
+      raw.execute('DROP TABLE IF EXISTS dive_profiles');
+      raw.execute('''
+          CREATE TABLE dive_profiles (
+            id TEXT NOT NULL PRIMARY KEY,
+            dive_id TEXT NOT NULL,
+            computer_id TEXT,
+            source_id TEXT,
+            is_primary INTEGER NOT NULL DEFAULT 1,
+            timestamp INTEGER NOT NULL,
+            depth REAL NOT NULL,
+            temperature REAL
+          )
+        ''');
+      raw.execute(
+        'CREATE INDEX idx_dive_profiles_dive_id ON dive_profiles(dive_id)',
+      );
+      final stmt = raw.prepare(
+        'INSERT INTO dive_profiles (id, dive_id, timestamp, depth, '
+        'temperature) VALUES (?, ?, ?, ?, ?)',
+      );
+      raw.execute('BEGIN');
+      for (var i = 0; i < 20000; i++) {
+        // Dangling dive id, as in the test above: the rows are skipped as
+        // orphans, so the residue is zero and the backstop drops the table.
+        stmt.execute(['sample-$i', 'ghost-dive', i, i % 40 + 0.5, 21.0]);
+      }
+      raw.execute('COMMIT');
+      stmt.close();
+      // Already at the current version, so there is no ladder to run.
+      raw.execute('PRAGMA user_version = 183');
+    });
+
+    expect(freelistOnDisk(), 0);
+
+    await DatabaseService.instance.initialize(
+      locationService: _FakeLocation(dbPath),
+    );
+    expect(DatabaseService.instance.lastOpenMode, DatabaseOpenMode.background);
+    await DatabaseService.instance.close(strict: true);
+
+    expect(
+      freelistOnDisk(),
+      0,
+      reason: 'the pages the backstop freed have to come back',
+    );
+  });
+
   test('a file already at 183 is not VACUUMed', () async {
     await seedFile((raw) {
       // A freelist the open must leave alone: pages freed by a bulk delete

--- a/test/core/services/sync/legacy_sample_entities_inbound_test.dart
+++ b/test/core/services/sync/legacy_sample_entities_inbound_test.dart
@@ -531,6 +531,73 @@ void main() {
         );
       },
     );
+
+    test('adopting a base that carries only the missing parent drains the rows '
+        'staged by an earlier changeset', () async {
+      // A pre-v183 peer published diveProfiles for a dive before the dive
+      // itself synced, so the rows staged and were kept for a later apply.
+      // The cloud base was written by an upgraded peer: it carries the
+      // dive but no legacy rows at all, so only the parent flag can tell
+      // the packer that the block is gone.
+      await SyncDataSerializer().upsertRecord('diveProfiles', {
+        'id': 'p-orphan',
+        'diveId': 'd-late-parent',
+        'timestamp': 0,
+        'depth': 7.0,
+        'isPrimary': true,
+      });
+      expect(
+        await SyncDataSerializer().hasStagedLegacySamples(),
+        isTrue,
+        reason: 'the row stages even though its dive has not arrived',
+      );
+
+      await DiveRepository().createDive(_dive('template-late', const []));
+      final diveRow =
+          Map<String, dynamic>.from(
+              (await SyncDataSerializer().fetchRecord(
+                'dives',
+                'template-late',
+              ))!,
+            )
+            ..['id'] = 'd-late-parent'
+            ..['hlc'] = const Hlc(9000, 0, 'peer-183-adopt').toString();
+      final dataJson = SyncData(dives: [diveRow]).toJson();
+      final payloadJson = <String, dynamic>{
+        'version': syncFormatVersion,
+        'exportedAt': 9000,
+        'deviceId': 'peer-183-adopt',
+        'lastSyncTimestamp': null,
+        'checksum': sha256
+            .convert(utf8.encode(jsonEncode(dataJson)))
+            .toString(),
+        'data': dataJson,
+        'deletions': <String, dynamic>{},
+        'uploadNonce': null,
+        'epochId': null,
+        'seq': null,
+        'baseSeq': null,
+        'sinceHlc': null,
+        'toHlc': null,
+      };
+
+      final tmpDir = await Directory.systemTemp.createTemp('adopt_parent');
+      final tmp = File('${tmpDir.path}/base.json');
+      await tmp.writeAsBytes(utf8.encode(jsonEncode(payloadJson)));
+      await buildService().debugAdoptStreaming([tmp.path], [9000], const []);
+      await tmpDir.delete(recursive: true);
+
+      final series = await ProfileSeriesRepository().getSeriesForDive(
+        'd-late-parent',
+      );
+      expect(
+        series,
+        hasLength(1),
+        reason: 'the adopt delivered the parent that was blocking the pack',
+      );
+      expect(series.single.samples.single.depth, 7.0);
+      expect(await SyncDataSerializer().hasStagedLegacySamples(), isFalse);
+    });
   });
 
   group('serializer: direct upsertRecord/upsertRecords staging paths', () {

--- a/test/core/services/sync/series_header_scalar_comparison_test.dart
+++ b/test/core/services/sync/series_header_scalar_comparison_test.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_data_serializer.dart';
+import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_sample.dart';
+import 'package:submersion/features/dive_log/domain/codecs/profile_series_codec.dart';
+
+import '../../../helpers/test_database.dart';
+
+/// The soundness check that compares a peer's header scalars against the
+/// summary its blob decodes to compares doubles by bit pattern, not with
+/// `!=`: `!=` calls -0.0 equal to 0.0, which let a header that genuinely
+/// disagrees with its blob through the very check that exists to catch one.
+///
+/// A non-finite depth scalar is refused ahead of that comparison, because
+/// SQLite stores a non-finite double as NULL and the depth columns are NOT
+/// NULL: admitting one would fail the batch insert that carries every other
+/// series record in the payload, not just itself.
+void main() {
+  late AppDatabase db;
+  const now = 1750000000000;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion.insert(
+            id: 'dive-1',
+            diveDateTime: now,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+  });
+  tearDown(tearDownTestDatabase);
+
+  /// The wire record a peer sends for [encoded]. The named overrides stand
+  /// in for a header that disagrees with the blob it ships with.
+  Map<String, dynamic> record(
+    String id,
+    EncodedProfileSeries encoded, {
+    double? maxDepth,
+    double? lastDepth,
+  }) => {
+    'id': id,
+    'diveId': 'dive-1',
+    'isPrimary': true,
+    'sampleCount': encoded.summary.sampleCount,
+    'startTimestamp': encoded.summary.startTimestamp,
+    'endTimestamp': encoded.summary.endTimestamp,
+    'maxDepth': maxDepth ?? encoded.summary.maxDepth,
+    'firstDepth': encoded.summary.firstDepth,
+    'lastDepth': lastDepth ?? encoded.summary.lastDepth,
+    'hasDecoType': encoded.summary.hasDecoType,
+    'hasDecoStop': encoded.summary.hasDecoStop,
+    'hasPositiveCeiling': encoded.summary.hasPositiveCeiling,
+    'codecVersion': encoded.codecVersion,
+    'samples': base64Encode(encoded.bytes),
+    'createdAt': now,
+    'updatedAt': now,
+  };
+
+  Future<void> upsert(
+    String id,
+    EncodedProfileSeries encoded, {
+    double? maxDepth,
+    double? lastDepth,
+  }) => SyncDataSerializer().upsertRecord(
+    'diveProfileSeries',
+    record(id, encoded, maxDepth: maxDepth, lastDepth: lastDepth),
+  );
+
+  test('a NaN depth scalar is skipped without failing its batch', () async {
+    // ProfileSeriesSummary.of seeds maxDepth from the first sample with a
+    // `>` comparison that never overwrites a NaN seed, so this header
+    // agrees with its blob exactly; it is still unstorable, because the
+    // depth columns are NOT NULL and SQLite writes a non-finite double as
+    // NULL. The record next to it in the same batch must still land.
+    final nan = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: double.nan),
+      ProfileSample(timestamp: 60, depth: 9.0),
+    ]);
+    expect(nan.summary.maxDepth, isNaN);
+    expect(nan.summary.firstDepth, isNaN);
+    final sound = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: 3.0),
+      ProfileSample(timestamp: 60, depth: 12.0),
+    ]);
+
+    await SyncDataSerializer().upsertRecords('diveProfileSeries', [
+      record('nan-depths', nan),
+      record('sound', sound),
+    ]);
+
+    expect(
+      (await ProfileSeriesRepository().getRowsForDives([
+        'dive-1',
+      ])).map((r) => r.id),
+      ['sound'],
+      reason: 'the unstorable row must cost only itself',
+    );
+  });
+
+  test('a NaN depth inside the profile is fine: only the header matters', () {
+    // The scalars are the first, last and greatest depth, so a NaN in the
+    // middle of a dive never reaches one of them and the row stores.
+    final summary = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: 3.0),
+      ProfileSample(timestamp: 30, depth: double.nan),
+      ProfileSample(timestamp: 60, depth: 12.0),
+    ]).summary;
+    expect(summary.maxDepth, 12.0);
+    expect(summary.firstDepth, 3.0);
+    expect(summary.lastDepth, 12.0);
+  });
+
+  test('a header claiming 0.0 for a blob holding -0.0 is refused', () async {
+    final encoded = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: 5.0),
+      ProfileSample(timestamp: 60, depth: -0.0),
+    ]);
+    expect(encoded.summary.lastDepth, -0.0);
+
+    await upsert('negative-zero', encoded, lastDepth: 0.0);
+
+    expect(
+      await ProfileSeriesRepository().getRowsForDives(['dive-1']),
+      isEmpty,
+      reason: 'a header that disagrees with its blob is what the check is for',
+    );
+  });
+
+  test('a header that agrees with its blob at -0.0 is stored', () async {
+    final encoded = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: 5.0),
+      ProfileSample(timestamp: 60, depth: -0.0),
+    ]);
+
+    await upsert('negative-zero-ok', encoded);
+
+    expect(
+      (await ProfileSeriesRepository().getRowsForDives([
+        'dive-1',
+      ])).map((r) => r.id),
+      ['negative-zero-ok'],
+    );
+  });
+
+  test('an ordinary header mismatch is still refused', () async {
+    final encoded = const ProfileSeriesCodec().encode(const [
+      ProfileSample(timestamp: 0, depth: 5.0),
+      ProfileSample(timestamp: 60, depth: 9.0),
+    ]);
+
+    await upsert('tampered', encoded, maxDepth: 99.0);
+
+    expect(
+      await ProfileSeriesRepository().getRowsForDives(['dive-1']),
+      isEmpty,
+    );
+  });
+}

--- a/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
+++ b/test/features/data_quality/presentation/data_quality_inbox_page_test.dart
@@ -791,6 +791,46 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 6));
   });
 
+  testWidgets('split-source repair reports a failure through a SnackBar', (
+    tester,
+  ) async {
+    // DiveSplitService.split() throws for a source that does not belong to
+    // the dive, and it also refuses a dive whose stored series this build
+    // cannot decode. Either way the diver must be told: the repair used to
+    // run outside any try/catch, so the tap silently did nothing and the
+    // finding stayed open forever.
+    final prefs = await _prefs();
+    await tester.pumpWidget(
+      _scope(
+        prefs,
+        findings: [
+          _f(
+            id: 'r-splitsource',
+            detectorId: 'source_conflict',
+            category: QualityCategory.source,
+            params: const {
+              'sourceId': 's1',
+              'primaryMaxDepth': 30.0,
+              'sourceMaxDepth': 28.0,
+            },
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Split is not the card's primary action; expand the card to reach it.
+    // Tap the title rather than the tile's center: the trailing primary
+    // button is wide enough to sit under it.
+    await tester.tap(find.text('Conflicting sources'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Split into separate dives'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Split failed'), findsOneWidget);
+    await tester.pumpAndSettle(const Duration(seconds: 6));
+  });
+
   testWidgets('combine-split repair opens the combine dialog', (tester) async {
     final prefs = await _prefs();
     await tester.pumpWidget(

--- a/test/features/dive_log/data/repositories/dive_computer_repository_series_writes_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_repository_series_writes_test.dart
@@ -150,6 +150,39 @@ void main() {
     },
   );
   test(
+    'clearSourceAndProfiles restamps the edited series whose source it deletes',
+    () async {
+      // deleteByComputer never matches the null-computer edit, so the edit
+      // survives the clear while the cascade on the deleted
+      // dive_data_sources row nulls its source_id: ON DELETE SET NULL moves
+      // no updated_at, restamps no hlc and marks nothing pending, so this
+      // device reads the edit as unattributed while every peer still reads
+      // it as owned by the deleted source, permanently.
+      final diveId = await importDive();
+      final sourceId = (await series.getSeriesForDive(diveId)).single.sourceId;
+      final edit = await series.insertSeries(
+        diveId: diveId,
+        sourceId: sourceId,
+        samples: const [ProfileSample(timestamp: 0, depth: 9.0)],
+        now: 1000,
+      );
+      final before = (await series.getRowsForDives([
+        diveId,
+      ])).firstWhere((r) => r.id == edit);
+      await computers.clearSourceAndProfiles(
+        diveId: diveId,
+        computerId: 'comp-1',
+      );
+      final after = (await series.getRowsForDives([
+        diveId,
+      ])).firstWhere((r) => r.id == edit);
+      expect(after.sourceId, isNull);
+      expect(after.updatedAt, greaterThan(before.updatedAt));
+      expect(after.hlc, isNot(before.hlc));
+    },
+  );
+
+  test(
     'the computer list survives a series whose blob will not decode',
     () async {
       // These questions are about identity columns, which live unencoded on

--- a/test/features/dive_log/data/repositories/dive_repository_series_writes_test.dart
+++ b/test/features/dive_log/data/repositories/dive_repository_series_writes_test.dart
@@ -49,6 +49,20 @@ void main() {
         );
   }
 
+  /// The `local_updated_at` of the pending sync record of [seriesId], or null
+  /// when the series was never marked pending.
+  Future<int?> pendingSince(String seriesId) async {
+    final row = await db
+        .customSelect(
+          "SELECT local_updated_at AS t FROM sync_records "
+          "WHERE entity_type = 'diveProfileSeries' AND record_id = ? "
+          "AND sync_status = 'pending'",
+          variables: [Variable<String>(seriesId)],
+        )
+        .getSingleOrNull();
+    return row?.read<int>('t');
+  }
+
   setUp(() async {
     db = await setUpTestDatabase();
     dives = DiveRepository();
@@ -205,6 +219,70 @@ void main() {
         (await series.getSeriesForDive('dive-1')).every((s) => s.isPrimary),
         isTrue,
       );
+    },
+  );
+
+  test(
+    'restoreOriginalProfile leaves a primary when the primary source owns no series',
+    () async {
+      // The primary dive_data_sources row names comp-1, which owns nothing:
+      // a metadata-only source, or one whose samples a consolidation
+      // re-stamped onto another computer. Deleting the edit and then
+      // promoting by comp-1 matches zero rows, and the dive is left with no
+      // primary series at all. It keeps rendering, because getDiveById and
+      // getMergedProfile ignore the flag, while getDiveProfile,
+      // getAscentDescentRates, getTimeAtDepthRanges and the data-quality
+      // prefilters all silently skip it (issue #1149).
+      await computer('comp-1');
+      await computer('comp-2');
+      await dives.createDive(dive('dive-1', const []));
+      await source('src-1', 'dive-1', 'comp-1', primary: true);
+      final owned = await series.insertSeries(
+        diveId: 'dive-1',
+        computerId: 'comp-2',
+        isPrimary: false,
+        samples: const [ProfileSample(timestamp: 0, depth: 1.0)],
+        now: 1000,
+      );
+      await series.insertSeries(
+        diveId: 'dive-1',
+        sourceId: 'src-1',
+        samples: const [ProfileSample(timestamp: 0, depth: 9.0)],
+        now: 1000,
+      );
+      await dives.restoreOriginalProfile('dive-1');
+      final rows = await series.getSeriesForDive('dive-1');
+      expect(rows.map((s) => s.id), [owned]);
+      expect(rows.single.isPrimary, isTrue);
+      expect((await dives.getDiveProfile('dive-1')).map((p) => p.depth), [1.0]);
+    },
+  );
+
+  test(
+    'deleteComputerReading restamps the series whose source it deletes',
+    () async {
+      // dive_profile_series.source_id is ON DELETE SET NULL, so the cascade
+      // changes the row with no updated_at bump, no hlc restamp and nothing
+      // pending. This device then reads the series as unattributed while
+      // every peer still reads it as owned by the deleted source, and no
+      // later write republishes it.
+      await computer('comp-1');
+      await dives.createDive(dive('dive-1', const []));
+      await source('src-1', 'dive-1', 'comp-1', primary: true);
+      final id = await series.insertSeries(
+        diveId: 'dive-1',
+        computerId: 'comp-1',
+        sourceId: 'src-1',
+        samples: const [ProfileSample(timestamp: 0, depth: 1.0)],
+        now: 1000,
+      );
+      final before = (await series.getRowsForDives(['dive-1'])).single;
+      await dives.deleteComputerReading('src-1');
+      final after = (await series.getRowsForDives(['dive-1'])).single;
+      expect(after.sourceId, isNull);
+      expect(after.updatedAt, greaterThan(before.updatedAt));
+      expect(after.hlc, isNot(before.hlc));
+      expect(await pendingSince(id), greaterThan(1000));
     },
   );
 

--- a/test/features/dive_log/data/repositories/series_computer_link_test.dart
+++ b/test/features/dive_log/data/repositories/series_computer_link_test.dart
@@ -185,6 +185,58 @@ void main() {
       expect(rows.firstWhere((r) => r.id == a).computerId, 'comp-a');
       expect(rows.firstWhere((r) => r.id == b).computerId, isNull);
     });
+
+    test('relinkComputer leaves a user-edited series unattributed and takes '
+        'back the demoted original', () async {
+      // The state a re-added computer finds on a dive the user edited before
+      // the old computer was deleted: the computer's own samples demoted and
+      // stripped of their computer by clearComputer, and the manual edit
+      // primary with a null computer of its own. Stamping the edit hands it
+      // to the next reparse, whose first act is deleteByComputer, and a
+      // series is deleted whole.
+      await insertComputerDataSource('d-mine');
+      final original = await profileSeries.insertSeries(
+        diveId: 'd-mine',
+        isPrimary: false,
+        samples: one,
+        now: 1000,
+      );
+      final edit = await profileSeries.insertSeries(
+        diveId: 'd-mine',
+        isPrimary: true,
+        samples: one,
+        now: 1000,
+      );
+      expect(
+        await profileSeries.relinkComputer('comp-a', ['d-mine'], now: 2000),
+        1,
+      );
+      final rows = await profileSeries.getRowsForDives(['d-mine']);
+      expect(rows.firstWhere((r) => r.id == original).computerId, 'comp-a');
+      expect(rows.firstWhere((r) => r.id == edit).computerId, isNull);
+    });
+
+    test(
+      'relinkComputer still stamps the live series of an unedited dive',
+      () async {
+        // The same shape without an edit: one primary null-computer series and
+        // nothing demoted beside it, which is what a plain computer delete
+        // leaves behind. That one is the computer's own and has to come back.
+        await insertComputerDataSource('d-mine');
+        final live = await profileSeries.insertSeries(
+          diveId: 'd-mine',
+          isPrimary: true,
+          samples: one,
+          now: 1000,
+        );
+        expect(
+          await profileSeries.relinkComputer('comp-a', ['d-mine'], now: 2000),
+          1,
+        );
+        final rows = await profileSeries.getRowsForDives(['d-mine']);
+        expect(rows.firstWhere((r) => r.id == live).computerId, 'comp-a');
+      },
+    );
   });
 
   group('TankPressureSeriesRepository computer link', () {

--- a/test/features/divers/data/repositories/diver_delete_fk_sync_test.dart
+++ b/test/features/divers/data/repositories/diver_delete_fk_sync_test.dart
@@ -181,6 +181,72 @@ void main() {
     expect(await pendingCountFor('dives', 'dive-c'), 1);
   });
 
+  test(
+    'a surviving legacy dive_profiles row does not block the delete',
+    () async {
+      // The v183 rung drops dive_profiles only once its rows have moved into
+      // the series table, so a device whose pack threw still carries it, and
+      // its computer_id FK has no ON DELETE action. A row of that table on
+      // another diver's dive fails `DELETE FROM dive_computers` with
+      // SqliteException(787) and rolls the whole delete back, so the diver can
+      // never be deleted on that device. DiveComputerRepository.deleteComputer
+      // guards the same statement the same way (#823).
+      await db.customStatement(
+        'CREATE TABLE dive_profiles ('
+        'id TEXT NOT NULL PRIMARY KEY, '
+        'dive_id TEXT NOT NULL REFERENCES dives (id) ON DELETE CASCADE, '
+        'computer_id TEXT REFERENCES dive_computers (id), '
+        'timestamp INTEGER NOT NULL, '
+        'depth REAL NOT NULL)',
+      );
+      await insertDiver('diver-a');
+      await insertDiver('diver-b');
+      const stale = 1000;
+      await db
+          .into(db.diveComputers)
+          .insert(
+            DiveComputersCompanion.insert(
+              id: 'comp-a',
+              name: 'Perdix',
+              diverId: const Value('diver-a'),
+              createdAt: stale,
+              updatedAt: stale,
+            ),
+          );
+      await db
+          .into(db.dives)
+          .insert(
+            DivesCompanion.insert(
+              id: 'dive-b',
+              diverId: const Value('diver-b'),
+              diveDateTime: stale,
+              createdAt: stale,
+              updatedAt: stale,
+            ),
+          );
+      await db.customStatement(
+        'INSERT INTO dive_profiles (id, dive_id, computer_id, timestamp, depth) '
+        'VALUES (?, ?, ?, ?, ?)',
+        ['dp-b', 'dive-b', 'comp-a', 0, 1.0],
+      );
+
+      await repository.deleteDiverWithReassignment('diver-a');
+
+      expect(
+        await db
+            .customSelect("SELECT id FROM divers WHERE id = 'diver-a'")
+            .get(),
+        isEmpty,
+      );
+      final profile = await db
+          .customSelect(
+            "SELECT computer_id FROM dive_profiles WHERE id = 'dp-b'",
+          )
+          .getSingle();
+      expect(profile.readNullable<String>('computer_id'), isNull);
+    },
+  );
+
   test('a dive of the deleted diver is not marked pending', () async {
     // It is about to be deleted with its diver; marking it pending would
     // publish a row that no longer exists.

--- a/test/features/import_wizard/data/adapters/dive_computer_adapter_consolidate_integration_test.dart
+++ b/test/features/import_wizard/data/adapters/dive_computer_adapter_consolidate_integration_test.dart
@@ -7,6 +7,7 @@ import 'package:submersion/features/dive_import/domain/services/dive_matcher.dar
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart'
     hide DiveMatchResult;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
+import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart'
     as domain;
@@ -386,5 +387,143 @@ void main() {
       db.deletionLog,
     )..where((t) => t.entityType.equals('dives'))).get();
     expect(deletionLogAfter.length, equals(deletionLogBefore.length + 1));
+  });
+
+  test('when the PRE-EXISTING target holds a series this build cannot '
+      'decode, the freshly downloaded dive is KEPT standalone instead of '
+      'being deleted', () async {
+    // The target dive was downloaded from another computer some time ago and
+    // its stored profile series has since bit-rotted (or was written by a
+    // newer peer's codec). DiveConsolidationService.apply refuses the fold
+    // with UnreadableSeriesException before touching anything.
+    await computerRepository.createComputer(
+      DiveComputer.create(
+        id: 'primary-computer-unreadable',
+        name: 'Primary Computer',
+        diverId: diverId,
+      ),
+    );
+
+    final entryTime = DateTime.utc(2026, 7, 4, 9);
+    await diveRepository.createDive(
+      domain.Dive(
+        id: 'target-dive-unreadable',
+        dateTime: entryTime,
+        entryTime: entryTime,
+        runtime: const Duration(minutes: 40),
+        maxDepth: 25.0,
+        diverId: diverId,
+        profile: const [
+          domain.DiveProfilePoint(timestamp: 0, depth: 0),
+          domain.DiveProfilePoint(timestamp: 600, depth: 25),
+          domain.DiveProfilePoint(timestamp: 1200, depth: 0),
+        ],
+      ),
+    );
+    await (db.update(
+      db.dives,
+    )..where((t) => t.id.equals('target-dive-unreadable'))).write(
+      const DivesCompanion(computerId: Value('primary-computer-unreadable')),
+    );
+
+    // Corrupt the target's stored blob in place, the way storage bit-rot
+    // would: the row and its summary scalars still look sound.
+    final seriesRow = (await ProfileSeriesRepository().getRowsForDives([
+      'target-dive-unreadable',
+    ])).single;
+    final broken = Uint8List.fromList(seriesRow.samples)..[3] ^= 0xFF;
+    await db.customStatement(
+      'UPDATE dive_profile_series SET samples = ? WHERE id = ?',
+      [broken, seriesRow.id],
+    );
+
+    final secondaryComputer = await computerRepository.createComputer(
+      DiveComputer.create(
+        id: 'secondary-computer-unreadable',
+        name: 'Secondary Computer',
+        diverId: diverId,
+      ),
+    );
+
+    final downloadedDive = DownloadedDive(
+      startTime: entryTime,
+      durationSeconds: 2400,
+      maxDepth: 24.5,
+      profile: [
+        const ProfileSample(timeSeconds: 0, depth: 0.0),
+        const ProfileSample(timeSeconds: 60, depth: 24.5),
+      ],
+      tanks: const [],
+      events: const [],
+    );
+
+    final importService = DiveImportService(
+      repository: computerRepository,
+      diveRepository: diveRepository,
+    );
+
+    final adapter = DiveComputerAdapter(
+      importService: importService,
+      computerRepository: computerRepository,
+      diveRepository: diveRepository,
+      consolidationService: consolidationService,
+      diverId: diverId,
+      knownComputer: secondaryComputer,
+    );
+    adapter.setDownloadedDives([downloadedDive]);
+
+    final rawBundle = await adapter.buildBundle();
+    final bundleWithDupes = ImportBundle(
+      source: rawBundle.source,
+      groups: {
+        ImportEntityType.dives: EntityGroup(
+          items: rawBundle.groups[ImportEntityType.dives]!.items,
+          duplicateIndices: {0},
+          matchResults: const {
+            0: DiveMatchResult(
+              diveId: 'target-dive-unreadable',
+              score: 0.9,
+              timeDifferenceMs: 0,
+              matchedComputerId: 'primary-computer-unreadable',
+            ),
+          },
+        ),
+      },
+    );
+
+    final deletionLogBefore = await (db.select(
+      db.deletionLog,
+    )..where((t) => t.entityType.equals('dives'))).get();
+
+    final result = await adapter.performImport(
+      bundleWithDupes,
+      {
+        ImportEntityType.dives: {0},
+      },
+      {
+        ImportEntityType.dives: {0: DuplicateAction.consolidate},
+      },
+    );
+
+    // The fold did not happen, but the download is good data and the
+    // computer's fingerprint advances past it on the way out of
+    // performImport, so it counts as imported rather than skipped.
+    expect(result.consolidatedCount, equals(0));
+    expect(result.skippedCount, equals(0));
+    expect(result.importedCounts[ImportEntityType.dives], equals(1));
+    expect(result.importedDiveIds, hasLength(1));
+
+    // Both dives are still there: the target untouched, the download kept
+    // standalone rather than compensated away.
+    final allDives = await db.select(db.dives).get();
+    expect(allDives.map((d) => d.id), contains('target-dive-unreadable'));
+    expect(allDives, hasLength(2));
+    expect(allDives.map((d) => d.id), contains(result.importedDiveIds.single));
+
+    // Nothing was tombstoned.
+    final deletionLogAfter = await (db.select(
+      db.deletionLog,
+    )..where((t) => t.entityType.equals('dives'))).get();
+    expect(deletionLogAfter.length, equals(deletionLogBefore.length));
   });
 }

--- a/test/features/import_wizard/data/adapters/suunto_cloud_adapter_test.dart
+++ b/test/features/import_wizard/data/adapters/suunto_cloud_adapter_test.dart
@@ -10,6 +10,7 @@ import 'package:submersion/features/dive_log/data/repositories/dive_computer_rep
     hide DiveMatchResult;
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
+import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/import_wizard/data/adapters/suunto_cloud_adapter.dart';
 import 'package:submersion/features/import_wizard/domain/models/duplicate_action.dart';
@@ -476,6 +477,39 @@ void main() {
       expect(result.consolidatedCount, 0);
       expect(result.skippedCount, 1);
       verify(mockDiveRepo.bulkDeleteDives(['new-dive-id'])).called(1);
+    });
+
+    test('keeps the imported dive standalone when the PRE-EXISTING target '
+        'holds a series this build cannot decode', () async {
+      final bundle = await bundleWithMatch();
+      when(
+        mockDiveRepo.getComputerIdForDive('existing-dive'),
+      ).thenAnswer((_) async => 'other-computer');
+      stubImportAsNew();
+      when(
+        mockConsolidationService.apply(
+          targetDiveId: anyNamed('targetDiveId'),
+          secondaryDiveIds: anyNamed('secondaryDiveIds'),
+        ),
+      ).thenThrow(const UnreadableSeriesException(['series-1']));
+
+      final result = await adapter.performImport(
+        bundle,
+        {
+          ImportEntityType.dives: {0},
+        },
+        {
+          ImportEntityType.dives: {0: DuplicateAction.consolidate},
+        },
+      );
+
+      // The refusal is about the target's stored blob, not the download, so
+      // the freshly imported dive is kept rather than compensated away.
+      expect(result.consolidatedCount, 0);
+      expect(result.skippedCount, 0);
+      expect(result.importedCounts[ImportEntityType.dives], 1);
+      expect(result.importedDiveIds, ['new-dive-id']);
+      verifyNever(mockDiveRepo.bulkDeleteDives(any));
     });
 
     test('does not rethrow when the compensating delete also fails', () async {

--- a/test/features/universal_import/presentation/providers/import_consolidation_service_test.dart
+++ b/test/features/universal_import/presentation/providers/import_consolidation_service_test.dart
@@ -5,6 +5,7 @@ import 'package:submersion/features/dive_import/domain/services/dive_matcher.dar
 import 'package:submersion/features/dive_log/data/repositories/dive_repository_impl.dart';
 import 'package:submersion/features/dive_log/data/services/dive_consolidation_service.dart';
 import 'package:submersion/features/dive_log/data/services/dive_merge_snapshot.dart';
+import 'package:submersion/features/dive_log/domain/services/unreadable_series_exception.dart';
 import 'package:submersion/features/universal_import/data/services/import_duplicate_checker.dart';
 import 'package:submersion/features/universal_import/presentation/providers/import_consolidation_service.dart';
 
@@ -250,6 +251,45 @@ void main() {
     // -------------------------------------------------------------------
     // Non-atomic import+consolidate hardening (Task 8, PR review finding 2)
     // -------------------------------------------------------------------
+
+    test('when apply() reports the PRE-EXISTING target holds an undecodable '
+        'series, the freshly-imported dive is KEPT standalone', () async {
+      when(
+        mockConsolidationService.apply(
+          targetDiveId: 'existing-dive-a',
+          secondaryDiveIds: ['new-dive-0'],
+        ),
+      ).thenThrow(const UnreadableSeriesException(['series-1']));
+
+      final summary = await performConsolidations(
+        indices: {0, 1},
+        diveIdByIndex: {0: 'new-dive-0', 1: 'new-dive-1'},
+        duplicateResult: const ImportDuplicateResult(
+          diveMatches: {
+            0: DiveMatchResult(
+              diveId: 'existing-dive-a',
+              score: 0.9,
+              timeDifferenceMs: 100,
+            ),
+            1: DiveMatchResult(
+              diveId: 'existing-dive-b',
+              score: 0.95,
+              timeDifferenceMs: 50,
+            ),
+          },
+        ),
+        consolidationService: mockConsolidationService,
+        diveRepository: mockDiveRepository,
+      );
+
+      expect(summary.consolidated, 1);
+      expect(summary.failed, 0);
+      expect(summary.keptStandalone, 1);
+      // new-dive-0 is still in the DB as its own dive, so it must NOT be
+      // reported as removed; only the folded new-dive-1 is.
+      expect(summary.removedDiveIds, {'new-dive-1'});
+      verifyNever(mockDiveRepository.bulkDeleteDives(any));
+    });
 
     test('when apply() throws, the freshly-imported standalone dive is '
         'deleted and the loop continues to remaining indices', () async {


### PR DESCRIPTION
## Summary

Follow-ups from a max-effort code review of #1406 (profile sample storage, schema v182/v183), which is already merged to `main`. Twelve fixes, each with a test that failed before the change. Two of the review's findings were refuted by measurement and deliberately not acted on; one was declined with a reason. Details below.

Nothing here has shipped: `main` is at v183 with the app version 1.7.7 unreleased, so no device in the wild has run this migration yet.

## Changes

### Packer coverage parity

"Is this legacy row already represented by a series row" is answered **twice**, in two languages: in Dart by `profile_series_pack.dart` to decide whether to WRITE a series, and in SQL by `legacyRowCoveredSql` to decide whether to DELETE the staged rows. Three places the two had drifted apart, each producing the identical failure: nothing written, nothing cleared, the staging table never drains, and the pack re-runs over those rows on every sync apply for the life of the install while the peer's samples are never visible.

- The Dart side asked coverage of the **resolved** parent ids (a dangling computer collapsed to null) while the SQL asked it of the **raw** `p.computer_id`. A staged row naming a computer this device has not merged yet was therefore swallowed by the null-means-any wildcard, dropping a genuine second source. A merged group now carries every raw identity that resolved into it and is covered only when all of them are.
- The staged tank clear ran without `byGroupIdentity` while the pack that had just run used the null-is-a-wildcard rule, so unattributed pressures never drained against a series carrying a computer. This is the documented motivating case: consolidation's `stampComputerWhereNull` puts a computer on this device's series while a below-floor peer still holds the readings unattributed. The tank scan had the same gap.
- `_boolOf` and the coverage predicate disagreed on a NULL `is_primary` and on text SQLite cannot read as a number (the staging table takes a peer's JSON, and INTEGER affinity leaves an unconvertible value as TEXT). The SQL is now spelled to agree on every value, and both sides carry a "change these together" note.

### Page reclamation

The one-shot post-migration `VACUUM` was gated on `storedBefore < 183`, but the drop is decided by a different layer. The v183 rung is explicitly allowed to skip its drop, and the `beforeOpen` backstop then drops on a later open, which no version comparison can see. That open never reclaimed, and this is the only `VACUUM` of the live database anywhere in the app, so the file kept its freed pages permanently. Reclamation now keys off a drop having actually happened.

### Series attribution

- `relinkComputer` stamped the user's edited profile, which carries a null `computerId` on purpose. The next reparse of that dive calls `deleteByComputer` first, and a series is one all-or-nothing row: the correction would be deleted whole and tombstoned to every peer.
- `restoreOriginalProfile` promoted by computer with no ownership pre-check, the guard both sibling promote paths already got in #1406, and could leave a dive with zero primary series (still rendering in some readers, silently skipped by others).
- `deleteComputerReading` and `clearSourceAndProfiles` let the `ON DELETE SET NULL` cascade change `source_id` with no `updated_at` bump, no hlc restamp and nothing pending. This device then resolved ownership as unattributed while every peer still resolved it to the deleted source, and nothing healed it: a series row publishes only when its own hlc advances.
- `deleteDiverWithReassignment` lost its legacy `dive_profiles` clear, but that table can survive v183 (the rung logs "Keeping dive_profiles: N row(s)") and its `computer_id` FK has no `ON DELETE` action. A surviving row on another diver's dive failed step 4 with `SqliteException(787)` and rolled the whole delete back, so the diver could never be deleted on that device.

### Import and sync

- An `UnreadableSeriesException` from the consolidation fold is about the **pre-existing** dive, not the new one, so deleting the fresh download and then advancing the computer's `lastFingerprint` past it lost data libdivecomputer would never offer again. The new dive is now kept standalone at all three call sites. The Suunto path's bare `catch (_)` gained a log line while I was there.
- The data quality inbox called `DiveSplitService.split()` outside any error handling and never awaited the result, so a failure was a silent no-op: the diver tapped Repair, nothing happened, and the finding stayed open forever.
- `_adoptApplyStreaming`'s base-file branch set `sawLegacySamples` but never `sawParents`, unlike the other three copies of that loop, so rows staged by an earlier changeset did not drain on the adopt that delivered the parent unblocking them.
- Header scalars are compared by bit pattern rather than `!=`, and a non-finite depth is now rejected explicitly: it cannot be stored in a NOT NULL REAL column and would take down its whole insert batch rather than itself.

### From review of this PR

Copilot raised two findings on #1444, both variations on "a declared column type is not a guarantee about any particular value, because SQLite stores a class per value":

- The tank-pressure loop cast `timestamp` and `pressure` with `as num?`, so one unreadable byte cost the dive its whole pressure curve. Both loops, and `profileSampleOf`'s `timestamp` / `depth`, now use `is! num` type tests, which folds the unreadable case into the null case that has always been stepped over as a skipped row. Failing the dive only looked like a deferred retry: the retry reads the same byte and fails identically, so the dive's good samples stayed invisible and its legacy rows kept the table alive forever, which also blocks the reclamation above. The residue count now agrees on what "holds no sample" means, or it waits forever for a pack that can never claim the row.
- The orphan-adoption pre-pass read `MIN(timestamp)` as an int behind an `IS NOT NULL` filter. It runs outside the per-dive `try/catch`, so that throw cost every dive, profile side included.

### Smaller

- `realOf` / `intOf` degrade one unreadable optional field to null instead of costing the dive its entire profile. `timestamp` and `depth` deliberately still fail the row, since without them there is no sample.
- `adoptStrandedTankPressures` moves to `legacy_tank_orphan_adoption.dart`, keeping `profile_series_pack.dart` under the project's 800-line limit.

## Findings deliberately not acted on

Two of the review's findings do not hold, checked empirically rather than from the description:

- **"The backstop drops the legacy tables after `PRAGMA foreign_keys = ON`, so SQLite performs an implicit row-by-row DELETE of ~1.3M rows on the main isolate during app open."** Measured at 400k rows: **3ms with foreign keys off, 4ms with them on.** `dive_profiles` is only a *child* in its FK relationships, so the implicit delete has no per-row work and SQLite's truncate optimization still applies. The documentation the finding cites is accurate; the performance consequence does not follow.
- **"Unchecked `read<int>` / `read<String>` over dynamically typed legacy columns throws a TypeError and aborts the whole pack."** Partly right, and I originally dismissed this on incomplete evidence. Drift's `read<T>` converts rather than `as`-casts, which absorbs a REAL where an INTEGER was expected (`read<int>` over `0.5` returns `0`). But converting means parsing, so `read<int>` over TEXT `'noon'` throws a `FormatException`. Copilot caught the one place that mattered, `MIN(timestamp)` in the orphan-adoption pre-pass, where SQLite's storage-class ordering can return TEXT and the read sits outside the per-dive `try`. Fixed, and the readability rule now lives in one shared predicate (`readableNumberSql` / `readableTextSql`) used by the residue count, the packer's loops and the pre-pass alike.

And one declined:

- **`profileSeriesMigratedId` still folds `is_primary` into the derived v5 id.** Removing it, as suggested, would let a dive's saved edit and the demoted original it supersedes collide on a single id, which `INSERT OR IGNORE` would silently discard. That is a worse failure than the two-device pre-migration flag divergence it would fix, and the review itself rated this its lowest-confidence finding.

## Test Plan

- [x] `flutter test` passes: **23,114 passed, 21 skipped, 0 failed**, plus a 658-test re-run covering the two files touched after that run
- [x] `flutter analyze` passes: `dart analyze` project-wide reports **No issues found** (CI treats infos as fatal)
- [x] `dart format .` reports 0 files changed
- [ ] Manual testing: not applicable, no UI change beyond the data quality inbox now showing an existing error snackbar on a failed split

New tests worth naming:

- `test/core/database/profile_series_pack_coverage_parity_test.dart`, covering all three Dart/SQL coverage disagreements plus the per-field degradation
- `test/core/services/database_service_vacuum_test.dart`, a file stamped 183 whose legacy table the backstop drops (stranded 439 pages before the fix)
- `test/core/services/sync/series_header_scalar_comparison_test.dart`, the `-0.0` vs `0.0` header disagreement
