### PR TITLE
fix(ble): stop the Oceans S1 descriptor claiming a Suunto Ocean

### DIFF
--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -271,8 +271,9 @@ int libdc_descriptor_match(const char *name, unsigned int transport,
         return 0;
     }
 
-    // A name belonging to a device libdivecomputer cannot download must not be
-    // claimed by a descriptor that merely prefix-matches it. See issue #123.
+    // Some advertised names identify hardware libdivecomputer has no support
+    // for. Reject those up front, so that no descriptor can claim one on a
+    // loose prefix match. See issue #123.
     if ((transport & LIBDC_TRANSPORT_BLE) && is_suunto_ng_ble_name(name)) {
         return 0;
     }

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -213,9 +213,63 @@ static const char *ble_alias_product(const char *name) {
     return NULL;
 }
 
+// Some BLE names belong to a device libdivecomputer does not support, yet are
+// still claimed by a descriptor whose filter is too loose. Claiming one is
+// worse than ignoring it: the download wizard announces a "Recognized Device"
+// and promises the download will work, and the connect then fails because the
+// app is speaking the wrong vendor's protocol.
+//
+// Issue #123: a Suunto Ocean advertises "S19 <4 hex> LE". dc_filter_oceans
+// prefix-matches the two characters "S1" with strncasecmp, so the Oceans S1
+// descriptor swallowed the watch. The two are unrelated: the Ocean is on
+// Suunto's next-generation smartwatch platform, whose dive-download protocol
+// has never been captured, let alone implemented, in libdivecomputer.
+//
+// The rejection is keyed on the whole advertised shape rather than on the
+// looser "S1" prefix on the libdivecomputer side. The Oceans S1's own
+// advertised name is documented nowhere: not in libdivecomputer, not in
+// Subsurface, not in the S1 manual, which pairs by QR code. Tightening that
+// prefix would be a guess against a discontinued product, and a wrong guess
+// there silently hides working hardware.
+//
+// Across two scans five minutes apart the same watch advertised "S19 1DFC LE"
+// and then "S19 700B LE" from two different MAC addresses, so the hex group is
+// a rotating privacy identifier and "S19" is the stable model code. The second
+// digit is left open because a sibling model on the same platform would differ
+// there while colliding with the identical "S1" prefix; everything else is
+// pinned, so a name of any other shape is left alone.
+static int is_suunto_ng_ble_name(const char *name) {
+    // "S1d hhhh LE"
+    static const size_t kLength = 11;
+
+    if (name == NULL || strlen(name) != kLength) {
+        return 0;
+    }
+    if (toupper((unsigned char)name[0]) != 'S' || name[1] != '1' ||
+        !isdigit((unsigned char)name[2])) {
+        return 0;
+    }
+    if (name[3] != ' ' || name[8] != ' ') {
+        return 0;
+    }
+    for (size_t i = 4; i < 8; i++) {
+        if (!isxdigit((unsigned char)name[i])) {
+            return 0;
+        }
+    }
+    return toupper((unsigned char)name[9]) == 'L' &&
+           toupper((unsigned char)name[10]) == 'E';
+}
+
 int libdc_descriptor_match(const char *name, unsigned int transport,
                            libdc_descriptor_info_t *info) {
     if (name == NULL || info == NULL) {
+        return 0;
+    }
+
+    // A name belonging to a device libdivecomputer cannot download must not be
+    // claimed by a descriptor that merely prefix-matches it. See issue #123.
+    if ((transport & LIBDC_TRANSPORT_BLE) && is_suunto_ng_ble_name(name)) {
         return 0;
     }
 

--- a/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
+++ b/packages/libdivecomputer_plugin/macos/Classes/libdc_wrapper.c
@@ -234,19 +234,23 @@ static const char *ble_alias_product(const char *name) {
 //
 // Across two scans five minutes apart the same watch advertised "S19 1DFC LE"
 // and then "S19 700B LE" from two different MAC addresses, so the hex group is
-// a rotating privacy identifier and "S19" is the stable model code. The second
-// digit is left open because a sibling model on the same platform would differ
-// there while colliding with the identical "S1" prefix; everything else is
-// pinned, so a name of any other shape is left alone.
+// a rotating privacy identifier and "S19" is the stable model code.
+//
+// Every character outside the rotating group is pinned, including the "9".
+// A sibling model on the same platform would carry a different code and would
+// collide with the same "S1" prefix, but suppressing a name nobody has
+// captured is the same guess this fix exists to avoid, and its cost is worse:
+// hiding a device is harder to diagnose than mislabelling one. Add a model
+// code here only with a real advertised name behind it, from a log.
 static int is_suunto_ng_ble_name(const char *name) {
-    // "S1d hhhh LE"
+    // "S19 hhhh LE"
     static const size_t kLength = 11;
 
     if (name == NULL || strlen(name) != kLength) {
         return 0;
     }
     if (toupper((unsigned char)name[0]) != 'S' || name[1] != '1' ||
-        !isdigit((unsigned char)name[2])) {
+        name[2] != '9') {
         return 0;
     }
     if (name[3] != ' ' || name[8] != ' ') {

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -47,6 +47,17 @@ static void expect_ble_match(const char *name, const char *expected_product,
     }
 }
 
+static void expect_no_ble_match(const char *name) {
+    libdc_descriptor_info_t info;
+    memset(&info, 0, sizeof(info));
+    int ok = libdc_descriptor_match(name, LIBDC_TRANSPORT_BLE, &info);
+    if (ok) {
+        fprintf(stderr, "FAIL: \"%s\" resolved to %s %s/0x%02x, expected no match\n",
+                name, info.vendor, info.product, info.model);
+        assert(!ok);
+    }
+}
+
 // The reported device: BLE name "HUD" must resolve to the G2 HUD (0x42),
 // not the family-level "Aladin Sport Matrix" fallback (0x17).
 static void test_hud_resolves_to_g2_hud(void) {
@@ -167,6 +178,53 @@ static void test_symbios_hud_resolves_to_hud(void) {
     printf("PASS: test_symbios_hud_resolves_to_hud\n");
 }
 
+// Issue #123: the Suunto Ocean advertises "S19 <4 hex> LE". dc_filter_oceans
+// prefix-matches the two characters "S1" with strncasecmp, so the Oceans S1
+// descriptor claimed the watch: the download wizard announced a "Recognized
+// Device" and the connect then failed, because Submersion was speaking the
+// Oceans line protocol to a Suunto smartwatch. libdivecomputer has no support
+// for the Ocean (its protocol is still uncaptured upstream), so the only
+// correct answer is to claim nothing.
+//
+// Both the hex group and the MAC address rotate between sessions
+// ("S19 1DFC LE", then "S19 700B LE" five minutes later), so only the "S19"
+// model code and the " LE" suffix are stable enough to match on.
+static void test_suunto_ocean_is_not_claimed_by_oceans_s1(void) {
+    expect_no_ble_match("S19 1DFC LE");
+    expect_no_ble_match("S19 700B LE");
+    printf("PASS: test_suunto_ocean_is_not_claimed_by_oceans_s1\n");
+}
+
+// Advertised names vary in case by Bluetooth stack and firmware, exactly as
+// the alias tables above assume.
+static void test_suunto_ocean_rejection_is_case_insensitive(void) {
+    expect_no_ble_match("s19 1dfc le");
+    expect_no_ble_match("S19 1dfc Le");
+    printf("PASS: test_suunto_ocean_rejection_is_case_insensitive\n");
+}
+
+// The rejection is keyed on the whole observed shape, not on the "S19" model
+// code alone, so it cannot quietly grow to cover names we have never seen.
+static void test_suunto_rejection_requires_the_full_shape(void) {
+    expect_ble_match("S19", "S1", 0);
+    expect_ble_match("S19 1DFC", "S1", 0);
+    expect_ble_match("S19 1DFC LE EXTRA", "S1", 0);
+    printf("PASS: test_suunto_rejection_requires_the_full_shape\n");
+}
+
+// Issue #123 regression guard: the Oceans S1 itself must be untouched. Its
+// real advertised name is documented nowhere: not in libdivecomputer, not in
+// Subsurface, not in the S1 manual, which pairs by QR code. That is exactly
+// why this fix rejects one known-foreign name instead of tightening the "S1"
+// prefix on a guess. Every plausible S1 name still resolves.
+static void test_oceans_s1_names_still_resolve(void) {
+    expect_ble_match("S1", "S1", 0);
+    expect_ble_match("S1 1234", "S1", 0);
+    expect_ble_match("S12345", "S1", 0);
+    expect_ble_match("S1-1234", "S1", 0);
+    printf("PASS: test_oceans_s1_names_still_resolve\n");
+}
+
 int main(void) {
     test_hud_resolves_to_g2_hud();
     test_other_short_aliases_resolve();
@@ -180,6 +238,10 @@ int main(void) {
     test_other_perdix_models_unchanged();
     test_symbios_handset_resolves_to_handset();
     test_symbios_hud_resolves_to_hud();
+    test_suunto_ocean_is_not_claimed_by_oceans_s1();
+    test_suunto_ocean_rejection_is_case_insensitive();
+    test_suunto_rejection_requires_the_full_shape();
+    test_oceans_s1_names_still_resolve();
     printf("\nAll descriptor match integration tests passed.\n");
     return 0;
 }

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -22,6 +22,13 @@
 // and unit-number digits are zeroed (the bug was first reported against real
 // Symbios devices in issue #288).
 
+// Every check in this file is an assert, so a build that defines NDEBUG would
+// compile all of them out and leave each test printing PASS while verifying
+// nothing. CI configures without a build type today, so asserts are live, but
+// adding -DCMAKE_BUILD_TYPE=Release is an ordinary thing to do and would
+// silently turn this file into a no-op. Keep assertions regardless.
+#undef NDEBUG
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
+++ b/packages/libdivecomputer_plugin/test/native/test_descriptor_match_integration.c
@@ -212,6 +212,17 @@ static void test_suunto_rejection_requires_the_full_shape(void) {
     printf("PASS: test_suunto_rejection_requires_the_full_shape\n");
 }
 
+// The model code is pinned to the captured "S19" rather than to any "S1x", so
+// a sibling model on the same Suunto platform is still claimed by the Oceans
+// S1 row until someone logs its advertised name. That is deliberate:
+// suppressing a name nobody has captured is the same guess this fix avoids,
+// and hiding a device is harder to diagnose than mislabelling one.
+static void test_unobserved_model_codes_are_not_suppressed(void) {
+    expect_ble_match("S18 1DFC LE", "S1", 0);
+    expect_ble_match("S10 700B LE", "S1", 0);
+    printf("PASS: test_unobserved_model_codes_are_not_suppressed\n");
+}
+
 // Issue #123 regression guard: the Oceans S1 itself must be untouched. Its
 // real advertised name is documented nowhere: not in libdivecomputer, not in
 // Subsurface, not in the S1 manual, which pairs by QR code. That is exactly
@@ -241,6 +252,7 @@ int main(void) {
     test_suunto_ocean_is_not_claimed_by_oceans_s1();
     test_suunto_ocean_rejection_is_case_insensitive();
     test_suunto_rejection_requires_the_full_shape();
+    test_unobserved_model_codes_are_not_suppressed();
     test_oceans_s1_names_still_resolve();
     printf("\nAll descriptor match integration tests passed.\n");
     return 0;


### PR DESCRIPTION
Fixes #123.

## Problem

A Suunto Ocean was identified as an **Oceans S1**, shown as a "Recognized Device" whose download "should work automatically", and then failed at connect. From the reporter's debug log:

```
[BLE] [INFO] Discovered S19 1DFC LE (E1:A1:42:5F:12:1D) as Oceans S1
[LDC] [ERROR] Download failed (connect_failed): Failed to connect to device
```

This is the second of two bugs on that issue. The first (a BLE scan that logged nothing, so an empty log was indistinguishable from "the user never scanned") shipped in #947, and fixing it is what made this one visible.

## Root cause

The Suunto Ocean advertises `S19 <4 hex> LE`. In `descriptor.c` the Oceans S1 row uses `dc_filter_oceans`, which prefix-matches the two characters `"S1"` through `dc_match_prefix`, itself `strncasecmp(name, prefix, strlen(prefix))`. `S19 1DFC LE` starts with `S1`, so the Oceans S1 descriptor claimed the watch and the app spoke the Oceans line protocol to a Suunto smartwatch.

Across two scans five minutes apart the same watch advertised `S19 1DFC LE` and then `S19 700B LE` from two different MAC addresses, so the hex group and the address are rotating privacy identifiers and `S19` is the stable model code.

Not Android-specific despite the issue title: every platform scanner reaches the same matcher.

## Fix

`is_suunto_ng_ble_name` in `libdc_wrapper.c` matches the exact 11-character shape `S19 <4 hex> LE`, and `libdc_descriptor_match` returns 0 for it on BLE before the descriptor scan. Every character outside the rotating hex group is pinned, including the `9`: a sibling model on the same platform would carry a different code, but suppressing a name nobody has captured is the same guess this fix exists to avoid, and hiding a device is harder to diagnose than mislabelling one.

`libdc_descriptor_match` is the single choke point for BLE identification on every platform (Android `libdc_jni.cpp`, Windows `ble_scanner.cc`, Darwin `BleScanner.swift`, Linux `ble_scanner.c`), so one predicate covers all five. The file already hosts two issue-scoped BLE name tables layered over libdivecomputer's filters, `uwatec_ble_alias_model` (#285) and `ble_alias_product` (#1246), so this follows an established seam rather than opening a new one.

## Why not tighten the "S1" prefix in descriptor.c

That was the obvious fix and it is deliberately not what this PR does.

The Oceans S1's own advertised name is documented nowhere: not in libdivecomputer, not in Subsurface, not in the S1 manual, which pairs by QR code. Any boundary rule on that prefix is therefore a guess against a discontinued product, and a wrong guess silently hides working hardware, which is a worse failure than the one being fixed. Keying on the name we actually captured carries no such guess: `S1`, `S1 1234`, `S12345` and `S1-1234` all still resolve to the Oceans S1, and there are tests pinning that.

It also keeps the vendored libdivecomputer closer to upstream across rebases of the `submersion-patches` branch.

## Scope

This does **not** add Suunto Ocean download support, and should not be read as a step toward it. The Ocean is on Suunto's next-generation smartwatch platform rather than the EON Steel dive computer platform, and its download protocol has never been captured upstream. Adding a descriptor on a guessed family would recreate the same false "Recognized Device" promise with a different wrong protocol.

After this change the Ocean is passed over and recorded in the debug log as `Unmatched device <addr> (S19 1DFC LE) rssi=...`, which is the honest answer given no protocol support exists.

Note for later: if the in-progress Ocean work in libdivecomputer lands, `is_suunto_ng_ble_name` must be removed in the same change, or it will suppress the very device the new descriptor supports. That is called out in the code comment.

## Testing

Five cases added to `test_descriptor_match_integration.c`, which links the real `descriptor.c` so it exercises BLE name to descriptor resolution end to end:

- the two observed Ocean names resolve to nothing
- the rejection is case-insensitive
- it requires the full shape, so `S19`, `S19 1DFC` and `S19 1DFC LE EXTRA` still resolve to the Oceans S1
- unobserved model codes are not suppressed, so `S18 1DFC LE` and `S10 700B LE` still resolve, recording the deliberate boundary
- every plausible Oceans S1 name still resolves

The first of these fails on `main` with `FAIL: "S19 1DFC LE" resolved to Oceans S1/0x00, expected no match`.

`ctest`: 11/11 native tests pass, including the 12 pre-existing descriptor-match cases. No Dart or Kotlin files are touched and the submodule pointer is unchanged.

## Follow-up, not in this PR

An unsupported computer currently just does not appear, which from the user's side still looks like scanning forever. Surfacing "Suunto Ocean detected, download not supported, import from the Suunto app instead" would be a real improvement, and Submersion already parses FIT so the import path exists. There is no unsupported-device concept in the Dart layer today, so that means new l10n keys across 11 catalogs and belongs in its own PR.
