### PR TITLE
fix(media): render orphaned thumbnails through the resolver chain

### DIFF
--- a/lib/features/media/presentation/widgets/media_grid.dart
+++ b/lib/features/media/presentation/widgets/media_grid.dart
@@ -53,9 +53,16 @@ class MediaEmptyState extends StatelessWidget {
 /// Purely visual thumbnail content for media items.
 ///
 /// Tap, long-press, and drag gestures are handled by the enclosing grid.
-/// Decides the orphaned-placeholder treatment itself so every consumer
-/// gets it for free; badges (store transfer, video, document extension,
-/// depth) self-hide when their data is absent.
+/// Badges (store transfer, video, document extension, depth) self-hide when
+/// their data is absent.
+///
+/// Every row, orphaned or not, renders through [MediaItemView]. The orphan
+/// flag is a persisted claim from an earlier verification, and the device
+/// that wrote it may be one that never had the file, so drawing a broken
+/// tile from the flag alone hid photos the resolver chain could still serve:
+/// the row's own source on the device that imported it, or the media store's
+/// copy anywhere else (#1409). Health stays visible through the status badge,
+/// and a row nothing can serve still ends in the missing-file placeholder.
 class MediaThumbnailTile extends StatelessWidget {
   final MediaItem item;
   final AppSettings settings;
@@ -84,20 +91,16 @@ class MediaThumbnailTile extends StatelessWidget {
         child: Stack(
           fit: StackFit.expand,
           children: [
-            // Thumbnail or placeholder.
-            // Orphaned items show a distinct error tile; all other items
-            // route through MediaItemView which dispatches to the correct
-            // resolver for the item's sourceType (gallery, signature, etc.)
-            // and renders UnavailableMediaPlaceholder for missing assets.
-            if (item.isOrphaned)
-              const OrphanedMediaPlaceholder()
-            else
-              MediaItemView(
-                item: item,
-                thumbnail: true,
-                targetSize: const Size(200, 200),
-                fit: BoxFit.cover,
-              ),
+            // Thumbnail or placeholder. MediaItemView dispatches to the
+            // resolver for the item's sourceType, falls back to the media
+            // store, and renders UnavailableMediaPlaceholder when neither
+            // can produce bytes.
+            MediaItemView(
+              item: item,
+              thumbnail: true,
+              targetSize: const Size(200, 200),
+              fit: BoxFit.cover,
+            ),
 
             // Dimming overlay for unselected items in selection mode
             if (isSelectionMode && !isSelected)
@@ -213,26 +216,6 @@ class MediaThumbnailTile extends StatelessWidget {
                 ),
               ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Placeholder shown for orphaned media (file no longer exists)
-class OrphanedMediaPlaceholder extends StatelessWidget {
-  const OrphanedMediaPlaceholder({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
-      color: colorScheme.errorContainer,
-      child: Center(
-        child: Icon(
-          Icons.broken_image_outlined,
-          color: colorScheme.onErrorContainer,
         ),
       ),
     );

--- a/lib/features/trips/presentation/pages/trip_gallery_page.dart
+++ b/lib/features/trips/presentation/pages/trip_gallery_page.dart
@@ -365,13 +365,13 @@ class _GridThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final semanticsLabel = item.isOrphaned
-        ? (item.isVideo
-              ? l10n.trips_gallery_thumbnail_videoMissing
-              : l10n.trips_gallery_thumbnail_photoMissing)
-        : (item.isVideo
-              ? l10n.trips_gallery_thumbnail_video
-              : l10n.trips_gallery_thumbnail_photo);
+    // Availability-agnostic on purpose: the tile always tries to render the
+    // photo, so a label that read the orphan flag would announce "missing"
+    // over a thumbnail the resolver chain just served. When nothing can serve
+    // the row, UnavailableMediaPlaceholder carries its own reason text.
+    final semanticsLabel = item.isVideo
+        ? l10n.trips_gallery_thumbnail_video
+        : l10n.trips_gallery_thumbnail_photo;
 
     return Semantics(
       button: true,

--- a/lib/features/trips/presentation/pages/trip_gallery_page.dart
+++ b/lib/features/trips/presentation/pages/trip_gallery_page.dart
@@ -364,8 +364,6 @@ class _GridThumbnail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     final l10n = context.l10n;
     final semanticsLabel = item.isOrphaned
         ? (item.isVideo
@@ -385,26 +383,17 @@ class _GridThumbnail extends StatelessWidget {
           child: Stack(
             fit: StackFit.expand,
             children: [
-              // Orphaned items show a distinct error tile; all other items
-              // route through MediaItemView which dispatches to the correct
-              // resolver and shows UnavailableMediaPlaceholder for missing assets.
-              if (item.isOrphaned)
-                Container(
-                  color: colorScheme.errorContainer,
-                  child: Center(
-                    child: Icon(
-                      Icons.broken_image_outlined,
-                      color: colorScheme.onErrorContainer,
-                    ),
-                  ),
-                )
-              else
-                MediaItemView(
-                  item: item,
-                  thumbnail: true,
-                  targetSize: const Size(200, 200),
-                  fit: BoxFit.cover,
-                ),
+              // Every row renders through MediaItemView, orphaned or not:
+              // the flag is a persisted claim that may be stale or written
+              // by a device that never had the file, and the resolver chain
+              // (origin, then media store) can still serve the photo. See
+              // MediaThumbnailTile for the full reasoning (#1409).
+              MediaItemView(
+                item: item,
+                thumbnail: true,
+                targetSize: const Size(200, 200),
+                fit: BoxFit.cover,
+              ),
 
               // Video icon (top-right)
               if (item.isVideo)

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "صورة مصغّرة لصورة. انقر للعرض بملء الشاشة",
   "trips_gallery_thumbnail_video": "صورة مصغّرة لفيديو. انقر للعرض بملء الشاشة",
-  "trips_gallery_thumbnail_photoMissing": "صورة مصغّرة لصورة، مفقودة من الجهاز. انقر للعرض بملء الشاشة",
-  "trips_gallery_thumbnail_videoMissing": "صورة مصغّرة لفيديو، مفقود من الجهاز. انقر للعرض بملء الشاشة",
   "trips_photos_thumbnail_photo": "صورة مصغّرة لصورة. انقر لفتح المعرض",
   "trips_photos_thumbnail_video": "صورة مصغّرة لفيديو. انقر لفتح المعرض",
   "trips_picker_suggestedSemantics": "رحلة مقترحة: {name}. انقر للاستخدام",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Fotovorschau. Tippen, um im Vollbild anzuzeigen",
   "trips_gallery_thumbnail_video": "Videovorschau. Tippen, um im Vollbild anzuzeigen",
-  "trips_gallery_thumbnail_photoMissing": "Fotovorschau, auf dem Gerät nicht vorhanden. Tippen, um im Vollbild anzuzeigen",
-  "trips_gallery_thumbnail_videoMissing": "Videovorschau, auf dem Gerät nicht vorhanden. Tippen, um im Vollbild anzuzeigen",
   "trips_photos_thumbnail_photo": "Fotovorschau. Tippen, um die Galerie zu öffnen",
   "trips_photos_thumbnail_video": "Videovorschau. Tippen, um die Galerie zu öffnen",
   "trips_picker_suggestedSemantics": "Vorgeschlagene Reise: {name}. Tippen, um sie zu verwenden",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -20028,8 +20028,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Photo thumbnail. Tap to view full screen",
   "trips_gallery_thumbnail_video": "Video thumbnail. Tap to view full screen",
-  "trips_gallery_thumbnail_photoMissing": "Photo thumbnail, missing from device. Tap to view full screen",
-  "trips_gallery_thumbnail_videoMissing": "Video thumbnail, missing from device. Tap to view full screen",
   "trips_photos_thumbnail_photo": "Photo thumbnail. Tap to open gallery",
   "trips_photos_thumbnail_video": "Video thumbnail. Tap to open gallery",
   "trips_picker_suggestedSemantics": "Suggested trip: {name}. Tap to use",

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Miniatura de foto. Toca para ver en pantalla completa",
   "trips_gallery_thumbnail_video": "Miniatura de vídeo. Toca para ver en pantalla completa",
-  "trips_gallery_thumbnail_photoMissing": "Miniatura de foto, no está en el dispositivo. Toca para ver en pantalla completa",
-  "trips_gallery_thumbnail_videoMissing": "Miniatura de vídeo, no está en el dispositivo. Toca para ver en pantalla completa",
   "trips_photos_thumbnail_photo": "Miniatura de foto. Toca para abrir la galería",
   "trips_photos_thumbnail_video": "Miniatura de vídeo. Toca para abrir la galería",
   "trips_picker_suggestedSemantics": "Viaje sugerido: {name}. Toca para usarlo",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Miniature de photo. Appuyez pour voir en plein écran",
   "trips_gallery_thumbnail_video": "Miniature de vidéo. Appuyez pour voir en plein écran",
-  "trips_gallery_thumbnail_photoMissing": "Miniature de photo, absente de l’appareil. Appuyez pour voir en plein écran",
-  "trips_gallery_thumbnail_videoMissing": "Miniature de vidéo, absente de l’appareil. Appuyez pour voir en plein écran",
   "trips_photos_thumbnail_photo": "Miniature de photo. Appuyez pour ouvrir la galerie",
   "trips_photos_thumbnail_video": "Miniature de vidéo. Appuyez pour ouvrir la galerie",
   "trips_picker_suggestedSemantics": "Voyage suggéré : {name}. Appuyez pour l’utiliser",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "תמונה ממוזערת של תמונה. הקש לצפייה במסך מלא",
   "trips_gallery_thumbnail_video": "תמונה ממוזערת של סרטון. הקש לצפייה במסך מלא",
-  "trips_gallery_thumbnail_photoMissing": "תמונה ממוזערת של תמונה, חסרה במכשיר. הקש לצפייה במסך מלא",
-  "trips_gallery_thumbnail_videoMissing": "תמונה ממוזערת של סרטון, חסר במכשיר. הקש לצפייה במסך מלא",
   "trips_photos_thumbnail_photo": "תמונה ממוזערת של תמונה. הקש לפתיחת הגלריה",
   "trips_photos_thumbnail_video": "תמונה ממוזערת של סרטון. הקש לפתיחת הגלריה",
   "trips_picker_suggestedSemantics": "טיול מוצע: {name}. הקש לשימוש",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Fotó indexkép. Koppints a teljes képernyős megtekintéshez",
   "trips_gallery_thumbnail_video": "Videó indexkép. Koppints a teljes képernyős megtekintéshez",
-  "trips_gallery_thumbnail_photoMissing": "Fotó indexkép, hiányzik az eszközről. Koppints a teljes képernyős megtekintéshez",
-  "trips_gallery_thumbnail_videoMissing": "Videó indexkép, hiányzik az eszközről. Koppints a teljes képernyős megtekintéshez",
   "trips_photos_thumbnail_photo": "Fotó indexkép. Koppints a galéria megnyitásához",
   "trips_photos_thumbnail_video": "Videó indexkép. Koppints a galéria megnyitásához",
   "trips_picker_suggestedSemantics": "Javasolt út: {name}. Koppints a használatához",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Miniatura foto. Tocca per visualizzare a schermo intero",
   "trips_gallery_thumbnail_video": "Miniatura video. Tocca per visualizzare a schermo intero",
-  "trips_gallery_thumbnail_photoMissing": "Miniatura foto, assente dal dispositivo. Tocca per visualizzare a schermo intero",
-  "trips_gallery_thumbnail_videoMissing": "Miniatura video, assente dal dispositivo. Tocca per visualizzare a schermo intero",
   "trips_photos_thumbnail_photo": "Miniatura foto. Tocca per aprire la galleria",
   "trips_photos_thumbnail_video": "Miniatura video. Tocca per aprire la galleria",
   "trips_picker_suggestedSemantics": "Viaggio suggerito: {name}. Tocca per usarlo",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -55793,18 +55793,6 @@ abstract class AppLocalizations {
   /// **'Video thumbnail. Tap to view full screen'**
   String get trips_gallery_thumbnail_video;
 
-  /// No description provided for @trips_gallery_thumbnail_photoMissing.
-  ///
-  /// In en, this message translates to:
-  /// **'Photo thumbnail, missing from device. Tap to view full screen'**
-  String get trips_gallery_thumbnail_photoMissing;
-
-  /// No description provided for @trips_gallery_thumbnail_videoMissing.
-  ///
-  /// In en, this message translates to:
-  /// **'Video thumbnail, missing from device. Tap to view full screen'**
-  String get trips_gallery_thumbnail_videoMissing;
-
   /// No description provided for @trips_photos_thumbnail_photo.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -33452,14 +33452,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'صورة مصغّرة لفيديو. انقر للعرض بملء الشاشة';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'صورة مصغّرة لصورة، مفقودة من الجهاز. انقر للعرض بملء الشاشة';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'صورة مصغّرة لفيديو، مفقود من الجهاز. انقر للعرض بملء الشاشة';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'صورة مصغّرة لصورة. انقر لفتح المعرض';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -33733,14 +33733,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Videovorschau. Tippen, um im Vollbild anzuzeigen';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Fotovorschau, auf dem Gerät nicht vorhanden. Tippen, um im Vollbild anzuzeigen';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Videovorschau, auf dem Gerät nicht vorhanden. Tippen, um im Vollbild anzuzeigen';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Fotovorschau. Tippen, um die Galerie zu öffnen';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -33310,14 +33310,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Video thumbnail. Tap to view full screen';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Photo thumbnail, missing from device. Tap to view full screen';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Video thumbnail, missing from device. Tap to view full screen';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Photo thumbnail. Tap to open gallery';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -33837,14 +33837,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Miniatura de vídeo. Toca para ver en pantalla completa';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Miniatura de foto, no está en el dispositivo. Toca para ver en pantalla completa';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Miniatura de vídeo, no está en el dispositivo. Toca para ver en pantalla completa';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Miniatura de foto. Toca para abrir la galería';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -33894,14 +33894,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Miniature de vidéo. Appuyez pour voir en plein écran';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Miniature de photo, absente de l’appareil. Appuyez pour voir en plein écran';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Miniature de vidéo, absente de l’appareil. Appuyez pour voir en plein écran';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Miniature de photo. Appuyez pour ouvrir la galerie';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -33143,14 +33143,6 @@ class AppLocalizationsHe extends AppLocalizations {
       'תמונה ממוזערת של סרטון. הקש לצפייה במסך מלא';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'תמונה ממוזערת של תמונה, חסרה במכשיר. הקש לצפייה במסך מלא';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'תמונה ממוזערת של סרטון, חסר במכשיר. הקש לצפייה במסך מלא';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'תמונה ממוזערת של תמונה. הקש לפתיחת הגלריה';
 

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -33652,14 +33652,6 @@ class AppLocalizationsHu extends AppLocalizations {
       'Videó indexkép. Koppints a teljes képernyős megtekintéshez';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Fotó indexkép, hiányzik az eszközről. Koppints a teljes képernyős megtekintéshez';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Videó indexkép, hiányzik az eszközről. Koppints a teljes képernyős megtekintéshez';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Fotó indexkép. Koppints a galéria megnyitásához';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -33806,14 +33806,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Miniatura video. Tocca per visualizzare a schermo intero';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Miniatura foto, assente dal dispositivo. Tocca per visualizzare a schermo intero';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Miniatura video, assente dal dispositivo. Tocca per visualizzare a schermo intero';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Miniatura foto. Tocca per aprire la galleria';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -33577,14 +33577,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Videominiatuur. Tik om volledig scherm te bekijken';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Fotominiatuur, ontbreekt op het apparaat. Tik om volledig scherm te bekijken';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Videominiatuur, ontbreekt op het apparaat. Tik om volledig scherm te bekijken';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Fotominiatuur. Tik om de galerij te openen';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -33820,14 +33820,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Miniatura de vídeo. Toque para ver em tela cheia';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing =>
-      'Miniatura de foto, ausente no dispositivo. Toque para ver em tela cheia';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing =>
-      'Miniatura de vídeo, ausente no dispositivo. Toque para ver em tela cheia';
-
-  @override
   String get trips_photos_thumbnail_photo =>
       'Miniatura de foto. Toque para abrir a galeria';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -31839,12 +31839,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get trips_gallery_thumbnail_video => '视频缩略图。点按以全屏查看';
 
   @override
-  String get trips_gallery_thumbnail_photoMissing => '照片缩略图，设备上已缺失。点按以全屏查看';
-
-  @override
-  String get trips_gallery_thumbnail_videoMissing => '视频缩略图，设备上已缺失。点按以全屏查看';
-
-  @override
   String get trips_photos_thumbnail_photo => '照片缩略图。点按以打开图库';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Fotominiatuur. Tik om volledig scherm te bekijken",
   "trips_gallery_thumbnail_video": "Videominiatuur. Tik om volledig scherm te bekijken",
-  "trips_gallery_thumbnail_photoMissing": "Fotominiatuur, ontbreekt op het apparaat. Tik om volledig scherm te bekijken",
-  "trips_gallery_thumbnail_videoMissing": "Videominiatuur, ontbreekt op het apparaat. Tik om volledig scherm te bekijken",
   "trips_photos_thumbnail_photo": "Fotominiatuur. Tik om de galerij te openen",
   "trips_photos_thumbnail_video": "Videominiatuur. Tik om de galerij te openen",
   "trips_picker_suggestedSemantics": "Voorgestelde reis: {name}. Tik om te gebruiken",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date} ({count} {photoLabel})",
   "trips_gallery_thumbnail_photo": "Miniatura de foto. Toque para ver em tela cheia",
   "trips_gallery_thumbnail_video": "Miniatura de vídeo. Toque para ver em tela cheia",
-  "trips_gallery_thumbnail_photoMissing": "Miniatura de foto, ausente no dispositivo. Toque para ver em tela cheia",
-  "trips_gallery_thumbnail_videoMissing": "Miniatura de vídeo, ausente no dispositivo. Toque para ver em tela cheia",
   "trips_photos_thumbnail_photo": "Miniatura de foto. Toque para abrir a galeria",
   "trips_photos_thumbnail_video": "Miniatura de vídeo. Toque para abrir a galeria",
   "trips_picker_suggestedSemantics": "Viagem sugerida: {name}. Toque para usar",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -9949,8 +9949,6 @@
   "trips_gallery_diveSection_subtitle": "{date}（{count} {photoLabel}）",
   "trips_gallery_thumbnail_photo": "照片缩略图。点按以全屏查看",
   "trips_gallery_thumbnail_video": "视频缩略图。点按以全屏查看",
-  "trips_gallery_thumbnail_photoMissing": "照片缩略图，设备上已缺失。点按以全屏查看",
-  "trips_gallery_thumbnail_videoMissing": "视频缩略图，设备上已缺失。点按以全屏查看",
   "trips_photos_thumbnail_photo": "照片缩略图。点按以打开图库",
   "trips_photos_thumbnail_video": "视频缩略图。点按以打开图库",
   "trips_picker_suggestedSemantics": "建议的旅行：{name}。点按以使用",

--- a/test/features/media/presentation/support/capturing_media_repository.dart
+++ b/test/features/media/presentation/support/capturing_media_repository.dart
@@ -1,0 +1,22 @@
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
+
+/// Records [markVerified] calls and refuses every other member, so a write
+/// the code under test was not supposed to make shows up as a failure rather
+/// than as a silently accepted no-op.
+///
+/// Shared by every test that exercises MediaItemView's orphan-flag
+/// reconciliation, whether directly or through a tile that embeds the view.
+class CapturingMediaRepository implements MediaRepository {
+  final List<({String id, bool isOrphaned})> writes = [];
+
+  @override
+  Future<void> markVerified(
+    String id, {
+    required bool isOrphaned,
+    required DateTime verifiedAt,
+  }) async => writes.add((id: id, isOrphaned: isOrphaned));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not stubbed');
+}

--- a/test/features/media/presentation/support/capturing_media_repository.dart
+++ b/test/features/media/presentation/support/capturing_media_repository.dart
@@ -17,6 +17,13 @@ class CapturingMediaRepository implements MediaRepository {
   }) async => writes.add((id: id, isOrphaned: isOrphaned));
 
   @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError('${invocation.memberName} is not stubbed');
+  dynamic noSuchMethod(Invocation invocation) {
+    // Symbol.toString() renders as Symbol("name"); report just the name so
+    // the failure reads as the method that was called.
+    final name = invocation.memberName
+        .toString()
+        .replaceFirst(RegExp(r'^Symbol\("'), '')
+        .replaceFirst(RegExp(r'"\)$'), '');
+    throw UnimplementedError('CapturingMediaRepository.$name is not stubbed');
+  }
 }

--- a/test/features/media/presentation/widgets/media_grid_test.dart
+++ b/test/features/media/presentation/widgets/media_grid_test.dart
@@ -90,6 +90,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
+      expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
       // Bytes came from the row's own source, so the stale flag is corrected
       // in place instead of staying red until the viewer happens to open.
       expect(repository.writes, [(id: 'm1', isOrphaned: false)]);

--- a/test/features/media/presentation/widgets/media_grid_test.dart
+++ b/test/features/media/presentation/widgets/media_grid_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
-import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
@@ -11,25 +10,8 @@ import 'package:submersion/features/media/presentation/widgets/unavailable_media
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
 import '../../../../helpers/mock_providers.dart';
+import '../support/capturing_media_repository.dart';
 import '../support/media_widget_harness.dart';
-
-/// Records markVerified calls and refuses every other member, so a write the
-/// tile was not supposed to cause shows up as a failure rather than as a
-/// silently accepted no-op.
-class _CapturingRepository implements MediaRepository {
-  final List<({String id, bool isOrphaned})> writes = [];
-
-  @override
-  Future<void> markVerified(
-    String id, {
-    required bool isOrphaned,
-    required DateTime verifiedAt,
-  }) async => writes.add((id: id, isOrphaned: isOrphaned));
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError('${invocation.memberName} is not stubbed');
-}
 
 void main() {
   testWidgets('MediaEmptyState renders icon and message', (tester) async {
@@ -93,14 +75,20 @@ void main() {
       // chain (origin, then media store) try anyway, so a photo the flag
       // calls missing draws its thumbnail whenever anything can serve it
       // (#1409).
-      final repository = _CapturingRepository();
+      final repository = CapturingMediaRepository();
       await pumpTile(
         tester,
         item: testMediaItem(isOrphaned: true),
         overrides: [mediaRepositoryProvider.overrideWithValue(repository)],
       );
       expect(find.byType(MediaItemView), findsOneWidget);
-      expect(find.byType(Image), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(MediaItemView),
+          matching: find.byType(Image),
+        ),
+        findsOneWidget,
+      );
       expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
       // Bytes came from the row's own source, so the stale flag is corrected
       // in place instead of staying red until the viewer happens to open.

--- a/test/features/media/presentation/widgets/media_grid_test.dart
+++ b/test/features/media/presentation/widgets/media_grid_test.dart
@@ -1,14 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/utils/unit_formatter.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
 import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_grid.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/features/media/presentation/widgets/unavailable_media_placeholder.dart';
 import 'package:submersion/features/settings/presentation/providers/settings_providers.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import '../support/media_widget_harness.dart';
+
+/// Records markVerified calls and refuses every other member, so a write the
+/// tile was not supposed to cause shows up as a failure rather than as a
+/// silently accepted no-op.
+class _CapturingRepository implements MediaRepository {
+  final List<({String id, bool isOrphaned})> writes = [];
+
+  @override
+  Future<void> markVerified(
+    String id, {
+    required bool isOrphaned,
+    required DateTime verifiedAt,
+  }) async => writes.add((id: id, isOrphaned: isOrphaned));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not stubbed');
+}
 
 void main() {
   testWidgets('MediaEmptyState renders icon and message', (tester) async {
@@ -30,10 +51,12 @@ void main() {
       bool isSelectionMode = false,
       bool isSelected = false,
       MediaSourceData? resolverData,
+      List<Override> overrides = const [],
     }) async {
       await tester.pumpWidget(
         await mediaTestApp(
           resolverData: resolverData,
+          overrides: overrides,
           home: Scaffold(
             body: Center(
               child: SizedBox(
@@ -57,20 +80,44 @@ void main() {
     testWidgets('a plain photo renders through MediaItemView', (tester) async {
       await pumpTile(tester, item: testMediaItem());
       expect(find.byType(MediaItemView), findsOneWidget);
-      expect(find.byType(OrphanedMediaPlaceholder), findsNothing);
       // No badges for an unselected, unenriched photo.
       expect(find.byIcon(Icons.videocam), findsNothing);
       expect(find.byIcon(Icons.check), findsNothing);
     });
 
-    testWidgets('an orphaned item shows the broken-image placeholder', (
+    testWidgets('an orphaned item still renders through MediaItemView', (
       tester,
     ) async {
-      await pumpTile(tester, item: testMediaItem(isOrphaned: true));
-      expect(find.byType(OrphanedMediaPlaceholder), findsOneWidget);
+      // The persisted flag is a claim from an earlier verification, possibly
+      // made on a device that never had the file. The tile lets the resolver
+      // chain (origin, then media store) try anyway, so a photo the flag
+      // calls missing draws its thumbnail whenever anything can serve it
+      // (#1409).
+      final repository = _CapturingRepository();
+      await pumpTile(
+        tester,
+        item: testMediaItem(isOrphaned: true),
+        overrides: [mediaRepositoryProvider.overrideWithValue(repository)],
+      );
+      expect(find.byType(MediaItemView), findsOneWidget);
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
+      // Bytes came from the row's own source, so the stale flag is corrected
+      // in place instead of staying red until the viewer happens to open.
+      expect(repository.writes, [(id: 'm1', isOrphaned: false)]);
+    });
+
+    testWidgets('an orphaned item nothing can serve shows the missing tile', (
+      tester,
+    ) async {
+      await pumpTile(
+        tester,
+        item: testMediaItem(isOrphaned: true),
+        resolverData: const UnavailableData(kind: UnavailableKind.notFound),
+      );
+      expect(find.byType(MediaItemView), findsOneWidget);
+      expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
       expect(find.byIcon(Icons.broken_image_outlined), findsOneWidget);
-      // The resolver is never consulted for an orphaned row.
-      expect(find.byType(MediaItemView), findsNothing);
     });
 
     testWidgets('selection puts a checkmark on the tile', (tester) async {

--- a/test/features/media/presentation/widgets/media_item_view_reconcile_test.dart
+++ b/test/features/media/presentation/widgets/media_item_view_reconcile_test.dart
@@ -21,6 +21,8 @@ import 'package:submersion/features/media/presentation/providers/media_resolver_
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
 
+import '../support/capturing_media_repository.dart';
+
 /// A 1x1 transparent PNG, so Image.memory has something it can decode.
 final Uint8List _png = base64Decode(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
@@ -51,24 +53,6 @@ class _FixedResolver implements MediaSourceResolver {
 
   @override
   Future<VerifyResult> verify(MediaItem item) async => VerifyResult.available;
-}
-
-/// Records markVerified calls and refuses every other member, so a write the
-/// reconciler was not supposed to make shows up as a failure rather than as
-/// a silently accepted no-op.
-class _CapturingRepository implements MediaRepository {
-  final List<({String id, bool isOrphaned})> writes = [];
-
-  @override
-  Future<void> markVerified(
-    String id, {
-    required bool isOrphaned,
-    required DateTime verifiedAt,
-  }) async => writes.add((id: id, isOrphaned: isOrphaned));
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError('${invocation.memberName} is not stubbed');
 }
 
 /// Stands in for the store runtime so the fallback can SUCCEED, which is the
@@ -175,7 +159,7 @@ Future<void> _pump(
 
 void main() {
   testWidgets('a notFound resolution orphans the row', (tester) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -189,7 +173,7 @@ void main() {
   testWidgets('a successful resolution clears a stale orphan flag', (
     tester,
   ) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -205,7 +189,7 @@ void main() {
     // The steady state. Every MediaRepository write calls markRecordPending,
     // so a write here would queue one pending sync row per thumbnail that
     // scrolled into view.
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -219,7 +203,7 @@ void main() {
   // A revoked photo permission makes EVERY gallery tile fail at once, so a
   // write on this path would orphan a whole library and sync the claim.
   testWidgets('an accessDenied resolution never orphans', (tester) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -233,7 +217,7 @@ void main() {
   // The availability work's own constraint: a fetch that outlived its time
   // budget must not permanently mark a diver's photo dead.
   testWidgets('a stillFetching resolution never orphans', (tester) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -252,7 +236,7 @@ void main() {
   testWidgets('a store fallback covering a dead origin still orphans', (
     tester,
   ) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -270,7 +254,7 @@ void main() {
   testWidgets('a store fallback that finds nothing still orphans', (
     tester,
   ) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -288,7 +272,7 @@ void main() {
   ) async {
     // accessDenied still means nothing was learned, whether or not the cloud
     // covered for it.
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,
@@ -306,7 +290,7 @@ void main() {
   testWidgets('an already-orphaned row that stays missing writes nothing', (
     tester,
   ) async {
-    final repository = _CapturingRepository();
+    final repository = CapturingMediaRepository();
 
     await _pump(
       tester,

--- a/test/features/trips/presentation/pages/trip_gallery_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_gallery_page_test.dart
@@ -6,32 +6,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
-import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/domain/value_objects/media_source_data.dart';
 import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
 import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
+import 'package:submersion/features/media/presentation/widgets/unavailable_media_placeholder.dart';
 import 'package:submersion/features/trips/presentation/pages/trip_gallery_page.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_media_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+import 'package:submersion/l10n/l10n_extension.dart';
 
+import '../../../media/presentation/support/capturing_media_repository.dart';
 import '../../../media/presentation/support/media_widget_harness.dart';
-
-/// Records markVerified calls and refuses every other member.
-class _CapturingRepository implements MediaRepository {
-  final List<({String id, bool isOrphaned})> writes = [];
-
-  @override
-  Future<void> markVerified(
-    String id, {
-    required bool isOrphaned,
-    required DateTime verifiedAt,
-  }) async => writes.add((id: id, isOrphaned: isOrphaned));
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError('${invocation.memberName} is not stubbed');
-}
 
 void main() {
   group('TripGalleryPage', () {
@@ -368,7 +355,7 @@ void main() {
         updatedAt: DateTime(2024, 1, 15),
       );
 
-      final repository = _CapturingRepository();
+      final repository = CapturingMediaRepository();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -391,20 +378,89 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(MediaItemView), findsOneWidget);
-      expect(find.byType(Image), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(MediaItemView),
+          matching: find.byType(Image),
+        ),
+        findsOneWidget,
+      );
       expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
       // The label must not read the stale flag either: a screen reader
       // should never hear "missing" over a thumbnail that just rendered.
+      final l10n = tester.element(find.byType(TripGalleryPage)).l10n;
       expect(
         find.byWidgetPredicate(
           (w) =>
               w is Semantics &&
-              w.properties.label == 'Photo thumbnail. Tap to view full screen',
+              w.properties.label == l10n.trips_gallery_thumbnail_photo,
         ),
         findsOneWidget,
       );
       // The resolver produced bytes, so the stale flag is corrected.
       expect(repository.writes, [(id: 'media-orphan', isOrphaned: false)]);
+    });
+
+    testWidgets('an item nothing can serve announces the missing reason', (
+      tester,
+    ) async {
+      // The tile's own label is availability-agnostic, so the placeholder
+      // has to be what tells a screen reader the photo is not here.
+      final testDive = Dive(
+        id: 'dive-1',
+        dateTime: DateTime(2024, 1, 15, 10, 30),
+        diveNumber: 1,
+      );
+
+      final missingMedia = MediaItem(
+        id: 'media-missing',
+        diveId: 'dive-1',
+        mediaType: MediaType.photo,
+        takenAt: DateTime(2024, 1, 15, 10, 45),
+        platformAssetId: 'asset-missing',
+        isOrphaned: true,
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mediaForTripProvider('test-trip').overrideWith((ref) {
+              return Future.value({
+                testDive: [missingMedia],
+              });
+            }),
+            mediaResolverOverride(
+              resolverData: const UnavailableData(
+                kind: UnavailableKind.notFound,
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: TripGalleryPage(tripId: 'test-trip'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final l10n = tester.element(find.byType(TripGalleryPage)).l10n;
+      expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+      expect(
+        find.text(l10n.media_unavailablePlaceholder_fileNotFound),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label == l10n.trips_gallery_thumbnail_photo,
+        ),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/features/trips/presentation/pages/trip_gallery_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_gallery_page_test.dart
@@ -356,6 +356,9 @@ void main() {
       );
 
       final repository = CapturingMediaRepository();
+      // Assert against the semantics tree itself, not the widgets that feed
+      // it: the claim under test is what assistive tech hears.
+      final semantics = tester.ensureSemantics();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -386,19 +389,23 @@ void main() {
         findsOneWidget,
       );
       expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
+      expect(find.byType(UnavailableMediaPlaceholder), findsNothing);
       // The label must not read the stale flag either: a screen reader
       // should never hear "missing" over a thumbnail that just rendered.
       final l10n = tester.element(find.byType(TripGalleryPage)).l10n;
       expect(
-        find.byWidgetPredicate(
-          (w) =>
-              w is Semantics &&
-              w.properties.label == l10n.trips_gallery_thumbnail_photo,
-        ),
+        find.bySemanticsLabel(_contains(l10n.trips_gallery_thumbnail_photo)),
         findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(
+          _contains(l10n.media_unavailablePlaceholder_fileNotFound),
+        ),
+        findsNothing,
       );
       // The resolver produced bytes, so the stale flag is corrected.
       expect(repository.writes, [(id: 'media-orphan', isOrphaned: false)]);
+      semantics.dispose();
     });
 
     testWidgets('an item nothing can serve announces the missing reason', (
@@ -423,6 +430,7 @@ void main() {
         updatedAt: DateTime(2024, 1, 15),
       );
 
+      final semantics = tester.ensureSemantics();
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -449,18 +457,26 @@ void main() {
 
       final l10n = tester.element(find.byType(TripGalleryPage)).l10n;
       expect(find.byType(UnavailableMediaPlaceholder), findsOneWidget);
+      // Both reach the semantics tree: the tile's plain label and the
+      // placeholder's reason.
       expect(
-        find.text(l10n.media_unavailablePlaceholder_fileNotFound),
+        find.bySemanticsLabel(_contains(l10n.trips_gallery_thumbnail_photo)),
         findsOneWidget,
       );
       expect(
-        find.byWidgetPredicate(
-          (w) =>
-              w is Semantics &&
-              w.properties.label == l10n.trips_gallery_thumbnail_photo,
+        find.bySemanticsLabel(
+          _contains(l10n.media_unavailablePlaceholder_fileNotFound),
         ),
         findsOneWidget,
       );
+      semantics.dispose();
     });
   });
 }
+
+/// A semantics-label pattern that matches a node containing [text].
+///
+/// [CommonFinders.bySemanticsLabel] compares a String label for equality,
+/// so a merged node ("Photo thumbnail...\nFile not found") would miss a
+/// plain-string match while still being exactly what a screen reader reads.
+RegExp _contains(String text) => RegExp(RegExp.escape(text));

--- a/test/features/trips/presentation/pages/trip_gallery_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_gallery_page_test.dart
@@ -393,6 +393,16 @@ void main() {
       expect(find.byType(MediaItemView), findsOneWidget);
       expect(find.byType(Image), findsOneWidget);
       expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
+      // The label must not read the stale flag either: a screen reader
+      // should never hear "missing" over a thumbnail that just rendered.
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label == 'Photo thumbnail. Tap to view full screen',
+        ),
+        findsOneWidget,
+      );
       // The resolver produced bytes, so the stale flag is corrected.
       expect(repository.writes, [(id: 'media-orphan', isOrphaned: false)]);
     });

--- a/test/features/trips/presentation/pages/trip_gallery_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_gallery_page_test.dart
@@ -6,11 +6,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:submersion/core/providers/provider.dart';
 import 'package:submersion/features/dive_log/domain/entities/dive.dart';
 import 'package:submersion/features/dive_sites/domain/entities/dive_site.dart';
+import 'package:submersion/features/media/data/repositories/media_repository.dart';
 import 'package:submersion/features/media/domain/entities/media_item.dart';
+import 'package:submersion/features/media/presentation/providers/media_providers.dart';
 import 'package:submersion/features/media/presentation/providers/photo_picker_providers.dart';
+import 'package:submersion/features/media/presentation/widgets/media_item_view.dart';
 import 'package:submersion/features/trips/presentation/pages/trip_gallery_page.dart';
 import 'package:submersion/features/trips/presentation/providers/trip_media_providers.dart';
 import 'package:submersion/l10n/arb/app_localizations.dart';
+
+import '../../../media/presentation/support/media_widget_harness.dart';
+
+/// Records markVerified calls and refuses every other member.
+class _CapturingRepository implements MediaRepository {
+  final List<({String id, bool isOrphaned})> writes = [];
+
+  @override
+  Future<void> markVerified(
+    String id, {
+    required bool isOrphaned,
+    required DateTime verifiedAt,
+  }) async => writes.add((id: id, isOrphaned: isOrphaned));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not stubbed');
+}
 
 void main() {
   group('TripGalleryPage', () {
@@ -324,49 +345,56 @@ void main() {
       expect(delegate.crossAxisCount, 4);
     });
 
-    testWidgets(
-      'orphaned media renders distinct error tile (broken_image_outlined)',
-      (tester) async {
-        final testDive = Dive(
-          id: 'dive-1',
-          dateTime: DateTime(2024, 1, 15, 10, 30),
-          diveNumber: 1,
-        );
+    testWidgets('orphaned media still renders through MediaItemView', (
+      tester,
+    ) async {
+      // The orphan flag is a persisted claim that may be stale or may have
+      // been written by another device; the tile lets the resolver chain
+      // decide instead of drawing a broken tile from the flag (#1409).
+      final testDive = Dive(
+        id: 'dive-1',
+        dateTime: DateTime(2024, 1, 15, 10, 30),
+        diveNumber: 1,
+      );
 
-        final orphanedMedia = MediaItem(
-          id: 'media-orphan',
-          diveId: 'dive-1',
-          mediaType: MediaType.photo,
-          takenAt: DateTime(2024, 1, 15, 10, 45),
-          platformAssetId: 'asset-orphan',
-          isOrphaned: true,
-          createdAt: DateTime(2024, 1, 15),
-          updatedAt: DateTime(2024, 1, 15),
-        );
+      final orphanedMedia = MediaItem(
+        id: 'media-orphan',
+        diveId: 'dive-1',
+        mediaType: MediaType.photo,
+        takenAt: DateTime(2024, 1, 15, 10, 45),
+        platformAssetId: 'asset-orphan',
+        isOrphaned: true,
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+      );
 
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              mediaForTripProvider('test-trip').overrideWith((ref) {
-                return Future.value({
-                  testDive: [orphanedMedia],
-                });
-              }),
-            ],
-            child: const MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: TripGalleryPage(tripId: 'test-trip'),
-            ),
+      final repository = _CapturingRepository();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mediaForTripProvider('test-trip').overrideWith((ref) {
+              return Future.value({
+                testDive: [orphanedMedia],
+              });
+            }),
+            mediaResolverOverride(),
+            mediaRepositoryProvider.overrideWithValue(repository),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: TripGalleryPage(tripId: 'test-trip'),
           ),
-        );
+        ),
+      );
 
-        await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
 
-        // Orphaned items render the broken_image_outlined icon, distinct from
-        // the regular MediaItemView+UnavailableMediaPlaceholder error tile.
-        expect(find.byIcon(Icons.broken_image_outlined), findsOneWidget);
-      },
-    );
+      expect(find.byType(MediaItemView), findsOneWidget);
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byIcon(Icons.broken_image_outlined), findsNothing);
+      // The resolver produced bytes, so the stale flag is corrected.
+      expect(repository.writes, [(id: 'media-orphan', isOrphaned: false)]);
+    });
   });
 }

--- a/test/features/trips/presentation/pages/trip_gallery_page_test.dart
+++ b/test/features/trips/presentation/pages/trip_gallery_page_test.dart
@@ -471,6 +471,53 @@ void main() {
       );
       semantics.dispose();
     });
+
+    testWidgets('a video tile carries the video label', (tester) async {
+      final testDive = Dive(
+        id: 'dive-1',
+        dateTime: DateTime(2024, 1, 15, 10, 30),
+        diveNumber: 1,
+      );
+
+      final video = MediaItem(
+        id: 'media-video',
+        diveId: 'dive-1',
+        mediaType: MediaType.video,
+        takenAt: DateTime(2024, 1, 15, 10, 45),
+        platformAssetId: 'asset-video',
+        createdAt: DateTime(2024, 1, 15),
+        updatedAt: DateTime(2024, 1, 15),
+      );
+
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mediaForTripProvider('test-trip').overrideWith((ref) {
+              return Future.value({
+                testDive: [video],
+              });
+            }),
+            mediaResolverOverride(),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: TripGalleryPage(tripId: 'test-trip'),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final l10n = tester.element(find.byType(TripGalleryPage)).l10n;
+      expect(
+        find.bySemanticsLabel(_contains(l10n.trips_gallery_thumbnail_video)),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.videocam), findsOneWidget);
+      semantics.dispose();
+    });
   });
 }
 


### PR DESCRIPTION
Closes #1409

## Symptom

In a dive's Photos & Video section, photos imported as files showed a dark red square with a broken-image icon and a cloud badge, on both macOS and iOS, including the device that imported them. Tapping the tile opened the photo full screen without trouble.

## Cause

The red square is `OrphanedMediaPlaceholder`. `MediaThumbnailTile` (and its copy in the trip gallery) drew it whenever the row's persisted `isOrphaned` flag was true, without ever building `MediaItemView`. The full-screen viewer always builds `MediaItemView`, which tries the row's own source, then the media store, then the missing-file placeholder. So the grid trusted a claim the viewer re-verified.

That flag is sync-visible and written by whichever device last checked the file. `LocalFileResolver` only downgrades a not-found result to "from another device" when the row records an origin device id, and origin tracking shipped in v1.5.4, so older file imports get flagged by the second device and the flag syncs back to the importer. The cloud badge in the report's screenshot is `MediaStatus.cloudOnly`, which confirms the store had a copy the tile refused to draw.

## Fix

- `MediaThumbnailTile` and the trip gallery `_GridThumbnail` always build `MediaItemView(thumbnail: true)`. Origin first, media store second (still gated on upload stamps, so an unbacked-up row never builds the store runtime), `UnavailableMediaPlaceholder` last.
- Because `MediaItemView` reconciles the orphan flag on a successful origin read, a stale flag now repairs itself the first time the tile scrolls into view instead of waiting for a viewer tap.
- `OrphanedMediaPlaceholder` is deleted; nothing else used it. Health stays visible through the status badge, which is where the provenance design spec puts it ("not broken: it still displays, it just streams").

## Tests

- `media_grid_test`: an orphaned row renders through `MediaItemView`, draws the image, and writes `isOrphaned: false` through a capturing `MediaRepository`; an orphaned row nothing can serve shows the standard missing-file placeholder.
- `trip_gallery_page_test`: same assertion for the trip grid, using the shared media resolver override instead of the previous real-registry path.
- All media and trips tests: 2,664 passed. Whole-project `dart analyze` and `dart format` clean.

## Not changed

Rows without an origin device id can still be re-flagged by a non-importing device in the background. After this change that is a sync write the user never sees, so the resolver was left alone.
