### PR TITLE
fix(statistics): count dives that inherit water type or entry method from their site

### DIFF
--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -300,6 +300,21 @@ class Dive extends Equatable {
   /// only its own value.
   WaterType? get effectiveWaterType => waterType ?? site?.waterType;
 
+  /// Entry method of the dive, falling back to the assigned site's (issue
+  /// #1427). The entry-method twin of [effectiveWaterType], with the same
+  /// reasoning: the site's value is snapped onto a dive when the site is
+  /// assigned (issue #1104), so only dives predating that, or whose site was
+  /// filled in later, are left without one.
+  ///
+  /// [exitMethod] has no such getter on purpose. Its snap-on-assign rule turns
+  /// on whether the diver has unlinked exit from entry, and that flag is dive
+  /// form state which is never persisted, so a read-time fallback cannot
+  /// reproduce it. See `entryExitAfterSiteAssign`.
+  ///
+  /// Requires [site] to be hydrated; a dive loaded without its site reports
+  /// only its own value.
+  EntryMethod? get effectiveEntryMethod => entryMethod ?? site?.entryMethod;
+
   /// User-defined name, normalized for display: trimmed, with empty or
   /// whitespace-only values treated as unset (null). In-app writes never
   /// store such values, but synced rows from other writers can; display

--- a/lib/features/dive_log/domain/entities/dive.dart
+++ b/lib/features/dive_log/domain/entities/dive.dart
@@ -285,6 +285,21 @@ class Dive extends Equatable {
   /// Effective start time of the dive (entryTime if set, otherwise dateTime)
   DateTime get effectiveEntryTime => entryTime ?? dateTime;
 
+  /// Water type of the dive, falling back to the assigned site's (issue
+  /// #1427).
+  ///
+  /// [waterType] is snapped from the site when a site is assigned (see
+  /// `waterTypeAfterSiteAssign`), but dives logged or imported before that,
+  /// and dives whose site gained its water type later, still carry null. The
+  /// site's answer is the best one available for those, so displays and
+  /// statistics read this rather than [waterType]. A value the diver set on
+  /// the dive always wins: a site's water type is a default, not a fact about
+  /// every dive made there.
+  ///
+  /// Requires [site] to be hydrated; a dive loaded without its site reports
+  /// only its own value.
+  WaterType? get effectiveWaterType => waterType ?? site?.waterType;
+
   /// User-defined name, normalized for display: trimmed, with empty or
   /// whitespace-only values treated as unset (null). In-app writes never
   /// store such values, but synced rows from other writers can; display

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -3402,7 +3402,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         dive.currentDirection != null ||
         dive.currentStrength != null ||
         dive.swellHeight != null ||
-        dive.entryMethod != null ||
+        dive.effectiveEntryMethod != null ||
         dive.exitMethod != null;
   }
 
@@ -3480,7 +3480,7 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
         dive.currentDirection != null ||
         dive.currentStrength != null ||
         dive.swellHeight != null ||
-        dive.entryMethod != null ||
+        dive.effectiveEntryMethod != null ||
         dive.exitMethod != null;
 
     return Card(
@@ -3616,11 +3616,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                   context.l10n.diveLog_detail_label_swellHeight,
                   units.formatDepth(dive.swellHeight, decimals: 1),
                 ),
-              if (dive.entryMethod != null)
+              // Effective, so a dive that never had an entry method of its
+              // own still shows the one its site carries (issue #1427).
+              if (dive.effectiveEntryMethod != null)
                 _buildDetailRow(
                   context,
                   context.l10n.diveLog_detail_label_entryMethod,
-                  dive.entryMethod!.localizedName(context.l10n),
+                  dive.effectiveEntryMethod!.localizedName(context.l10n),
                 ),
               if (dive.exitMethod != null)
                 _buildDetailRow(

--- a/lib/features/dive_log/presentation/pages/dive_detail_page.dart
+++ b/lib/features/dive_log/presentation/pages/dive_detail_page.dart
@@ -3311,11 +3311,13 @@ class _DiveDetailPageState extends ConsumerState<DiveDetailPage> {
                 context.l10n.diveLog_detail_label_avgDepth,
                 units.formatDepth(dive.avgDepth),
               ),
-            if (dive.waterType != null)
+            // Effective, so a dive that never had a water type of its own
+            // still shows the one its site carries (issue #1427).
+            if (dive.effectiveWaterType != null)
               _buildDetailRow(
                 context,
                 context.l10n.diveLog_detail_label_waterType,
-                dive.waterType!.displayName,
+                dive.effectiveWaterType!.displayName,
               ),
             if (dive.buddy != null && dive.buddy!.isNotEmpty)
               _buildDetailRow(

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -1247,6 +1247,13 @@ class StatisticsRepository {
 
   /// Get entry method distribution.
   ///
+  /// Buckets each dive by its *effective* entry method: the value on the dive
+  /// when it has one, otherwise the one on its site (issue #1427). The site's
+  /// entry method is snapped onto a dive when the site is assigned (#1104),
+  /// so dives logged or imported before that, and dives whose site gained an
+  /// entry method later, would otherwise sit outside the chart. Mirrors
+  /// `Dive.effectiveEntryMethod`, and the water type distribution above.
+  ///
   /// Emits the stored EntryMethod enum name as a stable key; the
   /// presentation layer translates it (see `entryMethodDistributionLabel`).
   Future<List<DistributionSegment>> getEntryMethodDistribution({
@@ -1254,16 +1261,28 @@ class StatisticsRepository {
     DiveFilterState filter = const DiveFilterState(),
   }) async {
     try {
-      final diverFilter = diverId != null ? 'AND diver_id = ?' : '';
+      // Qualified: dive_sites carries a diver_id of its own, so the bare
+      // column name is ambiguous once the site is joined in.
+      final diverFilter = diverId != null ? 'AND dives.diver_id = ?' : '';
       final df = _diveFilter(filter, alias: 'dives');
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
+      // The fallback is resolved in a subquery so the outer GROUP BY names one
+      // unambiguous column rather than repeating the COALESCE.
       final results = await _db.customSelect('''
         SELECT
           entry_method,
           COUNT(*) AS count
-        FROM dives
-        WHERE entry_method IS NOT NULL AND entry_method != '' $diverFilter ${df.clause}
+        FROM (
+          SELECT COALESCE(
+            NULLIF(dives.entry_method, ''),
+            NULLIF(dive_sites.entry_method, '')
+          ) AS entry_method
+          FROM dives
+          LEFT JOIN dive_sites ON dive_sites.id = dives.site_id
+          WHERE 1 = 1 $diverFilter ${df.clause}
+        )
+        WHERE entry_method IS NOT NULL
         GROUP BY entry_method
         ORDER BY count DESC
         ''', variables: params.map((p) => Variable(p)).toList()).get();
@@ -1301,6 +1320,12 @@ class StatisticsRepository {
   /// for values the diver never actually set. Rows with no entry method carry
   /// no information and are excluded; a null exit method is meaningful and is
   /// carried through as null.
+  ///
+  /// Deliberately reads the stored `entry_method`, NOT the site fallback the
+  /// entry method distribution applies (issue #1427). This query is what the
+  /// site suggests its own entry method from, so folding that site value back
+  /// in would let a single dive that recorded nothing echo the site's answer
+  /// back as evidence for it.
   Future<List<EntryExitPairCount>> getEntryExitMethodPairsForSite({
     required String siteId,
     String? diverId,

--- a/lib/features/statistics/data/repositories/statistics_repository.dart
+++ b/lib/features/statistics/data/repositories/statistics_repository.dart
@@ -1181,6 +1181,12 @@ class StatisticsRepository {
 
   /// Get water type distribution (salt/fresh).
   ///
+  /// Buckets each dive by its *effective* water type: the value on the dive
+  /// when it has one, otherwise the one on its site (issue #1427). Dives
+  /// logged before the site's water type was filled in, and imports that never
+  /// carried the field, would otherwise sit outside the chart even though the
+  /// app knows what water they were in. Mirrors `Dive.effectiveWaterType`.
+  ///
   /// Emits the stored WaterType enum name as a stable key; the presentation
   /// layer translates it (see `waterTypeDistributionLabel`).
   Future<List<DistributionSegment>> getWaterTypeDistribution({
@@ -1188,16 +1194,29 @@ class StatisticsRepository {
     DiveFilterState filter = const DiveFilterState(),
   }) async {
     try {
-      final diverFilter = diverId != null ? 'AND diver_id = ?' : '';
+      // Qualified: dive_sites carries a diver_id of its own, so the bare
+      // column name is ambiguous once the site is joined in.
+      final diverFilter = diverId != null ? 'AND dives.diver_id = ?' : '';
       final df = _diveFilter(filter, alias: 'dives');
       final params = diverId != null ? [diverId, ...df.params] : [...df.params];
 
+      // The fallback is resolved in a subquery so the outer GROUP BY names one
+      // unambiguous column rather than repeating the COALESCE, matching the
+      // shape the visibility distribution above already uses.
       final results = await _db.customSelect('''
         SELECT
           water_type,
           COUNT(*) AS count
-        FROM dives
-        WHERE water_type IS NOT NULL AND water_type != '' $diverFilter ${df.clause}
+        FROM (
+          SELECT COALESCE(
+            NULLIF(dives.water_type, ''),
+            NULLIF(dive_sites.water_type, '')
+          ) AS water_type
+          FROM dives
+          LEFT JOIN dive_sites ON dive_sites.id = dives.site_id
+          WHERE 1 = 1 $diverFilter ${df.clause}
+        )
+        WHERE water_type IS NOT NULL
         GROUP BY water_type
         ORDER BY count DESC
         ''', variables: params.map((p) => Variable(p)).toList()).get();

--- a/test/features/dive_log/domain/entities/dive_effective_entry_method_test.dart
+++ b/test/features/dive_log/domain/entities/dive_effective_entry_method_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// Issue #1427: a dive with no entry method of its own reports its site's.
+void main() {
+  DiveSite site({EntryMethod? entryMethod}) =>
+      DiveSite(id: 'site', name: 'Site', entryMethod: entryMethod);
+
+  Dive dive({EntryMethod? entryMethod, DiveSite? site}) => Dive(
+    id: 'dive',
+    dateTime: DateTime(2026),
+    entryMethod: entryMethod,
+    site: site,
+  );
+
+  test('falls back to the site when the dive has no entry method', () {
+    expect(
+      dive(site: site(entryMethod: EntryMethod.shore)).effectiveEntryMethod,
+      EntryMethod.shore,
+    );
+  });
+
+  test("the dive's own value wins over the site's", () {
+    expect(
+      dive(
+        entryMethod: EntryMethod.boat,
+        site: site(entryMethod: EntryMethod.shore),
+      ).effectiveEntryMethod,
+      EntryMethod.boat,
+    );
+  });
+
+  test('is null when neither the dive nor its site knows', () {
+    expect(dive(site: site()).effectiveEntryMethod, isNull);
+    expect(dive().effectiveEntryMethod, isNull);
+  });
+
+  test('exit method is not derived from the site', () {
+    // The site-assign rule for exit depends on whether the diver has unlinked
+    // exit from entry, and that flag is form state, never persisted. A
+    // read-time fallback cannot reproduce it, so exit stays as stored.
+    expect(dive(site: site(entryMethod: EntryMethod.shore)).exitMethod, isNull);
+  });
+}

--- a/test/features/dive_log/domain/entities/dive_effective_water_type_test.dart
+++ b/test/features/dive_log/domain/entities/dive_effective_water_type_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+
+/// Issue #1427: a dive with no water type of its own reports its site's.
+void main() {
+  DiveSite site({WaterType? waterType}) =>
+      DiveSite(id: 'site', name: 'Site', waterType: waterType);
+
+  Dive dive({WaterType? waterType, DiveSite? site}) => Dive(
+    id: 'dive',
+    dateTime: DateTime(2026),
+    waterType: waterType,
+    site: site,
+  );
+
+  test('falls back to the site when the dive has no water type', () {
+    expect(
+      dive(site: site(waterType: WaterType.salt)).effectiveWaterType,
+      WaterType.salt,
+    );
+  });
+
+  test("the dive's own value wins over the site's", () {
+    expect(
+      dive(
+        waterType: WaterType.fresh,
+        site: site(waterType: WaterType.salt),
+      ).effectiveWaterType,
+      WaterType.fresh,
+    );
+  });
+
+  test('is null when neither the dive nor its site knows', () {
+    expect(dive(site: site()).effectiveWaterType, isNull);
+    expect(dive().effectiveWaterType, isNull);
+  });
+}

--- a/test/features/dive_log/presentation/pages/dive_detail_inherited_site_fields_test.dart
+++ b/test/features/dive_log/presentation/pages/dive_detail_inherited_site_fields_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:submersion/core/constants/enums.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive.dart';
+import 'package:submersion/features/dive_log/presentation/pages/dive_detail_page.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/dive_detail_row.dart';
+import 'package:submersion/features/dive_log/presentation/widgets/environment_enum_display.dart';
+import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+/// Issue #1427: a dive that never recorded a water type or entry method of its
+/// own shows the ones its site carries, so the value the statistics now count
+/// is the same one the diver can see on the dive.
+void main() {
+  DiveSite siteWith({WaterType? waterType, EntryMethod? entryMethod}) =>
+      DiveSite(
+        id: 'site-1',
+        name: 'Blue Hole',
+        waterType: waterType,
+        entryMethod: entryMethod,
+      );
+
+  Dive diveWith({
+    WaterType? waterType,
+    EntryMethod? entryMethod,
+    DiveSite? site,
+  }) => createTestDiveWithBottomTime().copyWith(
+    waterType: waterType,
+    entryMethod: entryMethod,
+    site: site,
+  );
+
+  /// The detail page renders a profile chart that can overflow an
+  /// unconstrained test viewport. Ignore only that, and forward everything
+  /// else, so a real rendering failure still fails the test.
+  void ignoreOverflowErrors() {
+    final originalOnError = FlutterError.onError;
+    addTearDown(() => FlutterError.onError = originalOnError);
+    FlutterError.onError = (details) {
+      if (details.toString().contains('overflowed')) return;
+      originalOnError?.call(details);
+    };
+  }
+
+  Future<void> pumpWith(WidgetTester tester, Dive dive) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          settingsProvider.overrideWith(
+            (ref) => MockSettingsNotifier(const AppSettings()),
+          ),
+          currentDiverIdProvider.overrideWith(
+            (ref) => MockCurrentDiverIdNotifier(),
+          ),
+          diveProvider(dive.id).overrideWith((ref) async => dive),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DiveDetailPage(diveId: dive.id, embedded: true),
+        ),
+      ),
+    );
+
+    ignoreOverflowErrors();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  AppLocalizations l10nOf(WidgetTester tester) =>
+      AppLocalizations.of(tester.element(find.byType(DiveDetailPage)));
+
+  Finder rowValued(String value) => find.widgetWithText(DiveDetailRow, value);
+
+  testWidgets('water type falls back to the site', (tester) async {
+    await pumpWith(tester, diveWith(site: siteWith(waterType: WaterType.salt)));
+
+    expect(rowValued(WaterType.salt.displayName), findsOneWidget);
+  });
+
+  testWidgets("water type prefers the dive's own value", (tester) async {
+    await pumpWith(
+      tester,
+      diveWith(
+        waterType: WaterType.fresh,
+        site: siteWith(waterType: WaterType.salt),
+      ),
+    );
+
+    expect(rowValued(WaterType.fresh.displayName), findsOneWidget);
+    expect(rowValued(WaterType.salt.displayName), findsNothing);
+  });
+
+  testWidgets('no water type anywhere shows no water type row', (tester) async {
+    await pumpWith(tester, diveWith(site: siteWith()));
+
+    final label = l10nOf(tester).diveLog_detail_label_waterType;
+    expect(find.widgetWithText(DiveDetailRow, label), findsNothing);
+  });
+
+  testWidgets('entry method falls back to the site', (tester) async {
+    // Also proves the section gate opens: the environment section is hidden
+    // unless something in it has a value, so an inherited-only entry method
+    // needs the gate to read the effective value too.
+    await pumpWith(
+      tester,
+      diveWith(site: siteWith(entryMethod: EntryMethod.shore)),
+    );
+
+    final l10n = l10nOf(tester);
+    expect(
+      find.widgetWithText(DiveDetailRow, EntryMethod.shore.localizedName(l10n)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets("entry method prefers the dive's own value", (tester) async {
+    await pumpWith(
+      tester,
+      diveWith(
+        entryMethod: EntryMethod.boat,
+        site: siteWith(entryMethod: EntryMethod.shore),
+      ),
+    );
+
+    final l10n = l10nOf(tester);
+    expect(
+      find.widgetWithText(DiveDetailRow, EntryMethod.boat.localizedName(l10n)),
+      findsOneWidget,
+    );
+    expect(
+      find.widgetWithText(DiveDetailRow, EntryMethod.shore.localizedName(l10n)),
+      findsNothing,
+    );
+  });
+
+  testWidgets('exit method is not inherited from the site', (tester) async {
+    // Its snap-on-assign rule depends on the exit/entry link flag, which is
+    // form state and never persisted, so there is nothing to derive from.
+    await pumpWith(
+      tester,
+      diveWith(site: siteWith(entryMethod: EntryMethod.shore)),
+    );
+
+    final label = l10nOf(tester).diveLog_detail_label_exitMethod;
+    expect(find.widgetWithText(DiveDetailRow, label), findsNothing);
+  });
+}

--- a/test/features/statistics/data/repositories/entry_method_distribution_test.dart
+++ b/test/features/statistics/data/repositories/entry_method_distribution_test.dart
@@ -1,0 +1,183 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1427: the same site-fallback gap the water type chart had. A dive
+/// that takes its entry method from its site was missing from the chart.
+void main() {
+  late StatisticsRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = StatisticsRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertSite({required String id, String? entryMethod}) async {
+    await db
+        .into(db.diveSites)
+        .insert(
+          DiveSitesCompanion.insert(
+            id: id,
+            name: 'Site $id',
+            entryMethod: Value(entryMethod),
+            createdAt: 0,
+            updatedAt: 0,
+          ),
+        );
+    return id;
+  }
+
+  Future<String> insertDive({
+    required String id,
+    String? siteId,
+    String? entryMethod,
+    String? diverId,
+    bool excludedFromStats = false,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            siteId: Value(siteId),
+            entryMethod: Value(entryMethod),
+            excludedFromStats: Value(excludedFromStats),
+            diveDateTime: Value(DateTime(2026, 1, 1).millisecondsSinceEpoch),
+            createdAt: const Value(0),
+            updatedAt: const Value(0),
+          ),
+        );
+    return id;
+  }
+
+  Future<Map<String, int>> countsByLabel() async {
+    final dist = await repository.getEntryMethodDistribution();
+    return {for (final s in dist) s.label: s.count};
+  }
+
+  test('a dive with no entry method inherits its site entry method', () async {
+    await insertSite(id: 'beach', entryMethod: 'shore');
+    await insertDive(id: 'own', entryMethod: 'shore');
+    await insertDive(id: 'inherited', siteId: 'beach');
+
+    expect(await countsByLabel(), {'shore': 2});
+  });
+
+  test("the dive's own entry method wins over the site's", () async {
+    // The site says shore, but this diver was dropped in from a boat.
+    await insertSite(id: 'beach', entryMethod: 'shore');
+    await insertDive(id: 'by-boat', siteId: 'beach', entryMethod: 'boat');
+
+    expect(await countsByLabel(), {'boat': 1});
+  });
+
+  test('an empty entry method string falls back to the site', () async {
+    await insertSite(id: 'beach', entryMethod: 'shore');
+    await insertDive(id: 'blank', siteId: 'beach', entryMethod: '');
+
+    expect(await countsByLabel(), {'shore': 1});
+  });
+
+  test('a dive with no entry method anywhere stays out of the chart', () async {
+    await insertSite(id: 'unknown-site');
+    await insertDive(id: 'sited', siteId: 'unknown-site');
+    await insertDive(id: 'siteless');
+    await insertDive(id: 'known', entryMethod: 'giantStride');
+
+    expect(await countsByLabel(), {'giantStride': 1});
+  });
+
+  test(
+    'percentages are shares of the dives that have an entry method',
+    () async {
+      await insertSite(id: 'beach', entryMethod: 'shore');
+      await insertDive(id: 'a', siteId: 'beach');
+      await insertDive(id: 'b', entryMethod: 'shore');
+      await insertDive(id: 'c', entryMethod: 'boat');
+      await insertDive(id: 'd'); // no entry method at all
+
+      final dist = await repository.getEntryMethodDistribution();
+      final byLabel = {for (final s in dist) s.label: s};
+      expect(byLabel['shore']!.percentage, closeTo(200 / 3, 0.001));
+      expect(byLabel['boat']!.percentage, closeTo(100 / 3, 0.001));
+    },
+  );
+
+  test(
+    'an inherited entry method still honours the statistics scope',
+    () async {
+      await insertSite(id: 'beach', entryMethod: 'shore');
+      await insertDive(id: 'counted', siteId: 'beach');
+      await insertDive(
+        id: 'excluded',
+        siteId: 'beach',
+        excludedFromStats: true,
+      );
+
+      expect(await countsByLabel(), {'shore': 1});
+    },
+  );
+
+  test('the view filter still applies to an inherited entry method', () async {
+    await insertSite(id: 'beach', entryMethod: 'shore');
+    await insertSite(id: 'marina', entryMethod: 'boat');
+    await insertDive(id: 'in-filter', siteId: 'beach');
+    await insertDive(id: 'out-of-filter', siteId: 'marina');
+
+    final dist = await repository.getEntryMethodDistribution(
+      filter: const DiveFilterState(siteId: 'beach'),
+    );
+    expect({for (final s in dist) s.label: s.count}, {'shore': 1});
+  });
+
+  test('the diver filter reads the dive, not the site', () async {
+    // dive_sites carries its own diver_id, so an unqualified `diver_id = ?`
+    // would be ambiguous once the site is joined in.
+    await db
+        .into(db.divers)
+        .insert(
+          const DiversCompanion(
+            id: Value('diver-a'),
+            name: Value('A'),
+            medicalNotes: Value(''),
+            notes: Value(''),
+            isDefault: Value(false),
+            createdAt: Value(0),
+            updatedAt: Value(0),
+          ),
+        );
+    await insertSite(id: 'beach', entryMethod: 'shore');
+    await insertDive(id: 'mine', siteId: 'beach', diverId: 'diver-a');
+    await insertDive(id: 'theirs', siteId: 'beach');
+
+    final dist = await repository.getEntryMethodDistribution(
+      diverId: 'diver-a',
+    );
+    expect({for (final s in dist) s.label: s.count}, {'shore': 1});
+  });
+
+  group('getEntryExitMethodPairsForSite', () {
+    test('does not inherit the site methods it exists to suggest', () async {
+      // This query feeds the site-assign suggestion, so folding the site's own
+      // entry method back in would make the site suggest itself from a single
+      // dive that never recorded one.
+      await insertSite(id: 'beach', entryMethod: 'shore');
+      await insertDive(id: 'no-entry', siteId: 'beach');
+
+      final pairs = await repository.getEntryExitMethodPairsForSite(
+        siteId: 'beach',
+      );
+      expect(pairs, isEmpty);
+    });
+  });
+}

--- a/test/features/statistics/data/repositories/water_type_distribution_test.dart
+++ b/test/features/statistics/data/repositories/water_type_distribution_test.dart
@@ -1,0 +1,161 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/domain/models/dive_filter_state.dart';
+import 'package:submersion/features/statistics/data/repositories/statistics_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+/// Issue #1427: the water type chart counted only the value stored on the
+/// dive, so a dive that inherits its water type from its site was missing.
+void main() {
+  late StatisticsRepository repository;
+  late AppDatabase db;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = StatisticsRepository();
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  Future<String> insertSite({required String id, String? waterType}) async {
+    await db
+        .into(db.diveSites)
+        .insert(
+          DiveSitesCompanion.insert(
+            id: id,
+            name: 'Site $id',
+            waterType: Value(waterType),
+            createdAt: 0,
+            updatedAt: 0,
+          ),
+        );
+    return id;
+  }
+
+  Future<String> insertDive({
+    required String id,
+    String? siteId,
+    String? waterType,
+    String? diverId,
+    bool excludedFromStats = false,
+  }) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            siteId: Value(siteId),
+            waterType: Value(waterType),
+            excludedFromStats: Value(excludedFromStats),
+            diveDateTime: Value(DateTime(2026, 1, 1).millisecondsSinceEpoch),
+            createdAt: const Value(0),
+            updatedAt: const Value(0),
+          ),
+        );
+    return id;
+  }
+
+  Future<Map<String, int>> countsByLabel() async {
+    final dist = await repository.getWaterTypeDistribution();
+    return {for (final s in dist) s.label: s.count};
+  }
+
+  test('a dive with no water type inherits its site water type', () async {
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertDive(id: 'own', waterType: 'salt');
+    await insertDive(id: 'inherited', siteId: 'reef');
+
+    expect(await countsByLabel(), {'salt': 2});
+  });
+
+  test("the dive's own water type wins over the site's", () async {
+    // A quarry flooded with sea water, or simply a diver who corrected the
+    // site's default: the value on the dive is the diver's explicit answer.
+    await insertSite(id: 'quarry', waterType: 'fresh');
+    await insertDive(id: 'corrected', siteId: 'quarry', waterType: 'salt');
+
+    expect(await countsByLabel(), {'salt': 1});
+  });
+
+  test('an empty water type string falls back to the site', () async {
+    // Older imports wrote '' rather than NULL.
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertDive(id: 'blank', siteId: 'reef', waterType: '');
+
+    expect(await countsByLabel(), {'salt': 1});
+  });
+
+  test('a dive with no water type anywhere stays out of the chart', () async {
+    await insertSite(id: 'unknown-site');
+    await insertDive(id: 'sited', siteId: 'unknown-site');
+    await insertDive(id: 'siteless');
+    await insertDive(id: 'known', waterType: 'fresh');
+
+    expect(await countsByLabel(), {'fresh': 1});
+  });
+
+  test('percentages are shares of the dives that have a water type', () async {
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertDive(id: 'a', siteId: 'reef');
+    await insertDive(id: 'b', waterType: 'salt');
+    await insertDive(id: 'c', waterType: 'fresh');
+    await insertDive(id: 'd'); // no water type at all
+
+    final dist = await repository.getWaterTypeDistribution();
+    final byLabel = {for (final s in dist) s.label: s};
+    expect(byLabel['salt']!.percentage, closeTo(200 / 3, 0.001));
+    expect(byLabel['fresh']!.percentage, closeTo(100 / 3, 0.001));
+  });
+
+  test('an inherited water type still honours the statistics scope', () async {
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertDive(id: 'counted', siteId: 'reef');
+    await insertDive(id: 'excluded', siteId: 'reef', excludedFromStats: true);
+
+    expect(await countsByLabel(), {'salt': 1});
+  });
+
+  test('the view filter still applies to an inherited water type', () async {
+    // The filter is an `AND dives.id IN (SELECT id FROM dives WHERE ...)`
+    // subquery that names the dives table itself; it has to keep resolving now
+    // that dive_sites is joined alongside.
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertSite(id: 'lake', waterType: 'fresh');
+    await insertDive(id: 'in-filter', siteId: 'reef');
+    await insertDive(id: 'out-of-filter', siteId: 'lake');
+
+    final dist = await repository.getWaterTypeDistribution(
+      filter: const DiveFilterState(siteId: 'reef'),
+    );
+    expect({for (final s in dist) s.label: s.count}, {'salt': 1});
+  });
+
+  test('the diver filter reads the dive, not the site', () async {
+    // dive_sites carries its own diver_id, so an unqualified `diver_id = ?`
+    // would be ambiguous once the site is joined in.
+    await db
+        .into(db.divers)
+        .insert(
+          const DiversCompanion(
+            id: Value('diver-a'),
+            name: Value('A'),
+            medicalNotes: Value(''),
+            notes: Value(''),
+            isDefault: Value(false),
+            createdAt: Value(0),
+            updatedAt: Value(0),
+          ),
+        );
+    await insertSite(id: 'reef', waterType: 'salt');
+    await insertDive(id: 'mine', siteId: 'reef', diverId: 'diver-a');
+    await insertDive(id: 'theirs', siteId: 'reef');
+
+    final dist = await repository.getWaterTypeDistribution(diverId: 'diver-a');
+    expect({for (final s in dist) s.label: s.count}, {'salt': 1});
+  });
+}


### PR DESCRIPTION
Fixes #1427

## The problem

Water type lives in two places: `dives.water_type` and `dive_sites.water_type`. The app snaps the site's value onto a dive when a site is assigned (`waterTypeAfterSiteAssign`, shipped in v1.7.0), but only at that moment. Dives logged or imported before that feature, and dives whose site gained its water type afterwards, still hold `null`.

`getWaterTypeDistribution` read only the dive column, so every one of those dives fell out of the chart even though the app knows perfectly well what water they were in. That is what the reporter's screenshot shows.

**Entry method has the identical gap on the same page** and is fixed here too: `dive_sites.entry_method` is snapped on assign the same way (#1104), and `getEntryMethodDistribution` also read only the dive column.

## The fix

Bucket on the effective value instead. Both queries take the same shape:

```sql
FROM (
  SELECT COALESCE(NULLIF(dives.water_type,''), NULLIF(dive_sites.water_type,'')) AS water_type
  FROM dives LEFT JOIN dive_sites ON dive_sites.id = dives.site_id
  WHERE 1 = 1 $diverFilter ${df.clause}
)
WHERE water_type IS NOT NULL
GROUP BY water_type
```

Three details worth flagging for review:

- **`NULLIF`, not a bare `COALESCE`.** The original queries guarded with `!= ''` because some importers wrote empty strings rather than `NULL`. A plain `COALESCE` would return `''` for those rows and never reach the site, so the bug would survive for exactly the imported dives most likely to be missing the field.
- **The fallback is resolved one level down.** SQLite would let `GROUP BY water_type` bind to either joined table's real column instead of the aliased expression. Doing it in a subquery leaves one such column in scope. This also matches the shape the visibility distribution already uses.
- **`dives.diver_id`, qualified.** `dive_sites` carries a `diver_id` of its own, so the previous unqualified `AND diver_id = ?` becomes ambiguous once the site is joined. Because the repository catches and returns `[]`, that would have shown up as an empty pie chart rather than an error.

## Inheriting on the dive itself

The issue also asks that the dive inherit the site's water type. `Dive.effectiveWaterType` (`waterType ?? site?.waterType`) and `Dive.effectiveEntryMethod` are the Dart mirrors of the COALESCE, and the dive detail page reads them, so the dive visibly shows its site's values. For entry method that meant updating the two `hasDiveConditions` gates as well, or an inherited-only dive would never open the section that shows the row.

This is a read-time derivation rather than a backfill migration. Writing site values into dive rows would make the site's default indistinguishable from the diver's own answer and would sync that guess to every device. A value set on the dive always wins: a site's water type is a default, not a fact about every dive made there.

## Two queries deliberately left alone

**`getEntryExitMethodPairsForSite` keeps reading the stored column.** It is what the site-assign feature reads to suggest an entry method for a site, so giving it the same fallback builds a feedback loop: a site with `entry_method = 'shore'` and one dive that recorded nothing would report "shore observed once here," and the site would cite that as evidence for its own value. Same table, same column, opposite correct answer, because one query describes what the diver logged and the other infers a default from it. Now a doc comment and a regression test rather than tribal knowledge.

**`exitMethod` gets no `effective` getter.** Its snap-on-assign rule (`entryExitAfterSiteAssign`) turns on whether the diver has unlinked exit from entry, and that flag is dive form state that is never persisted. A read-time fallback cannot reproduce it, so exit stays as stored.

## Tests

23 new tests across four files. The repository tests were confirmed to fail against the old queries by reverting the implementation: 5 of 7 for water type, 6 of 8 for entry method. The ones that pass either way are those asserting the dive's own value still wins, which is correctly unchanged.

`water_type_distribution_test.dart` and `entry_method_distribution_test.dart` each cover:
- inheritance from the site, and the dive's own value winning over it
- the empty-string value falling back to the site
- a dive with the value nowhere staying out of the chart
- percentages taken over the dives that have a value
- `DiveStatsScope` exclusion still applying to an inherited value
- the view filter still resolving now that `dive_sites` is joined alongside
- the diver filter reading the dive's `diver_id`, not the site's

plus, for entry method, that `getEntryExitMethodPairsForSite` does not inherit.

`dive_effective_water_type_test.dart` and `dive_effective_entry_method_test.dart` cover the getters, including that exit method stays underived.

`flutter analyze lib test` clean; `flutter test test/features/statistics test/features/dive_log` 3976 passed.

## Not in scope

Exports and the logbook table column still emit the stored value verbatim, which is what CSV/UDDF round-trips and sync depend on.
