### PR TITLE
feat(sync): garbage-collect tombstones on libraries that never sync

### DIFF
--- a/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
+++ b/docs/superpowers/specs/2026-08-29-storage-reclamation-design.md
@@ -432,15 +432,44 @@ Backup retention counts are out of scope here; they belong to issue #1376.
 ### Slice E: tombstone GC for local-only libraries
 
 Reach `clearAcknowledgedDeletions` when sync is not configured, using the
-existing `SyncLiveness.gcFloorMillis` 30-day floor and the existing
-`TombstoneGcDecision.unbounded()`.
+existing `SyncLiveness.gcFloorMillis` 30-day floor and a null horizon, which
+is the `TombstoneGcDecision.unbounded()` branch the cloud path already takes
+when no live peer constrains GC. A never-synced device is that case with an
+empty fleet, so no new deletion logic is needed, only a second caller.
 
 The gate must be precise. A device that has never synced can safely purge
 tombstones, because a peer joining later adopts a full base publish rather than
 replaying our log. A device that *has* synced and then went local-only must not
 purge, because peers still need its tombstones to converge. So the condition is
-"no provider configured and no prior sync has ever occurred", evidenced by the
-absence of peer cursors, not merely "sync is currently off".
+"no provider configured and no prior sync has ever occurred", not merely "sync
+is currently off".
+
+"No prior sync" is evidenced by the absence of four durable signals, any one
+of which blocks GC:
+
+| Signal | Why it is read |
+| --- | --- |
+| `sync_metadata.lastSyncTimestamp` | Set at the tail of every successful sync; sign-out does not clear it |
+| any `sync_peer_cursors` row | This device consumed a peer's log |
+| any `local_publish_states` row | This device published or adopted a base. A single-device cloud library has no peers and so no peer cursor; this row is the only transport-side trace it ever synced |
+| `sync_metadata.lastAcceptedEpochId` | Survives the user-facing Reset Sync State, which wipes the other three |
+
+Peer cursors alone, as first drafted, were too weak: a single-device cloud
+library leaves none, so a signed-out device could have purged tombstones its
+cloud log still owed a later joiner.
+
+Implementation: `LocalOnlyTombstoneGc` in
+`lib/core/services/sync/changeset_log/`, in the `MediaOrphanBacklogSweep`
+shape (constructed inline in `startup_page.dart`, `unawaited`, swallow and
+log). Runs every launch; the probe is one metadata read and two indexed
+existence checks. `SyncHistoryEvidence` separates the signals from the
+decision so the gate is a pure function under test.
+
+Known residual, accepted: a user who runs Reset Sync State and then signs out
+erases all four signals, so a reconnect more than 30 days later could
+resurrect rows deleted in between. That pair of actions is already a deliberate
+cold start of the sync transport, and the status quo for every other user is a
+log that never shrinks.
 
 This is the whole of item 6. Item 6b is a separate issue.
 

--- a/lib/core/presentation/pages/startup_page.dart
+++ b/lib/core/presentation/pages/startup_page.dart
@@ -13,7 +13,11 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'package:submersion/app.dart' show resolveAppLocale;
 import 'package:submersion/app.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
 import 'package:submersion/core/services/storage/scratch_sweep.dart';
+import 'package:submersion/core/services/sync/changeset_log/local_only_tombstone_gc.dart';
+import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
 import 'package:submersion/core/database/database.dart';
 import 'package:submersion/core/database/database_engine_preflight.dart';
 import 'package:submersion/core/database/database_version_exception.dart';
@@ -717,6 +721,27 @@ class _StartupWrapperState extends State<StartupWrapper>
       } catch (e, stackTrace) {
         debugPrint(
           'Orphaned-media backlog sweep failed (will retry): $e\n$stackTrace',
+        );
+      }
+    }());
+
+    // Tombstone GC for a library that never syncs, every launch. The cloud
+    // path runs GC at the tail of a successful sync, which a device with no
+    // provider never reaches, so its deletion log otherwise grows forever.
+    // Gated on there being no trace of a prior sync: a device that synced
+    // and then went local-only still owes its peers those tombstones. Same
+    // fire-and-forget shape as the media sweep above, for the same reasons.
+    unawaited(() async {
+      try {
+        final db = DatabaseService.instance.database;
+        await LocalOnlyTombstoneGc(
+          syncRepository: SyncRepository(database: db),
+          peerCursors: PeerCursorStore(db),
+          publishStates: PublishStateStore(db),
+        ).run();
+      } catch (e, stackTrace) {
+        debugPrint(
+          'Local-only tombstone GC failed (will retry): $e\n$stackTrace',
         );
       }
     }());

--- a/lib/core/services/sync/changeset_log/local_only_tombstone_gc.dart
+++ b/lib/core/services/sync/changeset_log/local_only_tombstone_gc.dart
@@ -89,13 +89,17 @@ class LocalOnlyTombstoneGc {
   final PublishStateStore _publishStates;
   final _log = LoggerService.forClass(LocalOnlyTombstoneGc);
 
+  /// One metadata read and two indexed existence checks. The three metadata
+  /// signals come off a single row rather than through the repository's
+  /// per-field accessors, each of which would re-read it.
   Future<SyncHistoryEvidence> gatherEvidence() async {
+    final metadata = await _syncRepository.getOrCreateMetadata();
     return SyncHistoryEvidence(
-      providerConfigured: await _syncRepository.getCloudProvider() != null,
-      hasLastSyncTime: await _syncRepository.getLastSyncTime() != null,
+      providerConfigured: metadata.syncProvider != null,
+      hasLastSyncTime: metadata.lastSyncTimestamp != null,
       hasPeerCursors: await _peerCursors.hasAny(),
       hasPublishState: await _publishStates.hasAny(),
-      hasAcceptedEpoch: await _syncRepository.getLastAcceptedEpochId() != null,
+      hasAcceptedEpoch: metadata.lastAcceptedEpochId != null,
     );
   }
 

--- a/lib/core/services/sync/changeset_log/local_only_tombstone_gc.dart
+++ b/lib/core/services/sync/changeset_log/local_only_tombstone_gc.dart
@@ -1,0 +1,116 @@
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/services/logger_service.dart';
+import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_liveness.dart';
+
+/// Every durable trace that this device has taken part in a sync, read once
+/// so the GC decision is a pure function of them.
+///
+/// Sign-out clears only the provider and the remote file id, so the other
+/// four survive it and keep a formerly synced device from purging tombstones
+/// its cloud log still owes a peer. The user-facing Reset Sync State wipes the
+/// cursor and publish rows and the last sync time but leaves the accepted
+/// epoch, which is why the epoch is read as well.
+class SyncHistoryEvidence {
+  const SyncHistoryEvidence({
+    required this.providerConfigured,
+    required this.hasLastSyncTime,
+    required this.hasPeerCursors,
+    required this.hasPublishState,
+    required this.hasAcceptedEpoch,
+  });
+
+  /// A cloud provider is connected. The cloud path owns GC in that case: it
+  /// computes the fleet-acked horizon from live peer manifests at the tail of
+  /// every successful sync.
+  final bool providerConfigured;
+
+  /// `sync_metadata.lastSyncTimestamp` is set.
+  final bool hasLastSyncTime;
+
+  /// At least one `sync_peer_cursors` row: this device consumed a peer's log.
+  final bool hasPeerCursors;
+
+  /// At least one `local_publish_states` row: this device published a base or
+  /// adopted one. The only trace a single-device cloud library leaves.
+  final bool hasPublishState;
+
+  /// `sync_metadata.lastAcceptedEpochId` is set.
+  final bool hasAcceptedEpoch;
+
+  bool get hasEverSynced =>
+      hasLastSyncTime || hasPeerCursors || hasPublishState || hasAcceptedEpoch;
+
+  /// Tombstones may be purged past the floor only on a device that has no
+  /// provider connected AND has never synced. A never-synced device has no
+  /// peer that could hold the deleted rows, and a device joining a library
+  /// later adopts the cloud's base rather than replaying this log. A device
+  /// that has synced and then went local-only must keep its tombstones: the
+  /// peers it left behind still need them to converge when it returns.
+  bool get allowsLocalOnlyGc => !providerConfigured && !hasEverSynced;
+
+  @override
+  String toString() =>
+      'SyncHistoryEvidence(provider: $providerConfigured, '
+      'lastSync: $hasLastSyncTime, peerCursors: $hasPeerCursors, '
+      'publishState: $hasPublishState, epoch: $hasAcceptedEpoch)';
+}
+
+/// Reaches tombstone GC on a device that never syncs.
+///
+/// `SyncRepository.clearAcknowledgedDeletions` is otherwise called from
+/// exactly one place, the tail of a successful cloud sync, so a library that
+/// never configured a provider keeps every tombstone forever. This runs the
+/// same deletion with the same 30-day floor and a null horizon, which is the
+/// branch the cloud path already takes when no live peer constrains it
+/// (`TombstoneGcDecision.unbounded()`): a never-synced device is that case
+/// with an empty fleet.
+///
+/// Runs on every launch, unawaited, in the shape of `MediaOrphanBacklogSweep`:
+/// the probe is one metadata read and two indexed existence checks, and the
+/// delete is a no-op on a library with nothing past the floor.
+///
+/// Known residual: a user who runs Reset Sync State and then signs out erases
+/// every trace in [SyncHistoryEvidence], so a reconnect more than 30 days
+/// later could resurrect rows deleted in between. That pair of actions is
+/// already a deliberate cold start of the sync transport.
+class LocalOnlyTombstoneGc {
+  LocalOnlyTombstoneGc({
+    required SyncRepository syncRepository,
+    required PeerCursorStore peerCursors,
+    required PublishStateStore publishStates,
+  }) : _syncRepository = syncRepository,
+       _peerCursors = peerCursors,
+       _publishStates = publishStates;
+
+  final SyncRepository _syncRepository;
+  final PeerCursorStore _peerCursors;
+  final PublishStateStore _publishStates;
+  final _log = LoggerService.forClass(LocalOnlyTombstoneGc);
+
+  Future<SyncHistoryEvidence> gatherEvidence() async {
+    return SyncHistoryEvidence(
+      providerConfigured: await _syncRepository.getCloudProvider() != null,
+      hasLastSyncTime: await _syncRepository.getLastSyncTime() != null,
+      hasPeerCursors: await _peerCursors.hasAny(),
+      hasPublishState: await _publishStates.hasAny(),
+      hasAcceptedEpoch: await _syncRepository.getLastAcceptedEpochId() != null,
+    );
+  }
+
+  /// Returns whether a purge ran. Throws on repository failure so the caller
+  /// can log it; the next launch simply runs again.
+  Future<bool> run({DateTime? now}) async {
+    final evidence = await gatherEvidence();
+    if (!evidence.allowsLocalOnlyGc) return false;
+
+    final at = now ?? DateTime.now();
+    await _syncRepository.clearAcknowledgedDeletions(
+      upToHlc: null,
+      floorCutoffMillis: at.millisecondsSinceEpoch - SyncLiveness.gcFloorMillis,
+    );
+    _log.info('Local-only tombstone GC ran: $evidence');
+    return true;
+  }
+}

--- a/lib/core/services/sync/changeset_log/peer_cursor_store.dart
+++ b/lib/core/services/sync/changeset_log/peer_cursor_store.dart
@@ -48,6 +48,18 @@ class PeerCursorStore {
         );
   }
 
+  /// Whether any peer cursor exists for any provider. A cursor is written the
+  /// first time this device consumes a peer's log, so a true here is proof
+  /// the device has synced against at least one other device.
+  Future<bool> hasAny() async {
+    final row =
+        await (_db.selectOnly(_db.syncPeerCursors)
+              ..addColumns([_db.syncPeerCursors.peerDeviceId])
+              ..limit(1))
+            .getSingleOrNull();
+    return row != null;
+  }
+
   /// Drop every cursor for [provider] -- used on backend switch and on
   /// stale-restore recovery so the device re-pulls each peer from scratch.
   Future<void> resetForProvider(String provider) async {

--- a/lib/core/services/sync/changeset_log/publish_state_store.dart
+++ b/lib/core/services/sync/changeset_log/publish_state_store.dart
@@ -57,6 +57,19 @@ class PublishStateStore {
         );
   }
 
+  /// Whether a publish row exists for any provider. Written by the first
+  /// base publish or adopt, so a true here is proof this device has synced
+  /// even when it never had a peer (a single-device cloud library leaves no
+  /// peer cursor, only this row).
+  Future<bool> hasAny() async {
+    final row =
+        await (_db.selectOnly(_db.localPublishStates)
+              ..addColumns([_db.localPublishStates.provider])
+              ..limit(1))
+            .getSingleOrNull();
+    return row != null;
+  }
+
   /// Drop publish state for [provider] -- used on backend switch so the device
   /// republishes a base as if new on the new backend.
   Future<void> resetForProvider(String provider) async {

--- a/test/core/services/sync/changeset_log/local_only_tombstone_gc_test.dart
+++ b/test/core/services/sync/changeset_log/local_only_tombstone_gc_test.dart
@@ -1,0 +1,212 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/data/repositories/sync_repository.dart';
+import 'package:submersion/core/database/database.dart';
+import 'package:submersion/core/services/sync/changeset_log/local_only_tombstone_gc.dart';
+import 'package:submersion/core/services/sync/changeset_log/peer_cursor_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/publish_state_store.dart';
+import 'package:submersion/core/services/sync/changeset_log/sync_liveness.dart';
+
+void main() {
+  group('SyncHistoryEvidence', () {
+    const neverSynced = SyncHistoryEvidence(
+      providerConfigured: false,
+      hasLastSyncTime: false,
+      hasPeerCursors: false,
+      hasPublishState: false,
+      hasAcceptedEpoch: false,
+    );
+
+    test('a device with no provider and no history may GC', () {
+      expect(neverSynced.hasEverSynced, isFalse);
+      expect(neverSynced.allowsLocalOnlyGc, isTrue);
+    });
+
+    test('a connected provider blocks GC even with no history', () {
+      // The cloud path owns GC while a provider is connected: it computes
+      // the fleet-acked horizon from live peer manifests. Running the local
+      // purge as well would race it with a weaker gate.
+      const e = SyncHistoryEvidence(
+        providerConfigured: true,
+        hasLastSyncTime: false,
+        hasPeerCursors: false,
+        hasPublishState: false,
+        hasAcceptedEpoch: false,
+      );
+      expect(e.allowsLocalOnlyGc, isFalse);
+    });
+
+    test('any single trace of a prior sync blocks GC', () {
+      const traces = [
+        SyncHistoryEvidence(
+          providerConfigured: false,
+          hasLastSyncTime: true,
+          hasPeerCursors: false,
+          hasPublishState: false,
+          hasAcceptedEpoch: false,
+        ),
+        SyncHistoryEvidence(
+          providerConfigured: false,
+          hasLastSyncTime: false,
+          hasPeerCursors: true,
+          hasPublishState: false,
+          hasAcceptedEpoch: false,
+        ),
+        SyncHistoryEvidence(
+          providerConfigured: false,
+          hasLastSyncTime: false,
+          hasPeerCursors: false,
+          hasPublishState: true,
+          hasAcceptedEpoch: false,
+        ),
+        SyncHistoryEvidence(
+          providerConfigured: false,
+          hasLastSyncTime: false,
+          hasPeerCursors: false,
+          hasPublishState: false,
+          hasAcceptedEpoch: true,
+        ),
+      ];
+      for (final e in traces) {
+        expect(e.hasEverSynced, isTrue, reason: '$e');
+        expect(e.allowsLocalOnlyGc, isFalse, reason: '$e');
+      }
+    });
+  });
+
+  group('LocalOnlyTombstoneGc', () {
+    late AppDatabase db;
+    late SyncRepository repo;
+    late LocalOnlyTombstoneGc gc;
+
+    final now = DateTime.utc(2026, 9, 1, 12);
+    final oldDeletedAt = now
+        .subtract(const Duration(days: 31))
+        .millisecondsSinceEpoch;
+    final youngDeletedAt = now
+        .subtract(const Duration(days: 1))
+        .millisecondsSinceEpoch;
+
+    setUp(() async {
+      db = AppDatabase(NativeDatabase.memory());
+      repo = SyncRepository(database: db);
+      gc = LocalOnlyTombstoneGc(
+        syncRepository: repo,
+        peerCursors: PeerCursorStore(db),
+        publishStates: PublishStateStore(db),
+      );
+      // Mint the metadata row (device id) so the sync clock can configure
+      // and every tombstone below carries an HLC, as it does in production.
+      await repo.getOrCreateMetadata();
+      await repo.logDeletion(
+        entityType: 'dives',
+        recordId: 'old',
+        deletedAt: oldDeletedAt,
+      );
+      await repo.logDeletion(
+        entityType: 'dives',
+        recordId: 'young',
+        deletedAt: youngDeletedAt,
+      );
+    });
+    tearDown(() => db.close());
+
+    Future<Set<String>> remaining() async =>
+        (await repo.getAllDeletions()).map((d) => d.recordId).toSet();
+
+    test('never-synced device purges tombstones past the floor only', () async {
+      expect(await gc.run(now: now), isTrue);
+      expect(await remaining(), {'young'});
+    });
+
+    test('the floor is SyncLiveness.gcFloorMillis, shared with the cloud '
+        'path', () async {
+      // Exactly at the floor is kept: the cloud path deletes strictly older.
+      final atFloor = now.millisecondsSinceEpoch - SyncLiveness.gcFloorMillis;
+      await repo.logDeletion(
+        entityType: 'dives',
+        recordId: 'at-floor',
+        deletedAt: atFloor,
+      );
+      await repo.logDeletion(
+        entityType: 'dives',
+        recordId: 'past-floor',
+        deletedAt: atFloor - 1,
+      );
+      await gc.run(now: now);
+      expect(await remaining(), {'young', 'at-floor'});
+    });
+
+    test('a connected provider leaves the log to the cloud path', () async {
+      await repo.setCloudProvider(CloudProviderType.s3);
+      expect(await gc.run(now: now), isFalse);
+      expect(await remaining(), {'old', 'young'});
+    });
+
+    test('a signed-out device that once synced keeps its tombstones', () async {
+      // Sign-out clears the provider but not the last sync time: the cloud
+      // still holds this device's log, and a peer may still need these.
+      await repo.setCloudProvider(CloudProviderType.s3);
+      await repo.updateLastSyncTime(
+        now.subtract(const Duration(days: 90)),
+        providerId: 's3',
+      );
+      await repo.setCloudProvider(null);
+
+      expect(await gc.run(now: now), isFalse);
+      expect(await remaining(), {'old', 'young'});
+    });
+
+    test('a peer cursor alone is evidence of a prior sync', () async {
+      await PeerCursorStore(
+        db,
+      ).upsert(peerDeviceId: 'peer-1', provider: 's3', lastSeqApplied: 3);
+      expect(await gc.run(now: now), isFalse);
+      expect(await remaining(), {'old', 'young'});
+    });
+
+    test('a publish state alone is evidence of a prior sync', () async {
+      // A single-device cloud library has no peers and so no peer cursors;
+      // its own publish row is the only transport-side trace it ever synced.
+      await PublishStateStore(db).upsert(
+        LocalPublishStatesCompanion(
+          provider: const Value('icloud'),
+          baseSeq: const Value(1),
+          headSeq: const Value(1),
+          updatedAt: Value(now.millisecondsSinceEpoch),
+        ),
+      );
+      expect(await gc.run(now: now), isFalse);
+      expect(await remaining(), {'old', 'young'});
+    });
+
+    test(
+      'an accepted library epoch alone is evidence of a prior sync',
+      () async {
+        // Survives the user-facing Reset Sync State, which wipes the cursor and
+        // publish rows and the last sync time but leaves the epoch in place.
+        await repo.setLastAcceptedEpochId('epoch-1');
+        expect(await gc.run(now: now), isFalse);
+        expect(await remaining(), {'old', 'young'});
+      },
+    );
+
+    test('gatherEvidence reports each signal independently', () async {
+      var e = await gc.gatherEvidence();
+      expect(e.providerConfigured, isFalse);
+      expect(e.hasLastSyncTime, isFalse);
+      expect(e.hasPeerCursors, isFalse);
+      expect(e.hasPublishState, isFalse);
+      expect(e.hasAcceptedEpoch, isFalse);
+
+      await repo.setCloudProvider(CloudProviderType.dropbox);
+      await repo.updateLastSyncTime(now, providerId: 'dropbox');
+      await repo.setLastAcceptedEpochId('epoch-2');
+      e = await gc.gatherEvidence();
+      expect(e.providerConfigured, isTrue);
+      expect(e.hasLastSyncTime, isTrue);
+      expect(e.hasAcceptedEpoch, isTrue);
+    });
+  });
+}

--- a/test/core/services/sync/changeset_log/peer_cursor_store_test.dart
+++ b/test/core/services/sync/changeset_log/peer_cursor_store_test.dart
@@ -72,4 +72,15 @@ void main() {
     expect(cursor!.lastSeqApplied, 2);
     expect(cursor.appliedHlcHigh, '00000000000010:000000:p1');
   });
+
+  test(
+    'hasAny is false on an empty table and true once any cursor exists',
+    () async {
+      expect(await store.hasAny(), isFalse);
+      await store.upsert(peerDeviceId: 'p1', provider: 's3', lastSeqApplied: 1);
+      expect(await store.hasAny(), isTrue);
+      await store.resetForProvider('s3');
+      expect(await store.hasAny(), isFalse);
+    },
+  );
 }

--- a/test/core/services/sync/changeset_log/publish_state_store_test.dart
+++ b/test/core/services/sync/changeset_log/publish_state_store_test.dart
@@ -107,4 +107,15 @@ void main() {
       expect(s.publishedHlcHigh, isNull);
     });
   });
+
+  test(
+    'hasAny is false before any publish and true once a row exists',
+    () async {
+      expect(await store.hasAny(), isFalse);
+      await store.markAdoptedPendingBase('s3', null);
+      expect(await store.hasAny(), isTrue);
+      await store.resetForProvider('s3');
+      expect(await store.hasAny(), isFalse);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Slice E of #1375: tombstone GC reachability for local-only libraries.

`SyncRepository.clearAcknowledgedDeletions` was reached from exactly one place, the tail of a successful cloud sync (`sync_service.dart`). A device that never configured a provider never arrives there, so its `deletion_log` grows forever. Every other part of GC already existed: the 30-day floor (`SyncLiveness.gcFloorMillis`) and the "no live peers" branch (`TombstoneGcDecision.unbounded()`).

This adds a second caller with a stricter gate, not new deletion logic.

## Changes

- **`LocalOnlyTombstoneGc`** (`lib/core/services/sync/changeset_log/`): runs once per launch from `startup_page.dart`, in the `MediaOrphanBacklogSweep` shape (constructed inline, `unawaited`, swallow and log). Calls `clearAcknowledgedDeletions(upToHlc: null, floorCutoffMillis: now - gcFloorMillis)`, the same call and floor the cloud path uses when no peer constrains it.
- **`SyncHistoryEvidence`**: a pure value type carrying the gate, so the decision is unit-tested without a database.
- **`hasAny()`** on `PeerCursorStore` and `PublishStateStore`.
- **Spec** (`docs/superpowers/specs/2026-08-29-storage-reclamation-design.md`): slice E section rewritten to record the final gate and why it changed.

## The gate, and why it differs from the spec

GC runs only when no provider is connected AND none of four durable traces of a prior sync exist:

| Signal | Why it is read |
| --- | --- |
| `sync_metadata.lastSyncTimestamp` | Set at the tail of every successful sync; sign-out does not clear it |
| any `sync_peer_cursors` row | This device consumed a peer's log |
| any `local_publish_states` row | This device published or adopted a base. A single-device cloud library has no peers and so no peer cursor; this row is the only transport-side trace it ever synced |
| `sync_metadata.lastAcceptedEpochId` | Survives the user-facing Reset Sync State, which wipes the other three |

The spec gated on peer cursors alone. That was too weak: a single-device cloud library leaves zero cursor rows, and `SyncService.signOut` clears only `syncProvider` and `remoteFileId`, so such a device, signed out, would have purged tombstones its cloud log still owed a later joiner. The three extra signals all survive sign-out and close that hole.

A device that HAS synced and then went local-only keeps its tombstones: the peers it left behind still need them to converge when it returns. That is the status quo for those users, so there is no regression.

**Known residual, accepted and documented in code and spec:** Reset Sync State followed by sign-out erases all four signals, so a reconnect more than 30 days later could resurrect rows deleted in between. That pair of actions is already a deliberate cold start of the sync transport.

## Why the purge is not neutered by null HLCs

`clearAcknowledgedDeletions` keeps null-HLC tombstones. `logDeletion` calls `ensureSyncClockConfigured()` before stamping, which configures the clock from the device id without any sync, so local-only tombstones do carry an HLC and are eligible.

## Out of scope

Item 6b of the audit (per-dive tombstones) is a wire-format change against the v114 `(entityType, recordId)` uniqueness index and needs its own issue, as the spec directs.

## Testing

- New: `local_only_tombstone_gc_test.dart` (pure gate combinations; never-synced purge past the floor only; exactly-at-floor kept; provider connected, signed-out-after-sync, peer cursor only, publish state only, epoch only all block), plus `hasAny()` tests in both store test files. 24 tests.
- Red check: inverting the gate fails 3 of the GC tests.
- `test/core/services/sync`, `test/core/data/repositories`, `test/core/presentation/pages`: 949 pass.
- `flutter analyze` clean, `dart format` clean across the project.
