### PR TITLE
fix(sync): keep a large peer base adoption alive, fast, and visible

### DIFF
--- a/lib/core/services/sync/changeset_log/base_apply_progress.dart
+++ b/lib/core/services/sync/changeset_log/base_apply_progress.dart
@@ -17,16 +17,14 @@ class BaseApplyProgress {
   final void Function(double fraction)? _onProgress;
   final LoggerService _log = LoggerService.forClass(BaseApplyProgress);
   final Stopwatch _stopwatch = Stopwatch()..start();
+  Duration _passStarted = Duration.zero;
   int _pass = 0;
   double _floor = 0.0;
   double _last = 0.0;
 
   /// Marks the start of zero-based [pass]; the previous pass is complete.
   void beginPass(int pass) {
-    _log.info(
-      'Peer base pass ${_pass + 1}/$_passes done in '
-      '${_stopwatch.elapsed.inSeconds}s',
-    );
+    _logPassDone();
     _pass = pass;
     _emit(_pass / _passes);
   }
@@ -50,14 +48,23 @@ class BaseApplyProgress {
     );
     _floor = _last;
     _pass = 0;
+    _passStarted = _stopwatch.elapsed;
   }
 
   void done() {
-    _log.info(
-      'Peer base pass $_passes/$_passes done in '
-      '${_stopwatch.elapsed.inSeconds}s',
-    );
+    _logPassDone();
     _emit(1.0);
+  }
+
+  /// Logs the pass that just ended with its own duration and the running
+  /// total, then starts timing the next one.
+  void _logPassDone() {
+    final now = _stopwatch.elapsed;
+    _log.info(
+      'Peer base pass ${_pass + 1}/$_passes done in '
+      '${(now - _passStarted).inSeconds}s (${now.inSeconds}s total)',
+    );
+    _passStarted = now;
   }
 
   void _emit(double fraction) {

--- a/lib/core/services/sync/changeset_log/base_apply_progress.dart
+++ b/lib/core/services/sync/changeset_log/base_apply_progress.dart
@@ -1,0 +1,69 @@
+import 'package:submersion/core/services/logger_service.dart';
+
+/// Maps the three file passes of a peer base apply onto one 0.0 to 1.0
+/// fraction (each pass is a third) and logs when each pass completes, so a
+/// debug log of a large adoption shows steady progress instead of minutes of
+/// silence (issue #1421).
+///
+/// Progress never moves backwards. If the worker-isolate apply fails part way
+/// and the caller falls back to the inline apply, [restart] folds the three
+/// inline passes into whatever share of the bar is still unspent.
+class BaseApplyProgress {
+  BaseApplyProgress(this._totalBytes, this._onProgress);
+
+  static const int _passes = 3;
+
+  final int _totalBytes;
+  final void Function(double fraction)? _onProgress;
+  final LoggerService _log = LoggerService.forClass(BaseApplyProgress);
+  final Stopwatch _stopwatch = Stopwatch()..start();
+  int _pass = 0;
+  double _floor = 0.0;
+  double _last = 0.0;
+
+  /// Marks the start of zero-based [pass]; the previous pass is complete.
+  void beginPass(int pass) {
+    _log.info(
+      'Peer base pass ${_pass + 1}/$_passes done in '
+      '${_stopwatch.elapsed.inSeconds}s',
+    );
+    _pass = pass;
+    _emit(_pass / _passes);
+  }
+
+  /// Bytes of the file consumed so far in the current pass (inline path).
+  void consumed(int bytes) => this.bytes(bytes, _totalBytes);
+
+  /// Bytes of the file consumed so far in the current pass (worker path).
+  void bytes(int consumed, int total) {
+    final within = total <= 0 ? 1.0 : (consumed / total).clamp(0.0, 1.0);
+    _emit((_pass + within) / _passes);
+  }
+
+  /// The apply is starting over from pass 1 (worker failed, inline fallback).
+  /// Everything reported so far becomes the floor; the restarted passes fill
+  /// the remainder, so the bar keeps moving and never rewinds.
+  void restart() {
+    _log.info(
+      'Peer base apply restarting from pass 1 after '
+      '${_stopwatch.elapsed.inSeconds}s',
+    );
+    _floor = _last;
+    _pass = 0;
+  }
+
+  void done() {
+    _log.info(
+      'Peer base pass $_passes/$_passes done in '
+      '${_stopwatch.elapsed.inSeconds}s',
+    );
+    _emit(1.0);
+  }
+
+  void _emit(double fraction) {
+    final scaled = _floor + (1.0 - _floor) * fraction;
+    if (scaled < _last) return;
+    _last = scaled;
+    _onProgress?.call(scaled);
+  }
+}

--- a/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
+++ b/lib/core/services/sync/changeset_log/base_json_stream_reader.dart
@@ -37,10 +37,14 @@ class BaseJsonStreamReader {
   String? _section;
   String? _table;
 
-  final BytesBuilder _key = BytesBuilder(copy: false);
+  // Copying builders on purpose: the non-copying BytesBuilder allocates a
+  // one-element list per addByte, which on a multi-hundred-MB base is one
+  // allocation per captured byte. The copying builder writes into a grown
+  // buffer instead (issue #1421).
+  final BytesBuilder _key = BytesBuilder();
   bool _keyEscaped = false;
 
-  final BytesBuilder _cap = BytesBuilder(copy: false);
+  final BytesBuilder _cap = BytesBuilder();
   int _capDepth = 0;
   bool _capInString = false;
   bool _capEscaped = false;
@@ -75,7 +79,28 @@ class BaseJsonStreamReader {
     _want = wantRows ?? (_, _) => true;
 
     await for (final chunk in bytes) {
-      for (final c in chunk) {
+      final data = chunk is Uint8List ? chunk : Uint8List.fromList(chunk);
+      final n = data.length;
+      var i = 0;
+      while (i < n) {
+        // Fast path: inside a string body nothing but a quote or a backslash
+        // can change state, so take the whole run in one slice instead of one
+        // state-machine step per byte. Blob-bearing rows are almost entirely
+        // string body, and a skipped table's bytes are not copied at all.
+        if (_inStringBody) {
+          var j = i;
+          while (j < n) {
+            final b = data[j];
+            if (b == _quote || b == _backslash) break;
+            j++;
+          }
+          if (j > i && _capKind != _Cap.skip) {
+            _cap.add(Uint8List.sublistView(data, i, j));
+          }
+          i = j;
+          if (i >= n) break;
+        }
+        final c = data[i++];
         var consumed = false;
         while (!consumed) {
           final r = _consume(c);
@@ -108,6 +133,19 @@ class BaseJsonStreamReader {
         '(empty or truncated document)',
       );
     }
+  }
+
+  bool get _inStringBody =>
+      (_state == _S.capture ||
+          _state == _S.captureArray ||
+          _state == _S.captureSection) &&
+      _capInString &&
+      !_capEscaped;
+
+  /// Appends a captured byte unless this capture is being skipped, in which
+  /// case nothing is retained (the bytes are discarded at finish anyway).
+  void _capAdd(int c) {
+    if (_capKind != _Cap.skip) _cap.addByte(c);
   }
 
   _Step _consume(int c) {
@@ -256,7 +294,7 @@ class BaseJsonStreamReader {
 
   _Step _captureByte(int c) {
     if (_capInString) {
-      _cap.addByte(c);
+      _capAdd(c);
       if (_capEscaped) {
         _capEscaped = false;
       } else if (c == _backslash) {
@@ -270,13 +308,13 @@ class BaseJsonStreamReader {
     if (c == _quote) {
       _capStarted = true;
       _capInString = true;
-      _cap.addByte(c);
+      _capAdd(c);
       return const _Step(true);
     }
     if (c == _lbrace || c == _lbracket) {
       _capStarted = true;
       _capDepth++;
-      _cap.addByte(c);
+      _capAdd(c);
       return const _Step(true);
     }
     if (c == _rbrace || c == _rbracket) {
@@ -286,7 +324,7 @@ class BaseJsonStreamReader {
         return _finishCapture(consume: false);
       }
       _capDepth--;
-      _cap.addByte(c);
+      _capAdd(c);
       if (_capDepth == 0) return _finishCapture(consume: true);
       return const _Step(true);
     }
@@ -303,14 +341,13 @@ class BaseJsonStreamReader {
       return const _Step(true); // leading/interior structural whitespace
     }
     _capStarted = true;
-    _cap.addByte(c);
+    _capAdd(c);
     return const _Step(true);
   }
 
   _Step _finishCapture({required bool consume}) {
     final kind = _capKind;
     final bytes = (kind == _Cap.skip) ? null : _cap.takeBytes();
-    if (kind == _Cap.skip) _cap.clear();
 
     // Transition to the parent state.
     if (_state == _S.capture) {

--- a/lib/core/services/sync/changeset_log/base_parse_client.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_client.dart
@@ -17,12 +17,24 @@ class BaseParseException implements Exception {
 /// decoded rows back, pull-backpressured (one ≤500-row batch per [nextDataBatch]).
 /// Operations are sequential — one in flight at a time.
 class BaseParseClient {
-  BaseParseClient._(this._isolate, this._toWorker, this._fromWorker, this._sub);
+  BaseParseClient._(
+    this._isolate,
+    this._toWorker,
+    this._fromWorker,
+    this._sub,
+    this.onProgress,
+  );
 
   final Isolate _isolate;
   final SendPort _toWorker;
   final ReceivePort _fromWorker;
   final StreamSubscription<dynamic> _sub;
+
+  /// Receives the worker's byte-progress heartbeats: bytes of the file
+  /// consumed so far in the current pass, and the file's total length.
+  /// Settable after [spawn] so a caller can attach it to a client it obtained
+  /// through an injected spawn hook.
+  void Function(int bytes, int total)? onProgress;
 
   // Buffered request/response mailbox: messages that arrive before a reader is
   // waiting are queued, so a batch sent before the first [nextDataBatch] pull is
@@ -40,9 +52,13 @@ class BaseParseClient {
   /// handshake within [handshakeTimeout]. The port, subscription, and isolate
   /// it created are torn down before the error propagates.
   ///
+  /// [onProgress] receives the worker's byte-progress heartbeats (bytes of the
+  /// file consumed so far in the current pass, and the file's total length).
+  ///
   /// [entryPoint] and [handshakeTimeout] are injectable for tests only.
   static Future<BaseParseClient> spawn(
     String filePath, {
+    void Function(int bytes, int total)? onProgress,
     @visibleForTesting
     void Function(List<Object>) entryPoint = baseParseWorkerMain,
     @visibleForTesting Duration handshakeTimeout = const Duration(seconds: 10),
@@ -99,7 +115,13 @@ class BaseParseClient {
         errorsAreFatal: false,
       );
       final toWorker = await ready.future;
-      client = BaseParseClient._(isolate, toWorker, fromWorker, sub);
+      client = BaseParseClient._(
+        isolate,
+        toWorker,
+        fromWorker,
+        sub,
+        onProgress,
+      );
     } catch (_) {
       // Spawn failed, the worker errored before handshake, or it timed out:
       // tear down so we never leak the port/subscription/isolate, then rethrow
@@ -128,15 +150,29 @@ class BaseParseClient {
     }
   }
 
-  /// Per-message backstop: after the handshake, a worker can still die or hang
+  /// Inactivity backstop: after the handshake, a worker can still die or hang
   /// without delivering an `onError` (e.g. an OS OOM kill), which would leave a
   /// waiting pull blocked forever and hang the whole sync. Time out and surface
   /// a [BaseParseException] so the caller (readScalarsAndDeletions /
   /// nextDataBatch) falls back to the inline parser. Injectable for tests.
+  ///
+  /// This bounds worker SILENCE, not reply latency. A single reply (pass 1 over
+  /// a 730 MB base, or a data batch that must skip a giant table first) can
+  /// legitimately take minutes; the worker's progress heartbeats restart this
+  /// window each time they arrive, so only a worker that has stopped reading
+  /// the file trips it (issue #1421).
   @visibleForTesting
   static Duration messageTimeout = const Duration(seconds: 60);
 
-  Future<Map<dynamic, dynamic>> _nextMessage() {
+  Future<Map<dynamic, dynamic>> _nextMessage() async {
+    while (true) {
+      final m = await _nextRawMessage();
+      if (m['type'] != 'progress') return m;
+      onProgress?.call(m['bytes'] as int, m['total'] as int);
+    }
+  }
+
+  Future<Map<dynamic, dynamic>> _nextRawMessage() {
     if (_queue.isNotEmpty) return Future.value(_queue.removeAt(0));
     final c = Completer<Map<dynamic, dynamic>>();
     _waiters.add(c);

--- a/lib/core/services/sync/changeset_log/base_parse_worker.dart
+++ b/lib/core/services/sync/changeset_log/base_parse_worker.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
+import 'package:submersion/core/services/sync/changeset_log/byte_progress_stream.dart';
 
 /// Isolate entrypoint for the base-file parse worker.
 ///
@@ -17,7 +18,14 @@ import 'package:submersion/core/services/sync/changeset_log/base_json_stream_rea
 ///     {'type': 'ready', 'port': SendPort}           (handshake)
 ///     {'type': 'deletions', 'exportedAt': int, 'rows': List}
 ///     {'type': 'batch', 'rows': List, 'done': bool}
+///     {'type': 'progress', 'bytes': int, 'total': int}  (liveness heartbeat)
 ///     {'type': 'error', 'message': String}
+///
+/// A progress message is sent every few MiB of file consumed during a pass
+/// and once at its end. It is not a reply: the client treats it as proof the
+/// worker is alive and restarts its inactivity timeout, so a pass over a
+/// multi-hundred-MB base can legitimately take minutes without being mistaken
+/// for a dead worker (issue #1421).
 ///
 /// [args] is `[mainSendPort, filePath]` (Isolate.spawn passes one message).
 void baseParseWorkerMain(List<Object> args) {
@@ -45,12 +53,22 @@ void baseParseWorkerMain(List<Object> args) {
     'message': e.toString(),
   });
 
+  final total = File(filePath).lengthSync();
+  Stream<List<int>> openWithProgress() => withByteProgress(
+    File(filePath).openRead(),
+    onProgress: (consumed) => mainSendPort.send(<String, Object>{
+      'type': 'progress',
+      'bytes': consumed,
+      'total': total,
+    }),
+  );
+
   Future<void> runDeletions() async {
     try {
       var exportedAt = 0;
       final rows = <Map<String, Object?>>[];
       await BaseJsonStreamReader().parse(
-        File(filePath).openRead(),
+        openWithProgress(),
         onScalar: (key, raw) async {
           if (key == 'exportedAt') {
             exportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
@@ -86,7 +104,7 @@ void baseParseWorkerMain(List<Object> args) {
     try {
       var batch = <Map<String, Object?>>[];
       await BaseJsonStreamReader().parse(
-        File(filePath).openRead(),
+        openWithProgress(),
         wantRows: (section, table) =>
             section == 'data' && tables.contains(table),
         onRow: (section, table, rowBytes) async {

--- a/lib/core/services/sync/changeset_log/base_part_file_sink.dart
+++ b/lib/core/services/sync/changeset_log/base_part_file_sink.dart
@@ -26,6 +26,7 @@ class BasePartFileSink {
     required String? wholeChecksum,
     required List<String> partChecksums,
     required Future<Uint8List?> Function(int index) downloadPart,
+    void Function(int downloaded, int total)? onPartDownloaded,
   }) async {
     final dir = await _tempDir();
     final path = basePartTempPath(dir.path, name, _uuid.v4());
@@ -51,6 +52,7 @@ class BasePartFileSink {
         }
         wholeInput.add(part);
         out.add(part);
+        onPartDownloaded?.call(i + 1, partCount);
       }
     } catch (_) {
       ok = false;

--- a/lib/core/services/sync/changeset_log/byte_progress_stream.dart
+++ b/lib/core/services/sync/changeset_log/byte_progress_stream.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+/// Default reporting granularity for [withByteProgress]: every 4 MiB consumed.
+const int defaultByteProgressInterval = 4 << 20;
+
+/// Passes [source] through unchanged while reporting the running byte count
+/// to [onProgress]: once every [interval] bytes and once more when the stream
+/// ends, so the final report always equals the total bytes consumed even for
+/// a stream shorter than one interval.
+///
+/// Used by the base-file parse passes to turn a long, otherwise silent scan
+/// into a stream of liveness ticks for the isolate client and the sync
+/// progress bar (issue #1421).
+Stream<List<int>> withByteProgress(
+  Stream<List<int>> source, {
+  required void Function(int consumed) onProgress,
+  int interval = defaultByteProgressInterval,
+}) async* {
+  var consumed = 0;
+  var nextReport = interval;
+  await for (final chunk in source) {
+    consumed += chunk.length;
+    if (consumed >= nextReport) {
+      onProgress(consumed);
+      nextReport = consumed + interval;
+    }
+    yield chunk;
+  }
+  onProgress(consumed);
+}

--- a/lib/core/services/sync/changeset_log/changeset_reader.dart
+++ b/lib/core/services/sync/changeset_log/changeset_reader.dart
@@ -16,6 +16,12 @@ import 'package:submersion/core/services/sync/changeset_log/sync_manifest.dart';
 /// so the merge stays the single source of truth.
 typedef ApplyPayload = Future<void> Function(SyncPayload payload);
 
+/// Progress of a peer base download: [downloaded] of [total] parts have landed
+/// for the base named by [manifest]. Lets the caller keep the progress bar
+/// moving through a multi-hundred-MB adoption (issue #1421).
+typedef BaseDownloadProgress =
+    void Function(SyncManifest manifest, int downloaded, int total);
+
 /// Applies a base that has been streamed to a local temp [filePath]. The real
 /// implementation streams the file through the merge in bounded memory; see
 /// SyncService._applyRemoteBaseFile.
@@ -105,6 +111,7 @@ class ChangesetReader {
     String? currentEpochId,
     int localSchemaVersion = AppDatabase.currentSchemaVersion,
     List<CloudFileInfo>? preListedFiles,
+    BaseDownloadProgress? onBaseDownloadProgress,
   }) async {
     final providerId = provider.providerId;
     // [preListedFiles] lets the caller reuse a listing it just made (the
@@ -208,20 +215,47 @@ class ChangesetReader {
         // Cold-start, or lapped by the peer's compaction: adopt the base.
         final baseSeq = manifest.baseSeq;
         if (baseSeq != null && lastApplied < baseSeq) {
+          // A base adoption can run for minutes on a large library, so log
+          // its shape and timing: a debug log that goes silent here is
+          // otherwise indistinguishable from a hang.
+          _log.info(
+            'Adopting base seq $baseSeq from peer $peerId'
+            '${peerName != null ? ' ($peerName)' : ''}: '
+            '${manifest.basePartCount ?? 0} parts, '
+            '${manifest.baseBytes ?? 0} bytes '
+            '(cursor at $lastApplied, head ${manifest.headSeq})',
+          );
+          final stopwatch = Stopwatch()..start();
           final path = await _fetchBaseToFile(
             provider,
             peerId,
             manifest,
             byName,
+            onPartDownloaded: onBaseDownloadProgress == null
+                ? null
+                : (downloaded, total) =>
+                      onBaseDownloadProgress(manifest, downloaded, total),
           );
           if (path == null) {
+            _log.warning(
+              'Base seq $baseSeq from peer $peerId is incomplete or corrupt; '
+              'will retry next sync',
+            );
             continue; // missing or corrupt base -> transient, retry next sync
           }
+          _log.info(
+            'Base seq $baseSeq from peer $peerId assembled in '
+            '${stopwatch.elapsed.inSeconds}s; applying',
+          );
           try {
             await applyBaseFile(path, manifest);
           } finally {
             await _baseSink.deleteQuietly(path);
           }
+          _log.info(
+            'Base seq $baseSeq from peer $peerId applied '
+            '(${stopwatch.elapsed.inSeconds}s total)',
+          );
           payloadsApplied++;
           appliedThrough = baseSeq;
           baseSeqApplied = baseSeq;
@@ -320,8 +354,9 @@ class ChangesetReader {
     CloudStorageProvider provider,
     String peerId,
     SyncManifest manifest,
-    Map<String, CloudFileInfo> byName,
-  ) {
+    Map<String, CloudFileInfo> byName, {
+    void Function(int downloaded, int total)? onPartDownloaded,
+  }) {
     final baseSeq = manifest.baseSeq!;
     final partCount = manifest.basePartCount ?? 0;
     // A manifest that names a base (baseSeq set) but no parts is malformed --
@@ -339,6 +374,7 @@ class ChangesetReader {
         if (pf == null) return null;
         return provider.downloadFile(pf.id);
       },
+      onPartDownloaded: onPartDownloaded,
     );
   }
 }

--- a/lib/core/services/sync/sync_service.dart
+++ b/lib/core/services/sync/sync_service.dart
@@ -13,9 +13,11 @@ import 'package:submersion/core/services/cloud_storage/cloud_storage_provider.da
 import 'package:submersion/core/services/database_service.dart';
 import 'package:submersion/core/services/logger_service.dart';
 import 'package:submersion/core/services/sync/conflict_reference.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_apply_progress.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_json_stream_reader.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_parse_client.dart';
 import 'package:submersion/core/services/sync/changeset_log/base_part_file_sink.dart';
+import 'package:submersion/core/services/sync/changeset_log/byte_progress_stream.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_codec.dart';
 import 'package:submersion/core/services/sync/changeset_log/sync_temp_dir.dart';
 import 'package:submersion/core/services/sync/changeset_log/changeset_log_layout.dart';
@@ -325,8 +327,16 @@ class SyncService {
   /// Test seam: apply a base from a local file through the streaming merge.
   @visibleForTesting
   Future<({int recordsApplied, int conflictsFound, int recordsFailed})>
-  debugApplyBaseFile(String filePath, {DateTime? lastSync}) async {
-    final r = await _applyRemoteBaseFile(filePath, lastSync);
+  debugApplyBaseFile(
+    String filePath, {
+    DateTime? lastSync,
+    void Function(double fraction)? onProgress,
+  }) async {
+    final r = await _applyRemoteBaseFile(
+      filePath,
+      lastSync,
+      onProgress: onProgress,
+    );
     return (
       recordsApplied: r.recordsApplied,
       conflictsFound: r.conflictsFound,
@@ -607,8 +617,32 @@ class SyncService {
           conflictsFound += r.conflictsFound;
           recordsFailed += r.recordsFailed;
         },
+        // A peer's base can run to hundreds of megabytes and take minutes
+        // to download and import. Spread it across the pull's share of the
+        // bar (0.4 to 0.8) so the user sees it advancing instead of reading a
+        // motionless bar as a hang and killing the app, which restarts the
+        // whole adoption from part 0 (issue #1421).
+        onBaseDownloadProgress: (manifest, downloaded, total) =>
+            _reportProgress(
+              SyncPhase.downloading,
+              0.4 + 0.15 * (downloaded / total),
+              _l10n.settings_cloudSync_progress_downloadingLibrary(
+                downloaded,
+                total,
+              ),
+            ),
         applyBaseFile: (path, manifest) async {
-          final r = await _applyRemoteBaseFile(path, lastSyncTime);
+          final r = await _applyRemoteBaseFile(
+            path,
+            lastSyncTime,
+            onProgress: (fraction) => _reportProgress(
+              SyncPhase.downloading,
+              0.55 + 0.25 * fraction,
+              _l10n.settings_cloudSync_progress_importingLibrary(
+                (fraction * 100).round(),
+              ),
+            ),
+          );
           recordsSynced += r.recordsApplied;
           conflictsFound += r.conflictsFound;
           recordsFailed += r.recordsFailed;
@@ -1646,24 +1680,54 @@ class SyncService {
   /// main isolate in BasePartFileSink.assemble -- folding it in is a deferred
   /// follow-up) and falls back to the inline path on any worker failure, so a
   /// broken isolate degrades to old behaviour and never fails or corrupts sync.
+  ///
+  /// [onProgress] receives a 0.0 to 1.0 fraction spanning the three passes
+  /// (each pass is one third), with a final 1.0 once the transaction commits.
   Future<_MergeResult> _applyRemoteBaseFile(
     String filePath,
-    DateTime? localLastSync,
-  ) async {
+    DateTime? localLastSync, {
+    void Function(double fraction)? onProgress,
+  }) async {
+    final totalBytes = await File(filePath).length();
+    final stopwatch = Stopwatch()..start();
+    _log.info('Applying peer base: $totalBytes bytes');
+    final progress = BaseApplyProgress(totalBytes, onProgress);
     BaseParseClient? client;
+    _MergeResult result;
     try {
       client = await baseParseClientSpawn(filePath);
-      return await _applyRemoteBaseFileViaWorker(client, localLastSync);
+      client.onProgress = progress.bytes;
+      result = await _applyRemoteBaseFileViaWorker(
+        client,
+        localLastSync,
+        progress,
+      );
     } catch (e, st) {
       _log.warning(
         'Base-apply worker failed; falling back to inline',
         error: e,
         stackTrace: st,
       );
-      return _applyRemoteBaseFileInline(filePath, localLastSync);
+      // Kill the (possibly wedged, memory-hungry) worker BEFORE the inline
+      // passes start competing with it for memory and file I/O.
+      await client?.dispose();
+      client = null;
+      progress.restart();
+      result = await _applyRemoteBaseFileInline(
+        filePath,
+        localLastSync,
+        progress,
+      );
     } finally {
       await client?.dispose();
     }
+    progress.done();
+    _log.info(
+      'Peer base applied in ${stopwatch.elapsed.inSeconds}s: '
+      '${result.recordsApplied} applied, ${result.conflictsFound} conflicts, '
+      '${result.recordsFailed} failed',
+    );
+    return result;
   }
 
   /// Worker-backed base apply: the file read + JSON parse run in [client]'s
@@ -1674,6 +1738,7 @@ class SyncService {
   Future<_MergeResult> _applyRemoteBaseFileViaWorker(
     BaseParseClient client,
     DateTime? localLastSync,
+    BaseApplyProgress progress,
   ) async {
     final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
 
@@ -1702,6 +1767,7 @@ class SyncService {
         if (parentTypes.contains(table) || deletionIds.containsKey(table))
           table,
     };
+    progress.beginPass(1);
     client.startDataRows(pass2Tables);
     List<({String table, Map<String, dynamic> row})>? p2batch;
     while ((p2batch = await client.nextDataBatch()) != null) {
@@ -1782,6 +1848,7 @@ class SyncService {
         batch = <Map<String, dynamic>>[];
       }
 
+      progress.beginPass(2);
       client.startDataRows(_baseApplyEntityFlags.keys.toSet());
       List<({String table, Map<String, dynamic> row})>? p3batch;
       while ((p3batch = await client.nextDataBatch()) != null) {
@@ -1823,15 +1890,20 @@ class SyncService {
   Future<_MergeResult> _applyRemoteBaseFileInline(
     String filePath,
     DateTime? localLastSync,
+    BaseApplyProgress progress,
   ) async {
     final file = File(filePath);
     final lastSyncMs = localLastSync?.millisecondsSinceEpoch;
+    // The inline parse blocks the UI isolate, so its heartbeats are what
+    // keep the bar moving; the fallback runs the whole file three times.
+    Stream<List<int>> openWithProgress() =>
+        withByteProgress(file.openRead(), onProgress: progress.consumed);
 
     // ---- Pass 1: exportedAt + deletions ----
     var baseExportedAt = 0;
     final deletions = <String, List<SyncDeletion>>{};
     await BaseJsonStreamReader().parse(
-      file.openRead(),
+      openWithProgress(),
       onScalar: (key, raw) async {
         if (key == 'exportedAt') {
           baseExportedAt = (jsonDecode(utf8.decode(raw)) as num?)?.toInt() ?? 0;
@@ -1866,8 +1938,9 @@ class SyncService {
     };
     final parentUpdatedAt = <String, Map<String, int>>{};
     final contradictedByEntity = <String, Set<String>>{};
+    progress.beginPass(1);
     await BaseJsonStreamReader().parse(
-      file.openRead(),
+      openWithProgress(),
       wantRows: (section, table) =>
           section == 'data' &&
           _baseApplyEntityFlags.containsKey(table) &&
@@ -1954,8 +2027,9 @@ class SyncService {
         batch = <Map<String, dynamic>>[];
       }
 
+      progress.beginPass(2);
       await BaseJsonStreamReader().parse(
-        file.openRead(),
+        openWithProgress(),
         wantRows: (section, table) =>
             section == 'data' && _baseApplyEntityFlags.containsKey(table),
         onRow: (section, table, rowBytes) async {

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "جارٍ سحب التغييرات...",
   "settings_cloudSync_progress_publishing": "جارٍ نشر التغييرات...",
   "settings_cloudSync_progress_uploadingLibrary": "جارٍ رفع المكتبة ({uploaded} من {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "جارٍ تنزيل المكتبة ({downloaded} من {total})",
+  "settings_cloudSync_progress_importingLibrary": "جارٍ استيراد المكتبة ({percent}%)",
   "settings_cloudSync_result_noProvider": "لم يتم إعداد أي مزود تخزين سحابي",
   "settings_cloudSync_result_notAuthenticated": "لم تتم المصادقة مع مزود التخزين السحابي",
   "settings_cloudSync_result_timedOut": "انتهت مهلة المزامنة",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Änderungen werden abgerufen...",
   "settings_cloudSync_progress_publishing": "Änderungen werden veröffentlicht...",
   "settings_cloudSync_progress_uploadingLibrary": "Bibliothek wird hochgeladen ({uploaded} von {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Bibliothek wird heruntergeladen ({downloaded} von {total})",
+  "settings_cloudSync_progress_importingLibrary": "Bibliothek wird importiert ({percent} %)",
   "settings_cloudSync_result_noProvider": "Kein Cloud-Anbieter konfiguriert",
   "settings_cloudSync_result_notAuthenticated": "Nicht beim Cloud-Anbieter authentifiziert",
   "settings_cloudSync_result_timedOut": "Zeitüberschreitung bei der Synchronisierung",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -21114,6 +21114,8 @@
   "settings_cloudSync_progress_pulling": "Pulling changes...",
   "settings_cloudSync_progress_publishing": "Publishing changes...",
   "settings_cloudSync_progress_uploadingLibrary": "Uploading library ({uploaded} of {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Downloading library ({downloaded} of {total})",
+  "settings_cloudSync_progress_importingLibrary": "Importing library ({percent}%)",
   "settings_cloudSync_result_noProvider": "No cloud provider configured",
   "settings_cloudSync_result_notAuthenticated": "Not authenticated with cloud provider",
   "settings_cloudSync_result_timedOut": "Sync timed out",
@@ -21309,6 +21311,23 @@
         "type": "int"
       },
       "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_progress_downloadingLibrary": {
+    "placeholders": {
+      "downloaded": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "@settings_cloudSync_progress_importingLibrary": {
+    "placeholders": {
+      "percent": {
         "type": "int"
       }
     }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Descargando cambios...",
   "settings_cloudSync_progress_publishing": "Publicando cambios...",
   "settings_cloudSync_progress_uploadingLibrary": "Subiendo la biblioteca ({uploaded} de {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Descargando la biblioteca ({downloaded} de {total})",
+  "settings_cloudSync_progress_importingLibrary": "Importando la biblioteca ({percent} %)",
   "settings_cloudSync_result_noProvider": "No hay ningún proveedor en la nube configurado",
   "settings_cloudSync_result_notAuthenticated": "Sin autenticar con el proveedor en la nube",
   "settings_cloudSync_result_timedOut": "Se agotó el tiempo de sincronización",

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Récupération des modifications...",
   "settings_cloudSync_progress_publishing": "Publication des modifications...",
   "settings_cloudSync_progress_uploadingLibrary": "Envoi de la bibliothèque ({uploaded} sur {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Téléchargement de la bibliothèque ({downloaded} sur {total})",
+  "settings_cloudSync_progress_importingLibrary": "Importation de la bibliothèque ({percent} %)",
   "settings_cloudSync_result_noProvider": "Aucun fournisseur cloud configuré",
   "settings_cloudSync_result_notAuthenticated": "Non authentifié auprès du fournisseur cloud",
   "settings_cloudSync_result_timedOut": "Délai de synchronisation dépassé",

--- a/lib/l10n/arb/app_he.arb
+++ b/lib/l10n/arb/app_he.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "מושך שינויים...",
   "settings_cloudSync_progress_publishing": "מפרסם שינויים...",
   "settings_cloudSync_progress_uploadingLibrary": "מעלה את הספרייה ({uploaded} מתוך {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "מוריד את הספרייה ({downloaded} מתוך {total})",
+  "settings_cloudSync_progress_importingLibrary": "מייבא את הספרייה ({percent}%)",
   "settings_cloudSync_result_noProvider": "לא הוגדר ספק ענן",
   "settings_cloudSync_result_notAuthenticated": "אין אימות מול ספק הענן",
   "settings_cloudSync_result_timedOut": "תם הזמן המוקצב לסנכרון",

--- a/lib/l10n/arb/app_hu.arb
+++ b/lib/l10n/arb/app_hu.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Változások letöltése...",
   "settings_cloudSync_progress_publishing": "Változások közzététele...",
   "settings_cloudSync_progress_uploadingLibrary": "Könyvtár feltöltése ({uploaded} / {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Könyvtár letöltése ({downloaded} / {total})",
+  "settings_cloudSync_progress_importingLibrary": "Könyvtár importálása ({percent}%)",
   "settings_cloudSync_result_noProvider": "Nincs beállítva felhőszolgáltató",
   "settings_cloudSync_result_notAuthenticated": "Nincs hitelesítve a felhőszolgáltatónál",
   "settings_cloudSync_result_timedOut": "A szinkronizálás túllépte az időkorlátot",

--- a/lib/l10n/arb/app_it.arb
+++ b/lib/l10n/arb/app_it.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Recupero delle modifiche...",
   "settings_cloudSync_progress_publishing": "Pubblicazione delle modifiche...",
   "settings_cloudSync_progress_uploadingLibrary": "Caricamento della libreria ({uploaded} di {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Download della libreria ({downloaded} di {total})",
+  "settings_cloudSync_progress_importingLibrary": "Importazione della libreria ({percent}%)",
   "settings_cloudSync_result_noProvider": "Nessun provider cloud configurato",
   "settings_cloudSync_result_notAuthenticated": "Non autenticato con il provider cloud",
   "settings_cloudSync_result_timedOut": "Sincronizzazione scaduta per timeout",

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -57881,6 +57881,21 @@ abstract class AppLocalizations {
   /// **'Uploading library ({uploaded} of {total})'**
   String settings_cloudSync_progress_uploadingLibrary(int uploaded, int total);
 
+  /// No description provided for @settings_cloudSync_progress_downloadingLibrary.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading library ({downloaded} of {total})'**
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  );
+
+  /// No description provided for @settings_cloudSync_progress_importingLibrary.
+  ///
+  /// In en, this message translates to:
+  /// **'Importing library ({percent}%)'**
+  String settings_cloudSync_progress_importingLibrary(int percent);
+
   /// No description provided for @settings_cloudSync_result_noProvider.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -34868,6 +34868,19 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'جارٍ تنزيل المكتبة ($downloaded من $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'جارٍ استيراد المكتبة ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'لم يتم إعداد أي مزود تخزين سحابي';
 

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -35143,6 +35143,19 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Bibliothek wird heruntergeladen ($downloaded von $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Bibliothek wird importiert ($percent %)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Kein Cloud-Anbieter konfiguriert';
 

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -34680,6 +34680,19 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Downloading library ($downloaded of $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Importing library ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'No cloud provider configured';
 

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -35258,6 +35258,19 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Descargando la biblioteca ($downloaded de $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Importando la biblioteca ($percent %)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'No hay ningún proveedor en la nube configurado';
 

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -35311,6 +35311,19 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Téléchargement de la bibliothèque ($downloaded sur $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Importation de la bibliothèque ($percent %)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Aucun fournisseur cloud configuré';
 

--- a/lib/l10n/arb/app_localizations_he.dart
+++ b/lib/l10n/arb/app_localizations_he.dart
@@ -34520,6 +34520,19 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'מוריד את הספרייה ($downloaded מתוך $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'מייבא את הספרייה ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider => 'לא הוגדר ספק ענן';
 
   @override

--- a/lib/l10n/arb/app_localizations_hu.dart
+++ b/lib/l10n/arb/app_localizations_hu.dart
@@ -35062,6 +35062,19 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Könyvtár letöltése ($downloaded / $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Könyvtár importálása ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Nincs beállítva felhőszolgáltató';
 

--- a/lib/l10n/arb/app_localizations_it.dart
+++ b/lib/l10n/arb/app_localizations_it.dart
@@ -35214,6 +35214,19 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Download della libreria ($downloaded di $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Importazione della libreria ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Nessun provider cloud configurato';
 

--- a/lib/l10n/arb/app_localizations_nl.dart
+++ b/lib/l10n/arb/app_localizations_nl.dart
@@ -34975,6 +34975,19 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Bibliotheek downloaden ($downloaded van $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Bibliotheek importeren ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Geen cloudprovider ingesteld';
 

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -35227,6 +35227,19 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return 'Baixando a biblioteca ($downloaded de $total)';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return 'Importando a biblioteca ($percent%)';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider =>
       'Nenhum provedor de nuvem configurado';
 

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -33138,6 +33138,19 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String settings_cloudSync_progress_downloadingLibrary(
+    int downloaded,
+    int total,
+  ) {
+    return '正在下载资料库（$downloaded/$total）';
+  }
+
+  @override
+  String settings_cloudSync_progress_importingLibrary(int percent) {
+    return '正在导入资料库（$percent%）';
+  }
+
+  @override
   String get settings_cloudSync_result_noProvider => '未配置云服务商';
 
   @override

--- a/lib/l10n/arb/app_nl.arb
+++ b/lib/l10n/arb/app_nl.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Wijzigingen ophalen...",
   "settings_cloudSync_progress_publishing": "Wijzigingen publiceren...",
   "settings_cloudSync_progress_uploadingLibrary": "Bibliotheek uploaden ({uploaded} van {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Bibliotheek downloaden ({downloaded} van {total})",
+  "settings_cloudSync_progress_importingLibrary": "Bibliotheek importeren ({percent}%)",
   "settings_cloudSync_result_noProvider": "Geen cloudprovider ingesteld",
   "settings_cloudSync_result_notAuthenticated": "Niet geverifieerd bij de cloudprovider",
   "settings_cloudSync_result_timedOut": "Time-out bij de synchronisatie",

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "Baixando alterações...",
   "settings_cloudSync_progress_publishing": "Publicando alterações...",
   "settings_cloudSync_progress_uploadingLibrary": "Enviando a biblioteca ({uploaded} de {total})",
+  "settings_cloudSync_progress_downloadingLibrary": "Baixando a biblioteca ({downloaded} de {total})",
+  "settings_cloudSync_progress_importingLibrary": "Importando a biblioteca ({percent}%)",
   "settings_cloudSync_result_noProvider": "Nenhum provedor de nuvem configurado",
   "settings_cloudSync_result_notAuthenticated": "Sem autenticação no provedor de nuvem",
   "settings_cloudSync_result_timedOut": "Tempo esgotado na sincronização",

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -10291,6 +10291,8 @@
   "settings_cloudSync_progress_pulling": "正在拉取更改...",
   "settings_cloudSync_progress_publishing": "正在发布更改...",
   "settings_cloudSync_progress_uploadingLibrary": "正在上传资料库（{uploaded}/{total}）",
+  "settings_cloudSync_progress_downloadingLibrary": "正在下载资料库（{downloaded}/{total}）",
+  "settings_cloudSync_progress_importingLibrary": "正在导入资料库（{percent}%）",
   "settings_cloudSync_result_noProvider": "未配置云服务商",
   "settings_cloudSync_result_notAuthenticated": "未通过云服务商的身份验证",
   "settings_cloudSync_result_timedOut": "同步超时",

--- a/test/core/services/sync/changeset_log/base_apply_progress_test.dart
+++ b/test/core/services/sync/changeset_log/base_apply_progress_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/base_apply_progress.dart';
+
+void main() {
+  List<double> drive(void Function(BaseApplyProgress p) script) {
+    final seen = <double>[];
+    final p = BaseApplyProgress(1000, seen.add);
+    script(p);
+    return seen;
+  }
+
+  test('maps three passes onto thirds and ends at 1.0', () {
+    final seen = drive((p) {
+      p.bytes(500, 1000);
+      p.bytes(1000, 1000);
+      p.beginPass(1);
+      p.bytes(1000, 1000);
+      p.beginPass(2);
+      p.bytes(300, 1000);
+      p.done();
+    });
+    expect(seen.first, closeTo(1 / 6, 1e-9));
+    expect(seen.last, 1.0);
+    expect(
+      seen,
+      containsAllInOrder([closeTo(1 / 3, 1e-9), closeTo(2 / 3, 1e-9)]),
+    );
+    for (var i = 1; i < seen.length; i++) {
+      expect(seen[i], greaterThanOrEqualTo(seen[i - 1]));
+    }
+  });
+
+  test('the inline path reports through consumed bytes against the total', () {
+    final seen = drive((p) => p.consumed(250));
+    expect(seen, [closeTo(0.25 / 3, 1e-9)]);
+  });
+
+  test('a restart after a mid-apply worker failure keeps every inline pass '
+      'visible, never rewinds, and still ends at 1.0', () {
+    // Worker dies three quarters into pass 3, then the inline fallback runs
+    // all three passes over the same file (issue #1421 review finding).
+    final seen = drive((p) {
+      p.bytes(1000, 1000);
+      p.beginPass(1);
+      p.bytes(1000, 1000);
+      p.beginPass(2);
+      p.bytes(750, 1000);
+      p.restart();
+      p.consumed(500);
+      p.consumed(1000);
+      p.beginPass(1);
+      p.consumed(500);
+      p.consumed(1000);
+      p.beginPass(2);
+      p.consumed(500);
+      p.done();
+    });
+    // Five ticks precede the restart (a pass boundary may repeat a value).
+    const preRestart = 5;
+    for (var i = 1; i < preRestart; i++) {
+      expect(seen[i], greaterThanOrEqualTo(seen[i - 1]));
+    }
+    expect(seen[preRestart - 1], closeTo(2.75 / 3, 1e-9));
+    // Every inline tick must land above the worker's high-water mark and
+    // keep climbing: a stale pass index would park the bar at 100% here.
+    final inline = seen.sublist(preRestart);
+    expect(inline.first, greaterThan(seen[preRestart - 1]));
+    for (var i = 1; i < inline.length; i++) {
+      expect(inline[i], greaterThanOrEqualTo(inline[i - 1]));
+    }
+    // Seven inline reports, two of them pass-boundary repeats: five distinct
+    // climbing values below 1.0, then the final 1.0.
+    expect(inline.toSet().length, 6);
+    expect(seen.last, 1.0);
+    // Every inline tick before done() must stay strictly below 1.0 so the
+    // bar keeps moving through the fallback instead of parking at 100%.
+    for (final v in seen.sublist(0, seen.length - 1)) {
+      expect(v, lessThan(1.0));
+    }
+  });
+}

--- a/test/core/services/sync/changeset_log/base_parse_client_test.dart
+++ b/test/core/services/sync/changeset_log/base_parse_client_test.dart
@@ -33,6 +33,31 @@ void _workerReadyThenSilent(List<Object> args) {
   cmdPort.listen((_) {}); // stay alive, but never reply
 }
 
+/// Test worker that answers 'deletions' only after a long scan, but sends a
+/// progress heartbeat every 100 ms while it works, the shape of a real worker
+/// grinding through a multi-hundred-MB base.
+void _workerSlowWithHeartbeats(List<Object> args) {
+  final toMain = args[0] as SendPort;
+  final cmdPort = ReceivePort();
+  toMain.send(<String, Object>{'type': 'ready', 'port': cmdPort.sendPort});
+  cmdPort.listen((msg) async {
+    if ((msg as Map)['cmd'] != 'deletions') return;
+    for (var i = 1; i <= 10; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      toMain.send(<String, Object>{
+        'type': 'progress',
+        'bytes': i * 10,
+        'total': 100,
+      });
+    }
+    toMain.send(<String, Object>{
+      'type': 'deletions',
+      'exportedAt': 5,
+      'rows': <Object>[],
+    });
+  });
+}
+
 void main() {
   late Directory tmp;
   setUp(() => tmp = Directory.systemTemp.createTempSync('s3base'));
@@ -238,4 +263,66 @@ void main() {
       throwsA(isA<BaseParseException>()),
     );
   });
+
+  test(
+    'progress heartbeats keep a slow worker alive past the message timeout',
+    () async {
+      // A 730 MB base takes a single pass well over 60 s on a phone. The
+      // timeout must measure worker SILENCE, not reply latency: as long as the
+      // worker keeps reporting bytes consumed, the pull waits for it instead
+      // of degrading to the UI-isolate parse (issue #1421).
+      final f = _writeBase(tmp, {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': <String, dynamic>{},
+      });
+      final original = BaseParseClient.messageTimeout;
+      BaseParseClient.messageTimeout = const Duration(milliseconds: 300);
+      final seen = <(int, int)>[];
+      try {
+        final client = await BaseParseClient.spawn(
+          f.path,
+          entryPoint: _workerSlowWithHeartbeats,
+          onProgress: (bytes, total) => seen.add((bytes, total)),
+        );
+        final r = await client.readScalarsAndDeletions();
+        await client.dispose();
+        expect(r.exportedAt, 5);
+      } finally {
+        BaseParseClient.messageTimeout = original;
+      }
+      expect(seen.length, 10);
+      expect(seen.last, (100, 100));
+    },
+  );
+
+  test(
+    'the real worker reports bytes consumed, ending at the file length',
+    () async {
+      final f = _writeBase(tmp, {
+        'exportedAt': 1,
+        'deletions': <String, dynamic>{},
+        'data': {
+          'dives': [
+            for (var i = 0; i < 50; i++) {'id': 'd$i', 'updatedAt': i},
+          ],
+        },
+      });
+      final length = f.lengthSync();
+      final seen = <(int, int)>[];
+      final client = await BaseParseClient.spawn(
+        f.path,
+        onProgress: (bytes, total) => seen.add((bytes, total)),
+      );
+      await client.readScalarsAndDeletions();
+      expect(seen, isNotEmpty, reason: 'pass 1 must report progress');
+      expect(seen.last, (length, length));
+
+      seen.clear();
+      client.startDataRows({'dives'});
+      while (await client.nextDataBatch() != null) {}
+      await client.dispose();
+      expect(seen.last, (length, length));
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
+++ b/test/core/services/sync/changeset_log/base_part_file_sink_test.dart
@@ -211,4 +211,19 @@ void main() {
       },
     );
   });
+
+  test('reports each part as it lands, as (downloaded, total)', () async {
+    final parts = [bytes('a'), bytes('b'), bytes('c')];
+    final seen = <(int, int)>[];
+    final path = await sink.assemble(
+      name: 'base',
+      partCount: 3,
+      wholeChecksum: null,
+      partChecksums: [for (final p in parts) BaseChunker.checksum(p)],
+      downloadPart: (i) async => parts[i],
+      onPartDownloaded: (downloaded, total) => seen.add((downloaded, total)),
+    );
+    expect(path, isNotNull);
+    expect(seen, [(1, 3), (2, 3), (3, 3)]);
+  });
 }

--- a/test/core/services/sync/changeset_log/byte_progress_stream_test.dart
+++ b/test/core/services/sync/changeset_log/byte_progress_stream_test.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/services/sync/changeset_log/byte_progress_stream.dart';
+
+void main() {
+  Future<(List<int> passed, List<int> reports)> run(
+    List<List<int>> chunks,
+    int interval,
+  ) async {
+    final reports = <int>[];
+    final passed = <int>[];
+    await for (final c in withByteProgress(
+      Stream.fromIterable(chunks),
+      onProgress: reports.add,
+      interval: interval,
+    )) {
+      passed.addAll(c);
+    }
+    return (passed, reports);
+  }
+
+  test('passes every byte through unchanged', () async {
+    final (passed, _) = await run([
+      [1, 2, 3],
+      [4],
+      [5, 6],
+    ], 100);
+    expect(passed, [1, 2, 3, 4, 5, 6]);
+  });
+
+  test('reports once per interval crossed and once more at the end', () async {
+    final (_, reports) = await run([
+      List.filled(3, 0),
+      List.filled(3, 0), // crosses 4 at 6
+      List.filled(1, 0),
+      List.filled(5, 0), // crosses 10 at 12
+      List.filled(1, 0),
+    ], 4);
+    expect(reports, [6, 12, 13]);
+  });
+
+  test('a stream shorter than one interval still reports its total', () async {
+    final (_, reports) = await run([
+      [1, 2],
+    ], 1 << 20);
+    expect(reports, [2]);
+  });
+
+  test('an empty stream reports zero', () async {
+    final (_, reports) = await run([], 8);
+    expect(reports, [0]);
+  });
+}

--- a/test/core/services/sync/changeset_log/changeset_reader_test.dart
+++ b/test/core/services/sync/changeset_log/changeset_reader_test.dart
@@ -326,4 +326,28 @@ void main() {
     expect(result.retiredPeerIds, isEmpty);
     expect(result.retiredPeerHasFiles, isFalse);
   });
+
+  test(
+    'reports base download progress per part, naming the peer manifest',
+    () async {
+      await DiveRepository().createDive(
+        createTestDiveWithBottomTime(id: 'd1', diveNumber: 1),
+      );
+      final peerId = await publishAsPeer();
+
+      final seen = <(String, int, int)>[];
+      await reader.pull(
+        provider: provider,
+        selfDeviceId: 'progress-reader',
+        folderId: folder,
+        apply: spyApply,
+        applyBaseFile: spyApplyBaseFile(applied),
+        onBaseDownloadProgress: (manifest, downloaded, total) =>
+            seen.add((manifest.deviceId, downloaded, total)),
+      );
+
+      // A tiny library publishes as a single part, so exactly one tick.
+      expect(seen, [(peerId, 1, 1)]);
+    },
+  );
 }

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -312,4 +312,63 @@ void main() {
       expect(counts.recordsFailed, 0);
     },
   );
+
+  group('base apply progress', () {
+    Future<List<double>> applyWithProgress(SyncService svc) async {
+      await _seedRichLibrary();
+      final payload = await SyncDataSerializer().exportData(
+        deviceId: 'peer',
+        deletions: await SyncRepository().getAllDeletions(),
+      );
+      await tearDownTestDatabase();
+      await setUpTestDatabase();
+      final tmpDir = await Directory.systemTemp.createTemp('parity_progress');
+      final tmp = File('${tmpDir.path}/base.json');
+      await tmp.writeAsBytes(
+        utf8.encode(SyncDataSerializer().serializePayload(payload)),
+      );
+      final seen = <double>[];
+      await svc.debugApplyBaseFile(tmp.path, onProgress: seen.add);
+      await tmpDir.delete(recursive: true);
+      return seen;
+    }
+
+    void expectMonotonicToOne(List<double> seen) {
+      expect(seen, isNotEmpty, reason: 'a base apply must report progress');
+      for (var i = 1; i < seen.length; i++) {
+        expect(
+          seen[i],
+          greaterThanOrEqualTo(seen[i - 1]),
+          reason: 'progress must never move backwards',
+        );
+      }
+      expect(seen.first, greaterThanOrEqualTo(0.0));
+      expect(seen.last, 1.0);
+    }
+
+    test('the worker path reports monotonic progress ending at 1.0', () async {
+      final seen = await applyWithProgress(
+        SyncService(
+          syncRepository: SyncRepository(),
+          serializer: SyncDataSerializer(),
+        ),
+      );
+      expectMonotonicToOne(seen);
+    });
+
+    test(
+      'the inline fallback reports monotonic progress ending at 1.0',
+      () async {
+        final seen = await applyWithProgress(
+          SyncService(
+              syncRepository: SyncRepository(),
+              serializer: SyncDataSerializer(),
+            )
+            ..baseParseClientSpawn = (_) async =>
+                throw StateError('forced failure'),
+        );
+        expectMonotonicToOne(seen);
+      },
+    );
+  });
 }

--- a/test/core/services/sync/sync_base_streaming_parity_test.dart
+++ b/test/core/services/sync/sync_base_streaming_parity_test.dart
@@ -323,14 +323,17 @@ void main() {
       await tearDownTestDatabase();
       await setUpTestDatabase();
       final tmpDir = await Directory.systemTemp.createTemp('parity_progress');
-      final tmp = File('${tmpDir.path}/base.json');
-      await tmp.writeAsBytes(
-        utf8.encode(SyncDataSerializer().serializePayload(payload)),
-      );
-      final seen = <double>[];
-      await svc.debugApplyBaseFile(tmp.path, onProgress: seen.add);
-      await tmpDir.delete(recursive: true);
-      return seen;
+      try {
+        final tmp = File('${tmpDir.path}/base.json');
+        await tmp.writeAsBytes(
+          utf8.encode(SyncDataSerializer().serializePayload(payload)),
+        );
+        final seen = <double>[];
+        await svc.debugApplyBaseFile(tmp.path, onProgress: seen.add);
+        return seen;
+      } finally {
+        await tmpDir.delete(recursive: true);
+      }
     }
 
     void expectMonotonicToOne(List<double> seen) {


### PR DESCRIPTION
Fixes #1421

## Problem

The reporter's iPhone sat at "Pulling changes..." with a motionless progress bar and 173 pending changes. The debug log shows the device downloading a peer's full base snapshot, 88 parts of 8 MiB (about 730 MB), then going silent. Nothing was hung: the base was being applied, but nothing on the consume side reported progress or logged between the 40% "Pulling" tick and the 80% "Publishing" tick, and the apply itself was far slower than it needed to be.

Three defects on the consume side of a peer base (`ChangesetReader.pull` -> `BasePartFileSink.assemble` -> `SyncService._applyRemoteBaseFile`):

1. **Worker timeout bounded the wrong quantity.** `BaseParseClient.messageTimeout` (60 s) applied per reply, but pass 1 is a single reply after scanning the entire file, and a pass-2 batch may first have to skip a several-hundred-MB table. On timeout the service silently fell back to the same three passes on the UI isolate, which freezes the app for the rest of the apply.
2. **Streaming parser throughput.** `BaseJsonStreamReader` stepped its state machine once per byte and appended captured bytes through `BytesBuilder(copy: false).addByte`, which allocates a one-element list per byte. Skipped tables were copied too.
3. **No progress or logging** during base download or apply.

## Changes

- **Worker liveness.** The parse worker sends `{'type': 'progress', 'bytes', 'total'}` heartbeats every 4 MiB and at the end of each pass (new `withByteProgress` in `byte_progress_stream.dart`). The client treats them as liveness and re-arms the timeout, so it now only fires after 60 s of worker silence.
- **Parser fast path.** String bodies are consumed as runs (only a quote or a backslash can change state inside one), skipped bytes are never copied, and the builders copy into a grown buffer. A differential fuzz of 400 random documents across 8 chunkings, plus an exhaustive two-chunk split at every offset of a boundary-case document, produced identical output to the previous implementation.
- **Visible progress.** Per-part download fills 40% to 55% (`onBaseDownloadProgress`), the three import passes fill 55% to 80% (`BaseApplyProgress`, monotonic; a worker failure mid-apply disposes the worker first and restarts the inline passes into the unspent share of the bar). Two new localized messages in all eleven ARB files.
- **Logging.** The adoption logs peer, part count, byte size, cursor position vs head, assembly time, each pass, and the final counts, so a future debug log shows steady progress instead of minutes of silence.

## Measured

200 MB synthetic base, JIT on an M-series Mac, one pass:

| Pass shape | Before | After |
| --- | --- | --- |
| Blob-heavy rows, skip or collect | 25 to 35 MB/s | 400 to 1300 MB/s |
| Small-field rows, skip passes | about 30 MB/s | about 200 MB/s |
| Small-field rows with jsonDecode | about 25 MB/s | about 95 MB/s |

## Tests

Nine new tests: heartbeat keeps a slow worker alive past the timeout; the real worker reports bytes ending at the file length; `withByteProgress` interval and end reporting; sink per-part callback; reader per-part pass-through naming the peer manifest; monotonic progress ending at 1.0 on both the worker and inline apply paths; and the restart mapping after a mid-apply worker failure.

## Not addressed here

- The apply is still one deferred-FK transaction, so an app kill mid-way restarts from part 0 on the next sync.
- A peer lapped by compaction re-merges the whole library through LWW even though it already holds most of it.
- The same log shows `Failed to get settings for diver ... Bad state: Too many elements`: `diver_settings` has no uniqueness on `diverId`, so two devices creating a row for the same diver produce two rows.
