### PR TITLE
fix(ble): strip the trailing NUL from an Android advertised name (#723)

### DIFF
--- a/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
+++ b/packages/libdivecomputer_plugin/android/src/main/kotlin/com/submersion/libdivecomputer/BleScanDiagnostics.kt
@@ -75,10 +75,25 @@ class BleScanDiagnostics {
          * logged as a nameless `(...)`, and -- because the dedupe key is
          * `address|name` -- would collide with the key used for devices that
          * advertised no name at all.
+         *
+         * The name is also cut at the first NUL and stripped of surrounding
+         * whitespace (issue #723). The Shearwater Perdix 3 pads its Complete
+         * Local Name with the C string terminator and Android's scan record
+         * parser keeps it. Every other platform hands the name to C as a
+         * real NUL-terminated string, so the terminator silently ends the
+         * name there; on Android it reached the native matcher as JNI's
+         * two-byte modified-UTF-8 encoding of U+0000, and the exact
+         * strcasecmp against "Perdix 3" failed. Padding of either kind can
+         * never be part of a descriptor product name, so dropping it cannot
+         * cost a match.
          */
         fun resolveName(scanRecordName: String?, deviceName: String?): String? =
-            scanRecordName?.takeIf { it.isNotEmpty() }
-                ?: deviceName?.takeIf { it.isNotEmpty() }
+            sanitizeName(scanRecordName) ?: sanitizeName(deviceName)
+
+        private fun sanitizeName(name: String?): String? =
+            name?.substringBefore(NUL)?.trim()?.takeIf { it.isNotEmpty() }
+
+        private val NUL = 0.toChar()
 
         // Mirrors android.bluetooth.le.ScanCallback. Duplicated rather than
         // referenced so this class stays free of Android imports.

--- a/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
+++ b/packages/libdivecomputer_plugin/android/src/test/kotlin/com/submersion/libdivecomputer/BleScanDiagnosticsTest.kt
@@ -12,7 +12,15 @@ import org.junit.Test
 // and could not produce it, because every failure mode ahead of that line
 // returned silently. These tests pin the behaviour that makes an
 // unsupported -- or unnamed -- dive computer visible in the debug log.
+//
+// The resolveName tests also cover issue #723, where a supported computer
+// was visible in that log but still unmatched because its advertised name
+// carried a trailing NUL.
 class BleScanDiagnosticsTest {
+
+    // Spelled out rather than escaped so the terminator is obvious in the
+    // assertions below.
+    private val NUL = 0.toChar().toString()
 
     @Test
     fun unmatchedNamedDeviceIsDescribedWithAddressAndName() {
@@ -133,6 +141,43 @@ class BleScanDiagnosticsTest {
     @Test
     fun anEmptyScanRecordNameFallsBackToTheDeviceName() {
         assertEquals("Suunto D5", BleScanDiagnostics.resolveName("", "Suunto D5"))
+    }
+
+    @Test
+    fun aTrailingNulInTheAdvertisedNameIsStripped() {
+        // Issue #723: the Shearwater Perdix 3 pads its Complete Local Name
+        // with the C string terminator, and Android's scan record parser
+        // keeps it. JNI encodes U+0000 as two non-zero bytes, so the exact
+        // strcasecmp in libdivecomputer never saw "Perdix 3" and the
+        // computer was logged as "Unmatched device ... (Perdix 3 )".
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName("Perdix 3$NUL", null))
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName(null, "Perdix 3$NUL"))
+    }
+
+    @Test
+    fun theNameEndsAtTheFirstNulLikeEveryOtherPlatform() {
+        // iOS, macOS, Windows and Linux hand the name to C as a real
+        // NUL-terminated string, so anything after the terminator is
+        // invisible there. Mirror that rather than only trimming the end.
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName("Perdix 3$NUL$NUL", null))
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName("Perdix 3${NUL}junk", null))
+    }
+
+    @Test
+    fun surroundingWhitespacePaddingIsStripped() {
+        // The same log had a camera advertising "EOSR7_fabian    ": padding
+        // is common in fixed-width name fields and can never be part of a
+        // descriptor product name.
+        assertEquals("EOSR7_fabian", BleScanDiagnostics.resolveName("EOSR7_fabian    ", null))
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName(" Perdix 3  ", null))
+    }
+
+    @Test
+    fun aNameThatIsOnlyPaddingCountsAsAbsent() {
+        assertNull(BleScanDiagnostics.resolveName(NUL, null))
+        assertNull(BleScanDiagnostics.resolveName("   ", ""))
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName(" ", "Perdix 3"))
+        assertEquals("Perdix 3", BleScanDiagnostics.resolveName(NUL, "Perdix 3"))
     }
 
     @Test


### PR DESCRIPTION
Fixes #723.

## Root cause

The reporter's debug log shows the Perdix 3 being rejected by the scanner:

```
[BLE] [DEBUG] Unmatched device 61:3A:D1:BC:13:CE (Perdix 3 )
```

GitHub renders the name as `Perdix 3??`, but a hexdump of the attached log file shows the bytes are `50 65 72 64 69 78 20 33 00`: the string `Perdix 3` followed by a NUL. The computer pads its Complete Local Name with the C string terminator, and Android's scan record parser keeps it.

Nothing on the Android path stripped it. `resolveName` only rejected empty names, `nativeDescriptorMatch` converts the Kotlin string with `GetStringUTFChars`, and JNI's modified UTF-8 encodes U+0000 as the two non-zero bytes `C0 80`. So `libdc_descriptor_match` compared `Perdix 3\xC0\x80` against the whitelist with an exact `strcasecmp` and failed.

This is why the descriptor row (#483), the V2 download protocol (#595) and the whitelist entry all looked correct during the earlier investigation, and why the same model is recognised on an iPad (#865): Swift, WinRT and BlueZ all hand the name to C as a real NUL-terminated string, so the terminator silently ends the name on every platform except Android.

## Fix

`BleScanDiagnostics.resolveName` now cuts each candidate name at the first NUL and trims surrounding whitespace before the existing empty check. Cutting at the first NUL mirrors the C semantics the other platforms already get for free. The whitespace trim covers the fixed-width padding also visible in the same log (`EOSR7_fabian    `); padding can never be part of a descriptor product name, so dropping it cannot cost a match.

## Tests

Four new JVM tests in `BleScanDiagnosticsTest` pin the behaviour: trailing NUL stripped, name cut at the first NUL, surrounding whitespace stripped, and padding-only names counting as absent. Verified red against the unmodified resolver (4 of 21 failed) and green with the fix, with a bogus `--tests` filter as a control that the filter selects real tests.

## Not changed

Windows and Darwin pass the raw advertised string on to Dart for display, so a saved Perdix 3 there could carry the NUL in its display name. Recognition and download are unaffected on those platforms, so that is left for a follow-up.
