### PR TITLE
feat(dc): merge duplicate dive computer records

### DIFF
--- a/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
+++ b/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
@@ -124,7 +124,7 @@ DiveComputer mergedDiveComputer(
       survivor.bluetoothAddress,
       ...duplicates.map((d) => d.bluetoothAddress),
     ]),
-    equipmentId: _firstNonBlank([
+    equipmentId: _firstNonBlankId([
       survivor.equipmentId,
       ...duplicates.map((d) => d.equipmentId),
     ]),
@@ -155,7 +155,23 @@ String? _newestFingerprint(List<DiveComputer> records) {
   return best?.lastDiveFingerprint;
 }
 
+/// The first value that is not blank, trimmed. A record can carry padding
+/// from a file import, and the survivor should not inherit it along with the
+/// value; the identity rules compare through [normalizeComputerIdentityPart],
+/// so a padded serial matched here would be stored padded and displayed that
+/// way. Mirrors [_mergedNotes], which trims for the same reason.
 String? _firstNonBlank(Iterable<String?> values) {
+  for (final value in values) {
+    final trimmed = value?.trim();
+    if (trimmed != null && trimmed.isNotEmpty) return trimmed;
+  }
+  return null;
+}
+
+/// The first value that is not blank, verbatim. For `equipmentId`, which is a
+/// foreign key into `equipment.id` and has to match the stored row exactly;
+/// the repository picks the merged gear twin the same way.
+String? _firstNonBlankId(Iterable<String?> values) {
   for (final value in values) {
     if (value != null && value.trim().isNotEmpty) return value;
   }

--- a/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
+++ b/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
@@ -82,24 +82,25 @@ bool _isLater(DateTime? a, DateTime? b) {
 ///
 /// Identity fields (id, name, owner) stay the survivor's. Blank descriptive
 /// fields are filled from the first duplicate that has them. Dive counts add
-/// up, favorite status is kept if any record had it, the newest download wins
-/// together with its fingerprint (the two travel as a pair: a fingerprint is
-/// the cursor of the download that produced it), and distinct notes are
-/// appended.
+/// up, favorite status is kept if any record had it, the newest download wins,
+/// and distinct notes are appended.
+///
+/// `lastDiveFingerprint` is picked by download recency rather than by list
+/// order: it is the cursor the next incremental download resumes from, so it
+/// has to come from the most recent download that actually recorded one. A
+/// record can hold a `lastDownload` with no fingerprint (the two are written
+/// separately), and taking the survivor's stale cursor in that case would
+/// resume from the wrong dive.
 DiveComputer mergedDiveComputer(
   DiveComputer survivor,
   List<DiveComputer> duplicates,
 ) {
-  final newest = duplicates.fold<DiveComputer>(
-    survivor,
+  final records = [survivor, ...duplicates];
+  final newest = records.reduce(
     (best, candidate) =>
         _isLater(candidate.lastDownload, best.lastDownload) ? candidate : best,
   );
-  final fingerprint = _firstNonBlank([
-    newest.lastDiveFingerprint,
-    survivor.lastDiveFingerprint,
-    ...duplicates.map((d) => d.lastDiveFingerprint),
-  ]);
+  final fingerprint = _newestFingerprint(records);
 
   return survivor.copyWith(
     manufacturer: _firstNonBlank([
@@ -136,6 +137,22 @@ DiveComputer mergedDiveComputer(
     isFavorite: survivor.isFavorite || duplicates.any((d) => d.isFavorite),
     notes: _mergedNotes(survivor.notes, duplicates.map((d) => d.notes)),
   );
+}
+
+/// The `lastDiveFingerprint` of the most recently downloaded record that has
+/// one. Records without a fingerprint are skipped rather than shadowing an
+/// older record's cursor, and ties keep the earliest entry, which is the
+/// survivor.
+String? _newestFingerprint(List<DiveComputer> records) {
+  DiveComputer? best;
+  for (final record in records) {
+    final fingerprint = record.lastDiveFingerprint;
+    if (fingerprint == null || fingerprint.trim().isEmpty) continue;
+    if (best == null || _isLater(record.lastDownload, best.lastDownload)) {
+      best = record;
+    }
+  }
+  return best?.lastDiveFingerprint;
 }
 
 String? _firstNonBlank(Iterable<String?> values) {

--- a/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
+++ b/lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart
@@ -1,0 +1,157 @@
+import 'package:submersion/core/database/imported_computer_identity.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+
+/// Pure rules for reconciling dive computer records that describe one
+/// physical device (issue #645).
+///
+/// A Bluetooth identifier is local to the host that discovered the computer,
+/// so the same Petrel can be saved once per Mac, iPhone and iPad. The serial
+/// number, with manufacturer and model, is the stable identity these rules
+/// compare on. Everything here is side-effect free so the repository, the
+/// merge sheet and the duplicate banner share one definition of "duplicate".
+
+/// Other records in [all] that look like the same physical computer as
+/// [target]: a shared non-blank serial number, a compatible manufacturer and
+/// model, and the same owner.
+///
+/// Manufacturer and model are compatible when they agree after normalisation
+/// or when either side is blank; a file import can register a serial without
+/// a model, and that record is still the same device.
+List<DiveComputer> duplicateCandidatesFor(
+  DiveComputer target,
+  Iterable<DiveComputer> all,
+) {
+  final serial = normalizeComputerIdentityPart(target.serialNumber);
+  if (serial.isEmpty) return const [];
+  final diver = normalizeComputerIdentityPart(target.diverId);
+  return [
+    for (final candidate in all)
+      if (candidate.id != target.id &&
+          normalizeComputerIdentityPart(candidate.serialNumber) == serial &&
+          normalizeComputerIdentityPart(candidate.diverId) == diver &&
+          _compatible(target.manufacturer, candidate.manufacturer) &&
+          _compatible(target.model, candidate.model))
+        candidate,
+  ];
+}
+
+bool _compatible(String? a, String? b) {
+  final left = normalizeComputerIdentityPart(a);
+  final right = normalizeComputerIdentityPart(b);
+  return left.isEmpty || right.isEmpty || left == right;
+}
+
+/// Whether [records] carry two different non-blank serial numbers, which
+/// means the user is about to merge what are probably different devices.
+bool serialNumbersConflict(Iterable<DiveComputer> records) {
+  final serials = {
+    for (final record in records)
+      if (normalizeComputerIdentityPart(record.serialNumber).isNotEmpty)
+        normalizeComputerIdentityPart(record.serialNumber),
+  };
+  return serials.length > 1;
+}
+
+/// The record a merge should keep unless the user says otherwise: the
+/// favorite, else the one with the most dives, else the most recently
+/// downloaded, else the first.
+DiveComputer defaultSurvivor(List<DiveComputer> records) {
+  assert(records.isNotEmpty, 'defaultSurvivor needs at least one record');
+  var best = records.first;
+  for (final candidate in records.skip(1)) {
+    if (_ranksAbove(candidate, best)) best = candidate;
+  }
+  return best;
+}
+
+bool _ranksAbove(DiveComputer candidate, DiveComputer incumbent) {
+  if (candidate.isFavorite != incumbent.isFavorite) return candidate.isFavorite;
+  if (candidate.diveCount != incumbent.diveCount) {
+    return candidate.diveCount > incumbent.diveCount;
+  }
+  return _isLater(candidate.lastDownload, incumbent.lastDownload);
+}
+
+bool _isLater(DateTime? a, DateTime? b) {
+  if (a == null) return false;
+  if (b == null) return true;
+  return a.isAfter(b);
+}
+
+/// The surviving record after [duplicates] fold into [survivor].
+///
+/// Identity fields (id, name, owner) stay the survivor's. Blank descriptive
+/// fields are filled from the first duplicate that has them. Dive counts add
+/// up, favorite status is kept if any record had it, the newest download wins
+/// together with its fingerprint (the two travel as a pair: a fingerprint is
+/// the cursor of the download that produced it), and distinct notes are
+/// appended.
+DiveComputer mergedDiveComputer(
+  DiveComputer survivor,
+  List<DiveComputer> duplicates,
+) {
+  final newest = duplicates.fold<DiveComputer>(
+    survivor,
+    (best, candidate) =>
+        _isLater(candidate.lastDownload, best.lastDownload) ? candidate : best,
+  );
+  final fingerprint = _firstNonBlank([
+    newest.lastDiveFingerprint,
+    survivor.lastDiveFingerprint,
+    ...duplicates.map((d) => d.lastDiveFingerprint),
+  ]);
+
+  return survivor.copyWith(
+    manufacturer: _firstNonBlank([
+      survivor.manufacturer,
+      ...duplicates.map((d) => d.manufacturer),
+    ]),
+    model: _firstNonBlank([survivor.model, ...duplicates.map((d) => d.model)]),
+    serialNumber: _firstNonBlank([
+      survivor.serialNumber,
+      ...duplicates.map((d) => d.serialNumber),
+    ]),
+    firmwareVersion: _firstNonBlank([
+      survivor.firmwareVersion,
+      ...duplicates.map((d) => d.firmwareVersion),
+    ]),
+    connectionType: _firstNonBlank([
+      survivor.connectionType,
+      ...duplicates.map((d) => d.connectionType),
+    ]),
+    bluetoothAddress: _firstNonBlank([
+      survivor.bluetoothAddress,
+      ...duplicates.map((d) => d.bluetoothAddress),
+    ]),
+    equipmentId: _firstNonBlank([
+      survivor.equipmentId,
+      ...duplicates.map((d) => d.equipmentId),
+    ]),
+    lastDownload: newest.lastDownload,
+    lastDiveFingerprint: fingerprint,
+    diveCount: duplicates.fold<int>(
+      survivor.diveCount,
+      (sum, d) => sum + d.diveCount,
+    ),
+    isFavorite: survivor.isFavorite || duplicates.any((d) => d.isFavorite),
+    notes: _mergedNotes(survivor.notes, duplicates.map((d) => d.notes)),
+  );
+}
+
+String? _firstNonBlank(Iterable<String?> values) {
+  for (final value in values) {
+    if (value != null && value.trim().isNotEmpty) return value;
+  }
+  return null;
+}
+
+String _mergedNotes(String survivorNotes, Iterable<String> duplicateNotes) {
+  final parts = <String>[];
+  final seen = <String>{};
+  for (final notes in [survivorNotes, ...duplicateNotes]) {
+    final trimmed = notes.trim();
+    if (trimmed.isEmpty || !seen.add(trimmed)) continue;
+    parts.add(trimmed);
+  }
+  return parts.join('\n\n');
+}

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:libdivecomputer_plugin/libdivecomputer_plugin.dart' as pigeon;
 import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/core/utils/log_failure.dart';
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
 
+import 'package:submersion/features/dive_computer/domain/services/dive_computer_merge_rules.dart';
 import 'package:submersion/features/dive_computer/presentation/providers/reparse_providers.dart';
+import 'package:submersion/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
@@ -84,6 +87,14 @@ class DeviceDetailPage extends ConsumerWidget {
                 ),
               ),
               PopupMenuItem(
+                value: 'merge',
+                child: ListTile(
+                  leading: const Icon(Icons.merge_type),
+                  title: Text(context.l10n.diveComputer_detail_mergeMenu),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+              PopupMenuItem(
                 value: 'delete',
                 child: ListTile(
                   leading: const Icon(Icons.delete),
@@ -100,6 +111,7 @@ class DeviceDetailPage extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            _buildDuplicateBanner(context, ref, computer),
             _buildInfoCard(context, computer, colorScheme),
             const SizedBox(height: 16),
             _buildStatsCard(context, computer, colorScheme),
@@ -110,6 +122,63 @@ class DeviceDetailPage extends ConsumerWidget {
               _buildNotesCard(context, computer, colorScheme),
             ],
           ],
+        ),
+      ),
+    );
+  }
+
+  /// Points at another saved record that reports this computer's serial
+  /// number (#645). Shrinks to nothing while loading or when there is none,
+  /// so the page never reserves space for a banner it may not show.
+  Widget _buildDuplicateBanner(
+    BuildContext context,
+    WidgetRef ref,
+    DiveComputer computer,
+  ) {
+    final duplicates =
+        ref.watch(possibleDuplicateComputersProvider(computer.id)).value ??
+        const <DiveComputer>[];
+    if (duplicates.isEmpty) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final names = duplicates.map((d) => d.displayName).join(', ');
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Card(
+        key: const ValueKey('duplicate_banner'),
+        color: colorScheme.tertiaryContainer,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.copy_all, color: colorScheme.onTertiaryContainer),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      context.l10n.diveComputer_detail_duplicateBanner(names),
+                      style: TextStyle(color: colorScheme.onTertiaryContainer),
+                    ),
+                  ),
+                ],
+              ),
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: TextButton.icon(
+                  key: const ValueKey('duplicate_banner_merge'),
+                  onPressed: () =>
+                      _mergeWith(context, ref, computer, duplicates),
+                  icon: const Icon(Icons.merge_type),
+                  label: Text(
+                    context.l10n.diveComputer_detail_duplicateBannerAction,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -525,9 +594,123 @@ class DeviceDetailPage extends ConsumerWidget {
       case 'edit':
         _showEditDialog(context, ref, computer);
         break;
+      case 'merge':
+        logFailure(
+          _showMergePicker(context, ref, computer),
+          DeviceDetailPage,
+          'open merge picker',
+        );
+        break;
       case 'delete':
         _showDeleteConfirmation(context, ref, computer);
         break;
+    }
+  }
+
+  /// Lists the diver's other computers so one can be merged with this one.
+  /// Records that share this computer's serial number are listed first.
+  Future<void> _showMergePicker(
+    BuildContext context,
+    WidgetRef ref,
+    DiveComputer computer,
+  ) async {
+    final all = await ref.read(allDiveComputersProvider.future);
+    if (!context.mounted) return;
+
+    final duplicates = duplicateCandidatesFor(computer, all);
+    final duplicateIds = duplicates.map((d) => d.id).toSet();
+    final others = [
+      ...duplicates,
+      for (final other in all)
+        if (other.id != computer.id && !duplicateIds.contains(other.id)) other,
+    ];
+
+    final chosen = await showModalBottomSheet<DiveComputer>(
+      context: context,
+      builder: (sheetContext) {
+        final theme = Theme.of(sheetContext);
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text(
+                  sheetContext.l10n.diveComputer_detail_mergePickerTitle,
+                  style: theme.textTheme.titleLarge,
+                ),
+              ),
+              if (others.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                  child: Text(
+                    sheetContext.l10n.diveComputer_detail_mergePickerEmpty,
+                  ),
+                )
+              else
+                Flexible(
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: [
+                      for (final other in others)
+                        ListTile(
+                          key: ValueKey('merge_pick_${other.id}'),
+                          leading: const Icon(Icons.watch),
+                          title: Text(other.displayName),
+                          subtitle: Text(
+                            duplicateIds.contains(other.id)
+                                ? sheetContext
+                                      .l10n
+                                      .diveComputer_detail_mergePickerSameSerial
+                                : other.fullName,
+                          ),
+                          trailing: duplicateIds.contains(other.id)
+                              ? Icon(
+                                  Icons.copy_all,
+                                  color: theme.colorScheme.tertiary,
+                                )
+                              : null,
+                          onTap: () => Navigator.of(sheetContext).pop(other),
+                        ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+    if (chosen == null || !context.mounted) return;
+    await _mergeWith(context, ref, computer, [chosen]);
+  }
+
+  /// Opens the merge sheet for this computer and [others]. When another
+  /// record survives, the page moves to it: this one no longer exists.
+  Future<void> _mergeWith(
+    BuildContext context,
+    WidgetRef ref,
+    DiveComputer computer,
+    List<DiveComputer> others,
+  ) async {
+    final computers = [computer, ...others];
+    final messenger = ScaffoldMessenger.of(context);
+    final result = await DiveComputerMergeSheet.show(context, computers);
+    if (result == null || !context.mounted) return;
+
+    final survivor = computers.firstWhere((c) => c.id == result.survivorId);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.diveComputer_merge_snackbar(
+            result.mergedComputerIds.length,
+            survivor.displayName,
+          ),
+        ),
+      ),
+    );
+    if (survivor.id != computer.id) {
+      context.pushReplacement('/dive-computers/${survivor.id}');
     }
   }
 

--- a/lib/features/dive_computer/presentation/pages/device_detail_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_detail_page.dart
@@ -141,7 +141,15 @@ class DeviceDetailPage extends ConsumerWidget {
     if (duplicates.isEmpty) return const SizedBox.shrink();
 
     final colorScheme = Theme.of(context).colorScheme;
-    final names = duplicates.map((d) => d.displayName).join(', ');
+    // One duplicate is named; several are counted. Joining names into the
+    // singular message reads as "A, B reports the same serial number".
+    final message = duplicates.length == 1
+        ? context.l10n.diveComputer_detail_duplicateBanner(
+            duplicates.first.displayName,
+          )
+        : context.l10n.diveComputer_detail_duplicateBannerMultiple(
+            duplicates.length,
+          );
     return Padding(
       padding: const EdgeInsets.only(bottom: 16),
       child: Card(
@@ -159,7 +167,7 @@ class DeviceDetailPage extends ConsumerWidget {
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      context.l10n.diveComputer_detail_duplicateBanner(names),
+                      message,
                       style: TextStyle(color: colorScheme.onTertiaryContainer),
                     ),
                   ),

--- a/lib/features/dive_computer/presentation/pages/device_list_page.dart
+++ b/lib/features/dive_computer/presentation/pages/device_list_page.dart
@@ -3,9 +3,11 @@ import 'package:submersion/core/providers/provider.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:submersion/features/dive_computer/presentation/utils/last_download_formatter.dart';
+import 'package:submersion/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
 import 'package:submersion/l10n/l10n_extension.dart';
+import 'package:submersion/shared/selection/bulk_action.dart';
 import 'package:submersion/shared/selection/selectable_list_scope.dart';
 import 'package:submersion/shared/selection/selection_leading.dart';
 import 'package:submersion/shared/selection/selection_app_bar.dart';
@@ -57,9 +59,19 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
               ? SelectionAppBar(
                   controller: _selection,
                   selectableIds: visibleIds,
-                  // Delete only: favourite reads as singular, and a multi-device
-                  // download would be a new flow rather than a lifted action.
-                  actions: const [],
+                  // Merge and delete: favourite reads as singular, and a
+                  // multi-device download would be a new flow rather than a
+                  // lifted action.
+                  actions: [
+                    BulkAction(
+                      id: 'merge',
+                      icon: Icons.merge_type,
+                      label:
+                          context.l10n.diveComputer_list_selection_mergeTooltip,
+                      minCount: 2,
+                      onInvoke: _startMerge,
+                    ),
+                  ],
                   shell: SelectionBarShell.appBar,
                   onDelete: _confirmAndDelete,
                 )
@@ -120,6 +132,35 @@ class _DeviceListPageState extends ConsumerState<DeviceListPage> {
                   icon: const Icon(Icons.add),
                   label: Text(context.l10n.diveComputer_list_addComputer),
                 ),
+        ),
+      ),
+    );
+  }
+
+  /// Folds the checked computers into one (#645). The sheet owns the
+  /// confirmation; this only reports the outcome and leaves selection mode.
+  Future<void> _startMerge() async {
+    final ids = _selectedIds;
+    final computers = [
+      for (final computer
+          in ref.read(allDiveComputersProvider).value ?? const <DiveComputer>[])
+        if (ids.contains(computer.id)) computer,
+    ];
+    if (computers.length < 2) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final result = await DiveComputerMergeSheet.show(context, computers);
+    if (result == null || !mounted) return;
+
+    _selection.exit();
+    final survivor = computers.firstWhere((c) => c.id == result.survivorId);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          context.l10n.diveComputer_merge_snackbar(
+            result.mergedComputerIds.length,
+            survivor.displayName,
+          ),
         ),
       ),
     );

--- a/lib/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart
+++ b/lib/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:submersion/core/providers/provider.dart';
+
+import 'package:submersion/core/utils/log_failure.dart';
+import 'package:submersion/features/dive_computer/domain/services/dive_computer_merge_rules.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_providers.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
+
+/// Bottom sheet that folds two or more dive computer records into one.
+///
+/// The user picks which record to keep; every dive, profile and download
+/// cursor moves to it and the others are deleted. The sheet is the review
+/// step issue #645 asks for before any duplicate is removed, so it shows each
+/// record's identity, how many dives will move, and a warning when the
+/// records report different serial numbers.
+class DiveComputerMergeSheet extends ConsumerStatefulWidget {
+  const DiveComputerMergeSheet({super.key, required this.computers});
+
+  /// The records to merge, at least two.
+  final List<DiveComputer> computers;
+
+  /// Opens the sheet. Resolves to the merge result, or null when dismissed.
+  static Future<DiveComputerMergeResult?> show(
+    BuildContext context,
+    List<DiveComputer> computers,
+  ) {
+    return showModalBottomSheet<DiveComputerMergeResult>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => DiveComputerMergeSheet(computers: computers),
+    );
+  }
+
+  @override
+  ConsumerState<DiveComputerMergeSheet> createState() =>
+      _DiveComputerMergeSheetState();
+}
+
+class _DiveComputerMergeSheetState
+    extends ConsumerState<DiveComputerMergeSheet> {
+  late String _survivorId;
+  int? _affectedDives;
+  bool _isMerging = false;
+
+  List<String> get _duplicateIds => [
+    for (final computer in widget.computers)
+      if (computer.id != _survivorId) computer.id,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _survivorId = defaultSurvivor(widget.computers).id;
+    _reloadAffectedDives();
+  }
+
+  void _reloadAffectedDives() {
+    _affectedDives = null;
+    logFailure(
+      _loadAffectedDives(_duplicateIds),
+      _DiveComputerMergeSheetState,
+      'count affected dives',
+    );
+  }
+
+  Future<void> _loadAffectedDives(List<String> duplicateIds) async {
+    final count = await ref
+        .read(diveComputerMergeRepositoryProvider)
+        .countAffectedDives(duplicateIds);
+    // The survivor may have changed while the count was in flight.
+    if (mounted && _duplicateIds.join(',') == duplicateIds.join(',')) {
+      setState(() => _affectedDives = count);
+    }
+  }
+
+  Future<void> _performMerge() async {
+    setState(() => _isMerging = true);
+    try {
+      final result = await ref
+          .read(diveComputerNotifierProvider.notifier)
+          .merge(survivorId: _survivorId, duplicateIds: _duplicateIds);
+      // Dive attribution changed under the dive list; the computer notifier
+      // cannot reach these providers without an import cycle.
+      ref.invalidate(divesProvider);
+      ref.invalidate(diveListNotifierProvider);
+      if (mounted) Navigator.of(context).pop(result);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isMerging = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.diveComputer_merge_failed('$e'))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final conflict = serialNumbersConflict(widget.computers);
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomInset),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.diveComputer_merge_title,
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.diveComputer_merge_intro(widget.computers.length),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (conflict) ...[
+              const SizedBox(height: 12),
+              const _SerialMismatchWarning(
+                key: ValueKey('merge_serial_warning'),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Text(
+              l10n.diveComputer_merge_keepLabel,
+              style: theme.textTheme.titleSmall,
+            ),
+            RadioGroup<String>(
+              groupValue: _survivorId,
+              onChanged: (value) {
+                if (value == null || value == _survivorId) return;
+                setState(() {
+                  _survivorId = value;
+                  _reloadAffectedDives();
+                });
+              },
+              child: Column(
+                children: [
+                  for (final computer in widget.computers)
+                    RadioListTile<String>(
+                      key: ValueKey('merge_keep_${computer.id}'),
+                      value: computer.id,
+                      title: Text(computer.displayName),
+                      subtitle: Text(_subtitleFor(context, computer)),
+                      secondary: computer.isFavorite
+                          ? Icon(Icons.star, color: theme.colorScheme.primary)
+                          : null,
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (_affectedDives != null)
+              Text(
+                l10n.diveComputer_merge_affectedDives(_affectedDives!),
+                key: const ValueKey('merge_affected_dives'),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: _isMerging
+                      ? null
+                      : () => Navigator.of(context).pop(),
+                  child: Text(l10n.common_action_cancel),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  key: const ValueKey('merge_confirm'),
+                  onPressed: _isMerging ? null : _performMerge,
+                  child: _isMerging
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(l10n.diveComputer_merge_action),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _subtitleFor(BuildContext context, DiveComputer computer) {
+    final l10n = context.l10n;
+    final serial = computer.serialNumber?.trim();
+    final parts = <String>[
+      if (computer.fullName != computer.displayName) computer.fullName,
+      serial != null && serial.isNotEmpty
+          ? l10n.diveComputer_merge_serialLabel(serial)
+          : l10n.diveComputer_merge_noSerial,
+      l10n.diveComputer_list_diveCount(computer.diveCount),
+    ];
+    return parts.join(' · ');
+  }
+}
+
+class _SerialMismatchWarning extends StatelessWidget {
+  const _SerialMismatchWarning({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.warning_amber_rounded,
+            color: colorScheme.onErrorContainer,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              context.l10n.diveComputer_merge_serialMismatchWarning,
+              style: TextStyle(color: colorScheme.onErrorContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart
+++ b/lib/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart
@@ -60,18 +60,21 @@ class _DiveComputerMergeSheetState
   void _reloadAffectedDives() {
     _affectedDives = null;
     logFailure(
-      _loadAffectedDives(_duplicateIds),
+      _loadAffectedDives(_survivorId, _duplicateIds),
       _DiveComputerMergeSheetState,
       'count affected dives',
     );
   }
 
-  Future<void> _loadAffectedDives(List<String> duplicateIds) async {
+  Future<void> _loadAffectedDives(
+    String survivorId,
+    List<String> duplicateIds,
+  ) async {
     final count = await ref
         .read(diveComputerMergeRepositoryProvider)
-        .countAffectedDives(duplicateIds);
+        .countAffectedDives(survivorId: survivorId, duplicateIds: duplicateIds);
     // The survivor may have changed while the count was in flight.
-    if (mounted && _duplicateIds.join(',') == duplicateIds.join(',')) {
+    if (mounted && survivorId == _survivorId) {
       setState(() => _affectedDives = count);
     }
   }

--- a/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
@@ -1,0 +1,430 @@
+import 'package:drift/drift.dart';
+
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart' as db;
+import 'package:submersion/core/services/database_service.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
+import 'package:submersion/features/dive_computer/domain/services/dive_computer_merge_rules.dart';
+import 'package:submersion/features/dive_log/data/repositories/profile_series_repository.dart';
+import 'package:submersion/features/dive_log/data/repositories/series_id_chunks.dart';
+import 'package:submersion/features/dive_log/data/repositories/tank_pressure_series_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart'
+    as domain;
+
+/// What a merge did, for the snackbar and for navigation.
+class DiveComputerMergeResult {
+  const DiveComputerMergeResult({
+    required this.survivorId,
+    required this.mergedComputerIds,
+    required this.movedDiveCount,
+  });
+
+  /// The record every reference now points at.
+  final String survivorId;
+
+  /// The records that were folded in and deleted, in the order given.
+  final List<String> mergedComputerIds;
+
+  /// Distinct dives that referenced a merged record through any table.
+  final int movedDiveCount;
+}
+
+/// Folds duplicate dive computer records into one (issue #645).
+///
+/// Extracted from [DiveComputerRepository], which is already at its size
+/// limit, in the same way the buddy merge lives beside the buddy repository.
+///
+/// The same physical computer is saved once per host when its Bluetooth
+/// identifier differs between a Mac, an iPhone and an iPad. Every table that
+/// attributes data to a computer is repointed at the survivor in one
+/// transaction, the duplicates are deleted with tombstones, and every dive
+/// that referenced a duplicate is restamped: `dive_data_sources`,
+/// `dive_tanks` and `dive_profile_events` have no clock of their own and only
+/// replicate when their parent dive does.
+class DiveComputerMergeRepository {
+  DiveComputerMergeRepository({
+    SyncRepository? syncRepository,
+    ProfileSeriesRepository? profileSeries,
+    TankPressureSeriesRepository? tankSeries,
+  }) : _syncRepository = syncRepository ?? SyncRepository(),
+       _profileSeries = profileSeries ?? ProfileSeriesRepository(),
+       _tankSeries = tankSeries ?? TankPressureSeriesRepository();
+
+  final SyncRepository _syncRepository;
+  final ProfileSeriesRepository _profileSeries;
+  final TankPressureSeriesRepository _tankSeries;
+  final _log = LoggerService.forClass(DiveComputerMergeRepository);
+
+  db.AppDatabase get _db => DatabaseService.instance.database;
+
+  /// Distinct dives that reference any of [computerIds] through any table.
+  Future<int> countAffectedDives(List<String> computerIds) async {
+    if (computerIds.isEmpty) return 0;
+    return (await _affectedDiveIds(computerIds)).length;
+  }
+
+  /// Folds [duplicateIds] into [survivorId].
+  ///
+  /// Throws [ArgumentError] when there is nothing to merge and [StateError]
+  /// when any record is missing; nothing is written in either case.
+  Future<DiveComputerMergeResult> mergeComputers({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    final duplicates = duplicateIds
+        .where((id) => id != survivorId)
+        .toSet()
+        .toList(growable: false);
+    if (duplicates.isEmpty) {
+      throw ArgumentError.value(
+        duplicateIds,
+        'duplicateIds',
+        'must name at least one computer other than the survivor',
+      );
+    }
+
+    try {
+      _log.info(
+        'Merging ${duplicates.length} dive computer(s) into $survivorId',
+      );
+
+      final rows = await (_db.select(
+        _db.diveComputers,
+      )..where((t) => t.id.isIn([survivorId, ...duplicates]))).get();
+      final byId = {for (final row in rows) row.id: row};
+      final survivorRow = byId[survivorId];
+      if (survivorRow == null) {
+        throw StateError('Survivor dive computer $survivorId does not exist');
+      }
+      final missing = duplicates.where((id) => !byId.containsKey(id));
+      if (missing.isNotEmpty) {
+        throw StateError('Dive computers not found: ${missing.join(', ')}');
+      }
+
+      final survivor = _toDomain(survivorRow);
+      final merged = mergedDiveComputer(survivor, [
+        for (final id in duplicates) _toDomain(byId[id]!),
+      ]);
+      final duplicateTwinIds = {
+        for (final id in duplicates) ?byId[id]!.equipmentId,
+      };
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      late final Set<String> affectedDives;
+
+      await _db.transaction(() async {
+        affectedDives = await _affectedDiveIds(duplicates);
+
+        await _repointDiveOwnedTables(duplicates, survivorId, now);
+        await _repointQualityFindings(duplicates, survivorId, now);
+        await _profileSeries.repointComputer(duplicates, survivorId, now: now);
+        await _tankSeries.repointComputer(duplicates, survivorId, now: now);
+        await _repointLegacyProfiles(duplicates, survivorId);
+
+        final relinked = await _repointGearLinks(
+          survivorTwinId: merged.equipmentId,
+          duplicateTwinIds: duplicateTwinIds,
+          now: now,
+        );
+        affectedDives.addAll(relinked);
+
+        await _bumpDives(affectedDives.toList(growable: false), now);
+        await _writeSurvivor(merged, now);
+
+        for (final id in duplicates) {
+          await (_db.delete(
+            _db.diveComputers,
+          )..where((t) => t.id.equals(id))).go();
+          await _syncRepository.logDeletion(
+            entityType: 'diveComputers',
+            recordId: id,
+          );
+        }
+      });
+
+      SyncEventBus.notifyLocalChange();
+      _log.info(
+        'Merged ${duplicates.length} dive computer(s) into $survivorId; '
+        '${affectedDives.length} dive(s) restamped',
+      );
+
+      return DiveComputerMergeResult(
+        survivorId: survivorId,
+        mergedComputerIds: duplicates,
+        movedDiveCount: affectedDives.length,
+      );
+    } catch (e, stackTrace) {
+      _log.error(
+        'Failed to merge dive computers $duplicateIds into $survivorId',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Steps
+  // ---------------------------------------------------------------------------
+
+  /// Every dive that references one of [computerIds] through any table.
+  Future<Set<String>> _affectedDiveIds(List<String> computerIds) async {
+    final ids = <String>{};
+
+    final dives =
+        await (_db.selectOnly(_db.dives)
+              ..addColumns([_db.dives.id])
+              ..where(_db.dives.computerId.isIn(computerIds)))
+            .get();
+    ids.addAll(dives.map((r) => r.read(_db.dives.id)!));
+
+    Future<void> collect<T extends Table, R>(
+      TableInfo<T, R> table,
+      GeneratedColumn<String> diveId,
+      GeneratedColumn<String> computerId,
+    ) async {
+      final rows =
+          await (_db.selectOnly(table)
+                ..addColumns([diveId])
+                ..where(computerId.isIn(computerIds)))
+              .get();
+      ids.addAll(rows.map((r) => r.read(diveId)!));
+    }
+
+    await collect(
+      _db.diveDataSources,
+      _db.diveDataSources.diveId,
+      _db.diveDataSources.computerId,
+    );
+    await collect(
+      _db.diveTanks,
+      _db.diveTanks.diveId,
+      _db.diveTanks.computerId,
+    );
+    await collect(
+      _db.diveProfileEvents,
+      _db.diveProfileEvents.diveId,
+      _db.diveProfileEvents.computerId,
+    );
+    await collect(
+      _db.qualityFindings,
+      _db.qualityFindings.diveId,
+      _db.qualityFindings.computerId,
+    );
+    await collect(
+      _db.diveProfileSeries,
+      _db.diveProfileSeries.diveId,
+      _db.diveProfileSeries.computerId,
+    );
+    await collect(
+      _db.tankPressureSeries,
+      _db.tankPressureSeries.diveId,
+      _db.tankPressureSeries.computerId,
+    );
+    return ids;
+  }
+
+  /// The tables whose rows ride their parent dive's clock: a plain repoint,
+  /// with the dive restamped afterwards by [_bumpDives].
+  Future<void> _repointDiveOwnedTables(
+    List<String> fromIds,
+    String toId,
+    int now,
+  ) async {
+    await (_db.update(
+      _db.dives,
+    )..where((t) => t.computerId.isIn(fromIds))).write(
+      db.DivesCompanion(computerId: Value(toId), updatedAt: Value(now)),
+    );
+    await (_db.update(_db.diveDataSources)
+          ..where((t) => t.computerId.isIn(fromIds)))
+        .write(db.DiveDataSourcesCompanion(computerId: Value(toId)));
+    await (_db.update(_db.diveTanks)..where((t) => t.computerId.isIn(fromIds)))
+        .write(db.DiveTanksCompanion(computerId: Value(toId)));
+    await (_db.update(_db.diveProfileEvents)
+          ..where((t) => t.computerId.isIn(fromIds)))
+        .write(db.DiveProfileEventsCompanion(computerId: Value(toId)));
+  }
+
+  /// Quality findings carry their own hlc, so each moved row is restamped.
+  Future<void> _repointQualityFindings(
+    List<String> fromIds,
+    String toId,
+    int now,
+  ) async {
+    final rows =
+        await (_db.selectOnly(_db.qualityFindings)
+              ..addColumns([_db.qualityFindings.id])
+              ..where(_db.qualityFindings.computerId.isIn(fromIds)))
+            .get();
+    final ids = rows.map((r) => r.read(_db.qualityFindings.id)!).toList();
+    if (ids.isEmpty) return;
+
+    for (final chunk in seriesIdChunks(ids)) {
+      await (_db.update(
+        _db.qualityFindings,
+      )..where((t) => t.id.isIn(chunk))).write(
+        db.QualityFindingsCompanion(
+          computerId: Value(toId),
+          updatedAt: Value(now),
+        ),
+      );
+      for (final id in chunk) {
+        await _syncRepository.markRecordPending(
+          entityType: 'qualityFindings',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+  }
+
+  /// The pre-v183 row-per-sample table survives on a device whose pack could
+  /// not finish, and its FK has no ON DELETE action, so a lingering reference
+  /// would block the duplicate's delete (the #823 shape).
+  Future<void> _repointLegacyProfiles(List<String> fromIds, String toId) async {
+    final exists = await _db
+        .customSelect(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+          "AND name = 'dive_profiles'",
+        )
+        .get();
+    if (exists.isEmpty) return;
+    final placeholders = List.filled(fromIds.length, '?').join(', ');
+    await _db.customStatement(
+      'UPDATE dive_profiles SET computer_id = ? '
+      'WHERE computer_id IN ($placeholders)',
+      [toId, ...fromIds],
+    );
+  }
+
+  /// Moves `dive_equipment` links from each duplicate's gear twin onto the
+  /// survivor's twin. Returns the dives whose links changed so they can be
+  /// restamped: the junction has no clock and rides the dive.
+  ///
+  /// The duplicate's gear item itself is left alone. It may carry service
+  /// history the user wants, and the gear list has its own delete.
+  Future<Set<String>> _repointGearLinks({
+    required String? survivorTwinId,
+    required Set<String> duplicateTwinIds,
+    required int now,
+  }) async {
+    final touched = <String>{};
+    if (survivorTwinId == null) return touched;
+    final fromTwins = duplicateTwinIds.where((id) => id != survivorTwinId);
+    if (fromTwins.isEmpty) return touched;
+
+    final links = await (_db.select(
+      _db.diveEquipment,
+    )..where((t) => t.equipmentId.isIn(fromTwins.toList()))).get();
+    if (links.isEmpty) return touched;
+
+    final alreadyLinked =
+        await (_db.selectOnly(_db.diveEquipment)
+              ..addColumns([_db.diveEquipment.diveId])
+              ..where(_db.diveEquipment.equipmentId.equals(survivorTwinId)))
+            .get();
+    final linkedDives = {
+      for (final row in alreadyLinked) row.read(_db.diveEquipment.diveId)!,
+    };
+
+    for (final link in links) {
+      touched.add(link.diveId);
+      if (linkedDives.add(link.diveId)) {
+        await _db
+            .into(_db.diveEquipment)
+            .insert(
+              db.DiveEquipmentCompanion(
+                diveId: Value(link.diveId),
+                equipmentId: Value(survivorTwinId),
+              ),
+            );
+        await _syncRepository.markRecordPending(
+          entityType: 'diveEquipment',
+          recordId: '${link.diveId}|$survivorTwinId',
+          localUpdatedAt: now,
+        );
+      }
+      await (_db.delete(_db.diveEquipment)..where(
+            (t) =>
+                t.diveId.equals(link.diveId) &
+                t.equipmentId.equals(link.equipmentId),
+          ))
+          .go();
+      await _syncRepository.logDeletion(
+        entityType: 'diveEquipment',
+        recordId: '${link.diveId}|${link.equipmentId}',
+      );
+    }
+    return touched;
+  }
+
+  /// Restamps every affected dive so its clockless children replicate.
+  Future<void> _bumpDives(List<String> diveIds, int now) async {
+    if (diveIds.isEmpty) return;
+    for (final chunk in seriesIdChunks(diveIds)) {
+      await (_db.update(_db.dives)..where((t) => t.id.isIn(chunk))).write(
+        db.DivesCompanion(updatedAt: Value(now)),
+      );
+      for (final id in chunk) {
+        await _syncRepository.markRecordPending(
+          entityType: 'dives',
+          recordId: id,
+          localUpdatedAt: now,
+        );
+      }
+    }
+  }
+
+  Future<void> _writeSurvivor(domain.DiveComputer merged, int now) async {
+    await (_db.update(
+      _db.diveComputers,
+    )..where((t) => t.id.equals(merged.id))).write(
+      db.DiveComputersCompanion(
+        manufacturer: Value(merged.manufacturer),
+        model: Value(merged.model),
+        serialNumber: Value(merged.serialNumber),
+        firmwareVersion: Value(merged.firmwareVersion),
+        connectionType: Value(merged.connectionType),
+        bluetoothAddress: Value(merged.bluetoothAddress),
+        lastDiveFingerprint: Value(merged.lastDiveFingerprint),
+        lastDownloadTimestamp: Value(
+          merged.lastDownload?.millisecondsSinceEpoch,
+        ),
+        diveCount: Value(merged.diveCount),
+        isFavorite: Value(merged.isFavorite),
+        notes: Value(merged.notes),
+        equipmentId: Value(merged.equipmentId),
+        updatedAt: Value(now),
+      ),
+    );
+    await _syncRepository.markRecordPending(
+      entityType: 'diveComputers',
+      recordId: merged.id,
+      localUpdatedAt: now,
+    );
+  }
+
+  domain.DiveComputer _toDomain(db.DiveComputer row) => domain.DiveComputer(
+    id: row.id,
+    diverId: row.diverId,
+    name: row.name,
+    manufacturer: row.manufacturer,
+    model: row.model,
+    serialNumber: row.serialNumber,
+    firmwareVersion: row.firmwareVersion,
+    connectionType: row.connectionType,
+    bluetoothAddress: row.bluetoothAddress,
+    lastDiveFingerprint: row.lastDiveFingerprint,
+    lastDownload: row.lastDownloadTimestamp != null
+        ? DateTime.fromMillisecondsSinceEpoch(row.lastDownloadTimestamp!)
+        : null,
+    diveCount: row.diveCount,
+    isFavorite: row.isFavorite,
+    notes: row.notes,
+    equipmentId: row.equipmentId,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(row.createdAt),
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(row.updatedAt),
+  );
+}

--- a/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
@@ -98,7 +98,8 @@ class DiveComputerMergeRepository {
 
   /// The gear twin the survivor holds after the merge: its own, else the
   /// first one a duplicate has. Mirrors `mergedDiveComputer`, which fills the
-  /// survivor's blank `equipmentId` from the first duplicate that has one.
+  /// survivor's blank `equipmentId` from the first duplicate that has one,
+  /// verbatim: it is a foreign key and has to match `equipment.id` exactly.
   String? _adoptedTwinId(
     String survivorId,
     List<String> duplicateIds,

--- a/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
+++ b/lib/features/dive_log/data/repositories/dive_computer_merge_repository.dart
@@ -58,10 +58,85 @@ class DiveComputerMergeRepository {
 
   db.AppDatabase get _db => DatabaseService.instance.database;
 
-  /// Distinct dives that reference any of [computerIds] through any table.
-  Future<int> countAffectedDives(List<String> computerIds) async {
-    if (computerIds.isEmpty) return 0;
-    return (await _affectedDiveIds(computerIds)).length;
+  /// Distinct dives a merge of [duplicateIds] into [survivorId] would move.
+  ///
+  /// Takes the survivor because gear links are counted the way the merge
+  /// moves them: a dive can reference a duplicate through its gear twin
+  /// alone, and whether that link moves depends on which twin the survivor
+  /// ends up with.
+  Future<int> countAffectedDives({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    final duplicates = _duplicatesToMerge(survivorId, duplicateIds);
+    if (duplicates.isEmpty) return 0;
+
+    final rows = await (_db.select(
+      _db.diveComputers,
+    )..where((t) => t.id.isIn([survivorId, ...duplicates]))).get();
+    final byId = {for (final row in rows) row.id: row};
+
+    final ids = await _affectedDiveIds(duplicates);
+    ids.addAll(
+      await _gearLinkedDiveIds(
+        survivorTwinId: _adoptedTwinId(survivorId, duplicates, byId),
+        duplicateTwinIds: {for (final id in duplicates) ?byId[id]?.equipmentId},
+      ),
+    );
+    return ids.length;
+  }
+
+  /// The duplicates a merge actually folds in: [duplicateIds] without the
+  /// survivor and without repeats, in the order given.
+  List<String> _duplicatesToMerge(
+    String survivorId,
+    List<String> duplicateIds,
+  ) => duplicateIds
+      .where((id) => id != survivorId)
+      .toSet()
+      .toList(growable: false);
+
+  /// The gear twin the survivor holds after the merge: its own, else the
+  /// first one a duplicate has. Mirrors `mergedDiveComputer`, which fills the
+  /// survivor's blank `equipmentId` from the first duplicate that has one.
+  String? _adoptedTwinId(
+    String survivorId,
+    List<String> duplicateIds,
+    Map<String, db.DiveComputer> byId,
+  ) {
+    for (final id in [survivorId, ...duplicateIds]) {
+      final twin = byId[id]?.equipmentId;
+      if (twin != null && twin.trim().isNotEmpty) return twin;
+    }
+    return null;
+  }
+
+  /// The duplicate twins whose dive links move onto [survivorTwinId]. A twin
+  /// the survivor already holds keeps its links where they are.
+  List<String> _twinsToMove(
+    String? survivorTwinId,
+    Set<String> duplicateTwinIds,
+  ) => survivorTwinId == null
+      ? const []
+      : duplicateTwinIds
+            .where((id) => id != survivorTwinId)
+            .toList(growable: false);
+
+  /// Dives that reference a duplicate through its gear twin alone. These
+  /// carry no `computer_id` of their own, so [_affectedDiveIds] cannot see
+  /// them, but [_repointGearLinks] moves and restamps them.
+  Future<Set<String>> _gearLinkedDiveIds({
+    required String? survivorTwinId,
+    required Set<String> duplicateTwinIds,
+  }) async {
+    final fromTwins = _twinsToMove(survivorTwinId, duplicateTwinIds);
+    if (fromTwins.isEmpty) return {};
+    final rows =
+        await (_db.selectOnly(_db.diveEquipment)
+              ..addColumns([_db.diveEquipment.diveId])
+              ..where(_db.diveEquipment.equipmentId.isIn(fromTwins)))
+            .get();
+    return {for (final row in rows) row.read(_db.diveEquipment.diveId)!};
   }
 
   /// Folds [duplicateIds] into [survivorId].
@@ -72,10 +147,7 @@ class DiveComputerMergeRepository {
     required String survivorId,
     required List<String> duplicateIds,
   }) async {
-    final duplicates = duplicateIds
-        .where((id) => id != survivorId)
-        .toSet()
-        .toList(growable: false);
+    final duplicates = _duplicatesToMerge(survivorId, duplicateIds);
     if (duplicates.isEmpty) {
       throw ArgumentError.value(
         duplicateIds,
@@ -312,12 +384,12 @@ class DiveComputerMergeRepository {
   }) async {
     final touched = <String>{};
     if (survivorTwinId == null) return touched;
-    final fromTwins = duplicateTwinIds.where((id) => id != survivorTwinId);
+    final fromTwins = _twinsToMove(survivorTwinId, duplicateTwinIds);
     if (fromTwins.isEmpty) return touched;
 
     final links = await (_db.select(
       _db.diveEquipment,
-    )..where((t) => t.equipmentId.isIn(fromTwins.toList()))).get();
+    )..where((t) => t.equipmentId.isIn(fromTwins))).get();
     if (links.isEmpty) return touched;
 
     final alreadyLinked =

--- a/lib/features/dive_log/data/repositories/profile_series_repository.dart
+++ b/lib/features/dive_log/data/repositories/profile_series_repository.dart
@@ -554,6 +554,10 @@ class ProfileSeriesRepository {
 
   /// Moves every series of [fromComputerIds] onto [toComputerId] and restamps
   /// each, for a dive computer merge (#645). Returns the number touched.
+  ///
+  /// Does not notify the sync bus: the merge runs this inside its own
+  /// transaction and notifies once after commit, so a notification here
+  /// would fire while the rows are still uncommitted.
   Future<int> repointComputer(
     List<String> fromComputerIds,
     String toComputerId, {
@@ -564,6 +568,7 @@ class ProfileSeriesRepository {
       toComputerId,
       (t) => t.computerId.isIn(fromComputerIds),
       now: now,
+      notify: false,
     );
   }
 
@@ -643,6 +648,7 @@ class ProfileSeriesRepository {
     String? computerId,
     Expression<bool> Function($DiveProfileSeriesTable t) where, {
     int? now,
+    bool notify = true,
   }) async {
     final nowMs = now ?? DateTime.now().millisecondsSinceEpoch;
     final ids = await _ids(where);
@@ -655,7 +661,7 @@ class ProfileSeriesRepository {
       ),
       nowMs,
     );
-    SyncEventBus.notifyLocalChange();
+    if (notify) SyncEventBus.notifyLocalChange();
     return ids.length;
   }
 

--- a/lib/features/dive_log/data/repositories/profile_series_repository.dart
+++ b/lib/features/dive_log/data/repositories/profile_series_repository.dart
@@ -552,6 +552,21 @@ class ProfileSeriesRepository {
   Future<int> clearComputer(String computerId, {int? now}) =>
       _setComputer(null, (t) => t.computerId.equals(computerId), now: now);
 
+  /// Moves every series of [fromComputerIds] onto [toComputerId] and restamps
+  /// each, for a dive computer merge (#645). Returns the number touched.
+  Future<int> repointComputer(
+    List<String> fromComputerIds,
+    String toComputerId, {
+    int? now,
+  }) {
+    if (fromComputerIds.isEmpty) return Future.value(0);
+    return _setComputer(
+      toComputerId,
+      (t) => t.computerId.isIn(fromComputerIds),
+      now: now,
+    );
+  }
+
   /// Diver reassignment: a computer that now belongs to [diverId] must not
   /// stay attributed on dives the diver does not own.
   Future<int> clearComputersOfDiverForForeignDives(

--- a/lib/features/dive_log/data/repositories/tank_pressure_series_repository.dart
+++ b/lib/features/dive_log/data/repositories/tank_pressure_series_repository.dart
@@ -281,6 +281,11 @@ class TankPressureSeriesRepository {
 
   /// Moves every series of [fromComputerIds] onto [toComputerId] and restamps
   /// each, for a dive computer merge (#645). Returns the number touched.
+  ///
+  /// Notifies nothing: `_setComputer` here never touches the sync bus (unlike
+  /// its profile-series twin, which takes a `notify` switch for this reason).
+  /// The merge runs this inside its own transaction and notifies once after
+  /// commit, so a notification here would publish uncommitted rows.
   Future<int> repointComputer(
     List<String> fromComputerIds,
     String toComputerId, {

--- a/lib/features/dive_log/data/repositories/tank_pressure_series_repository.dart
+++ b/lib/features/dive_log/data/repositories/tank_pressure_series_repository.dart
@@ -279,6 +279,21 @@ class TankPressureSeriesRepository {
   Future<int> clearComputer(String computerId, {int? now}) =>
       _setComputer(null, (t) => t.computerId.equals(computerId), now: now);
 
+  /// Moves every series of [fromComputerIds] onto [toComputerId] and restamps
+  /// each, for a dive computer merge (#645). Returns the number touched.
+  Future<int> repointComputer(
+    List<String> fromComputerIds,
+    String toComputerId, {
+    int? now,
+  }) {
+    if (fromComputerIds.isEmpty) return Future.value(0);
+    return _setComputer(
+      toComputerId,
+      (t) => t.computerId.isIn(fromComputerIds),
+      now: now,
+    );
+  }
+
   /// Diver reassignment: a computer that now belongs to [diverId] must not
   /// stay attributed on dives the diver does not own.
   Future<int> clearComputersOfDiverForForeignDives(

--- a/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
+++ b/lib/features/dive_log/presentation/providers/dive_computer_providers.dart
@@ -1,6 +1,8 @@
 import 'package:submersion/core/providers/provider.dart';
 
+import 'package:submersion/features/dive_computer/domain/services/dive_computer_merge_rules.dart';
 import 'package:submersion/features/divers/presentation/providers/diver_providers.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_repository_impl.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
 import 'package:submersion/features/dive_log/presentation/providers/dive_repository_provider.dart';
@@ -10,6 +12,12 @@ import 'package:submersion/core/utils/log_failure.dart';
 final diveComputerRepositoryProvider = Provider<DiveComputerRepository>((ref) {
   return DiveComputerRepository();
 });
+
+/// Repository provider for folding duplicate dive computer records together.
+final diveComputerMergeRepositoryProvider =
+    Provider<DiveComputerMergeRepository>((ref) {
+      return DiveComputerMergeRepository();
+    });
 
 /// All dive computers
 final allDiveComputersProvider = FutureProvider<List<DiveComputer>>((
@@ -48,6 +56,21 @@ final diveComputerByIdProvider = FutureProvider.family<DiveComputer?, String>((
   ref.invalidateSelfWhen(repository.watchComputersChanges());
   return repository.getComputerById(id);
 });
+
+/// Other saved computers that look like the same physical device as [id]:
+/// a shared serial number with a compatible manufacturer and model (#645).
+///
+/// Empty when the computer is unknown or has no serial number to compare on.
+final possibleDuplicateComputersProvider =
+    FutureProvider.family<List<DiveComputer>, String>((ref, id) async {
+      final computers = await ref.watch(allDiveComputersProvider.future);
+      for (final computer in computers) {
+        if (computer.id == id) {
+          return duplicateCandidatesFor(computer, computers);
+        }
+      }
+      return const [];
+    });
 
 /// Get the favorite (primary) dive computer
 final favoriteDiveComputerProvider = FutureProvider<DiveComputer?>((ref) async {
@@ -220,6 +243,29 @@ class DiveComputerNotifier
     final validatedId = await _ref.read(validatedCurrentDiverIdProvider.future);
     await _repository.setFavoriteComputer(id, diverId: validatedId);
     await _load();
+  }
+
+  /// Folds [duplicateIds] into [survivorId] and refreshes every computer
+  /// provider. Dive-side providers are the caller's to invalidate: this file
+  /// is imported by the dive providers, so it cannot import them back.
+  Future<DiveComputerMergeResult> merge({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    final result = await _ref
+        .read(diveComputerMergeRepositoryProvider)
+        .mergeComputers(survivorId: survivorId, duplicateIds: duplicateIds);
+    await _load();
+    _ref.invalidate(allDiveComputersProvider);
+    _ref.invalidate(favoriteDiveComputerProvider);
+    _ref.invalidate(possibleDuplicateComputersProvider);
+    _ref.invalidate(computersForDiveProvider);
+    _ref.invalidate(primaryComputerIdProvider);
+    _ref.invalidate(diveComputerByIdProvider(survivorId));
+    for (final id in result.mergedComputerIds) {
+      _ref.invalidate(diveComputerByIdProvider(id));
+    }
+    return result;
   }
 }
 

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "هذه الصورة كبيرة جدًا. جرّب صورة أصغر.",
   "profilePhoto_error_undecodable": "تعذّرت قراءة هذا الملف كصورة.",
   "profilePhoto_error_contactNoPhoto": "جهة الاتصال هذه ليس لها صورة.",
-  "profilePhoto_error_contactPermission": "يلزم إذن الوصول إلى جهات الاتصال لاختيار صورة."
+  "profilePhoto_error_contactPermission": "يلزم إذن الوصول إلى جهات الاتصال لاختيار صورة.",
+  "diveComputer_merge_title": "دمج أجهزة كمبيوتر الغوص",
+  "diveComputer_merge_intro": "ستصبح {count} سجلات سجلاً واحداً. تنتقل الغطسات والملفات وسجل التنزيل إلى السجل الذي تحتفظ به، وتُحذف السجلات الأخرى.",
+  "diveComputer_merge_keepLabel": "الاحتفاظ بهذا السجل",
+  "diveComputer_merge_serialLabel": "الرقم التسلسلي {serial}",
+  "diveComputer_merge_noSerial": "لا يوجد رقم تسلسلي",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{لا توجد غطسات مرتبطة بالسجلات الأخرى.} =1{ستنتقل غطسة واحدة إلى السجل المحتفظ به.} other{ستنتقل {count} غطسات إلى السجل المحتفظ به.}}",
+  "diveComputer_merge_serialMismatchWarning": "تُبلغ هذه السجلات عن أرقام تسلسلية مختلفة. قد تكون أجهزة مختلفة.",
+  "diveComputer_merge_action": "دمج",
+  "diveComputer_merge_snackbar": "{count, plural, =1{تم دمج سجل واحد في {name}} other{تم دمج {count} سجلات في {name}}}",
+  "diveComputer_merge_failed": "تعذّر دمج أجهزة الكمبيوتر: {error}",
+  "diveComputer_list_selection_mergeTooltip": "دمج أجهزة الكمبيوتر",
+  "diveComputer_detail_mergeMenu": "الدمج مع جهاز كمبيوتر آخر",
+  "diveComputer_detail_mergePickerTitle": "الدمج مع",
+  "diveComputer_detail_mergePickerEmpty": "لا توجد أجهزة كمبيوتر أخرى للدمج معها.",
+  "diveComputer_detail_mergePickerSameSerial": "نفس الرقم التسلسلي",
+  "diveComputer_detail_duplicateBanner": "يُبلغ {name} عن نفس الرقم التسلسلي. قد يكون هذا الجهاز محفوظاً مرتين.",
+  "diveComputer_detail_duplicateBannerAction": "دمج"
 }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "لا توجد أجهزة كمبيوتر أخرى للدمج معها.",
   "diveComputer_detail_mergePickerSameSerial": "نفس الرقم التسلسلي",
   "diveComputer_detail_duplicateBanner": "يُبلغ {name} عن نفس الرقم التسلسلي. قد يكون هذا الجهاز محفوظاً مرتين.",
+  "diveComputer_detail_duplicateBannerMultiple": "تُبلغ {count} سجلات محفوظة أخرى عن نفس الرقم التسلسلي. قد يكون هذا الجهاز محفوظاً أكثر من مرة.",
   "diveComputer_detail_duplicateBannerAction": "دمج"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Dieses Bild ist zu groß. Bitte ein kleineres wählen.",
   "profilePhoto_error_undecodable": "Diese Datei konnte nicht als Bild gelesen werden.",
   "profilePhoto_error_contactNoPhoto": "Dieser Kontakt hat kein Foto.",
-  "profilePhoto_error_contactPermission": "Für die Auswahl eines Fotos wird die Kontaktberechtigung benötigt."
+  "profilePhoto_error_contactPermission": "Für die Auswahl eines Fotos wird die Kontaktberechtigung benötigt.",
+  "diveComputer_merge_title": "Tauchcomputer zusammenführen",
+  "diveComputer_merge_intro": "{count} Einträge werden zu einem. Tauchgänge, Profile und Download-Verlauf wandern zu dem Eintrag, den du behältst. Die anderen Einträge werden gelöscht.",
+  "diveComputer_merge_keepLabel": "Diesen Eintrag behalten",
+  "diveComputer_merge_serialLabel": "Seriennummer {serial}",
+  "diveComputer_merge_noSerial": "Keine Seriennummer",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Den anderen Einträgen sind keine Tauchgänge zugeordnet.} =1{1 Tauchgang wandert zu dem Eintrag, den du behältst.} other{{count} Tauchgänge wandern zu dem Eintrag, den du behältst.}}",
+  "diveComputer_merge_serialMismatchWarning": "Diese Einträge melden unterschiedliche Seriennummern. Es könnten verschiedene Geräte sein.",
+  "diveComputer_merge_action": "Zusammenführen",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 Eintrag in {name} zusammengeführt} other{{count} Einträge in {name} zusammengeführt}}",
+  "diveComputer_merge_failed": "Computer konnten nicht zusammengeführt werden: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Computer zusammenführen",
+  "diveComputer_detail_mergeMenu": "Mit anderem Computer zusammenführen",
+  "diveComputer_detail_mergePickerTitle": "Zusammenführen mit",
+  "diveComputer_detail_mergePickerEmpty": "Es gibt keine anderen Computer zum Zusammenführen.",
+  "diveComputer_detail_mergePickerSameSerial": "Gleiche Seriennummer",
+  "diveComputer_detail_duplicateBanner": "{name} meldet dieselbe Seriennummer. Möglicherweise ist dieser Computer doppelt gespeichert.",
+  "diveComputer_detail_duplicateBannerAction": "Zusammenführen"
 }

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Es gibt keine anderen Computer zum Zusammenführen.",
   "diveComputer_detail_mergePickerSameSerial": "Gleiche Seriennummer",
   "diveComputer_detail_duplicateBanner": "{name} meldet dieselbe Seriennummer. Möglicherweise ist dieser Computer doppelt gespeichert.",
+  "diveComputer_detail_duplicateBannerMultiple": "{count} andere gespeicherte Einträge melden dieselbe Seriennummer. Möglicherweise ist dieser Computer mehrfach gespeichert.",
   "diveComputer_detail_duplicateBannerAction": "Zusammenführen"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -21804,5 +21804,67 @@
   "profilePhoto_error_tooLarge": "That image is too large to use. Try a smaller one.",
   "profilePhoto_error_undecodable": "That file could not be read as an image.",
   "profilePhoto_error_contactNoPhoto": "That contact does not have a photo.",
-  "profilePhoto_error_contactPermission": "Contacts permission is required to choose a photo."
+  "profilePhoto_error_contactPermission": "Contacts permission is required to choose a photo.",
+  "diveComputer_merge_title": "Merge Dive Computers",
+  "diveComputer_merge_intro": "{count} records will become one. Dives, profiles and download history move to the record you keep. The other records are deleted.",
+  "@diveComputer_merge_intro": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "diveComputer_merge_keepLabel": "Keep this record",
+  "diveComputer_merge_serialLabel": "Serial {serial}",
+  "@diveComputer_merge_serialLabel": {
+    "placeholders": {
+      "serial": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_merge_noSerial": "No serial number",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{No dives are attached to the other records.} =1{1 dive will move to the record you keep.} other{{count} dives will move to the record you keep.}}",
+  "@diveComputer_merge_affectedDives": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "diveComputer_merge_serialMismatchWarning": "These records report different serial numbers. They may be different physical computers.",
+  "diveComputer_merge_action": "Merge",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 record merged into {name}} other{{count} records merged into {name}}}",
+  "@diveComputer_merge_snackbar": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_merge_failed": "Could not merge computers: {error}",
+  "@diveComputer_merge_failed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_list_selection_mergeTooltip": "Merge computers",
+  "diveComputer_detail_mergeMenu": "Merge with another computer",
+  "diveComputer_detail_mergePickerTitle": "Merge with",
+  "diveComputer_detail_mergePickerEmpty": "There are no other computers to merge with.",
+  "diveComputer_detail_mergePickerSameSerial": "Same serial number",
+  "diveComputer_detail_duplicateBanner": "{name} reports the same serial number. It may be this computer saved twice.",
+  "@diveComputer_detail_duplicateBanner": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "diveComputer_detail_duplicateBannerAction": "Merge"
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -21866,5 +21866,13 @@
       }
     }
   },
+  "diveComputer_detail_duplicateBannerMultiple": "{count} other saved records report the same serial number. They may be this computer saved more than once.",
+  "@diveComputer_detail_duplicateBannerMultiple": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "diveComputer_detail_duplicateBannerAction": "Merge"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "No hay otros ordenadores con los que combinar.",
   "diveComputer_detail_mergePickerSameSerial": "Mismo número de serie",
   "diveComputer_detail_duplicateBanner": "{name} indica el mismo número de serie. Puede que este ordenador esté guardado dos veces.",
+  "diveComputer_detail_duplicateBannerMultiple": "Otros {count} registros guardados indican el mismo número de serie. Puede que este ordenador esté guardado más de una vez.",
   "diveComputer_detail_duplicateBannerAction": "Combinar"
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Esa imagen es demasiado grande. Prueba con una más pequeña.",
   "profilePhoto_error_undecodable": "No se pudo leer ese archivo como imagen.",
   "profilePhoto_error_contactNoPhoto": "Ese contacto no tiene foto.",
-  "profilePhoto_error_contactPermission": "Se necesita permiso de contactos para elegir una foto."
+  "profilePhoto_error_contactPermission": "Se necesita permiso de contactos para elegir una foto.",
+  "diveComputer_merge_title": "Combinar ordenadores de buceo",
+  "diveComputer_merge_intro": "{count} registros pasarán a ser uno. Las inmersiones, los perfiles y el historial de descargas se moverán al registro que conserves. Los demás registros se eliminarán.",
+  "diveComputer_merge_keepLabel": "Conservar este registro",
+  "diveComputer_merge_serialLabel": "Número de serie {serial}",
+  "diveComputer_merge_noSerial": "Sin número de serie",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Los otros registros no tienen inmersiones asociadas.} =1{1 inmersión se moverá al registro que conserves.} other{{count} inmersiones se moverán al registro que conserves.}}",
+  "diveComputer_merge_serialMismatchWarning": "Estos registros indican números de serie distintos. Podrían ser ordenadores físicos diferentes.",
+  "diveComputer_merge_action": "Combinar",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 registro combinado en {name}} other{{count} registros combinados en {name}}}",
+  "diveComputer_merge_failed": "No se pudieron combinar los ordenadores: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Combinar ordenadores",
+  "diveComputer_detail_mergeMenu": "Combinar con otro ordenador",
+  "diveComputer_detail_mergePickerTitle": "Combinar con",
+  "diveComputer_detail_mergePickerEmpty": "No hay otros ordenadores con los que combinar.",
+  "diveComputer_detail_mergePickerSameSerial": "Mismo número de serie",
+  "diveComputer_detail_duplicateBanner": "{name} indica el mismo número de serie. Puede que este ordenador esté guardado dos veces.",
+  "diveComputer_detail_duplicateBannerAction": "Combinar"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Cette image est trop volumineuse. Essayez-en une plus petite.",
   "profilePhoto_error_undecodable": "Ce fichier n'a pas pu être lu comme une image.",
   "profilePhoto_error_contactNoPhoto": "Ce contact n'a pas de photo.",
-  "profilePhoto_error_contactPermission": "L'autorisation d'accès aux contacts est requise pour choisir une photo."
+  "profilePhoto_error_contactPermission": "L'autorisation d'accès aux contacts est requise pour choisir une photo.",
+  "diveComputer_merge_title": "Fusionner les ordinateurs de plongée",
+  "diveComputer_merge_intro": "{count} fiches n'en feront plus qu'une. Les plongées, les profils et l'historique des téléchargements passent sur la fiche que vous conservez. Les autres fiches sont supprimées.",
+  "diveComputer_merge_keepLabel": "Conserver cette fiche",
+  "diveComputer_merge_serialLabel": "Numéro de série {serial}",
+  "diveComputer_merge_noSerial": "Pas de numéro de série",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Aucune plongée n'est rattachée aux autres fiches.} =1{1 plongée passera sur la fiche conservée.} other{{count} plongées passeront sur la fiche conservée.}}",
+  "diveComputer_merge_serialMismatchWarning": "Ces fiches indiquent des numéros de série différents. Il peut s'agir d'ordinateurs distincts.",
+  "diveComputer_merge_action": "Fusionner",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 fiche fusionnée dans {name}} other{{count} fiches fusionnées dans {name}}}",
+  "diveComputer_merge_failed": "Impossible de fusionner les ordinateurs : {error}",
+  "diveComputer_list_selection_mergeTooltip": "Fusionner les ordinateurs",
+  "diveComputer_detail_mergeMenu": "Fusionner avec un autre ordinateur",
+  "diveComputer_detail_mergePickerTitle": "Fusionner avec",
+  "diveComputer_detail_mergePickerEmpty": "Aucun autre ordinateur avec lequel fusionner.",
+  "diveComputer_detail_mergePickerSameSerial": "Même numéro de série",
+  "diveComputer_detail_duplicateBanner": "{name} indique le même numéro de série. Cet ordinateur est peut-être enregistré deux fois.",
+  "diveComputer_detail_duplicateBannerAction": "Fusionner"
 }

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Aucun autre ordinateur avec lequel fusionner.",
   "diveComputer_detail_mergePickerSameSerial": "Même numéro de série",
   "diveComputer_detail_duplicateBanner": "{name} indique le même numéro de série. Cet ordinateur est peut-être enregistré deux fois.",
+  "diveComputer_detail_duplicateBannerMultiple": "{count} autres enregistrements indiquent le même numéro de série. Cet ordinateur est peut-être enregistré plusieurs fois.",
   "diveComputer_detail_duplicateBannerAction": "Fusionner"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "התמונה הזו גדולה מדי. נסו תמונה קטנה יותר.",
   "profilePhoto_error_undecodable": "לא ניתן היה לקרוא את הקובץ הזה כתמונה.",
   "profilePhoto_error_contactNoPhoto": "לאיש הקשר הזה אין תמונה.",
-  "profilePhoto_error_contactPermission": "נדרשת הרשאת גישה לאנשי הקשר כדי לבחור תמונה."
+  "profilePhoto_error_contactPermission": "נדרשת הרשאת גישה לאנשי הקשר כדי לבחור תמונה.",
+  "diveComputer_merge_title": "מיזוג מחשבי צלילה",
+  "diveComputer_merge_intro": "{count} רשומות יהפכו לאחת. הצלילות, הפרופילים והיסטוריית ההורדות יעברו לרשומה שתשמור. שאר הרשומות יימחקו.",
+  "diveComputer_merge_keepLabel": "לשמור רשומה זו",
+  "diveComputer_merge_serialLabel": "מספר סידורי {serial}",
+  "diveComputer_merge_noSerial": "אין מספר סידורי",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{לא משויכות צלילות לרשומות האחרות.} =1{צלילה אחת תעבור לרשומה שתישמר.} other{{count} צלילות יעברו לרשומה שתישמר.}}",
+  "diveComputer_merge_serialMismatchWarning": "רשומות אלו מדווחות על מספרים סידוריים שונים. ייתכן שמדובר במחשבים שונים.",
+  "diveComputer_merge_action": "מיזוג",
+  "diveComputer_merge_snackbar": "{count, plural, =1{רשומה אחת מוזגה לתוך {name}} other{{count} רשומות מוזגו לתוך {name}}}",
+  "diveComputer_merge_failed": "לא ניתן למזג את המחשבים: {error}",
+  "diveComputer_list_selection_mergeTooltip": "מיזוג מחשבים",
+  "diveComputer_detail_mergeMenu": "מיזוג עם מחשב אחר",
+  "diveComputer_detail_mergePickerTitle": "מיזוג עם",
+  "diveComputer_detail_mergePickerEmpty": "אין מחשבים אחרים למיזוג.",
+  "diveComputer_detail_mergePickerSameSerial": "אותו מספר סידורי",
+  "diveComputer_detail_duplicateBanner": "{name} מדווח על אותו מספר סידורי. ייתכן שזהו אותו מחשב שנשמר פעמיים.",
+  "diveComputer_detail_duplicateBannerAction": "מיזוג"
 }

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "אין מחשבים אחרים למיזוג.",
   "diveComputer_detail_mergePickerSameSerial": "אותו מספר סידורי",
   "diveComputer_detail_duplicateBanner": "{name} מדווח על אותו מספר סידורי. ייתכן שזהו אותו מחשב שנשמר פעמיים.",
+  "diveComputer_detail_duplicateBannerMultiple": "{count} רשומות שמורות נוספות מדווחות על אותו מספר סידורי. ייתכן שזהו אותו מחשב שנשמר יותר מפעם אחת.",
   "diveComputer_detail_duplicateBannerAction": "מיזוג"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Nincs masik szamitogep, amivel ossze lehetne vonni.",
   "diveComputer_detail_mergePickerSameSerial": "Azonos sorozatszam",
   "diveComputer_detail_duplicateBanner": "{name} ugyanazt a sorozatszamot jelzi. Lehet, hogy ez a szamitogep ketszer van elmentve.",
+  "diveComputer_detail_duplicateBannerMultiple": "{count} masik mentett rekord ugyanazt a sorozatszamot jelzi. Lehet, hogy ez a szamitogep tobbszor van elmentve.",
   "diveComputer_detail_duplicateBannerAction": "Osszevonas"
 }

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Ez a kép túl nagy. Próbáljon egy kisebbet.",
   "profilePhoto_error_undecodable": "Ezt a fájlt nem sikerült képként beolvasni.",
   "profilePhoto_error_contactNoPhoto": "Ennek a névjegynek nincs fényképe.",
-  "profilePhoto_error_contactPermission": "A fénykép kiválasztásához névjegy-hozzáférési engedély szükséges."
+  "profilePhoto_error_contactPermission": "A fénykép kiválasztásához névjegy-hozzáférési engedély szükséges.",
+  "diveComputer_merge_title": "Buvarszamitogepek osszevonasa",
+  "diveComputer_merge_intro": "{count} bejegyzesbol egy lesz. A merulesek, profilok es a letoltesi elozmenyek a megtartott bejegyzeshez kerulnek. A tobbi bejegyzes torlodik.",
+  "diveComputer_merge_keepLabel": "Ezt a bejegyzest megtartom",
+  "diveComputer_merge_serialLabel": "Sorozatszam: {serial}",
+  "diveComputer_merge_noSerial": "Nincs sorozatszam",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{A tobbi bejegyzeshez nem tartozik merules.} =1{1 merules kerul at a megtartott bejegyzeshez.} other{{count} merules kerul at a megtartott bejegyzeshez.}}",
+  "diveComputer_merge_serialMismatchWarning": "Ezek a bejegyzesek eltero sorozatszamot jeleznek. Lehet, hogy kulonbozo keszulekek.",
+  "diveComputer_merge_action": "Osszevonas",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 bejegyzes osszevonva ide: {name}} other{{count} bejegyzes osszevonva ide: {name}}}",
+  "diveComputer_merge_failed": "A szamitogepek osszevonasa nem sikerult: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Szamitogepek osszevonasa",
+  "diveComputer_detail_mergeMenu": "Osszevonas masik szamitogeppel",
+  "diveComputer_detail_mergePickerTitle": "Osszevonas ezzel",
+  "diveComputer_detail_mergePickerEmpty": "Nincs masik szamitogep, amivel ossze lehetne vonni.",
+  "diveComputer_detail_mergePickerSameSerial": "Azonos sorozatszam",
+  "diveComputer_detail_duplicateBanner": "{name} ugyanazt a sorozatszamot jelzi. Lehet, hogy ez a szamitogep ketszer van elmentve.",
+  "diveComputer_detail_duplicateBannerAction": "Osszevonas"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Non ci sono altri computer con cui unire.",
   "diveComputer_detail_mergePickerSameSerial": "Stesso numero di serie",
   "diveComputer_detail_duplicateBanner": "{name} riporta lo stesso numero di serie. Potrebbe essere questo computer salvato due volte.",
+  "diveComputer_detail_duplicateBannerMultiple": "Altri {count} record salvati riportano lo stesso numero di serie. Potrebbe essere questo computer salvato più di una volta.",
   "diveComputer_detail_duplicateBannerAction": "Unisci"
 }

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Questa immagine è troppo grande. Provane una più piccola.",
   "profilePhoto_error_undecodable": "Impossibile leggere questo file come immagine.",
   "profilePhoto_error_contactNoPhoto": "Questo contatto non ha una foto.",
-  "profilePhoto_error_contactPermission": "È necessaria l'autorizzazione ai contatti per scegliere una foto."
+  "profilePhoto_error_contactPermission": "È necessaria l'autorizzazione ai contatti per scegliere una foto.",
+  "diveComputer_merge_title": "Unisci computer subacquei",
+  "diveComputer_merge_intro": "{count} schede diventeranno una sola. Immersioni, profili e cronologia dei download passano alla scheda che conservi. Le altre schede vengono eliminate.",
+  "diveComputer_merge_keepLabel": "Conserva questa scheda",
+  "diveComputer_merge_serialLabel": "Numero di serie {serial}",
+  "diveComputer_merge_noSerial": "Nessun numero di serie",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Nessuna immersione è collegata alle altre schede.} =1{1 immersione passerà alla scheda conservata.} other{{count} immersioni passeranno alla scheda conservata.}}",
+  "diveComputer_merge_serialMismatchWarning": "Queste schede riportano numeri di serie diversi. Potrebbero essere computer fisici diversi.",
+  "diveComputer_merge_action": "Unisci",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 scheda unita in {name}} other{{count} schede unite in {name}}}",
+  "diveComputer_merge_failed": "Impossibile unire i computer: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Unisci computer",
+  "diveComputer_detail_mergeMenu": "Unisci con un altro computer",
+  "diveComputer_detail_mergePickerTitle": "Unisci con",
+  "diveComputer_detail_mergePickerEmpty": "Non ci sono altri computer con cui unire.",
+  "diveComputer_detail_mergePickerSameSerial": "Stesso numero di serie",
+  "diveComputer_detail_duplicateBanner": "{name} riporta lo stesso numero di serie. Potrebbe essere questo computer salvato due volte.",
+  "diveComputer_detail_duplicateBannerAction": "Unisci"
 }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -59339,6 +59339,12 @@ abstract class AppLocalizations {
   /// **'{name} reports the same serial number. It may be this computer saved twice.'**
   String diveComputer_detail_duplicateBanner(String name);
 
+  /// No description provided for @diveComputer_detail_duplicateBannerMultiple.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} other saved records report the same serial number. They may be this computer saved more than once.'**
+  String diveComputer_detail_duplicateBannerMultiple(int count);
+
   /// No description provided for @diveComputer_detail_duplicateBannerAction.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -59242,6 +59242,108 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Contacts permission is required to choose a photo.'**
   String get profilePhoto_error_contactPermission;
+
+  /// No description provided for @diveComputer_merge_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge Dive Computers'**
+  String get diveComputer_merge_title;
+
+  /// No description provided for @diveComputer_merge_intro.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} records will become one. Dives, profiles and download history move to the record you keep. The other records are deleted.'**
+  String diveComputer_merge_intro(int count);
+
+  /// No description provided for @diveComputer_merge_keepLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep this record'**
+  String get diveComputer_merge_keepLabel;
+
+  /// No description provided for @diveComputer_merge_serialLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Serial {serial}'**
+  String diveComputer_merge_serialLabel(String serial);
+
+  /// No description provided for @diveComputer_merge_noSerial.
+  ///
+  /// In en, this message translates to:
+  /// **'No serial number'**
+  String get diveComputer_merge_noSerial;
+
+  /// No description provided for @diveComputer_merge_affectedDives.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No dives are attached to the other records.} =1{1 dive will move to the record you keep.} other{{count} dives will move to the record you keep.}}'**
+  String diveComputer_merge_affectedDives(int count);
+
+  /// No description provided for @diveComputer_merge_serialMismatchWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'These records report different serial numbers. They may be different physical computers.'**
+  String get diveComputer_merge_serialMismatchWarning;
+
+  /// No description provided for @diveComputer_merge_action.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get diveComputer_merge_action;
+
+  /// No description provided for @diveComputer_merge_snackbar.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 record merged into {name}} other{{count} records merged into {name}}}'**
+  String diveComputer_merge_snackbar(int count, String name);
+
+  /// No description provided for @diveComputer_merge_failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not merge computers: {error}'**
+  String diveComputer_merge_failed(String error);
+
+  /// No description provided for @diveComputer_list_selection_mergeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge computers'**
+  String get diveComputer_list_selection_mergeTooltip;
+
+  /// No description provided for @diveComputer_detail_mergeMenu.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge with another computer'**
+  String get diveComputer_detail_mergeMenu;
+
+  /// No description provided for @diveComputer_detail_mergePickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge with'**
+  String get diveComputer_detail_mergePickerTitle;
+
+  /// No description provided for @diveComputer_detail_mergePickerEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'There are no other computers to merge with.'**
+  String get diveComputer_detail_mergePickerEmpty;
+
+  /// No description provided for @diveComputer_detail_mergePickerSameSerial.
+  ///
+  /// In en, this message translates to:
+  /// **'Same serial number'**
+  String get diveComputer_detail_mergePickerSameSerial;
+
+  /// No description provided for @diveComputer_detail_duplicateBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} reports the same serial number. It may be this computer saved twice.'**
+  String diveComputer_detail_duplicateBanner(String name);
+
+  /// No description provided for @diveComputer_detail_duplicateBannerAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get diveComputer_detail_duplicateBannerAction;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -35756,5 +35756,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return 'تُبلغ $count سجلات محفوظة أخرى عن نفس الرقم التسلسلي. قد يكون هذا الجهاز محفوظاً أكثر من مرة.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'دمج';
 }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -35679,4 +35679,82 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'يلزم إذن الوصول إلى جهات الاتصال لاختيار صورة.';
+
+  @override
+  String get diveComputer_merge_title => 'دمج أجهزة كمبيوتر الغوص';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return 'ستصبح $count سجلات سجلاً واحداً. تنتقل الغطسات والملفات وسجل التنزيل إلى السجل الذي تحتفظ به، وتُحذف السجلات الأخرى.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'الاحتفاظ بهذا السجل';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'الرقم التسلسلي $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'لا يوجد رقم تسلسلي';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ستنتقل $count غطسات إلى السجل المحتفظ به.',
+      one: 'ستنتقل غطسة واحدة إلى السجل المحتفظ به.',
+      zero: 'لا توجد غطسات مرتبطة بالسجلات الأخرى.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'تُبلغ هذه السجلات عن أرقام تسلسلية مختلفة. قد تكون أجهزة مختلفة.';
+
+  @override
+  String get diveComputer_merge_action => 'دمج';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تم دمج $count سجلات في $name',
+      one: 'تم دمج سجل واحد في $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'تعذّر دمج أجهزة الكمبيوتر: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'دمج أجهزة الكمبيوتر';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'الدمج مع جهاز كمبيوتر آخر';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'الدمج مع';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'لا توجد أجهزة كمبيوتر أخرى للدمج معها.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => 'نفس الرقم التسلسلي';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return 'يُبلغ $name عن نفس الرقم التسلسلي. قد يكون هذا الجهاز محفوظاً مرتين.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'دمج';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -35967,4 +35967,85 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'Für die Auswahl eines Fotos wird die Kontaktberechtigung benötigt.';
+
+  @override
+  String get diveComputer_merge_title => 'Tauchcomputer zusammenführen';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count Einträge werden zu einem. Tauchgänge, Profile und Download-Verlauf wandern zu dem Eintrag, den du behältst. Die anderen Einträge werden gelöscht.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Diesen Eintrag behalten';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Seriennummer $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Keine Seriennummer';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Tauchgänge wandern zu dem Eintrag, den du behältst.',
+      one: '1 Tauchgang wandert zu dem Eintrag, den du behältst.',
+      zero: 'Den anderen Einträgen sind keine Tauchgänge zugeordnet.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Diese Einträge melden unterschiedliche Seriennummern. Es könnten verschiedene Geräte sein.';
+
+  @override
+  String get diveComputer_merge_action => 'Zusammenführen';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Einträge in $name zusammengeführt',
+      one: '1 Eintrag in $name zusammengeführt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Computer konnten nicht zusammengeführt werden: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip =>
+      'Computer zusammenführen';
+
+  @override
+  String get diveComputer_detail_mergeMenu =>
+      'Mit anderem Computer zusammenführen';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Zusammenführen mit';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Es gibt keine anderen Computer zum Zusammenführen.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial =>
+      'Gleiche Seriennummer';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name meldet dieselbe Seriennummer. Möglicherweise ist dieser Computer doppelt gespeichert.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Zusammenführen';
 }

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -36047,5 +36047,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count andere gespeicherte Einträge melden dieselbe Seriennummer. Möglicherweise ist dieser Computer mehrfach gespeichert.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Zusammenführen';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -35561,5 +35561,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count other saved records report the same serial number. They may be this computer saved more than once.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Merge';
 }

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -35484,4 +35484,82 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'Contacts permission is required to choose a photo.';
+
+  @override
+  String get diveComputer_merge_title => 'Merge Dive Computers';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count records will become one. Dives, profiles and download history move to the record you keep. The other records are deleted.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Keep this record';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Serial $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'No serial number';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dives will move to the record you keep.',
+      one: '1 dive will move to the record you keep.',
+      zero: 'No dives are attached to the other records.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'These records report different serial numbers. They may be different physical computers.';
+
+  @override
+  String get diveComputer_merge_action => 'Merge';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count records merged into $name',
+      one: '1 record merged into $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Could not merge computers: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'Merge computers';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'Merge with another computer';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Merge with';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'There are no other computers to merge with.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => 'Same serial number';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name reports the same serial number. It may be this computer saved twice.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Merge';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -36078,4 +36078,83 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'Se necesita permiso de contactos para elegir una foto.';
+
+  @override
+  String get diveComputer_merge_title => 'Combinar ordenadores de buceo';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count registros pasarán a ser uno. Las inmersiones, los perfiles y el historial de descargas se moverán al registro que conserves. Los demás registros se eliminarán.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Conservar este registro';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Número de serie $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Sin número de serie';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count inmersiones se moverán al registro que conserves.',
+      one: '1 inmersión se moverá al registro que conserves.',
+      zero: 'Los otros registros no tienen inmersiones asociadas.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Estos registros indican números de serie distintos. Podrían ser ordenadores físicos diferentes.';
+
+  @override
+  String get diveComputer_merge_action => 'Combinar';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count registros combinados en $name',
+      one: '1 registro combinado en $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'No se pudieron combinar los ordenadores: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'Combinar ordenadores';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'Combinar con otro ordenador';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Combinar con';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'No hay otros ordenadores con los que combinar.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial =>
+      'Mismo número de serie';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name indica el mismo número de serie. Puede que este ordenador esté guardado dos veces.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Combinar';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -36156,5 +36156,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return 'Otros $count registros guardados indican el mismo número de serie. Puede que este ordenador esté guardado más de una vez.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Combinar';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -36133,4 +36133,85 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'L\'autorisation d\'accès aux contacts est requise pour choisir une photo.';
+
+  @override
+  String get diveComputer_merge_title => 'Fusionner les ordinateurs de plongée';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count fiches n\'en feront plus qu\'une. Les plongées, les profils et l\'historique des téléchargements passent sur la fiche que vous conservez. Les autres fiches sont supprimées.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Conserver cette fiche';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Numéro de série $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Pas de numéro de série';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count plongées passeront sur la fiche conservée.',
+      one: '1 plongée passera sur la fiche conservée.',
+      zero: 'Aucune plongée n\'est rattachée aux autres fiches.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Ces fiches indiquent des numéros de série différents. Il peut s\'agir d\'ordinateurs distincts.';
+
+  @override
+  String get diveComputer_merge_action => 'Fusionner';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count fiches fusionnées dans $name',
+      one: '1 fiche fusionnée dans $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Impossible de fusionner les ordinateurs : $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip =>
+      'Fusionner les ordinateurs';
+
+  @override
+  String get diveComputer_detail_mergeMenu =>
+      'Fusionner avec un autre ordinateur';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Fusionner avec';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Aucun autre ordinateur avec lequel fusionner.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial =>
+      'Même numéro de série';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name indique le même numéro de série. Cet ordinateur est peut-être enregistré deux fois.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Fusionner';
 }

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -36213,5 +36213,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count autres enregistrements indiquent le même numéro de série. Cet ordinateur est peut-être enregistré plusieurs fois.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Fusionner';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -35398,5 +35398,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count רשומות שמורות נוספות מדווחות על אותו מספר סידורי. ייתכן שזהו אותו מחשב שנשמר יותר מפעם אחת.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'מיזוג';
 }

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -35322,4 +35322,81 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'נדרשת הרשאת גישה לאנשי הקשר כדי לבחור תמונה.';
+
+  @override
+  String get diveComputer_merge_title => 'מיזוג מחשבי צלילה';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count רשומות יהפכו לאחת. הצלילות, הפרופילים והיסטוריית ההורדות יעברו לרשומה שתשמור. שאר הרשומות יימחקו.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'לשמור רשומה זו';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'מספר סידורי $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'אין מספר סידורי';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count צלילות יעברו לרשומה שתישמר.',
+      one: 'צלילה אחת תעבור לרשומה שתישמר.',
+      zero: 'לא משויכות צלילות לרשומות האחרות.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'רשומות אלו מדווחות על מספרים סידוריים שונים. ייתכן שמדובר במחשבים שונים.';
+
+  @override
+  String get diveComputer_merge_action => 'מיזוג';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count רשומות מוזגו לתוך $name',
+      one: 'רשומה אחת מוזגה לתוך $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'לא ניתן למזג את המחשבים: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'מיזוג מחשבים';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'מיזוג עם מחשב אחר';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'מיזוג עם';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty => 'אין מחשבים אחרים למיזוג.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => 'אותו מספר סידורי';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name מדווח על אותו מספר סידורי. ייתכן שזהו אותו מחשב שנשמר פעמיים.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'מיזוג';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -35958,5 +35958,10 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count masik mentett rekord ugyanazt a sorozatszamot jelzi. Lehet, hogy ez a szamitogep tobbszor van elmentve.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Osszevonas';
 }

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -35880,4 +35880,83 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'A fénykép kiválasztásához névjegy-hozzáférési engedély szükséges.';
+
+  @override
+  String get diveComputer_merge_title => 'Buvarszamitogepek osszevonasa';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count bejegyzesbol egy lesz. A merulesek, profilok es a letoltesi elozmenyek a megtartott bejegyzeshez kerulnek. A tobbi bejegyzes torlodik.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Ezt a bejegyzest megtartom';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Sorozatszam: $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Nincs sorozatszam';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count merules kerul at a megtartott bejegyzeshez.',
+      one: '1 merules kerul at a megtartott bejegyzeshez.',
+      zero: 'A tobbi bejegyzeshez nem tartozik merules.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Ezek a bejegyzesek eltero sorozatszamot jeleznek. Lehet, hogy kulonbozo keszulekek.';
+
+  @override
+  String get diveComputer_merge_action => 'Osszevonas';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bejegyzes osszevonva ide: $name',
+      one: '1 bejegyzes osszevonva ide: $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'A szamitogepek osszevonasa nem sikerult: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip =>
+      'Szamitogepek osszevonasa';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'Osszevonas masik szamitogeppel';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Osszevonas ezzel';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Nincs masik szamitogep, amivel ossze lehetne vonni.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => 'Azonos sorozatszam';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name ugyanazt a sorozatszamot jelzi. Lehet, hogy ez a szamitogep ketszer van elmentve.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Osszevonas';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -36033,4 +36033,83 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'È necessaria l\'autorizzazione ai contatti per scegliere una foto.';
+
+  @override
+  String get diveComputer_merge_title => 'Unisci computer subacquei';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count schede diventeranno una sola. Immersioni, profili e cronologia dei download passano alla scheda che conservi. Le altre schede vengono eliminate.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Conserva questa scheda';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Numero di serie $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Nessun numero di serie';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count immersioni passeranno alla scheda conservata.',
+      one: '1 immersione passerà alla scheda conservata.',
+      zero: 'Nessuna immersione è collegata alle altre schede.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Queste schede riportano numeri di serie diversi. Potrebbero essere computer fisici diversi.';
+
+  @override
+  String get diveComputer_merge_action => 'Unisci';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count schede unite in $name',
+      one: '1 scheda unita in $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Impossibile unire i computer: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'Unisci computer';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'Unisci con un altro computer';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Unisci con';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Non ci sono altri computer con cui unire.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial =>
+      'Stesso numero di serie';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name riporta lo stesso numero di serie. Potrebbe essere questo computer salvato due volte.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Unisci';
 }

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -36111,5 +36111,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return 'Altri $count record salvati riportano lo stesso numero di serie. Potrebbe essere questo computer salvato più di una volta.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Unisci';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -35792,4 +35792,84 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'Toegang tot contacten is vereist om een foto te kiezen.';
+
+  @override
+  String get diveComputer_merge_title => 'Duikcomputers samenvoegen';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count records worden één. Duiken, profielen en downloadgeschiedenis gaan naar het record dat je bewaart. De andere records worden verwijderd.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Dit record bewaren';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Serienummer $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Geen serienummer';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count duiken gaan naar het record dat je bewaart.',
+      one: '1 duik gaat naar het record dat je bewaart.',
+      zero: 'Aan de andere records zijn geen duiken gekoppeld.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Deze records melden verschillende serienummers. Het kunnen verschillende computers zijn.';
+
+  @override
+  String get diveComputer_merge_action => 'Samenvoegen';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count records samengevoegd in $name',
+      one: '1 record samengevoegd in $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Computers konden niet worden samengevoegd: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip =>
+      'Computers samenvoegen';
+
+  @override
+  String get diveComputer_detail_mergeMenu =>
+      'Samenvoegen met een andere computer';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Samenvoegen met';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Er zijn geen andere computers om mee samen te voegen.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => 'Zelfde serienummer';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name meldt hetzelfde serienummer. Mogelijk is deze computer twee keer opgeslagen.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Samenvoegen';
 }

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -35871,5 +35871,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '$count andere opgeslagen records melden hetzelfde serienummer. Mogelijk is deze computer meer dan één keer opgeslagen.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Samenvoegen';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -36126,5 +36126,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return 'Outros $count registros salvos informam o mesmo número de série. Pode ser este computador salvo mais de uma vez.';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => 'Mesclar';
 }

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -36048,4 +36048,83 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get profilePhoto_error_contactPermission =>
       'É necessária permissão de contactos para escolher uma foto.';
+
+  @override
+  String get diveComputer_merge_title => 'Mesclar computadores de mergulho';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count registros se tornarão um. Mergulhos, perfis e histórico de download passam para o registro que você mantiver. Os outros registros são excluídos.';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => 'Manter este registro';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return 'Número de série $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => 'Sem número de série';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count mergulhos passarão para o registro mantido.',
+      one: '1 mergulho passará para o registro mantido.',
+      zero: 'Nenhum mergulho está vinculado aos outros registros.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning =>
+      'Estes registros informam números de série diferentes. Podem ser computadores físicos diferentes.';
+
+  @override
+  String get diveComputer_merge_action => 'Mesclar';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count registros mesclados em $name',
+      one: '1 registro mesclado em $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return 'Não foi possível mesclar os computadores: $error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => 'Mesclar computadores';
+
+  @override
+  String get diveComputer_detail_mergeMenu => 'Mesclar com outro computador';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => 'Mesclar com';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty =>
+      'Não há outros computadores para mesclar.';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial =>
+      'Mesmo número de série';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name informa o mesmo número de série. Pode ser este computador salvo duas vezes.';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => 'Mesclar';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -33902,4 +33902,80 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get profilePhoto_error_contactPermission => '选择照片需要通讯录访问权限。';
+
+  @override
+  String get diveComputer_merge_title => '合并潜水电脑';
+
+  @override
+  String diveComputer_merge_intro(int count) {
+    return '$count 条记录将合并为一条。潜水、剖面和下载历史会移到你保留的记录中，其余记录将被删除。';
+  }
+
+  @override
+  String get diveComputer_merge_keepLabel => '保留此记录';
+
+  @override
+  String diveComputer_merge_serialLabel(String serial) {
+    return '序列号 $serial';
+  }
+
+  @override
+  String get diveComputer_merge_noSerial => '无序列号';
+
+  @override
+  String diveComputer_merge_affectedDives(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 次潜水将移到保留的记录中。',
+      one: '1 次潜水将移到保留的记录中。',
+      zero: '其他记录没有关联的潜水。',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get diveComputer_merge_serialMismatchWarning => '这些记录的序列号不同，可能是不同的设备。';
+
+  @override
+  String get diveComputer_merge_action => '合并';
+
+  @override
+  String diveComputer_merge_snackbar(int count, String name) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已将 $count 条记录合并到 $name',
+      one: '已将 1 条记录合并到 $name',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String diveComputer_merge_failed(String error) {
+    return '无法合并潜水电脑：$error';
+  }
+
+  @override
+  String get diveComputer_list_selection_mergeTooltip => '合并潜水电脑';
+
+  @override
+  String get diveComputer_detail_mergeMenu => '与其他潜水电脑合并';
+
+  @override
+  String get diveComputer_detail_mergePickerTitle => '合并到';
+
+  @override
+  String get diveComputer_detail_mergePickerEmpty => '没有其他可合并的潜水电脑。';
+
+  @override
+  String get diveComputer_detail_mergePickerSameSerial => '序列号相同';
+
+  @override
+  String diveComputer_detail_duplicateBanner(String name) {
+    return '$name 的序列号与此相同，可能是同一台潜水电脑被保存了两次。';
+  }
+
+  @override
+  String get diveComputer_detail_duplicateBannerAction => '合并';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -33977,5 +33977,10 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String diveComputer_detail_duplicateBannerMultiple(int count) {
+    return '另有 $count 条已保存记录的序列号与此相同，可能是同一台潜水电脑被保存了多次。';
+  }
+
+  @override
   String get diveComputer_detail_duplicateBannerAction => '合并';
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Er zijn geen andere computers om mee samen te voegen.",
   "diveComputer_detail_mergePickerSameSerial": "Zelfde serienummer",
   "diveComputer_detail_duplicateBanner": "{name} meldt hetzelfde serienummer. Mogelijk is deze computer twee keer opgeslagen.",
+  "diveComputer_detail_duplicateBannerMultiple": "{count} andere opgeslagen records melden hetzelfde serienummer. Mogelijk is deze computer meer dan één keer opgeslagen.",
   "diveComputer_detail_duplicateBannerAction": "Samenvoegen"
 }

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Deze afbeelding is te groot. Probeer een kleinere.",
   "profilePhoto_error_undecodable": "Dit bestand kon niet als afbeelding worden gelezen.",
   "profilePhoto_error_contactNoPhoto": "Dit contact heeft geen foto.",
-  "profilePhoto_error_contactPermission": "Toegang tot contacten is vereist om een foto te kiezen."
+  "profilePhoto_error_contactPermission": "Toegang tot contacten is vereist om een foto te kiezen.",
+  "diveComputer_merge_title": "Duikcomputers samenvoegen",
+  "diveComputer_merge_intro": "{count} records worden één. Duiken, profielen en downloadgeschiedenis gaan naar het record dat je bewaart. De andere records worden verwijderd.",
+  "diveComputer_merge_keepLabel": "Dit record bewaren",
+  "diveComputer_merge_serialLabel": "Serienummer {serial}",
+  "diveComputer_merge_noSerial": "Geen serienummer",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Aan de andere records zijn geen duiken gekoppeld.} =1{1 duik gaat naar het record dat je bewaart.} other{{count} duiken gaan naar het record dat je bewaart.}}",
+  "diveComputer_merge_serialMismatchWarning": "Deze records melden verschillende serienummers. Het kunnen verschillende computers zijn.",
+  "diveComputer_merge_action": "Samenvoegen",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 record samengevoegd in {name}} other{{count} records samengevoegd in {name}}}",
+  "diveComputer_merge_failed": "Computers konden niet worden samengevoegd: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Computers samenvoegen",
+  "diveComputer_detail_mergeMenu": "Samenvoegen met een andere computer",
+  "diveComputer_detail_mergePickerTitle": "Samenvoegen met",
+  "diveComputer_detail_mergePickerEmpty": "Er zijn geen andere computers om mee samen te voegen.",
+  "diveComputer_detail_mergePickerSameSerial": "Zelfde serienummer",
+  "diveComputer_detail_duplicateBanner": "{name} meldt hetzelfde serienummer. Mogelijk is deze computer twee keer opgeslagen.",
+  "diveComputer_detail_duplicateBannerAction": "Samenvoegen"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "Essa imagem é demasiado grande. Tente uma mais pequena.",
   "profilePhoto_error_undecodable": "Não foi possível ler esse ficheiro como imagem.",
   "profilePhoto_error_contactNoPhoto": "Esse contacto não tem foto.",
-  "profilePhoto_error_contactPermission": "É necessária permissão de contactos para escolher uma foto."
+  "profilePhoto_error_contactPermission": "É necessária permissão de contactos para escolher uma foto.",
+  "diveComputer_merge_title": "Mesclar computadores de mergulho",
+  "diveComputer_merge_intro": "{count} registros se tornarão um. Mergulhos, perfis e histórico de download passam para o registro que você mantiver. Os outros registros são excluídos.",
+  "diveComputer_merge_keepLabel": "Manter este registro",
+  "diveComputer_merge_serialLabel": "Número de série {serial}",
+  "diveComputer_merge_noSerial": "Sem número de série",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{Nenhum mergulho está vinculado aos outros registros.} =1{1 mergulho passará para o registro mantido.} other{{count} mergulhos passarão para o registro mantido.}}",
+  "diveComputer_merge_serialMismatchWarning": "Estes registros informam números de série diferentes. Podem ser computadores físicos diferentes.",
+  "diveComputer_merge_action": "Mesclar",
+  "diveComputer_merge_snackbar": "{count, plural, =1{1 registro mesclado em {name}} other{{count} registros mesclados em {name}}}",
+  "diveComputer_merge_failed": "Não foi possível mesclar os computadores: {error}",
+  "diveComputer_list_selection_mergeTooltip": "Mesclar computadores",
+  "diveComputer_detail_mergeMenu": "Mesclar com outro computador",
+  "diveComputer_detail_mergePickerTitle": "Mesclar com",
+  "diveComputer_detail_mergePickerEmpty": "Não há outros computadores para mesclar.",
+  "diveComputer_detail_mergePickerSameSerial": "Mesmo número de série",
+  "diveComputer_detail_duplicateBanner": "{name} informa o mesmo número de série. Pode ser este computador salvo duas vezes.",
+  "diveComputer_detail_duplicateBannerAction": "Mesclar"
 }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "Não há outros computadores para mesclar.",
   "diveComputer_detail_mergePickerSameSerial": "Mesmo número de série",
   "diveComputer_detail_duplicateBanner": "{name} informa o mesmo número de série. Pode ser este computador salvo duas vezes.",
+  "diveComputer_detail_duplicateBannerMultiple": "Outros {count} registros salvos informam o mesmo número de série. Pode ser este computador salvo mais de uma vez.",
   "diveComputer_detail_duplicateBannerAction": "Mesclar"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -10519,5 +10519,22 @@
   "profilePhoto_error_tooLarge": "该图片太大，请尝试较小的图片。",
   "profilePhoto_error_undecodable": "无法将该文件读取为图片。",
   "profilePhoto_error_contactNoPhoto": "该联系人没有照片。",
-  "profilePhoto_error_contactPermission": "选择照片需要通讯录访问权限。"
+  "profilePhoto_error_contactPermission": "选择照片需要通讯录访问权限。",
+  "diveComputer_merge_title": "合并潜水电脑",
+  "diveComputer_merge_intro": "{count} 条记录将合并为一条。潜水、剖面和下载历史会移到你保留的记录中，其余记录将被删除。",
+  "diveComputer_merge_keepLabel": "保留此记录",
+  "diveComputer_merge_serialLabel": "序列号 {serial}",
+  "diveComputer_merge_noSerial": "无序列号",
+  "diveComputer_merge_affectedDives": "{count, plural, =0{其他记录没有关联的潜水。} =1{1 次潜水将移到保留的记录中。} other{{count} 次潜水将移到保留的记录中。}}",
+  "diveComputer_merge_serialMismatchWarning": "这些记录的序列号不同，可能是不同的设备。",
+  "diveComputer_merge_action": "合并",
+  "diveComputer_merge_snackbar": "{count, plural, =1{已将 1 条记录合并到 {name}} other{已将 {count} 条记录合并到 {name}}}",
+  "diveComputer_merge_failed": "无法合并潜水电脑：{error}",
+  "diveComputer_list_selection_mergeTooltip": "合并潜水电脑",
+  "diveComputer_detail_mergeMenu": "与其他潜水电脑合并",
+  "diveComputer_detail_mergePickerTitle": "合并到",
+  "diveComputer_detail_mergePickerEmpty": "没有其他可合并的潜水电脑。",
+  "diveComputer_detail_mergePickerSameSerial": "序列号相同",
+  "diveComputer_detail_duplicateBanner": "{name} 的序列号与此相同，可能是同一台潜水电脑被保存了两次。",
+  "diveComputer_detail_duplicateBannerAction": "合并"
 }

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -10536,5 +10536,6 @@
   "diveComputer_detail_mergePickerEmpty": "没有其他可合并的潜水电脑。",
   "diveComputer_detail_mergePickerSameSerial": "序列号相同",
   "diveComputer_detail_duplicateBanner": "{name} 的序列号与此相同，可能是同一台潜水电脑被保存了两次。",
+  "diveComputer_detail_duplicateBannerMultiple": "另有 {count} 条已保存记录的序列号与此相同，可能是同一台潜水电脑被保存了多次。",
   "diveComputer_detail_duplicateBannerAction": "合并"
 }

--- a/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
+++ b/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/features/dive_computer/domain/services/dive_computer_merge_rules.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+
+DiveComputer _computer({
+  required String id,
+  String name = 'Petrel 3',
+  String? diverId = 'diver-1',
+  String? manufacturer = 'Shearwater',
+  String? model = 'Petrel 3',
+  String? serialNumber = '3101949313',
+  String? firmwareVersion,
+  String? connectionType,
+  String? bluetoothAddress,
+  DateTime? lastDownload,
+  String? lastDiveFingerprint,
+  int diveCount = 0,
+  bool isFavorite = false,
+  String notes = '',
+  String? equipmentId,
+}) {
+  final now = DateTime(2026, 1, 1);
+  return DiveComputer(
+    id: id,
+    name: name,
+    diverId: diverId,
+    manufacturer: manufacturer,
+    model: model,
+    serialNumber: serialNumber,
+    firmwareVersion: firmwareVersion,
+    connectionType: connectionType,
+    bluetoothAddress: bluetoothAddress,
+    lastDownload: lastDownload,
+    lastDiveFingerprint: lastDiveFingerprint,
+    diveCount: diveCount,
+    isFavorite: isFavorite,
+    notes: notes,
+    equipmentId: equipmentId,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  group('duplicateCandidatesFor', () {
+    test('returns other records that share serial, manufacturer and model', () {
+      final target = _computer(id: 'a');
+      final twin = _computer(id: 'b', name: 'ssss');
+      final other = _computer(id: 'c', serialNumber: '999');
+
+      final result = duplicateCandidatesFor(target, [target, twin, other]);
+
+      expect(result.map((c) => c.id), ['b']);
+    });
+
+    test('matches case-insensitively and ignores surrounding whitespace', () {
+      final target = _computer(id: 'a');
+      final twin = _computer(
+        id: 'b',
+        manufacturer: ' shearwater ',
+        model: 'PETREL 3',
+        serialNumber: ' 3101949313 ',
+      );
+
+      expect(duplicateCandidatesFor(target, [twin]).map((c) => c.id), ['b']);
+    });
+
+    test(
+      'treats a blank manufacturer or model on either side as compatible',
+      () {
+        final target = _computer(id: 'a', manufacturer: null);
+        final twin = _computer(id: 'b', model: '');
+
+        expect(duplicateCandidatesFor(target, [twin]).map((c) => c.id), ['b']);
+      },
+    );
+
+    test('never matches on a blank serial number', () {
+      final target = _computer(id: 'a', serialNumber: '');
+      final twin = _computer(id: 'b', serialNumber: null);
+
+      expect(duplicateCandidatesFor(target, [twin]), isEmpty);
+    });
+
+    test('rejects a different model with the same serial', () {
+      final target = _computer(id: 'a');
+      final other = _computer(id: 'b', model: 'Perdix 2');
+
+      expect(duplicateCandidatesFor(target, [other]), isEmpty);
+    });
+
+    test('rejects a record owned by another diver', () {
+      final target = _computer(id: 'a');
+      final other = _computer(id: 'b', diverId: 'diver-2');
+
+      expect(duplicateCandidatesFor(target, [other]), isEmpty);
+    });
+  });
+
+  group('serialNumbersConflict', () {
+    test('is false when every serial agrees or is blank', () {
+      final records = [
+        _computer(id: 'a'),
+        _computer(id: 'b', serialNumber: ' 3101949313'),
+        _computer(id: 'c', serialNumber: null),
+      ];
+
+      expect(serialNumbersConflict(records), isFalse);
+    });
+
+    test('is true when two records carry different non-blank serials', () {
+      final records = [
+        _computer(id: 'a'),
+        _computer(id: 'b', serialNumber: '7'),
+      ];
+
+      expect(serialNumbersConflict(records), isTrue);
+    });
+  });
+
+  group('defaultSurvivor', () {
+    test('prefers the favorite record', () {
+      final records = [
+        _computer(id: 'a', diveCount: 50),
+        _computer(id: 'b', isFavorite: true),
+      ];
+
+      expect(defaultSurvivor(records).id, 'b');
+    });
+
+    test('then prefers the record with the most dives', () {
+      final records = [
+        _computer(id: 'a', diveCount: 2),
+        _computer(id: 'b', diveCount: 9),
+      ];
+
+      expect(defaultSurvivor(records).id, 'b');
+    });
+
+    test('then prefers the most recently downloaded record', () {
+      final records = [
+        _computer(id: 'a', lastDownload: DateTime(2026, 1, 1)),
+        _computer(id: 'b', lastDownload: DateTime(2026, 3, 1)),
+      ];
+
+      expect(defaultSurvivor(records).id, 'b');
+    });
+
+    test('falls back to the first record', () {
+      final records = [_computer(id: 'a'), _computer(id: 'b')];
+
+      expect(defaultSurvivor(records).id, 'a');
+    });
+  });
+
+  group('mergedDiveComputer', () {
+    test('keeps the survivor identity and fills its blank fields', () {
+      final survivor = _computer(
+        id: 'a',
+        name: 'Petrel 3',
+        manufacturer: null,
+        model: '',
+        firmwareVersion: null,
+        connectionType: null,
+        bluetoothAddress: null,
+        equipmentId: null,
+      );
+      final duplicate = _computer(
+        id: 'b',
+        name: 'ssss',
+        firmwareVersion: '103',
+        connectionType: 'bluetooth',
+        bluetoothAddress: 'AAAA',
+        equipmentId: 'gear-b',
+      );
+
+      final merged = mergedDiveComputer(survivor, [duplicate]);
+
+      expect(merged.id, 'a');
+      expect(merged.name, 'Petrel 3');
+      expect(merged.manufacturer, 'Shearwater');
+      expect(merged.model, 'Petrel 3');
+      expect(merged.firmwareVersion, '103');
+      expect(merged.connectionType, 'bluetooth');
+      expect(merged.bluetoothAddress, 'AAAA');
+      expect(merged.equipmentId, 'gear-b');
+    });
+
+    test('does not overwrite survivor fields that are already set', () {
+      final survivor = _computer(
+        id: 'a',
+        firmwareVersion: '101',
+        bluetoothAddress: 'SURVIVOR',
+        equipmentId: 'gear-a',
+      );
+      final duplicate = _computer(
+        id: 'b',
+        firmwareVersion: '103',
+        bluetoothAddress: 'DUP',
+        equipmentId: 'gear-b',
+      );
+
+      final merged = mergedDiveComputer(survivor, [duplicate]);
+
+      expect(merged.firmwareVersion, '101');
+      expect(merged.bluetoothAddress, 'SURVIVOR');
+      expect(merged.equipmentId, 'gear-a');
+    });
+
+    test(
+      'sums dive counts and keeps favorite when any record was favorite',
+      () {
+        final survivor = _computer(id: 'a', diveCount: 21);
+        final dupes = [
+          _computer(id: 'b', diveCount: 2, isFavorite: true),
+          _computer(id: 'c', diveCount: 3),
+        ];
+
+        final merged = mergedDiveComputer(survivor, dupes);
+
+        expect(merged.diveCount, 26);
+        expect(merged.isFavorite, isTrue);
+      },
+    );
+
+    test('keeps the newest download timestamp with its fingerprint', () {
+      final survivor = _computer(
+        id: 'a',
+        lastDownload: DateTime(2026, 1, 1),
+        lastDiveFingerprint: 'old',
+      );
+      final duplicate = _computer(
+        id: 'b',
+        lastDownload: DateTime(2026, 2, 1),
+        lastDiveFingerprint: 'new',
+      );
+
+      final merged = mergedDiveComputer(survivor, [duplicate]);
+
+      expect(merged.lastDownload, DateTime(2026, 2, 1));
+      expect(merged.lastDiveFingerprint, 'new');
+    });
+
+    test(
+      'keeps the survivor fingerprint when no duplicate downloaded later',
+      () {
+        final survivor = _computer(
+          id: 'a',
+          lastDownload: DateTime(2026, 2, 1),
+          lastDiveFingerprint: 'mine',
+        );
+        final duplicate = _computer(id: 'b', lastDiveFingerprint: 'theirs');
+
+        final merged = mergedDiveComputer(survivor, [duplicate]);
+
+        expect(merged.lastDownload, DateTime(2026, 2, 1));
+        expect(merged.lastDiveFingerprint, 'mine');
+      },
+    );
+
+    test(
+      'adopts a duplicate fingerprint when the survivor has none at all',
+      () {
+        final survivor = _computer(id: 'a');
+        final duplicate = _computer(id: 'b', lastDiveFingerprint: 'theirs');
+
+        expect(
+          mergedDiveComputer(survivor, [duplicate]).lastDiveFingerprint,
+          'theirs',
+        );
+      },
+    );
+
+    test('appends distinct non-blank notes from duplicates', () {
+      final survivor = _computer(id: 'a', notes: 'Primary');
+      final dupes = [
+        _computer(id: 'b', notes: 'Primary'),
+        _computer(id: 'c', notes: '  '),
+        _computer(id: 'd', notes: 'Bought 2024'),
+      ];
+
+      expect(
+        mergedDiveComputer(survivor, dupes).notes,
+        'Primary\n\nBought 2024',
+      );
+    });
+  });
+}

--- a/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
+++ b/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
@@ -317,6 +317,42 @@ void main() {
       );
     });
 
+    test('trims the descriptive fields it adopts', () {
+      // A file import can register padded values. The survivor should not
+      // inherit the padding along with the value, and the identity rules
+      // compare through normalizeComputerIdentityPart, so the padded serial
+      // still matched as a duplicate before reaching here.
+      final survivor = _computer(
+        id: 'a',
+        manufacturer: '  ',
+        model: '',
+        serialNumber: null,
+      );
+      final duplicate = _computer(
+        id: 'b',
+        manufacturer: '  Shearwater ',
+        model: ' Petrel 3',
+        serialNumber: ' 3101949313 ',
+        firmwareVersion: ' 93 ',
+      );
+
+      final merged = mergedDiveComputer(survivor, [duplicate]);
+
+      expect(merged.manufacturer, 'Shearwater');
+      expect(merged.model, 'Petrel 3');
+      expect(merged.serialNumber, '3101949313');
+      expect(merged.firmwareVersion, '93');
+    });
+
+    test('keeps the adopted gear twin id verbatim', () {
+      // equipmentId is a foreign key into equipment.id, so it has to match
+      // the stored row exactly rather than be normalised on the way through.
+      final survivor = _computer(id: 'a', equipmentId: null);
+      final duplicate = _computer(id: 'b', equipmentId: ' gear-b ');
+
+      expect(mergedDiveComputer(survivor, [duplicate]).equipmentId, ' gear-b ');
+    });
+
     test('appends distinct non-blank notes from duplicates', () {
       final survivor = _computer(id: 'a', notes: 'Primary');
       final dupes = [

--- a/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
+++ b/test/features/dive_computer/domain/services/dive_computer_merge_rules_test.dart
@@ -271,6 +271,52 @@ void main() {
       },
     );
 
+    test(
+      'takes the newest recorded fingerprint when the newest download has none',
+      () {
+        // lastDownload and lastDiveFingerprint are written separately, so the
+        // most recently downloaded record can hold no cursor at all. Falling
+        // back to the survivor's would resume the next incremental download
+        // from January and re-fetch everything the February record already had.
+        final survivor = _computer(
+          id: 'a',
+          lastDownload: DateTime(2026, 1, 1),
+          lastDiveFingerprint: 'january',
+        );
+        final duplicates = [
+          _computer(
+            id: 'b',
+            lastDownload: DateTime(2026, 2, 1),
+            lastDiveFingerprint: 'february',
+          ),
+          _computer(id: 'c', lastDownload: DateTime(2026, 3, 1)),
+        ];
+
+        final merged = mergedDiveComputer(survivor, duplicates);
+
+        expect(merged.lastDownload, DateTime(2026, 3, 1));
+        expect(merged.lastDiveFingerprint, 'february');
+      },
+    );
+
+    test('ignores a blank fingerprint on the most recent download', () {
+      final survivor = _computer(
+        id: 'a',
+        lastDownload: DateTime(2026, 1, 1),
+        lastDiveFingerprint: 'january',
+      );
+      final duplicate = _computer(
+        id: 'b',
+        lastDownload: DateTime(2026, 2, 1),
+        lastDiveFingerprint: '   ',
+      );
+
+      expect(
+        mergedDiveComputer(survivor, [duplicate]).lastDiveFingerprint,
+        'january',
+      );
+    });
+
     test('appends distinct non-blank notes from duplicates', () {
       final survivor = _computer(id: 'a', notes: 'Primary');
       final dupes = [

--- a/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_computer/presentation/pages/device_detail_page.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../../helpers/mock_providers.dart';
+
+DiveComputer _computer({
+  required String id,
+  required String name,
+  String? serialNumber = '3101949313',
+  int diveCount = 0,
+}) {
+  return DiveComputer(
+    id: id,
+    name: name,
+    diverId: 'diver-1',
+    manufacturer: 'Shearwater',
+    model: 'Petrel 3',
+    serialNumber: serialNumber,
+    connectionType: 'bluetooth',
+    diveCount: diveCount,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+}
+
+class _FakeMergeRepository implements DiveComputerMergeRepository {
+  @override
+  Future<int> countAffectedDives(List<String> computerIds) async => 2;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<DiveComputer>>>
+    implements DiveComputerNotifier {
+  _CapturingNotifier() : super(const AsyncValue.data([]));
+
+  String? survivorId;
+  List<String>? duplicateIds;
+
+  @override
+  Future<DiveComputerMergeResult> merge({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    this.survivorId = survivorId;
+    this.duplicateIds = duplicateIds;
+    return DiveComputerMergeResult(
+      survivorId: survivorId,
+      mergedComputerIds: duplicateIds,
+      movedDiveCount: 2,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late _CapturingNotifier notifier;
+
+  setUp(() {
+    notifier = _CapturingNotifier();
+  });
+
+  /// Routes the detail page for every computer in [all] so a merge that
+  /// keeps another record can land on that record's page.
+  Future<void> pumpDetail(
+    WidgetTester tester, {
+    required DiveComputer computer,
+    required List<DiveComputer> all,
+  }) async {
+    final router = GoRouter(
+      initialLocation: '/dive-computers/${computer.id}',
+      routes: [
+        GoRoute(
+          path: '/dive-computers/:id',
+          builder: (context, state) =>
+              DeviceDetailPage(computerId: state.pathParameters['id']!),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier()),
+          diveComputerNotifierProvider.overrideWith((ref) => notifier),
+          diveComputerMergeRepositoryProvider.overrideWithValue(
+            _FakeMergeRepository(),
+          ),
+          allDiveComputersProvider.overrideWith((ref) async => all),
+          for (final c in all)
+            diveComputerByIdProvider(c.id).overrideWith((ref) async => c),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('DeviceDetailPage duplicate banner', () {
+    testWidgets('names the record that shares this serial number', (
+      tester,
+    ) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3', diveCount: 21);
+      final ssss = _computer(id: 'b', name: 'ssss', diveCount: 2);
+
+      await pumpDetail(tester, computer: petrel, all: [petrel, ssss]);
+
+      expect(find.byKey(const ValueKey('duplicate_banner')), findsOneWidget);
+      expect(
+        find.textContaining('ssss reports the same serial'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('stays hidden when no other record matches', (tester) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3');
+      final other = _computer(id: 'b', name: 'Perdix', serialNumber: '7');
+
+      await pumpDetail(tester, computer: petrel, all: [petrel, other]);
+
+      expect(find.byKey(const ValueKey('duplicate_banner')), findsNothing);
+    });
+
+    testWidgets('its Merge button opens the sheet with both records', (
+      tester,
+    ) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3', diveCount: 21);
+      final ssss = _computer(id: 'b', name: 'ssss', diveCount: 2);
+
+      await pumpDetail(tester, computer: petrel, all: [petrel, ssss]);
+      await tester.tap(find.byKey(const ValueKey('duplicate_banner_merge')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Merge Dive Computers'), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_keep_a')), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_keep_b')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, 'a');
+      expect(notifier.duplicateIds, ['b']);
+      expect(find.text('1 record merged into Petrel 3'), findsOneWidget);
+    });
+  });
+
+  group('DeviceDetailPage merge menu', () {
+    testWidgets('lists the other computers with same-serial ones flagged', (
+      tester,
+    ) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3');
+      final ssss = _computer(id: 'b', name: 'ssss');
+      final perdix = _computer(id: 'c', name: 'Perdix', serialNumber: '7');
+
+      await pumpDetail(tester, computer: petrel, all: [perdix, petrel, ssss]);
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Merge with another computer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Merge with'), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_pick_b')), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_pick_c')), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_pick_a')), findsNothing);
+      expect(find.text('Same serial number'), findsOneWidget);
+    });
+
+    testWidgets('explains when there is nothing to merge with', (tester) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3');
+
+      await pumpDetail(tester, computer: petrel, all: [petrel]);
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Merge with another computer'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('There are no other computers to merge with.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('moves to the surviving record when this one is folded in', (
+      tester,
+    ) async {
+      final petrel = _computer(id: 'a', name: 'Petrel 3', diveCount: 2);
+      final ssss = _computer(id: 'b', name: 'ssss', diveCount: 21);
+
+      await pumpDetail(tester, computer: petrel, all: [petrel, ssss]);
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Merge with another computer'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('merge_pick_b')));
+      await tester.pumpAndSettle();
+
+      // ssss has more dives, so it is the default survivor.
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, 'b');
+      expect(notifier.duplicateIds, ['a']);
+      final page = tester.widget<DeviceDetailPage>(
+        find.byType(DeviceDetailPage),
+      );
+      expect(page.computerId, 'b');
+    });
+  });
+}

--- a/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
@@ -128,6 +128,23 @@ void main() {
       );
     });
 
+    testWidgets('counts the records instead of listing names', (tester) async {
+      // The singular message reads "{name} reports...", so joining two names
+      // into it would render "ssss, ipad reports the same serial number".
+      final petrel = _computer(id: 'a', name: 'Petrel 3', diveCount: 21);
+      final ssss = _computer(id: 'b', name: 'ssss', diveCount: 2);
+      final ipad = _computer(id: 'c', name: 'ipad', diveCount: 1);
+
+      await pumpDetail(tester, computer: petrel, all: [petrel, ssss, ipad]);
+
+      expect(find.byKey(const ValueKey('duplicate_banner')), findsOneWidget);
+      expect(
+        find.textContaining('2 other saved records report the same serial'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('ssss, ipad'), findsNothing);
+    });
+
     testWidgets('stays hidden when no other record matches', (tester) async {
       final petrel = _computer(id: 'a', name: 'Petrel 3');
       final other = _computer(id: 'b', name: 'Perdix', serialNumber: '7');

--- a/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_detail_page_merge_test.dart
@@ -33,7 +33,10 @@ DiveComputer _computer({
 
 class _FakeMergeRepository implements DiveComputerMergeRepository {
   @override
-  Future<int> countAffectedDives(List<String> computerIds) async => 2;
+  Future<int> countAffectedDives({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async => 2;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;

--- a/test/features/dive_computer/presentation/pages/device_list_page_merge_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_list_page_merge_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_computer/presentation/pages/device_list_page.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+DiveComputer _makeComputer({
+  required String id,
+  required String name,
+  int diveCount = 0,
+}) {
+  return DiveComputer(
+    id: id,
+    name: name,
+    serialNumber: '3101949313',
+    diveCount: diveCount,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+}
+
+class _FakeMergeRepository implements DiveComputerMergeRepository {
+  @override
+  Future<int> countAffectedDives(List<String> computerIds) async => 2;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<DiveComputer>>>
+    implements DiveComputerNotifier {
+  _CapturingNotifier() : super(const AsyncValue.data([]));
+
+  String? survivorId;
+  List<String>? duplicateIds;
+
+  @override
+  Future<DiveComputerMergeResult> merge({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    this.survivorId = survivorId;
+    this.duplicateIds = duplicateIds;
+    return DiveComputerMergeResult(
+      survivorId: survivorId,
+      mergedComputerIds: duplicateIds,
+      movedDiveCount: 2,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  late _CapturingNotifier notifier;
+
+  setUp(() {
+    notifier = _CapturingNotifier();
+  });
+
+  Future<void> pumpList(WidgetTester tester, List<DiveComputer> computers) {
+    return tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        overrides: [
+          allDiveComputersProvider.overrideWith((ref) async => computers),
+          diveComputerNotifierProvider.overrideWith((ref) => notifier),
+          diveComputerMergeRepositoryProvider.overrideWithValue(
+            _FakeMergeRepository(),
+          ),
+        ],
+        child: const DeviceListPage(),
+      ),
+    );
+  }
+
+  group('DeviceListPage merge action', () {
+    testWidgets('is disabled until two computers are checked', (tester) async {
+      await pumpList(tester, [
+        _makeComputer(id: 'c1', name: 'Petrel 3'),
+        _makeComputer(id: 'c2', name: 'ssss'),
+      ]);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+
+      final mergeButton = find.byKey(const ValueKey('selection_action_merge'));
+      expect(mergeButton, findsOneWidget);
+      expect(tester.widget<IconButton>(mergeButton).onPressed, isNull);
+
+      await tester.tap(find.byKey(const ValueKey('selection_select_all')));
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<IconButton>(mergeButton).onPressed, isNotNull);
+    });
+
+    testWidgets('opens the merge sheet for the checked computers and reports', (
+      tester,
+    ) async {
+      await pumpList(tester, [
+        _makeComputer(id: 'c1', name: 'Petrel 3', diveCount: 21),
+        _makeComputer(id: 'c2', name: 'ssss', diveCount: 2),
+      ]);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_select_all')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Merge Dive Computers'), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_keep_c1')), findsOneWidget);
+      expect(find.byKey(const ValueKey('merge_keep_c2')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, 'c1');
+      expect(notifier.duplicateIds, ['c2']);
+      expect(find.text('1 record merged into Petrel 3'), findsOneWidget);
+      // Selection mode is left behind once the merge completes.
+      expect(find.byKey(const ValueKey('enter_selection')), findsOneWidget);
+    });
+
+    testWidgets('dismissing the sheet keeps the selection', (tester) async {
+      await pumpList(tester, [
+        _makeComputer(id: 'c1', name: 'Petrel 3'),
+        _makeComputer(id: 'c2', name: 'ssss'),
+      ]);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('enter_selection')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_select_all')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('selection_action_merge')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, isNull);
+      expect(
+        find.byKey(const ValueKey('selection_action_merge')),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/dive_computer/presentation/pages/device_list_page_merge_test.dart
+++ b/test/features/dive_computer/presentation/pages/device_list_page_merge_test.dart
@@ -25,7 +25,10 @@ DiveComputer _makeComputer({
 
 class _FakeMergeRepository implements DiveComputerMergeRepository {
   @override
-  Future<int> countAffectedDives(List<String> computerIds) async => 2;
+  Future<int> countAffectedDives({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async => 2;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;

--- a/test/features/dive_computer/presentation/widgets/dive_computer_merge_sheet_test.dart
+++ b/test/features/dive_computer/presentation/widgets/dive_computer_merge_sheet_test.dart
@@ -31,10 +31,15 @@ DiveComputer _computer({
 /// Stands in for the database-backed count.
 class _FakeMergeRepository implements DiveComputerMergeRepository {
   final requested = <List<String>>[];
+  final requestedSurvivors = <String>[];
 
   @override
-  Future<int> countAffectedDives(List<String> computerIds) async {
-    requested.add(computerIds);
+  Future<int> countAffectedDives({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    requestedSurvivors.add(survivorId);
+    requested.add(duplicateIds);
     return 5;
   }
 
@@ -151,8 +156,10 @@ void main() {
         find.text('5 dives will move to the record you keep.'),
         findsOneWidget,
       );
-      // The count is for the records that will be folded in, not the survivor.
+      // The count is for the records that will be folded in, not the survivor,
+      // and the survivor goes with it: it decides which gear links move.
       expect(mergeRepository.requested.last, ['a']);
+      expect(mergeRepository.requestedSurvivors.last, 'b');
       expect(
         find.text('Shearwater Petrel 3 · Serial 3101949313 · 21 dives'),
         findsOneWidget,
@@ -213,6 +220,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('merge_keep_b')));
       await tester.pumpAndSettle();
       expect(mergeRepository.requested.last, ['a']);
+      expect(mergeRepository.requestedSurvivors.last, 'b');
 
       await tester.tap(find.byKey(const ValueKey('merge_confirm')));
       await tester.pumpAndSettle();

--- a/test/features/dive_computer/presentation/widgets/dive_computer_merge_sheet_test.dart
+++ b/test/features/dive_computer/presentation/widgets/dive_computer_merge_sheet_test.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/providers/provider.dart';
+import 'package:submersion/features/dive_computer/presentation/widgets/dive_computer_merge_sheet.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
+import 'package:submersion/features/dive_log/domain/entities/dive_computer.dart';
+import 'package:submersion/features/dive_log/presentation/providers/dive_computer_providers.dart';
+
+import '../../../../helpers/test_app.dart';
+
+DiveComputer _computer({
+  required String id,
+  required String name,
+  String? serialNumber = '3101949313',
+  int diveCount = 0,
+  bool isFavorite = false,
+}) {
+  return DiveComputer(
+    id: id,
+    name: name,
+    manufacturer: 'Shearwater',
+    model: 'Petrel 3',
+    serialNumber: serialNumber,
+    diveCount: diveCount,
+    isFavorite: isFavorite,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
+}
+
+/// Stands in for the database-backed count.
+class _FakeMergeRepository implements DiveComputerMergeRepository {
+  final requested = <List<String>>[];
+
+  @override
+  Future<int> countAffectedDives(List<String> computerIds) async {
+    requested.add(computerIds);
+    return 5;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Records the merge the sheet asked for, or fails it on demand.
+class _CapturingNotifier extends StateNotifier<AsyncValue<List<DiveComputer>>>
+    implements DiveComputerNotifier {
+  _CapturingNotifier({this.failWith}) : super(const AsyncValue.data([]));
+
+  final Object? failWith;
+  String? survivorId;
+  List<String>? duplicateIds;
+
+  @override
+  Future<DiveComputerMergeResult> merge({
+    required String survivorId,
+    required List<String> duplicateIds,
+  }) async {
+    this.survivorId = survivorId;
+    this.duplicateIds = duplicateIds;
+    if (failWith != null) throw failWith!;
+    return DiveComputerMergeResult(
+      survivorId: survivorId,
+      mergedComputerIds: duplicateIds,
+      movedDiveCount: 5,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// Hosts a button that opens the sheet so the popped result can be captured.
+class _Host extends StatefulWidget {
+  const _Host({required this.computers});
+
+  final List<DiveComputer> computers;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  DiveComputerMergeResult? result;
+  bool dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      key: const ValueKey('open'),
+      onPressed: () async {
+        final r = await DiveComputerMergeSheet.show(context, widget.computers);
+        setState(() {
+          result = r;
+          dismissed = r == null;
+        });
+      },
+      child: const Text('open'),
+    );
+  }
+}
+
+void main() {
+  late _FakeMergeRepository mergeRepository;
+  late _CapturingNotifier notifier;
+
+  setUp(() {
+    mergeRepository = _FakeMergeRepository();
+    notifier = _CapturingNotifier();
+  });
+
+  Future<_HostState> pumpSheet(
+    WidgetTester tester,
+    List<DiveComputer> computers, {
+    _CapturingNotifier? customNotifier,
+  }) async {
+    await tester.pumpWidget(
+      testApp(
+        locale: const Locale('en'),
+        overrides: [
+          diveComputerMergeRepositoryProvider.overrideWithValue(
+            mergeRepository,
+          ),
+          diveComputerNotifierProvider.overrideWith(
+            (ref) => customNotifier ?? notifier,
+          ),
+        ],
+        child: _Host(computers: computers),
+      ),
+    );
+    await tester.tap(find.byKey(const ValueKey('open')));
+    await tester.pumpAndSettle();
+    return tester.state<_HostState>(find.byType(_Host));
+  }
+
+  group('DiveComputerMergeSheet', () {
+    testWidgets('preselects the favorite record and shows the dive count', (
+      tester,
+    ) async {
+      await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3', diveCount: 21),
+        _computer(id: 'b', name: 'ssss', diveCount: 2, isFavorite: true),
+      ]);
+
+      expect(find.text('Merge Dive Computers'), findsOneWidget);
+      final favorite = tester.widget<RadioListTile<String>>(
+        find.byKey(const ValueKey('merge_keep_b')),
+      );
+      expect(favorite.value, 'b');
+      expect(
+        find.text('5 dives will move to the record you keep.'),
+        findsOneWidget,
+      );
+      // The count is for the records that will be folded in, not the survivor.
+      expect(mergeRepository.requested.last, ['a']);
+      expect(
+        find.text('Shearwater Petrel 3 · Serial 3101949313 · 21 dives'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides the serial warning when every serial agrees', (
+      tester,
+    ) async {
+      await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3'),
+        _computer(id: 'b', name: 'ssss'),
+      ]);
+
+      expect(find.byKey(const ValueKey('merge_serial_warning')), findsNothing);
+    });
+
+    testWidgets('warns when the records report different serial numbers', (
+      tester,
+    ) async {
+      await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3'),
+        _computer(id: 'b', name: 'Other', serialNumber: '7'),
+      ]);
+
+      expect(
+        find.byKey(const ValueKey('merge_serial_warning')),
+        findsOneWidget,
+      );
+      expect(find.textContaining('different serial numbers'), findsOneWidget);
+    });
+
+    testWidgets('merges into the default survivor and pops the result', (
+      tester,
+    ) async {
+      final host = await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3', diveCount: 21),
+        _computer(id: 'b', name: 'ssss', diveCount: 2),
+        _computer(id: 'c', name: 'third'),
+      ]);
+
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, 'a');
+      expect(notifier.duplicateIds, ['b', 'c']);
+      expect(host.result?.survivorId, 'a');
+      expect(host.result?.mergedComputerIds, ['b', 'c']);
+      expect(find.text('Merge Dive Computers'), findsNothing);
+    });
+
+    testWidgets('lets the user keep a different record', (tester) async {
+      await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3', diveCount: 21),
+        _computer(id: 'b', name: 'ssss', diveCount: 2),
+      ]);
+
+      await tester.tap(find.byKey(const ValueKey('merge_keep_b')));
+      await tester.pumpAndSettle();
+      expect(mergeRepository.requested.last, ['a']);
+
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(notifier.survivorId, 'b');
+      expect(notifier.duplicateIds, ['a']);
+    });
+
+    testWidgets('cancel dismisses without merging', (tester) async {
+      final host = await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3'),
+        _computer(id: 'b', name: 'ssss'),
+      ]);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(host.dismissed, isTrue);
+      expect(notifier.survivorId, isNull);
+    });
+
+    testWidgets('reports a failed merge and keeps the sheet open', (
+      tester,
+    ) async {
+      final failing = _CapturingNotifier(failWith: StateError('boom'));
+      await pumpSheet(tester, [
+        _computer(id: 'a', name: 'Petrel 3'),
+        _computer(id: 'b', name: 'ssss'),
+      ], customNotifier: failing);
+
+      await tester.tap(find.byKey(const ValueKey('merge_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Could not merge computers'), findsOneWidget);
+      expect(find.text('Merge Dive Computers'), findsOneWidget);
+      final button = tester.widget<FilledButton>(
+        find.byKey(const ValueKey('merge_confirm')),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+  });
+}

--- a/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
@@ -1,0 +1,583 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
+
+import '../../../../helpers/test_database.dart';
+
+void main() {
+  late AppDatabase db;
+  late DiveComputerMergeRepository repository;
+
+  setUp(() async {
+    db = await setUpTestDatabase();
+    repository = DiveComputerMergeRepository();
+    await db
+        .into(db.divers)
+        .insert(
+          const DiversCompanion(
+            id: Value('diver-1'),
+            name: Value('Diver'),
+            createdAt: Value(1000),
+            updatedAt: Value(1000),
+          ),
+        );
+  });
+
+  tearDown(() async {
+    await tearDownTestDatabase();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  Future<void> insertComputer({
+    required String id,
+    String name = 'Petrel 3',
+    String? diverId = 'diver-1',
+    String? manufacturer = 'Shearwater',
+    String? model = 'Petrel 3',
+    String? serialNumber = '3101949313',
+    String? firmwareVersion,
+    String? bluetoothAddress,
+    int diveCount = 0,
+    bool isFavorite = false,
+    String notes = '',
+    int? lastDownloadTimestamp,
+    String? lastDiveFingerprint,
+    String? equipmentId,
+    int updatedAt = 1000,
+  }) async {
+    await db
+        .into(db.diveComputers)
+        .insert(
+          DiveComputersCompanion(
+            id: Value(id),
+            diverId: Value(diverId),
+            name: Value(name),
+            manufacturer: Value(manufacturer),
+            model: Value(model),
+            serialNumber: Value(serialNumber),
+            firmwareVersion: Value(firmwareVersion),
+            bluetoothAddress: Value(bluetoothAddress),
+            diveCount: Value(diveCount),
+            isFavorite: Value(isFavorite),
+            notes: Value(notes),
+            lastDownloadTimestamp: Value(lastDownloadTimestamp),
+            lastDiveFingerprint: Value(lastDiveFingerprint),
+            equipmentId: Value(equipmentId),
+            createdAt: const Value(1000),
+            updatedAt: Value(updatedAt),
+          ),
+        );
+  }
+
+  Future<void> insertDive(String id, {String? computerId}) async {
+    await db
+        .into(db.dives)
+        .insert(
+          DivesCompanion(
+            id: Value(id),
+            diveDateTime: const Value(1000),
+            computerId: Value(computerId),
+            createdAt: const Value(1000),
+            updatedAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> insertDataSource(
+    String id, {
+    required String diveId,
+    String? computerId,
+    bool isPrimary = false,
+  }) async {
+    await db
+        .into(db.diveDataSources)
+        .insert(
+          DiveDataSourcesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            sourceFormat: const Value('dive_computer'),
+            importedAt: Value(DateTime(2026)),
+            createdAt: Value(DateTime(2026)),
+          ),
+        );
+  }
+
+  Future<void> insertTank(
+    String id, {
+    required String diveId,
+    String? computerId,
+  }) async {
+    await db
+        .into(db.diveTanks)
+        .insert(
+          DiveTanksCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+          ),
+        );
+  }
+
+  Future<void> insertProfileEvent(
+    String id, {
+    required String diveId,
+    String? computerId,
+  }) async {
+    await db
+        .into(db.diveProfileEvents)
+        .insert(
+          DiveProfileEventsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            timestamp: const Value(0),
+            eventType: const Value('ascent'),
+            computerId: Value(computerId),
+            createdAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> insertQualityFinding(
+    String id, {
+    required String diveId,
+    String? computerId,
+  }) async {
+    await db
+        .into(db.qualityFindings)
+        .insert(
+          QualityFindingsCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            detectorId: const Value('detector'),
+            detectorVersion: const Value(1),
+            category: const Value('profile'),
+            severity: const Value('info'),
+            createdAt: const Value(1000),
+            updatedAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> insertProfileSeries(
+    String id, {
+    required String diveId,
+    String? computerId,
+    bool isPrimary = true,
+  }) async {
+    await db
+        .into(db.diveProfileSeries)
+        .insert(
+          DiveProfileSeriesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            computerId: Value(computerId),
+            isPrimary: Value(isPrimary),
+            sampleCount: const Value(0),
+            startTimestamp: const Value(0),
+            endTimestamp: const Value(0),
+            maxDepth: const Value(0),
+            firstDepth: const Value(0),
+            lastDepth: const Value(0),
+            codecVersion: const Value(1),
+            samples: Value(Uint8List(0)),
+            createdAt: const Value(1000),
+            updatedAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> insertTankSeries(
+    String id, {
+    required String diveId,
+    required String tankId,
+    String? computerId,
+  }) async {
+    await db
+        .into(db.tankPressureSeries)
+        .insert(
+          TankPressureSeriesCompanion(
+            id: Value(id),
+            diveId: Value(diveId),
+            tankId: Value(tankId),
+            computerId: Value(computerId),
+            sampleCount: const Value(0),
+            startTimestamp: const Value(0),
+            endTimestamp: const Value(0),
+            codecVersion: const Value(1),
+            samples: Value(Uint8List(0)),
+            createdAt: const Value(1000),
+            updatedAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> insertEquipment(String id) async {
+    await db
+        .into(db.equipment)
+        .insert(
+          EquipmentCompanion(
+            id: Value(id),
+            name: Value('Gear $id'),
+            type: const Value('computer'),
+            createdAt: const Value(1000),
+            updatedAt: const Value(1000),
+          ),
+        );
+  }
+
+  Future<void> linkDiveEquipment(String diveId, String equipmentId) async {
+    await db
+        .into(db.diveEquipment)
+        .insert(
+          DiveEquipmentCompanion(
+            diveId: Value(diveId),
+            equipmentId: Value(equipmentId),
+          ),
+        );
+  }
+
+  Future<List<String>> computerIdsIn(
+    String table, {
+    String column = 'computer_id',
+  }) async {
+    final rows = await db
+        .customSelect('SELECT $column AS c FROM $table ORDER BY rowid')
+        .get();
+    return rows.map((r) => r.read<String?>('c') ?? 'NULL').toList();
+  }
+
+  Future<bool> isPending(String entityType, String recordId) async {
+    final row =
+        await (db.select(db.syncRecords)..where(
+              (t) =>
+                  t.entityType.equals(entityType) & t.recordId.equals(recordId),
+            ))
+            .getSingleOrNull();
+    return row != null;
+  }
+
+  Future<bool> hasTombstone(String entityType, String recordId) async {
+    final row =
+        await (db.select(db.deletionLog)..where(
+              (t) =>
+                  t.entityType.equals(entityType) & t.recordId.equals(recordId),
+            ))
+            .getSingleOrNull();
+    return row != null;
+  }
+
+  Future<DiveComputer?> computerRow(String id) => (db.select(
+    db.diveComputers,
+  )..where((t) => t.id.equals(id))).getSingleOrNull();
+
+  Future<Dive> diveRow(String id) =>
+      (db.select(db.dives)..where((t) => t.id.equals(id))).getSingle();
+
+  // ---------------------------------------------------------------------------
+  // Argument validation
+  // ---------------------------------------------------------------------------
+
+  group('argument validation', () {
+    test('rejects an empty duplicate list', () async {
+      await insertComputer(id: 'a');
+
+      expect(
+        () =>
+            repository.mergeComputers(survivorId: 'a', duplicateIds: const []),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a duplicate list that only names the survivor', () async {
+      await insertComputer(id: 'a');
+
+      expect(
+        () => repository.mergeComputers(survivorId: 'a', duplicateIds: ['a']),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws when the survivor does not exist', () async {
+      await insertComputer(id: 'b');
+
+      expect(
+        () => repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']),
+        throwsStateError,
+      );
+    });
+
+    test(
+      'throws when a duplicate does not exist and changes nothing',
+      () async {
+        await insertComputer(id: 'a');
+        await insertComputer(id: 'b');
+        await insertDive('d1', computerId: 'b');
+
+        await expectLater(
+          () => repository.mergeComputers(
+            survivorId: 'a',
+            duplicateIds: ['b', 'missing'],
+          ),
+          throwsStateError,
+        );
+
+        expect((await diveRow('d1')).computerId, 'b');
+        expect(await computerRow('b'), isNotNull);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Repointing
+  // ---------------------------------------------------------------------------
+
+  group('mergeComputers', () {
+    test(
+      'moves every reference from the duplicates onto the survivor',
+      () async {
+        await insertComputer(id: 'a');
+        await insertComputer(id: 'b', name: 'ssss');
+        await insertComputer(id: 'c', name: 'third');
+        await insertDive('d1', computerId: 'b');
+        await insertDive('d2', computerId: 'c');
+        await insertDive('d3', computerId: 'a');
+        await insertDataSource('ds1', diveId: 'd1', computerId: 'b');
+        await insertTank('t1', diveId: 'd1', computerId: 'b');
+        await insertProfileEvent('e1', diveId: 'd2', computerId: 'c');
+        await insertQualityFinding('q1', diveId: 'd1', computerId: 'b');
+        await insertProfileSeries('ps1', diveId: 'd1', computerId: 'b');
+        await insertProfileSeries('ps2', diveId: 'd3', computerId: 'a');
+        await insertTankSeries(
+          'ts1',
+          diveId: 'd2',
+          tankId: 't1',
+          computerId: 'c',
+        );
+
+        final result = await repository.mergeComputers(
+          survivorId: 'a',
+          duplicateIds: ['b', 'c'],
+        );
+
+        expect(result.survivorId, 'a');
+        expect(result.mergedComputerIds, ['b', 'c']);
+        expect(result.movedDiveCount, 2);
+
+        expect(await computerIdsIn('dives'), ['a', 'a', 'a']);
+        expect(await computerIdsIn('dive_data_sources'), ['a']);
+        expect(await computerIdsIn('dive_tanks'), ['a']);
+        expect(await computerIdsIn('dive_profile_events'), ['a']);
+        expect(await computerIdsIn('quality_findings'), ['a']);
+        expect(await computerIdsIn('dive_profile_series'), ['a', 'a']);
+        expect(await computerIdsIn('tank_pressure_series'), ['a']);
+      },
+    );
+
+    test(
+      'deletes the duplicates with tombstones and keeps the survivor',
+      () async {
+        await insertComputer(id: 'a');
+        await insertComputer(id: 'b');
+
+        await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+        expect(await computerRow('a'), isNotNull);
+        expect(await computerRow('b'), isNull);
+        expect(await hasTombstone('diveComputers', 'b'), isTrue);
+        expect(await hasTombstone('diveComputers', 'a'), isFalse);
+      },
+    );
+
+    test('writes the merged fields onto the survivor row', () async {
+      await insertComputer(
+        id: 'a',
+        firmwareVersion: null,
+        diveCount: 21,
+        lastDownloadTimestamp: 5000,
+        lastDiveFingerprint: 'old',
+        notes: 'Primary',
+      );
+      await insertComputer(
+        id: 'b',
+        name: 'ssss',
+        firmwareVersion: '103',
+        diveCount: 2,
+        isFavorite: true,
+        lastDownloadTimestamp: 9000,
+        lastDiveFingerprint: 'new',
+        notes: 'From the iPhone',
+      );
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+      final survivor = (await computerRow('a'))!;
+      expect(survivor.name, 'Petrel 3');
+      expect(survivor.firmwareVersion, '103');
+      expect(survivor.diveCount, 23);
+      expect(survivor.isFavorite, isTrue);
+      expect(survivor.lastDownloadTimestamp, 9000);
+      expect(survivor.lastDiveFingerprint, 'new');
+      expect(survivor.notes, 'Primary\n\nFrom the iPhone');
+      expect(survivor.updatedAt, greaterThan(1000));
+    });
+
+    test(
+      'marks the survivor, affected dives and clocked children pending',
+      () async {
+        await insertComputer(id: 'a');
+        await insertComputer(id: 'b');
+        await insertDive('d1', computerId: 'b');
+        await insertDive('d2', computerId: 'a');
+        await insertDataSource('ds2', diveId: 'd2', computerId: 'b');
+        await insertQualityFinding('q1', diveId: 'd1', computerId: 'b');
+        await insertProfileSeries('ps1', diveId: 'd1', computerId: 'b');
+        await insertTank('t', diveId: 'd1');
+        await insertTankSeries(
+          'ts1',
+          diveId: 'd1',
+          tankId: 't',
+          computerId: 'b',
+        );
+
+        await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+        expect(await isPending('diveComputers', 'a'), isTrue);
+        expect(await isPending('dives', 'd1'), isTrue);
+        // d2 already pointed at the survivor, but its data source moved and
+        // that table has no clock of its own: the dive must carry the change.
+        expect(await isPending('dives', 'd2'), isTrue);
+        expect((await diveRow('d2')).updatedAt, greaterThan(1000));
+        expect(await isPending('qualityFindings', 'q1'), isTrue);
+        expect(await isPending('diveProfileSeries', 'ps1'), isTrue);
+        expect(await isPending('tankPressureSeries', 'ts1'), isTrue);
+      },
+    );
+
+    test('leaves dives that never referenced a duplicate untouched', () async {
+      await insertComputer(id: 'a');
+      await insertComputer(id: 'b');
+      await insertDive('d1', computerId: 'a');
+      await insertDive('d2');
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+      expect((await diveRow('d1')).updatedAt, 1000);
+      expect((await diveRow('d2')).updatedAt, 1000);
+      expect(await isPending('dives', 'd1'), isFalse);
+    });
+
+    test('keeps the survivor bluetooth address when it has one', () async {
+      await insertComputer(id: 'a', bluetoothAddress: 'MAC-A');
+      await insertComputer(id: 'b', bluetoothAddress: 'MAC-B');
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+      expect((await computerRow('a'))!.bluetoothAddress, 'MAC-A');
+    });
+
+    test(
+      'adopts a duplicate bluetooth address when the survivor has none',
+      () async {
+        await insertComputer(id: 'a', bluetoothAddress: null);
+        await insertComputer(id: 'b', bluetoothAddress: 'MAC-B');
+
+        await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+        expect((await computerRow('a'))!.bluetoothAddress, 'MAC-B');
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Gear twins
+  // ---------------------------------------------------------------------------
+
+  group('gear twins', () {
+    test(
+      'repoints dive gear links from the duplicate twin to the survivor twin',
+      () async {
+        await insertEquipment('gear-a');
+        await insertEquipment('gear-b');
+        await insertComputer(id: 'a', equipmentId: 'gear-a');
+        await insertComputer(id: 'b', equipmentId: 'gear-b');
+        await insertDive('d1', computerId: 'b');
+        await insertDive('d2', computerId: 'b');
+        await linkDiveEquipment('d1', 'gear-b');
+        await linkDiveEquipment('d2', 'gear-b');
+        await linkDiveEquipment('d2', 'gear-a');
+
+        await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+        final links = await (db.select(db.diveEquipment)).get();
+        final pairs = links.map((l) => '${l.diveId}|${l.equipmentId}').toSet();
+        expect(pairs, {'d1|gear-a', 'd2|gear-a'});
+        expect(await isPending('diveEquipment', 'd1|gear-a'), isTrue);
+        expect(await hasTombstone('diveEquipment', 'd1|gear-b'), isTrue);
+        expect(await hasTombstone('diveEquipment', 'd2|gear-b'), isTrue);
+        expect((await computerRow('a'))!.equipmentId, 'gear-a');
+        // The duplicate's gear item itself is left for the user to manage.
+        final gearB = await (db.select(
+          db.equipment,
+        )..where((t) => t.id.equals('gear-b'))).getSingleOrNull();
+        expect(gearB, isNotNull);
+      },
+    );
+
+    test('adopts the duplicate twin when the survivor has none', () async {
+      await insertEquipment('gear-b');
+      await insertComputer(id: 'a', equipmentId: null);
+      await insertComputer(id: 'b', equipmentId: 'gear-b');
+      await insertDive('d1', computerId: 'b');
+      await linkDiveEquipment('d1', 'gear-b');
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+      expect((await computerRow('a'))!.equipmentId, 'gear-b');
+      final links = await (db.select(db.diveEquipment)).get();
+      expect(links.single.equipmentId, 'gear-b');
+    });
+
+    test('does nothing when both records share one twin', () async {
+      await insertEquipment('gear');
+      await insertComputer(id: 'a', equipmentId: 'gear');
+      await insertComputer(id: 'b', equipmentId: 'gear');
+      await insertDive('d1', computerId: 'b');
+      await linkDiveEquipment('d1', 'gear');
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+
+      final links = await (db.select(db.diveEquipment)).get();
+      expect(links.single.equipmentId, 'gear');
+      expect(await hasTombstone('diveEquipment', 'd1|gear'), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Counting
+  // ---------------------------------------------------------------------------
+
+  group('countAffectedDives', () {
+    test('counts each dive once across every referencing table', () async {
+      await insertComputer(id: 'a');
+      await insertComputer(id: 'b');
+      await insertDive('d1', computerId: 'b');
+      await insertDive('d2', computerId: 'a');
+      await insertDive('d3');
+      await insertDataSource('ds1', diveId: 'd1', computerId: 'b');
+      await insertProfileSeries('ps1', diveId: 'd1', computerId: 'b');
+      await insertTank('t', diveId: 'd3');
+      await insertTankSeries('ts3', diveId: 'd3', tankId: 't', computerId: 'b');
+
+      expect(await repository.countAffectedDives(['b']), 2);
+      expect(await repository.countAffectedDives(['a', 'b']), 3);
+      expect(await repository.countAffectedDives(const []), 0);
+    });
+  });
+}

--- a/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
@@ -590,6 +590,8 @@ void main() {
     test('counts each dive once across every referencing table', () async {
       await insertComputer(id: 'a');
       await insertComputer(id: 'b');
+      // A third record so the a-and-b case has a survivor outside the pair.
+      await insertComputer(id: 'c');
       await insertDive('d1', computerId: 'b');
       await insertDive('d2', computerId: 'a');
       await insertDive('d3');
@@ -598,9 +600,105 @@ void main() {
       await insertTank('t', diveId: 'd3');
       await insertTankSeries('ts3', diveId: 'd3', tankId: 't', computerId: 'b');
 
-      expect(await repository.countAffectedDives(['b']), 2);
-      expect(await repository.countAffectedDives(['a', 'b']), 3);
-      expect(await repository.countAffectedDives(const []), 0);
+      expect(
+        await repository.countAffectedDives(
+          survivorId: 'a',
+          duplicateIds: ['b'],
+        ),
+        2,
+      );
+      expect(
+        await repository.countAffectedDives(
+          survivorId: 'c',
+          duplicateIds: ['a', 'b'],
+        ),
+        3,
+      );
+      expect(
+        await repository.countAffectedDives(
+          survivorId: 'a',
+          duplicateIds: const [],
+        ),
+        0,
+      );
+      // The survivor is never one of the duplicates it absorbs.
+      expect(
+        await repository.countAffectedDives(
+          survivorId: 'a',
+          duplicateIds: ['a'],
+        ),
+        0,
+      );
+    });
+
+    test(
+      'counts a dive that references a duplicate through gear only',
+      () async {
+        await insertEquipment('gear-a');
+        await insertEquipment('gear-b');
+        await insertComputer(id: 'a', equipmentId: 'gear-a');
+        await insertComputer(id: 'b', equipmentId: 'gear-b');
+        // d1 carries no computer_id anywhere: the duplicate reaches it solely
+        // through the gear twin the merge is about to repoint.
+        await insertDive('d1');
+        await linkDiveEquipment('d1', 'gear-b');
+
+        final preview = await repository.countAffectedDives(
+          survivorId: 'a',
+          duplicateIds: ['b'],
+        );
+        final result = await repository.mergeComputers(
+          survivorId: 'a',
+          duplicateIds: ['b'],
+        );
+
+        expect(preview, 1);
+        expect(result.movedDiveCount, preview);
+      },
+    );
+
+    test('does not count gear links the survivor already holds', () async {
+      await insertEquipment('gear');
+      await insertComputer(id: 'a', equipmentId: 'gear');
+      await insertComputer(id: 'b', equipmentId: 'gear');
+      await insertDive('d1');
+      await linkDiveEquipment('d1', 'gear');
+
+      // Both records share one twin, the common case when the identity
+      // resolver matched them by serial. Nothing moves.
+      expect(
+        await repository.countAffectedDives(
+          survivorId: 'a',
+          duplicateIds: ['b'],
+        ),
+        0,
+      );
+    });
+
+    test('counts gear links against the twin the survivor adopts', () async {
+      await insertEquipment('gear-b');
+      await insertEquipment('gear-c');
+      await insertComputer(id: 'a', equipmentId: null);
+      await insertComputer(id: 'b', equipmentId: 'gear-b');
+      await insertComputer(id: 'c', equipmentId: 'gear-c');
+      await insertDive('d1');
+      await insertDive('d2');
+      await linkDiveEquipment('d1', 'gear-b');
+      await linkDiveEquipment('d2', 'gear-c');
+
+      // The survivor has no twin, so it adopts gear-b from the first
+      // duplicate. Only gear-c's links move.
+      final preview = await repository.countAffectedDives(
+        survivorId: 'a',
+        duplicateIds: ['b', 'c'],
+      );
+      final result = await repository.mergeComputers(
+        survivorId: 'a',
+        duplicateIds: ['b', 'c'],
+      );
+
+      expect(preview, 1);
+      expect(result.movedDiveCount, preview);
     });
   });
 }

--- a/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
+++ b/test/features/dive_log/data/repositories/dive_computer_merge_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' hide isNull, isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/sync_event_bus.dart';
 import 'package:submersion/features/dive_log/data/repositories/dive_computer_merge_repository.dart';
 
 import '../../../../helpers/test_database.dart';
@@ -471,6 +472,28 @@ void main() {
       expect((await diveRow('d1')).updatedAt, 1000);
       expect((await diveRow('d2')).updatedAt, 1000);
       expect(await isPending('dives', 'd1'), isFalse);
+    });
+
+    test('notifies the sync bus exactly once, after the commit', () async {
+      await insertComputer(id: 'a');
+      await insertComputer(id: 'b');
+      await insertDive('d1', computerId: 'b');
+      await insertProfileSeries('ps1', diveId: 'd1', computerId: 'b');
+      await insertTank('t', diveId: 'd1');
+      await insertTankSeries('ts1', diveId: 'd1', tankId: 't', computerId: 'b');
+
+      var notifications = 0;
+      final subscription = SyncEventBus.changes.listen((_) {
+        notifications += 1;
+      });
+      addTearDown(subscription.cancel);
+
+      await repository.mergeComputers(survivorId: 'a', duplicateIds: ['b']);
+      await Future<void>.delayed(Duration.zero);
+
+      // The series repositories restamp their rows inside the merge
+      // transaction; only the merge itself may announce the change.
+      expect(notifications, 1);
     });
 
     test('keeps the survivor bluetooth address when it has one', () async {


### PR DESCRIPTION
## Summary

Addresses #645. The same physical dive computer is saved once per Apple host because each host mints its own CoreBluetooth identifier for it, so the reporter ended up with a "Petrel 3" record and an "ssss" record that both carry serial 3101949313. PR #682 stopped new duplicates from forming (the BLE address is no longer synced, and a freshly discovered computer rebinds by serial). This PR adds the missing half: reconciling records that already exist, while keeping every historical dive attached to the surviving record.

## Changes

- **Merge rules** (`lib/features/dive_computer/domain/services/dive_computer_merge_rules.dart`): pure functions that find duplicate candidates (shared non-blank serial, compatible manufacturer and model, same diver), detect conflicting serials, choose a default survivor (favorite, then most dives, then newest download), and combine the survivor's fields (blanks filled from duplicates, dive counts summed, newest download kept with its fingerprint, favorite preserved, distinct notes appended).
- **`DiveComputerMergeRepository`** (a separate class, since the main repository is already 2,300 lines): one transaction repoints every table that references the duplicates (`dives`, `dive_data_sources`, `dive_tanks`, `dive_profile_events`, `quality_findings`, `dive_profile_series`, `tank_pressure_series`, and legacy `dive_profiles` when it survives), moves `dive_equipment` links from the duplicates' gear twins to the survivor's twin, restamps every affected dive so the clockless child tables replicate, writes the merged fields onto the survivor, and deletes the duplicates with tombstones. Sync bookkeeping follows the site-merge shape: `markRecordPending` per clocked row, `logDeletion` per duplicate, one `notifyLocalChange`.
- **`repointComputer`** on `ProfileSeriesRepository` and `TankPressureSeriesRepository`, mirroring `clearComputer` so each moved series is restamped.
- **UI**: a merge bottom sheet (pick the record to keep, see how many dives move, warning when serials differ), a merge bulk action on the dive computer list (enabled at two or more checked), a "Merge with another computer" item in the detail page menu (same-serial records listed first), and a detail-page banner when another record shares this computer's serial number with a one-tap Merge. When the current record is folded into another, the detail page moves to the survivor.
- **l10n**: 17 keys under `diveComputer_merge_*` and `diveComputer_detail_merge*` in all 11 locales.

Deliberately left out: undo (the sheet is the review step the issue asks for), deleting the duplicate's gear-twin equipment row (it may carry service history, and the gear list has its own delete), and collapsing profile series when both records hold samples for the same dive (no data is deleted).

## Test Plan

- [x] `flutter test` passes (23,210 passed, 21 skipped; one unrelated flake in `sync_hlc_merge_test.dart` passed on rerun)
- [x] `flutter analyze` passes
- [x] New tests: merge rules (19), merge repository (15), merge sheet (7), list bulk action (3), detail banner and picker (6)
- [x] Manual testing on: macOS with two records sharing one serial
