### PR TITLE
fix(uddf): import Subsurface dives without a time, and their trips

### DIFF
--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -484,29 +484,37 @@ class UddfFullImportService {
     List<Map<String, dynamic>> trips,
     List<Map<String, dynamic>> dives,
   ) {
-    for (final trip in trips) {
-      if (trip['startDate'] != null && trip['endDate'] != null) continue;
+    final undatedTrips = trips
+        .where((trip) => trip['startDate'] == null || trip['endDate'] == null)
+        .toList();
+    if (undatedTrips.isEmpty) return;
 
+    // One pass over the dives, so a large logbook does not pay for a scan per
+    // trip.
+    final ranges = <String, ({DateTime earliest, DateTime latest})>{};
+    for (final dive in dives) {
+      final tripRef = dive['tripRef'] as String?;
+      final diveDateTime = dive['dateTime'] as DateTime?;
+      if (tripRef == null || diveDateTime == null) continue;
+      final range = ranges[tripRef];
+      ranges[tripRef] = range == null
+          ? (earliest: diveDateTime, latest: diveDateTime)
+          : (
+              earliest: diveDateTime.isBefore(range.earliest)
+                  ? diveDateTime
+                  : range.earliest,
+              latest: diveDateTime.isAfter(range.latest)
+                  ? diveDateTime
+                  : range.latest,
+            );
+    }
+
+    for (final trip in undatedTrips) {
       final uddfId = trip['uddfId'] as String?;
-      DateTime? earliest;
-      DateTime? latest;
-      if (uddfId != null) {
-        for (final dive in dives) {
-          if (dive['tripRef'] != uddfId) continue;
-          final diveDateTime = dive['dateTime'] as DateTime?;
-          if (diveDateTime == null) continue;
-          if (earliest == null || diveDateTime.isBefore(earliest)) {
-            earliest = diveDateTime;
-          }
-          if (latest == null || diveDateTime.isAfter(latest)) {
-            latest = diveDateTime;
-          }
-        }
-      }
-
+      final range = uddfId == null ? null : ranges[uddfId];
       final nameDate = trip['nameDate'] as DateTime?;
-      final start = earliest ?? nameDate;
-      final end = latest ?? nameDate;
+      final start = range?.earliest ?? nameDate;
+      final end = range?.latest ?? nameDate;
       // Trip dates are calendar days in the diver's own frame, while dive
       // datetimes are wall clocks flagged UTC, so carry the components across
       // rather than the instant.

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -515,7 +515,7 @@ class UddfFullImportService {
     for (final trip in undatedTrips) {
       final uddfId = trip['uddfId'] as String?;
       final range = uddfId == null ? null : ranges[uddfId];
-      final nameDate = trip['nameDate'] as DateTime?;
+      final nameDate = trip['_nameDate'] as DateTime?;
       final start = range?.earliest ?? nameDate;
       final end = range?.latest ?? nameDate;
       // Trip dates are calendar days in the diver's own frame, while dive
@@ -539,7 +539,7 @@ class UddfFullImportService {
   /// key left behind does not stay local to parsing.
   void _dropTripNameDates(List<Map<String, dynamic>> trips) {
     for (final trip in trips) {
-      trip.remove('nameDate');
+      trip.remove('_nameDate');
     }
   }
 
@@ -694,17 +694,6 @@ class UddfFullImportService {
         }
       }
 
-      // Subsurface points a dive at its trip with <tripmembership>, and its
-      // generated trip ids carry none of the prefixes the <link> handling
-      // below keys on.
-      final tripMembershipRef = beforeElement
-          .findElements('tripmembership')
-          .firstOrNull
-          ?.getAttribute('ref');
-      if (tripMembershipRef != null && tripMembershipRef.isNotEmpty) {
-        diveData['tripRef'] = tripMembershipRef;
-      }
-
       // Extract link references for trip, dive center, and buddies
       final buddyRefs = <String>[];
       final unmatchedBuddyNames = <String>[];
@@ -722,6 +711,18 @@ class UddfFullImportService {
             buddyRefs.add(ref);
           }
         }
+      }
+
+      // Subsurface points a dive at its trip with <tripmembership>, and its
+      // generated trip ids carry none of the prefixes the <link> handling
+      // above keys on. Read after the links, so that where a file somehow
+      // carries both, the UDDF-standard element is the one that decides.
+      final tripMembershipRef = beforeElement
+          .findElements('tripmembership')
+          .firstOrNull
+          ?.getAttribute('ref');
+      if (tripMembershipRef != null && tripMembershipRef.isNotEmpty) {
+        diveData['tripRef'] = tripMembershipRef;
       }
 
       // Also parse inline buddy elements in informationbeforedive

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -487,7 +487,10 @@ class UddfFullImportService {
     final undatedTrips = trips
         .where((trip) => trip['startDate'] == null || trip['endDate'] == null)
         .toList();
-    if (undatedTrips.isEmpty) return;
+    if (undatedTrips.isEmpty) {
+      _dropTripNameDates(trips);
+      return;
+    }
 
     // One pass over the dives, so a large logbook does not pay for a scan per
     // trip.
@@ -524,6 +527,19 @@ class UddfFullImportService {
       if (trip['endDate'] == null && end != null) {
         trip['endDate'] = DateTime(end.year, end.month, end.day);
       }
+    }
+
+    _dropTripNameDates(trips);
+  }
+
+  /// Drops the date recovered from a trip's name once it has been used.
+  ///
+  /// These maps travel across layers, and the payload merger copies every key
+  /// it finds when folding a duplicate trip from a second file, so a scratch
+  /// key left behind does not stay local to parsing.
+  void _dropTripNameDates(List<Map<String, dynamic>> trips) {
+    for (final trip in trips) {
+      trip.remove('nameDate');
     }
   }
 

--- a/lib/core/services/export/uddf/uddf_full_import_service.dart
+++ b/lib/core/services/export/uddf/uddf_full_import_service.dart
@@ -70,17 +70,32 @@ class UddfFullImportService {
       }
     }
 
-    // Parse trips (UDDF standard divetrip elements)
+    // Parse trips. Submersion writes one <divetrip> per trip, carrying the
+    // trip's fields directly; UDDF 3.2 and Subsurface's exporter instead wrap
+    // <trip> children in a single <divetrip> container. Reading only the
+    // outer element turned a whole Subsurface trip list into one nameless
+    // trip, which the entity importer then skipped (#239).
     final trips = <Map<String, dynamic>>[];
     final tripMap = <String, Map<String, dynamic>>{};
-    for (final tripElement in uddfElement.findElements('divetrip')) {
-      final tripData = UddfImportParsers.parseTrip(tripElement);
-      final tripId = tripElement.getAttribute('id');
-      if (tripId != null) {
-        tripData['uddfId'] = tripId;
-        tripMap[tripId] = tripData;
+    for (final diveTripElement in uddfElement.findElements('divetrip')) {
+      final nestedTrips = diveTripElement.findElements('trip').toList();
+      final tripElements = nestedTrips.isEmpty
+          ? [diveTripElement]
+          : nestedTrips;
+      for (final tripElement in tripElements) {
+        final tripData = UddfImportParsers.parseTrip(tripElement);
+        // Subsurface writes an empty <divetrip/> even when the logbook has no
+        // trips at all. Carrying that through as a nameless trip made the
+        // import preview offer a trip the entity importer then skipped.
+        final tripName = tripData['name'] as String?;
+        if (tripName == null || tripName.isEmpty) continue;
+        final tripId = tripElement.getAttribute('id');
+        if (tripId != null) {
+          tripData['uddfId'] = tripId;
+          tripMap[tripId] = tripData;
+        }
+        trips.add(tripData);
       }
-      trips.add(tripData);
     }
 
     // Parse gas definitions
@@ -434,6 +449,8 @@ class UddfFullImportService {
       }
     }
 
+    _applyTripDateRanges(trips, dives);
+
     return UddfImportResult(
       dives: dives,
       sites: sites,
@@ -454,6 +471,52 @@ class UddfFullImportService {
       equipmentSets: equipmentSets,
       courses: courses,
     );
+  }
+
+  /// Fills in a trip's date range from the dives that belong to it.
+  ///
+  /// Only Submersion's own export writes `<dateoftrip>`. A Subsurface trip
+  /// carries no dates at all, and an undated trip lands in the library dated
+  /// the day of the import. The trip's dives cover the same days, so derive
+  /// the range from them, falling back to the date Subsurface embeds in the
+  /// trip name when none of its dives were imported.
+  void _applyTripDateRanges(
+    List<Map<String, dynamic>> trips,
+    List<Map<String, dynamic>> dives,
+  ) {
+    for (final trip in trips) {
+      if (trip['startDate'] != null && trip['endDate'] != null) continue;
+
+      final uddfId = trip['uddfId'] as String?;
+      DateTime? earliest;
+      DateTime? latest;
+      if (uddfId != null) {
+        for (final dive in dives) {
+          if (dive['tripRef'] != uddfId) continue;
+          final diveDateTime = dive['dateTime'] as DateTime?;
+          if (diveDateTime == null) continue;
+          if (earliest == null || diveDateTime.isBefore(earliest)) {
+            earliest = diveDateTime;
+          }
+          if (latest == null || diveDateTime.isAfter(latest)) {
+            latest = diveDateTime;
+          }
+        }
+      }
+
+      final nameDate = trip['nameDate'] as DateTime?;
+      final start = earliest ?? nameDate;
+      final end = latest ?? nameDate;
+      // Trip dates are calendar days in the diver's own frame, while dive
+      // datetimes are wall clocks flagged UTC, so carry the components across
+      // rather than the instant.
+      if (trip['startDate'] == null && start != null) {
+        trip['startDate'] = DateTime(start.year, start.month, start.day);
+      }
+      if (trip['endDate'] == null && end != null) {
+        trip['endDate'] = DateTime(end.year, end.month, end.day);
+      }
+    }
   }
 
   Map<String, dynamic> _parseFullSite(XmlElement siteElement) {
@@ -605,6 +668,17 @@ class UddfFullImportService {
         if (altitudeMeters != null && altitudeMeters > 0) {
           diveData['altitude'] = altitudeMeters;
         }
+      }
+
+      // Subsurface points a dive at its trip with <tripmembership>, and its
+      // generated trip ids carry none of the prefixes the <link> handling
+      // below keys on.
+      final tripMembershipRef = beforeElement
+          .findElements('tripmembership')
+          .firstOrNull
+          ?.getAttribute('ref');
+      if (tripMembershipRef != null && tripMembershipRef.isNotEmpty) {
+        diveData['tripRef'] = tripMembershipRef;
       }
 
       // Extract link references for trip, dive center, and buddies

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -336,12 +336,15 @@ class UddfImportParsers {
     // Strip any trailing timezone info (Z, +HH:MM, -HH:MM, etc.)
     final bare =
         _timeZoneSuffixPattern.firstMatch(trimmed)?.group(1) ?? trimmed;
-    final dt =
-        DateTime.tryParse(bare) ??
-        DateTime.tryParse(
-          _dateWithoutTimePattern.firstMatch(bare)?.group(1) ?? '',
-        );
-    if (dt == null) return null;
+    var dt = DateTime.tryParse(bare);
+    if (dt == null) {
+      final dateWithoutTime = _dateWithoutTimePattern
+          .firstMatch(bare)
+          ?.group(1);
+      if (dateWithoutTime == null) return null;
+      dt = DateTime.tryParse(dateWithoutTime);
+      if (dt == null) return null;
+    }
     return DateTime.utc(
       dt.year,
       dt.month,
@@ -477,7 +480,7 @@ class UddfImportParsers {
       final location = nameParts.group(1)?.trim();
       final nameDate = DateTime.tryParse(nameParts.group(2)!);
       if (nameDate != null) {
-        trip['nameDate'] = nameDate;
+        trip['_nameDate'] = nameDate;
         if (location != null && location.isNotEmpty) {
           name = location;
           locationFromName = location;

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -292,16 +292,22 @@ class UddfImportParsers {
     return GasMix(o2: o2, he: he);
   }
 
-  /// Trailing timezone info on a UDDF datetime: a "Z", or an offset in any of
-  /// the shapes ISO 8601 allows ("+02:00", "+0200", "+02").
+  /// A datetime carrying trailing timezone info: a "Z", or an offset in any
+  /// of the shapes ISO 8601 allows ("+02:00", "+0200", "+02"). Group 1 is the
+  /// datetime with that suffix removed.
   ///
-  /// The lookbehind is what makes the compact forms safe to strip: it demands
-  /// a clock time immediately before the offset, so the trailing "-05" of a
-  /// bare "2008-09-05" cannot be mistaken for one. Without the compact forms
-  /// the suffix survived, [DateTime.parse] applied the offset, and the wall
-  /// clock was stored shifted by it ("08:42:30+0200" landed as 06:42:30).
+  /// Requiring a clock time in front of the offset is what makes the compact
+  /// forms safe to strip: the trailing "-05" of a bare "2008-09-05" cannot be
+  /// mistaken for one. Without the compact forms the suffix survived,
+  /// [DateTime.parse] applied the offset, and the wall clock was stored
+  /// shifted by it ("08:42:30+0200" landed as 06:42:30).
+  ///
+  /// The time is captured rather than asserted with a lookbehind, because
+  /// this package builds for web too, where a Dart RegExp becomes a JS one
+  /// and lookbehind throws on Safari older than 16.4. A static final field
+  /// would take UDDF import down entirely on first use there.
   static final RegExp _timeZoneSuffixPattern = RegExp(
-    r'(?<=\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?)\s*(?:Z|[+-]\d{2}:?\d{2}|[+-]\d{2})$',
+    r'^(.*\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?)\s*(?:Z|[+-]\d{2}:?\d{2}|[+-]\d{2})$',
   );
 
   /// A date carrying no time, optionally followed by the "T" separator that
@@ -328,7 +334,8 @@ class UddfImportParsers {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return null;
     // Strip any trailing timezone info (Z, +HH:MM, -HH:MM, etc.)
-    final bare = trimmed.replaceFirst(_timeZoneSuffixPattern, '');
+    final bare =
+        _timeZoneSuffixPattern.firstMatch(trimmed)?.group(1) ?? trimmed;
     final dt =
         DateTime.tryParse(bare) ??
         DateTime.tryParse(

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -48,9 +48,12 @@ class UddfImportParsers {
   static final RegExp _zeroFractionPattern = RegExp(r'^([+-]?\d+)\.0*$');
 
   // A trip name of the form "<location><non-breaking space><ISO date>", which
-  // is how Subsurface's UDDF exporter names a trip.
+  // is how Subsurface's UDDF exporter names a trip. The location half is
+  // optional: a trip with no location exports as just the separator and the
+  // date, and Dart counts U+00A0 as whitespace, so by the time the name has
+  // been read and trimmed the separator is gone and only the date is left.
   static final RegExp _tripNamePattern = RegExp(
-    r'^(.*)\u00A0(\d{4}-\d{2}-\d{2})$',
+    r'^(?:(.*)\u00A0)?(\d{4}-\d{2}-\d{2})$',
   );
 
   /// Parses a UDDF integer-semantics value, tolerating the float
@@ -289,6 +292,12 @@ class UddfImportParsers {
     return GasMix(o2: o2, he: he);
   }
 
+  /// Trailing timezone info on a UDDF datetime: a "Z", or an offset such as
+  /// "+02:00" or "-05:00".
+  static final RegExp _timeZoneSuffixPattern = RegExp(
+    r'[Z+\-](?=\d{2}:\d{2}$)|Z$',
+  );
+
   /// A date carrying no time, optionally followed by the "T" separator that
   /// an exporter leaves dangling when the time is unknown.
   static final RegExp _dateWithoutTimePattern = RegExp(
@@ -313,7 +322,7 @@ class UddfImportParsers {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return null;
     // Strip any trailing timezone info (Z, +HH:MM, -HH:MM, etc.)
-    final bare = trimmed.split(RegExp(r'[Z+\-](?=\d{2}:\d{2}$)|Z$')).first;
+    final bare = trimmed.split(_timeZoneSuffixPattern).first;
     final dt =
         DateTime.tryParse(bare) ??
         DateTime.tryParse(
@@ -436,26 +445,27 @@ class UddfImportParsers {
     final trip = <String, dynamic>{};
 
     final tripPart = tripElement.findElements('trippart').firstOrNull;
+    // getElementText already trims, but the name is matched against a
+    // pattern below, so trim once here and use that value throughout.
     final rawName =
-        getElementText(tripElement, 'name') ??
-        (tripPart == null ? null : getElementText(tripPart, 'name')) ??
-        '';
+        (getElementText(tripElement, 'name') ??
+                (tripPart == null ? null : getElementText(tripPart, 'name')) ??
+                '')
+            .trim();
 
     // Subsurface has no trip-name field of its own, so its exporter builds
     // one as "<location>\u00A0<start date>". Recovering the two halves keeps
     // the trip out of the library named after a date, and gives it a date to
     // fall back on when no dive of the trip was imported.
     String? locationFromName;
-    var name = rawName.trim();
+    var name = rawName;
     final nameParts = _tripNamePattern.firstMatch(rawName);
     if (nameParts != null) {
-      final location = nameParts.group(1)!.trim();
+      final location = nameParts.group(1)?.trim();
       final nameDate = DateTime.tryParse(nameParts.group(2)!);
       if (nameDate != null) {
         trip['nameDate'] = nameDate;
-        if (location.isEmpty) {
-          name = nameParts.group(2)!;
-        } else {
+        if (location != null && location.isNotEmpty) {
           name = location;
           locationFromName = location;
         }

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -292,10 +292,16 @@ class UddfImportParsers {
     return GasMix(o2: o2, he: he);
   }
 
-  /// Trailing timezone info on a UDDF datetime: a "Z", or an offset such as
-  /// "+02:00" or "-05:00".
+  /// Trailing timezone info on a UDDF datetime: a "Z", or an offset in any of
+  /// the shapes ISO 8601 allows ("+02:00", "+0200", "+02").
+  ///
+  /// The lookbehind is what makes the compact forms safe to strip: it demands
+  /// a clock time immediately before the offset, so the trailing "-05" of a
+  /// bare "2008-09-05" cannot be mistaken for one. Without the compact forms
+  /// the suffix survived, [DateTime.parse] applied the offset, and the wall
+  /// clock was stored shifted by it ("08:42:30+0200" landed as 06:42:30).
   static final RegExp _timeZoneSuffixPattern = RegExp(
-    r'[Z+\-](?=\d{2}:\d{2}$)|Z$',
+    r'(?<=\d{2}:\d{2}(?::\d{2})?(?:[.,]\d+)?)\s*(?:Z|[+-]\d{2}:?\d{2}|[+-]\d{2})$',
   );
 
   /// A date carrying no time, optionally followed by the "T" separator that
@@ -322,7 +328,7 @@ class UddfImportParsers {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return null;
     // Strip any trailing timezone info (Z, +HH:MM, -HH:MM, etc.)
-    final bare = trimmed.split(_timeZoneSuffixPattern).first;
+    final bare = trimmed.replaceFirst(_timeZoneSuffixPattern, '');
     final dt =
         DateTime.tryParse(bare) ??
         DateTime.tryParse(

--- a/lib/core/services/export/uddf/uddf_import_parsers.dart
+++ b/lib/core/services/export/uddf/uddf_import_parsers.dart
@@ -47,6 +47,12 @@ class UddfImportParsers {
   // "15.0" or "15.000". Captures the integer so it can be parsed exactly.
   static final RegExp _zeroFractionPattern = RegExp(r'^([+-]?\d+)\.0*$');
 
+  // A trip name of the form "<location><non-breaking space><ISO date>", which
+  // is how Subsurface's UDDF exporter names a trip.
+  static final RegExp _tripNamePattern = RegExp(
+    r'^(.*)\u00A0(\d{4}-\d{2}-\d{2})$',
+  );
+
   /// Parses a UDDF integer-semantics value, tolerating the float
   /// serialization several exporters emit.
   ///
@@ -283,17 +289,36 @@ class UddfImportParsers {
     return GasMix(o2: o2, he: he);
   }
 
+  /// A date carrying no time, optionally followed by the "T" separator that
+  /// an exporter leaves dangling when the time is unknown.
+  static final RegExp _dateWithoutTimePattern = RegExp(
+    r'^(\d{4}-\d{2}-\d{2})[T ]?$',
+  );
+
   /// Parse a UDDF datetime string using the wall-clock-as-UTC convention.
   ///
   /// UDDF dive datetimes represent the wall-clock reading from the dive
   /// computer (e.g. "2024-06-15T08:42:00"). Any timezone suffix is ignored
   /// and the date/time components are stored verbatim as a UTC DateTime so
   /// that they survive a DB round-trip unchanged.
+  ///
+  /// A value with no time is read as midnight on that date. Subsurface builds
+  /// this element as `concat(@date, 'T', @time)`, so a dive logged by hand
+  /// with no entry time exports as a bare "2008-09-05T" that
+  /// [DateTime.parse] rejects. Returning null for those let the caller fall
+  /// back to the import clock, which stamped every such dive with the day it
+  /// was imported rather than the day it was dived (#239).
   static DateTime? parseDiveDateTime(String? text) {
-    if (text == null || text.isEmpty) return null;
+    if (text == null) return null;
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return null;
     // Strip any trailing timezone info (Z, +HH:MM, -HH:MM, etc.)
-    final bare = text.split(RegExp(r'[Z+\-](?=\d{2}:\d{2}$)|Z$')).first;
-    final dt = DateTime.tryParse(bare);
+    final bare = trimmed.split(RegExp(r'[Z+\-](?=\d{2}:\d{2}$)|Z$')).first;
+    final dt =
+        DateTime.tryParse(bare) ??
+        DateTime.tryParse(
+          _dateWithoutTimePattern.firstMatch(bare)?.group(1) ?? '',
+        );
     if (dt == null) return null;
     return DateTime.utc(
       dt.year,
@@ -401,11 +426,47 @@ class UddfImportParsers {
     }
   }
 
+  /// Reads one trip element.
+  ///
+  /// Handles both shapes in circulation: Submersion writes each trip as its
+  /// own `<divetrip>` carrying the trip fields directly, while UDDF 3.2 (and
+  /// Subsurface's exporter) nests `<trip>` elements inside a single
+  /// `<divetrip>` container and hangs the name and notes off a `<trippart>`.
   static Map<String, dynamic> parseTrip(XmlElement tripElement) {
     final trip = <String, dynamic>{};
 
-    trip['name'] = getElementText(tripElement, 'name') ?? '';
-    trip['notes'] = getElementText(tripElement, 'notes') ?? '';
+    final tripPart = tripElement.findElements('trippart').firstOrNull;
+    final rawName =
+        getElementText(tripElement, 'name') ??
+        (tripPart == null ? null : getElementText(tripPart, 'name')) ??
+        '';
+
+    // Subsurface has no trip-name field of its own, so its exporter builds
+    // one as "<location>\u00A0<start date>". Recovering the two halves keeps
+    // the trip out of the library named after a date, and gives it a date to
+    // fall back on when no dive of the trip was imported.
+    String? locationFromName;
+    var name = rawName.trim();
+    final nameParts = _tripNamePattern.firstMatch(rawName);
+    if (nameParts != null) {
+      final location = nameParts.group(1)!.trim();
+      final nameDate = DateTime.tryParse(nameParts.group(2)!);
+      if (nameDate != null) {
+        trip['nameDate'] = nameDate;
+        if (location.isEmpty) {
+          name = nameParts.group(2)!;
+        } else {
+          name = location;
+          locationFromName = location;
+        }
+      }
+    }
+
+    trip['name'] = name;
+    trip['notes'] =
+        getElementText(tripElement, 'notes') ??
+        (tripPart == null ? null : getElementText(tripPart, 'notes')) ??
+        '';
 
     // Parse date range
     final dateOfTrip = tripElement.findElements('dateoftrip').firstOrNull;
@@ -428,8 +489,13 @@ class UddfImportParsers {
 
     // Parse geography
     final geographyElement = tripElement.findElements('geography').firstOrNull;
-    if (geographyElement != null) {
-      trip['location'] = getElementText(geographyElement, 'location');
+    final location = geographyElement == null
+        ? null
+        : getElementText(geographyElement, 'location');
+    if (location != null) {
+      trip['location'] = location;
+    } else if (locationFromName != null) {
+      trip['location'] = locationFromName;
     }
 
     return trip;

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1389,11 +1389,14 @@ class UddfEntityImporter {
     final diveIdByIndex = <int, String>{};
     final inlineBuddyIds = <String>{};
 
-    // Sort selected indices by dateTime (oldest first) for sequential numbering.
+    // Sort selected indices by dateTime (oldest first) for sequential
+    // numbering. An undated dive is stored at [now] further down, so it has
+    // to sort as [now] here too: keying it as year zero handed the newest
+    // row in the batch the lowest dive number (#239).
     final sortedSelected = selected.toList()
       ..sort((a, b) {
-        final aTime = items[a]['dateTime'] as DateTime? ?? DateTime(0);
-        final bTime = items[b]['dateTime'] as DateTime? ?? DateTime(0);
+        final aTime = items[a]['dateTime'] as DateTime? ?? now;
+        final bTime = items[b]['dateTime'] as DateTime? ?? now;
         return aTime.compareTo(bTime);
       });
 

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1397,7 +1397,12 @@ class UddfEntityImporter {
       ..sort((a, b) {
         final aTime = items[a]['dateTime'] as DateTime? ?? now;
         final bTime = items[b]['dateTime'] as DateTime? ?? now;
-        return aTime.compareTo(bTime);
+        final byTime = aTime.compareTo(bTime);
+        // Dives sharing a timestamp keep the order the file lists them in.
+        // List.sort is only stable below its insertion-sort threshold (ties
+        // start reordering around 40 elements), and a logbook of dives
+        // entered by hand arrives with a whole day of them at midnight.
+        return byTime != 0 ? byTime : a.compareTo(b);
       });
 
     // Auto-assign dive numbers starting from the next available number,

--- a/lib/features/dive_import/data/services/uddf_entity_importer.dart
+++ b/lib/features/dive_import/data/services/uddf_entity_importer.dart
@@ -1399,9 +1399,9 @@ class UddfEntityImporter {
         final bTime = items[b]['dateTime'] as DateTime? ?? now;
         final byTime = aTime.compareTo(bTime);
         // Dives sharing a timestamp keep the order the file lists them in.
-        // List.sort is only stable below its insertion-sort threshold (ties
-        // start reordering around 40 elements), and a logbook of dives
-        // entered by hand arrives with a whole day of them at midnight.
+        // List.sort makes no stability guarantee, so a tie left to it can
+        // come out in any order, and a logbook of dives entered by hand
+        // arrives with a whole day of them tied at midnight.
         return byTime != 0 ? byTime : a.compareTo(b);
       });
 

--- a/test/core/services/export/uddf/uddf_subsurface_import_test.dart
+++ b/test/core/services/export/uddf/uddf_subsurface_import_test.dart
@@ -138,6 +138,39 @@ void main() {
       );
     });
 
+    test('ignores a compact timezone offset', () {
+      // "+0200" and "+02" are valid ISO 8601. Left in place, DateTime.parse
+      // applies the offset and the wall clock is stored shifted by it.
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30+0200'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30-0500'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30+02'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30.500+02:00'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+    });
+
+    test('does not mistake a date for a timezone offset', () {
+      // The "-05" ending a bare date must not be stripped as an offset.
+      expect(
+        UddfImportParsers.parseDiveDateTime('2008-09-05'),
+        DateTime.utc(2008, 9, 5),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2008-09-05T'),
+        DateTime.utc(2008, 9, 5),
+      );
+    });
+
     test('returns null for empty and unparseable input', () {
       expect(UddfImportParsers.parseDiveDateTime(null), isNull);
       expect(UddfImportParsers.parseDiveDateTime(''), isNull);

--- a/test/core/services/export/uddf/uddf_subsurface_import_test.dart
+++ b/test/core/services/export/uddf/uddf_subsurface_import_test.dart
@@ -252,7 +252,7 @@ void main() {
       // so the scratch key has to be gone by the time parsing returns.
       final result = await service.importAllDataFromUddf(_subsurfaceUddf);
 
-      expect(result.trips.single.containsKey('nameDate'), isFalse);
+      expect(result.trips.single.containsKey('_nameDate'), isFalse);
     });
 
     test('dates a trip with no location from the date in its name', () async {
@@ -274,7 +274,7 @@ void main() {
       expect(trip['location'], isNull);
       expect(trip['startDate'], DateTime(2019, 11, 2));
       expect(trip['endDate'], DateTime(2019, 11, 2));
-      expect(trip.containsKey('nameDate'), isFalse);
+      expect(trip.containsKey('_nameDate'), isFalse);
     });
 
     test('still reads a divetrip that is itself the trip', () async {

--- a/test/core/services/export/uddf/uddf_subsurface_import_test.dart
+++ b/test/core/services/export/uddf/uddf_subsurface_import_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/export/uddf/uddf_full_import_service.dart';
+import 'package:submersion/core/services/export/uddf/uddf_import_parsers.dart';
+
+/// A UDDF file shaped the way Subsurface's `xslt/uddf-export.xslt` writes one
+/// (issue #239):
+///
+/// - the datetime is built as `concat(@date, 'T', @time)`, so a dive entered
+///   by hand with no time is exported as a bare "2008-09-05T";
+/// - trips live as `<trip>` children of a single `<divetrip>` container, and
+///   each trip name is the Subsurface location and date joined by U+00A0;
+/// - a dive points at its trip with `<tripmembership>`, not a `<link>`.
+const _subsurfaceUddf = '''<?xml version="1.0" encoding="utf-8"?>
+<uddf xmlns="http://www.streit.cc/uddf/3.2/" version="3.2.0">
+  <generator>
+    <name>Subsurface Divelog</name>
+  </generator>
+  <divesite>
+    <site id="site1">
+      <name>Klein Bonaire</name>
+      <geography>
+        <location>Klein Bonaire</location>
+      </geography>
+    </site>
+  </divesite>
+  <profiledata>
+    <repetitiongroup id="rg1">
+      <dive id="dive1">
+        <informationbeforedive>
+          <link ref="site1"/>
+          <divenumber>12</divenumber>
+          <datetime>2008-09-05T</datetime>
+          <tripmembership ref="tripA"/>
+        </informationbeforedive>
+        <informationafterdive>
+          <greatestdepth>18.3</greatestdepth>
+          <diveduration>2400</diveduration>
+        </informationafterdive>
+      </dive>
+      <dive id="dive2">
+        <informationbeforedive>
+          <link ref="site1"/>
+          <divenumber>13</divenumber>
+          <datetime>2008-09-07T10:15:00</datetime>
+          <tripmembership ref="tripA"/>
+        </informationbeforedive>
+        <informationafterdive>
+          <greatestdepth>22.1</greatestdepth>
+          <diveduration>2700</diveduration>
+        </informationafterdive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+  <divetrip>
+    <trip id="tripA">
+      <name>Bonaire&#160;2008-09-05</name>
+      <trippart>
+        <name>Bonaire&#160;2008-09-05</name>
+        <relateddives>
+          <link ref="dive1"/>
+          <link ref="dive2"/>
+        </relateddives>
+        <notes>
+          <para>Shore diving week</para>
+        </notes>
+      </trippart>
+    </trip>
+  </divetrip>
+</uddf>''';
+
+/// The shape Submersion's own exporter writes: one `<divetrip>` per trip,
+/// carrying an explicit `<dateoftrip>` range.
+const _submersionUddf = '''<uddf version="3.2.1">
+  <divetrip id="trip_abc">
+    <name>Red Sea Liveaboard</name>
+    <dateoftrip>
+      <startdate>
+        <datetime>2024-05-04T00:00:00.000</datetime>
+      </startdate>
+      <enddate>
+        <datetime>2024-05-11T00:00:00.000</datetime>
+      </enddate>
+    </dateoftrip>
+    <geography>
+      <location>Egypt</location>
+    </geography>
+    <notes>Brothers and Daedalus</notes>
+  </divetrip>
+  <profiledata>
+    <repetitiongroup id="rg1">
+      <dive id="dive1">
+        <informationbeforedive>
+          <link ref="trip_abc"/>
+          <datetime>2024-05-05T08:00:00</datetime>
+        </informationbeforedive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+</uddf>''';
+
+void main() {
+  group('UddfImportParsers.parseDiveDateTime', () {
+    test('parses a full datetime as a wall clock stamped UTC', () {
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+    });
+
+    test('reads a date with an empty time as midnight', () {
+      // Subsurface writes concat(@date, 'T', @time); a dive with no recorded
+      // time exports as a dangling "T" that DateTime.parse rejects outright.
+      expect(
+        UddfImportParsers.parseDiveDateTime('2008-09-05T'),
+        DateTime.utc(2008, 9, 5),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2008-09-05T '),
+        DateTime.utc(2008, 9, 5),
+      );
+    });
+
+    test('reads a date-only value as midnight', () {
+      expect(
+        UddfImportParsers.parseDiveDateTime('2008-09-05'),
+        DateTime.utc(2008, 9, 5),
+      );
+    });
+
+    test('ignores a timezone suffix', () {
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30+02:00'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+      expect(
+        UddfImportParsers.parseDiveDateTime('2024-06-15T08:42:30Z'),
+        DateTime.utc(2024, 6, 15, 8, 42, 30),
+      );
+    });
+
+    test('returns null for empty and unparseable input', () {
+      expect(UddfImportParsers.parseDiveDateTime(null), isNull);
+      expect(UddfImportParsers.parseDiveDateTime(''), isNull);
+      expect(UddfImportParsers.parseDiveDateTime('   '), isNull);
+      expect(UddfImportParsers.parseDiveDateTime('T'), isNull);
+      expect(UddfImportParsers.parseDiveDateTime('not a date'), isNull);
+      expect(UddfImportParsers.parseDiveDateTime('2008-09'), isNull);
+    });
+  });
+
+  group('Subsurface UDDF import (#239)', () {
+    late UddfFullImportService service;
+
+    setUp(() {
+      service = UddfFullImportService();
+    });
+
+    test('keeps the file date of a dive exported without a time', () async {
+      final result = await service.importAllDataFromUddf(_subsurfaceUddf);
+
+      expect(result.dives, hasLength(2));
+      expect(result.dives.first['dateTime'], DateTime.utc(2008, 9, 5));
+      expect(result.dives.last['dateTime'], DateTime.utc(2008, 9, 7, 10, 15));
+    });
+
+    test('imports trips nested inside a divetrip container', () async {
+      final result = await service.importAllDataFromUddf(_subsurfaceUddf);
+
+      expect(result.trips, hasLength(1));
+      final trip = result.trips.single;
+      expect(trip['uddfId'], 'tripA');
+      expect(trip['name'], 'Bonaire');
+      expect(trip['location'], 'Bonaire');
+      expect(trip['notes'], 'Shore diving week');
+    });
+
+    test('dates a trip from the dives that belong to it', () async {
+      final result = await service.importAllDataFromUddf(_subsurfaceUddf);
+
+      final trip = result.trips.single;
+      expect(trip['startDate'], DateTime(2008, 9, 5));
+      expect(trip['endDate'], DateTime(2008, 9, 7));
+    });
+
+    test('links dives to their trip through tripmembership', () async {
+      final result = await service.importAllDataFromUddf(_subsurfaceUddf);
+
+      expect(result.dives.first['tripRef'], 'tripA');
+      expect(result.dives.last['tripRef'], 'tripA');
+    });
+
+    test(
+      'offers no trip for the empty divetrip Subsurface always writes',
+      () async {
+        // A Subsurface logbook with no trips still exports <divetrip/>.
+        const noTrips = '''<uddf version="3.2.0">
+  <profiledata>
+    <repetitiongroup id="rg1">
+      <dive id="dive1">
+        <informationbeforedive>
+          <datetime>2024-05-05T08:00:00</datetime>
+        </informationbeforedive>
+      </dive>
+    </repetitiongroup>
+  </profiledata>
+  <divetrip/>
+</uddf>''';
+
+        final result = await service.importAllDataFromUddf(noTrips);
+
+        expect(result.dives, hasLength(1));
+        expect(result.trips, isEmpty);
+      },
+    );
+
+    test('still reads a divetrip that is itself the trip', () async {
+      final result = await service.importAllDataFromUddf(_submersionUddf);
+
+      expect(result.trips, hasLength(1));
+      final trip = result.trips.single;
+      expect(trip['uddfId'], 'trip_abc');
+      expect(trip['name'], 'Red Sea Liveaboard');
+      expect(trip['location'], 'Egypt');
+      expect(trip['notes'], 'Brothers and Daedalus');
+      // The explicit range wins over anything derived from the dives.
+      expect(trip['startDate'], DateTime(2024, 5, 4));
+      expect(trip['endDate'], DateTime(2024, 5, 11));
+      expect(result.dives.single['tripRef'], 'trip_abc');
+    });
+  });
+}

--- a/test/core/services/export/uddf/uddf_subsurface_import_test.dart
+++ b/test/core/services/export/uddf/uddf_subsurface_import_test.dart
@@ -246,6 +246,15 @@ void main() {
       },
     );
 
+    test('does not leak the date recovered from a trip name', () async {
+      // The trip maps travel across layers, and the payload merger copies
+      // every key it finds when folding a duplicate trip from a second file,
+      // so the scratch key has to be gone by the time parsing returns.
+      final result = await service.importAllDataFromUddf(_subsurfaceUddf);
+
+      expect(result.trips.single.containsKey('nameDate'), isFalse);
+    });
+
     test('dates a trip with no location from the date in its name', () async {
       // Subsurface names a trip "<location><NBSP><date>", so a trip with no
       // location is just the separator and the date. Dart counts U+00A0 as
@@ -265,6 +274,7 @@ void main() {
       expect(trip['location'], isNull);
       expect(trip['startDate'], DateTime(2019, 11, 2));
       expect(trip['endDate'], DateTime(2019, 11, 2));
+      expect(trip.containsKey('nameDate'), isFalse);
     });
 
     test('still reads a divetrip that is itself the trip', () async {

--- a/test/core/services/export/uddf/uddf_subsurface_import_test.dart
+++ b/test/core/services/export/uddf/uddf_subsurface_import_test.dart
@@ -213,6 +213,27 @@ void main() {
       },
     );
 
+    test('dates a trip with no location from the date in its name', () async {
+      // Subsurface names a trip "<location><NBSP><date>", so a trip with no
+      // location is just the separator and the date. Dart counts U+00A0 as
+      // whitespace, so the name arrives as the bare date once trimmed.
+      const noLocation = '''<uddf version="3.2.0">
+  <divetrip>
+    <trip id="tripB">
+      <name>&#160;2019-11-02</name>
+    </trip>
+  </divetrip>
+</uddf>''';
+
+      final result = await service.importAllDataFromUddf(noLocation);
+
+      final trip = result.trips.single;
+      expect(trip['name'], '2019-11-02');
+      expect(trip['location'], isNull);
+      expect(trip['startDate'], DateTime(2019, 11, 2));
+      expect(trip['endDate'], DateTime(2019, 11, 2));
+    });
+
     test('still reads a divetrip that is itself the trip', () async {
       final result = await service.importAllDataFromUddf(_submersionUddf);
 

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -448,9 +448,10 @@ void main() {
 
     test('numbers dives sharing a timestamp in file order', () async {
       // A logbook of dives entered by hand carries no times, so a whole day
-      // of them ties at midnight. List.sort only preserves input order below
-      // its insertion-sort threshold, so the batch has to be big enough to
-      // reach the quicksort path (ties reorder from around 40 elements).
+      // of them ties at midnight, and the numbering must follow the file.
+      // List.sort makes no stability guarantee: small batches happen to keep
+      // their input order today, so this one is deliberately large enough
+      // that ties are observably reordered without the tie-breaker.
       const undatedCount = 60;
       final data = UddfImportResult(
         dives: [

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -412,6 +412,41 @@ void main() {
     });
   });
 
+  group('Import dives (auto numbering)', () {
+    setUp(() {
+      when(
+        mockDiveRepo.createDive(any),
+      ).thenAnswer((inv) async => inv.positionalArguments[0] as Dive);
+      when(mockDiveRepo.saveComputerReading(any)).thenAnswer((_) async {});
+    });
+
+    test('numbers an undated dive by the date it is stored with', () async {
+      // A dive whose datetime could not be parsed is stored at the import
+      // clock, which makes it the most recent dive in the batch. Numbering
+      // used to sort it as if it were dated year zero and hand it the lowest
+      // number, contradicting the date written to the row (#239).
+      final data = UddfImportResult(
+        dives: [
+          {'maxDepth': 12.0},
+          {'dateTime': DateTime.utc(2020, 3, 4, 9, 0), 'maxDepth': 18.0},
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: const UddfImportSelections(dives: {0, 1}),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final dives = verify(
+        mockDiveRepo.createDive(captureAny),
+      ).captured.cast<Dive>();
+      expect(dives.firstWhere((d) => d.maxDepth == 18.0).diveNumber, 1);
+      expect(dives.firstWhere((d) => d.maxDepth == 12.0).diveNumber, 2);
+    });
+  });
+
   group('Import dives (deco dive type default)', () {
     setUp(() {
       when(

--- a/test/features/dive_import/data/services/uddf_entity_importer_test.dart
+++ b/test/features/dive_import/data/services/uddf_entity_importer_test.dart
@@ -445,6 +445,41 @@ void main() {
       expect(dives.firstWhere((d) => d.maxDepth == 18.0).diveNumber, 1);
       expect(dives.firstWhere((d) => d.maxDepth == 12.0).diveNumber, 2);
     });
+
+    test('numbers dives sharing a timestamp in file order', () async {
+      // A logbook of dives entered by hand carries no times, so a whole day
+      // of them ties at midnight. List.sort only preserves input order below
+      // its insertion-sort threshold, so the batch has to be big enough to
+      // reach the quicksort path (ties reorder from around 40 elements).
+      const undatedCount = 60;
+      final data = UddfImportResult(
+        dives: [
+          {'dateTime': DateTime.utc(2020, 3, 4, 9, 0), 'maxDepth': 1000.0},
+          for (var i = 0; i < undatedCount; i++) {'maxDepth': i.toDouble()},
+        ],
+      );
+
+      await importer.import(
+        data: data,
+        selections: UddfImportSelections(
+          dives: {for (var i = 0; i <= undatedCount; i++) i},
+        ),
+        repositories: repos,
+        diverId: diverId,
+      );
+
+      final dives = verify(
+        mockDiveRepo.createDive(captureAny),
+      ).captured.cast<Dive>();
+      expect(dives.firstWhere((d) => d.maxDepth == 1000.0).diveNumber, 1);
+      for (var i = 0; i < undatedCount; i++) {
+        expect(
+          dives.firstWhere((d) => d.maxDepth == i.toDouble()).diveNumber,
+          i + 2,
+          reason: 'undated dive at file position $i',
+        );
+      }
+    });
   });
 
   group('Import dives (deco dive type default)', () {


### PR DESCRIPTION
Fixes #239.

A UDDF export from Subsurface produced three distinct symptoms. Two of them turn out to be the same defect.

## 1. Dives dated the day they were imported

Subsurface builds the dive datetime as `concat(@date, 'T', @time)` (`xslt/uddf-export.xslt`). A dive entered by hand with no time, which Subsurface itself displays as 00:00, exports as a bare `2008-09-05T`. `DateTime.parse` rejects that, so `parseDiveDateTime` returned null and the entity importer's `?? now` fallback stamped the dive with the import clock.

`parseDiveDateTime` now reads a date carrying no time as midnight on that date, keeping the existing wall-clock-as-UTC convention.

## 2. Wrong dive numbers

The same null, one step downstream. The auto-numbering sort keyed an undated dive as `DateTime(0)`, so it sorted first and took the lowest number, while the row itself was written at `now`, making it the most recent dive in the batch. The sort key now uses the same `now` fallback the row is written with, so numbering and stored dates agree. With the datetime fix the reporter's dives keep their real dates and simply sort correctly.

## 3. Trips not imported

Submersion writes one `<divetrip id="trip_<uuid>">` per trip with the fields inline. UDDF 3.2 and Subsurface instead nest `<trip>` children inside a single `<divetrip>` container, so the whole trip list parsed as one nameless trip, which `_importTrips` then skipped on its empty-name guard.

The importer now reads both shapes, and along with that:

- links dives through `<tripmembership ref="..."/>`; Subsurface's generated trip ids carry none of the `trip_` prefix the existing `<link>` handling keys on
- recovers the name and location from the `location<NBSP><date>` string Subsurface packs into the trip name, since it has no trip-name field of its own
- derives a trip's date range from its member dives, because Subsurface emits no `<dateoftrip>` and an undated trip would land in the library dated the day of the import; the date embedded in the trip name is the fallback when none of its dives were imported
- drops the empty `<divetrip/>` Subsurface writes even for a logbook with no trips, which used to surface as a phantom nameless trip in the import preview

Trip dates are local calendar days while dive datetimes are wall clocks flagged UTC, so the derived range copies the date components rather than the instant.

## Testing

- New `test/core/services/export/uddf/uddf_subsurface_import_test.dart` (11 tests) built from the XSLT templates: dangling-`T` datetimes, nested trips, tripmembership links, derived ranges, the empty container, and a regression case for Submersion's own one-divetrip-per-trip shape. Six of them fail on `main`.
- New auto-numbering case in `uddf_entity_importer_test.dart`; fails on `main` with `Expected: <1> Actual: <2>`.
- Smoke-checked against a real 944 KB Subsurface export: 16 dives with unchanged dates, phantom trip count 1 to 0.
- `flutter test test/core/services/export test/features/dive_import test/features/universal_import test/features/import_wizard test/integration/uddf_round_trip_test.dart test/features/trips`: 3637 passed.
- `dart format .` clean, `flutter analyze` reports no issues.
