### PR TITLE
feat(import): decode MacDive ZRAWDATA for any libdivecomputer model

### DIFF
--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -573,7 +573,11 @@ That last tolerance is deliberately gross. MacDive routinely omits its units
 row, so a whole logbook can be read as feet when it is metres (#912) - a 3.28x
 error in the recorded scalar that says nothing about whether the raw bytes
 decoded correctly. A tighter bound would discard good profiles to catch bad
-ones that the absolute limits already catch. A rejected parse falls back to
+ones that the absolute limits already catch. The two sides of that comparison
+are not symmetric: a recorded value of zero is MacDive saying it has no figure
+and cannot reject anything, while a parsed depth of zero is libdivecomputer
+asserting the diver never left the surface, which against a recorded 30 m dive
+is exactly the wrong-format parse this check exists to catch. A rejected parse falls back to
 exactly the behaviour an unrecognised computer already had: it counts toward
 one aggregated warning pointing at MacDive's XML export.
 

--- a/docs/import-formats/macdive-zsamples.md
+++ b/docs/import-formats/macdive-zsamples.md
@@ -4,10 +4,12 @@
 
 `ZSAMPLES` remains NO-GO (AES-encrypted with a per-dive key, documented below) but is now moot: every Shearwater dive that has `ZSAMPLES` also has `ZRAWDATA`.
 
+**Second correction (see "Update 2026-09-01" below):** the per-model tables both earlier updates produced are gone. `ZCOMPUTER` is now resolved against libdivecomputer's own descriptor list, so any model it supports is attempted and the result is sanity-checked rather than trusted. Read that section before adding anything model-specific here.
+
 **Correction (see "Update 2026-08-29" below):** the claim in the previous paragraph that "non-Shearwater dives have neither [`ZSAMPLES` nor `ZRAWDATA`] and still need MacDive's XML export" was never actually tested against Suunto computers — the investigation corpus contained none. It turns out at least three Suunto models (EON Steel, EON Steel Black, Cobra) do populate `ZRAWDATA`, and unlike Shearwater's, theirs needs no decompression at all.
 
 The 2026-04-24 "ZRAWDATA pivot invalidated" section below is **historically inaccurate** and is retained only to show how the wrong conclusion was reached.
-**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved), 2026-08-29 (Suunto ZRAWDATA confirmed)
+**Date:** 2026-04-23 (initial), 2026-04-24 (ZRAWDATA invalidation), 2026-08-09 (ZRAWDATA solved), 2026-08-29 (Suunto ZRAWDATA confirmed), 2026-09-01 (model allowlist removed)
 **Author:** Eric Griffin
 **Spec:** `docs/superpowers/specs/2026-04-23-macdive-sqlite-profile-decoding-design.md`
 **Plan:** `docs/superpowers/plans/2026-04-23-macdive-zsamples-phase-1-spike.md`
@@ -493,4 +495,128 @@ Confirmed by model (against real MacDive `ZRAWDATA`, not just the vendor name):
 
 Implemented in `MacDiveDiveMapper._suuntoVendorProduct` / `_attachProfile` (`lib/features/universal_import/data/services/macdive_dive_mapper.dart`): the mapper now branches on vendor, running `ShearwaterRawDecompressor` only for Shearwater and passing every other recognized vendor's bytes straight to `parse`. See [submersion-app/submersion#1399](https://github.com/submersion-app/submersion/issues/1399) and the fix PR.
 
-**Not yet validated:** other Suunto models likely follow the same uncompressed-native-format pattern (Suunto's own product line shares firmware lineage), but no real `ZRAWDATA` from any other Suunto model has been confirmed. Computers outside the three above still fall through to the "no `ZRAWDATA`" warning path — a future contributor with real data from another Suunto model should add it to `_suuntoVendorProduct` only after confirming its `ZRAWDATA` parses cleanly, per the caller-facing trap noted above (a failed native parse can silently return a zeroed dive rather than an error).
+**Superseded by the 2026-09-01 update below:** `_suuntoVendorProduct` no longer exists, and no table entry is needed to support another model. The paragraph is kept for the reasoning it records.
+
+**Not yet validated (as of 2026-08-29):** other Suunto models likely follow the same uncompressed-native-format pattern (Suunto's own product line shares firmware lineage), but no real `ZRAWDATA` from any other Suunto model has been confirmed. Computers outside the three above still fall through to the "no `ZRAWDATA`" warning path — a future contributor with real data from another Suunto model should add it to `_suuntoVendorProduct` only after confirming its `ZRAWDATA` parses cleanly, per the caller-facing trap noted above (a failed native parse can silently return a zeroed dive rather than an error).
+
+## Update 2026-09-01: the model allowlist is gone
+
+Two rounds of this feature landed as one-model-at-a-time table entries: #961
+added Shearwater, #1400 added three Suunto models. Both were correct about the
+bytes and wrong about the scope, because both recorded a *data* limit ("we only
+had blobs for these") as a *format* limit ("only these have usable
+`ZRAWDATA`"). A user with a Suunto D5, a Mares Puck, or an Oceanic Geo hit the
+warning path with a perfectly decodable blob sitting in the database. #1436
+removed the tables rather than adding a third entry.
+
+### What resolution does now
+
+`ZDIVE.ZCOMPUTER` is matched against libdivecomputer's own descriptor list,
+read once per import through `DiveComputerHostApi.getDeviceDescriptors()` and
+indexed by `DiveComputerDescriptorIndex`
+(`lib/features/universal_import/data/services/dive_computer_descriptor_index.dart`).
+Every model the vendored submodule supports is a candidate, and the set grows
+on its own when the submodule advances.
+
+Matching rules, in order:
+
+1. Case and whitespace are ignored, the same tolerance the native BLE-name
+   matcher applies (`strcasecmp_nospace` in `libdc_wrapper.c`), so "Puck4"
+   matches the product "Puck 4".
+2. The name is matched a whole token at a time from the front, longest first,
+   so "Suunto EON Steel Black" prefers its own descriptor over the shorter
+   "Suunto EON Steel", and a decorated name falls back to the longest known
+   prefix.
+3. A name matching nothing resolves to nothing. This is load-bearing:
+   "Oceanic Matrix Master" pairs a real libdivecomputer vendor with a product
+   that does not exist there, and "No Computer" is not a device at all.
+
+The #1400 note that Suunto has "no prefix convention to strip" was not quite
+right. All three of its entries were exactly `"Suunto " + <libdivecomputer
+product>`, the same shape as `"Shearwater Teric"`; the convention was already
+general, which is why one matcher now covers both.
+
+### Ambiguous product names
+
+libdivecomputer declares seven `(vendor, product)` pairs more than once, with
+different model numbers:
+
+| Vendor | Product | Models |
+|---|---|---|
+| Aeris | Elite T3 | 0x4259, 0x4455 |
+| Aeris | Epic | 0x4257, 0x4453 |
+| Aqualung | i100 | 0x464E, 0x4745 |
+| Aqualung | i200C | 0x4649, 0x4749 |
+| Oceanic | OC1 | 0x434E, 0x4449, 0x4451 |
+| Suunto | Zoop Novo | 0x1E, 0x1F |
+| Uwatec | Aladin 2G | 0x13, 0x15 |
+
+Each set sits within one family, so the parser is the same either way, but the
+model number reaches the parser and can steer header layout. The mapper tries
+each candidate in declaration order and keeps the first whose parse passes the
+sanity check below. Passing a real model number also means
+`find_descriptor`'s `model == 0` wildcard (`libdc_download.c`) is no longer
+load-bearing for this path.
+
+### The parse is checked, not trusted
+
+Attempting any recognised model makes a structurally plausible parse of the
+wrong bytes a live possibility, which the "caller-facing trap" above already
+warned about in its narrower form. `RawProfileSanityCheck`
+(`lib/features/universal_import/data/services/raw_profile_sanity_check.dart`)
+gates every result: samples must exist, sample times must be non-negative and
+non-decreasing, depth must sit within (-3 m, 350 m], duration within 24 h, and
+the parsed depth and duration must not contradict MacDive's own scalars for
+the same dive by more than a factor of five.
+
+That last tolerance is deliberately gross. MacDive routinely omits its units
+row, so a whole logbook can be read as feet when it is metres (#912) - a 3.28x
+error in the recorded scalar that says nothing about whether the raw bytes
+decoded correctly. A tighter bound would discard good profiles to catch bad
+ones that the absolute limits already catch. A rejected parse falls back to
+exactly the behaviour an unrecognised computer already had: it counts toward
+one aggregated warning pointing at MacDive's XML export.
+
+### Vendor pre-passes
+
+Shearwater remains the only vendor whose `ZRAWDATA` needs work before the
+parser sees it, and it is the exception rather than the rule: libdivecomputer
+decompresses inside its own device layer (`shearwater_common.c:550` and `:567`),
+so any host that downloads through libdivecomputer ends up holding native
+bytes. MacDive storing the compressed stream tells us its Shearwater download
+path is its own. The transform is now a vendor-keyed entry in
+`MacDiveDiveMapper._rawPrePasses`, so a second such vendor is one line.
+
+### Correcting the per-computer presence table
+
+The table under "Per-computer presence" is still accurate as a count, but the
+conclusion drawn from it was not. Presence of `ZRAWDATA` tracks **how the dive
+entered MacDive** - a native download versus manual entry or a file import -
+not which vendor made the computer. The corpus happened to contain Shearwater
+dives that MacDive downloaded and Oceanic dives that it did not, and that
+coincidence read as a vendor rule for two releases running.
+
+### Confirming a new family
+
+The generic path means no code change is needed to support another computer.
+What is still worth doing, when someone has real data, is proving a family
+decodes:
+
+1. Pull one `ZRAWDATA` blob for the dive:
+   `sqlite3 MacDive.sqlite "SELECT writefile('blob.bin', ZRAWDATA) FROM ZDIVE WHERE Z_PK = <pk>;"`
+2. Feed it to `libdc_parse_raw_dive` with the vendor, product and model the
+   descriptor list gives for that `ZCOMPUTER` string. The native harness in
+   `packages/libdivecomputer_plugin/test/native/test_parse_raw_dive.c` is the
+   template; `fixtures/dive1_raw.bin` shows the shape.
+3. Check the result against what MacDive shows for the dive: max depth,
+   duration and sample count, not just a zero return code.
+4. Commit the blob as a fixture with an assertion on real decoded values.
+   Anonymise it first if it carries a serial number.
+
+**Still missing:** no anonymised Suunto `ZRAWDATA` exists in this repository,
+so the #1400 tests continue to stub `parseRaw` and prove byte pass-through and
+name resolution rather than a real decode. The Shearwater path does have real
+bytes (`shearwater_raw_decompressor_test.dart` pins the Dart port against a
+blob generated from the 540-dive corpus). A contributor with a real Suunto
+database can close that gap by following the recipe above; it needs data, not
+a design change.

--- a/lib/features/universal_import/data/services/dive_computer_descriptor_index.dart
+++ b/lib/features/universal_import/data/services/dive_computer_descriptor_index.dart
@@ -76,9 +76,10 @@ class DiveComputerDescriptorIndex {
     for (final d in descriptors) {
       final vendor = d.vendor.trim();
       final product = d.product.trim();
+      // Both are non-empty after trimming, so the normalised key cannot be
+      // empty either.
       if (vendor.isEmpty || product.isEmpty) continue;
       final key = normalize('$vendor $product');
-      if (key.isEmpty) continue;
       byKey
           .putIfAbsent(key, () => <DiveComputerModel>[])
           .add(

--- a/lib/features/universal_import/data/services/dive_computer_descriptor_index.dart
+++ b/lib/features/universal_import/data/services/dive_computer_descriptor_index.dart
@@ -1,0 +1,131 @@
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+
+/// One libdivecomputer descriptor reduced to the three values
+/// `DiveComputerHostApi.parseRawDiveData` needs.
+class DiveComputerModel {
+  final String vendor;
+  final String product;
+
+  /// libdivecomputer's model number. Several descriptors can share a
+  /// `(vendor, product)` pair and differ only here; see
+  /// [DiveComputerDescriptorIndex.resolve].
+  final int model;
+
+  const DiveComputerModel({
+    required this.vendor,
+    required this.product,
+    required this.model,
+  });
+
+  @override
+  String toString() => '$vendor $product (0x${model.toRadixString(16)})';
+
+  @override
+  bool operator ==(Object other) =>
+      other is DiveComputerModel &&
+      other.vendor == vendor &&
+      other.product == product &&
+      other.model == model;
+
+  @override
+  int get hashCode => Object.hash(vendor, product, model);
+}
+
+/// Resolves a free-text dive-computer name against libdivecomputer's own
+/// descriptor list.
+///
+/// Importers receive the computer as whatever string the source app wrote:
+/// MacDive's `ZDIVE.ZCOMPUTER` holds display names such as
+/// "Shearwater Teric" or "Suunto EON Steel Black". libdivecomputer names the
+/// same devices as a `(vendor, product)` pair, and the plugin exposes the
+/// whole table through `DiveComputerHostApi.getDeviceDescriptors()`. Matching
+/// against that table rather than a hand-maintained allowlist means every
+/// model libdivecomputer supports is reachable, and the set grows on its own
+/// whenever the vendored submodule advances (issue #1436).
+///
+/// Matching is deliberately narrow:
+///
+/// * Comparison ignores case and all whitespace, the same tolerance the
+///   native BLE-name matcher applies (`strcasecmp_nospace` in
+///   `libdc_wrapper.c`), so "Puck4" matches the product "Puck 4" and
+///   "Aqua Lung" matches the vendor "Aqualung".
+/// * A name is matched from its first token, one whole token at a time,
+///   longest first. "Suunto EON Steel Black" therefore prefers the descriptor
+///   of that exact name over the shorter "Suunto EON Steel".
+/// * A name that matches nothing resolves to an empty list. Failing closed
+///   matters because MacDive also stores names libdivecomputer has never
+///   heard of ("Oceanic Matrix Master", "No Computer"), and feeding their
+///   bytes to an arbitrary parser is worse than skipping them.
+class DiveComputerDescriptorIndex {
+  /// Normalised `"vendorproduct"` key to every descriptor sharing it, in the
+  /// order libdivecomputer declared them.
+  final Map<String, List<DiveComputerModel>> _byKey;
+
+  const DiveComputerDescriptorIndex._(this._byKey);
+
+  /// An index that resolves nothing. Used as the starting value before the
+  /// platform channel has been consulted, and as the result when it reports
+  /// no descriptors at all.
+  const DiveComputerDescriptorIndex.empty()
+    : _byKey = const <String, List<DiveComputerModel>>{};
+
+  factory DiveComputerDescriptorIndex.fromDescriptors(
+    List<pigeon.DeviceDescriptor> descriptors,
+  ) {
+    final byKey = <String, List<DiveComputerModel>>{};
+    for (final d in descriptors) {
+      final vendor = d.vendor.trim();
+      final product = d.product.trim();
+      if (vendor.isEmpty || product.isEmpty) continue;
+      final key = normalize('$vendor $product');
+      if (key.isEmpty) continue;
+      byKey
+          .putIfAbsent(key, () => <DiveComputerModel>[])
+          .add(
+            DiveComputerModel(vendor: vendor, product: product, model: d.model),
+          );
+    }
+    return DiveComputerDescriptorIndex._(byKey);
+  }
+
+  /// True when there is nothing to match against, which on a real device
+  /// means the descriptor list could not be read rather than that
+  /// libdivecomputer supports no computers.
+  bool get isEmpty => _byKey.isEmpty;
+
+  /// Number of distinct `(vendor, product)` names known. Models that differ
+  /// only by number count once.
+  int get length => _byKey.length;
+
+  /// Every descriptor matching [name], or an empty list when none does.
+  ///
+  /// More than one is returned only for the handful of `(vendor, product)`
+  /// pairs libdivecomputer declares twice (Oceanic OC1, Suunto Zoop Novo,
+  /// Uwatec Aladin 2G and four more). Those duplicates always sit inside one
+  /// family, so the parser they select is the same either way, but the model
+  /// number reaches the parser and can steer header layout. Callers should
+  /// try them in order rather than assume the first is right.
+  List<DiveComputerModel> resolve(String? name) {
+    if (name == null) return const [];
+    final tokens = name
+        .trim()
+        .split(RegExp(r'\s+'))
+        .map(normalize)
+        .where((t) => t.isNotEmpty)
+        .toList();
+    // A descriptor key always spans at least a vendor and a product, so a
+    // one-token prefix can never match; starting at the full name and
+    // shrinking gives longest-match-wins for free.
+    for (var take = tokens.length; take >= 2; take--) {
+      final match = _byKey[tokens.take(take).join()];
+      if (match != null) return match;
+    }
+    return const [];
+  }
+
+  /// Lowercases and strips whitespace, so that spacing differences between
+  /// how an app displays a model and how libdivecomputer spells it do not
+  /// prevent a match.
+  static String normalize(String value) =>
+      value.replaceAll(RegExp(r'\s+'), '').toLowerCase();
+}

--- a/lib/features/universal_import/data/services/macdive_dive_mapper.dart
+++ b/lib/features/universal_import/data/services/macdive_dive_mapper.dart
@@ -9,12 +9,13 @@ import 'package:submersion/features/dive_types/domain/entities/dive_type_entity.
 import 'package:submersion/features/universal_import/data/models/import_enums.dart';
 import 'package:submersion/features/universal_import/data/models/import_payload.dart';
 import 'package:submersion/features/universal_import/data/models/import_warning.dart';
+import 'package:submersion/features/universal_import/data/services/dive_computer_descriptor_index.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_raw_types.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_converter.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_unit_inference.dart';
 import 'package:submersion/features/universal_import/data/services/macdive_value_mapper.dart';
 import 'package:submersion/features/universal_import/data/services/parsed_dive_profile_mapper.dart';
-import 'package:submersion/features/universal_import/data/services/shearwater_filename_parser.dart';
+import 'package:submersion/features/universal_import/data/services/raw_profile_sanity_check.dart';
 import 'package:submersion/features/universal_import/data/services/shearwater_raw_decompressor.dart';
 
 /// Signature of the native raw-parse call, injectable so tests can exercise
@@ -27,31 +28,52 @@ typedef MacDiveRawParseFn =
       Uint8List data,
     );
 
+/// Signature of the native descriptor-list call, injectable for the same
+/// reason as [MacDiveRawParseFn].
+typedef MacDiveDescriptorFetchFn =
+    Future<List<pigeon.DeviceDescriptor>> Function();
+
+/// A transform applied to `ZRAWDATA` before libdivecomputer sees it, returning
+/// null when the bytes are not in the form this vendor's transform expects.
+typedef MacDiveRawPrePass = Uint8List? Function(Uint8List raw);
+
 /// Maps a [MacDiveRawLogbook] (raw SQLite rows read by [MacDiveDbReader])
 /// into a unified [ImportPayload] the rest of the import pipeline consumes
 /// without knowing the source was SQLite. Key conventions mirror the M2
 /// `MacDiveXmlParser` so the downstream `UddfEntityImporter` processes
 /// both sources through the same code path.
 ///
-/// Profile samples come from `ZRAWDATA`. For Shearwater computers this holds
-/// the raw download stream still in its compressed form: [ShearwaterRawDecompressor]
-/// reverses the two compression passes to recover Petrel Native Format, which
-/// libdivecomputer parses directly. See
+/// Profile samples come from `ZRAWDATA`, the raw download MacDive kept from
+/// whatever device layer it used. Decoding it takes two steps.
+///
+/// First, resolve `ZDIVE.ZCOMPUTER` - a display string such as
+/// "Shearwater Teric" - to a libdivecomputer descriptor. That resolution runs
+/// against libdivecomputer's own descriptor list via
+/// [DiveComputerDescriptorIndex], not a table maintained here: every model the
+/// vendored submodule supports is a candidate, and the set grows on its own as
+/// the submodule advances. Two earlier rounds of this feature each added a
+/// hardcoded entry for one more family (#961 for Shearwater, #1400 for three
+/// Suunto models) and each left every other model on the warning path with its
+/// bytes sitting unread in the database; #1436 replaced the tables outright.
+///
+/// Second, hand the bytes to `parseRawDiveData`. Almost every vendor's
+/// `ZRAWDATA` is already in the exact layout libdivecomputer's parsers expect,
+/// because MacDive downloaded it through libdivecomputer too. Shearwater is
+/// the one known exception ([_rawPrePasses]): its stream is still transport
+/// compressed, so [ShearwaterRawDecompressor] has to reverse two passes first.
+///
+/// Nothing about that resolution proves the bytes belong to the parser it
+/// selected, so [RawProfileSanityCheck] gates the result. A dive whose parse
+/// is rejected, or whose computer resolves to nothing, counts toward one
+/// aggregated [ImportWarning] pointing at MacDive's XML export - exactly the
+/// behaviour every unrecognised computer already had. See
 /// `docs/import-formats/macdive-zsamples.md`.
 ///
-/// A handful of Suunto computers ([_suuntoVendorProduct]) store `ZRAWDATA`
-/// uncompressed, already in the exact byte layout libdivecomputer's own
-/// parsers expect (SBEM for the EON Steel family, the Vyper dive-header
-/// format for Cobra) - confirmed by feeding real MacDive exports through
-/// `parseRawDiveData` with no transformation. Those bytes go straight to the
-/// parser; only Shearwater's stream needs decompressing first.
-///
-/// `ZSAMPLES` is AES-encrypted with a per-dive key and remains undecodable,
-/// but it is also redundant: every dive that has `ZSAMPLES` from a computer
-/// [_vendorProduct] recognises also has a usable `ZRAWDATA`. Dives on an
-/// unrecognised computer carry no decodable `ZRAWDATA`; those raise one
-/// aggregated [ImportWarning] pointing at MacDive's XML export as the
-/// working profile path.
+/// Not every dive has `ZRAWDATA` at all: presence tracks how the dive entered
+/// MacDive (a native download versus manual entry or a file import) rather
+/// than the vendor. `ZSAMPLES` is AES-encrypted with a per-dive key and
+/// remains undecodable, but where a dive has both columns the `ZRAWDATA` one
+/// is the readable one.
 class MacDiveDiveMapper {
   const MacDiveDiveMapper._();
 
@@ -65,6 +87,7 @@ class MacDiveDiveMapper {
   static Future<ImportPayload> toPayload(
     MacDiveRawLogbook logbook, {
     MacDiveRawParseFn? parseRaw,
+    MacDiveDescriptorFetchFn? fetchDescriptors,
   }) async {
     // MacDive routinely omits its own SystemOfUnits row, so fall back to
     // inferring the display unit from the stored magnitudes rather than
@@ -97,6 +120,31 @@ class MacDiveDiveMapper {
     // retrying it for the remaining 500 dives.
     var ffiAvailable = true;
     var undecoded = 0;
+
+    // The descriptor list is a static table inside libdivecomputer, identical
+    // for every dive, so it is read once per import rather than once per dive.
+    // Skipped entirely when no dive has raw bytes, so a logbook of manual
+    // entries never touches the platform channel.
+    var descriptors = const DiveComputerDescriptorIndex.empty();
+    if (logbook.dives.any(_hasRawProfile)) {
+      try {
+        descriptors = DiveComputerDescriptorIndex.fromDescriptors(
+          await (fetchDescriptors ?? _defaultDescriptors)(),
+        );
+        // libdivecomputer always knows some computers, so an empty list means
+        // the native side could not answer, not that nothing is supported.
+        // Reporting that as "this platform cannot decode profiles" is more
+        // honest than reporting every dive as undecodable.
+        ffiAvailable = !descriptors.isEmpty;
+      } on MissingPluginException {
+        ffiAvailable = false;
+      } on PlatformException {
+        ffiAvailable = false;
+      } catch (_) {
+        ffiAvailable = false;
+      }
+    }
+
     for (final d in logbook.dives) {
       final map = _buildDiveMap(
         d,
@@ -106,7 +154,7 @@ class MacDiveDiveMapper {
       );
       if (ffiAvailable && _hasRawProfile(d)) {
         try {
-          if (!await _attachProfile(d, map, parse)) undecoded++;
+          if (!await _attachProfile(d, map, parse, descriptors)) undecoded++;
         } on MissingPluginException {
           ffiAvailable = false;
         } on PlatformException catch (e) {
@@ -150,8 +198,10 @@ class MacDiveDiveMapper {
       );
     }
 
-    // Dives recorded on non-Shearwater computers keep their samples only in
-    // the encrypted ZSAMPLES column, so there is nothing to decode for them.
+    // Dives that MacDive did not download itself - manual entries and file
+    // imports - keep their samples only in the encrypted ZSAMPLES column, so
+    // there is nothing to decode for them regardless of which computer they
+    // name.
     final encryptedOnly = logbook.dives
         .where(
           (d) =>
@@ -254,42 +304,24 @@ class MacDiveDiveMapper {
     data,
   );
 
+  static Future<List<pigeon.DeviceDescriptor>> _defaultDescriptors() =>
+      pigeon.DiveComputerHostApi().getDeviceDescriptors();
+
   static bool _hasRawProfile(MacDiveRawDive d) =>
       d.rawDataBlob != null && d.rawDataBlob!.isNotEmpty;
 
-  /// MacDive's `ZCOMPUTER` strings for the handful of Suunto models confirmed
-  /// (against real MacDive `ZRAWDATA`, not just the vendor name) to store
-  /// their raw download already in libdivecomputer's native format. Every
-  /// entry here is a full string match against `ZCOMPUTER` as MacDive writes
-  /// it, unlike Shearwater's "strip the prefix, look up the model" scheme,
-  /// because these were verified one model at a time rather than derived from
-  /// a general naming convention. Add a computer here only after confirming
-  /// its `ZRAWDATA` parses cleanly - unlike Shearwater's transport-compressed
-  /// stream, an unverified Suunto model could be stored in a different raw
-  /// format entirely.
-  static const _suuntoVendorProduct = {
-    'Suunto EON Steel': ('Suunto', 'EON Steel'),
-    'Suunto EON Steel Black': ('Suunto', 'EON Steel Black'),
-    'Suunto Cobra': ('Suunto', 'Cobra'),
+  /// Vendors whose `ZRAWDATA` is not yet in the layout libdivecomputer's
+  /// parsers read, keyed by the descriptor vendor name.
+  ///
+  /// Shearwater is the only known member and is the exception rather than the
+  /// rule: libdivecomputer decompresses inside its own device layer
+  /// (`shearwater_common.c`), so any host that downloads through
+  /// libdivecomputer ends up holding native bytes. MacDive storing the
+  /// compressed stream tells us its Shearwater download path is its own.
+  /// A second such vendor is one entry here, not a rework.
+  static const _rawPrePasses = <String, MacDiveRawPrePass>{
+    'Shearwater': ShearwaterRawDecompressor.decompress,
   };
-
-  /// MacDive records the computer as a display string such as
-  /// "Shearwater Teric". Strip the vendor prefix and reuse the model table
-  /// the Shearwater Cloud importer already maintains. Suunto has no such
-  /// prefix convention to strip, so [_suuntoVendorProduct] matches the whole
-  /// string instead.
-  static (String, String)? _vendorProduct(String? computer) {
-    if (computer == null) return null;
-    final trimmed = computer.trim();
-    if (trimmed.isEmpty) return null;
-    final suunto = _suuntoVendorProduct[trimmed];
-    if (suunto != null) return suunto;
-    const prefix = 'Shearwater ';
-    final model = trimmed.startsWith(prefix)
-        ? trimmed.substring(prefix.length)
-        : trimmed;
-    return ShearwaterFilenameParser.vendorProduct(model);
-  }
 
   /// Decodes [d]'s `ZRAWDATA` into profile samples on [map]. Returns false
   /// when the dive carries raw bytes we could not turn into a profile, so the
@@ -298,41 +330,75 @@ class MacDiveDiveMapper {
     MacDiveRawDive d,
     Map<String, dynamic> map,
     MacDiveRawParseFn parse,
+    DiveComputerDescriptorIndex descriptors,
   ) async {
-    final vendorProduct = _vendorProduct(d.computer);
-    if (vendorProduct == null) return false;
+    final candidates = descriptors.resolve(d.computer);
+    if (candidates.isEmpty) return false;
 
-    // Only Shearwater stores ZRAWDATA in its own transport-compressed form;
-    // every other recognised vendor's bytes are already the native format
-    // libdivecomputer expects (see _suuntoVendorProduct).
-    final payload = vendorProduct.$1 == 'Shearwater'
-        ? ShearwaterRawDecompressor.decompress(d.rawDataBlob!)
-        : d.rawDataBlob!;
+    // Every candidate shares a vendor and product and differs only by model
+    // number, so the pre-pass runs once rather than per candidate.
+    final prePass = _rawPrePasses[candidates.first.vendor];
+    final payload = prePass == null ? d.rawDataBlob! : prePass(d.rawDataBlob!);
     if (payload == null || payload.isEmpty) return false;
 
-    final parsed = await parse(vendorProduct.$1, vendorProduct.$2, 0, payload);
-    // A failed native parse does not always surface as an error: the macOS
-    // wrapper has been observed returning success with a zeroed dive (no
-    // samples, 0 m, epoch date). Treat "no samples" as the real signal, so a
-    // regression in decompression shows up as a warning rather than a wave of
-    // silently empty dives.
-    final samples = ParsedDiveProfileMapper.samples(parsed);
-    if (samples.isEmpty) return false;
+    for (final candidate in candidates) {
+      final parsed = await _tryParse(parse, candidate, payload);
+      if (parsed == null) continue;
 
-    map['profile'] = samples;
-    // MacDive's own scalar fields win where it has them - the user may have
-    // corrected them - so parsed values only fill gaps, and only with values
-    // that mean something.
-    if (parsed.maxDepthMeters > 0) map['maxDepth'] ??= parsed.maxDepthMeters;
-    if (parsed.avgDepthMeters > 0) map['avgDepth'] ??= parsed.avgDepthMeters;
-    map['decoAlgorithm'] ??= parsed.decoAlgorithm;
-    map['gradientFactorLow'] ??= parsed.gfLow;
-    map['gradientFactorHigh'] ??= parsed.gfHigh;
-    map['waterTemp'] ??= ParsedDiveProfileMapper.minSampleTemperature(parsed);
-    if (map['runtime'] == null && parsed.durationSeconds > 0) {
-      map['runtime'] = Duration(seconds: parsed.durationSeconds);
+      // A failed native parse does not always surface as an error: the macOS
+      // wrapper has been observed returning success with a zeroed dive, and
+      // now that any libdivecomputer-supported model is attempted rather than
+      // an allowlist, a structurally plausible parse of the wrong format is a
+      // live possibility too.
+      if (!RawProfileSanityCheck.accepts(
+        parsed,
+        recordedMaxDepthMeters: (map['maxDepth'] as num?)?.toDouble(),
+        recordedDuration: map['runtime'] as Duration?,
+      )) {
+        continue;
+      }
+      final samples = ParsedDiveProfileMapper.samples(parsed);
+      if (samples.isEmpty) continue;
+
+      map['profile'] = samples;
+      // MacDive's own scalar fields win where it has them - the user may have
+      // corrected them - so parsed values only fill gaps, and only with values
+      // that mean something.
+      if (parsed.maxDepthMeters > 0) map['maxDepth'] ??= parsed.maxDepthMeters;
+      if (parsed.avgDepthMeters > 0) map['avgDepth'] ??= parsed.avgDepthMeters;
+      map['decoAlgorithm'] ??= parsed.decoAlgorithm;
+      map['gradientFactorLow'] ??= parsed.gfLow;
+      map['gradientFactorHigh'] ??= parsed.gfHigh;
+      map['waterTemp'] ??= ParsedDiveProfileMapper.minSampleTemperature(parsed);
+      if (map['runtime'] == null && parsed.durationSeconds > 0) {
+        map['runtime'] = Duration(seconds: parsed.durationSeconds);
+      }
+      return true;
     }
-    return true;
+    return false;
+  }
+
+  /// Runs one candidate model through the parser, returning null when that
+  /// model did not work out. Errors that mean the channel itself is gone are
+  /// rethrown, because retrying the next candidate cannot help.
+  static Future<pigeon.ParsedDive?> _tryParse(
+    MacDiveRawParseFn parse,
+    DiveComputerModel candidate,
+    Uint8List payload,
+  ) async {
+    try {
+      return await parse(
+        candidate.vendor,
+        candidate.product,
+        candidate.model,
+        payload,
+      );
+    } on MissingPluginException {
+      rethrow;
+    } on PlatformException catch (e) {
+      if (e.code == 'UNSUPPORTED' || e.code == 'channel-error') rethrow;
+      return null;
+    }
   }
 
   // ---- dive types / centers / certifications / service records / divers ----

--- a/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
+++ b/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
@@ -1,0 +1,115 @@
+import 'dart:math' as math;
+
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+
+/// Decides whether a speculative libdivecomputer parse produced a dive
+/// profile worth keeping.
+///
+/// Importers that recover raw device bytes from a third-party logbook do not
+/// know for certain which parser those bytes belong to: the source app records
+/// a display name, not a libdivecomputer descriptor, and the mapping between
+/// them is a best guess. A wrong guess does not necessarily fail loudly.
+/// libdivecomputer will happily walk bytes in the wrong format and emit a
+/// structurally plausible series - the macOS wrapper has even been observed
+/// returning success with a zeroed dive - so "the call did not throw" is not
+/// evidence the profile is real (issue #1436).
+///
+/// The checks here are intentionally coarse. Their job is to reject nonsense,
+/// not to referee a close call: a rejected dive falls back to exactly the
+/// behaviour a dive on an unrecognised computer already has, so a false
+/// negative costs a profile that would otherwise be garbage, while a false
+/// positive attaches an invented depth series to a real dive.
+class RawProfileSanityCheck {
+  const RawProfileSanityCheck._();
+
+  /// Deeper than any dive on record (the open-circuit record is ~332 m), so
+  /// anything past this is a misread field, not a dive.
+  static const maxPlausibleDepthMeters = 350.0;
+
+  /// Long enough for any saturation-adjacent rebreather dive a recreational
+  /// logbook will hold.
+  static const maxPlausibleDuration = Duration(hours: 24);
+
+  /// Computers occasionally log a slightly negative depth at the surface from
+  /// pressure-sensor drift. Anything past this is a sign bit read out of the
+  /// wrong field.
+  static const _minPlausibleDepthMeters = -3.0;
+
+  /// How far the parsed values may diverge from what the source app recorded
+  /// for the same dive before the parse is rejected.
+  ///
+  /// This is a *gross* tolerance on purpose. A tight one would reject good
+  /// parses whenever the source's own scalars are off, and MacDive's are:
+  /// it routinely omits its units row, so a whole logbook can be read as feet
+  /// when it is metres or the reverse (#912), a 3.28x error that says nothing
+  /// about whether the raw bytes decoded correctly. Wrong-format parses miss
+  /// by far more than this.
+  static const _grossFactor = 5.0;
+  static const _depthFloorMeters = 5.0;
+  static const _durationFloor = Duration(minutes: 5);
+
+  /// Whether [parsed] should be accepted as this dive's profile.
+  ///
+  /// [recordedMaxDepthMeters] and [recordedDuration] are the source app's own
+  /// values for the same dive, in SI units, or null where it recorded none.
+  /// They are used only as a gross cross-check; the hard bounds apply either
+  /// way.
+  static bool accepts(
+    pigeon.ParsedDive parsed, {
+    double? recordedMaxDepthMeters,
+    Duration? recordedDuration,
+  }) {
+    // No samples means the parser found no profile at all, whatever else it
+    // filled in. This is the failure mode a zeroed dive presents as.
+    if (parsed.samples.isEmpty) return false;
+
+    var deepest = parsed.maxDepthMeters;
+    var previousTime = -1;
+    for (final s in parsed.samples) {
+      // libdivecomputer accumulates sample time as it walks the record
+      // stream, so a real profile is always non-negative and non-decreasing.
+      // Bytes read in the wrong format are not.
+      if (s.timeSeconds < 0 || s.timeSeconds < previousTime) return false;
+      previousTime = s.timeSeconds;
+      if (s.depthMeters < _minPlausibleDepthMeters) return false;
+      if (s.depthMeters > deepest) deepest = s.depthMeters;
+    }
+
+    if (deepest > maxPlausibleDepthMeters) return false;
+
+    final durationSeconds = math.max(parsed.durationSeconds, previousTime);
+    if (durationSeconds < 0) return false;
+    if (durationSeconds > maxPlausibleDuration.inSeconds) return false;
+
+    if (!_withinGross(
+      parsed: deepest,
+      recorded: recordedMaxDepthMeters,
+      floor: _depthFloorMeters,
+    )) {
+      return false;
+    }
+    if (!_withinGross(
+      parsed: durationSeconds.toDouble(),
+      recorded: recordedDuration?.inSeconds.toDouble(),
+      floor: _durationFloor.inSeconds.toDouble(),
+    )) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// True unless [parsed] and [recorded] disagree by more than a factor of
+  /// [_grossFactor]. A missing or non-positive value on either side carries no
+  /// information, so it cannot reject anything.
+  static bool _withinGross({
+    required double parsed,
+    required double? recorded,
+    required double floor,
+  }) {
+    if (recorded == null || recorded <= 0 || parsed <= 0) return true;
+    if (parsed > recorded * _grossFactor + floor) return false;
+    if (parsed * _grossFactor + floor < recorded) return false;
+    return true;
+  }
+}

--- a/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
+++ b/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
@@ -109,17 +109,27 @@ class RawProfileSanityCheck {
   }
 
   /// True unless [parsed] and [recorded] disagree by more than a factor of
-  /// [_grossFactor]. A missing, non-positive or non-finite value on either
-  /// side carries no information, so it cannot reject anything. [parsed] is
-  /// already known finite by the time this runs; [recorded] comes from the
-  /// source app and is checked here.
+  /// [_grossFactor].
+  ///
+  /// The two sides are treated differently, and deliberately so. A missing,
+  /// non-positive or non-finite [recorded] value is the source app saying it
+  /// has nothing for this dive, so it cannot reject anything; MacDive stores a
+  /// plain 0 where it has no figure. A [parsed] value of 0 is not the absence
+  /// of a claim - it is libdivecomputer asserting the diver never left the
+  /// surface, or that the dive took no time - and against a source that
+  /// recorded a real dive that is exactly the wrong-format parse this check
+  /// exists to catch. So [parsed] goes through the arithmetic like any other
+  /// value, where the floors keep it from firing on magnitudes too small to
+  /// mean anything.
+  ///
+  /// [parsed] is already known finite by the time this runs; [recorded] comes
+  /// from the source app and is checked here.
   static bool _withinGross({
     required double parsed,
     required double? recorded,
     required double floor,
   }) {
     if (recorded == null || !recorded.isFinite || recorded <= 0) return true;
-    if (parsed <= 0) return true;
     if (parsed > recorded * _grossFactor + floor) return false;
     if (parsed * _grossFactor + floor < recorded) return false;
     return true;

--- a/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
+++ b/lib/features/universal_import/data/services/raw_profile_sanity_check.dart
@@ -63,6 +63,13 @@ class RawProfileSanityCheck {
     // filled in. This is the failure mode a zeroed dive presents as.
     if (parsed.samples.isEmpty) return false;
 
+    // NaN has to be rejected explicitly rather than left to the bounds below.
+    // Every comparison against it is false, so a NaN depth would slip past the
+    // lower bound, never become the running maximum, and never trip the upper
+    // bound either, arriving in the profile as a sample depth of NaN. Infinity
+    // needs no special case - it propagates through the bounds correctly.
+    if (!parsed.maxDepthMeters.isFinite) return false;
+
     var deepest = parsed.maxDepthMeters;
     var previousTime = -1;
     for (final s in parsed.samples) {
@@ -71,14 +78,16 @@ class RawProfileSanityCheck {
       // Bytes read in the wrong format are not.
       if (s.timeSeconds < 0 || s.timeSeconds < previousTime) return false;
       previousTime = s.timeSeconds;
+      if (!s.depthMeters.isFinite) return false;
       if (s.depthMeters < _minPlausibleDepthMeters) return false;
       if (s.depthMeters > deepest) deepest = s.depthMeters;
     }
 
     if (deepest > maxPlausibleDepthMeters) return false;
 
+    // Cannot go negative: the samples are non-empty and every negative time
+    // already returned above, so `previousTime` is at least 0 by here.
     final durationSeconds = math.max(parsed.durationSeconds, previousTime);
-    if (durationSeconds < 0) return false;
     if (durationSeconds > maxPlausibleDuration.inSeconds) return false;
 
     if (!_withinGross(
@@ -100,14 +109,17 @@ class RawProfileSanityCheck {
   }
 
   /// True unless [parsed] and [recorded] disagree by more than a factor of
-  /// [_grossFactor]. A missing or non-positive value on either side carries no
-  /// information, so it cannot reject anything.
+  /// [_grossFactor]. A missing, non-positive or non-finite value on either
+  /// side carries no information, so it cannot reject anything. [parsed] is
+  /// already known finite by the time this runs; [recorded] comes from the
+  /// source app and is checked here.
   static bool _withinGross({
     required double parsed,
     required double? recorded,
     required double floor,
   }) {
-    if (recorded == null || recorded <= 0 || parsed <= 0) return true;
+    if (recorded == null || !recorded.isFinite || recorded <= 0) return true;
+    if (parsed <= 0) return true;
     if (parsed > recorded * _grossFactor + floor) return false;
     if (parsed * _grossFactor + floor < recorded) return false;
     return true;

--- a/test/features/universal_import/data/services/dive_computer_descriptor_index_test.dart
+++ b/test/features/universal_import/data/services/dive_computer_descriptor_index_test.dart
@@ -135,6 +135,47 @@ void main() {
       expect(const DiveComputerDescriptorIndex.empty().isEmpty, isTrue);
     });
 
+    test('DiveComputerModel compares by value', () {
+      // Callers hold these in lists and compare them; identity equality would
+      // make "did we already try this model" quietly wrong.
+      const a = DiveComputerModel(
+        vendor: 'Suunto',
+        product: 'Zoop Novo',
+        model: 0x1E,
+      );
+      const b = DiveComputerModel(
+        vendor: 'Suunto',
+        product: 'Zoop Novo',
+        model: 0x1E,
+      );
+      const differentModel = DiveComputerModel(
+        vendor: 'Suunto',
+        product: 'Zoop Novo',
+        model: 0x1F,
+      );
+      const differentProduct = DiveComputerModel(
+        vendor: 'Suunto',
+        product: 'D5',
+        model: 0x1E,
+      );
+      const differentVendor = DiveComputerModel(
+        vendor: 'Mares',
+        product: 'Zoop Novo',
+        model: 0x1E,
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(differentModel));
+      expect(a, isNot(differentProduct));
+      expect(a, isNot(differentVendor));
+      expect(a, isNot('Suunto Zoop Novo'));
+      // The model number is hex everywhere else it appears (descriptor.c, the
+      // docs), so a decimal toString would be needless friction when reading a
+      // failure.
+      expect(a.toString(), 'Suunto Zoop Novo (0x1e)');
+    });
+
     test('skips descriptors with a blank vendor or product', () {
       final index = DiveComputerDescriptorIndex.fromDescriptors([
         _d('', 'Teric', 1),

--- a/test/features/universal_import/data/services/dive_computer_descriptor_index_test.dart
+++ b/test/features/universal_import/data/services/dive_computer_descriptor_index_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/features/universal_import/data/services/dive_computer_descriptor_index.dart';
+
+pigeon.DeviceDescriptor _d(String vendor, String product, int model) =>
+    pigeon.DeviceDescriptor(
+      vendor: vendor,
+      product: product,
+      model: model,
+      transports: const [pigeon.TransportType.ble],
+    );
+
+/// A slice of libdivecomputer's `g_descriptors[]` chosen to cover the shapes
+/// the matcher has to handle: a plain name, two names where one is a prefix of
+/// the other, a product libdivecomputer spells with a space that vendors write
+/// without, and a `(vendor, product)` pair declared more than once.
+final _descriptors = <pigeon.DeviceDescriptor>[
+  _d('Shearwater', 'Teric', 8),
+  _d('Shearwater', 'Tern', 12),
+  _d('Suunto', 'EON Steel', 0),
+  _d('Suunto', 'EON Steel Black', 3),
+  _d('Suunto', 'D5', 2),
+  _d('Suunto', 'Zoop Novo', 0x1E),
+  _d('Suunto', 'Zoop Novo', 0x1F),
+  _d('Mares', 'Puck 4', 0x35),
+  _d('Aqualung', 'i200C', 0x4649),
+  _d('Aqualung', 'i200C', 0x4749),
+  _d('Oceanic', 'Geo 4.0', 0x4653),
+];
+
+void main() {
+  group('DiveComputerDescriptorIndex', () {
+    final index = DiveComputerDescriptorIndex.fromDescriptors(_descriptors);
+
+    test('resolves a "Vendor Product" display name', () {
+      expect(index.resolve('Shearwater Teric'), [
+        const DiveComputerModel(
+          vendor: 'Shearwater',
+          product: 'Teric',
+          model: 8,
+        ),
+      ]);
+    });
+
+    test('is case and whitespace insensitive', () {
+      // MacDive, Shearwater Cloud and BLE advertisements all spell the same
+      // device slightly differently; libdivecomputer's own name matcher
+      // ignores case and spaces for exactly this reason.
+      for (final name in [
+        'MARES PUCK 4',
+        'mares puck4',
+        'Mares  Puck 4',
+        ' Mares Puck4 ',
+      ]) {
+        expect(
+          index.resolve(name).single.product,
+          'Puck 4',
+          reason: 'should match "$name"',
+        );
+      }
+    });
+
+    test('prefers the longest matching name', () {
+      // "Suunto EON Steel" is a prefix of "Suunto EON Steel Black". Matching
+      // the shorter one would hand the bytes to a different model number.
+      expect(
+        index.resolve('Suunto EON Steel Black').single.product,
+        'EON Steel Black',
+      );
+      expect(index.resolve('Suunto EON Steel').single.product, 'EON Steel');
+    });
+
+    test('matches only on whole tokens', () {
+      // "Tern" must not be found inside "Ternary": a prefix match that ignored
+      // token boundaries would resolve names that share only a few letters.
+      expect(index.resolve('Shearwater Ternary'), isEmpty);
+    });
+
+    test('returns every model sharing one name, in declaration order', () {
+      // libdivecomputer declares seven (vendor, product) pairs twice. The
+      // parser they select is the same, but the model number reaches it, so
+      // the caller has to be able to try each.
+      expect(index.resolve('Suunto Zoop Novo').map((m) => m.model), [
+        0x1E,
+        0x1F,
+      ]);
+      expect(index.resolve('Aqualung i200C').map((m) => m.model), [
+        0x4649,
+        0x4749,
+      ]);
+    });
+
+    test('fails closed on a name libdivecomputer does not know', () {
+      // Real MacDive values. "Oceanic Matrix Master" has a real vendor but no
+      // such product; the others are not computers at all. Resolving any of
+      // them would send raw bytes to an arbitrary parser.
+      for (final name in [
+        'Oceanic Matrix Master',
+        'No Computer',
+        'Some Unknown Thing',
+        'Teric',
+        'Shearwater',
+        '',
+        '   ',
+      ]) {
+        expect(
+          index.resolve(name),
+          isEmpty,
+          reason: 'should not match "$name"',
+        );
+      }
+      expect(index.resolve(null), isEmpty);
+    });
+
+    test('falls back to the longest known prefix of a decorated name', () {
+      // Source apps decorate names ("... (Bluetooth)", a variant suffix).
+      // Dropping to the longest known prefix keeps those decodable, and the
+      // prefix still pins the vendor and nearly all of the product, so the
+      // parser it selects is the right family. RawProfileSanityCheck is what
+      // catches the case where it was not.
+      expect(
+        index.resolve('Oceanic Geo 4.0 Titanium').single.product,
+        'Geo 4.0',
+      );
+      expect(
+        index.resolve('Shearwater Teric (Bluetooth)').single.product,
+        'Teric',
+      );
+    });
+
+    test('empty descriptor list resolves nothing and reports itself empty', () {
+      final empty = DiveComputerDescriptorIndex.fromDescriptors(const []);
+      expect(empty.isEmpty, isTrue);
+      expect(empty.resolve('Shearwater Teric'), isEmpty);
+      expect(const DiveComputerDescriptorIndex.empty().isEmpty, isTrue);
+    });
+
+    test('skips descriptors with a blank vendor or product', () {
+      final index = DiveComputerDescriptorIndex.fromDescriptors([
+        _d('', 'Teric', 1),
+        _d('Shearwater', '  ', 2),
+        _d('Shearwater', 'Teric', 3),
+      ]);
+      expect(index.length, 1);
+      expect(index.resolve('Shearwater Teric').single.model, 3);
+    });
+  });
+}

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -351,6 +351,7 @@ void main() {
       final calls = <(String, String, int)>[];
       final payload = await MacDiveDiveMapper.toPayload(
         _rawDataLogbook(),
+        fetchDescriptors: _fakeDescriptors,
         parseRaw: (vendor, product, model, data) async {
           calls.add((vendor, product, data.length));
           return _parsedDive(
@@ -402,6 +403,7 @@ void main() {
             computer: 'Suunto EON Steel Black',
             raw: _suuntoFixture,
           ),
+          fetchDescriptors: _fakeDescriptors,
           parseRaw: (vendor, product, model, data) async {
             calls.add((vendor, product, data));
             return _parsedDive(
@@ -433,16 +435,20 @@ void main() {
     );
 
     test(
-      'Suunto EON Steel and Cobra also resolve to (Suunto, model)',
+      'any libdivecomputer-supported model resolves, not an allowlist',
       () async {
-        final calls = <(String, String)>[];
+        // Before #1436 only three Suunto models were decodable, because they
+        // were the three someone happened to have data for. Every model
+        // libdivecomputer knows must now reach the parser; the D5 and Zoop
+        // Novo were on the warning path with their bytes sitting unread.
+        final calls = <(String, String, int)>[];
         Future<pigeon.ParsedDive> parse(
           String vendor,
           String product,
           int model,
           Uint8List data,
         ) async {
-          calls.add((vendor, product));
+          calls.add((vendor, product, model));
           return _parsedDive(
             samples: [
               pigeon.ProfileSample(
@@ -455,27 +461,115 @@ void main() {
           );
         }
 
-        await MacDiveDiveMapper.toPayload(
-          _suuntoRawDataLogbook(
-            computer: 'Suunto EON Steel',
-            raw: _suuntoFixture,
-          ),
-          parseRaw: parse,
-        );
-        await MacDiveDiveMapper.toPayload(
-          _suuntoRawDataLogbook(computer: 'Suunto Cobra', raw: _suuntoFixture),
-          parseRaw: parse,
-        );
+        for (final computer in [
+          'Suunto EON Steel',
+          'Suunto Cobra',
+          'Suunto D5',
+          'Mares Puck 4',
+        ]) {
+          final payload = await MacDiveDiveMapper.toPayload(
+            _suuntoRawDataLogbook(computer: computer, raw: _suuntoFixture),
+            fetchDescriptors: _fakeDescriptors,
+            parseRaw: parse,
+          );
+          expect(
+            payload.warnings,
+            isEmpty,
+            reason: '$computer should decode without a warning',
+          );
+        }
 
-        expect(calls, [('Suunto', 'EON Steel'), ('Suunto', 'Cobra')]);
+        // The model number now comes from the descriptor rather than being
+        // left as 0 for find_descriptor to wildcard-match.
+        expect(calls, [
+          ('Suunto', 'EON Steel', 0x00),
+          ('Suunto', 'Cobra', 0x0C),
+          ('Suunto', 'D5', 0x02),
+          ('Mares', 'Puck 4', 0x35),
+        ]);
       },
     );
+
+    test('a spacing variant still resolves to the descriptor name', () async {
+      // Source apps spell products without the space libdivecomputer uses.
+      final calls = <(String, String)>[];
+      await MacDiveDiveMapper.toPayload(
+        _suuntoRawDataLogbook(computer: 'Mares Puck4', raw: _suuntoFixture),
+        fetchDescriptors: _fakeDescriptors,
+        parseRaw: (vendor, product, model, data) async {
+          calls.add((vendor, product));
+          return _parsedDive(
+            samples: [pigeon.ProfileSample(timeSeconds: 0, depthMeters: 3.0)],
+          );
+        },
+      );
+      expect(calls, [('Mares', 'Puck 4')]);
+    });
+
+    test('every model of an ambiguous product name is tried', () async {
+      // libdivecomputer declares (Suunto, Zoop Novo) twice, 0x1E and 0x1F.
+      // The parser is the same either way, but the model number reaches it,
+      // so a first-match-wins rule would silently pick a header layout.
+      final models = <int>[];
+      final payload = await MacDiveDiveMapper.toPayload(
+        _suuntoRawDataLogbook(
+          computer: 'Suunto Zoop Novo',
+          raw: _suuntoFixture,
+        ),
+        fetchDescriptors: _fakeDescriptors,
+        parseRaw: (vendor, product, model, data) async {
+          models.add(model);
+          // 0x1E produces a dive no one has ever made; only 0x1F is real.
+          return model == 0x1E
+              ? _parsedDive(
+                  samples: [
+                    pigeon.ProfileSample(timeSeconds: 0, depthMeters: 4000.0),
+                  ],
+                )
+              : _parsedDive(
+                  samples: [
+                    pigeon.ProfileSample(timeSeconds: 0, depthMeters: 12.0),
+                  ],
+                );
+        },
+      );
+
+      expect(models, [0x1E, 0x1F]);
+      final dives = payload.entitiesOf(ImportEntityType.dives);
+      expect(dives.single.containsKey('profile'), isTrue);
+      expect(payload.warnings, isEmpty);
+    });
+
+    test('an implausible parse is rejected rather than attached', () async {
+      // Dropping the allowlist means the parser is now offered bytes it may
+      // not own. A structurally valid series that no dive could produce must
+      // not become a profile.
+      final payload = await MacDiveDiveMapper.toPayload(
+        _suuntoRawDataLogbook(computer: 'Suunto D5', raw: _suuntoFixture),
+        fetchDescriptors: _fakeDescriptors,
+        parseRaw: (v, p, m, d) async => _parsedDive(
+          samples: [
+            pigeon.ProfileSample(timeSeconds: 0, depthMeters: 0.0),
+            pigeon.ProfileSample(timeSeconds: 600, depthMeters: 4000.0),
+          ],
+        ),
+      );
+
+      final dives = payload.entitiesOf(ImportEntityType.dives);
+      expect(dives.single.containsKey('profile'), isFalse);
+      expect(payload.warnings, hasLength(1));
+      expect(payload.warnings.single.message.toLowerCase(), contains('xml'));
+    });
 
     test(
       'unrecognised computer counts toward one aggregated warning',
       () async {
+        // A real MacDive value: "Oceanic" is a libdivecomputer vendor but
+        // "Matrix Master" is not one of its products, so resolution has to
+        // fail closed rather than settle for the vendor.
         final payload = await MacDiveDiveMapper.toPayload(
           _rawDataLogbook(computer: 'Oceanic Matrix Master'),
+          fetchDescriptors: _fakeDescriptors,
           parseRaw: (v, p, m, d) async =>
               fail('parser must not be reached for an unknown model'),
         );
@@ -492,12 +586,56 @@ void main() {
     test('missing platform channel warns once, not once per dive', () async {
       final payload = await MacDiveDiveMapper.toPayload(
         _rawDataLogbook(),
+        fetchDescriptors: _fakeDescriptors,
         parseRaw: (v, p, m, d) async =>
             throw MissingPluginException('no channel'),
       );
 
       expect(payload.warnings, hasLength(1));
       expect(payload.warnings.single.message, contains('this platform'));
+    });
+
+    test('an unreadable descriptor list warns about the platform', () async {
+      // libdivecomputer always knows some computers, so an empty or failing
+      // descriptor call means the native side could not answer. Reporting
+      // that as "every one of your dives is undecodable" would be wrong.
+      for (final fetch in <MacDiveDescriptorFetchFn>[
+        () async => throw MissingPluginException('no channel'),
+        () async => [],
+      ]) {
+        final payload = await MacDiveDiveMapper.toPayload(
+          _rawDataLogbook(),
+          fetchDescriptors: fetch,
+          parseRaw: (v, p, m, d) async =>
+              fail('parser must not be reached without descriptors'),
+        );
+        expect(payload.warnings, hasLength(1));
+        expect(payload.warnings.single.message, contains('this platform'));
+      }
+    });
+
+    test('the descriptor list is read once per import, not per dive', () async {
+      var fetches = 0;
+      await MacDiveDiveMapper.toPayload(
+        _rawDataLogbook(),
+        fetchDescriptors: () async {
+          fetches++;
+          return _fakeDescriptors();
+        },
+        parseRaw: (v, p, m, d) async => _parsedDive(
+          samples: [pigeon.ProfileSample(timeSeconds: 0, depthMeters: 3.0)],
+        ),
+      );
+      expect(fetches, 1);
+    });
+
+    test('a logbook with no raw bytes never asks for descriptors', () async {
+      final logbook = await MacDiveDbReader.readAll(bytes);
+      await MacDiveDiveMapper.toPayload(
+        logbook,
+        fetchDescriptors: () async =>
+            fail('descriptors must not be fetched with nothing to decode'),
+      );
     });
 
     test(
@@ -606,6 +744,34 @@ Uint8List _hex(String s) {
   }
   return out;
 }
+
+pigeon.DeviceDescriptor _descriptor(String vendor, String product, int model) =>
+    pigeon.DeviceDescriptor(
+      vendor: vendor,
+      product: product,
+      model: model,
+      transports: const [pigeon.TransportType.ble],
+    );
+
+/// A slice of what `getDeviceDescriptors()` returns, with the real vendor,
+/// product and model values from libdivecomputer's `descriptor.c`. The full
+/// list is a few hundred entries across thirty-odd vendors; these cover the
+/// cases the mapper has to get right - one Shearwater (the only vendor
+/// needing a pre-pass), the three Suunto models #1400 hardcoded, a Suunto and
+/// a Mares that were unreachable before #1436, and a product name
+/// libdivecomputer declares twice.
+Future<List<pigeon.DeviceDescriptor>> _fakeDescriptors() async => [
+  _descriptor('Shearwater', 'Teric', 8),
+  _descriptor('Shearwater', 'Tern', 12),
+  _descriptor('Suunto', 'EON Steel', 0),
+  _descriptor('Suunto', 'D5', 2),
+  _descriptor('Suunto', 'EON Steel Black', 3),
+  _descriptor('Suunto', 'Cobra', 0x0C),
+  _descriptor('Suunto', 'Zoop Novo', 0x1E),
+  _descriptor('Suunto', 'Zoop Novo', 0x1F),
+  _descriptor('Mares', 'Puck 4', 0x35),
+  _descriptor('Oceanic', 'Geo 4.0', 0x4653),
+];
 
 /// Stand-in for a Suunto `ZRAWDATA` blob. The real format (SBEM for EON
 /// Steel, the Vyper dive-header layout for Cobra) is confirmed elsewhere

--- a/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
+++ b/test/features/universal_import/data/services/macdive_dive_mapper_test.dart
@@ -540,6 +540,51 @@ void main() {
       expect(payload.warnings, isEmpty);
     });
 
+    test('a parser error on one model falls through to the next', () async {
+      // libdivecomputer rejecting one model of an ambiguous name is a normal
+      // result, not a reason to give up on the dive.
+      final models = <int>[];
+      final payload = await MacDiveDiveMapper.toPayload(
+        _suuntoRawDataLogbook(
+          computer: 'Suunto Zoop Novo',
+          raw: _suuntoFixture,
+        ),
+        fetchDescriptors: _fakeDescriptors,
+        parseRaw: (vendor, product, model, data) async {
+          models.add(model);
+          if (model == 0x1E) {
+            throw PlatformException(code: 'PARSE_ERROR', message: 'bad header');
+          }
+          return _parsedDive(
+            samples: [pigeon.ProfileSample(timeSeconds: 0, depthMeters: 12.0)],
+          );
+        },
+      );
+
+      expect(models, [0x1E, 0x1F]);
+      final dives = payload.entitiesOf(ImportEntityType.dives);
+      expect(dives.single.containsKey('profile'), isTrue);
+      expect(payload.warnings, isEmpty);
+    });
+
+    test('an unsupported-platform error stops the whole import', () async {
+      // Unlike a parse error, this says the channel itself cannot serve us, so
+      // trying the next model - or the next dive - cannot help.
+      var calls = 0;
+      final payload = await MacDiveDiveMapper.toPayload(
+        _rawDataLogbook(),
+        fetchDescriptors: _fakeDescriptors,
+        parseRaw: (v, p, m, d) async {
+          calls++;
+          throw PlatformException(code: 'UNSUPPORTED', message: 'no parser');
+        },
+      );
+
+      expect(calls, 1, reason: 'must not retry once the channel is out');
+      expect(payload.warnings, hasLength(1));
+      expect(payload.warnings.single.message, contains('this platform'));
+    });
+
     test('an implausible parse is rejected rather than attached', () async {
       // Dropping the allowlist means the parser is now offered bytes it may
       // not own. A structurally valid series that no dive could produce must
@@ -601,6 +646,8 @@ void main() {
       // that as "every one of your dives is undecodable" would be wrong.
       for (final fetch in <MacDiveDescriptorFetchFn>[
         () async => throw MissingPluginException('no channel'),
+        () async => throw PlatformException(code: 'UNSUPPORTED'),
+        () async => throw StateError('something else entirely'),
         () async => [],
       ]) {
         final payload = await MacDiveDiveMapper.toPayload(

--- a/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
+++ b/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
@@ -234,6 +234,59 @@ void main() {
       );
     });
 
+    test('rejects an all-surface profile the source says was a real dive', () {
+      // Zero on the two sides means opposite things, which is why they are not
+      // treated alike. A zero *recorded* scalar is MacDive saying it has no
+      // value. A zero *parsed* depth is libdivecomputer asserting the diver
+      // never left the surface, and against a recorded 30 m dive that is a
+      // wrong-format parse, not a shallow one.
+      final allSurface = _parsed(
+        durationSeconds: 2400,
+        samples: [_sample(0, 0.0), _sample(1200, 0.0), _sample(2400, 0.0)],
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          allSurface,
+          recordedMaxDepthMeters: 30.0,
+          recordedDuration: const Duration(minutes: 40),
+        ),
+        isFalse,
+      );
+      // With nothing to contradict it, the same series is still accepted: the
+      // cross-check is the only thing that can know better.
+      expect(RawProfileSanityCheck.accepts(allSurface), isTrue);
+    });
+
+    test('rejects a zero-length profile the source says lasted an hour', () {
+      // One sample at t = 0 with no duration field is the duration-side twin
+      // of the case above.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(maxDepthMeters: 28.0, samples: [_sample(0, 28.0)]),
+          recordedMaxDepthMeters: 30.0,
+          recordedDuration: const Duration(minutes: 60),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a shallow recorded depth still tolerates a zero parse', () {
+      // The floors exist because relative tolerance is meaningless at small
+      // magnitudes; a 3 m recorded dive is not enough to call a 0 m parse
+      // wrong.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(
+            durationSeconds: 200,
+            samples: [_sample(0, 0.0), _sample(200, 0.0)],
+          ),
+          recordedMaxDepthMeters: 3.0,
+          recordedDuration: const Duration(minutes: 4),
+        ),
+        isTrue,
+      );
+    });
+
     test('a missing or zero recorded scalar cannot reject anything', () {
       expect(
         RawProfileSanityCheck.accepts(

--- a/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
+++ b/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
@@ -120,6 +120,56 @@ void main() {
       );
     });
 
+    test('rejects a non-finite depth', () {
+      // NaN compares false against everything, so a NaN depth slides past the
+      // lower bound, never becomes the running maximum, and never trips the
+      // upper bound either. Without an explicit finiteness check it reaches
+      // the profile as a sample depth of NaN.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(samples: [_sample(0, 0.0), _sample(60, double.nan)]),
+        ),
+        isFalse,
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(maxDepthMeters: double.nan, samples: [_sample(0, 5.0)]),
+        ),
+        isFalse,
+      );
+      // Infinity propagates through comparisons correctly, so the ordinary
+      // bounds already catch it. Pinned so a future rewrite of those bounds
+      // cannot quietly lose it.
+      for (final value in [double.infinity, double.negativeInfinity]) {
+        expect(
+          RawProfileSanityCheck.accepts(
+            _parsed(samples: [_sample(0, 0.0), _sample(60, value)]),
+          ),
+          isFalse,
+          reason: 'should reject $value',
+        );
+      }
+    });
+
+    test('a non-finite recorded scalar cannot reject anything', () {
+      // Same rule as a missing one: it carries no information, so it must not
+      // be allowed to veto an otherwise sound parse.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: double.nan,
+        ),
+        isTrue,
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: double.infinity,
+        ),
+        isTrue,
+      );
+    });
+
     test('rejects a depth far below the surface sign', () {
       expect(
         RawProfileSanityCheck.accepts(

--- a/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
+++ b/test/features/universal_import/data/services/raw_profile_sanity_check_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
+import 'package:submersion/features/universal_import/data/services/raw_profile_sanity_check.dart';
+
+pigeon.ProfileSample _sample(int t, double depth) => pigeon.ProfileSample(
+  timeSeconds: t,
+  depthMeters: depth,
+  temperatureCelsius: 20.0,
+);
+
+pigeon.ParsedDive _parsed({
+  required List<pigeon.ProfileSample> samples,
+  double maxDepthMeters = 0.0,
+  int durationSeconds = 0,
+}) => pigeon.ParsedDive(
+  fingerprint: 'fp',
+  dateTimeYear: 2026,
+  dateTimeMonth: 1,
+  dateTimeDay: 1,
+  dateTimeHour: 10,
+  dateTimeMinute: 0,
+  dateTimeSecond: 0,
+  maxDepthMeters: maxDepthMeters,
+  avgDepthMeters: 0.0,
+  durationSeconds: durationSeconds,
+  samples: samples,
+  tanks: const [],
+  gasMixes: const [],
+  events: const [],
+);
+
+/// A 30 m, 40 minute dive - the shape a correct parse produces.
+pigeon.ParsedDive _plausibleDive() => _parsed(
+  maxDepthMeters: 30.0,
+  durationSeconds: 2400,
+  samples: [
+    _sample(0, 0.0),
+    _sample(600, 30.0),
+    _sample(1800, 18.0),
+    _sample(2400, 0.0),
+  ],
+);
+
+void main() {
+  group('RawProfileSanityCheck', () {
+    test('accepts an ordinary dive', () {
+      expect(RawProfileSanityCheck.accepts(_plausibleDive()), isTrue);
+    });
+
+    test('accepts an ordinary dive that agrees with the recorded scalars', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: 30.4,
+          recordedDuration: const Duration(minutes: 41),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a parse with no samples', () {
+      // The macOS wrapper has been seen returning success with a zeroed dive.
+      expect(
+        RawProfileSanityCheck.accepts(_parsed(samples: const [])),
+        isFalse,
+      );
+    });
+
+    test('rejects a depth no dive reaches', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(samples: [_sample(0, 0.0), _sample(60, 900.0)]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a depth reported only in the summary field', () {
+      // maxDepthMeters comes from a different libdivecomputer field than the
+      // samples, so a misread header can blow the bound on its own.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(
+            maxDepthMeters: 6000.0,
+            samples: [_sample(0, 0.0), _sample(60, 12.0)],
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a duration no dive lasts', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(
+            durationSeconds: 400000,
+            samples: [_sample(0, 0.0), _sample(60, 12.0)],
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects samples that move backwards in time', () {
+      // libdivecomputer accumulates sample time as it walks the record stream,
+      // so real profiles never do this; bytes read in the wrong format do.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(
+            samples: [_sample(0, 0.0), _sample(600, 10.0), _sample(5, 8.0)],
+          ),
+        ),
+        isFalse,
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(samples: [_sample(-5, 0.0), _sample(600, 10.0)]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a depth far below the surface sign', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(samples: [_sample(0, 0.0), _sample(60, -240.0)]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('tolerates the slight negative depth a surface sample can show', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _parsed(
+            durationSeconds: 600,
+            samples: [_sample(0, -0.4), _sample(600, 12.0)],
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects a parse that grossly contradicts the recorded depth', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: 3.0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a parse that grossly contradicts the recorded duration', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedDuration: const Duration(minutes: 2),
+        ),
+        isFalse,
+      );
+    });
+
+    test('survives a source logbook read in the wrong depth unit', () {
+      // MacDive routinely omits its units row, so a whole logbook can be read
+      // as feet when it is metres (#912) - a 3.28x error in the recorded
+      // scalar that says nothing about whether the raw bytes decoded. The
+      // cross-check is deliberately loose enough to let that through.
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: 30.0 * 3.28084,
+          recordedDuration: const Duration(minutes: 40),
+        ),
+        isTrue,
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: 30.0 / 3.28084,
+          recordedDuration: const Duration(minutes: 40),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a missing or zero recorded scalar cannot reject anything', () {
+      expect(
+        RawProfileSanityCheck.accepts(
+          _plausibleDive(),
+          recordedMaxDepthMeters: 0.0,
+          recordedDuration: Duration.zero,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a short shallow dive is not rejected by the tolerance floor', () {
+      // 4 m for 6 minutes against a recorded 3 m / 10 minutes: small absolute
+      // numbers make relative tolerance meaningless, which is what the floors
+      // are for.
+      final shallow = _parsed(
+        maxDepthMeters: 4.0,
+        durationSeconds: 360,
+        samples: [_sample(0, 0.0), _sample(180, 4.0), _sample(360, 0.0)],
+      );
+      expect(
+        RawProfileSanityCheck.accepts(
+          shallow,
+          recordedMaxDepthMeters: 3.0,
+          recordedDuration: const Duration(minutes: 10),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

MacDive SQLite import gated `ZRAWDATA` decoding on a hardcoded name table: Shearwater from #961, three Suunto models from #1400. Both entries recorded a *data* limit ("we only had blobs for these") as a *format* limit ("only these have usable `ZRAWDATA`"). A user with a Suunto D5, a Mares Puck, or an Oceanic Geo hit the "no usable `ZRAWDATA`, use MacDive's XML export" warning with a perfectly decodable blob sitting in their database, and closing that gap needed a third issue and a third table entry.

This removes the tables rather than adding a third entry. `ZCOMPUTER` is now resolved against libdivecomputer's own descriptor list, so every model the vendored submodule supports is reachable and the set grows on its own when the submodule advances.

Closes #1436. Follow-up to #1399 / #1400 and to #912 / #961 before them.

## Changes

- **`DiveComputerDescriptorIndex` (new).** Indexes `DiveComputerHostApi.getDeviceDescriptors()` by normalised `"vendor product"`. Matching ignores case and whitespace, the same tolerance the native BLE-name matcher applies (`strcasecmp_nospace` in `libdc_wrapper.c`), so `"Puck4"` finds the product `"Puck 4"` and `"Aqua Lung"` finds the vendor `"Aqualung"`. A name is matched a whole token at a time from the front, longest first, so `"Suunto EON Steel Black"` prefers its own descriptor over the shorter `"Suunto EON Steel"`, and a decorated name falls back to the longest known prefix. A name matching nothing resolves to nothing, which is load-bearing: `"Oceanic Matrix Master"` pairs a real libdivecomputer vendor with a product that does not exist there.
- **Ambiguous product names are tried, not guessed.** `descriptor.c` declares seven `(vendor, product)` pairs twice with different model numbers (Oceanic OC1, Suunto Zoop Novo, Uwatec Aladin 2G, Aeris Elite T3 / Epic, Aqualung i100 / i200C). The mapper keeps every match and tries each in declaration order, accepting the first whose parse passes the sanity check. Passing a real model number also means `find_descriptor`'s `model == 0` wildcard is no longer load-bearing on this path.
- **`RawProfileSanityCheck` (new).** Attempting any recognised model makes a structurally plausible parse of the wrong bytes a live possibility, so every result is gated: samples must exist, sample times must be non-negative and non-decreasing, depth must sit within (-3 m, 350 m], duration within 24 h, and neither parsed value may contradict MacDive's own scalar for the same dive by more than a factor of five. A rejected parse falls back to exactly the behaviour an unrecognised computer already had, so the worst case is today's behaviour.
- **Vendor pre-passes are a keyed hook.** Shearwater's decompression moved into `MacDiveDiveMapper._rawPrePasses`, keyed by descriptor vendor. It remains the only known member and is the exception rather than the rule: libdivecomputer decompresses inside its own device layer (`shearwater_common.c:550`, `:567`), so any host downloading through libdivecomputer holds native bytes. A second such vendor is one line.
- **Descriptor read once per import**, and skipped entirely when no dive has raw bytes. An empty or failing descriptor fetch is treated as a *platform* failure (one "could not be decoded on this platform" warning) rather than as N undecodable dives.
- **Docs.** `docs/import-formats/macdive-zsamples.md` gets the correction the issue asked for: the per-computer presence table is accurate as a count, but the conclusion drawn from it was not. `ZRAWDATA` presence tracks how the dive entered MacDive (native download versus manual entry or file import), not the vendor. The corpus happened to pair downloaded Shearwater dives with non-downloaded Oceanic ones, and that coincidence read as a vendor rule for two releases.

### On the tolerance being deliberately loose

The cross-check against MacDive's own depth and duration is a factor of five, not a tight bound, and that is the calibration to argue with if any. MacDive routinely omits its units row, so a whole logbook can be read as feet when it is metres (#912) - a 3.28x error in *MacDive's* number that says nothing about whether the raw bytes decoded. A 25% bound would look rigorous and would silently discard every profile in such a logbook. The absolute limits do the real filtering; the cross-check only catches gross nonsense.

### What is not in this PR

Item 6 of the issue (real fixtures per confirmed family) is only partly delivered. `scripts/sample_data/` is gitignored and the reference corpus contains Shearwater, Oceanic, and no-computer dives only, so there is no anonymised Suunto `ZRAWDATA` anywhere in the repo. The #1400 tests still stub `parseRaw` and assert byte pass-through and name resolution rather than a real decode. Rather than fabricate a blob, the docs now carry a contributor recipe for confirming a family from real data (extract with `writefile`, run through `test_parse_raw_dive.c`, assert against MacDive's own displayed values). That gap needs data, not a design change.

Also considered and left out: falling back to the untransformed bytes when a vendor pre-pass returns null. It would remove the last storage-form assumption and the sanity check would guard it, but there is no evidence any Shearwater `ZRAWDATA` is stored uncompressed, so it would be speculative.

## Test Plan

- [x] `flutter test` passes - `test/features/universal_import`: 1678 passed, 6 skipped (pre-existing skips)
- [x] `flutter analyze` passes - `dart analyze` clean across the whole project; `dart format .` produced no unrelated churn
- [ ] Manual testing on: not run against a real MacDive database (none available with a non-Shearwater computer)

New coverage:

- any libdivecomputer-supported model resolves, including the Suunto D5 and Mares Puck 4 that were unreachable before, and asserts the real model number reaches the parser
- a spacing variant (`"Mares Puck4"`) resolves to the descriptor name
- every model of an ambiguous product name is tried, and the second wins when the first fails the sanity check
- an implausible parse is rejected rather than attached, and counts toward the aggregated warning
- `"Oceanic Matrix Master"` still fails closed and never reaches the parser
- an empty or throwing descriptor list warns about the platform, once
- descriptors are read once per import, and not at all for a logbook with no raw bytes
- `DiveComputerDescriptorIndex` and `RawProfileSanityCheck` each get a full unit suite, including the ft/m case the loose tolerance exists for

#1400's byte-pass-through regression test is preserved intact, including its `_suuntoFixture` shape constraints (>32 bytes, non-uniform, length divisible by 9) that make an accidental Shearwater transformation visible.
