### PR TITLE
fix(charts): move the reset zoom button ahead of the zoom controls

### DIFF
--- a/lib/core/presentation/widgets/chart_zoom_controls.dart
+++ b/lib/core/presentation/widgets/chart_zoom_controls.dart
@@ -36,7 +36,7 @@ class ChartZoomControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final isZoomed = zoomLevel > 1.0;
+    final isZoomed = zoomLevel > minZoom;
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/core/presentation/widgets/chart_zoom_controls.dart
+++ b/lib/core/presentation/widgets/chart_zoom_controls.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:submersion/l10n/l10n_extension.dart';
 
-/// Minus / level / plus, with a reset button once zoomed.
+/// Minus / level / plus, led by a reset button once zoomed.
 ///
 /// Extracted from the dive profile legend so the statistics trend charts get
 /// the same control rather than a lookalike. Zooming in with no visible way
@@ -41,6 +41,20 @@ class ChartZoomControls extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
+        // Leads the row so that appearing does not displace the buttons: the
+        // hosts pin these controls to the trailing edge, so a trailing reset
+        // button would slide minus/plus left and land on the plus the user
+        // just clicked.
+        if (isZoomed)
+          IconButton(
+            key: _key('zoom-reset'),
+            onPressed: onResetZoom,
+            icon: const Icon(Icons.fit_screen),
+            iconSize: 18,
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            tooltip: context.l10n.diveLog_profile_tooltip_resetZoom,
+          ),
         IconButton(
           key: _key('zoom-out'),
           onPressed: zoomLevel > minZoom ? onZoomOut : null,
@@ -71,16 +85,6 @@ class ChartZoomControls extends StatelessWidget {
           constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
           tooltip: context.l10n.diveLog_profile_tooltip_zoomIn,
         ),
-        if (isZoomed)
-          IconButton(
-            key: _key('zoom-reset'),
-            onPressed: onResetZoom,
-            icon: const Icon(Icons.fit_screen),
-            iconSize: 18,
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-            tooltip: context.l10n.diveLog_profile_tooltip_resetZoom,
-          ),
       ],
     );
   }

--- a/test/core/presentation/widgets/chart_zoom_controls_test.dart
+++ b/test/core/presentation/widgets/chart_zoom_controls_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:submersion/core/presentation/widgets/chart_zoom_controls.dart';
+import 'package:submersion/l10n/arb/app_localizations.dart';
+
+/// Mirrors the real hosts: the legend and the trend chart both pin the
+/// controls to the trailing edge, so any width change moves the buttons.
+Widget host(Widget child) => MaterialApp(
+  locale: const Locale('en'),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(
+    body: SizedBox(
+      width: 400,
+      child: Align(alignment: AlignmentDirectional.centerEnd, child: child),
+    ),
+  ),
+);
+
+Widget controls(double zoomLevel) => ChartZoomControls(
+  keyPrefix: 'test',
+  zoomLevel: zoomLevel,
+  minZoom: 1,
+  maxZoom: 8,
+  onZoomIn: () {},
+  onZoomOut: () {},
+  onResetZoom: () {},
+);
+
+Finder byName(String name) => find.byKey(ValueKey('test-$name'));
+
+void main() {
+  testWidgets('the reset button renders only once zoomed', (tester) async {
+    await tester.pumpWidget(host(controls(1)));
+    expect(byName('zoom-reset'), findsNothing);
+
+    await tester.pumpWidget(host(controls(2)));
+    expect(byName('zoom-reset'), findsOneWidget);
+  });
+
+  testWidgets('zoom in stays put when the reset button appears', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(controls(1)));
+    final before = tester.getCenter(byName('zoom-in'));
+
+    await tester.pumpWidget(host(controls(2)));
+    final after = tester.getCenter(byName('zoom-in'));
+
+    expect(after, before);
+  });
+
+  testWidgets('zoom out stays put when the reset button appears', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(controls(1)));
+    final before = tester.getCenter(byName('zoom-out'));
+
+    await tester.pumpWidget(host(controls(2)));
+    final after = tester.getCenter(byName('zoom-out'));
+
+    expect(after, before);
+  });
+
+  testWidgets('the reset button leads the zoom controls', (tester) async {
+    await tester.pumpWidget(host(controls(2)));
+
+    expect(
+      tester.getCenter(byName('zoom-reset')).dx,
+      lessThan(tester.getCenter(byName('zoom-out')).dx),
+    );
+  });
+}

--- a/test/core/presentation/widgets/chart_zoom_controls_test.dart
+++ b/test/core/presentation/widgets/chart_zoom_controls_test.dart
@@ -47,7 +47,10 @@ void main() {
     await tester.pumpWidget(host(controls(2)));
     final after = tester.getCenter(byName('zoom-in'));
 
-    expect(after, before);
+    // The regression displaced the button by a whole 32px slot, so a
+    // sub-pixel tolerance still catches it without tripping on layout
+    // rounding.
+    expect(after, offsetMoreOrLessEquals(before, epsilon: 0.5));
   });
 
   testWidgets('zoom out stays put when the reset button appears', (
@@ -59,7 +62,7 @@ void main() {
     await tester.pumpWidget(host(controls(2)));
     final after = tester.getCenter(byName('zoom-out'));
 
-    expect(after, before);
+    expect(after, offsetMoreOrLessEquals(before, epsilon: 0.5));
   });
 
   testWidgets('the reset button leads the zoom controls', (tester) async {

--- a/test/core/presentation/widgets/chart_zoom_controls_test.dart
+++ b/test/core/presentation/widgets/chart_zoom_controls_test.dart
@@ -17,10 +17,10 @@ Widget host(Widget child) => MaterialApp(
   ),
 );
 
-Widget controls(double zoomLevel) => ChartZoomControls(
+Widget controls(double zoomLevel, {double minZoom = 1}) => ChartZoomControls(
   keyPrefix: 'test',
   zoomLevel: zoomLevel,
-  minZoom: 1,
+  minZoom: minZoom,
   maxZoom: 8,
   onZoomIn: () {},
   onZoomOut: () {},
@@ -35,6 +35,16 @@ void main() {
     expect(byName('zoom-reset'), findsNothing);
 
     await tester.pumpWidget(host(controls(2)));
+    expect(byName('zoom-reset'), findsOneWidget);
+  });
+
+  testWidgets('the configured minimum is the unzoomed baseline', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(controls(2, minZoom: 2)));
+    expect(byName('zoom-reset'), findsNothing);
+
+    await tester.pumpWidget(host(controls(3, minZoom: 2)));
     expect(byName('zoom-reset'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Problem

In dive details, clicking the zoom `+` button made the reset-zoom icon appear
in the exact spot the `+` had just occupied, so zooming in a second time
required moving the mouse first (and a quick second click hit reset instead).

## Cause

`ChartZoomControls` rendered the reset button as the trailing child, and both
hosts pin the control row to the trailing edge: the dive profile legend places
it after an `Expanded`, and the statistics trend chart wraps it in
`Align(alignment: AlignmentDirectional.centerEnd)`. In a trailing-anchored
`Row`, appending a child does not extend the row rightward; it pushes every
existing child left by the new child's width. The `+` button vacated its pixel
and the reset button landed on it.

## Fix

Render the reset button as the leading child. The row now grows leftward when
it appears, so minus, the level readout and plus keep fixed positions. This
fixes the dive profile legend and the statistics trend charts together, since
both use the same widget.

## Tests

New `test/core/presentation/widgets/chart_zoom_controls_test.dart` hosts the
control row trailing-aligned, the way the real callers do, and asserts:

- the reset button renders only once zoomed
- the zoom-in button's center does not move when reset appears
- the zoom-out button's center does not move when reset appears
- the reset button sits left of the zoom-out button

All four fail before the change (three on position, as expected) and pass
after. `flutter analyze` is clean and the dive log and statistics widget
suites (1158 tests) pass.